### PR TITLE
Fix two possible exceptions and one redefined function

### DIFF
--- a/scripts/events.py
+++ b/scripts/events.py
@@ -1532,7 +1532,8 @@ class Events():
         cat.gone()
         # The outside-value must be set to True before the cat can go to cotc
         cat.thought = "Is terrified as they are trapped in a large silver Twoleg den"
-        cat_class.other_cats[cat.ID] = cat
+        # FIXME: Not sure what this is intended to do; 'cat_class' has no 'other_cats' attribute.
+        #cat_class.other_cats[cat.ID] = cat
 
     def handle_outbreaks(self, cat):
         """

--- a/scripts/game_structure/image_button.py
+++ b/scripts/game_structure/image_button.py
@@ -236,8 +236,21 @@ class UIImageTextBox():
                  pre_parsing_enabled: bool = True,
                  text_kwargs=None,
                  allow_split_dashes: bool = True) -> None:
-        self.image = pygame_gui.elements.UIImage(relative_rect, image, layer_starting_height=layer_starting_height,
-                                                 container=container, anchors=anchors, visible=visible)
+        # FIXME: layer_starting_height throws a TypeError, not sure if this is a valid argument.
+        try:
+            self.image = pygame_gui.elements.UIImage(relative_rect,
+                                                     image,
+                                                     layer_starting_height=layer_starting_height,
+                                                     container=container,
+                                                     anchors=anchors,
+                                                     visible=visible)
+        except TypeError:
+            self.image = pygame_gui.elements.UIImage(relative_rect,
+                                                     image,
+                                                     container=container,
+                                                     anchors=anchors,
+                                                     visible=visible)
+            
         self.text_box = UITextBoxTweaked(html_text, relative_rect, object_id=object_id,
                                          layer_starting_height=layer_starting_height,
                                          container=container, anchors=anchors, visible=visible, text_kwargs=text_kwargs,

--- a/scripts/screens/cat_screens.py
+++ b/scripts/screens/cat_screens.py
@@ -12,7 +12,7 @@ from scripts.cat.pelts import collars, wild_accessories
 import scripts.game_structure.image_cache as image_cache
 import pygame_gui
 from re import sub
-from scripts.game_structure.image_button import UIImageButton, UISpriteButton, UITextBoxTweaked, UIImageTextBox
+from scripts.game_structure.image_button import UIImageButton, UITextBoxTweaked#, UIImageTextBox, UISpriteButton
 from scripts.game_structure import image_cache
 from scripts.game_structure.game_essentials import *
 from scripts.cat.names import *

--- a/scripts/screens/patrol_screens.py
+++ b/scripts/screens/patrol_screens.py
@@ -862,12 +862,6 @@ class PatrolScreen(Screens):
     def on_use(self):
         pass
 
-    def get_list_text(self, patrol_list):
-        if not patrol_list:
-            return ""
-        patrol_set = list(patrol_list)
-        return ", ".join(patrol_set)
-
     def chunks(self, L, n):
         return [L[x: x + n] for x in range(0, len(L), n)]
 


### PR DESCRIPTION
- Comments out line in 'handle_twoleg_capture' that caused an AttributeError.  https://github.com/Thlumyn/clangen/commit/2241f8f43286fc52e173e2b95e2faeaba544acea
    - Not sure what this was supposed to do, so maybe it should be looked at by whoever wrote the section.
- Comments out unused imports of UIImageTextBox and UISpriteButton, UIImageTextBox seems possibly broken since it calls pygame_gui.elements.UIImage with 'layer_starting_height', which doesn't seem to be a valid argument. https://github.com/Thlumyn/clangen/commit/b4f98ab7b372bcc8521637d4876bbc02c99d1e29
    - Same as above, not sure what the section does exactly :"3
- Removed extra instance of the 'get_list_text' function in patrol_screens.py, it seemingly got redefined. https://github.com/Thlumyn/clangen/commit/001340e9cdf1e4668536dd6f5a95d1589eaad7d0