### PR TITLE
Other: Clarify Settings Text

### DIFF
--- a/scripts/screens/organizational_screens.py
+++ b/scripts/screens/organizational_screens.py
@@ -537,7 +537,7 @@ class SettingsScreen(Screens):
             pygame.Rect((x_value, 376), (500, 50)), object_id=get_text_box_theme("#setting_text_box")
         )
         self.checkboxes_text['first_cousin_mates'] = pygame_gui.elements.UITextBox(
-            "Allow first cousins to become mates have romantic interactions",
+            "Allow first cousins to become mates/have romantic interactions",
             pygame.Rect((x_value, 415), (500, 50)), object_id=get_text_box_theme("#setting_text_box")
         )
 

--- a/scripts/screens/organizational_screens.py
+++ b/scripts/screens/organizational_screens.py
@@ -537,7 +537,7 @@ class SettingsScreen(Screens):
             pygame.Rect((x_value, 376), (500, 50)), object_id=get_text_box_theme("#setting_text_box")
         )
         self.checkboxes_text['first_cousin_mates'] = pygame_gui.elements.UITextBox(
-            "Allow romantic interactions with first cousins",
+            "Allow first cousins to become mates have romantic interactions",
             pygame.Rect((x_value, 415), (500, 50)), object_id=get_text_box_theme("#setting_text_box")
         )
 


### PR DESCRIPTION
I released the setting text for the first cousins settings my have been vague. It has the same wording as "Allow romantic interactions between former apprentices/mentor", but the behavior is slightly different, since it also disallows you from selected them as mates in the ChooseMate Screen. 