### PR TITLE
fix: Crash on continue

### DIFF
--- a/scripts/utility.py
+++ b/scripts/utility.py
@@ -351,8 +351,6 @@ def update_sprite(cat):
             # THE SPRITE UPDATE
     # draw colour & style
     new_sprite = pygame.Surface((sprites.size, sprites.size), pygame.HWSURFACE | pygame.SRCALPHA)
-    game.switches['error_message'] = 'There was an error loading a cat\'s base coat sprite. Last cat read was ' + str(
-        cat)
     if cat.pelt.name not in ['Tortie', 'Calico']:
         if cat.pelt.length == 'long' and cat.status not in ['kitten', 'apprentice',
                                                             'medicine cat apprentice'] or cat.age == 'elder':
@@ -363,25 +361,15 @@ def update_sprite(cat):
             new_sprite.blit(sprites.sprites[cat.pelt.sprites[1] + cat.pelt.colour + str(cat.age_sprites[cat.age])],
                             (0, 0))
     else:
-        game.switches[
-            'error_message'] = 'There was an error loading a tortie\'s base coat sprite. Last cat read was ' + str(cat)
         if cat.pelt.length == 'long' and cat.status not in ['kitten', 'apprentice',
                                                             'medicine cat apprentice'] or cat.age == 'elder':
             new_sprite.blit(
                 sprites.sprites[cat.tortiebase + 'extra' + cat.tortiecolour + str(cat.age_sprites[cat.age])], (0, 0))
-            game.switches[
-                'error_message'] = 'There was an error loading a tortie\'s pattern sprite. Last cat read was ' + str(
-                cat)
             new_sprite.blit(sprites.sprites[cat.tortiepattern + 'extra' + cat.pattern + str(cat.age_sprites[cat.age])],
                             (0, 0))
         else:
             new_sprite.blit(sprites.sprites[cat.tortiebase + cat.tortiecolour + str(cat.age_sprites[cat.age])], (0, 0))
-            game.switches[
-                'error_message'] = 'There was an error loading a tortie\'s pattern sprite. Last cat read was ' + str(
-                cat)
             new_sprite.blit(sprites.sprites[cat.tortiepattern + cat.pattern + str(cat.age_sprites[cat.age])], (0, 0))
-    game.switches[
-        'error_message'] = 'There was an error loading a cat\'s white patches sprite. Last cat read was ' + str(cat)
     # draw white patches
     if cat.white_patches is not None:
         if cat.pelt.length == 'long' and cat.status not in ['kitten', 'apprentice', 'medicine cat apprentice'] \
@@ -393,9 +381,6 @@ def update_sprite(cat):
             new_sprite.blit(
                 sprites.sprites['white' + cat.white_patches +
                                 str(cat.age_sprites[cat.age])], (0, 0))
-    game.switches[
-        'error_message'] = 'There was an error loading a cat\'s scar and eye sprites. Last cat read was ' + str(
-        cat)
     # draw eyes & scars1
     if cat.pelt.length == 'long' and cat.status not in [
         'kitten', 'apprentice', 'medicine cat apprentice'
@@ -432,9 +417,6 @@ def update_sprite(cat):
                 )
         
 
