### PR TITLE
Only accept 'ascii' encoding for patrol/thought resource files.

### DIFF
--- a/resources/dicts/patrols/hunting/hunting_wetlands.json
+++ b/resources/dicts/patrols/hunting/hunting_wetlands.json
@@ -629,7 +629,7 @@
         "exp": 20,
         "success_text": [
             "They're interrupted by Twolegs wandering through the woods a couple times, but it's a successful hunt.",
-            "A friendly Twolegs makes a psspsspss noise, and pours kittypet food on the ground for r_c. They've always wondered what it might taste like… dry, is the answer. Very odd.",
+            "A friendly Twolegs makes a psspsspss noise, and pours kittypet food on the ground for r_c. They've always wondered what it might taste like... dry, is the answer. Very odd.",
             "s_c gets distracted from hunting by strange Twoleg activity around one of their dens. They appear to be hauling all their many, many varieties of nest lining out and into a big monster. s_c take the opportunity to grab a little soft thing, something that's almost shaped like prey. It'll be good for the nursery.",
             "Calmly, s_c weaves around the Twoleg dens, picking out the mice from the tunnels and the birds off the strange metal hanging fruit. A successful, sneaky hunt."
         ],
@@ -693,7 +693,7 @@
         "exp": 20,
         "success_text": [
             "They're interrupted by Twolegs wandering through the woods a couple times, so they miss a couple catches, but overall it works out.",
-            "A friendly Twolegs makes a psspsspss noise, and pours kittypet food on the ground for app1. They've always wondered what it might taste like… dry, is the answer. It's strangely appealing.",
+            "A friendly Twolegs makes a psspsspss noise, and pours kittypet food on the ground for app1. They've always wondered what it might taste like... dry, is the answer. It's strangely appealing.",
             null,
             "Tail lashing excitedly, app1 hunts in the strange, forbidden land, ducking around corners and crawling over gardens with their belly low to the ground. A successful, sneaky hunt."
         ],

--- a/resources/dicts/patrols/training/training_desert.json
+++ b/resources/dicts/patrols/training/training_desert.json
@@ -48,7 +48,7 @@
 			"training"
 		],
 		"intro_text":"r_c wanders past an old badger sett overlooking a dried up riverbed, only to freeze. There's new scent here, acrid and sour.",
-		"decline_text":"Surely it must be nothing… uneasily, r_c continues on.",
+		"decline_text":"Surely it must be nothing... uneasily, r_c continues on.",
 		"chance_of_success":40,
 		"exp":30,
 		"success_text":[
@@ -110,7 +110,7 @@
 			"training"
 		],
 		"intro_text":"p_l wanders past an old badger sett overlooking a dried up riverbed, only to freeze. There's new scent here, acrid and sour.",
