### PR TITLE
QOL: Option to Disable First-Cousin Relationships.

### DIFF
--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -1212,6 +1212,18 @@ class Cat():
             return True
         return False
 
+    def is_cousin(self, other_cat):
+        grandparent_id = []
+        for parent in other_cat.get_parents():
+            parent_ob = Cat.fetch_cat(parent)
+            grandparent_id.extend(parent_ob.get_parents())
+        for parent in self.get_parents():
+            parent_ob = Cat.fetch_cat(parent)
+            if set(parent_ob.get_parents()) & set(grandparent_id):
+                return True
+        return False
+
+
 # ---------------------------------------------------------------------------- #
 #                                  conditions                                  #
 # ---------------------------------------------------------------------------- #
@@ -1840,6 +1852,7 @@ class Cat():
                 if self.parent1:
                     if self.is_sibling(other_cat) or other_cat.is_sibling(self):
                         return False
+
             # Check for relation via self's parents (parent/grandparent)
             if self.parent1:
                 if other_cat.is_grandparent(self) or other_cat.is_parent(self):
@@ -1848,6 +1861,12 @@ class Cat():
                 if other_cat.siblings:
                     if other_cat.is_uncle_aunt(self):
                         return False
+
+            # Only need to check one.
+            if not game.settings['first_cousin_mates']:
+                if self.is_cousin(other_cat):
+                    return False
+
         else:
             if self.is_sibling(other_cat) or other_cat.is_sibling(self):
                         return False
@@ -1910,6 +1929,10 @@ class Cat():
                 if other_cat.siblings:
                     if other_cat.is_uncle_aunt(self):
                         return False
+            if not game.settings['first_cousin_mates']:
+                if self.is_cousin(other_cat):
+                    return False
+
         else:
             if self.is_sibling(other_cat) or other_cat.is_sibling(self):
                         return False

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -1921,6 +1921,7 @@ class Cat():
                 if self.parent1:
                     if self.is_sibling(other_cat) or other_cat.is_sibling(self):
                         return False
+
             # Check for relation via self's parents (parent/grandparent)
             if self.parent1:
                 if other_cat.is_grandparent(self) or other_cat.is_parent(self):
@@ -1929,6 +1930,7 @@ class Cat():
                 if other_cat.siblings:
                     if other_cat.is_uncle_aunt(self):
                         return False
+
             if not game.settings['first_cousin_mates']:
                 if self.is_cousin(other_cat):
                     return False

--- a/scripts/game_structure/game_essentials.py
+++ b/scripts/game_structure/game_essentials.py
@@ -168,7 +168,8 @@ class Game():
         'den labels': True,
         'fading': True,
         "save_faded_copy": False,
-        'favorite sub tab': None
+        'favorite sub tab': None,
+        'first_cousin_mates': True
     }  # The current settings
     setting_lists = {
         'no gendered breeding': [False, True],
@@ -192,7 +193,8 @@ class Game():
         'den labels': [False, True],
         'favorite sub tab': sub_tab_list,
         'fading': [True, False],
-        'save_faded_copy': [False, True]
+        'save_faded_copy': [False, True],
+        'first_cousin_mates': [True, False]
     }  # Lists of possible options for each setting
     settings_changed = False
 

--- a/scripts/screens/organizational_screens.py
+++ b/scripts/screens/organizational_screens.py
@@ -281,6 +281,11 @@ class SettingsScreen(Screens):
             self.settings_changed = True
             self.update_save_button()
             self.refresh_checkboxes()
+        elif event.ui_element == self.checkboxes['first_cousin_mates']:
+            game.switch_setting('first_cousin_mates')
+            self.settings_changed = True
+            self.update_save_button()
+            self.refresh_checkboxes()
 
     def handle_general_events(self, event):
         if event.ui_element == self.checkboxes['dark mode']:
@@ -531,6 +536,10 @@ class SettingsScreen(Screens):
             "Allow romantic interactions with former apprentices/mentor",
             pygame.Rect((x_value, 376), (500, 50)), object_id=get_text_box_theme("#setting_text_box")
         )
