### PR TITLE
Temporarily added ceremony text to ceremony tab

### DIFF
--- a/scripts/events.py
+++ b/scripts/events.py
@@ -441,6 +441,7 @@ class Events():
                 ])
         if (promoted_to == 'warrior' or promoted_to == 'apprentice'):
             game.cur_events_list.append(choice(ceremony))
+            game.ceremony_events_list.append(choice(ceremony))
         else:
             game.cur_events_list.append(f'{str(cat.name)}{ceremony_text}')
 


### PR DESCRIPTION
Before the new summary events for all the new warriors/apprentices per moon are added in, I have temporarily just put the new ceremony text 