### PR TITLE
Bugfixes: Misc

### DIFF
--- a/resources/dicts/conditions/healed_and_death_strings/injury_healed_strings.json
+++ b/resources/dicts/conditions/healed_and_death_strings/injury_healed_strings.json
@@ -153,7 +153,7 @@
     "water in their lungs": [
         "m_c's lungs finally feel back to normal.",
         "m_c is breathing normally again, the water in their lungs is gone.",
-        "m_c has recovered from the water in their lungs",
+        "m_c has recovered from the water in their lungs.",
         "There's no longer water in m_c's lungs, they're back to breathing normally.",
         "m_c's breathing has returned to normal, their lungs are no longer filled with water."
     ],

--- a/resources/dicts/events/death/general/warrior.json
+++ b/resources/dicts/events/death/general/warrior.json
@@ -12,8 +12,8 @@
     {
         "camp": "any",
         "tags": ["other_clan", "rel_up", "Newleaf", "Greenleaf", "Leaf-fall", "Leaf-bare"],
-        "death_text": "m_c was killed while trying to save the o_c_n medicine cat.",
-        "history_text": ["m_c was killed while trying to save the o_c_n medicine cat.", null],
+        "death_text": "m_c was killed while trying to save the o_c medicine cat.",
+        "history_text": ["m_c was killed while trying to save the o_c medicine cat.", null],
         "cat_trait": ["bold", "charismatic", "confident", "daring", "altruistic", "empathetic", "compassionate", "loving", "responsible", "thoughtful", "strange"],
         "cat_skill": null,
         "other_cat_trait": null,
@@ -22,8 +22,8 @@
     {
         "camp": "any",
         "tags": ["other_clan", "rel_down", "war", "Newleaf", "Greenleaf", "Leaf-fall", "Leaf-bare"],
-        "death_text": "m_c was killed by the o_c_n deputy.",
-        "history_text": ["m_c was killed by the o_c_n deputy.", null],
+        "death_text": "m_c was killed by the o_c deputy.",
+        "history_text": ["m_c was killed by the o_c deputy.", null],
         "cat_trait": null,
         "cat_skill": null,
         "other_cat_trait": null,
@@ -32,8 +32,8 @@
     {
         "camp": "any",
         "tags": ["other_clan", "rel_up", "Newleaf", "Greenleaf", "Leaf-fall", "Leaf-bare"],
-        "death_text": "m_c was killed while trying to save the o_c_n deputy.",
-        "history_text": ["m_c was killed while trying to save the o_c_n deputy.", null],
+        "death_text": "m_c was killed while trying to save the o_c deputy.",
+        "history_text": ["m_c was killed while trying to save the o_c deputy.", null],
         "cat_trait": ["bold", "charismatic", "confident", "daring", "altruistic", "empathetic", "compassionate", "loving", "responsible", "thoughtful", "strange"],
         "cat_skill": null,
         "other_cat_trait": null,

--- a/resources/dicts/patrols/hunting/hunting_plains.json
+++ b/resources/dicts/patrols/hunting/hunting_plains.json
@@ -432,7 +432,7 @@
     "win_trait": ["ambitious", "bloodthirsty", "cold", "fierce", "shameless", "strict", "troublesome", "vengeful"],
     "fail_skills": ["None"],
     "fail_trait": ["altruistic", "compassionate", "empathetic", "faithful", "loving", "patient", "responsible", "thoughtful", "wise"],
-    "min_cats": 1,
+    "min_cats": 2,
     "max_cats": 3,
     "antagonize_text": null,
     "antagonize_fail_text": null,

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -381,10 +381,19 @@ class Cat():
         elif self.status == 'leader' and game.clan.leader_lives <= 0:
             self.dead = True
             game.clan.leader_lives = 0
+            if game.clan.instructor.df is False:
+                text = str(game.clan.leader.name) + ' has lost their last life and has travelled to StarClan.'
+                game.birth_death_events_list.append(text)
+                game.cur_events_list.append(text)
+            else:
+                text = str(
+                    game.clan.leader.name) + ' has lost their last life and has travelled to the Dark Forest.'
+                game.birth_death_events_list.append(text)
+                game.cur_events_list.append(text)
         else:
             self.dead = True
 
-        if self.status != 'leader' and died_by_condition is False:
+        if self.status != 'leader':
             self.injuries.clear()
             self.illnesses.clear()
 

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -1039,6 +1039,7 @@ class Cat():
             self.injuries[injury]["moons_with"] += 1
         else:
             self.injuries[injury].update({'moons_with': 1})
+
         # if the cat has an infected wound, the wound shouldn't heal till the illness is cured
         if "an infected wound" not in self.illnesses and "a festering wound" not in self.illnesses:
             self.injuries[injury]["duration"] -= 1

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -163,60 +163,58 @@ class Events():
                 game.cur_events_list.insert(0, string)
                 game.health_events_list.insert(0, string)
 
-        if game.clan.deputy == 0 or game.clan.deputy is None or game.clan.deputy.dead or game.clan.deputy.outside or game.clan.deputy.retired:
+        if game.clan.deputy == 0 or \
+                game.clan.deputy is None or \
+                game.clan.deputy.dead or \
+                game.clan.deputy.outside or \
+                game.clan.deputy.retired:
             if game.settings.get('deputy') is True:
                 random_count = 0
                 while random_count < 30:
                     random_cat = str(random.choice(list(Cat.all_cats.keys())))
-                    if not Cat.all_cats[random_cat].dead and not Cat.all_cats[random_cat].outside:
-                        if Cat.all_cats[random_cat].status == 'warrior' and (
-                                len(Cat.all_cats[random_cat].former_apprentices) > 0 or len(
-                                Cat.all_cats[random_cat].apprentice) > 0):
-                            Cat.all_cats[random_cat].status = 'deputy'
-                            text = ''
-                            if game.clan.deputy is not None:
-                                if game.clan.deputy.dead and not game.clan.leader.dead and not game.clan.leader.exiled:
-                                    text = str(game.clan.leader.name) + ' chooses ' + str(Cat.all_cats[
-                                                                                              random_cat].name) + ' to take over as deputy. They know that ' + str(
-                                        game.clan.deputy.name) + ' would agree.'
-                                if not game.clan.deputy.dead and not game.clan.deputy.outside:
-                                    text = str(Cat.all_cats[
-                                                   random_cat].name) + ' has been chosen as the new deputy. The retired deputy nods their approval.'
 
-                                if game.clan.deputy.outside:
-                                    text = str(Cat.all_cats[
-                                                   random_cat].name) + ' has been chosen as the new deputy. The Clan hopes that ' + str(
-                                        game.clan.deputy.name) + ' would approve.'
-                            else:
-                                if Cat.all_cats[random_cat].trait == 'bloodthirsty':
-                                    text = str(Cat.all_cats[
-                                                   random_cat].name) + ' has been chosen as the new deputy. They look at the Clan leader with an odd glint in their eyes.'
-                                else:
-                                    r = choice([1, 2, 3, 4, 5, 6])
-                                    if r == 1:
-                                        text = str(Cat.all_cats[
-                                                       random_cat].name) + ' has been chosen as the new deputy. The Clan yowls their name in approval.'
-                                    elif r == 2:
-                                        text = str(Cat.all_cats[
-                                                       random_cat].name) + ' has been chosen as the new deputy. The Clan chants their name out in support of the choice.'
-                                    elif r == 3:
-                                        text = str(Cat.all_cats[
-                                                       random_cat].name) + ' has been chosen as the new deputy. Some of the older Clan members question the wisdom in this choice.'
-                                    elif r == 4:
-                                        text = str(Cat.all_cats[
-                                                       random_cat].name) + ' has been chosen as the new deputy. They hold their head up high and promise to do their best for the Clan.'
-                                    elif r == 5 and not game.clan.leader.dead:
-                                        text = str(game.clan.leader.name) + ' has been thinking deeply all day who they would respect and trust enough to stand at their side and at sunhigh makes the announcement that ' + str(Cat.all_cats[
-                                                       random_cat].name) + ' will be the clan\'s new deputy.'
-                                    else:
-                                        text = str(Cat.all_cats[
-                                                       random_cat].name) + ' has been chosen as the new deputy. They pray to StarClan that they are the right choice for the Clan.'
+                    if Cat.all_cats[random_cat].dead or Cat.all_cats[random_cat].outside:
+                        continue
+                    elif Cat.all_cats[random_cat].status != 'warrior':
+                        random_count += 1
+                        continue
+                    elif len(Cat.all_cats[random_cat].former_apprentices) == 0 and \
+                            len(Cat.all_cats[random_cat].apprentice) == 0:
+                        random_count += 1
+                        continue
 
-                            game.clan.deputy = Cat.all_cats[random_cat]
-                            game.cur_events_list.append(text)
-                            game.ceremony_events_list.append(text)
-                            break
-                    random_count += 1
+                    Cat.all_cats[random_cat].status = 'deputy'
+                    text = ''
+                    if game.clan.deputy is not None:
+                        if game.clan.deputy.dead and not game.clan.leader.dead and not game.clan.leader.exiled:
+                            text = f"{game.clan.leader.name} chooses {Cat.all_cats[random_cat].name} to take over as deputy. They know that {game.clan.deputy.name} would approve."
+
+                        if not game.clan.deputy.dead and not game.clan.deputy.outside:
+                            text = f"{Cat.all_cats[random_cat].name} has been chosen as the new deputy. The retired deputy nods their approval."
+
+                        if game.clan.deputy.outside:
+                            text = f"{Cat.all_cats[random_cat].name} has been chosen as the new deputy. The Clan hopes that {game.clan.deputy.name} would approve."
+
+                    elif game.clan.leader.dead or game.clan.leader.exiled:
+                        text = f"Since losing {game.clan.leader.name} the Clan has been directionless. They all turn to {Cat.all_cats[random_cat].name} with hope for the future."
+                    else:
+                        if Cat.all_cats[random_cat].trait == 'bloodthirsty':
+                            text = f"{Cat.all_cats[random_cat].name} has been chosen as the new deputy. They look at the Clan leader with an odd glint in their eyes."
+
+                        else:
+                            possible_events = [
+                                f"{Cat.all_cats[random_cat].name} has been chosen as the new deputy. The Clan yowls their name in approval.",
+                                f"{Cat.all_cats[random_cat].name} has been chosen as the new deputy. Some of the older Clan members question the wisdom in this choice.",
+                                f"{Cat.all_cats[random_cat].name} has been chosen as the new deputy. They hold their head up high and promise to do their best for the Clan.",
+                                f"{game.clan.leader.name} has been thinking deeply all day who they would respect and trust enough to stand at their side and at sunhigh makes the announcement that {Cat.all_cats[random_cat].name} will be the Clan's new deputy.",
+                                f"{Cat.all_cats[random_cat].name} has been chosen as the new deputy. They pray to StarClan that they are the right choice for the Clan.",
+                                               ]
+                            text = choice(possible_events)
+
+                    game.clan.deputy = Cat.all_cats[random_cat]
+                    game.cur_events_list.append(text)
+                    game.ceremony_events_list.append(text)
+                    break
                 if random_count == 30:
                     text = 'The Clan decides that no cat is fit to be deputy'
                     game.cur_events_list.append(text)
@@ -390,25 +388,13 @@ class Events():
             leader_dead = game.clan.leader.dead
             leader_outside = game.clan.leader.outside
         else:
-            leader_dead = True # If leader is None, treat them as dead (since they are dead - and faded away.)
+            leader_dead = True  # If leader is None, treat them as dead (since they are dead - and faded away.)
             leader_outside = True
 
-        if (leader_dead or leader_outside) \
-                and game.clan.deputy is not None and not game.clan.deputy.dead and not game.clan.deputy.outside:
-            if game.clan.leader.exiled:
-                text = str(game.clan.leader.name) + ' was exiled.'
-                game.ceremony_events_list.append(text)
-                game.cur_events_list.append(text)
-            else:
-                if game.clan.instructor.df is False:
-                    text = str(game.clan.leader.name) + ' has lost their last life and has travelled to StarClan.'
-                    game.birth_death_events_list.append(text)
-                    game.cur_events_list.append(text)
-                else:
-                    text = str(
-                        game.clan.leader.name) + ' has lost their last life and has travelled to the Dark Forest.'
-                    game.birth_death_events_list.append(text)
-                    game.cur_events_list.append(text)
+        if game.clan.deputy is not None and \
+                not game.clan.deputy.dead and \
+                not game.clan.deputy.outside and \
+                (leader_dead or leader_outside):
             game.clan.new_leader(game.clan.deputy)
             game.clan.leader_lives = 9
             text = ''

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -93,7 +93,6 @@ class Events():
                     game.birth_death_events_list.append(text)
                     game.clan.leader_lives = 0
 
-        # relationships have to be handled separately, because of the ceremony name change
         for cat in Cat.all_cats.copy().values():
             if cat.dead or cat.outside:
                 continue
@@ -107,6 +106,8 @@ class Events():
                 triggered_death = self.handle_illnesses_or_illness_deaths(cat)
                 if not triggered_death:
                     triggered_death = self.handle_injuries_or_general_death(cat)
+
+            # relationships have to be handled separately, because of the ceremony name change
 
             if not cat.dead or cat.outside:
                 self.relation_events.handle_relationships(cat)

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -19,7 +19,6 @@ class Events():
         self.at_war = False
         self.time_at_war = False
         self.enemy_clan = None
-        self.living_cats = 0
         self.new_cat_invited = False
         self.ceremony_accessory = False
         self.relation_events = Relation_Events()
@@ -35,7 +34,6 @@ class Events():
         game.other_clans_events_list = []
         game.misc_events_list = []
         game.switches['saved_clan'] = False
-        self.living_cats = 0
         self.new_cat_invited = False
         game.patrolled.clear()
         if any(str(cat.status) in {'leader', 'deputy', 'warrior', 'medicine cat', 'medicine cat apprentice',
@@ -295,8 +293,6 @@ class Events():
             cat.dead_for += 1
             self.handle_fading(cat)  # Deal with fading.
             return
-
-        self.living_cats += 1
 
         # prevent injured or sick cats from unrealistic clan events
         if cat.is_ill() or cat.is_injured():
@@ -776,7 +772,6 @@ class Events():
 
         name = str(cat.name)
         scar_chance = 0.015  # 1.5%
-        clancats = self.living_cats
         scar_text = []
         specialty = None  # Scar to be set
         alive_kits = list(filter(lambda kitty: (kitty.age == "kitten"

--- a/scripts/events_module/death_events.py
+++ b/scripts/events_module/death_events.py
@@ -113,7 +113,7 @@ class Death_Events():
 
         if "war" in death_cause.tags and other_clan is not None and enemy_clan is not None:
             other_clan = enemy_clan
-            other_clan_name = other_clan.name
+            other_clan_name = other_clan.name + "clan"
 
         # let's change some relationship values \o/ check if another cat is mentioned and if they live
         if "other_cat" in death_cause.tags and "multi_death" not in death_cause.tags:

--- a/scripts/screens/cat_screens.py
+++ b/scripts/screens/cat_screens.py
@@ -1209,7 +1209,7 @@ class ProfileScreen(Screens):
             if self.the_cat.status == 'leader':
                 insert2 = f"lost their lives"
                 if len(self.the_cat.died_by) > 2:
-                    insert = f"{', '.join(self.the_cat.died_by[:-2])}, and {self.the_cat.died_by[-1]}"
+                    insert = f"{', '.join(self.the_cat.died_by[0:-1])}, and {self.the_cat.died_by[-1]}"
                 elif len(self.the_cat.died_by) == 2:
                     insert = f"{self.the_cat.died_by[0]} and {self.the_cat.died_by[1]}"
                 else:

--- a/scripts/screens/cat_screens.py
+++ b/scripts/screens/cat_screens.py
@@ -1429,27 +1429,26 @@ class ProfileScreen(Screens):
 
         # collect details for perm conditions
         if name in self.the_cat.permanent_condition:
-            # moons with condition
-            keys = self.the_cat.permanent_condition[name].keys()
             # display if the cat was born with it
             if self.the_cat.permanent_condition[name]["born_with"] is True:
                 text_list.append(f"born with this condition")
+
             # moons with the condition if not born with condition
-            elif 'moons_with' in keys:  # need to check if it exists for older saves
-                moons_with = self.the_cat.permanent_condition[name]["moons_with"]
-                if moons_with != 1:
-                    text_list.append(f"has had this condition for {moons_with} moons")
-                else:
-                    text_list.append(f"has had this condition for 1 moon")
+            moons_with = self.the_cat.permanent_condition[name].get("moons_with", 1)
+            if moons_with != 1:
+                text_list.append(f"has had this condition for {moons_with} moons")
+            else:
+                text_list.append(f"has had this condition for 1 moon")
+
             # is permanent
             text_list.append('permanent condition')
+
             # infected or festering
-            if 'complication' in keys:
-                complication = self.the_cat.permanent_condition[name]["complication"]
-                if complication is not None:
-                    if 'a festering wound' in self.the_cat.illnesses:
-                        complication = 'festering'
-                    text_list.append(f'is {complication}!')
+            complication = self.the_cat.permanent_condition[name].get("complication", None)
+            if complication is not None:
+                if 'a festering wound' in self.the_cat.illnesses:
+                    complication = 'festering'
+                text_list.append(f'is {complication}!')
 
         # collect details for injuries
         if name in self.the_cat.injuries:


### PR DESCRIPTION
- death events including a warring clan will no longer omit the 'Clan' part of their name
- Adusted pln_hunt_gonetnr1 to not allow solo cats
- Previously, if a leader and deputy were both dead/exiled then the game would struggle with moon events regarding those two ranks (like how the leader death message wouldn't display till a new leader was chosen, sometimes moons later).  This is fixed and a new event was added to account for the clan choosing a new deputy without a leader present. 
- Made the deputy event strings into f strings for readability
- typos
- Leader death histories now display _all_ of the death histories while the cat is alive.