+        self.checkboxes_text['first_cousin_mates'] = pygame_gui.elements.UITextBox(
+            "Allow romantic interactions with first cousins",
+            pygame.Rect((x_value, 415), (500, 50)), object_id=get_text_box_theme("#setting_text_box")
+        )
 
         self.checkboxes_text['instr'] = pygame_gui.elements.UITextBox(
             "Change the relationship settings of your game here",
@@ -770,6 +779,14 @@ class SettingsScreen(Screens):
                 box_type = "#unchecked_checkbox"
             self.checkboxes['romantic with former mentor'] = UIImageButton(pygame.Rect((x_value, 376), (34, 34)), "",
                                                                            object_id=box_type)
+            # Allow romantic interations with first cousins:
+            if game.settings['first_cousin_mates']:
+                box_type = "#checked_checkbox"
+            else:
+                box_type = "#unchecked_checkbox"
+            self.checkboxes['first_cousin_mates'] = UIImageButton(pygame.Rect((x_value, 415), (34, 34)), "",
+                                                                           object_id=box_type)
+
 
         # CHECKBOXES (ehhh) FOR LANGUAGES
         elif self.sub_menu == 'language':

--- a/scripts/screens/relation_screens.py
+++ b/scripts/screens/relation_screens.py
@@ -1309,7 +1309,23 @@ class ChooseMateScreen(Screens):
         """Get a list of valid mates for the current cat"""
         valid_mates = []
         for relevant_cat in Cat.all_cats_list:
-            if relevant_cat.is_potential_mate(self.the_cat):
+            invalid_age = relevant_cat.age not in ['kitten', 'adolescent']
+
+            # cat.is_potential_mate() is not used here becuase that restricts to the same age catagory, which we
+            # don't want here.
+            direct_related = self.the_cat.is_sibling(relevant_cat) or self.the_cat.is_parent(relevant_cat) \
+                             or relevant_cat.is_parent(self.the_cat)
+            indirect_related = self.the_cat.is_uncle_aunt(relevant_cat) or relevant_cat.is_uncle_aunt(self.the_cat)
+
+            if not game.settings["first_cousin_mates"]:
+                indirect_related = indirect_related or relevant_cat.is_cousin(self.the_cat)
+
+            related = direct_related or indirect_related
+
+            not_available = relevant_cat.dead or relevant_cat.outside
+
+            if not related and relevant_cat.ID != self.the_cat.ID and invalid_age \
+                    and not not_available and relevant_cat.mate is None:
                 valid_mates.append(relevant_cat)
 
         return valid_mates

--- a/scripts/screens/relation_screens.py
+++ b/scripts/screens/relation_screens.py
@@ -1309,17 +1309,7 @@ class ChooseMateScreen(Screens):
         """Get a list of valid mates for the current cat"""
         valid_mates = []
         for relevant_cat in Cat.all_cats_list:
-            invalid_age = relevant_cat.age not in ['kitten', 'adolescent']
-
-            direct_related = self.the_cat.is_sibling(relevant_cat) or self.the_cat.is_parent(relevant_cat) \
-                             or relevant_cat.is_parent(self.the_cat)
-            indirect_related = self.the_cat.is_uncle_aunt(relevant_cat) or relevant_cat.is_uncle_aunt(self.the_cat)
-            related = direct_related or indirect_related
-
-            not_available = relevant_cat.dead or relevant_cat.outside
-
-            if not related and relevant_cat.ID != self.the_cat.ID and invalid_age \
-                    and not not_available and relevant_cat.mate is None:
+            if relevant_cat.is_potential_mate(self.the_cat):
                 valid_mates.append(relevant_cat)
 
         return valid_mates


### PR DESCRIPTION
- Added a relationship option is disable first-cousin relationships.  I know there are players that really don't want first-cousins having romantic interaction, and this allows those players to have the game auto-restrict those relationships. From my testings, it does not effect performance. 