### PR TITLE
Bugfixes

### DIFF
--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -686,15 +686,13 @@ class Cat():
 
             if old_status == 'leader':
                 game.clan.leader_lives = 0
+                self.died_by = []  # Clear their deaths.
                 if game.clan.leader:
                     if game.clan.leader.ID == self.ID:
                         game.clan.leader = None
                         game.clan.leader_predecessors += 1
 
         elif self.status == 'medicine cat':
-            if self.retired:
-                self.retired = False
-
             self.update_med_mentor()
             self.update_skill()
             if game.clan is not None:
@@ -702,7 +700,6 @@ class Cat():
 
         if self.status == 'elder':
             self.update_mentor()
-            self.retired = True
             self.skill = choice(self.elder_skills)
 
             # Will remove them from the clan med cat variables, if they are a med cat
@@ -711,6 +708,7 @@ class Cat():
 
             if old_status == 'leader':
                 game.clan.leader_lives = 0
+                self.died_by = []  # Clear their deaths.
                 if game.clan.leader:
                     if game.clan.leader.ID == self.ID:
                         game.clan.leader = None
@@ -1473,10 +1471,26 @@ class Cat():
                 break
         return not_working
 
+    #This is only for cats that retire due to the health condition.
     def retire_cat(self):
+        old_status = self.status
         self.retired = True
         self.status = 'elder'
         self.name.status = 'elder'
+
+        if old_status == 'leader':
+            game.clan.leader_lives = 0
+            self.died_by = []  # Clear their deaths.
+            if game.clan.leader:
+                if game.clan.leader.ID == self.ID:
+                    game.clan.leader = None
+                    game.clan.leader_predecessors += 1
+
+        if game.clan.deputy:
+            if game.clan.deputy.ID == self.ID:
+                game.clan.deputy = None
+                game.clan.deputy_predecessors += 1
+
         self.update_mentor()
 
     def additional_injury(self, injury):

--- a/scripts/cat_relations/relationship.py
+++ b/scripts/cat_relations/relationship.py
@@ -121,7 +121,7 @@ class Relationship():
             string_to_replace = '(' + action[action.find("(") + 1:action.find(")")] + ')'
             self.current_action_str = action.replace(string_to_replace, str(self.cat_to.name))
             game.cur_events_list.append(Single_Event(
-                f"{str(self.cat_from.name)} {self.current_action_str} (neutral effect)", "relation",
+                f"{str(self.cat_from.name)} {self.current_action_str} (neutral effect)", ["relation", "interaction"],
                 [self.cat_to.ID, self.cat_from.ID]))
             return
         elif self.cat_from.exiled and not self.cat_to.exiled:
@@ -129,7 +129,7 @@ class Relationship():
             string_to_replace = '(' + action[action.find("(") + 1:action.find(")")] + ')'
             self.current_action_str = action.replace(string_to_replace, str(self.cat_to.name))
             game.cur_events_list.append(Single_Event(
-                f"{str(self.cat_from.name)} {self.current_action_str} (neutral effect)", "relation",
+                f"{str(self.cat_from.name)} {self.current_action_str} (neutral effect)", ["relation", "interaction"],
                 [self.cat_to.ID, self.cat_from.ID]))
             return
         elif self.cat_from.exiled and self.cat_to.exiled:
@@ -137,7 +137,7 @@ class Relationship():
             string_to_replace = '(' + action[action.find("(") + 1:action.find(")")] + ')'
             self.current_action_str = action.replace(string_to_replace, str(self.cat_to.name))
             game.cur_events_list.append(Single_Event(
-                f"{str(self.cat_from.name)} {self.current_action_str} (neutral effect)", "relation",
+                f"{str(self.cat_from.name)} {self.current_action_str} (neutral effect)", ["relation", "interaction"],
                 [self.cat_to.ID, self.cat_from.ID]))
             return
 
