### PR TITLE
Minor changes/updates to tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
           python-version: '3.11'
           architecture: 'x64'
       - name: Install depends
-        run: python -m pip install --pre pygame ujson pygame_gui mock
+        run: python -m pip install --pre pygame ujson pygame_gui
       - name: Test relationships (unittest)
         env:
           SDL_VIDEODRIVER: "dummy"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,41 +15,11 @@ jobs:
           architecture: 'x64'
       - name: Install depends
         run: python -m pip install --pre pygame ujson pygame_gui
-      - name: Test relationships (unittest)
+      - name: Run unit tests
         env:
           SDL_VIDEODRIVER: "dummy"
           SDL_AUDIODRIVER: "disk"
-        run: python3 -m unittest tests/test_relationships.py
-      - name: Test thoughts (unittest)
-        env:
-          SDL_VIDEODRIVER: "dummy"
-          SDL_AUDIODRIVER: "disk"
-        run: python3 -m unittest tests/test_thoughts.py
-      - name: Test relationship events (unittest)
-        env:
-          SDL_VIDEODRIVER: "dummy"
-          SDL_AUDIODRIVER: "disk"
-        run: python3 -m unittest tests/test_relation_events.py
-      - name: Test patrol (unittest)
-        env:
-          SDL_VIDEODRIVER: "dummy"
-          SDL_AUDIODRIVER: "disk"
-        run: python3 -m unittest tests/test_patrol.py
-      - name: Test conditions (unittest)
-        env:
-          SDL_VIDEODRIVER: "dummy"
-          SDL_AUDIODRIVER: "disk"
-        run: python3 -m unittest tests/test_conditions.py
-      - name: Test utility (unittest)
-        env:
-          SDL_VIDEODRIVER: "dummy"
-          SDL_AUDIODRIVER: "disk"
-        run: python3 -m unittest tests/test_utility.py
-      - name: Test cat (unittest)
-        env:
-          SDL_VIDEODRIVER: "dummy"
-          SDL_AUDIODRIVER: "disk"
-        run: python3 -m unittest tests/test_cat.py
+        run: python3 -m unittest tests/test_relationships.py tests/test_thoughts.py tests/test_relation_events.py tests/test_patrol.py tests/test_conditions.py tests/test_utility.py tests/test_cat.py
         
   # Check if file encoding is correct.
   encoding_test:
@@ -62,7 +32,4 @@ jobs:
           python-version: '3.11'
           architecture: 'x64'
       - name: Check file encoding
-        env:
-          SDL_VIDEODRIVER: "dummy"
-          SDL_AUDIODRIVER: "disk"
         run: python3 tests/test_encoding.py

--- a/tests/test_cat.py
+++ b/tests/test_cat.py
@@ -396,10 +396,10 @@ class TestUpdateMentor(unittest.TestCase):
 
         # when
         self.assertTrue(app in mentor.apprentice and app not in mentor.former_apprentices)
-        self.assertTrue(app.mentor is mentor)
+        self.assertIs(app.mentor, mentor)
         app.exiled = True
         app.update_mentor()
 
         # then
         self.assertTrue(app not in mentor.apprentice and app in mentor.former_apprentices)
-        self.assertTrue(app.mentor is None)
+        self.assertIsNone(app.mentor)

--- a/tests/test_conditions.py
+++ b/tests/test_conditions.py
@@ -1,6 +1,6 @@
 import ujson
 import unittest
-from mock import patch
+from unittest.mock import patch
 
 from scripts.cat.cats import Cat
 from scripts.conditions import Illness, Injury, medical_cats_condition_fulfilled

--- a/tests/test_conditions.py
+++ b/tests/test_conditions.py
@@ -1,6 +1,10 @@
-import ujson
 import unittest
 from unittest.mock import patch
+
+try:
+    import ujson
+except ImportError:
+    import json as ujson
 
 from scripts.cat.cats import Cat
 from scripts.conditions import Illness, Injury, medical_cats_condition_fulfilled

--- a/tests/test_patrol.py
+++ b/tests/test_patrol.py
@@ -1,5 +1,9 @@
 import unittest
-import ujson
+
+try:
+    import ujson
+except ImportError:
+    import json as ujson
 
 from scripts.patrol import Patrol
 from scripts.cat.cats import Cat

--- a/tests/test_relation_events.py
+++ b/tests/test_relation_events.py
@@ -1,5 +1,5 @@
 import unittest
-from mock import patch
+from unittest.mock import patch
 
 from scripts.events_module.relation_events import Relation_Events
 from scripts.cat.cats import Cat

--- a/tests/test_relation_events.py
+++ b/tests/test_relation_events.py
@@ -159,7 +159,7 @@ class CanHaveKits(unittest.TestCase):
 
 
 class Pregnancy(unittest.TestCase):
-    @patch('scripts.cat_relations.relation_events.Relation_Events.get_kits_chance')
+    @patch('scripts.events_module.relation_events.Relation_Events.get_kits_chance')
     def test_single_cat_female(self, get_kits_chance):
         # given
         relation_events = Relation_Events()
@@ -174,7 +174,7 @@ class Pregnancy(unittest.TestCase):
         # then
         self.assertIn(cat.ID, clan.pregnancy_data.keys())
 
-    @patch('scripts.cat_relations.relation_events.Relation_Events.get_kits_chance')
+    @patch('scripts.events_module.relation_events.Relation_Events.get_kits_chance')
     def test_pair(self, get_kits_chance):
         # given
         relation_events = Relation_Events()
@@ -193,7 +193,7 @@ class Pregnancy(unittest.TestCase):
         self.assertIn(cat1.ID, clan.pregnancy_data.keys())
         self.assertEqual(clan.pregnancy_data[cat1.ID]["second_parent"], cat2.ID)
 
-    @patch('scripts.cat_relations.relation_events.Relation_Events.get_kits_chance')
+    @patch('scripts.events_module.relation_events.Relation_Events.get_kits_chance')
     def test_single_cat_male(self, get_kits_chance):
         # given
         relation_events = Relation_Events()

--- a/tests/test_relationships.py
+++ b/tests/test_relationships.py
@@ -1,5 +1,9 @@
 import unittest
-import ujson
+
+try:
+    import ujson
+except ImportError:
+    import json as ujson
 
 from scripts.cat.cats import Cat
 from scripts.cat_relations.relationship import Relationship

--- a/tests/test_thoughts.py
+++ b/tests/test_thoughts.py
@@ -1,5 +1,9 @@
-import ujson
 import unittest
+
+try:
+    import ujson
+except ImportError:
+    import json as ujson
 
 from scripts.cat.cats import Cat
 from scripts.cat.thoughts import *


### PR DESCRIPTION
 - Replaces 'mock' with 'unittest.mock', the standard library version is equivalent unless we need to backport specific behavior.
 - Reformats cat units tests with teyit, only two lines got changed.
 - Update get_kits_chance path in relationship events tests, this is a rly obvious fix.
 - Also make ujson optional for tests.
 - Combine unit tests runs into one job into the workflow, so all tests run even if a test fails.