### PR TITLE
Bugfixes: Misc

### DIFF
--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -813,10 +813,9 @@ class Cat():
         self.update_traits()
         self.in_camp = 1
 
-        if self.moons < 12:
+        if self.status in ['apprentice', 'medicine cat apprentice']:
             self.update_mentor()
-
-        if self.moons >= 12:
+        else:
             self.update_skill()
 
         self.create_interaction()
@@ -1435,6 +1434,8 @@ class Cat():
     def retire_cat(self):
         self.retired = True
         self.status = 'elder'
+        self.name.status = 'elder'
+        self.update_mentor()
 
     def additional_injury(self, injury):
         self.get_injured(injury, event_triggered=True)
@@ -1741,8 +1742,8 @@ class Cat():
         else:
             self.mentor = None
 
-        # append and remove from lists if the app has aged up to warrior
-        if self.status == 'warrior' or self.dead:
+        # append and remove from lists if the app has aged up to warrior, or become an elder
+        if self.status in ['warrior', 'elder'] or self.dead:
             # app has graduated, no mentor needed anymore
             self.mentor = None
             # append and remove

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -208,33 +208,45 @@ class Events():
                     text = ''
                     if game.clan.deputy is not None and game.clan.leader is not None:
                         if game.clan.deputy.dead and not leader_dead and not leader_exiled:
-                            text = f"{game.clan.leader.name} chooses {Cat.all_cats[random_cat].name} to take over as deputy. They know that {game.clan.deputy.name} would approve."
+                            text = f"{game.clan.leader.name} chooses {Cat.all_cats[random_cat].name} to take over " \
+                                   f"as deputy. They know that {game.clan.deputy.name} would approve."
                             involved_cats.extend([game.clan.leader.ID, game.clan.deputy.ID])
                         if not game.clan.deputy.dead and not game.clan.deputy.outside:
-                            text = f"{Cat.all_cats[random_cat].name} has been chosen as the new deputy. The retired deputy nods their approval."
+                            text = f"{Cat.all_cats[random_cat].name} has been chosen as the new deputy. " \
+                                   f"The retired deputy nods their approval."
                             # No other cat are involved here.
                         if game.clan.deputy.outside:
-                            text = f"{Cat.all_cats[random_cat].name} has been chosen as the new deputy. The Clan hopes that {game.clan.deputy.name} would approve."
+                            text = f"{Cat.all_cats[random_cat].name} has been chosen as the new deputy. " \
+                                   f"The Clan hopes that {game.clan.deputy.name} would approve."
                             involved_cats.append(game.clan.deputy.ID)
                     elif leader_dead or leader_exiled:
                         if game.clan.leader:
-                            text = f"Since losing {game.clan.leader.name} the Clan has been directionless. They all turn to {Cat.all_cats[random_cat].name} with hope for the future."
+                            text = f"Since losing {game.clan.leader.name} the Clan has been directionless. " \
+                                   f"They all turn to {Cat.all_cats[random_cat].name} with hope for the future."
                             involved_cats.append(game.clan.leader.ID)
                         else:
-                            text = f"Without a leader, the Clan has been directionless. They all turn to {Cat.all_cats[random_cat].name} with hope for the future."
+                            text = f"Without a leader, the Clan has been directionless. " \
+                                   f"They all turn to {Cat.all_cats[random_cat].name} with hope for the future."
                             # No additional involved cats.
                     else:
                         if Cat.all_cats[random_cat].trait == 'bloodthirsty':
-                            text = f"{Cat.all_cats[random_cat].name} has been chosen as the new deputy. They look at the Clan leader with an odd glint in their eyes."
+                            text = f"{Cat.all_cats[random_cat].name} has been chosen as the new deputy. " \
+                                   f"They look at the Clan leader with an odd glint in their eyes."
                             # No additional involved cats
 
                         else:
                             possible_events = [
-                                f"{Cat.all_cats[random_cat].name} has been chosen as the new deputy. The Clan yowls their name in approval.",
-                                f"{Cat.all_cats[random_cat].name} has been chosen as the new deputy. Some of the older Clan members question the wisdom in this choice.",
-                                f"{Cat.all_cats[random_cat].name} has been chosen as the new deputy. They hold their head up high and promise to do their best for the Clan.",
-                                f"{game.clan.leader.name} has been thinking deeply all day who they would respect and trust enough to stand at their side and at sunhigh makes the announcement that {Cat.all_cats[random_cat].name} will be the Clan's new deputy.",
-                                f"{Cat.all_cats[random_cat].name} has been chosen as the new deputy. They pray to StarClan that they are the right choice for the Clan.",
+                                f"{Cat.all_cats[random_cat].name} has been chosen as the new deputy. "
+                                f"The Clan yowls their name in approval.",
+                                f"{Cat.all_cats[random_cat].name} has been chosen as the new deputy. "
+                                f"Some of the older Clan members question the wisdom in this choice.",
+                                f"{Cat.all_cats[random_cat].name} has been chosen as the new deputy. "
+                                f"They hold their head up high and promise to do their best for the Clan.",
+                                f"{game.clan.leader.name} has been thinking deeply all day who they would "
+                                f"respect and trust enough to stand at their side and at sunhigh makes the "
+                                f"announcement that {Cat.all_cats[random_cat].name} will be the Clan's new deputy.",
+                                f"{Cat.all_cats[random_cat].name} has been chosen as the new deputy. They pray to "
+                                f"StarClan that they are the right choice for the Clan.",
                             ]
                             # No additional involved cats
                             text = choice(possible_events)

