### PR TITLE
QOL: More informative errors

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import sys
 import os
+import traceback
 directory = os.path.dirname(__file__)
 if directory:
     os.chdir(directory)
@@ -77,7 +78,7 @@ if clan_list:
         load_cats()
         clan_class.load_clan()
     except Exception as e:
-        print("\nERROR MESSAGE:\n", e, "\n")
+        print(traceback.format_exc())
         if not game.switches['error_message']:
             game.switches[
                 'error_message'] = 'There was an error loading the cats file!'

--- a/scripts/game_structure/load_cat.py
+++ b/scripts/game_structure/load_cat.py
@@ -31,81 +31,89 @@ def json_load():
         raise
         
     # create new cat objects
-    for cat in cat_data:
-        new_pelt = choose_pelt(cat["gender"], cat["pelt_color"],
-                               cat["pelt_white"], cat["pelt_name"],
-                               cat["pelt_length"], True)
-        new_cat = Cat(ID=cat["ID"],
-                      prefix=cat["name_prefix"],
-                      suffix=cat["name_suffix"],
-                      gender=cat["gender"],
-                      status=cat["status"],
-                      parent1=cat["parent1"],
-                      parent2=cat["parent2"],
-                      moons=cat["moons"],
-                      eye_colour=cat["eye_colour"],
-                      pelt=new_pelt)
-        new_cat.age = cat["age"]
-        new_cat.genderalign = cat["gender_align"]
-        new_cat.backstory = cat["backstory"] if "backstory" in cat else None
-        new_cat.birth_cooldown = cat[
-            "birth_cooldown"] if "birth_cooldown" in cat else 0
-        new_cat.moons = cat["moons"]
-        new_cat.trait = cat["trait"]
-        new_cat.mentor = cat["mentor"]
-        new_cat.former_mentor = cat["former_mentor"] if "former_mentor" in cat else []
-        new_cat.patrol_with_mentor = cat["patrol_with_mentor"] if "patrol_with_mentor" in cat else 0
-        new_cat.mentor_influence = cat["mentor_influence"] if "mentor_influence" in cat else []
-        new_cat.paralyzed = cat["paralyzed"]
-        new_cat.no_kits = cat["no_kits"]
-        new_cat.exiled = cat["exiled"]
-        new_cat.age_sprites['kitten'] = cat["spirit_kitten"]
-        new_cat.age_sprites['adolescent'] = cat["spirit_adolescent"]
-        new_cat.age_sprites['young adult'] = cat["spirit_young_adult"]
-        new_cat.age_sprites['adult'] = cat["spirit_adult"]
-        new_cat.age_sprites['senior adult'] = cat["spirit_senior_adult"]
-        new_cat.age_sprites['elder'] = cat["spirit_elder"]
-        new_cat.eye_colour = cat["eye_colour"]
-        new_cat.reverse = cat["reverse"]
-        new_cat.white_patches = cat["white_patches"]
-        new_cat.pattern = cat["pattern"]
-        new_cat.tortiebase = cat["tortie_base"]
-        new_cat.tortiecolour = cat["tortie_color"]
-        new_cat.tortiepattern = cat["tortie_pattern"]
-        new_cat.skin = cat["skin"]
-        new_cat.skill = cat["skill"]
-        new_cat.scars = cat["scars"] if "scars" in cat else []
+    for i, cat in enumerate(cat_data):
+        try:
+            new_pelt = choose_pelt(cat["gender"], cat["pelt_color"],
+                                cat["pelt_white"], cat["pelt_name"],
+                                cat["pelt_length"], True)
+            new_cat = Cat(ID=cat["ID"],
+                        prefix=cat["name_prefix"],
+                        suffix=cat["name_suffix"],
+                        gender=cat["gender"],
+                        status=cat["status"],
+                        parent1=cat["parent1"],
+                        parent2=cat["parent2"],
+                        moons=cat["moons"],
+                        eye_colour=cat["eye_colour"],
+                        pelt=new_pelt)
+            new_cat.age = cat["age"]
+            new_cat.genderalign = cat["gender_align"]
+            new_cat.backstory = cat["backstory"] if "backstory" in cat else None
+            new_cat.birth_cooldown = cat[
+                "birth_cooldown"] if "birth_cooldown" in cat else 0
+            new_cat.moons = cat["moons"]
+            new_cat.trait = cat["trait"]
+            new_cat.mentor = cat["mentor"]
+            new_cat.former_mentor = cat["former_mentor"] if "former_mentor" in cat else []
+            new_cat.patrol_with_mentor = cat["patrol_with_mentor"] if "patrol_with_mentor" in cat else 0
+            new_cat.mentor_influence = cat["mentor_influence"] if "mentor_influence" in cat else []
+            new_cat.paralyzed = cat["paralyzed"]
+            new_cat.no_kits = cat["no_kits"]
+            new_cat.exiled = cat["exiled"]
+            new_cat.age_sprites['kitten'] = cat["spirit_kitten"]
+            new_cat.age_sprites['adolescent'] = cat["spirit_adolescent"]
+            new_cat.age_sprites['young adult'] = cat["spirit_young_adult"]
+            new_cat.age_sprites['adult'] = cat["spirit_adult"]
+            new_cat.age_sprites['senior adult'] = cat["spirit_senior_adult"]
+            new_cat.age_sprites['elder'] = cat["spirit_elder"]
+            new_cat.eye_colour = cat["eye_colour"]
+            new_cat.reverse = cat["reverse"]
+            new_cat.white_patches = cat["white_patches"]
+            new_cat.pattern = cat["pattern"]
+            new_cat.tortiebase = cat["tortie_base"]
+            new_cat.tortiecolour = cat["tortie_color"]
+            new_cat.tortiepattern = cat["tortie_pattern"]
+            new_cat.skin = cat["skin"]
+            new_cat.skill = cat["skill"]
+            new_cat.scars = cat["scars"] if "scars" in cat else []
 