-		"decline_text":"Surely it must be nothing… uneasily, the patrol continues on.",
+		"decline_text":"Surely it must be nothing... uneasily, the patrol continues on.",
 		"chance_of_success":40,
 		"exp":30,
 		"success_text":[

--- a/resources/dicts/thoughts/other.json
+++ b/resources/dicts/thoughts/other.json
@@ -205,7 +205,7 @@
             "Is saddened by the fact that they can't tell stories to anyone.",
             "Misses the kits stumbling around and bothering them.",
             "Is feeling weary and tired, wondering if there even is a point to carry on.",
-            "Prays that they will see their friends again, in this world or StarClan…",
+            "Prays that they will see their friends again, in this world or StarClan...",
             "Their aches and pain make them unable to hunt",
             "Feels the cold seep and settle into their old bones",
             "Is unable to remember what herbs to look out for to ease their pain",

--- a/scripts/cat/thoughts.py
+++ b/scripts/cat/thoughts.py
@@ -623,23 +623,23 @@ def get_outside_thoughts(cat, other_cat):
 resource_directory = "resources/dicts/thoughts/"
 
 GENERAL_DEAD = None
-with open(f"{resource_directory}cat_dead_general.json", 'r') as read_file:
+with open(f"{resource_directory}cat_dead_general.json", 'r', encoding='ascii') as read_file:
     GENERAL_DEAD = ujson.loads(read_file.read())
 
 GENERAL_ALIVE = None
-with open(f"{resource_directory}cat_alive_general.json", 'r') as read_file:
+with open(f"{resource_directory}cat_alive_general.json", 'r', encoding='ascii') as read_file:
     GENERAL_ALIVE = ujson.loads(read_file.read())
     
 EXILE = None
-with open(f"{resource_directory}exile.json", 'r') as read_file:
+with open(f"{resource_directory}exile.json", 'r', encoding='ascii') as read_file:
     EXILE = ujson.loads(read_file.read())
     
 OUTSIDE = None
-with open(f"{resource_directory}other.json", 'r') as read_file:
+with open(f"{resource_directory}other.json", 'r', encoding='ascii') as read_file:
     OUTSIDE = ujson.loads(read_file.read())
 
 FAMILY = None
-with open(f"{resource_directory}family.json", 'r') as read_file:
+with open(f"{resource_directory}family.json", 'r', encoding='ascii') as read_file:
     FAMILY = ujson.loads(read_file.read())
 
 # ---------------------------------------------------------------------------- #
@@ -687,33 +687,33 @@ with open(f"{resource_directory}{in_depth_path}elder_to_other.json", 'r') as rea
 traits_path = "traits/"
 
 KITTEN_TRAITS = None
-with open(f"{resource_directory}{traits_path}kitten.json", 'r') as read_file:
+with open(f"{resource_directory}{traits_path}kitten.json", 'r', encoding='ascii') as read_file:
     KITTEN_TRAITS = ujson.loads(read_file.read())
 
 APPR_TRAITS = None
-with open(f"{resource_directory}{traits_path}apprentice.json", 'r') as read_file:
+with open(f"{resource_directory}{traits_path}apprentice.json", 'r', encoding='ascii') as read_file:
     APPR_TRAITS = ujson.loads(read_file.read())
 
 MED_APPR_TRAITS = None
-with open(f"{resource_directory}{traits_path}med_apprentice.json", 'r') as read_file:
+with open(f"{resource_directory}{traits_path}med_apprentice.json", 'r', encoding='ascii') as read_file:
     MED_APPR_TRAITS = ujson.loads(read_file.read())
 
 WARRIOR_TRAITS = None
-with open(f"{resource_directory}{traits_path}warrior.json", 'r') as read_file:
+with open(f"{resource_directory}{traits_path}warrior.json", 'r', encoding='ascii') as read_file:
     WARRIOR_TRAITS = ujson.loads(read_file.read())
 
 MEDICINE_TRAITS = None
-with open(f"{resource_directory}{traits_path}medicine.json", 'r') as read_file:
+with open(f"{resource_directory}{traits_path}medicine.json", 'r', encoding='ascii') as read_file:
     MEDICINE_TRAITS = ujson.loads(read_file.read())
 
 DEPUTY_TRAITS = None
-with open(f"{resource_directory}{traits_path}deputy.json", 'r') as read_file:
+with open(f"{resource_directory}{traits_path}deputy.json", 'r', encoding='ascii') as read_file:
     DEPUTY_TRAITS = ujson.loads(read_file.read())
 
 LEADER_TRAITS = None
-with open(f"{resource_directory}{traits_path}leader.json", 'r') as read_file:
+with open(f"{resource_directory}{traits_path}leader.json", 'r', encoding='ascii') as read_file:
     LEADER_TRAITS = ujson.loads(read_file.read())
 
 ELDER_TRAITS = None
-with open(f"{resource_directory}{traits_path}elder.json", 'r') as read_file:
+with open(f"{resource_directory}{traits_path}elder.json", 'r', encoding='ascii') as read_file:
     ELDER_TRAITS = ujson.loads(read_file.read())

--- a/scripts/patrol.py
+++ b/scripts/patrol.py
@@ -1449,117 +1449,117 @@ med_directory = "med/"
 
 # HUNTING #
 HUNTING = None
-with open(f"{resource_directory}{hunting_directory}hunting.json", 'r') as read_file:
+with open(f"{resource_directory}{hunting_directory}hunting.json", 'r', encoding='ascii') as read_file:
     HUNTING = ujson.loads(read_file.read())
 
 HUNTING_FST = None
-with open(f"{resource_directory}{hunting_directory}hunting_forest.json", 'r') as read_file:
+with open(f"{resource_directory}{hunting_directory}hunting_forest.json", 'r', encoding='ascii') as read_file:
     HUNTING_FST = ujson.loads(read_file.read())
 
 HUNTING_PLN = None
-with open(f"{resource_directory}{hunting_directory}hunting_plains.json", 'r') as read_file:
+with open(f"{resource_directory}{hunting_directory}hunting_plains.json", 'r', encoding='ascii') as read_file:
     HUNTING_PLN = ujson.loads(read_file.read())
 
 HUNTING_MTN = None
-with open(f"{resource_directory}{hunting_directory}hunting_mountains.json", 'r') as read_file:
+with open(f"{resource_directory}{hunting_directory}hunting_mountains.json", 'r', encoding='ascii') as read_file:
     HUNTING_MTN = ujson.loads(read_file.read())
 
 HUNTING_BCH = None
-with open(f"{resource_directory}{hunting_directory}hunting_beach.json", 'r') as read_file:
+with open(f"{resource_directory}{hunting_directory}hunting_beach.json", 'r', encoding='ascii') as read_file:
     HUNTING_BCH = ujson.loads(read_file.read())
 
 HUNTING_WTLND = None
-with open(f"{resource_directory}{hunting_directory}hunting_wetlands.json", 'r') as read_file:
+with open(f"{resource_directory}{hunting_directory}hunting_wetlands.json", 'r', encoding='ascii') as read_file:
     HUNTING_WTLND = ujson.loads(read_file.read())
 
 # BORDER #
 BORDER = None
-with open(f"{resource_directory}{border_directory}border.json", 'r') as read_file:
+with open(f"{resource_directory}{border_directory}border.json", 'r', encoding='ascii') as read_file:
     BORDER = ujson.loads(read_file.read())
 
 BORDER_FST = None
-with open(f"{resource_directory}{border_directory}border_forest.json", 'r') as read_file:
+with open(f"{resource_directory}{border_directory}border_forest.json", 'r', encoding='ascii') as read_file:
     BORDER_FST = ujson.loads(read_file.read())
 
 BORDER_PLN = None
-with open(f"{resource_directory}{border_directory}border_plains.json", 'r') as read_file:
+with open(f"{resource_directory}{border_directory}border_plains.json", 'r', encoding='ascii') as read_file:
     BORDER_PLN = ujson.loads(read_file.read())
 
 BORDER_MTN = None
-with open(f"{resource_directory}{border_directory}border_mountains.json", 'r') as read_file:
+with open(f"{resource_directory}{border_directory}border_mountains.json", 'r', encoding='ascii') as read_file:
     BORDER_MTN = ujson.loads(read_file.read())
 
 BORDER_BCH = None
-with open(f"{resource_directory}{border_directory}border_beach.json", 'r') as read_file:
+with open(f"{resource_directory}{border_directory}border_beach.json", 'r', encoding='ascii') as read_file:
     BORDER_BCH = ujson.loads(read_file.read())
 
 # TRAINING #
 TRAINING = None
-with open(f"{resource_directory}{training_directory}training.json", 'r') as read_file:
+with open(f"{resource_directory}{training_directory}training.json", 'r', encoding='ascii') as read_file:
     TRAINING = ujson.loads(read_file.read())
 
 TRAINING_FST = None
-with open(f"{resource_directory}{training_directory}training_forest.json", 'r') as read_file:
+with open(f"{resource_directory}{training_directory}training_forest.json", 'r', encoding='ascii') as read_file:
     TRAINING_FST = ujson.loads(read_file.read())
 
 TRAINING_PLN = None
-with open(f"{resource_directory}{training_directory}training_plains.json", 'r') as read_file:
+with open(f"{resource_directory}{training_directory}training_plains.json", 'r', encoding='ascii') as read_file:
     TRAINING_PLN = ujson.loads(read_file.read())
 
 TRAINING_MTN = None
-with open(f"{resource_directory}{training_directory}training_mountains.json", 'r') as read_file:
+with open(f"{resource_directory}{training_directory}training_mountains.json", 'r', encoding='ascii') as read_file:
     TRAINING_MTN = ujson.loads(read_file.read())
 
 TRAINING_BCH = None
-with open(f"{resource_directory}{training_directory}training_beach.json", 'r') as read_file:
+with open(f"{resource_directory}{training_directory}training_beach.json", 'r', encoding='ascii') as read_file:
     TRAINING_BCH = ujson.loads(read_file.read())
 
 # MED CAT #
 
 MEDCAT = None
-with open(f"{resource_directory}{med_directory}medcat.json", 'r') as read_file:
+with open(f"{resource_directory}{med_directory}medcat.json", 'r', encoding='ascii') as read_file:
     MEDCAT = ujson.loads(read_file.read())
 
 MEDCAT_FST = None
-with open(f"{resource_directory}{med_directory}medcat_forest.json", 'r') as read_file:
+with open(f"{resource_directory}{med_directory}medcat_forest.json", 'r', encoding='ascii') as read_file:
     MEDCAT_FST = ujson.loads(read_file.read())
 
 MEDCAT_PLN = None
-with open(f"{resource_directory}{med_directory}medcat_plains.json", 'r') as read_file:
+with open(f"{resource_directory}{med_directory}medcat_plains.json", 'r', encoding='ascii') as read_file:
     MEDCAT_PLN = ujson.loads(read_file.read())
 
 MEDCAT_MTN = None
-with open(f"{resource_directory}{med_directory}medcat_mountains.json", 'r') as read_file:
+with open(f"{resource_directory}{med_directory}medcat_mountains.json", 'r', encoding='ascii') as read_file:
     MEDCAT_MTN = ujson.loads(read_file.read())
 
 MEDCAT_BCH = None
-with open(f"{resource_directory}{med_directory}medcat_beach.json", 'r') as read_file:
+with open(f"{resource_directory}{med_directory}medcat_beach.json", 'r', encoding='ascii') as read_file:
     MEDCAT_BCH = ujson.loads(read_file.read())
 
 # NEW CAT #
 NEW_CAT = None
-with open(f"{resource_directory}new_cat.json", 'r') as read_file:
+with open(f"{resource_directory}new_cat.json", 'r', encoding='ascii') as read_file:
     NEW_CAT = ujson.loads(read_file.read())
 
 NEW_CAT_HOSTILE = None
-with open(f"{resource_directory}new_cat_hostile.json", 'r') as read_file:
+with open(f"{resource_directory}new_cat_hostile.json", 'r', encoding='ascii') as read_file:
     NEW_CAT_HOSTILE = ujson.loads(read_file.read())
 
 NEW_CAT_WELCOMING = None
-with open(f"{resource_directory}new_cat_welcoming.json", 'r') as read_file:
+with open(f"{resource_directory}new_cat_welcoming.json", 'r', encoding='ascii') as read_file:
     NEW_CAT_WELCOMING = ujson.loads(read_file.read())
 
 # OTHER CLAN #
 OTHER_CLAN = None
-with open(f"{resource_directory}other_clan.json", 'r') as read_file:
+with open(f"{resource_directory}other_clan.json", 'r', encoding='ascii') as read_file:
     OTHER_CLAN = ujson.loads(read_file.read())
 
 OTHER_CLAN_ALLIES = None
-with open(f"{resource_directory}other_clan_allies.json", 'r') as read_file:
+with open(f"{resource_directory}other_clan_allies.json", 'r', encoding='ascii') as read_file:
     OTHER_CLAN_ALLIES = ujson.loads(read_file.read())
 
 OTHER_CLAN_HOSTILE = None
-with open(f"{resource_directory}other_clan_hostile.json", 'r') as read_file:
+with open(f"{resource_directory}other_clan_hostile.json", 'r', encoding='ascii') as read_file:
     OTHER_CLAN_HOSTILE = ujson.loads(read_file.read())
 
 # ---------------------------------------------------------------------------- #
@@ -1567,5 +1567,5 @@ with open(f"{resource_directory}other_clan_hostile.json", 'r') as read_file:
 # ---------------------------------------------------------------------------- #
 
 DISASTER = None
-with open(f"{resource_directory}disaster.json", 'r') as read_file:
+with open(f"{resource_directory}disaster.json", 'r', encoding='ascii') as read_file:
     DISASTER = ujson.loads(read_file.read())


### PR DESCRIPTION
Prevents utf-8 characters from accidentally being included, since it'll always raise an exception. If the file encoding isn't explicitly stated, it's system/locale dependent, possibly causing an UnicodeDecodeError only on some systems when the chosen encoding can't decode a character:
```
  File "clangen/scripts/cat/thoughts.py", line 639, in <module>
    OUTSIDE = ujson.loads(read_file.read())
UnicodeDecodeError: 'cp949' codec can't decode byte 0xe2 in position 9958: illegal multibyte sequence
```

This pr also replaces the few remaining utf-8 characters, all json files in resources are ascii now as far as I can tell: https://bin.0xfc.de/?11951f232a554847#DVvadmU5WZTTYzMNEupYuT95BRr8sJMKXc1ZAffGePus

Guessing 2c1adffb1f20406e1ad7ea1e817e7095346a653f is related and was presumably meant to fix this issue in ``resources/dicts/thoughts/other.json``.