--- a/scripts/events_module/condition_events.py
+++ b/scripts/events_module/condition_events.py
@@ -745,10 +745,6 @@ class Condition_Events():
                 if dictionary != cat.permanent_condition:
                     risk["chance"] = risk["chance"] + 10  # lower risk of getting it again if not a perm condition
 
-                # if it is a progressive illness, then remove the old illness and keep the new one
-                if condition in progression and new_condition_name == progression.get(condition):
-                    dictionary.pop(condition)
-
                 # gather potential event strings for gotten illness
                 if dictionary == cat.illnesses:
                     possible_string_list = ILLNESS_RISK_STRINGS[condition][new_condition_name]
@@ -756,6 +752,13 @@ class Condition_Events():
                     possible_string_list = INJURY_RISK_STRINGS[condition][new_condition_name]
                 else:
                     possible_string_list = PERM_CONDITION_RISK_STRINGS[condition][new_condition_name]
+
+                # if it is a progressive illness, then remove the old illness and keep the new one
+                if condition in progression and new_condition_name == progression.get(condition):
+                    removed_condition = True
+                    dictionary.pop(condition)
+                else:
+                    removed_condition = False
 
                 # choose event string and ensure clan's med cat number aligns with event text
                 random_index = int(random.random() * len(possible_string_list))
@@ -779,7 +782,7 @@ class Condition_Events():
                     break
                 elif new_condition_name in ILLNESSES:
                     cat.get_ill(new_condition_name, event_triggered=event_triggered)
-                    if dictionary == cat.illnesses:
+                    if dictionary == cat.illnesses or removed_condition:
                         break
                     keys = dictionary[condition].keys()
                     complication = None

