### PR TITLE
Bugfix: Exile Cat Crash

### DIFF
--- a/scripts/screens/cat_screens.py
+++ b/scripts/screens/cat_screens.py
@@ -400,7 +400,7 @@ class ProfileScreen(Screens):
                     self.the_cat.outside = True
                     self.the_cat.thought = "Is shocked that they have been exiled"
                     for app in self.the_cat.apprentice:
-                        app.update_mentor()
+                        Cat.fetch_cat(app).update_mentor()
                     self.clear_profile()
                     self.build_profile()
                     self.update_disabled_buttons_and_text()


### PR DESCRIPTION
- The game will no longer crash when attempting to exile a cat with an apprentice.