### PR TITLE
Misc Bugfixes

### DIFF
--- a/resources/dicts/relationship_events/cat_to_other/deputy_to_other.json
+++ b/resources/dicts/relationship_events/cat_to_other/deputy_to_other.json
@@ -49,7 +49,6 @@
             "is telling (cat) about a hunting technique.",
             "is giving (cat) a task.",
             "wishes (cat) would take things more seriously.",
-            "is jealous that (cat) got to go to the last gathering.",
             "saw (cat) miss an easy catch today.",
             "is thinking about how much (cat) reminds them of their own apprentice days.",
             "had a disagreement with (cat) while on patrol earlier."
@@ -75,7 +74,7 @@
             "is giving (cat) a task.",
             "is frustrated that (cat) won't take their duties more seriously.",
             "is sparring with (cat).",
-            "is jealous that (cat) got to go to the last gathering.",
+            
             "has noticed (cat) isn't doing a lot of work lately.",
             "saw (cat) miss an easy catch today.",
             "had a disagreement with (cat) while on patrol earlier."

--- a/resources/dicts/relationship_events/cat_to_other/leader_to_other.json
+++ b/resources/dicts/relationship_events/cat_to_other/leader_to_other.json
@@ -70,7 +70,6 @@
             "is giving (cat) a task.",
             "is frustrated that (cat) won't take their duties more seriously.",
             "is sparring with (cat).",
-            "is jealous that (cat) got to go to the last gathering.",
             "has noticed (cat) isn't doing a lot of work lately.",
             "saw (cat) miss an easy catch today."
         ],

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -107,7 +107,7 @@ class Cat():
     outside_cats = {}  # cats outside the clan
     id_iter = itertools.count()
 
-    grief_strings = []
+    grief_strings = {}
 
     def __init__(self,
                  prefix=None,
@@ -538,7 +538,7 @@ class Cat():
                 # adjust and append text to grief string list
                 text = ' '.join(text)
                 text = event_text_adjust(Cat, text, self, cat)
-                Cat.grief_strings.append(text)
+                Cat.grief_strings[self.ID] = text
                 possible_strings.clear()
                 text = None
 

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -996,20 +996,21 @@ class Cat():
         moons_until = self.permanent_condition[condition]["moons_until"]
         born_with = self.permanent_condition[condition]["born_with"]
 
+        # handling the countdown till a congenital condition is revealed
+        if moons_until is not None and moons_until >= 0 and born_with is True:
+            self.permanent_condition[condition]["moons_until"] = int(moons_until - 1)
+            self.permanent_condition[condition]["moons_with"] = 0
+            return False
+        if self.permanent_condition[condition]["moons_until"] == -1 and\
+                self.permanent_condition[condition]["born_with"] is True:
+            self.permanent_condition[condition]["moons_until"] = -2
+            return True
+
         keys = self.permanent_condition[condition].keys()
         if 'moons_with' in keys:
             self.permanent_condition[condition]["moons_with"] += 1
         else:
             self.permanent_condition[condition].update({'moons_with': 1})
-
-        # handling the countdown till a congenital condition is revealed
-        if moons_until is not None and moons_until >= 0 and born_with is True:
-            self.permanent_condition[condition]["moons_until"] = int(moons_until - 1)
-            self.permanent_condition[condition]["moons_with"] = 0
-        if self.permanent_condition[condition]["moons_until"] == -1 and\
-                self.permanent_condition[condition]["born_with"] is True:
-            self.permanent_condition[condition]["moons_until"] = -2
-            return True
 
         # leader should have a higher chance of death
         if self.status == "leader" and mortality != 0:
@@ -1017,7 +1018,7 @@ class Cat():
             if mortality == 0:
                 mortality = 1
 
-        if mortality and not int(random.random() * mortality) and moons_until == 0:
+        if mortality and not int(random.random() * mortality):
             if self.status == 'leader':
                 game.clan.leader_lives -= 1
             self.die(died_by_condition=True)

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -538,7 +538,7 @@ class Cat():
                 # adjust and append text to grief string list
                 text = ' '.join(text)
                 text = event_text_adjust(Cat, text, self, cat)
-                Cat.grief_strings[self.ID] = text
+                Cat.grief_strings[cat.ID] = text
                 possible_strings.clear()
                 text = None
 

--- a/scripts/cat_relations/relation_events.py
+++ b/scripts/cat_relations/relation_events.py
@@ -527,8 +527,12 @@ class Relation_Events():
         if not chance:
             if relationship_from.dislike > 30:
                 will_break_up = True
+                relationship_to.romantic_love -= 10
+                relationship_from.romantic_love -= 10
             elif relationship_from.romantic_love < 50:
                 will_break_up = True
+                relationship_to.romantic_love -= 10
+                relationship_from.romantic_love -= 10
             elif had_fight:
                 text = f"{str(cat_from.name)} and {str(cat_to.name)} had a fight and nearly broke up."
                 game.relation_events_list.insert(0, text)

--- a/scripts/clan.py
+++ b/scripts/clan.py
@@ -353,14 +353,32 @@ class Clan():
             members = sections[4].split(',')
             other_clans = []
         if len(general) == 9:
-            if general[4] == 'None':
-                general[4] = 0
-            elif general[3] == 'None':
+            if general[3] == 'None':
                 general[3] = 'camp1'
+            elif general[4] == 'None':
+                general[4] = 0
             elif general[7] == 'None':
                 general[7] = 'classic'
             elif general[8] == 'None':
                 general[8] = 50
+            game.clan = Clan(general[0],
+                             Cat.all_cats[leader_info[0]],
+                             Cat.all_cats.get(deputy_info[0], None),
+                             Cat.all_cats.get(med_cat_info[0], None),
+                             biome=general[2],
+                             camp_bg=general[3],
+                             world_seed=int(general[4]),
+                             camp_site=(int(general[5]),
+                                        int(general[6])),
+                             game_mode=general[7],
+                             )
+        if len(general) == 8:
+            if general[3] == 'None':
+                general[3] = 'camp1'
+            elif general[4] == 'None':
+                general[4] = 0
+            elif general[7] == 'None':
+                general[7] = 'classic'
             game.clan = Clan(general[0],
                              Cat.all_cats[leader_info[0]],
                              Cat.all_cats.get(deputy_info[0], None),

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -1007,8 +1007,8 @@ class Events():
                         f'A loner leaves their litter to the clan. {str(parent1)} decides to adopt them as their own.'
                     ])
                     text = choice(a_kit_text)
