### PR TITLE
fix: FileNotFoundError error

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3
 import sys
 import os
+directory = os.path.dirname(__file__)
+if directory:
+    os.chdir(directory)
 from scripts.game_structure.load_cat import *
 from scripts.cat.sprites import sprites
 from scripts.clan import clan_class
@@ -9,10 +12,6 @@ import pygame
 # from scripts.world import load_map
 
 pygame.init()
-
-directory = os.path.dirname(__file__)
-if directory:
-    os.chdir(directory)
 
 # initialize pygame_gui manager, and load themes
 manager = pygame_gui.UIManager((800, 700), 'resources/defaults.json')


### PR DESCRIPTION
Files were being loaded before correct directory was loaded so they were not being found in certain situations, such as when launching the game from other folders.

Load directory earlier in execution so that the directory will be correct and files can be found.

This should also fix the error preventing the MacOS build from launching.