### PR TITLE
Use 'json' if 'ujson' fails to import

### DIFF
--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -2,7 +2,10 @@ from random import choice, randint
 import math
 import os.path
 import itertools
-import ujson
+try:
+    import ujson
+except ImportError:
+    import json as ujson
 
 from .pelts import *
 from .names import *

--- a/scripts/cat/sprites.py
+++ b/scripts/cat/sprites.py
@@ -1,7 +1,10 @@
 import pygame
 
 from scripts.game_structure.game_essentials import *
-import ujson
+try:
+    import ujson
+except ImportError:
+    import json as ujson
 
 
 class Sprites():

--- a/scripts/cat/thoughts.py
+++ b/scripts/cat/thoughts.py
@@ -1,6 +1,9 @@
 from random import choice
 
-import ujson
+try:
+    import ujson
+except ImportError:
+    import json as ujson
 
 def get_thoughts(cat, other_cat):
     # placeholder thought - should only appear in game, when there is only one cat left

--- a/scripts/cat_relations/relationship.py
+++ b/scripts/cat_relations/relationship.py
@@ -1,7 +1,10 @@
 import random
 from random import choice, randint
 import copy
-import ujson
+try:
+    import ujson
+except ImportError:
+    import json as ujson
 from scripts.event_class import Single_Event
 
 from scripts.utility import get_personality_compatibility

--- a/scripts/events_module/condition_events.py
+++ b/scripts/events_module/condition_events.py
@@ -1,7 +1,8 @@
-import ujson
+try:
+    import ujson
+except ImportError:
+    import json as ujson
 import random
-
-import ujson as ujson
 
 from scripts.cat.cats import Cat
 from scripts.conditions import medical_cats_condition_fulfilled, get_amount_cat_for_one_medic

--- a/scripts/events_module/death_events.py
+++ b/scripts/events_module/death_events.py
@@ -1,4 +1,7 @@
-import ujson
+try:
+    import ujson
+except ImportError:
+    import json as ujson
 import random
 
 from scripts.cat.cats import Cat, INJURIES

--- a/scripts/events_module/generate_events.py
+++ b/scripts/events_module/generate_events.py
@@ -1,4 +1,7 @@
-import ujson
+try:
+    import ujson
+except ImportError:
+    import json as ujson
 from scripts.game_structure.game_essentials import game
 
 resource_directory = "resources/dicts/events/"

--- a/scripts/events_module/scar_events.py
+++ b/scripts/events_module/scar_events.py
@@ -1,4 +1,7 @@
-import ujson
+try:
+    import ujson
+except ImportError:
+    import json as ujson
 import random
 
 from scripts.cat.cats import Cat

--- a/scripts/game_structure/game_essentials.py
+++ b/scripts/game_structure/game_essentials.py
@@ -1,6 +1,10 @@
 import pygame
 import pygame_gui
-import ujson
+try:
+    import ujson
+except ImportError as e:
+    print(f"{e}\nFailed to import ujson, saving may be slower.")
+    import json as ujson
 import os
 from ast import literal_eval
 

--- a/scripts/game_structure/load_cat.py
+++ b/scripts/game_structure/load_cat.py
@@ -4,7 +4,10 @@ from .game_essentials import *
 from scripts.cat.cats import Cat
 from scripts.cat.pelts import choose_pelt
 from scripts.utility import update_sprite, is_iterable
-from ujson import JSONDecodeError
+try:
+    from ujson import JSONDecodeError
+except ImportError:
+    from json import JSONDecodeError
 
 def load_cats():
     try:

--- a/scripts/utility.py
+++ b/scripts/utility.py
@@ -1,5 +1,8 @@
 import pygame
-import ujson
+try:
+    import ujson
+except ImportError:
+    import json as ujson
 import traceback
 from scripts.game_structure import image_cache
 


### PR DESCRIPTION
It's a plug-in replacement so it ought to be fine, think this is useful since:
 - ujson is slightly less portable than standard json, it got patched out downstream in the web fork and doesn't support 32 bit MacOS installations.
 - There seems to be an issue with 5.7.0 for some people using thonny on windows, "DLL load failed while importing json": 
     - https://web.archive.org/web/20230107232257/https://cdn.discordapp.com/attachments/1003759884694732990/1061400402521763880/image.png
     - https://web.archive.org/web/20230107232317/https://cdn.discordapp.com/attachments/1003759884694732990/1061415937812746280/image.png

It'd probably be cleaner to do
```python
import ujson as json
```
than
```python
import json as ujson
```
though.