### PR TITLE
Bugfixes: Previous cat buttons, and crashfixes

### DIFF
--- a/scripts/cat_relations/relation_events.py
+++ b/scripts/cat_relations/relation_events.py
@@ -498,7 +498,7 @@ class Relation_Events():
                 f"{str(cat.name)} to it, not after the {insert} was all born and seemed fine. "
                 f"They thought the blood loss was under control."
             ]
-            if len(get_med_cats(Cat)) == 0 or (len(get_med_cats(Cat) == 1 and cat.status == 'medicine cat')):  # check number of med cats in the clan
+            if len(get_med_cats(Cat)) == 0 or (len(get_med_cats(Cat)) == 1 and cat.status == 'medicine cat'):  # check number of med cats in the clan
                 event_list.append(choice(possible_events[2:]))  # limit possible events to those not mentioned med cats
             else:
                 event_list.append(choice(possible_events))

--- a/scripts/clan.py
+++ b/scripts/clan.py
@@ -575,8 +575,9 @@ class Clan():
                 print('Cat not found:', cat)
 
         if "faded_cats" in clan_data:
-            for cat in clan_data["faded_cats"].split(","):
-                game.clan.faded_ids.append(cat)
+            if clan_data["faded_cats"].strip(): # Check for empty string
+                for cat in clan_data["faded_cats"].split(","):
+                    game.clan.faded_ids.append(cat)
 
         self.load_pregnancy(game.clan)
         game.switches['error_message'] = ''

--- a/scripts/events_module/condition_events.py
+++ b/scripts/events_module/condition_events.py
@@ -760,10 +760,27 @@ class Condition_Events():
                 med_cat = None
                 has_parents = False
                 if cat.parent1 is not None and cat.parent2 is not None:
-                    if not cat.parent1.dead or not cat.parent2.dead:
+
+                    # Check if the parent is in Cat.all_cats. If not, they are faded are dead.
+
+                    med_parent = False # If they have a med parent, this will be flicked to True in the next couple lines.
+                    if cat.parent1 in Cat.all_cats:
+                        parent1_dead = Cat.all_cats[cat.parent1].dead
+                        if Cat.all_cats[cat.parent1].status == "medicine cat":
+                            med_parent = True
+                    else:
+                        parent1_dead = True
+
+                    if cat.parent2 in Cat.all_cats:
+                        parent2_dead = Cat.all_cats[cat.parent2.dead]
+                        if Cat.all_cats[cat.parent2].status == "medicine cat":
+                            med_parent = True
+                    else:
+                        parent2_dead = True
+
+                    if not parent1_dead or not parent2_dead and not med_parent:
                         has_parents = True
-                        if cat.parent2.status == 'medicine cat' or cat.parent1.status == 'medicine cat':
-                            has_parents = False
+
                 if len(med_list) == 0 or not has_parents:
                     if random_index == 0:
                         random_index = 1

--- a/scripts/game_structure/game_essentials.py
+++ b/scripts/game_structure/game_essentials.py
@@ -393,12 +393,16 @@ class Game():
             if not os.path.exists(directory):
                 os.makedirs(directory)
 
-
         #print(game.cat_to_fade)
         copy_of_info = ""
         for cat in game.cat_to_fade:
 
             inter_cat = self.cat_class.all_cats[cat]
+
+            # Add ID to list of faded cats.
+            print(self.clan.faded_ids)
+            self.clan.faded_ids.append(cat)
+            print(self.clan.faded_ids)
 
             # If they have a mate, break it up
             if inter_cat.mate:
@@ -503,9 +507,6 @@ class Game():
                 print("Something went wrong while saving a faded cat")
 
             self.clan.remove_cat(cat) # Remove the cat from the active cats lists
-
-            # Add ID to list of faded cats.
-            self.clan.faded_ids.append(cat)
 
         #Save the copy data is needed
         if game.settings["save_faded_copy"]:

--- a/scripts/screens/cat_screens.py
+++ b/scripts/screens/cat_screens.py
@@ -1593,7 +1593,7 @@ class ProfileScreen(Screens):
                 self.see_relationships_button.enable()
 
             if self.the_cat.age not in ['young adult', 'adult', 'senior adult', 'elder'
-                                        ] or self.the_cat.dead or self.the_cat.exiled:
+                                        ] or self.the_cat.dead or self.the_cat.exiled or self.the_cat.outside:
                 self.choose_mate_button.disable()
             else:
                 self.choose_mate_button.enable()
@@ -1605,7 +1605,7 @@ class ProfileScreen(Screens):
         # Roles Tab
         elif self.open_tab == 'roles':
             if self.the_cat.status not in [
-                'warrior'] or self.the_cat.dead or not game.clan.leader.dead or self.the_cat.exiled:
+                    'warrior'] or self.the_cat.dead or not game.clan.leader.dead or self.the_cat.exiled:
                 self.promote_leader_button.disable()
             else:
                 self.promote_leader_button.enable()
