### PR TITLE
Bugfix: Fix huge save files (November release)

### DIFF
--- a/scripts/cats.py
+++ b/scripts/cats.py
@@ -2910,7 +2910,7 @@ class Cat(object):
                             comfortable=rel['comfortable'] if rel['comfortable'] else 0,
                             jealousy=rel['jealousy'] if rel['jealousy'] else 0,
                             trust=rel['trust'] if rel['trust'] else 0,
-                            log =rel['log'] if rel['log'] else [])
+                            log =rel['log'])
                         relationships.append(new_rel)
                     self.relationships = relationships
             except:

--- a/scripts/cats.py
+++ b/scripts/cats.py
@@ -2621,6 +2621,10 @@ class Cat(object):
 
         rel = []
         for r in self.relationships:
+            if r.log:
+                log = [r.log[-1]]
+            else:
+                log = []
             r_data = {
                 "cat_from_id": r.cat_from.ID,
                 "cat_to_id": r.cat_to.ID,
@@ -2633,7 +2637,7 @@ class Cat(object):
                 "comfortable": r.comfortable,
                 "jealousy": r.jealousy,
                 "trust": r.trust,
-                "log": r.log
+                "log": log
             }
             rel.append(r_data)
 

--- a/scripts/relationship.py
+++ b/scripts/relationship.py
@@ -481,7 +481,7 @@ class Relationship(object):
         self.current_action_str = ''
         self.triggerd_event = False
         if log:
-             self.log = log
+             self.log = [log[-1]]
         else:
              self.log = []
 

--- a/scripts/relationship.py
+++ b/scripts/relationship.py
@@ -472,7 +472,7 @@ INDIRECT_INCREASE = 6
 INDIRECT_DECREASE = 3
 
 class Relationship(object):
-    def __init__(self, cat_from, cat_to, mates=False, family=False, romantic_love=0, platonic_like=0, dislike=0, admiration=0, comfortable=0, jealousy=0, trust=0, log = []) -> None:        
+    def __init__(self, cat_from, cat_to, mates=False, family=False, romantic_love=0, platonic_like=0, dislike=0, admiration=0, comfortable=0, jealousy=0, trust=0, log = None) -> None:        
         self.cat_from = cat_from
         self.cat_to = cat_to
         self.mates = mates
@@ -480,7 +480,10 @@ class Relationship(object):
         self.opposit_relationship = None #link to oppositting relationship will be created later
         self.current_action_str = ''
         self.triggerd_event = False
-        self.log = log
+        if log:
+             self.log = log
+        else:
+             self.log = []
 
         if self.cat_from.is_parent(self.cat_to) or self.cat_to.is_parent(self.cat_from):
             self.family = True


### PR DESCRIPTION
Lists are mutable, so Relationships were using the same list as default in construction, causing new logs to start with the same list. This caused save files to become unacceptably large due to redundant information. Also, as a temporary fix for large save files, only the most recent log entry will be opened and stored. Otherwise, people would be stuck with 300MB+ save files forever.

If you'd like to save the commit of the original release, please tag it before you merge.