### PR TITLE
Bugfix/Other: Misc

### DIFF
--- a/scripts/events_module/condition_events.py
+++ b/scripts/events_module/condition_events.py
@@ -676,7 +676,7 @@ class Condition_Events():
         }
 
         if not triggered and not cat.dead and not cat.retired and cat.status not in \
-                ['leader', 'medicine cat', 'kitten'] and game.settings['retirement'] is False:
+                ['leader', 'medicine cat', 'kitten', 'medicine cat apprentice'] and game.settings['retirement'] is False:
             for condition in cat.permanent_condition:
                 if cat.permanent_condition[condition]['severity'] == 'major':
                     chance = int(retire_chances.get(cat.age))

--- a/scripts/events_module/relation_events.py
+++ b/scripts/events_module/relation_events.py
@@ -313,7 +313,7 @@ class Relation_Events():
         no_hit = int(random.random() * chance)
         if no_hit:
             return
-        print("A KIT IS BORN")
+        # print("A KIT IS BORN")
 
         # even with no_gendered_breeding on a male cat with no second parent should not be count as pregnant
         # instead, the cat should get the kit instantly
@@ -768,7 +768,7 @@ class Relation_Events():
         if chance > 20 > living_cats:
             chance -= 10
 
-        print("CHANCE", chance)
+        # print("CHANCE", chance)
         return chance
 
     def get_affair_chance(self, mate_relation, affair_relation):

--- a/scripts/game_structure/load_cat.py
+++ b/scripts/game_structure/load_cat.py
@@ -179,11 +179,20 @@ def json_load():
             filter(lambda inter_cat: cat.is_sibling(inter_cat), all_cats))
         cat.siblings = [sibling.ID for sibling in siblings]
 
+        # Add faded siblings:
+        for parent in cat.get_parents():
+            cat_ob = Cat.fetch_cat(parent)
+            cat.siblings.extend(cat_ob.faded_offspring)
+        # Remove duplicates
+        cat.siblings = list(set(cat.siblings))
+
         # get all the children ids and save them
         children = list(
             filter(lambda inter_cat: cat.is_parent(inter_cat), all_cats))
         cat.children = [child.ID for child in children]
 
+        # Add faded children
+        cat.children.extend(cat.faded_offspring)
 
         # initialization of thoughts
         cat.thoughts()

--- a/scripts/screens/patrol_screens.py
+++ b/scripts/screens/patrol_screens.py
@@ -266,6 +266,8 @@ class PatrolScreen(Screens):
                         self.elements['paw'].disable()
                     else:
                         text = 'herb gathering'
