### PR TITLE
Bugfixes: Condition related problems

### DIFF
--- a/scripts/cat/appearance_utility.py
+++ b/scripts/cat/appearance_utility.py
@@ -188,38 +188,32 @@ def init_sprite(cat):
         cat.age_sprites['dead'] = None
 
 def init_scars(cat):
-    scar_choice = randint(0, 15)
-    if cat.age in ['kitten', 'adolescent']:
-        scar_choice = randint(0, 50)
-    elif cat.age in ['young adult', 'adult']:
-        scar_choice = randint(0, 20)
-    if scar_choice == 1:
-        cat.specialty = choice([
-            choice(scars1),
-            choice(scars2),
-            choice(scars3)
-        ])
-    else:
-        cat.specialty = None
+    if cat.specialty is not None:
+        scar_choice = randint(0, 15)
+        if cat.age in ['kitten', 'adolescent']:
+            scar_choice = randint(0, 50)
+        elif cat.age in ['young adult', 'adult']:
+            scar_choice = randint(0, 20)
+        if scar_choice == 1:
+            cat.specialty = choice([
+                choice(scars1),
+                choice(scars3)
+            ])
 
-    scar_choice2 = randint(0, 30)
-    if cat.age in ['kitten', 'adolescent']:
-        scar_choice2 = randint(0, 100)
-    elif cat.age in ['young adult', 'adult']:
-        scar_choice2 = randint(0, 40)
-    if scar_choice2 == 1:
-        cat.specialty2 = choice([
-            choice(scars1),
-            choice(scars2),
-            choice(scars3)
-        ])
-    else:
+    if cat.specialty2 is not None:
+        scar_choice2 = randint(0, 30)
+        if cat.age in ['kitten', 'adolescent']:
+            scar_choice2 = randint(0, 100)
+        elif cat.age in ['young adult', 'adult']:
+            scar_choice2 = randint(0, 40)
+        if scar_choice2 == 1:
+            cat.specialty2 = choice([
+                choice(scars1),
+                choice(scars3)
+            ])
+
+    if 'NOTAIL' in (cat.specialty, cat.specialty2) and 'HALFTAIL' in (cat.specialty, cat.specialty2):
         cat.specialty2 = None
-    if cat.specialty2 == 'NOTAIL':
-        if cat.specialty == 'HALFTAIL':
-            cat.specialty = None
-
-
 
 
 def init_accessories(cat):

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -116,6 +116,8 @@ class Cat():
                  parent2=None,
                  pelt=None,
                  eye_colour=None,
+                 specialty=None,
+                 specialty2=None,
                  suffix=None,
                  ID=None,
                  moons=None,
@@ -130,6 +132,8 @@ class Cat():
         self.parent2 = parent2
         self.pelt = pelt
         self.eye_colour = eye_colour
+        self.specialty = specialty
+        self.specialty2 = specialty2
         self.mentor = None
         self.former_mentor = []
         self.patrol_with_mentor = 0
@@ -272,13 +276,6 @@ class Cat():
         init_accessories(self)
         init_white_patches(self)
         init_pattern(self)
-
-        self.paralyzed = False
-        self.no_kits = False
-        self.exiled = False
-        self.retired = False
-        if self.genderalign is None:
-            self.genderalign = self.gender
 
         # Sprite sizes
         self.sprite = None
@@ -924,12 +921,18 @@ class Cat():
         elif new_condition == "born without a tail":
             cat.specialty = 'NOTAIL'
 
-        self.get_permanent_condition(cat, new_condition, born_with=True)
+        self.get_permanent_condition(new_condition, born_with=True)
 
-    def get_permanent_condition(self, cat, name, born_with=False, event_triggered=False):
+    def get_permanent_condition(self, name, born_with=False, event_triggered=False):
         if name not in PERMANENT:
             print(f"WARNING: {name} is not in the permanent conditions collection.")
             return
