### PR TITLE
Bugfixes: Misc

### DIFF
--- a/resources/dicts/conditions/illnesses.json
+++ b/resources/dicts/conditions/illnesses.json
@@ -234,7 +234,7 @@
         ]
     },
     "whitecough": {
-        "severity": "minor",
+        "severity": "major",
         "mortality": {
             "kitten": 10,
             "adolescent": 20,

--- a/resources/dicts/conditions/permanent_conditions.json
+++ b/resources/dicts/conditions/permanent_conditions.json
@@ -222,12 +222,12 @@
         "congenital": "sometimes",
         "moons_until": 0,
         "mortality": {
-            "kitten": 20,
-            "adolescent": 70,
-            "young adult": 150,
+            "kitten": 15,
+            "adolescent": 60,
+            "young adult": 120,
             "adult": 100,
-            "senior adult": 60,
-            "elder": 30
+            "senior adult": 50,
+            "elder": 20
         },
         "illness_infectiousness": [
             {
@@ -302,7 +302,7 @@
     "failing eyesight": {
         "severity": "major",
         "congenital": "sometimes",
-        "moons_until": 5,
+        "moons_until": 2,
         "mortality": {
             "kitten": 0,
             "adolescent": 0,
@@ -323,7 +323,7 @@
     "partial hearing loss": {
         "severity": "minor",
         "congenital": "sometimes",
-        "moons_until": 4,
+        "moons_until": 2,
         "mortality": {
             "kitten": 0,
             "adolescent": 0,
@@ -383,7 +383,7 @@
     "seizure prone": {
         "severity": "major",
         "congenital": "sometimes",
-        "moons_until": 4,
+        "moons_until": 3,
         "mortality": {
             "kitten": 0,
             "adolescent": 0,
@@ -404,7 +404,7 @@
     "allergies": {
         "severity": "minor",
         "congenital": "always",
-        "moons_until": 4,
+        "moons_until": 3,
         "mortality": {
             "kitten": 0,
             "adolescent": 0,

--- a/resources/dicts/events/injury/beach/kitten.json
+++ b/resources/dicts/events/injury/beach/kitten.json
@@ -101,7 +101,7 @@
             "Greenleaf",
             "Leaf-fall"
         ],
-        "event_text": "r_c is hopping around in the tide pools when they trip and fall onto the rocks. Thankfully they're only a bit bruised.",
+        "event_text": "m_c is hopping around in the tide pools when they trip and fall onto the rocks. Thankfully they're only a bit bruised.",
         "history_text": [
             null,
             null,
@@ -119,7 +119,7 @@
             "Leaf-bare",
             "Leaf-fall"
         ],
-        "event_text": "r_c is playing around on the iced over tide pools, slipping and sliding every which way, when they slip a little too much and take a tumble.",
+        "event_text": "r=m_c is playing around on the iced over tide pools, slipping and sliding every which way, when they slip a little too much and take a tumble.",
         "history_text": [
             null,
             null,
@@ -137,7 +137,7 @@
             "Leaf-bare",
             "Leaf-fall"
         ],
-        "event_text": "r_c is playing around on the iced over tide pools, slipping and sliding every which way, when they slip a little too much and take a tumble.",
+        "event_text": "m_c is playing around on the iced over tide pools, slipping and sliding every which way, when they slip a little too much and take a tumble.",
         "history_text": [
             null,
             null,
@@ -155,7 +155,7 @@
             "Leaf-bare",
             "Leaf-fall"
         ],
-        "event_text": "r_c is playing around on the iced over tide pools, slipping and sliding every which way, when they slip a little too much and twist their paw.",
+        "event_text": "m_c is playing around on the iced over tide pools, slipping and sliding every which way, when they slip a little too much and twist their paw.",
         "history_text": [
             null,
             null,
@@ -175,7 +175,7 @@
             "Leaf-bare",
             "Leaf-fall"
         ],
-        "event_text": "r_c is jumping around on the rocks when they slip and fall. The soft sand of the cave floor softens their landing, but they're still sporting some new bruises.",
+        "event_text": "m_c is jumping around on the rocks when they slip and fall. The soft sand of the cave floor softens their landing, but they're still sporting some new bruises.",
         "history_text": [
             null,
             null,

--- a/resources/dicts/relationship_events/special_character.json
+++ b/resources/dicts/relationship_events/special_character.json
@@ -121,7 +121,7 @@
     ],
     "cowardly": ["is hiding from (cat)"],
     "impulsive": [
-      "crashes into (cat) while eager for patrol.",
+      "crashes into (cat) while eager for the new day.",
       "rejects (cat)'s advice without letting them finish.",
       "interrupts (cat) during a conversation."
     ],

--- a/resources/dicts/thoughts/other.json
+++ b/resources/dicts/thoughts/other.json
@@ -51,7 +51,7 @@
             "Shivers in the cold",
             "Wonders if clan life is the only way to live with others",
             "Was chased away from the shelter they had been staying in",
-            "Hopes their mild cough won’t get worse",
+            "Hopes their mild cough won't get worse",
             "Wishes newleaf would come already",
             "Frowns deeply at the first frost",
             "Got invited to spend the night with a group of friendly loners"
@@ -81,11 +81,11 @@
             "Wonders if they should have joined a Clan when they were younger",
             "Debates finding housefolk to care for them in their old age. ",
             "Is enjoying the sun on their back.",
-            "Purring as the sun’s warmth eases their old joints",
+            "Purring as the sun's warmth eases their old joints",
             "Is glad they chose this life of freedom.",
             "Thinks about old friends",
-            "Hopes it isn’t too late to join a clan",
-            "Wonders where they’ll go when they die",
+            "Hopes it isn't too late to join a clan",
+            "Wonders where they'll go when they die",
             "Telling stories about their younger days"
         ]
     },
@@ -138,7 +138,7 @@
             "Misses their nest",
             "Feels homesick",
             "Thought they spotted r_c while wandering around earlier",
-            "Thinks they might’ve been visited by a StarClan cat",
+            "Thinks they might've been visited by a StarClan cat",
             "Misses their family",
             "Prays to StarClan that their loved ones are safe.",
             "Thinks they caught scent of a c_n patrol",
@@ -161,28 +161,28 @@
             "Refuses to give up!",
             "Thanks a loner who gave them shelter",
             "Hesitantly made a deal with a rogue",
-            "Wishes they weren’t as used to this as they are",
+            "Wishes they weren't as used to this as they are",
             "Got even more lost than they were before",
-            "Worries their Clan thinks they’re a runaway traitor",
+            "Worries their Clan thinks they're a runaway traitor",
             "Finds comfort in their solitude"
         ],
         "kitten": [
             "Misses playing moss ball"
         ],
         "apprentice": [
-            "Is missing their mentor’s guidance",
+            "Is missing their mentor's guidance",
             "Misses the elders stories",
-            "Wishes they could’ve become a warrior",
+            "Wishes they could've become a warrior",
             "Misses their parents/siblings dearly",
             "Refuses to let themself relax for even a moment",
-            "Hopes they’re going in the right direction",
+            "Hopes they're going in the right direction",
             "Wonders what their full name might have been",
             "Tries to come up with a warrior name for themself"
         ],
         "warrior": [
             "Hopes their kits are doing well without them",
             "Wonders if their mate has moved on",
-            "Misses the warmth of the warriors’ den",
+            "Misses the warmth of the warriors' den",
             "Hopes their friends from o_c_n are doing okay",
             "Dreams about hunting for their clan",
             "Wonders if their apprentice is doing okay"
@@ -191,7 +191,7 @@
             "Wonders if they are still the deputy",
             "Wonders how the patrols are currently organized without them",
             "Feels sad by the thought of being replaced",
-            "Is wondering if they’ll still remain deputy after returning"
+            "Is wondering if they'll still remain deputy after returning"
         ],
         "leader": [
             "Feels lost without the support of their clan behind them. ",
@@ -203,7 +203,7 @@
         "elder": [
             "Wishes they had some help getting around",
             "Wants an apprentice nearby to help with ticks.",
-            "Is saddened by the fact that they can’t tell stories to anyone.",
+            "Is saddened by the fact that they can't tell stories to anyone.",
             "Misses the kits stumbling around and bothering them.",
             "Is feeling weary and tired, wondering if there even is a point to carry on.",
             "Prays that they will see their friends again, in this world or StarClan…",

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -1047,6 +1047,10 @@ class Cat():
         is_disabled = True
         if len(self.permanent_condition) <= 0:
             is_disabled = False
+        for condition in self.permanent_condition:
+            if self.permanent_condition[condition]['born_with'] is True and self.permanent_condition[condition]['moons_until'] != -2:
+                is_disabled = False
+
         return is_disabled is not False
 
     def contact_with_ill_cat(self, cat):

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -407,9 +407,12 @@ class Events():
             ])
         cat.status_change(promoted_to)
         if (promoted_to == 'warrior'):
-            game.cur_events_list.append(choice(ceremony))
+            ceremony = choice(ceremony)
+            game.cur_events_list.append(ceremony)
+            game.ceremony_events_list.append(ceremony)
         else:
             game.cur_events_list.append(f'{str(cat.name)}{ceremony_text}')
+            game.ceremony_events_list.append(f'{str(cat.name)}{ceremony_text}')
 
     def gain_accessories(self, cat):
         # ---------------------------------------------------------------------------- #

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -877,7 +877,7 @@ class Events():
                 game.cur_events_list.append(choice(loner_text))
                 game.misc_events_list.append(choice(loner_text))
                 game.cur_events_list.append(choice(success_text))
-                game.misc_events_list.append(choice(loner_text))
+                game.misc_events_list.append(choice(success_text))
 
             elif type_of_new_cat == 6:
                 created_cats = self.create_new_cat(

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -431,7 +431,7 @@ class Events():
                     " to apprentice under. They know that " +
                     str(cat.mentor.name) + " was a good choice."
                 ])
-            if cat.permanent_condition and not game.clan.leader.dead:
+            if cat.is_disabled() and not game.clan.leader.dead:
                 ceremony.extend([
                     str(cat.name) + " is confidently telling " +
                     str(game.clan.leader.name) +

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -190,7 +190,7 @@ class Events():
             return
 
         # check for death/reveal/risks/retire caused by permanent conditions
-        if cat.is_disabled():
+        if cat.is_disabled() or len(cat.permanent_condition) > 0:
             self.condition_events.handle_already_disabled(cat)
         self.perform_ceremonies(cat)  # here is age up included
 

--- a/scripts/events_module/condition_events.py
+++ b/scripts/events_module/condition_events.py
@@ -313,7 +313,9 @@ class Condition_Events():
                         continue
                     if "other_cat_mentor" in event.tags and cat.mentor != other_cat.ID:
                         continue
-                    elif "other_cat_adult" in event.tags and other_cat.age in ["elder", "kitten"]:
+                    if "other_cat_adult" in event.tags and other_cat.age in ["elder", "kitten"]:
+                        continue
+                    if "other_cat_kit" in event.tags and other_cat.age != 'kitten':
                         continue
 
                     if "clan_kits" in event.tags and not alive_kits:

--- a/scripts/events_module/condition_events.py
+++ b/scripts/events_module/condition_events.py
@@ -386,6 +386,8 @@ class Condition_Events():
         if text is not None:
             game.cur_events_list.append(text)
             game.health_events_list.append(text)
+            if cat.dead:
+                game.birth_death_events_list.append(text)
             if has_other_clan:
                 game.other_clans_events_list.append(text)
 

--- a/scripts/events_module/death_events.py
+++ b/scripts/events_module/death_events.py
@@ -42,6 +42,9 @@ class Death_Events():
             if game.clan.game_mode in ["expanded", "cruel season"] and "classic" in event.tags:
                 continue
 
+            if "all_lives" in event.tags and int(random.random() * 10):
+                continue
+
             # check season
             if game.clan.current_season not in event.tags:
                 continue

--- a/scripts/events_module/death_events.py
+++ b/scripts/events_module/death_events.py
@@ -123,7 +123,7 @@ class Death_Events():
                 other_history_text = event_text_adjust(Cat, death_cause.history_text[1], cat, other_cat, other_clan_name)
 
         # handle leader lives
-        if cat.status == "leader":
+        if cat.status == "leader" and "other_cat_death" not in death_cause.tags:
             if "all_lives" in death_cause.tags:
                 game.clan.leader_lives -= 10
                 cat.die()

--- a/scripts/events_module/death_events.py
+++ b/scripts/events_module/death_events.py
@@ -123,7 +123,7 @@ class Death_Events():
             if cat.status != "leader" and death_cause.history_text[0] is not None:
                 other_history_text = event_text_adjust(Cat, death_cause.history_text[0], cat, other_cat, other_clan_name)
             elif cat.status == "leader" and death_cause.history_text[1] is not None:
-                other_history_text = event_text_adjust(Cat, death_cause.history_text[1], cat, other_cat, other_clan_name)
+                other_history_text = event_text_adjust(Cat, death_cause.history_text[1], other_cat, cat, other_clan_name)
 
         # handle leader lives
         if cat.status == "leader" and "other_cat_death" not in death_cause.tags:

--- a/scripts/screens/cat_screens.py
+++ b/scripts/screens/cat_screens.py
@@ -794,22 +794,14 @@ class ProfileScreen(Screens):
         else:
             output += 'backstory: ' + 'clanborn'
 
+        # NEWLINE ----------
+        output += "\n"
+
         if the_cat.is_disabled():
-            for condition in the_cat.permanent_condition:
-                if the_cat.permanent_condition[condition]["born_with"] is True and the_cat.permanent_condition[condition]["moons_until"] == -2:
-                    output += 'has a permanent condition'
-                    break
-                elif the_cat.permanent_condition[condition]["born_with"] is False:
-                    output += 'has a permanent condition'
-                    break
-                else:
-                    continue
+            output += 'has a permanent condition'
 
             # NEWLINE ----------
             output += "\n"
-
-        # NEWLINE ----------
-        output += "\n"
 
         if the_cat.is_injured():
             if "recovering from birth" in the_cat.injuries:
@@ -1185,126 +1177,126 @@ class ProfileScreen(Screens):
             visible=self.second_page_visible)
 
         # check for permanent conditions and create their detail boxes
-        for condition in self.the_cat.permanent_condition:
-            if self.the_cat.permanent_condition[condition]["born_with"] is True and \
-                    self.the_cat.permanent_condition[condition]["moons_until"] != -2:
-                continue
-            # move to second page if count gets too high
-            if count < 4 and container != self.second_page:
-                container = self.first_page
-            else:
-                container = self.second_page
-                x_pos = 14
-            # display the detail box
-            self.condition_box = pygame_gui.elements.UIImage(
-                pygame.Rect((x_pos, 13), (140, 138)),
-                self.condition_details_box,
-                container=container)
-            # display the detail text
-            y_adjust = 30
-            # title
-            if len(str(condition)) > 18:
-                y_adjust += 18
-            self.condition_name_text = UITextBoxTweaked(
-                condition,
-                pygame.Rect((x_pos, 13), (138, -1)),
-                line_spacing=.90,
-                object_id="text_box",
-                container=container
-            )
-            # details
-            text = self.get_condition_details(condition)
-            self.condition_detail_text = UITextBoxTweaked(
-                text,
-                pygame.Rect((x_pos, y_adjust), (138, 138)),
-                line_spacing=.90,
-                object_id="#condition_details_text_box",
-                container=container
-            )
-            # adjust the x_pos for the next box
-            x_pos += 152
-            count += 1
+        if self.the_cat.is_disabled():
+            for condition in self.the_cat.permanent_condition:
+                # move to second page if count gets too high
+                if count < 4 and container != self.second_page:
+                    container = self.first_page
+                else:
+                    container = self.second_page
+                    x_pos = 14
+                # display the detail box
+                self.condition_box = pygame_gui.elements.UIImage(
+                    pygame.Rect((x_pos, 13), (140, 138)),
+                    self.condition_details_box,
+                    container=container)
+                # display the detail text
+                y_adjust = 30
+                # title
+                if len(str(condition)) > 18:
+                    y_adjust += 18
+                self.condition_name_text = UITextBoxTweaked(
+                    condition,
+                    pygame.Rect((x_pos, 13), (138, -1)),
+                    line_spacing=.90,
+                    object_id="text_box",
+                    container=container
+                )
+                # details
+                text = self.get_condition_details(condition)
+                self.condition_detail_text = UITextBoxTweaked(
+                    text,
+                    pygame.Rect((x_pos, y_adjust), (138, 138)),
+                    line_spacing=.90,
+                    object_id="#condition_details_text_box",
+                    container=container
+                )
+                # adjust the x_pos for the next box
+                x_pos += 152
+                count += 1
 
         # check for injuries and display their detail boxes
-        for injury in self.the_cat.injuries:
-            # move to second page if count gets too high
-            if count < 4 and container != self.second_page:
-                container = self.first_page
-            else:
-                container = self.second_page
-                x_pos = 14
-            # display the detail box
-            self.condition_box = pygame_gui.elements.UIImage(
-                pygame.Rect((x_pos, 13), (140, 138)),
-                self.condition_details_box,
-                container=container
-            )
-            # display the detail text
-            y_adjust = 30
-            # title
-            if len(str(injury)) > 17:
-                y_adjust += 18
-            self.condition_name_text = UITextBoxTweaked(
-                injury,
-                pygame.Rect((x_pos, 13), (138, -1)),
-                line_spacing=.90,
-                object_id="text_box",
-                container=container
-            )
-            # details
-            text = self.get_condition_details(injury)
-            self.condition_detail_text = UITextBoxTweaked(
-                text,
-                pygame.Rect((x_pos, y_adjust), (138, 138)),
-                line_spacing=.90,
-                object_id="#condition_details_text_box",
-                container=container
-            )
-            # adjust the x_pos for the next box
-            x_pos += 152
-            count += 1
+        if self.the_cat.is_injured():
+            for injury in self.the_cat.injuries:
+                # move to second page if count gets too high
+                if count < 4 and container != self.second_page:
+                    container = self.first_page
+                else:
+                    container = self.second_page
+                    x_pos = 14
+                # display the detail box
+                self.condition_box = pygame_gui.elements.UIImage(
+                    pygame.Rect((x_pos, 13), (140, 138)),
+                    self.condition_details_box,
+                    container=container
+                )
+                # display the detail text
+                y_adjust = 30
+                # title
+                if len(str(injury)) > 17:
+                    y_adjust += 18
+                self.condition_name_text = UITextBoxTweaked(
+                    injury,
+                    pygame.Rect((x_pos, 13), (138, -1)),
+                    line_spacing=.90,
+                    object_id="text_box",
+                    container=container
+                )
+                # details
+                text = self.get_condition_details(injury)
+                self.condition_detail_text = UITextBoxTweaked(
+                    text,
+                    pygame.Rect((x_pos, y_adjust), (138, 138)),
+                    line_spacing=.90,
+                    object_id="#condition_details_text_box",
+                    container=container
+                )
+                # adjust the x_pos for the next box
+                x_pos += 152
+                count += 1
 
         # check for illnesses and display their detail boxes
-        for illness in self.the_cat.illnesses:
-            # don't display infected or festering as their own condition
-            if illness in ['an infected wound', 'a festering wound']:
-                continue
-            # move to second page if count gets too high
-            if count < 4 and container != self.second_page:
-                container = self.first_page
-            else:
-                container = self.second_page
-                x_pos = 14
-            # display the detail box
-            self.condition_box = pygame_gui.elements.UIImage(
-                pygame.Rect((x_pos, 13), (140, 138)),
-                self.condition_details_box,
-                container=container
-            )
-            # display the detail text
-            y_adjust = 30
-            # title
-            if len(str(illness)) > 17:
-                y_adjust += 18
-            self.condition_name_text = UITextBoxTweaked(
-                illness,
-                pygame.Rect((x_pos, 13), (138, -1)),
-                line_spacing=.90,
-                object_id="text_box",
-                container=container
-            )
-            # details
-            text = self.get_condition_details(illness)
-            self.condition_detail_text = UITextBoxTweaked(
-                text,
-                pygame.Rect((x_pos, y_adjust), (138, 138)),
-                line_spacing=.90,
-                object_id="#condition_details_text_box",
-                container=container
-            )
-            # adjust the x_pos for the next box
-            x_pos += 152
-            count += 1
+        if self.the_cat.is_ill():
+            for illness in self.the_cat.illnesses:
+                # don't display infected or festering as their own condition
+                if illness in ['an infected wound', 'a festering wound']:
+                    continue
+                # move to second page if count gets too high
+                if count < 4 and container != self.second_page:
+                    container = self.first_page
+                else:
+                    container = self.second_page
+                    x_pos = 14
+                # display the detail box
+                self.condition_box = pygame_gui.elements.UIImage(
+                    pygame.Rect((x_pos, 13), (140, 138)),
+                    self.condition_details_box,
+                    container=container
+                )
+                # display the detail text
+                y_adjust = 30
+                # title
+                if len(str(illness)) > 17:
+                    y_adjust += 18
+                self.condition_name_text = UITextBoxTweaked(
+                    illness,
+                    pygame.Rect((x_pos, 13), (138, -1)),
+                    line_spacing=.90,
+                    object_id="text_box",
+                    container=container
+                )
+                # details
+                text = self.get_condition_details(illness)
+                self.condition_detail_text = UITextBoxTweaked(
+                    text,
+                    pygame.Rect((x_pos, y_adjust), (138, 138)),
+                    line_spacing=.90,
+                    object_id="#condition_details_text_box",
+                    container=container
+                )
+                # adjust the x_pos for the next box
+                x_pos += 152
+                count += 1
 
         if count > 4:
             self.right_arrow.enable()

--- a/scripts/screens/cat_screens.py
+++ b/scripts/screens/cat_screens.py
@@ -919,10 +919,7 @@ class ProfileScreen(Screens):
             print(f"WARNING: Saving notes of cat #{self.the_cat.ID} didn't work.")
 
     def load_user_notes(self):
-        if game.switches['clan_name'] != '':
-            clanname = game.switches['clan_name']
-        else:
-            clanname = game.switches['clan_list'][0]
+        clanname = game.clan.name
 
         notes_directory = 'saves/' + clanname + '/notes'
         notes_file_path = notes_directory + '/' + self.the_cat.ID + '_notes.json'

--- a/scripts/screens/cat_screens.py
+++ b/scripts/screens/cat_screens.py
@@ -1080,6 +1080,10 @@ class ProfileScreen(Screens):
             # append influence blurb to history
             if mentor is None:
                 influence_history = "This cat either did not have a mentor, or their mentor is unknown."
+                if self.the_cat.status == 'kitten':
+                    influence_history = 'This cat has not begun training.'
+                if self.the_cat.status in ['apprentice', 'medicine cat apprentice']:
+                    influence_history = 'This cat has not finished training.'
             elif influenced_trait is not None and influenced_skill is None:
                 influence_history = f"The influence of their mentor, {mentor}, caused this cat to become more {influenced_trait}."
             elif influenced_trait is None and influenced_skill is not None:

--- a/scripts/screens/cat_screens.py
+++ b/scripts/screens/cat_screens.py
@@ -795,9 +795,18 @@ class ProfileScreen(Screens):
             output += 'backstory: ' + 'clanborn'
 
         if the_cat.is_disabled():
+            for condition in the_cat.permanent_condition:
+                if the_cat.permanent_condition[condition]["born_with"] is True and the_cat.permanent_condition[condition]["moons_until"] == -2:
+                    output += 'has a permanent condition'
+                    break
+                elif the_cat.permanent_condition[condition]["born_with"] is False:
+                    output += 'has a permanent condition'
+                    break
+                else:
+                    continue
+
             # NEWLINE ----------
             output += "\n"
-            output += 'has a permanent condition'
 
         # NEWLINE ----------
         output += "\n"

--- a/scripts/screens/organizational_screens.py
+++ b/scripts/screens/organizational_screens.py
@@ -637,7 +637,8 @@ class StatsScreen(Screens):
                      "Number of Dead Cats: " + str(starclan_num)
 
         self.stats_box = pygame_gui.elements.UITextBox(stats_text, pygame.Rect((100, 150), (600, 500)),
-                                                       self.update_heading_text(f'{game.clan.name}Clan'))
+                                                       self.update_heading_text(f'{game.clan.name}Clan'),
+                                                       object_id=get_text_box_theme())
 
     def exit_screen(self):
         self.stats_box.kill()

--- a/scripts/screens/relation_screens.py
+++ b/scripts/screens/relation_screens.py
@@ -664,7 +664,7 @@ class ViewChildrenScreen(Screens):
             self.next_sibling_page.disable()
         elif self.sibling_page_number == 1 and len(self.all_siblings) > 1:
             self.previous_sibling_page.disable()
-            self.next_sibling_page.ensable()
+            self.next_sibling_page.enable()
         else:
             self.previous_offspring_page.enable()
             self.next_offspring_page.enable()
@@ -715,7 +715,7 @@ class ViewChildrenScreen(Screens):
             self.next_offspring_page.disable()
         elif self.offspring_page_number == 1 and len(self.all_offspring) > 1:
             self.previous_offspring_page.disable()
-            self.next_offspring_page.ensable()
+            self.next_offspring_page.enable()
         else:
             self.previous_offspring_page.enable()
             self.next_offspring_page.enable()


### PR DESCRIPTION
- 'has permanent condition' notif no longer shows on the profiles of kits with unrevealed perm conditions
- death events involving the leader and a second cat were killing the wrong cat and giving the death text incorrectly, this is fixed
- 'all_lives' leader deaths have been made rarer (not rly a bugfix, but close enough)
- whitecough is now a major illness, previously it was a minor illness and cats could still patrol while sick with it
- new ceremony text now appears in the ceremony tab
- there was a relation event that did not account for the possibility of kits being part of the event, now it does
- main_cat and other_cat names were switched in some events, this is now fixed
- when two cats die in the same event, the death history wasn't working right. now it is.
- .enable() was mispelled as .ensable() in two areas, causing crashes. this is fixed.
- kittypet joining moon events will no longer be doubled in the misc tab
- deaths caused by injuries weren't showing up in the birth and death events tab, now they do
- the stats screen text was black on dark mode, now it's a light color as intended
- mentor history now takes kitten and adolescent ages into account
- made is_disabled() check for reveal status, which should fix any problems with congenital conditions causing moon events before they are revealed
- adjusted moons_until durations for congenital conditions as some seemed too high and made wasting disease deadlier as it seemed too forgiving
- fixed crash being caused by weird apostrophes (illegal multibyte sequence)