### PR TITLE
Fix Mac pyinstaller build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,7 +168,7 @@ jobs:
       - name: Update setuptools and wheel
         run: python -m pip install --upgrade setuptools wheel
       - name: Install dependencies
-        run: python -m pip install pygame==2.1.2 ujson
+        run: python -m pip install -r requirements.txt
       - name: Install Pillow for icon format conversion
         run: python -m pip install --upgrade Pillow
       - name: Install PyInstaller

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-pygame==2.1.3.dev8
+pygame==2.1.3.dev8; platform_system != "Darwin"
+pygame==2.1.2; platform_system == "Darwin"
 ujson==5.5.0
 pygame_gui==0.6.5


### PR DESCRIPTION
Rather than hard-coding the OS-specific dependencies (pygame 2.1.3 doesn't have an official release so there are no Mac wheels yet), put them back into `requirements.txt`. 

This also resolves the missing dependency.

For now, it's just some conditionals, but if there's ever more specific requirements we can probably make multiple requirements files. Note that `requirements.txt` should be updated when 2.1.3 has an official release.