### PR TITLE
Bugfix: Breaking up mates now effects relationships values

### DIFF
--- a/scripts/screens/relation_screens.py
+++ b/scripts/screens/relation_screens.py
@@ -874,8 +874,8 @@ class ChooseMateScreen(Screens):
                     Cat.set_mate(self.selected_cat, self.the_cat)
                     self.update_mate_screen()
                 else:
-                    self.selected_cat.mate = None
-                    self.the_cat.mate = None
+                    Cat.unset_mate(self.the_cat, breakup=True)
+                    Cat.unset_mate(self.selected_cat, breakup=True)
                     self.update_choose_mate(breakup=True)
                 self.update_cat_list()
             elif event.ui_element == self.previous_cat_button:


### PR DESCRIPTION
Breaking up cats on the choose mate screen now effects relationship values. It is no longer possible to get a couple to max romantic like by spamming the breakup button. 