### PR TITLE
Bugfix: Reputation related

### DIFF
--- a/scripts/clan.py
+++ b/scripts/clan.py
@@ -113,7 +113,6 @@ class Clan():
             self.camp_bg = camp_bg
             self.game_mode = game_mode
             self.pregnancy_data = {}
-            self.closed_borders = False
             self.reputation = 50
             self.starting_members = starting_members
 
@@ -544,6 +543,8 @@ class Clan():
                          camp_bg=clan_data["camp_bg"],
                          camp_site=(int(clan_data["camp_site_1"]), int(clan_data["camp_site_2"])),
                          game_mode=clan_data["gamemode"])
+
+        game.clan.reputation = clan_data["reputation"]
 
         game.clan.age = clan_data["clanage"]
         game.clan.current_season = game.clan.seasons[game.clan.age % 12]

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -314,8 +314,7 @@ class Events():
             self.condition_events.handle_already_disabled(cat)
         self.perform_ceremonies(cat)  # here is age up included
 
-        if not game.clan.closed_borders:
-            self.invite_new_cats(cat)
+        self.invite_new_cats(cat)
 
         self.other_interactions(cat)
         self.coming_out(cat)
@@ -960,13 +959,45 @@ class Events():
         # ---------------------------------------------------------------------------- #
         #                                   new cats                                   #
         # ---------------------------------------------------------------------------- #
-        chance = 100
-        if self.living_cats < 10:
-            chance = 100
-        elif self.living_cats > 50:
-            chance = 700
-        elif self.living_cats > 30:
-            chance = 300
+        chance = 200
+
+        alive_cats = list(filter(
+            lambda kitty: (kitty.status != "leader"
+                           and not kitty.dead
+                           and not kitty.outside),
+            Cat.all_cats.values()
+        ))
+
+        clan_size = len(alive_cats)
+
+        base_chance = 200
+        if clan_size < 10:
+            base_chance = 100
+        elif clan_size > 50:
+            base_chance = 700
+        elif clan_size > 30:
+            base_chance = 300
+
+        reputation = game.clan.reputation
+        # hostile
+        if reputation in range(1, 30):
+            if clan_size < 10:
+                chance = base_chance
+            else:
+                rep_adjust = int(reputation / 2)
+                chance = base_chance + int(300 / rep_adjust)
+        # neutral
+        elif reputation in range(31, 70):
+            if clan_size < 10:
+                chance = base_chance - reputation
+            else:
+                chance = base_chance
+        # welcoming
+        elif reputation in range(71, 100):
+            chance = base_chance - reputation
+
+        print('reputation:', reputation, "chance:", chance, "living", clan_size)
+
         if randint(1, chance) == 1 and cat.age != 'kitten' and cat.age != 'adolescent' and not self.new_cat_invited:
             self.new_cat_invited = True
             name = str(cat.name)

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -996,8 +996,6 @@ class Events():
         elif reputation in range(71, 100):
             chance = base_chance - reputation
 
-        print('reputation:', reputation, "chance:", chance, "living", clan_size)
-
         if randint(1, chance) == 1 and cat.age != 'kitten' and cat.age != 'adolescent' and not self.new_cat_invited:
             self.new_cat_invited = True
             name = str(cat.name)

--- a/scripts/screens/clan_creation_screens.py
+++ b/scripts/screens/clan_creation_screens.py
@@ -42,13 +42,15 @@ class MakeClanScreen(Screens):
     expanded_mode_text = "A more hands-on experience. " \
                          "This mode has everything in Classic Mode as well as more management-focused features.<br><br>" \
                          "New features include:<br>" \
-                         "- Illnesses, Injuries, and Permanent Conditions<br><br>" \
+                         "- Illnesses, Injuries, and Permanent Conditions<br>" \
                          "- Ability to choose patrol type<br><br>" \
                          "With this mode you'll be making the important clan-life decisions."
 
     cruel_mode_text = "This mode has all the features of Expanded mode, but is significantly more difficult. If " \
                       "you'd like a challenge with a bit of brutality, then this mode is for you.<br><br>" \
-                      "You heard the warnings... a Cruel Season is coming. Will you survive?"
+                      "You heard the warnings... a Cruel Season is coming. Will you survive?" \
+                      "<br> <br>" \
+                      "-COMING SOON-"
 
     # This section holds all the information needed
     game_mode = 'classic'  # To save the users selection before conformation.


### PR DESCRIPTION
Turns out Reputation wasn't being loaded properly and was just defaulting to 50 every single time the clan loaded up.  It now loads properly.

Also fixed it so that Rep now affects the frequency of cats joining the clan via moon events.  They're also now rarer just from the get go.  