+
+        # remove accessories if need be
+        if 'NOTAIL' in (self.specialty, self.specialty2) and self.accessory in ['RED FEATHERS', 'BLUE FEATHERS', 'JAY FEATHERS']:
+            self.accessory = None
+        if 'HALFTAIL' in (self.specialty, self.specialty2) and self.accessory in ['RED FEATHERS', 'BLUE FEATHERS', 'JAY FEATHERS']:
+            self.accessory = None
 
         condition = PERMANENT[name]
         new_condition = False

--- a/scripts/cat_relations/relation_events.py
+++ b/scripts/cat_relations/relation_events.py
@@ -755,7 +755,7 @@ class Relation_Events():
             kit.specialty2 = None
 
             # try to give them a permanent condition. 1/100 chance
-            if not int(random.random() * 100):
+            if not int(random.random() * 100) and game.clan.game_mode != 'classic':
                 kit.congenital_condition(kit)
                 for condition in kit.permanent_condition:
                     if kit.permanent_condition[condition] == 'born without a leg':

--- a/scripts/cat_relations/relation_events.py
+++ b/scripts/cat_relations/relation_events.py
@@ -425,15 +425,16 @@ class Relation_Events():
                                ]
         event_list.append(choice(possible_events))
 
-        cat.get_injured("recovering from birth", event_triggered=True)
-        if 'blood loss' in cat.injuries:
-            possible_events = [f"The birth was stressful and {str(cat.name)} lost a lot of blood.",
-                           f"{str(cat.name)} pants, looking at their wonderful {insert} and deciding that the pain and blood loss was all worth it.",
-                           f"Weak with blood loss, {str(cat.name)} nevertheless purrs at the sight of their {insert}.",
-                           f"Though the blood loss did not make the birth any easier for {str(cat.name)}.",
-                           f"Though {str(cat.name)} seems overly exhausted and weak from the birth."
-                           ]
-            event_list.append(choice(possible_events))
+        if game.clan.game_mode != 'classic':
+            cat.get_injured("recovering from birth", event_triggered=True)
+            if 'blood loss' in cat.injuries:
+                possible_events = [f"The birth was stressful and {str(cat.name)} lost a lot of blood.",
+                               f"{str(cat.name)} pants, looking at their wonderful {insert} and deciding that the pain and blood loss was all worth it.",
+                               f"Weak with blood loss, {str(cat.name)} nevertheless purrs at the sight of their {insert}.",
+                               f"Though the blood loss did not make the birth any easier for {str(cat.name)}.",
+                               f"Though {str(cat.name)} seems overly exhausted and weak from the birth."
+                               ]
+                event_list.append(choice(possible_events))
 
         print_event = " ".join(event_list)
         # display event

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -115,7 +115,8 @@ class Events():
                 amount_per_med = get_amount_cat_for_one_medic(game.clan)
                 med_fullfilled = medical_cats_condition_fulfilled(Cat.all_cats.values(), amount_per_med)
                 if not med_fullfilled:
