### PR TITLE
Bugfixes, QOL: Cat loading, SwitchClan

### DIFF
--- a/scripts/cat/appearance_utility.py
+++ b/scripts/cat/appearance_utility.py
@@ -468,10 +468,8 @@ def init_white_patches(cat):
 def init_tint(cat):
     # Basic tints as possible for all colors.
     possible_tints = Sprites.cat_tints["possible_tints"]["basic"].copy()
-    print(Sprites.cat_tints["possible_tints"]["basic"])
     if cat.pelt.colour in Sprites.cat_tints["colour_groups"]:
         color_group = Sprites.cat_tints["colour_groups"][cat.pelt.colour]
         possible_tints += Sprites.cat_tints["possible_tints"][color_group]
-        print(cat.pelt.colour, possible_tints)
         cat.tint = choice(possible_tints)
 

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -841,8 +841,12 @@ class Cat():
             chosen_thought = chosen_thought.replace("r_c", str(other_cat.name))
 
         # insert Clan name if needed
-        if "c_n" in chosen_thought:
-            chosen_thought = chosen_thought.replace("c_n", str(game.clan.name) + 'Clan')
+        try:
+            if "c_n" in chosen_thought:
+                chosen_thought = chosen_thought.replace("c_n", str(game.clan.name) + 'Clan')
+        except AttributeError:
+            if "c_n" in chosen_thought:
+                chosen_thought = chosen_thought.replace("c_n", game.switches["clan_list"][0] + 'Clan')
 
         # insert thought
         self.thought = str(chosen_thought)

--- a/scripts/screens/cat_screens.py
+++ b/scripts/screens/cat_screens.py
@@ -544,8 +544,6 @@ class ProfileScreen(Screens):
             or for changes in the profile."""
         self.the_cat = Cat.all_cats.get(game.switches["cat"])
 
-        print(self.the_cat.tint)
-
         # use these attributes to create differing profiles for starclan cats etc.
         is_sc_instructor = False
         is_df_instructor = False

--- a/scripts/screens/clan_screens.py
+++ b/scripts/screens/clan_screens.py
@@ -128,10 +128,13 @@ class ClanScreen(Screens):
                 if i > self.max_sprites_displayed:
                     break
 
-                self.cat_buttons.append(
-                    UISpriteButton(pygame.Rect(tuple(Cat.all_cats[x].placement), (50, 50)), Cat.all_cats[x].sprite,
-                                   cat_id=x)
-                )
+                try:
+                    self.cat_buttons.append(
+                        UISpriteButton(pygame.Rect(tuple(Cat.all_cats[x].placement), (50, 50)), Cat.all_cats[x].sprite,
+                                       cat_id=x)
+                    )
+                except:
+                    print(f"Error placing {str(Cat.all_cats[x].name)}\'s sprite on Clan page")
 
         self.save_button = UIImageButton(pygame.Rect(((343, 625), (114, 30))), "", object_id="#save_button")
 

--- a/scripts/screens/organizational_screens.py
+++ b/scripts/screens/organizational_screens.py
@@ -111,14 +111,15 @@ class SwitchClanScreen(Screens):
         del self.main_menu
         self.info.kill()
         del self.info
+        self.current_clan.kill()
+        del self.current_clan
 
         del self.screen  # No need to keep that in memory.
 
         for button in self.clan_buttons:
             button.kill()
-        button = []
+        self.clan_buttons = []
 
-        self.clan_name = []
 
     def screen_switches(self):
         self.screen = pygame.image.load("resources/images/clan_saves_frame.png").convert_alpha()
@@ -128,13 +129,20 @@ class SwitchClanScreen(Screens):
             'Note: This will close the game.\n When you open it next, it should have the new clan.',
             pygame.Rect((100, 540), (600, 70)), object_id=get_text_box_theme())
 
+        self.current_clan = pygame_gui.elements.UITextBox("", pygame.Rect((100, 100), (600, 70)),
+                                                          object_id=get_text_box_theme())
+        if game.clan:
+            self.current_clan.set_text(f"The currently loaded clan is {game.clan.name}Clan")
+        else:
+            self.current_clan.set_text("There is no clan currently loaded.")
+
         self.clan_list = game.read_clans()
 
         self.clan_buttons = []
         self.clan_name = []
         i = 0
         y_pos = 189
-        for clan in self.clan_list:
+        for clan in self.clan_list[1:]:
             self.clan_name.append(clan)
             self.clan_buttons.append(pygame_gui.elements.UIButton(pygame.Rect((300, y_pos), (200, 39)), clan + "Clan",
                                                                   object_id="#saved_clan"))


### PR DESCRIPTION
- Attempted fix on the issue sometimes causing loading cats to fail.
- Removed some prints
- The currently loaded clan no longer shows up on the SwitchClan screen. There is now a message on the SwitchClan screen telling you which clan is currently loaded.
- Error handling for when game cannot determine placement for cats on the clan screen