### PR TITLE
Content/Bugfix: History

### DIFF
--- a/resources/dicts/relationship_events/DE_IN_CREASE/DECREASE_LOW.json
+++ b/resources/dicts/relationship_events/DE_IN_CREASE/DECREASE_LOW.json
@@ -39,7 +39,6 @@
         "dislike": [
             "feels bad that they caused a problem for (cat).",
             "won't stop copying everything (cat) does.",
-            "said something that rubbed (cat) the wrong way."
         ],
         "admiration": [
             "is asking (cat) to tell them about how good they look.",

--- a/resources/dicts/relationship_events/DE_IN_CREASE/INCREASE_LOW.json
+++ b/resources/dicts/relationship_events/DE_IN_CREASE/INCREASE_LOW.json
@@ -153,7 +153,9 @@
             "is boasting about their accomplishments to (cat), but (cat) isn't impressed.",
             "prays that they aren't on patrol with (cat) tomorrow.",
             "bickered about something trivial with (cat).",
-            "is dissatisfied that (cat) can't seem to get rid of their chronic pain."
+            "is dissatisfied that (cat) can't seem to get rid of their chronic pain.",
+            "said something that rubbed (cat) the wrong way."
+
         ],
         "admiration": [
             "bestowing wisdom onto (cat).",

--- a/resources/text_boxes.json
+++ b/resources/text_boxes.json
@@ -160,7 +160,7 @@
             "border_width": "0",
             "shadow_width": "0",
             "text_horiz_alignment": "left",
-            "padding": "0,0"
+            "padding": "5,7"
         }
     },
     "#clan_header_text_box": {

--- a/resources/text_boxes.json
+++ b/resources/text_boxes.json
@@ -159,7 +159,7 @@
         "misc": {
             "border_width": "0",
             "shadow_width": "0",
-            "text_horiz_alignment": "center",
+            "text_horiz_alignment": "left",
             "padding": "0,0"
         }
     },

--- a/resources/text_boxes_dark.json
+++ b/resources/text_boxes_dark.json
@@ -177,7 +177,7 @@
             "border_width": "0",
             "shadow_width": "0",
             "text_horiz_alignment": "left",
-            "padding": "0,0"
+            "padding": "5,5"
         }
     },
     "#header_text_box_dark":

--- a/resources/text_boxes_dark.json
+++ b/resources/text_boxes_dark.json
@@ -176,7 +176,7 @@
         {
             "border_width": "0",
             "shadow_width": "0",
-            "text_horiz_alignment": "center",
+            "text_horiz_alignment": "left",
             "padding": "0,0"
         }
     },

--- a/scripts/events_module/condition_events.py
+++ b/scripts/events_module/condition_events.py
@@ -477,17 +477,17 @@ class Condition_Events():
                                   "water in their lungs", "frostbite", "shock"]:
                         if cat.status == "leader":
                             event = f"{cat.name} has died in the medicine den from {injury}, losing a life."
-                            cat.died_by = f"died from {injury}."
+                            cat.died_by.append(f"died from {injury}.")
                         else:
                             event = f"{cat.name} has died in the medicine den from {injury}."
-                            cat.died_by = f"{cat.name} died from {injury}."
+                            cat.died_by.append(f"{cat.name} died from {injury}.")
                     else:
                         if cat.status == "leader":
                             event = f"{cat.name} has died in the medicine den from a {injury}, losing a life."
-                            cat.died_by = f"died from a {injury}."
+                            cat.died_by.append(f"died from a {injury}.")
                         else:
                             event = f"{cat.name} has died in the medicine den from a {injury}."
-                            cat.died_by = f"{cat.name} died from a {injury}."
+                            cat.died_by.append(f"{cat.name} died from a {injury}.")
 
                     # clear event list first to make sure any heal or risk events from other injuries are not shown
                     event_list.clear()