-                    game.cur_events_list.insert(0, f"{game.clan.name}Clan does not have enough healthy medicine cats! Cats will be sick/hurt for longer and have a higher chance of dying.")
+                    game.cur_events_list.insert(0,
+                                                f"{game.clan.name}Clan does not have enough healthy medicine cats! Cats will be sick/hurt for longer and have a higher chance of dying.")
             else:
                 has_med = any(
                     str(cat.status) in {"medicine cat", "medicine cat apprentice"}
@@ -132,7 +133,7 @@ class Events():
                         if not Cat.all_cats[random_cat].dead and not Cat.all_cats[random_cat].exiled:
                             if Cat.all_cats[random_cat].status == 'warrior' and (
                                     len(Cat.all_cats[random_cat].former_apprentices) > 0 or len(
-                                    Cat.all_cats[random_cat].apprentice) > 0):
+                                Cat.all_cats[random_cat].apprentice) > 0):
                                 Cat.all_cats[random_cat].status = 'deputy'
                                 game.clan.deputy = Cat.all_cats[random_cat]
                                 game.cur_events_list.append(
@@ -243,14 +244,13 @@ class Events():
             if war_notice:
                 game.cur_events_list.append(war_notice)
 
-
     def perform_ceremonies(self, cat):
         # ---------------------------------------------------------------------------- #
         #                                  ceremonies                                  #
         # ---------------------------------------------------------------------------- #
 
         # leader dying or being exiled and dep promotion to leader
-        if (game.clan.leader.dead or game.clan.leader.exiled)\
+        if (game.clan.leader.dead or game.clan.leader.exiled) \
                 and game.clan.deputy is not None and not game.clan.deputy.dead:
             if game.clan.leader.exiled:
                 game.cur_events_list.append(
@@ -304,7 +304,9 @@ class Events():
 
                     # check if the clan has sufficient med cats
                     if game.clan.game_mode != 'classic':
-                        has_med = medical_cats_condition_fulfilled(Cat.all_cats.values(), amount_per_med=get_amount_cat_for_one_medic(game.clan))
+                        has_med = medical_cats_condition_fulfilled(Cat.all_cats.values(),
+                                                                   amount_per_med=get_amount_cat_for_one_medic(
+                                                                       game.clan))
                     else:
                         has_med = any(str(cat.status) in {"medicine cat", "medicine cat apprentice"}
                                       and not cat.dead and not cat.exiled for cat in Cat.all_cats.values())
@@ -411,6 +413,12 @@ class Events():
                     choice(plant_accessories),
                     choice(wild_accessories)
                 ])
+                # check if the cat is missing a tail before giving feather acc
+                if cat.accessory in ['RED FEATHERS', 'BLUE FEATHERS', 'JAY FEATHERS']:
+                    if 'NOTAIL' in (cat.specialty, cat.specialty2):
+                        cat.accessory = choice(plant_accessories)
+                    if 'HALFTAIL' in (cat.specialty, cat.specialty2):
+                        cat.accessory = choice(plant_accessories)
                 acc_singular = plural_acc_names(cat.accessory, False, True)
                 acc_plural = plural_acc_names(cat.accessory, True, False)
                 if self.ceremony_accessory is True:
@@ -909,20 +917,22 @@ class Events():
             new_cat.thought = 'Is looking around the camp with wonder'
 
             # chance to give the new cat a permanent condition, higher chance for found kits and litters
-            if kit or litter:
-                chance = 10
-            else:
-                chance = 200
-            if not int(random.random() * chance):
-                possible_conditions = []
-                for condition in PERMANENT:
-                    possible_conditions.append(condition)
-                chosen_condition = choice(possible_conditions)
-                new_cat.get_permanent_condition(new_cat, chosen_condition)
-                for condition in new_cat.permanent_condition:
-                    if new_cat.permanent_condition[condition] in ['lost a leg', 'born without a leg']:
+            if game.clan.game_mode != 'classic':
+                if kit or litter:
+                    chance = 10
+                else:
+                    chance = 200
+                if not int(random.random() * chance):
+                    possible_conditions = []
+                    for condition in PERMANENT:
+                        possible_conditions.append(condition)
+                    chosen_condition = choice(possible_conditions)
+                    new_cat.get_permanent_condition(chosen_condition)
+
+                    # assign scars
+                    if chosen_condition in ['lost a leg', 'born without a leg']:
                         new_cat.specialty = 'NOPAW'
-                    elif new_cat.permanent_condition[condition] in ['lost their tail', 'born without a tail']:
+                    elif chosen_condition in ['lost their tail', 'born without a tail']:
                         new_cat.specialty = "NOTAIL"
 
             created_cats.append(new_cat)
@@ -1011,7 +1021,6 @@ class Events():
         if interactions:
             game.cur_events_list.append(choice(interactions))
 
-
     def handle_injuries_or_general_death(self, cat):
         # ---------------------------------------------------------------------------- #
         #                           decide if cat dies                                 #
@@ -1041,7 +1050,8 @@ class Events():
         ))
 
         # chance to kill leader
