### PR TITLE
Add a Linux build workflow with Ubuntu 22.04 as the runner.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: PyInstaller build
 on: [push]
 
 jobs:
-  build_linux64:
+  build_ubuntu_20_04:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
@@ -26,16 +26,49 @@ jobs:
         #run: python -m PyInstaller -i resources/images/icon.png --name clangen --windowed --onedir --clean --add-data sprites:sprites --add-data resources:resources --add-data README.md:. main.py
         run: python -m PyInstaller Clangen.spec
       - name: Create archive (.tar.xz)
-        run: tar -cavf Clangen_Linux64.tar.xz -C dist Clangen
+        run: tar -cavf Clangen_Linux64_glibc2.31+.tar.xz -C dist Clangen
       - uses: actions/upload-artifact@v3
         with:
-          name: Clangen_Linux64.tar.xz
-          path: Clangen_Linux64.tar.xz
+          name: Clangen_Linux64_glibc2.31+.tar.xz
+          path: Clangen_Linux64_glibc2.31+.tar.xz
       - name: Release 
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          files: Clangen_Linux64.tar.xz
+          files: Clangen_Linux64_glibc2.31+.tar.xz
+          
+  build_ubuntu_22_04:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Python 3.11 x64
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+          architecture: 'x64'
+      - name: Update pip
+        run: python -m pip install --upgrade pip
+      - name: Update setuptools and wheel
+        run: python -m pip install --upgrade setuptools wheel
+      - name: Install dependencies
+        run: python -m pip install -r requirements.txt
+      - name: Install Pillow for icon format conversion
+        run: python -m pip install --upgrade Pillow
+      - name: Install PyInstaller
+        run: python -m pip install --upgrade PyInstaller
+      - name: Run PyInstaller
+        run: python -m PyInstaller Clangen.spec
+      - name: Create archive (.tar.xz)
+        run: tar -cavf Clangen_Linux64_glibc2.35+.tar.xz -C dist Clangen
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Clangen_Linux64_glibc2.35+.tar.xz
+          path: Clangen_Linux64_glibc2.35+.tar.xz
+      - name: Release 
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: Clangen_Linux64_glibc2.35+.tar.xz
           
   build_win32:
     runs-on: windows-2019


### PR DESCRIPTION
Builds made on Ubuntu 20.04 don't work on Linux distributions with newer versions of packages because the bundled version of libstdc++.so.6 is too old. The error I get running an Ubuntu 20.04 builds on Arch Linux is:
```
./Clangen 
pygame 2.1.3.dev8 (SDL 2.0.22, Python 3.11.1)
Hello from the pygame community. https://www.pygame.org/contribute.html
libGL error: MESA-LOADER: failed to open iris: /home/user/Downloads/Clangen/libstdc++.so.6: version `GLIBCXX_3.4.29' not found (required by /usr/lib/dri/iris_dri.so) (search paths /usr/lib/dri, suffix _dri)
libGL error: failed to load driver: iris
libGL error: MESA-LOADER: failed to open swrast: /home/user/Downloads/Clangen/libstdc++.so.6: version `GLIBCXX_3.4.29' not found (required by /usr/lib/dri/swrast_dri.so) (search paths /usr/lib/dri, suffix _dri)
libGL error: failed to load driver: swrast
X Error of failed request:  BadValue (integer parameter out of range for operation)
  Major opcode of failed request:  150 (GLX)
  Minor opcode of failed request:  3 (X_GLXCreateContext)
  Value in failed request:  0x0
  Serial number of failed request:  156
  Current serial number in output stream:  157
```

Some info on this recently got added to the PyInstaller docs: https://pyinstaller.org/en/stable/usage.html#making-gnu-linux-apps-forward-compatible

Both versions should probably be provided on itch with clarification:
 - Builds made on Ubuntu 20.04 should run on: Debian 11 and other stable Debian-like distributions.
 - Builds made on Ubuntu 22.04 should run on: Fedora, Arch Linux, and other more up-to-date distributions.

Alternatively, deleting libstdc++.so.6 from the build causes the system provided version to be used instead, and lets the Ubuntu 20.04 build run on at least Arch Linux.