+                else:
+                    text = ""
 
                 self.elements['info'] = pygame_gui.elements.UITextBox(
                     text, pygame.Rect((250, 525), (300, 400)), object_id=get_text_box_theme()
@@ -786,8 +788,6 @@ class PatrolScreen(Screens):
         if self.selected_cat is not None:
             # Now, if the selected cat is not None, we rebuild everything with the correct cat info
             # Selected Cat Image
-            self.selected_apprentice_index = 0
-
             self.elements["selected_image"] = pygame_gui.elements.UIImage(pygame.Rect((320, 175), (150, 150)),
                                                                           self.selected_cat.large_sprite)
 
@@ -848,13 +848,15 @@ class PatrolScreen(Screens):
                     relation = 'mentor'
 
                 elif self.selected_cat.apprentice:
+                    if self.selected_apprentice_index > len(self.selected_cat.apprentice) - 1:
+                        self.selected_apprentice_index = 0
                     self.app_mentor = Cat.fetch_cat(self.selected_cat.apprentice[self.selected_apprentice_index])
                     relation = 'apprentice'
                 else:
                     self.app_mentor = None
                     self.elements['app_mentor_frame'].hide()
 
-                # Failsafe, if apprentice or mentor is set to none. It should never happen.
+                # Failsafe, if apprentice or mentor is set to none.
                 if self.app_mentor is not None:
                     name = str(self.app_mentor.name)  # get name
                     if 11 <= len(name):  # check name length

--- a/scripts/screens/relation_screens.py
+++ b/scripts/screens/relation_screens.py
@@ -1617,28 +1617,32 @@ class RelationshipScreen(Screens):
             self.inspect_cat_elements["image"] = pygame_gui.elements.UIImage(pygame.Rect((75, 145), (150, 150)),
                                                                              self.inspect_cat.large_sprite)
 
-            # Family Dot
-            # Only show family dot on cousins if first cousin mates are disabled.
-            if game.settings['first_cousin_mates']:
-                check_cousins = False
-            else:
-                check_cousins = self.inspect_cat.is_cousin(self.the_cat)
-
-            if self.inspect_cat.is_uncle_aunt(self.the_cat) or self.the_cat.is_uncle_aunt(self.inspect_cat) \
-                    or self.inspect_cat.is_grandparent(self.the_cat) or \
-                    self.the_cat.is_grandparent(self.inspect_cat) or \
-                    self.inspect_cat.is_parent(self.the_cat) or \
-                    self.the_cat.is_parent(self.inspect_cat) or \
-                    self.inspect_cat.is_sibling(self.the_cat) or check_cousins:
-                self.inspect_cat_elements['family'] = pygame_gui.elements.UIImage(pygame.Rect((45, 150), (18, 18)),
-                                                                                  image_cache.load_image(
-                                                                                      "resources/images/dot_big.png").convert_alpha())
-
+            related = False
             # Mate Heart
             if self.the_cat.mate is not None and self.the_cat.mate != '' and self.inspect_cat.ID == self.the_cat.mate:
                 self.inspect_cat_elements["mate"] = pygame_gui.elements.UIImage(pygame.Rect((45, 150), (22, 20)),
                                                                                 image_cache.load_image(
                                                                                     "resources/images/heart_big.png").convert_alpha())
+            else:
+                # Family Dot
+                # Only show family dot on cousins if first cousin mates are disabled.
+                if game.settings['first_cousin_mates']:
+                    check_cousins = False
+                else:
+                    check_cousins = self.inspect_cat.is_cousin(self.the_cat)
+
+                if self.inspect_cat.is_uncle_aunt(self.the_cat) or self.the_cat.is_uncle_aunt(self.inspect_cat) \
+                        or self.inspect_cat.is_grandparent(self.the_cat) or \
+                        self.the_cat.is_grandparent(self.inspect_cat) or \
+                        self.inspect_cat.is_parent(self.the_cat) or \
+                        self.the_cat.is_parent(self.inspect_cat) or \
+                        self.inspect_cat.is_sibling(self.the_cat) or check_cousins:
+                    related = True
+                    self.inspect_cat_elements['family'] = pygame_gui.elements.UIImage(pygame.Rect((45, 150), (18, 18)),
+                                                                                      image_cache.load_image(
+                                                                                          "resources/images/dot_big.png").convert_alpha())
+
+
 
             # Gender
             if self.inspect_cat.genderalign == 'female':
@@ -1683,32 +1687,33 @@ class RelationshipScreen(Screens):
                 col2 += "mate: none\n"
 
             # Relation info:
-            if self.the_cat.is_uncle_aunt(self.inspect_cat):
-                if self.inspect_cat.genderalign in ['female', 'trans female']:
-                    col2 += "related: niece"
-                elif self.inspect_cat.genderalign in ['male', 'trans male']:
-                    col2 += "related: nephew"
-                else:
-                    col2 += "related: sibling's child\n"
-            elif self.inspect_cat.is_uncle_aunt(self.the_cat):
-                if self.inspect_cat.genderalign in ['female', 'trans female']:
-                    col2 += "related: aunt"
-                elif self.inspect_cat.genderalign in ['male', 'trans male']:
-                    col2 += "related: uncle"
-                else:
-                    col2 += "related: parent's sibling"
-            elif self.inspect_cat.is_grandparent(self.the_cat):
-                col2 += "related: grandparent"
-            elif self.the_cat.is_grandparent(self.inspect_cat):
-                col2 += "related: grandchild"
-            elif self.inspect_cat.is_parent(self.the_cat):
-                col2 += "related: parent"
-            elif self.the_cat.is_parent(self.inspect_cat):
-                col2 += "related: child"
-            elif self.inspect_cat.is_sibling(self.the_cat) or self.the_cat.is_sibling(self.inspect_cat):
-                col2 += "related: sibling"
-            elif not game.settings["first_cousin_mates"] and self.inspect_cat.is_cousin(self.the_cat):
-                col2 += "related: cousin"
+            if related:
+                if self.the_cat.is_uncle_aunt(self.inspect_cat):
+                    if self.inspect_cat.genderalign in ['female', 'trans female']:
+                        col2 += "related: niece"
+                    elif self.inspect_cat.genderalign in ['male', 'trans male']:
+                        col2 += "related: nephew"
+                    else:
+                        col2 += "related: sibling's child\n"
+                elif self.inspect_cat.is_uncle_aunt(self.the_cat):
+                    if self.inspect_cat.genderalign in ['female', 'trans female']:
+                        col2 += "related: aunt"
+                    elif self.inspect_cat.genderalign in ['male', 'trans male']:
+                        col2 += "related: uncle"
+                    else:
+                        col2 += "related: parent's sibling"
+                elif self.inspect_cat.is_grandparent(self.the_cat):
+                    col2 += "related: grandparent"
+                elif self.the_cat.is_grandparent(self.inspect_cat):
+                    col2 += "related: grandchild"
+                elif self.inspect_cat.is_parent(self.the_cat):
+                    col2 += "related: parent"
+                elif self.the_cat.is_parent(self.inspect_cat):
+                    col2 += "related: child"
+                elif self.inspect_cat.is_sibling(self.the_cat) or self.the_cat.is_sibling(self.inspect_cat):
+                    col2 += "related: sibling"
+                elif not game.settings["first_cousin_mates"] and self.inspect_cat.is_cousin(self.the_cat):
+                    col2 += "related: cousin"
 
             self.inspect_cat_elements["col2"] = UITextBoxTweaked(col2, pygame.Rect((150, 335), (85, -1)),
                                                                  object_id="#cat_profile_info_box",
@@ -1833,33 +1838,35 @@ class RelationshipScreen(Screens):
                                                                                                  (18, 18)),
                                                                                      gender_icon)
 