-        if not int(random.random() * 90) and cat.status == 'leader' and not triggered_death and not cat.not_working():  # 1/80
+        if not int(
+                random.random() * 90) and cat.status == 'leader' and not triggered_death and not cat.not_working():  # 1/80
             self.death_events.handle_deaths(cat, other_cat, self.at_war, self.enemy_clan, alive_kits)
             triggered_death = True
 
@@ -1056,7 +1066,8 @@ class Events():
                 self.death_events.handle_deaths(cat, other_cat, self.at_war, self.enemy_clan, alive_kits)
                 triggered_death = True
             else:
-                triggered_death = self.condition_events.handle_injuries(cat, other_cat, alive_kits, self.at_war, self.enemy_clan, game.clan.current_season)
+                triggered_death = self.condition_events.handle_injuries(cat, other_cat, alive_kits, self.at_war,
+                                                                        self.enemy_clan, game.clan.current_season)
                 return triggered_death
 
             # disaster death chance
@@ -1070,9 +1081,7 @@ class Events():
             self.death_events.handle_deaths(cat, other_cat, self.at_war, self.enemy_clan, alive_kits)
             triggered_death = True
 
-
         return triggered_death
-
 
     def handle_disasters(self, cat):
         """Handles events when the setting of disasters is turned on"""
@@ -1182,7 +1191,6 @@ class Events():
                 if countdown <= 0:
                     return
 