@@ -1738,7 +1738,7 @@ class ProfileScreen(Screens):
                     tool_tip_text='This cannot be reversed.')
                 self.exile_cat_button.disable()
 
-            if not self.the_cat.dead:
+            if not self.the_cat.dead and not self.the_cat.exiled and not self.the_cat.outside:
                 self.kill_cat_button.enable()
             else:
                 self.kill_cat_button.disable()

--- a/scripts/screens/relation_screens.py
+++ b/scripts/screens/relation_screens.py
@@ -654,6 +654,8 @@ class ViewChildrenScreen(Screens):
 
     def get_previous_next_cat(self):
         """Determines where the previous the next buttons should lead, and enables/diables them"""
+        """'Determines where the next and previous buttons point too."""
+
         is_instructor = False
         if self.the_cat.dead and game.clan.instructor.ID == self.the_cat.ID:
             is_instructor = True
@@ -673,16 +675,16 @@ class ViewChildrenScreen(Screens):
                 if next_cat == 0 and Cat.all_cats[
                         check_cat].ID != self.the_cat.ID and Cat.all_cats[
                         check_cat].dead == self.the_cat.dead and Cat.all_cats[
-                        check_cat].ID != game.clan.instructor.ID and not Cat.all_cats[
-                        check_cat].exiled and Cat.all_cats[
+                        check_cat].ID != game.clan.instructor.ID and Cat.all_cats[
+                        check_cat].outside == self.the_cat.outside and Cat.all_cats[
                         check_cat].df == self.the_cat.df and not Cat.all_cats[check_cat].faded:
                     previous_cat = Cat.all_cats[check_cat].ID
 
                 elif next_cat == 1 and Cat.all_cats[
                         check_cat].ID != self.the_cat.ID and Cat.all_cats[
                         check_cat].dead == self.the_cat.dead and Cat.all_cats[
-                        check_cat].ID != game.clan.instructor.ID and not Cat.all_cats[
-                        check_cat].exiled and Cat.all_cats[
+                        check_cat].ID != game.clan.instructor.ID and Cat.all_cats[
+                        check_cat].outside == self.the_cat.outside and Cat.all_cats[
                         check_cat].df == self.the_cat.df and not Cat.all_cats[check_cat].faded:
                     next_cat = Cat.all_cats[check_cat].ID
 
@@ -1488,6 +1490,8 @@ class RelationshipScreen(Screens):
 
     def get_previous_next_cat(self):
         """Determines where the previous the next buttons should lead, and enables/diables them"""
+        """'Determines where the next and previous buttons point too."""
+
         is_instructor = False
         if self.the_cat.dead and game.clan.instructor.ID == self.the_cat.ID:
             is_instructor = True
@@ -1505,19 +1509,19 @@ class RelationshipScreen(Screens):
                 next_cat = 1
             else:
                 if next_cat == 0 and Cat.all_cats[
-                    check_cat].ID != self.the_cat.ID and Cat.all_cats[
-                    check_cat].dead == self.the_cat.dead and Cat.all_cats[
-                    check_cat].ID != game.clan.instructor.ID and not Cat.all_cats[
-                    check_cat].exiled and Cat.all_cats[
-                    check_cat].df == self.the_cat.df:
+                        check_cat].ID != self.the_cat.ID and Cat.all_cats[
+                        check_cat].dead == self.the_cat.dead and Cat.all_cats[
+                        check_cat].ID != game.clan.instructor.ID and Cat.all_cats[
+                        check_cat].outside == self.the_cat.outside and Cat.all_cats[
+                        check_cat].df == self.the_cat.df and not Cat.all_cats[check_cat].faded:
                     previous_cat = Cat.all_cats[check_cat].ID
 
                 elif next_cat == 1 and Cat.all_cats[
-                    check_cat].ID != self.the_cat.ID and Cat.all_cats[
-                    check_cat].dead == self.the_cat.dead and Cat.all_cats[
-                    check_cat].ID != game.clan.instructor.ID and not Cat.all_cats[
-                    check_cat].exiled and Cat.all_cats[
-                    check_cat].df == self.the_cat.df:
+                        check_cat].ID != self.the_cat.ID and Cat.all_cats[
+                        check_cat].dead == self.the_cat.dead and Cat.all_cats[
+                        check_cat].ID != game.clan.instructor.ID and Cat.all_cats[
+                        check_cat].outside == self.the_cat.outside and Cat.all_cats[
+                        check_cat].df == self.the_cat.df and not Cat.all_cats[check_cat].faded:
                     next_cat = Cat.all_cats[check_cat].ID
 
                 elif int(next_cat) > 1:


### PR DESCRIPTION
- Next and previous cat button on family pages and relationship pages on cats outside the clan now work properly.
- You can no longer kill Cat's outside the clan. 
- Attempted to fix a crash bug that sometimes occurred with disabled cats.
- Fixed a crash associated with pregnancy events 
- Fixed a minor error with loading in faded cat IDs