--- a/scripts/events_module/condition_events.py
+++ b/scripts/events_module/condition_events.py
@@ -362,7 +362,7 @@ class Condition_Events():
                     if injury_event.history_text is not None:
                         if injury_event.history_text[0] is not None:
                             history_text = event_text_adjust(Cat, injury_event.history_text[0], cat, other_cat,
-                                                             other_clan_name)
+                                                             other_clan_name, keep_m_c=True)
                             cat.possible_scar = str(history_text)
                         if injury_event.history_text[1] is not None and cat.status != "leader":
                             history_text = event_text_adjust(Cat, injury_event.history_text[1], cat, other_cat,

--- a/scripts/screens/cat_screens.py
+++ b/scripts/screens/cat_screens.py
@@ -768,13 +768,13 @@ class ProfileScreen(Screens):
             self.open_tab = 'backstory'
             self.backstory_background = pygame_gui.elements.UIImage(pygame.Rect((64, 465), (645, 157)),
                                                                     self.backstory_tab)
-            self.sub_tab_1 = UIImageButton(pygame.Rect((710, 475), (42, 30)), "", object_id="#sub_tab_1_button")
+            self.sub_tab_1 = UIImageButton(pygame.Rect((709, 475), (42, 30)), "", object_id="#sub_tab_1_button")
             self.sub_tab_1.disable()
-            self.sub_tab_2 = UIImageButton(pygame.Rect((710, 512), (42, 30)), "", object_id="#sub_tab_2_button")
+            self.sub_tab_2 = UIImageButton(pygame.Rect((709, 512), (42, 30)), "", object_id="#sub_tab_2_button")
             self.sub_tab_2.disable()
-            self.sub_tab_3 = UIImageButton(pygame.Rect((710, 549), (42, 30)), "", object_id="#sub_tab_3_button")
+            self.sub_tab_3 = UIImageButton(pygame.Rect((709, 549), (42, 30)), "", object_id="#sub_tab_3_button")
             self.sub_tab_3.disable()
-            self.sub_tab_4 = UIImageButton(pygame.Rect((710, 586), (42, 30)), "", object_id="#sub_tab_4_button")
+            self.sub_tab_4 = UIImageButton(pygame.Rect((709, 586), (42, 30)), "", object_id="#sub_tab_4_button")
             self.sub_tab_4.disable()
 
             # This will be overwritten in update_disabled_buttons_and_text()
@@ -784,44 +784,162 @@ class ProfileScreen(Screens):
     def toggle_history_sub_tab(self):
         """To toggle the sub-tab, when that's added"""
 
-    def get_history_text(self):
+    def get_all_history_text(self):
         output = ""
         if self.open_sub_tab == 'relation':
-            life_history = []
-            bs_blurb = bs_blurb_text(self.the_cat)
-            if bs_blurb is not None:
-                life_history.append(str(bs_blurb))
-            else:
-                life_history.append("This cat was born into the clan where they currently reside.")
+            # start our history with the backstory, since all cats get one
+            life_history = [str(self.get_backstory_text())]
 
-            if self.the_cat.scar_event:
-                scar_text = self.the_cat.scar_event
-                for x in range(len(self.the_cat.scar_event)):
-                    scar_text[x] = str(self.the_cat.scar_event[x]).replace(' is ', ' was ', 1)
-                    scar_text[x] = str(self.the_cat.scar_event[x]).replace(' loses ', ' lost ')
-                    scar_text[x] = str(self.the_cat.scar_event[x]).replace(' forces ', ' forced ')
+            # now go get the scar history and add that if any exists
+            scar_history = self.get_scar_text()
+            if scar_history:
+                life_history.append(str(scar_history))
 
-                    not_scarred = ['wounded', 'injured', 'battered', 'hurt', 'punished']
-                    for y in not_scarred:
-                        scar_text[x] = str(self.the_cat.scar_event[x]).replace(f' got {y} ', ' was scarred ')
-                        scar_text[x] = str(self.the_cat.scar_event[x]).replace(y, ' scarred ')
-                        break
-                    if x == 0:
-                        scar_text[x] = str(self.the_cat.scar_event[x]).replace(f'{self.the_cat.name} ', 'This cat ', 1)
-                    elif x == 1:
-                        scar_text[x] = str(self.the_cat.scar_event[x]).replace(f'{self.the_cat.name} was ',
-                                                                               'They were also ', 1)
-                        scar_text[x] = str(self.the_cat.scar_event[x]).replace(str(self.the_cat.name), 'They also', 1)
-                    elif x >= 3:
-                        scar_text[x] = str(self.the_cat.scar_event[x]).replace(f'{self.the_cat.name} was ',
-                                                                               'Then they were ', 1)
-                        scar_text[x] = str(self.the_cat.scar_event[x]).replace(str(self.the_cat.name), 'Then they', 1)
-                scar_history = ' '.join(scar_text)
-                life_history.append(scar_history)
+            # now get mentor influence history and add that if any exists
+            influence_history = self.get_influence_text()
+            if influence_history:
+                life_history.append(str(influence_history))
+
+            if self.the_cat.dead or (self.the_cat.status == 'leader' and game.clan.leader_lives < 9):
+                death_history = self.get_death_text()
+                if death_history:
+                    life_history.append(str(death_history))
+                else:
+                    life_history.append(f"The cause of {self.the_cat.name}'s death is unknown.")
 
             # join together history list with line breaks
             output = '\n'.join(life_history)
         return output
+
+    def get_backstory_text(self):
+        text = None
+        bs_blurb = bs_blurb_text(self.the_cat)
+        if bs_blurb is not None:
+            adjust_text = str(bs_blurb).replace('This cat', str(self.the_cat.name))
+            text = adjust_text
+        else:
+            text = f"{str(self.the_cat.name)} was born into the clan where they currently reside."
+        return text
+
+    def get_scar_text(self):
+        scar_history = None
+
+        if self.the_cat.scar_event:
+            scar_text = self.the_cat.scar_event
+            for x in range(len(self.the_cat.scar_event)):
+                scar_text[x] = str(self.the_cat.scar_event[x]).replace(' is ', ' was ', 1)
+                scar_text[x] = str(self.the_cat.scar_event[x]).replace(' loses ', ' lost ')
+                scar_text[x] = str(self.the_cat.scar_event[x]).replace(' forces ', ' forced ')
+
+                not_scarred = ['wounded', 'injured', 'battered', 'hurt', 'punished']
+                for y in not_scarred:
+                    scar_text[x] = str(self.the_cat.scar_event[x]).replace(f' got {y} ', ' was scarred ')
+                    scar_text[x] = str(self.the_cat.scar_event[x]).replace(y, ' scarred ')
+                    break
+                if x == 0:
+                    scar_text[x] = str(self.the_cat.scar_event[x]).replace(f'{self.the_cat.name} ', 'This cat ', 1)
+                elif x == 1:
+                    scar_text[x] = str(self.the_cat.scar_event[x]).replace(f'{self.the_cat.name} was ',
+                                                                           'They were also ', 1)
+                    scar_text[x] = str(self.the_cat.scar_event[x]).replace(str(self.the_cat.name), 'They also', 1)
+                elif x >= 3:
+                    scar_text[x] = str(self.the_cat.scar_event[x]).replace(f'{self.the_cat.name} was ',
+                                                                           'Then they were ', 1)
+                    scar_text[x] = str(self.the_cat.scar_event[x]).replace(str(self.the_cat.name), 'Then they', 1)
+            scar_history = ' '.join(scar_text)
+
+        return scar_history
+
+    def get_influence_text(self):
+        influence_history = None
+
+        # check if cat has any mentor influence, else assign None
+        if len(self.the_cat.mentor_influence) >= 1:
+            influenced_skill = str(self.the_cat.mentor_influence[0])
+            if len(self.the_cat.mentor_influence) >= 2:
+                influenced_trait = str(self.the_cat.mentor_influence[1]).casefold()
+            else:
+                influenced_trait = None
+        else:
+            game.switches['sub_tab_group'] = 'life sub tab'
+            influenced_trait = None
+            influenced_skill = None
+
+        # if they did have mentor influence, check if skill or trait influence actually happened and assign None
+        if influenced_skill in ['None', 'none']:
+            influenced_skill = None
+        if influenced_trait in ['None', 'none']:
+            influenced_trait = None
+
+        # if cat had mentor influence then write history text for those influences and append to history
+        # assign proper grammar to skills
+        vowels = ['e', 'a', 'i', 'o', 'u']
+        if influenced_skill in Cat.skill_groups.get('special'):
+            adjust_skill = f'unlock their abilities as a {influenced_skill}'
+            for y in vowels:
+                if influenced_skill.startswith(y):
+                    adjust_skill = adjust_skill.replace(' a ', ' an ')
+                    break
+            influenced_skill = adjust_skill
+        elif influenced_skill in Cat.skill_groups.get('star'):
+            adjust_skill = f'grow a {influenced_skill}'
+            influenced_skill = adjust_skill
+        elif influenced_skill in Cat.skill_groups.get('smart'):
+            adjust_skill = f'become {influenced_skill}'
+            influenced_skill = adjust_skill
+        else:
+            # for loop to assign proper grammar to all these groups
+            become_group = ['heal', 'teach', 'mediate', 'hunt', 'fight', 'speak']
+            for x in become_group:
+                if influenced_skill in Cat.skill_groups.get(x):
+                    adjust_skill = f'become a {influenced_skill}'
+                    for y in vowels:
+                        if influenced_skill.startswith(y):
+                            adjust_skill = adjust_skill.replace(' a ', ' an ')
+                            break
+                    influenced_skill = adjust_skill
+                    break
+
+            if self.the_cat.former_mentor:
+                mentor = self.the_cat.former_mentor[-1].name
+            else:
+                mentor = None
+
+            # append influence blurb to history
+            if mentor is None:
+                influence_history = None
+            elif influenced_trait is not None and influenced_skill is None:
+                influence_history = f"The influence of their mentor, {mentor}, caused this cat to become more {influenced_trait}."
+            elif influenced_trait is None and influenced_skill is not None:
+                influence_history = f"The influence of their mentor, {mentor}, caused this cat to {influenced_skill}."
+            elif influenced_trait is not None and influenced_skill is not None:
+                influence_history = f"The influence of their mentor, {mentor}, caused this cat to become more {influenced_trait} as well as {influenced_skill}."
+            else:
+                influence_history = None
+
+        return influence_history
+
+    def get_death_text(self):
+        text = None
+        if self.the_cat.died_by:
+            if self.the_cat.status == 'leader':
+                insert2 = f"lost lives"
+                if len(self.the_cat.died_by) > 2:
+                    insert = f"{', '.join(self.the_cat.died_by[:-2])} and {self.the_cat.died_by[-1]}"
+                elif len(self.the_cat.died_by) == 2:
+                    insert = f"{self.the_cat.died_by[0]} and {self.the_cat.died_by[1]}"
+                else:
+                    insert = f"{self.the_cat.died_by[0]}"
+                    if self.the_cat.dead:
+                        insert2 = f'lost all their lives'
+                    elif game.clan.leader_lives == 8:
+                        insert2 = f"lost a life"
+                text = f"{self.the_cat.name} {insert2} when they {insert}."
+            else:
+                text = str(self.the_cat.died_by[0])
+        return text
+
+
 
     def toggle_conditions_tab(self):
         """Opens the conditions tab"""
@@ -1033,9 +1151,9 @@ class ProfileScreen(Screens):
             elif 'moons_with' in keys:  # need to check if it exists for older saves
                 moons_with = self.the_cat.permanent_condition[name]["moons_with"]
                 if moons_with != 1:
-                    text_list.append(f"{moons_with} moons")
+                    text_list.append(f"has had this condition for {moons_with} moons")
                 else:
-                    text_list.append(f"1 moon")
+                    text_list.append(f"has had this condition for 1 moon")
             # is permanent
             text_list.append('permanent condition')
             # infected or festering
@@ -1044,7 +1162,7 @@ class ProfileScreen(Screens):
                 if complication is not None:
                     if 'a festering wound' in self.the_cat.illnesses:
                         complication = 'festering'
-                    text_list.append(f'Is {complication}!')
+                    text_list.append(f'is {complication}!')
 
         # collect details for injuries
         if name in self.the_cat.injuries:
@@ -1052,20 +1170,23 @@ class ProfileScreen(Screens):
             keys = self.the_cat.injuries[name].keys()
             if 'moons_with' in keys:  # need to check if it exists for older saves
                 moons_with = self.the_cat.injuries[name]["moons_with"]
+                insert = 'has been hurt for'
+                if name == 'recovering from birth':
+                    insert = 'has been recovering for'
                 if moons_with != 1:
-                    text_list.append(f"{moons_with} moons")
+                    text_list.append(f"{insert} {moons_with} moons")
                 else:
-                    text_list.append(f"1 moon")
+                    text_list.append(f"{insert} 1 moon")
             # infected or festering
             if 'complication' in keys:
                 complication = self.the_cat.injuries[name]["complication"]
                 if complication is not None:
                     if 'a festering wound' in self.the_cat.illnesses:
                         complication = 'festering'
-                    text_list.append(f'Is {complication}!')
+                    text_list.append(f'is {complication}!')
             # can or can't patrol
             if self.the_cat.injuries[name]["severity"] != 'minor':
-                text_list.append("They cannot work with this condition")
+                text_list.append("they cannot work with this condition")
 
         # collect details for illnesses
         if name in self.the_cat.illnesses:
@@ -1073,10 +1194,13 @@ class ProfileScreen(Screens):
             keys = self.the_cat.illnesses[name].keys()
             if 'moons_with' in keys:  # need to check if it exists for older saves
                 moons_with = self.the_cat.illnesses[name]["moons_with"]
+                insert = "has been sick for"
+                if name == 'grief stricken':
+                    insert = 'has been grieving for'
                 if moons_with != 1:
-                    text_list.append(f"{moons_with} moons")
+                    text_list.append(f"{insert} {moons_with} moons")
                 else:
-                    text_list.append(f"1 moon")
+                    text_list.append(f"{insert} 1 moon")
             if self.the_cat.illnesses[name]['infectiousness'] != 0:
                 text_list.append("infectious!")
             # can or can't patrol
@@ -1324,7 +1448,7 @@ class ProfileScreen(Screens):
         # Backstory_tab:
         elif self.open_tab == 'backstory':
             self.history_text_box.kill()
-            self.history_text_box = pygame_gui.elements.UITextBox(self.get_history_text(),
+            self.history_text_box = pygame_gui.elements.UITextBox(self.get_all_history_text(),
                                                                   pygame.Rect((80, 480), (615, 142)),
                                                                   object_id="#history_tab_text_box")
 

--- a/scripts/utility.py
+++ b/scripts/utility.py
@@ -207,7 +207,7 @@ def add_children_to_cat(cat, cat_class):
 #                               Text Adjust                                    #
 # ---------------------------------------------------------------------------- #
 
-def event_text_adjust(Cat, text, cat, other_cat, other_clan_name=None):
+def event_text_adjust(Cat, text, cat, other_cat=None, other_clan_name=None, keep_m_c=False):
     danger = ["a rogue", "a dog", "a fox", "an otter", "a rat", "a hawk", "an enemy warrior", "a badger"]
     tail_danger = ["a rogue", "a dog", "a fox", "an otter", "a rat", "a hawk",
                    "an enemy warrior", "a badger", "a twoleg trap"]
@@ -224,7 +224,8 @@ def event_text_adjust(Cat, text, cat, other_cat, other_clan_name=None):
         mate = Cat.all_cats.get(cat.mate).name
 
     adjust_text = text
-    adjust_text = adjust_text.replace("m_c", str(name))
+    if keep_m_c is False:
+        adjust_text = adjust_text.replace("m_c", str(name))
     if other_name is not None:
         adjust_text = adjust_text.replace("r_c", str(other_name))
     if other_clan_name is not None:


### PR DESCRIPTION
History now displayed death text!  Some cat saves may have death text that doesn't display correctly (like only displaying the first letter of the text), this will only happen to old saves, newly created saves will not have this problem.  Dead cats that do not have a saved death event will display with the text 'The cause of this cat's death is unknown', this includes the SC/DF guide cat.  Scar history text is now adjusted differently.  I originally thought this would cause old saves to display oddly, but for the most part they still work well.

Bugfixes:
- Mentor influence history got lost in the UI update, it's been added back in
- One of the thoughts I added in my last PR was giving positive effects when it should've given negative, it now gives the correct effects.  