-    game.switches[
-        'error_message'] = 'There was an error loading a cat\'s shader sprites. Last cat read was ' + str(
-        cat)
     # draw line art
     if game.settings['shaders'] and not cat.dead:
         if cat.pelt.length == 'long' and cat.status not in [
@@ -484,9 +466,6 @@ def update_sprite(cat):
             new_sprite.blit(
                 sprites.sprites['lineartdead' +
                                 str(cat.age_sprites[cat.age])], (0, 0))
-    game.switches[
-        'error_message'] = 'There was an error loading a cat\'s skin and second set of scar sprites. Last cat read was ' + str(
-        cat)
     # draw skin and scars2
     blendmode = pygame.BLEND_RGBA_MIN
     if cat.pelt.length == 'long' and cat.status not in [
@@ -509,9 +488,6 @@ def update_sprite(cat):
                 new_sprite.blit(sprites.sprites['scars' + scar +
                                                 str(cat.age_sprites[cat.age])], (0, 0), special_flags=blendmode)
 
-    game.switches[
-        'error_message'] = 'There was an error loading a cat\'s accessory. Last cat read was ' + str(
-        cat)
     # draw accessories        
     if cat.pelt.length == 'long' and cat.status not in [
         'kitten', 'apprentice', 'medicine cat apprentice'
@@ -549,19 +525,10 @@ def update_sprite(cat):
             new_sprite.blit(
                 sprites.sprites['collars' + cat.accessory +
                                 str(cat.age_sprites[cat.age])], (0, 0))
-    game.switches[
-        'error_message'] = 'There was an error loading a cat\'s skin and second set of scar sprites. Last cat read was ' + str(
-        cat)
-    game.switches[
-        'error_message'] = 'There was an error reversing a cat\'s sprite. Last cat read was ' + str(
-        cat)
 
     # reverse, if assigned so
     if cat.reverse:
         new_sprite = pygame.transform.flip(new_sprite, True, False)
-    game.switches[
-        'error_message'] = 'There was an error scaling a cat\'s sprites. Last cat read was ' + str(
-        cat)
 
     # Apply opacity
     if cat.opacity < 100 and not cat.prevent_fading and game.settings["fading"]:
@@ -573,12 +540,8 @@ def update_sprite(cat):
         new_sprite, (sprites.new_size, sprites.new_size))
     cat.large_sprite = pygame.transform.scale(
         cat.big_sprite, (sprites.size * 3, sprites.size * 3))
-    game.switches[
-        'error_message'] = 'There was an error updating a cat\'s sprites. Last cat read was ' + str(
-        cat)
     # update class dictionary
     cat.all_cats[cat.ID] = cat
-    game.switches['error_message'] = ''
 
 
 def apply_opacity(surface, opacity):

--- a/scripts/utility.py
+++ b/scripts/utility.py
@@ -1,4 +1,6 @@
 import ujson
+import traceback
+from scripts.game_structure import image_cache
 
 from scripts.cat.sprites import *
 from scripts.cat.pelts import *
@@ -351,180 +353,191 @@ def update_sprite(cat):
             # THE SPRITE UPDATE
     # draw colour & style
     new_sprite = pygame.Surface((sprites.size, sprites.size), pygame.HWSURFACE | pygame.SRCALPHA)
-    if cat.pelt.name not in ['Tortie', 'Calico']:
-        if cat.pelt.length == 'long' and cat.status not in ['kitten', 'apprentice',
-                                                            'medicine cat apprentice'] or cat.age == 'elder':
-            new_sprite.blit(
-                sprites.sprites[cat.pelt.sprites[1] + 'extra' + cat.pelt.colour + str(cat.age_sprites[cat.age])],
-                (0, 0))
-        else:
-            new_sprite.blit(sprites.sprites[cat.pelt.sprites[1] + cat.pelt.colour + str(cat.age_sprites[cat.age])],
-                            (0, 0))
-    else:
-        if cat.pelt.length == 'long' and cat.status not in ['kitten', 'apprentice',
-                                                            'medicine cat apprentice'] or cat.age == 'elder':
-            new_sprite.blit(
-                sprites.sprites[cat.tortiebase + 'extra' + cat.tortiecolour + str(cat.age_sprites[cat.age])], (0, 0))
-            new_sprite.blit(sprites.sprites[cat.tortiepattern + 'extra' + cat.pattern + str(cat.age_sprites[cat.age])],
-                            (0, 0))
-        else:
-            new_sprite.blit(sprites.sprites[cat.tortiebase + cat.tortiecolour + str(cat.age_sprites[cat.age])], (0, 0))
-            new_sprite.blit(sprites.sprites[cat.tortiepattern + cat.pattern + str(cat.age_sprites[cat.age])], (0, 0))
-    # draw white patches
-    if cat.white_patches is not None:
-        if cat.pelt.length == 'long' and cat.status not in ['kitten', 'apprentice', 'medicine cat apprentice'] \
-                or cat.age == 'elder':
-            new_sprite.blit(
-                sprites.sprites['whiteextra' + cat.white_patches +
-                                str(cat.age_sprites[cat.age])], (0, 0))
-        else:
-            new_sprite.blit(
-                sprites.sprites['white' + cat.white_patches +
-                                str(cat.age_sprites[cat.age])], (0, 0))
-    # draw eyes & scars1
-    if cat.pelt.length == 'long' and cat.status not in [
-        'kitten', 'apprentice', 'medicine cat apprentice'
-    ] or cat.age == 'elder':
-        new_sprite.blit(
-            sprites.sprites['eyesextra' + cat.eye_colour +
-                            str(cat.age_sprites[cat.age])], (0, 0))
-        for scar in cat.scars:
-            if scar in scars1:
-                new_sprite.blit(
-                    sprites.sprites['scarsextra' + scar + str(cat.age_sprites[cat.age])],
-                    (0, 0)
-                )
-            if scar in scars3:
-                new_sprite.blit(
-                    sprites.sprites['scarsextra' + scar + str(cat.age_sprites[cat.age])],
-                    (0, 0)
-                )
-        
-    else:
-        new_sprite.blit(
-            sprites.sprites['eyes' + cat.eye_colour +
-                            str(cat.age_sprites[cat.age])], (0, 0))
-        for scar in cat.scars:
-            if scar in scars1:
-                new_sprite.blit(
-                    sprites.sprites['scars' + scar + str(cat.age_sprites[cat.age])],
-                    (0, 0)
-                )
-            if scar in scars3:
-                new_sprite.blit(
-                    sprites.sprites['scars' + scar + str(cat.age_sprites[cat.age])],
-                    (0, 0)
-                )
-        
 
-    # draw line art
-    if game.settings['shaders'] and not cat.dead:
+    try:
+        if cat.pelt.name not in ['Tortie', 'Calico']:
+            if cat.pelt.length == 'long' and cat.status not in ['kitten', 'apprentice',
+                                                                'medicine cat apprentice'] or cat.age == 'elder':
+                new_sprite.blit(
+                    sprites.sprites[cat.pelt.sprites[1] + 'extra' + cat.pelt.colour + str(cat.age_sprites[cat.age])],
+                    (0, 0))
+            else:
+                new_sprite.blit(sprites.sprites[cat.pelt.sprites[1] + cat.pelt.colour + str(cat.age_sprites[cat.age])],
+                                (0, 0))
+        else:
+            if cat.pelt.length == 'long' and cat.status not in ['kitten', 'apprentice',
+                                                                'medicine cat apprentice'] or cat.age == 'elder':
+                new_sprite.blit(
+                    sprites.sprites[cat.tortiebase + 'extra' + cat.tortiecolour + str(cat.age_sprites[cat.age])], (0, 0))
+                new_sprite.blit(sprites.sprites[cat.tortiepattern + 'extra' + cat.pattern + str(cat.age_sprites[cat.age])],
+                                (0, 0))
+            else:
+                new_sprite.blit(sprites.sprites[cat.tortiebase + cat.tortiecolour + str(cat.age_sprites[cat.age])], (0, 0))
+                new_sprite.blit(sprites.sprites[cat.tortiepattern + cat.pattern + str(cat.age_sprites[cat.age])], (0, 0))
+        # draw white patches
+        if cat.white_patches is not None:
+            if cat.pelt.length == 'long' and cat.status not in ['kitten', 'apprentice', 'medicine cat apprentice'] \
+                    or cat.age == 'elder':
+                new_sprite.blit(
+                    sprites.sprites['whiteextra' + cat.white_patches +
+                                    str(cat.age_sprites[cat.age])], (0, 0))
+            else:
+                new_sprite.blit(
+                    sprites.sprites['white' + cat.white_patches +
+                                    str(cat.age_sprites[cat.age])], (0, 0))
+        # draw eyes & scars1
         if cat.pelt.length == 'long' and cat.status not in [
             'kitten', 'apprentice', 'medicine cat apprentice'
         ] or cat.age == 'elder':
             new_sprite.blit(
-                sprites.sprites['shaders' +
-                                str(cat.age_sprites[cat.age] + 9)],
-                (0, 0))
-        else:
-            new_sprite.blit(
-                sprites.sprites['shaders' +
+                sprites.sprites['eyesextra' + cat.eye_colour +
                                 str(cat.age_sprites[cat.age])], (0, 0))
-    elif not cat.dead:
-        if cat.pelt.length == 'long' and cat.status not in [
-            'kitten', 'apprentice', 'medicine cat apprentice'
-        ] or cat.age == 'elder':
-            new_sprite.blit(
-                sprites.sprites['lines' +
-                                str(cat.age_sprites[cat.age] + 9)],
-                (0, 0))
+            for scar in cat.scars:
+                if scar in scars1:
+                    new_sprite.blit(
+                        sprites.sprites['scarsextra' + scar + str(cat.age_sprites[cat.age])],
+                        (0, 0)
+                    )
+                if scar in scars3:
+                    new_sprite.blit(
+                        sprites.sprites['scarsextra' + scar + str(cat.age_sprites[cat.age])],
+                        (0, 0)
+                    )
+            
         else:
             new_sprite.blit(
-                sprites.sprites['lines' + str(cat.age_sprites[cat.age])],
-                (0, 0))
-    elif cat.df:
-        if cat.pelt.length == 'long' and cat.status not in [
-            'kitten', 'apprentice', 'medicine cat apprentice'
-        ] or cat.age == 'elder':
-            new_sprite.blit(
-                sprites.sprites['lineartdf' +
-                                str(cat.age_sprites[cat.age] + 9)],
-                (0, 0))
-        else:
-            new_sprite.blit(
-                sprites.sprites['lineartdf' +
+                sprites.sprites['eyes' + cat.eye_colour +
                                 str(cat.age_sprites[cat.age])], (0, 0))
-    elif cat.dead:
-        if cat.pelt.length == 'long' and cat.status not in [
-            'kitten', 'apprentice', 'medicine cat apprentice'
-        ] or cat.age == 'elder':
-            new_sprite.blit(
-                sprites.sprites['lineartdead' +
-                                str(cat.age_sprites[cat.age] + 9)],
-                (0, 0))
-        else:
-            new_sprite.blit(
-                sprites.sprites['lineartdead' +
-                                str(cat.age_sprites[cat.age])], (0, 0))
-    # draw skin and scars2
-    blendmode = pygame.BLEND_RGBA_MIN
-    if cat.pelt.length == 'long' and cat.status not in [
-        'kitten', 'apprentice', 'medicine cat apprentice'
-    ] or cat.age == 'elder':
-        new_sprite.blit(
-            sprites.sprites['skinextra' + cat.skin +
-                            str(cat.age_sprites[cat.age])], (0, 0))
-        for scar in cat.scars:
-            if scar in scars2:
-                new_sprite.blit(sprites.sprites['scarsextra' + scar +
-                                                str(cat.age_sprites[cat.age])], (0, 0), special_flags=blendmode)
+            for scar in cat.scars:
+                if scar in scars1:
+                    new_sprite.blit(
+                        sprites.sprites['scars' + scar + str(cat.age_sprites[cat.age])],
+                        (0, 0)
+                    )
+                if scar in scars3:
+                    new_sprite.blit(
+                        sprites.sprites['scars' + scar + str(cat.age_sprites[cat.age])],
+                        (0, 0)
+                    )
+            
 
-    else:
-        new_sprite.blit(
-            sprites.sprites['skin' + cat.skin +
-                            str(cat.age_sprites[cat.age])], (0, 0))
-        for scar in cat.scars:
-            if scar in scars2:
-                new_sprite.blit(sprites.sprites['scars' + scar +
-                                                str(cat.age_sprites[cat.age])], (0, 0), special_flags=blendmode)
+        # draw line art
+        if game.settings['shaders'] and not cat.dead:
+            if cat.pelt.length == 'long' and cat.status not in [
+                'kitten', 'apprentice', 'medicine cat apprentice'
+            ] or cat.age == 'elder':
+                new_sprite.blit(
+                    sprites.sprites['shaders' +
+                                    str(cat.age_sprites[cat.age] + 9)],
+                    (0, 0))
+            else:
+                new_sprite.blit(
+                    sprites.sprites['shaders' +
+                                    str(cat.age_sprites[cat.age])], (0, 0))
+        elif not cat.dead:
+            if cat.pelt.length == 'long' and cat.status not in [
+                'kitten', 'apprentice', 'medicine cat apprentice'
+            ] or cat.age == 'elder':
+                new_sprite.blit(
+                    sprites.sprites['lines' +
+                                    str(cat.age_sprites[cat.age] + 9)],
+                    (0, 0))
+            else:
+                new_sprite.blit(
+                    sprites.sprites['lines' + str(cat.age_sprites[cat.age])],
+                    (0, 0))
+        elif cat.df:
+            if cat.pelt.length == 'long' and cat.status not in [
+                'kitten', 'apprentice', 'medicine cat apprentice'
+            ] or cat.age == 'elder':
+                new_sprite.blit(
+                    sprites.sprites['lineartdf' +
+                                    str(cat.age_sprites[cat.age] + 9)],
+                    (0, 0))
+            else:
+                new_sprite.blit(
+                    sprites.sprites['lineartdf' +
+                                    str(cat.age_sprites[cat.age])], (0, 0))
+        elif cat.dead:
+            if cat.pelt.length == 'long' and cat.status not in [
+                'kitten', 'apprentice', 'medicine cat apprentice'
+            ] or cat.age == 'elder':
+                new_sprite.blit(
+                    sprites.sprites['lineartdead' +
+                                    str(cat.age_sprites[cat.age] + 9)],
+                    (0, 0))
+            else:
+                new_sprite.blit(
+                    sprites.sprites['lineartdead' +
+                                    str(cat.age_sprites[cat.age])], (0, 0))
+        # draw skin and scars2
+        blendmode = pygame.BLEND_RGBA_MIN
+        if cat.pelt.length == 'long' and cat.status not in [
+            'kitten', 'apprentice', 'medicine cat apprentice'
+        ] or cat.age == 'elder':
+            new_sprite.blit(
+                sprites.sprites['skinextra' + cat.skin +
+                                str(cat.age_sprites[cat.age])], (0, 0))
+            for scar in cat.scars:
+                if scar in scars2:
+                    new_sprite.blit(sprites.sprites['scarsextra' + scar +
+                                                    str(cat.age_sprites[cat.age])], (0, 0), special_flags=blendmode)
 
-    # draw accessories        
-    if cat.pelt.length == 'long' and cat.status not in [
-        'kitten', 'apprentice', 'medicine cat apprentice'
-    ] or cat.age == 'elder':
-        if cat.accessory in plant_accessories:
+        else:
             new_sprite.blit(
-                sprites.sprites['acc_herbsextra' + cat.accessory +
+                sprites.sprites['skin' + cat.skin +
                                 str(cat.age_sprites[cat.age])], (0, 0))
-        elif cat.accessory in wild_accessories:
-            new_sprite.blit(
-                sprites.sprites['acc_wildextra' + cat.accessory +
-                                str(cat.age_sprites[cat.age])], (0, 0))
-        elif cat.accessory in collars:
-            new_sprite.blit(
-                sprites.sprites['collarsextra' + cat.accessory +
-                                str(cat.age_sprites[cat.age])], (0, 0))
-        elif cat.accessory in collars:
-            new_sprite.blit(
-                sprites.sprites['collarsextra' + cat.accessory +
-                                str(cat.age_sprites[cat.age])], (0, 0))
-    else:
-        if cat.accessory in plant_accessories:
-            new_sprite.blit(
-                sprites.sprites['acc_herbs' + cat.accessory +
-                                str(cat.age_sprites[cat.age])], (0, 0))
-        elif cat.accessory in wild_accessories:
-            new_sprite.blit(
-                sprites.sprites['acc_wild' + cat.accessory +
-                                str(cat.age_sprites[cat.age])], (0, 0))
-        elif cat.accessory in collars:
-            new_sprite.blit(
-                sprites.sprites['collars' + cat.accessory +
-                                str(cat.age_sprites[cat.age])], (0, 0))
-        elif cat.accessory in collars:
-            new_sprite.blit(
-                sprites.sprites['collars' + cat.accessory +
-                                str(cat.age_sprites[cat.age])], (0, 0))
+            for scar in cat.scars:
+                if scar in scars2:
+                    new_sprite.blit(sprites.sprites['scars' + scar +
+                                                    str(cat.age_sprites[cat.age])], (0, 0), special_flags=blendmode)
+
+        # draw accessories        
+        if cat.pelt.length == 'long' and cat.status not in [
+            'kitten', 'apprentice', 'medicine cat apprentice'
+        ] or cat.age == 'elder':
+            if cat.accessory in plant_accessories:
+                new_sprite.blit(
+                    sprites.sprites['acc_herbsextra' + cat.accessory +
+                                    str(cat.age_sprites[cat.age])], (0, 0))
+            elif cat.accessory in wild_accessories:
+                new_sprite.blit(
+                    sprites.sprites['acc_wildextra' + cat.accessory +
+                                    str(cat.age_sprites[cat.age])], (0, 0))
+            elif cat.accessory in collars:
+                new_sprite.blit(
+                    sprites.sprites['collarsextra' + cat.accessory +
+                                    str(cat.age_sprites[cat.age])], (0, 0))
+            elif cat.accessory in collars:
+                new_sprite.blit(
+                    sprites.sprites['collarsextra' + cat.accessory +
+                                    str(cat.age_sprites[cat.age])], (0, 0))
+        else:
+            if cat.accessory in plant_accessories:
+                new_sprite.blit(
+                    sprites.sprites['acc_herbs' + cat.accessory +
+                                    str(cat.age_sprites[cat.age])], (0, 0))
+            elif cat.accessory in wild_accessories:
+                new_sprite.blit(
+                    sprites.sprites['acc_wild' + cat.accessory +
+                                    str(cat.age_sprites[cat.age])], (0, 0))
+            elif cat.accessory in collars:
+                new_sprite.blit(
+                    sprites.sprites['collars' + cat.accessory +
+                                    str(cat.age_sprites[cat.age])], (0, 0))
+            elif cat.accessory in collars:
+                new_sprite.blit(
+                    sprites.sprites['collars' + cat.accessory +
+                                    str(cat.age_sprites[cat.age])], (0, 0))
+    except (TypeError, KeyError):
+        print(f"Failed to load cat ID #{cat}'s sprite:")
+        print(traceback.format_exc())
+
+        # Placeholder image
+        new_sprite.blit(
+            image_cache.load_image(f"sprites/faded/faded_adult.png").convert_alpha(),
+            (0, 0)
+        )
 
     # reverse, if assigned so
     if cat.reverse:


### PR DESCRIPTION
Previously the game would crash if the sprite could not be found or if pelt_name was set to Tortie or Calico but the tortie variables were null. Instead, if the sprite can't be found, replace the cat sprite with a placeholder image and print the error to console. Placeholder is the adult faded sprite.