-                    game.cur_events_list.append(text)
-                    game.misc_events_list.append(text)
+                    game.cur_events_list.append(a_kit_text)
+                    game.misc_events_list.append(a_kit_text)
 
     def create_new_cat(self,
                        loner=False,

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -106,12 +106,13 @@ class Events():
 
         if Cat.grief_strings:
             remove_cats = []
-            for ID in Cat.grief_strings.keys:
-                check_cat = Cat.all_cats[ID]
+
+            for ID in Cat.grief_strings.keys():
+                check_cat = Cat.all_cats.get(ID)
                 if check_cat.dead or check_cat.outside:
                     remove_cats.append(check_cat.ID)
             for ID in remove_cats:
-                if ID in Cat.grief_strings.keys:
+                if ID in Cat.grief_strings.keys():
                     Cat.grief_strings.pop(ID)
 
             grief_strings = "<br><br>".join(Cat.grief_strings.values())

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -229,7 +229,7 @@ class Events():
             return
 
         # check for death/reveal/risks/retire caused by permanent conditions
-        if cat.is_disabled() or len(cat.permanent_condition) > 0:
+        if cat.is_disabled():
             self.condition_events.handle_already_disabled(cat)
         self.perform_ceremonies(cat)  # here is age up included
 

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -105,7 +105,16 @@ class Events():
                 self.relation_events.handle_relationships(cat)
 
         if Cat.grief_strings:
-            grief_strings = "<br><br>".join(Cat.grief_strings)
+            remove_cats = []
+            for ID in Cat.grief_strings.keys:
+                check_cat = Cat.all_cats[ID]
+                if check_cat.dead or check_cat.outside:
+                    remove_cats.append(check_cat.ID)
+            for ID in remove_cats:
+                if ID in Cat.grief_strings.keys:
+                    Cat.grief_strings.pop(ID)
+
+            grief_strings = "<br><br>".join(Cat.grief_strings.values())
             game.cur_events_list.append(grief_strings)
             game.birth_death_events_list.append(grief_strings)
             game.relation_events_list.append(grief_strings)

--- a/scripts/screens/cat_screens.py
+++ b/scripts/screens/cat_screens.py
@@ -824,6 +824,7 @@ class ProfileScreen(Screens):
 
                 # NEWLINE ----------
                 output += "\n"
+                break
 
         if the_cat.is_injured():
             if "recovering from birth" in the_cat.injuries:

--- a/scripts/screens/cat_screens.py
+++ b/scripts/screens/cat_screens.py
@@ -1711,7 +1711,7 @@ class ProfileScreen(Screens):
                     self.notes_entry = pygame_gui.elements.UITextEntryBox(
                         pygame.Rect((100, 473), (600, 149)),
                         initial_text=self.user_notes,
-                        object_id='#history_tab_entry_box_smalltooltip'
+                        object_id='#history_tab_entry_box'
                     )
                 else:
                     self.edit_text = UIImageButton(pygame.Rect(

--- a/scripts/screens/cat_screens.py
+++ b/scripts/screens/cat_screens.py
@@ -1577,7 +1577,10 @@ class ProfileScreen(Screens):
                                                        object_id="#switch_med_cat_button")
                 close_button_location = (226, 574)
             # Switch med cat to warrior
-            elif self.the_cat.status == 'medicine cat' and not self.the_cat.dead and not self.the_cat.outside:
+            elif self.the_cat.status == 'medicine cat' and \
+                    not self.the_cat.dead and \
+                    not self.the_cat.outside and \
+                    self.the_cat.age != 'elder':
                 self.toggle_med_button = UIImageButton(pygame.Rect((226, 522), (172, 36)), "",
                                                        object_id="#switch_warrior_button")
                 close_button_location = (226, 558)


### PR DESCRIPTION
- Fixed the notes entry box having weird formatting
- 'has a permanent condition' no longer appears multiple times on a cat's profile
- The invisible adoption event is no longer invisible
- You can no longer force an elder to be a warrior for a moon by switching the elder to a medicine cat, then switching them again from med to warrior
- Deputies and Leaders will no longer be jealous of other cats going to the gathering
- Fixed the break up/get together loop that cats with tied hate and romance values would go through
- Dead cats will no longer mourn other dead cats
- Loading up old saves was causing the game mode and camp bg to reset to default, this is fixed
- Attempted to fix the permanent condition moons_with freeze, not sure if I actually did