### PR TITLE
Bugfix: Cat Buttons not cleared from memory

### DIFF
--- a/scripts/screens/clan_screens.py
+++ b/scripts/screens/clan_screens.py
@@ -345,9 +345,11 @@ class StarClanScreen(Screens):
         # Remove currently displayed cats and cat names.
         for cat in self.display_cats:
             cat.kill()
+        self.display_cats = []
 
         for name in self.cat_names:
             name.kill()
+        self.cat_names = []
 
     def screen_switches(self):
         # Determine the dead, non-exiled cats.
@@ -423,9 +425,11 @@ class StarClanScreen(Screens):
         # Remove the images for currently listed cats
         for cat in self.display_cats:
             cat.kill()
+        self.display_cats = []
 
         for name in self.cat_names:
             name.kill()
+        self.cat_names = []
 
         # Generate object for the current cats
         pos_x = 0
@@ -519,9 +523,11 @@ class DFScreen(Screens):
         # Remove currently displayed cats and cat names.
         for cat in self.display_cats:
             cat.kill()
+        self.display_cats = []
 
         for name in self.cat_names:
             name.kill()
+        self.cat_names = []
 
     def screen_switches(self):
         # Determine the dead, non-exiled cats.
@@ -598,9 +604,11 @@ class DFScreen(Screens):
         # Remove the images for currently listed cats
         for cat in self.display_cats:
             cat.kill()
+        self.display_cats = []
 
         for name in self.cat_names:
             name.kill()
+        self.cat_names = []
 
         # Generate object for the current cats
         pos_x = 0
@@ -709,9 +717,11 @@ class ListScreen(Screens):
         # Remove currently displayed cats and cat names.
         for cat in self.display_cats:
             cat.kill()
+        self.display_cats = []
 
         for name in self.cat_names:
             name.kill()
+        self.cat_names = []
 
     def update_search_cats(self, search_text):
         '''Run this function when the search text changes, or when the screen is switched to.'''
@@ -756,9 +766,11 @@ class ListScreen(Screens):
         # Remove the images for currently listed cats
         for cat in self.display_cats:
             cat.kill()
+        self.display_cats = []
 
         for name in self.cat_names:
             name.kill()
+        self.cat_names = []
 
         # Generate object for the current cats
         pos_x = 0

--- a/scripts/screens/patrol_screens.py
+++ b/scripts/screens/patrol_screens.py
@@ -253,6 +253,7 @@ class PatrolScreen(Screens):
                 self.elements['info'] = pygame_gui.elements.UITextBox(
                     text, pygame.Rect((250, 525), (300, 400)), object_id=get_text_box_theme()
                 )
+
     def open_choose_cats_screen(self):
         """Opens the choose-cat patrol stage. """
         self.clear_page()  # Clear the page

--- a/scripts/screens/world_screens.py
+++ b/scripts/screens/world_screens.py
@@ -81,9 +81,11 @@ class OutsideClanScreen(Screens):
         # Remove currently displayed cats and cat names.
         for cat in self.display_cats:
             cat.kill()
+        self.display_cats = []
 
         for name in self.cat_names:
             name.kill()
+        self.cat_names = []
         
 
     def update_search_cats(self, search_text):
@@ -133,9 +135,11 @@ class OutsideClanScreen(Screens):
         # Remove the images for currently listed cats
         for cat in self.display_cats:
             cat.kill()
+        self.display_cats = []
 
         for name in self.cat_names:
             name.kill()
+        self.cat_names = []
         
         # Generate object for the current cats
         pos_x = 0


### PR DESCRIPTION
This solves an issue where switching between list tabs would cause memory to quickly increase without bound. 