### PR TITLE
Rewrite Names.__init__() and fix appearance-based names usually not occuring.

### DIFF
--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -311,13 +311,6 @@ class Cat():
         else:
             self.genderalign = self.gender
 
-        # NAME
-        if self.pelt is not None:
-            self.name = Name(status, prefix, suffix, self.pelt.colour,
-                             self.eye_colour, self.pelt.name)
-        else:
-            self.name = Name(status, prefix, suffix, eyes=self.eye_colour)
-
         # APPEARANCE
         init_eyes(self)
         init_pelt(self)
@@ -326,6 +319,18 @@ class Cat():
         init_accessories(self)
         init_white_patches(self)
         init_pattern(self)
+
+        # NAME
+        if self.pelt is not None:
+            self.name = Name(status,
+                             prefix,
+                             suffix,
+                             self.pelt.colour,
+                             self.eye_colour,
+                             self.pelt.name,
+                             self.tortiepattern)
+        else:
+            self.name = Name(status, prefix, suffix, eyes=self.eye_colour)
 
         # Sprite sizes
         self.sprite = None

--- a/scripts/cat/names.py
+++ b/scripts/cat/names.py
@@ -289,50 +289,41 @@ class Name():
                  suffix=None,
                  colour=None,
                  eyes=None,
-                 pelt=None):
+                 pelt=None,
+                 tortiepattern=None):
         self.status = status
+        self.prefix = prefix
+        self.suffix = suffix
+        
+        # Set prefix
         if prefix is None:
-            if colour is None and eyes is None:
-                self.prefix = random.choice(self.normal_prefixes)
-            elif eyes is None:
-                a = random.randint(0, 5)
-                if a != 1:
-                    self.prefix = random.choice(self.normal_prefixes)
-                else:
-                    self.prefix = random.choice(self.colour_prefixes[colour])
-            elif colour is None:
-                a = random.randint(0, 5)
-                if a != 1:
-                    self.prefix = random.choice(self.normal_prefixes)
-                else:
-                    self.prefix = random.choice(self.eye_prefixes[eyes])
+            named_after_appearance = not random.getrandbits(3)  # Chance for True is '1/8'.
+            possible_prefix_categories = []
+            if named_after_appearance and (eyes is not None or colour is not None):
+                if eyes in self.eye_prefixes:
+                    possible_prefix_categories.append(self.eye_prefixes[eyes])
+                if colour in self.colour_prefixes:
+                    possible_prefix_categories.append(self.colour_prefixes[colour])
+                prefix_category = random.choice(possible_prefix_categories)
+                self.prefix = random.choice(prefix_category)
             else:
-                a = random.randint(0, 7)
-                if a == 1:
-                    self.prefix = random.choice(self.colour_prefixes[colour])
-                elif a == 2:
-                    self.prefix = random.choice(self.eye_prefixes[eyes])
+                self.prefix = random.choice(self.normal_prefixes)
+                    
+        # Set suffix
+        while self.suffix is None or self.suffix == self.prefix.casefold():
+            if pelt is None or pelt == 'SingleColour':
+                self.suffix = random.choice(self.normal_suffixes)
+            else:
+                named_after_pelt = not random.getrandbits(3) # Chance for True is '1/8'.
+                # Pelt name only gets used if there's an associated suffix.
+                if (named_after_pelt
+                    and pelt in ["Tortie", "Calico"]
+                    and tortiepattern in self.tortie_pelt_suffixes):
+                    self.suffix = random.choice(self.tortie_pelt_suffixes[tortiepattern])
+                elif named_after_pelt and pelt in self.pelt_suffixes:
+                    self.suffix = random.choice(self.pelt_suffixes[pelt])
                 else:
-                    self.prefix = random.choice(self.normal_prefixes)
-        else:
-            self.prefix = prefix
-        if suffix is None:
-            loop = True
-            while loop:
-                if pelt is None or pelt == 'SingleColour':
                     self.suffix = random.choice(self.normal_suffixes)
-                else:
-                    a = random.randint(0, 7)
-                    if a == 1:
-                        self.suffix = random.choice(self.pelt_suffixes[pelt])
-                    elif a == 1 and self.pelt.name in ["Tortie", "Calico"]:
-                        self.suffix = random.choice(self.tortie_pelt_suffixes)
-                    else:
-                        self.suffix = random.choice(self.normal_suffixes)
-                if self.suffix != self.prefix.lower():
-                    loop = False
-        else:
-            self.suffix = suffix
 
     def __repr__(self):
         if self.status in ["deputy", "warrior", "medicine cat", "elder"]:


### PR DESCRIPTION
Currently, it seems like appearance based names almost never occur since a cat's appearance is decided *after* the name is in the usual init, so values like ``pelt`` are always ``None``.

In addition to that, calico/tortie based names were completely impossible, as the block of code that set them was never executed. It also caused an exception from using self.pelt.name instead of just 'pelt'.

Seems to work now though:
![2023-01-01_23-23](https://user-images.githubusercontent.com/69427753/210187838-3c6c5b82-22a9-43b1-bb28-8881400e6193.png)
![2023-01-01_23-22_1](https://user-images.githubusercontent.com/69427753/210187839-5fed6602-4f32-4786-af28-04559c117bb9.png)
![2023-01-01_23-22](https://user-images.githubusercontent.com/69427753/210187840-f78e0265-bead-4c9a-baad-cf6f95c80034.png)

Works alright as far as I can tell but it's not a completely risk-free fix since it does rewrite the function, idnk if this should be backported to the release without at least a bit more testing.