-        # converting old specialty saves into new scar parameter
-        if "specialty" in cat or "specialty2" in cat:
-            if cat["specialty"] is not None:
-                new_cat.scars.append(cat["specialty"])
-            if cat["specialty2"] is not None:
-                new_cat.scars.append(cat["specialty2"])
+            # converting old specialty saves into new scar parameter
+            if "specialty" in cat or "specialty2" in cat:
+                if cat["specialty"] is not None:
+                    new_cat.scars.append(cat["specialty"])
+                if cat["specialty2"] is not None:
+                    new_cat.scars.append(cat["specialty2"])
 
-        new_cat.accessory = cat["accessory"]
-        new_cat.mate = cat["mate"]
-        new_cat.dead = cat["dead"]
-        new_cat.died_by = cat["died_by"] if "died_by" in cat else []
-        new_cat.age_sprites['dead'] = cat["spirit_dead"]
-        new_cat.experience = cat["experience"]
-        new_cat.dead_for = cat["dead_moons"]
-        new_cat.apprentice = cat["current_apprentice"]
-        new_cat.former_apprentices = cat["former_apprentices"]
-        new_cat.possible_scar = cat["possible_scar"] if "possible_scar" in cat else None
-        new_cat.scar_event = cat["scar_event"] if "scar_event" in cat else []
-        new_cat.death_event = cat["death_event"] if "death_event" in cat else []
-        new_cat.df = cat["df"] if "df" in cat else False
-        new_cat.corruption = cat["corruption"] if "corruption" in cat else 0
-        new_cat.life_givers = cat["life_givers"] if "life_givers" in cat else []
-        new_cat.known_life_givers = cat["known_life_givers"] if "known_life_givers" in cat else []
-        new_cat.virtues = cat["virtues"] if "virtues" in cat else []
-        new_cat.outside = cat["outside"] if "outside" in cat else False
-        new_cat.retired = cat["retired"] if "retired" in cat else False
-        new_cat.faded_offspring = cat["faded_offspring"] if "faded_offspring" in cat else []
-        new_cat.opacity = cat["opacity"] if "opacity" in cat else 100
-        new_cat.prevent_fading = cat["prevent_fading"] if "prevent_fading" in cat else False
-        all_cats.append(new_cat)
+            new_cat.accessory = cat["accessory"]
+            new_cat.mate = cat["mate"]
+            new_cat.dead = cat["dead"]
+            new_cat.died_by = cat["died_by"] if "died_by" in cat else []
+            new_cat.age_sprites['dead'] = cat["spirit_dead"]
+            new_cat.experience = cat["experience"]
+            new_cat.dead_for = cat["dead_moons"]
+            new_cat.apprentice = cat["current_apprentice"]
+            new_cat.former_apprentices = cat["former_apprentices"]
+            new_cat.possible_scar = cat["possible_scar"] if "possible_scar" in cat else None
+            new_cat.scar_event = cat["scar_event"] if "scar_event" in cat else []
+            new_cat.death_event = cat["death_event"] if "death_event" in cat else []
+            new_cat.df = cat["df"] if "df" in cat else False
+            new_cat.corruption = cat["corruption"] if "corruption" in cat else 0
+            new_cat.life_givers = cat["life_givers"] if "life_givers" in cat else []
+            new_cat.known_life_givers = cat["known_life_givers"] if "known_life_givers" in cat else []
+            new_cat.virtues = cat["virtues"] if "virtues" in cat else []
+            new_cat.outside = cat["outside"] if "outside" in cat else False
+            new_cat.retired = cat["retired"] if "retired" in cat else False
+            new_cat.faded_offspring = cat["faded_offspring"] if "faded_offspring" in cat else []
+            new_cat.opacity = cat["opacity"] if "opacity" in cat else 100
+            new_cat.prevent_fading = cat["prevent_fading"] if "prevent_fading" in cat else False
+            all_cats.append(new_cat)
+        except KeyError as e:
+            if "ID" in cat:
+                key = f" ID #{cat['ID']} "
+            else: 
+                key = f" at index {i} "
+            game.switches['error_message'] = f'Cat{key}in clan_cats.json is missing {e}!'
+            raise
 
     # replace cat ids with cat objects and add other needed variables
     for cat in all_cats:

--- a/scripts/game_structure/load_cat.py
+++ b/scripts/game_structure/load_cat.py
@@ -4,14 +4,17 @@ from .game_essentials import *
 from scripts.cat.cats import Cat
 from scripts.cat.pelts import choose_pelt
 from scripts.utility import update_sprite, is_iterable
-
+from ujson import JSONDecodeError
 
 def load_cats():
-    directory = 'saves/' + game.switches['clan_list'][0] + '/clan_cats.json'
-    if os.path.exists(directory):
+    try:
         json_load()
-    else:
-        csv_load(Cat.all_cats)
+    except FileNotFoundError:
+        try:
+            csv_load(Cat.all_cats)
+        except FileNotFoundError:
+            game.switches['error_message'] = 'Can\'t find clan_cats.json!'
+            raise
 
 def json_load():
     all_cats = []
@@ -20,9 +23,13 @@ def json_load():
     try:
         with open('saves/' + clanname + '/clan_cats.json', 'r') as read_file:
             cat_data = ujson.loads(read_file.read())
-    except:
-        game.switches['error_message'] = 'There was an error loading the json cats file!'
-        return
+    except PermissionError:
+        game.switches['error_message'] = f'Can\t open saves/{clanname}/clan_cats.json!'
+        raise
+    except JSONDecodeError:
+        game.switches['error_message'] = f'saves/{clanname}/clan_cats.json is malformed!'
+        raise
+        
     # create new cat objects
     for cat in cat_data:
         new_pelt = choose_pelt(cat["gender"], cat["pelt_color"],


### PR DESCRIPTION
Makes some error messages on the start screen more informative. More specifically: 
* The whole traceback gets printed to console when loading files now, rather than just the exception. This should help for debugging. In the future, Python's logging module should probably be used rather than print statements.
* Gives more informative error messages for KeyErrors, FileNotFoundErrors, PermissionErrors, and JSONDecodeErrors when loading `clan_cats.json`.

I was unsure of when `There was an error when relationships for cat #{cat} are created` and `There was an error loading this clan's relationships` occur, so these remain the same. Also, this does **not** fix or add error messages for errors that cause the game to crash on continuing a save, such as invalid torties or calicos.