-        # FAMILY DOT
-
-        # Only show family dot on cousins if first cousin mates are disabled.
-        if game.settings['first_cousin_mates']:
-            check_cousins = False
-        else:
-            check_cousins = the_relationship.cat_to.is_cousin(self.the_cat)
-
-        if the_relationship.cat_to.is_uncle_aunt(self.the_cat) or self.the_cat.is_uncle_aunt(the_relationship.cat_to) \
-                or the_relationship.cat_to.is_grandparent(self.the_cat) or \
-                self.the_cat.is_grandparent(the_relationship.cat_to) or \
-                the_relationship.cat_to.is_parent(self.the_cat) or \
-                self.the_cat.is_parent(the_relationship.cat_to) or \
-                the_relationship.cat_to.is_sibling(self.the_cat) or check_cousins:
-            self.relation_list_elements['relation_icon' + str(i)] = pygame_gui.elements.UIImage(pygame.Rect((pos_x + 5,
-                                                                                                             pos_y + 5),
-                                                                                                            (9, 9)),
-                                                                                                image_cache.load_image(
-                                                                                                    "resources/images/dot_big.png").convert_alpha())
-
+        related = False
         # MATE
         if self.the_cat.mate is not None and self.the_cat.mate != '' and the_relationship.cat_to.ID == self.the_cat.mate:
+
             self.relation_list_elements['mate_icon' + str(i)] = pygame_gui.elements.UIImage(
                 pygame.Rect((pos_x + 5, pos_y + 5),
                             (11, 10)),
                 image_cache.load_image(
                     "resources/images/heart_big.png").convert_alpha())
+        else:
+            # FAMILY DOT
+            # Only show family dot on cousins if first cousin mates are disabled.
+            if game.settings['first_cousin_mates']:
+                check_cousins = False
+            else:
+                check_cousins = the_relationship.cat_to.is_cousin(self.the_cat)
+
+            if the_relationship.cat_to.is_uncle_aunt(self.the_cat) or self.the_cat.is_uncle_aunt(the_relationship.cat_to) \
+                    or the_relationship.cat_to.is_grandparent(self.the_cat) or \
+                    self.the_cat.is_grandparent(the_relationship.cat_to) or \
+                    the_relationship.cat_to.is_parent(self.the_cat) or \
+                    self.the_cat.is_parent(the_relationship.cat_to) or \
+                    the_relationship.cat_to.is_sibling(self.the_cat) or check_cousins:
+                related = True
+                self.relation_list_elements['relation_icon' + str(i)] = pygame_gui.elements.UIImage(pygame.Rect((pos_x + 5,
+                                                                                                                 pos_y + 5),
+                                                                                                                (9, 9)),
+                                                                                                    image_cache.load_image(
+                                                                                                        "resources/images/dot_big.png").convert_alpha())
 
         # ------------------------------------------------------------------------------------------------------------ #
         # RELATION BARS
@@ -1874,7 +1881,18 @@ class RelationshipScreen(Screens):
         both_adult = the_relationship.cat_to.age in adult_ages and self.the_cat.age in adult_ages
         check_age = both_adult or same_age
 
-        if the_relationship.romantic_love > 49 and check_age:
+        # If they are not both adults, or the same age, OR they are related, don't display any romantic affection,
+        # even if they somehow have some. They should not be able to get any, but it never hurts to check.
+        if not check_age or related:
+            display_romantic = 0
+            # Print, just for bug checking. Again, they should not be able to get love towards their relative.
+            if the_relationship.romantic_love and related:
+                print(str(self.the_cat.name) + " has " + str(the_relationship.romantic_love) + " romantic love "
+                      "towards their relative, " + str(the_relationship.cat_to.name))
+        else:
+            display_romantic = the_relationship.romantic_love
+
+        if display_romantic > 49:
             text = "romantic love:"
         else:
             text = "romantic like:"
@@ -1887,7 +1905,7 @@ class RelationshipScreen(Screens):
                                                                                            pos_y + 65 + (
                                                                                                    barbar * bar_count)),
                                                                                           (94, 10)),
-                                                                              the_relationship.romantic_love,
+                                                                              display_romantic,
                                                                               positive_trait=True,
                                                                               dark_mode=game.settings['dark mode']
                                                                               )


### PR DESCRIPTION
- Apprentice page buttons on the patrol screen work again
- Failsafe against displaying romantic affection towards relatives. Even if they somehow gained romantic affection, it will not be displayed.
- If first-cousin mates are turned off, romantic affection between first cousins will always be displayed as zero, even if they gained affection while first-cousin mates were enabled.
- Faded siblings and children are added to the cat.sibling and cat.children list upon startup.
- Medicine cat apprentices will no longer retire due to permanent condition.