-
             # check if clan has kits, if True then clan has kits
             alive_kits = list(filter(
                 lambda kitty: (kitty.age == "kitten"
@@ -1195,7 +1203,6 @@ class Events():
             if not int(random.random() * 80) and cat.status == 'leader' and not triggered_death:  # 1/80
                 self.death_events.handle_deaths(cat, other_cat, self.at_war, self.enemy_clan, alive_kits)
                 triggered_death = True
-
 
             # chance to die of old age
             if cat.moons > int(random.random() * 51) + 140 and not triggered_death:  # cat.moons > 150 <--> 200
@@ -1216,7 +1223,8 @@ class Events():
         # check if the cat is ill, if game mode is classic, or if clan has sufficient med cats in expanded mode
         amount_per_med = get_amount_cat_for_one_medic(game.clan)
         if not cat.is_ill() or game.clan.game_mode == 'classic' or \
-                (medical_cats_condition_fulfilled(Cat.all_cats.values(), amount_per_med) and game.clan.game_mode != 'cruel season'):
+                (medical_cats_condition_fulfilled(Cat.all_cats.values(),
+                                                  amount_per_med) and game.clan.game_mode != 'cruel season'):
             return
 
         # check how many kitties are already ill
@@ -1283,13 +1291,12 @@ class Events():
                 elif illness == 'fleas':
                     event = f'Fleas have been hopping from pelt to pelt and now {", ".join(infected_names[:-1])}, and {infected_names[-1]} are all infested.'
                 else:
-                    event = f'{illness_name} has spread around the camp. '\
+                    event = f'{illness_name} has spread around the camp. ' \
                             f'{", ".join(infected_names[:-1])}, and {infected_names[-1]} have been infected.'
 
                 print('OUTBREAK - PANDEMIC ALERT')
                 game.cur_events_list.append(event)
                 break
-
 
     def coming_out(self, cat):
         """turnin' the kitties trans..."""
@@ -1324,5 +1331,5 @@ class Events():
             game.cur_events_list.append(
                 f"{cat.name} has realized that {gender} doesn't describe how they feel anymore.")
 
-events_class = Events()
 
+events_class = Events()

--- a/scripts/events_module/condition_events.py
+++ b/scripts/events_module/condition_events.py
@@ -72,6 +72,8 @@ class Condition_Events():
                 # kill
                 if cat.dead and cat.status != 'leader':
                     event = f"{cat.name} has died of {illness}."
+                    # clear event list to get rid of any healed or risk event texts from other illnesses
+                    event_list.clear()
                     event_list.append(event)
                     break
                 elif cat.dead and cat.status == 'leader':
@@ -195,6 +197,12 @@ class Condition_Events():
                     save_death(cat, event_string)
             game.cur_events_list.append(event_string)
 
+        # just double-checking that trigger is only returned True if the cat is dead
+        if cat.dead:
+            triggered = True
+        else:
+            triggered = False
+
         return triggered
 
     def handle_injuries(self, cat, other_cat, alive_kits, war, enemy_clan, season):
@@ -212,6 +220,7 @@ class Condition_Events():
         text = None
 
         if cat.dead:
+            triggered = True
             return triggered
 
         # handle if the current cat is already injured
@@ -241,8 +250,6 @@ class Condition_Events():
             if triggered:
                 possible_events = self.generate_events.possible_injury_events(cat.status, cat.age)
                 final_events = []
-
-                triggered = True
 
                 for event in possible_events:
 
@@ -320,15 +327,17 @@ class Condition_Events():
                             cat.possible_death = str(history_text)
 
                     cat.get_injured(injury_event.injury)
-                else:
-                    triggered = False
 
-        if not triggered:
-            return triggered
+        # just double-checking that trigger is only returned True if the cat is dead
+        if cat.dead:
+            triggered = True
         else:
+            triggered = False
+
+        if text is not None:
             game.cur_events_list.append(text)
 
-            return triggered
+        return triggered
 
     def handle_permanent_conditions(self,
                                     cat,
@@ -429,6 +438,9 @@ class Condition_Events():
                         else:
                             event = f"{cat.name} has died in the medicine den from a {injury}."
                             cat.died_by = f"{cat.name} died from a {injury}."
+
+                    # clear event list first to make sure any heal or risk events from other injuries are not shown
+                    event_list.clear()
                     event_list.append(event)
                     save_death(cat, event)
                     break

--- a/scripts/events_module/condition_events.py
+++ b/scripts/events_module/condition_events.py
@@ -391,7 +391,7 @@ class Condition_Events():
             perm_condition = condition
 
         if perm_condition is not None:
-            got_condition = cat.get_permanent_condition(cat, perm_condition, born_with)
+            got_condition = cat.get_permanent_condition(perm_condition, born_with)
 
         if got_condition is True:
             return perm_condition
@@ -643,7 +643,7 @@ class Condition_Events():
                         if x == old_condition[y]:
                             if new_condition[y] in condition_progression.get(x):
                                 cat.permanent_condition.pop(old_condition[y])
-                    cat.get_permanent_condition(cat, new_condition[y], event_triggered=True)
+                    cat.get_permanent_condition(new_condition[y], event_triggered=True)
 
         retire_chances = {
             'kitten': 0,

--- a/scripts/utility.py
+++ b/scripts/utility.py
@@ -201,6 +201,9 @@ def event_text_adjust(Cat, text, cat, other_cat, other_clan_name=None):
     tail_danger = ["a rogue", "a dog", "a fox", "an otter", "a rat", "a hawk",
                    "an enemy warrior", "a badger", "a twoleg trap"]
 
+    danger_choice = choice(danger)
+    tail_choice = choice(tail_danger)
+
     name = str(cat.name)
     other_name = None
     if other_cat is not None:
@@ -217,8 +220,8 @@ def event_text_adjust(Cat, text, cat, other_cat, other_clan_name=None):
         adjust_text = adjust_text.replace("o_c", str(other_clan_name))
     if mate is not None:
         adjust_text = adjust_text.replace("c_m", str(mate))
-    adjust_text = adjust_text.replace("d_l", choice(danger))
-    adjust_text = adjust_text.replace("t_l", choice(tail_danger))
+    adjust_text = adjust_text.replace("d_l", danger_choice)
+    adjust_text = adjust_text.replace("t_l", tail_choice)
 
     return adjust_text
 


### PR DESCRIPTION
Fixes

- Cats will no longer gain the 'recovering from birth' condition on Classic
- While playing Classic, cats should no longer gain any conditions.
- Durations should now tick down correctly on injuries and illnesses
- Sprites should now match with the missing leg and tail perm conditions
- Feather accessories should now be removed when a cat loses their tail