### PR TITLE
Bugfix: rerolls

### DIFF
--- a/scripts/screens/clan_creation_screens.py
+++ b/scripts/screens/clan_creation_screens.py
@@ -77,6 +77,7 @@ class MakeClanScreen(Screens):
 
     def __init__(self, name=None):
         super().__init__(name)
+        self.rolls_left = 3
         self.menu_warning = None
 
     def screen_switches(self):
@@ -155,9 +156,11 @@ class MakeClanScreen(Screens):
     def handle_choose_leader_event(self, event):
         if event.ui_element in [self.elements['roll1'], self.elements['roll2'], self.elements['roll3']]:
             event.ui_element.disable()
+            self.elements['select_cat'].hide()
             create_example_cats()  # create new cats
             self.selected_cat = None  # Your selected cat now no longer exists. Sad. They go away.
             self.refresh_cat_images_and_info()  # Refresh all the images.
+            self.rolls_left -= 1
         elif event.ui_element in [self.elements["cat" + str(u)] for u in range(0, 12)]:
             self.selected_cat = event.ui_element.return_cat_object()
             self.refresh_cat_images_and_info(self.selected_cat)
@@ -273,6 +276,7 @@ class MakeClanScreen(Screens):
         self.main_menu.kill()
         self.menu_warning.kill()
         self.clear_all_page()
+        self.rolls_left = 3
         return super().exit_screen()
 
     def on_use(self):
@@ -584,6 +588,13 @@ class MakeClanScreen(Screens):
         y_pos += 40
         self.elements['roll3'] = UIImageButton(pygame.Rect((x_pos, y_pos), (34, 34)), "",
                                                object_id="#random_dice_button")
+
+        if self.rolls_left <= 2:
+            self.elements['roll1'].disable()
+        if self.rolls_left <= 1:
+            self.elements['roll2'].disable()
+        if self.rolls_left == 0:
+            self.elements['roll3'].disable()
 
         # info for chosen cats:
         self.elements['cat_info'] = UITextBoxTweaked("", pygame.Rect((440, 260), (100, 100)), visible=False,


### PR DESCRIPTION
Fixed a bug in which the player could crash their game by not actually choosing a leader during clan creation.  This was related to the reroll feature.  While fixing it I also came upon a bug that let you infinitely reset your rolls by choosing a leader and then hitting "previous step".  The rolls would be reset even if they had been fully used up.  These are now fixed.