@@ -147,7 +147,7 @@ class Relationship():
             string_to_replace = '(' + action[action.find("(") + 1:action.find(")")] + ')'
             self.current_action_str = action.replace(string_to_replace, str(self.cat_to.name))
             game.cur_events_list.append(Single_Event(
-                f"{str(self.cat_from.name)} {self.current_action_str} (neutral effect)", "relation",
+                f"{str(self.cat_from.name)} {self.current_action_str} (neutral effect)", ["relation", "interaction"],
                 [self.cat_to.ID, self.cat_from.ID]))
             return
         elif self.cat_from.outside and not self.cat_to.outside:
@@ -155,7 +155,7 @@ class Relationship():
             string_to_replace = '(' + action[action.find("(") + 1:action.find(")")] + ')'
             self.current_action_str = action.replace(string_to_replace, str(self.cat_to.name))
             game.cur_events_list.append(Single_Event(
-                f"{str(self.cat_from.name)} {self.current_action_str} (neutral effect)", "relation",
+                f"{str(self.cat_from.name)} {self.current_action_str} (neutral effect)", ["relation", "interaction"],
                 [self.cat_to.ID, self.cat_from.ID]))
             return
         elif self.cat_from.outside and self.cat_to.outside:
@@ -163,7 +163,7 @@ class Relationship():
             string_to_replace = '(' + action[action.find("(") + 1:action.find(")")] + ')'
             self.current_action_str = action.replace(string_to_replace, str(self.cat_to.name))
             game.cur_events_list.append(Single_Event(
-                f"{str(self.cat_from.name)} {self.current_action_str} (neutral effect)", "relation",
+                f"{str(self.cat_from.name)} {self.current_action_str} (neutral effect)", ["relation", "interaction"],
                 [self.cat_to.ID, self.cat_from.ID]))
             return
 

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -1328,7 +1328,8 @@ class Events():
                 involved_cats = [kit.ID]
                 kit_text = [
                     f'{name} finds an abandoned kit and names them {kit.name}.',
-                    f'A loner brings their kit named {kit.name.prefix} to the clan, stating they no longer can care for them.'
+                    f'A loner brings their kit named {kit.name.prefix} '
+                    f'to the clan, stating they no longer can care for them.'
                 ]
                 text = choice(kit_text)
                 # If it's the first one, there is also the cat that found them to be added to the involved list
@@ -1488,10 +1489,11 @@ class Events():
                     backstory=backstory_choice,
                     other_clan=otherclan
                 )
-                involved_cats = [created_cats[0].ID, cat.ID]
+                involved_cats = [c.ID for c in created_cats] + [cat.ID]
                 if backstory == 'abandoned3':
                     a_kit_text = ([
-                        f'A {otherclan}Clan queen decides to leave their litter with you. {str(parent1)} takes them as their own.'
+                        f'A {otherclan}Clan queen decides to leave their litter with you. {str(parent1)} '
+                        f'takes them as their own.'
                     ])
                     a_kit_text = choice(a_kit_text)
                     # game.other_clans_events_list.append(a_kit_text)