--- a/scripts/events_module/condition_events.py
+++ b/scripts/events_module/condition_events.py
@@ -569,6 +569,7 @@ class Condition_Events():
         Returns: boolean (if something happened) and the event_string
         """
         triggered = False
+        event_types = ["health"]
 
         if game.clan.game_mode == "classic":
             return triggered
@@ -608,6 +609,7 @@ class Condition_Events():
 
             elif cat.dead:
                 triggered = True
+                event_types.append("birth_death")
 
                 event = f"{cat.name} died from complications caused by {condition}."
                 event_list.append(event)
@@ -673,41 +675,60 @@ class Condition_Events():
             'elder': 0
         }
 
-        if not triggered and not cat.dead and not cat.retired and cat.status not in ['leader', 'medicine cat',
-                                                                                     'kitten'] and game.settings[
-            'retirement'] is False:
+        if not triggered and not cat.dead and not cat.retired and cat.status not in \
+                ['leader', 'medicine cat', 'kitten'] and game.settings['retirement'] is False:
             for condition in cat.permanent_condition:
                 if cat.permanent_condition[condition]['severity'] == 'major':
                     chance = int(retire_chances.get(cat.age))
                     if not int(random.random() * chance):
-                        cat.retire_cat()
+                        event_types.append('ceremony')
                         if game.clan.leader is not None:
-                            if not game.clan.leader.dead and not game.clan.leader.exiled and not game.clan.leader.outside:
-                                event = f"{game.clan.leader.name}, seeing {cat.name} struggling the last few moons approaches them and promises them that no one would think less of them for retiring early and that they would still be a valuable member of the clan as an elder. {cat.name} agrees and later that day their elder ceremony is held."
+                            if not game.clan.leader.dead and not game.clan.leader.exiled and \
+                                    not game.clan.leader.outside:
+                                event = f"{game.clan.leader.name}, seeing {cat.name} struggling the last few moons " \
+                                        f"approaches them and promises them that no one would think less of them for " \
+                                        f"retiring early and that they would still be a valuable member of the clan " \
+                                        f"as an elder. {cat.name} agrees and later that day their elder ceremony " \
+                                        f"is held."
                             else:
                                 event = f'{cat.name} has decided to retire from normal Clan duty.'
                         else:
                             event = f'{cat.name} has decided to retire from normal Clan duty.'
+
+                        if cat.age == 'adolescent':
+                            event += f"They are given the name {cat.name.prefix}{cat.name.suffix} in honor " \
+                                     f"of their contributions to {game.clan.name}Clan."
+
+                        cat.retire_cat()
+                        game.ranks_changed_timeskip = True
                         event_list.append(event)
 
                 if cat.permanent_condition[condition]['severity'] == 'severe':
-                    cat.retire_cat()
+                    event_types.append('ceremony')
                     if game.clan.leader is not None:
-                            if not game.clan.leader.dead and not game.clan.leader.exiled and not game.clan.leader.outside:
-                                event = f"{game.clan.leader.name}, seeing {cat.name} struggling the last few moons approaches them and promises them that no one would think less of them for retiring early and that they would still be a valuable member of the clan as an elder. {cat.name} agrees and later that day their elder ceremony is held."
-                            else:
-                                event = f'{cat.name} has decided to retire from normal Clan duty.'
+                        if not game.clan.leader.dead and not game.clan.leader.exiled \
+                                and not game.clan.leader.outside:
+                            event = f"{game.clan.leader.name}, seeing {cat.name} struggling the last few moons " \
+                                    f"approaches them and promises them that no one would think less of them for " \
+                                    f"retiring early and that they would still be a valuable member of the clan " \
+                                    f"as an elder. {cat.name} agrees and later that day their elder ceremony " \
+                                    f"is held."
+                        else:
+                            event = f'{cat.name} has decided to retire from normal Clan duty.'
                     else:
                         event = f'{cat.name} has decided to retire from normal Clan duty.'
+
+                    if cat.age == 'adolescent':
+                        event += f"They are given the name {cat.name.prefix}{cat.name.suffix} in honor " \
+                                 f"of their contributions to {game.clan.name}Clan."
+
+                    cat.retire_cat()
+                    game.ranks_changed_timeskip = True
                     event_list.append(event)
 
         if len(event_list) > 0:
             event_string = ' '.join(event_list)
-            types = ["health"]
-            if cat.dead:
-                types.append("birth_death")
-
-            game.cur_events_list.append(Single_Event(event_string, types, cat.ID))
+            game.cur_events_list.append(Single_Event(event_string, event_types, cat.ID))
         return
 
     def give_risks(self, cat, event_list, condition, progression, conditions, dictionary):

--- a/scripts/screens/clan_creation_screens.py
+++ b/scripts/screens/clan_creation_screens.py
@@ -6,7 +6,7 @@ from .base_screens import Screens
 
 from scripts.utility import get_text_box_theme
 from scripts.clan import Clan, map_available
-from scripts.cat.cats import create_example_cats
+from scripts.cat.cats import create_example_cats, Cat
 from scripts.cat.names import names
 from scripts.cat.sprites import tiles
 from re import sub
@@ -859,6 +859,7 @@ class MakeClanScreen(Screens):
                          game.switches['camp_site'], convert_camp[self.selected_camp_tab],
                          self.game_mode, self.members)
         game.clan.create_clan()
+        Cat.sort_cats()
         if map_available:
             territory_claim = str(game.clan.name) + 'Clan Territory'
             otherclan_campsite = {}

--- a/scripts/screens/relation_screens.py
+++ b/scripts/screens/relation_screens.py
@@ -1274,19 +1274,19 @@ class ChooseMateScreen(Screens):
             self.previous_cat = game.clan.instructor.ID
 
         if is_instructor:
-            next_cat = 1
+            self.next_cat = 1
 
         for check_cat in Cat.all_cats_list:
             if check_cat.ID == self.the_cat.ID:
                 self.next_cat = 1
             if self.next_cat == 0 and check_cat.ID != self.the_cat.ID and check_cat.dead == self.the_cat.dead and \
-                    check_cat.ID != game.clan.instructor.ID and not check_cat.exiled and check_cat.status not in \
-                    ['apprentice', 'medicine cat apprentice', 'kitten'] and check_cat.df == self.the_cat.df:
+                    check_cat.ID != game.clan.instructor.ID and not check_cat.exiled and check_cat.age not in \
+                    ["adolescent", "kitten"] and check_cat.df == self.the_cat.df:
                 self.previous_cat = check_cat.ID
 
             elif self.next_cat == 1 and check_cat.ID != self.the_cat.ID and check_cat.dead == self.the_cat.dead and \
-                    check_cat.ID != game.clan.instructor.ID and not check_cat.exiled and check_cat.status not in \
-                    ['apprentice', 'medicine cat apprentice', 'kitten'] and check_cat.df == self.the_cat.df:
+                    check_cat.ID != game.clan.instructor.ID and not check_cat.exiled and check_cat.age not in \
+                    ["adolescent", "kitten"] and check_cat.df == self.the_cat.df:
                 self.next_cat = check_cat.ID
 
             elif int(self.next_cat) > 1:


### PR DESCRIPTION
- Fix crash with poisoned cats
- You can no longer give retired adolescents mates
- Cats that retire as apprentices due to health conditions will now have their mentors properly removed, and will be given a full name.
- Cat in new clans are now properly sorted.