--- a/scripts/events_module/condition_events.py
+++ b/scripts/events_module/condition_events.py
@@ -669,7 +669,7 @@ class Condition_Events():
         retire_chances = {
             'kitten': 0,
             'adolescent': 100,
-            'young adult': 1,
+            'young adult': 80,
             'adult': 70,
             'senior adult': 50,
             'elder': 0

--- a/scripts/events_module/condition_events.py
+++ b/scripts/events_module/condition_events.py
@@ -669,7 +669,7 @@ class Condition_Events():
         retire_chances = {
             'kitten': 0,
             'adolescent': 100,
-            'young adult': 80,
+            'young adult': 1,
             'adult': 70,
             'senior adult': 50,
             'elder': 0
@@ -699,7 +699,7 @@ class Condition_Events():
                             event += f"They are given the name {cat.name.prefix}{cat.name.suffix} in honor " \
                                      f"of their contributions to {game.clan.name}Clan."
 
-                        cat.status_change('elder')
+                        cat.retire_cat()
                         game.ranks_changed_timeskip = True
                         event_list.append(event)
 
@@ -722,7 +722,7 @@ class Condition_Events():
                         event += f"They are given the name {cat.name.prefix}{cat.name.suffix} in honor " \
                                  f"of their contributions to {game.clan.name}Clan."
 
-                    cat.status_change('elder')
+                    cat.retire_cat()
                     game.ranks_changed_timeskip = True
                     event_list.append(event)
 

--- a/scripts/events_module/relation_events.py
+++ b/scripts/events_module/relation_events.py
@@ -879,7 +879,7 @@ class Relation_Events():
             kit.scars.clear()
 
             # try to give them a permanent condition. 1/100 chance
-            if not int(random.random() * 90) and game.clan.game_mode != 'classic':
+            if not int(random.random() * 1) and game.clan.game_mode != 'classic':
                 kit.congenital_condition(kit)
                 for condition in kit.permanent_condition:
                     if kit.permanent_condition[condition] == 'born without a leg':

--- a/scripts/events_module/relation_events.py
+++ b/scripts/events_module/relation_events.py
@@ -878,8 +878,8 @@ class Relation_Events():
             # remove scars
             kit.scars.clear()
 
-            # try to give them a permanent condition. 1/100 chance
-            if not int(random.random() * 1) and game.clan.game_mode != 'classic':
+            # try to give them a permanent condition. 1/90 chance
+            if not int(random.random() * 90) and game.clan.game_mode != 'classic':
                 kit.congenital_condition(kit)
                 for condition in kit.permanent_condition:
                     if kit.permanent_condition[condition] == 'born without a leg':

--- a/scripts/screens/cat_screens.py
+++ b/scripts/screens/cat_screens.py
@@ -1708,8 +1708,8 @@ class ProfileScreen(Screens):
                                                        starting_height=2, object_id="#switch_med_app_button")
                 close_button_location = (226, 610)
             # Switch med apprentice to warrior apprentice
-            elif self.the_cat.status in [
-                'medicine cat apprentice'] and not self.the_cat.dead and not self.the_cat.outside:
+            elif self.the_cat.status in ['medicine cat apprentice'] and not self.the_cat.dead and \
+                    not self.the_cat.outside:
                 self.toggle_med_button = UIImageButton(pygame.Rect((226, 558), (172, 52)), "",
                                                        starting_height=2, object_id="#switch_warrior_app_button")
                 close_button_location = (226, 610)
@@ -1722,7 +1722,8 @@ class ProfileScreen(Screens):
             elif self.the_cat.status in ['medicine cat', 'leader'] and \
                     not self.the_cat.dead and \
                     not self.the_cat.outside and \
-                    self.the_cat.age != 'elder':
+                    self.the_cat.age != 'elder' and \
+                    not self.the_cat.retired:  # Retired is flipped true if that cat retired due to health conditions.
                 self.toggle_med_button = UIImageButton(pygame.Rect((226, 558), (172, 36)), "",
                                                        starting_height=2, object_id="#switch_warrior_button")
                 close_button_location = (226, 594)

--- a/scripts/screens/organizational_screens.py
+++ b/scripts/screens/organizational_screens.py
@@ -596,7 +596,8 @@ class SettingsScreen(Screens):
                 "",
                 object_id=box_type,
                 container=self.checkboxes_text["container"],
-                tool_tip_text='Camp backgrounds will match with the mode. Nighttime for Dark mode and daytime for Light mode.'
+                tool_tip_text='Camp backgrounds will match with the mode: '
+                              'nighttime for Dark mode and daytime for Light mode.'
             )
             n += 1
             # Enable clan page background

--- a/scripts/screens/patrol_screens.py
+++ b/scripts/screens/patrol_screens.py
@@ -252,7 +252,7 @@ class PatrolScreen(Screens):
 
                 if self.patrol_type == 'general':
                     text = 'random patrol type'
-                if self.patrol_type == 'training' and med is False:
+                elif self.patrol_type == 'training' and med is False:
                     text = 'training'
                 elif self.patrol_type == 'border' and med is False:
                     text = 'border'


### PR DESCRIPTION
-  Interactions with exiled or lost cats will no longer show up on in the "All Events" Tab
- When a litter is left to the clan, more than the first kitten will be shown on the "involved cats" tab.
- Fix for patrol type not showing correctly.
- You no longer "unretire" a cat that retired due to permanent conditions by switching them to a medicine cat, then to a warrior.
- Retired leaders and leaders-turned-warriors will now have their deaths cleared.