### PR TITLE
Convert all utf-8 characters to ascii equivalents and expand encoding test

### DIFF
--- a/scripts/events_module/generate_events.py
+++ b/scripts/events_module/generate_events.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+# -*- coding: ascii -*-
 try:
     import ujson
 except ImportError:
@@ -220,39 +222,39 @@ class DeathEvent:
 Tagging Guidelines: (if you add more tags, please add guidelines for them here) 
 "Newleaf", "Greenleaf", "Leaf-fall", "Leaf-bare" < specify season.  If event happens in all seasons then include all of those tags.
 
-“classic” < use for death events caused by illness.  This tag ensures that illness death events only happen in classic mode since illness deaths are caused differently in enhanced/cruel mode
+"classic" < use for death events caused by illness.  This tag ensures that illness death events only happen in classic mode since illness deaths are caused differently in enhanced/cruel mode
 
-“multi_death” < use to indicate that two cats have died.  Two cats is the limit here.  Any more than that is a disaster death and i haven't touched disasters yet (and might not touch at all bc the code is scary lol)
+"multi_death" < use to indicate that two cats have died.  Two cats is the limit here.  Any more than that is a disaster death and i haven't touched disasters yet (and might not touch at all bc the code is scary lol)
 
-“old_age” < use to mark deaths caused by old age
+"old_age" < use to mark deaths caused by old age
 
-“all_lives” < take all the lives from a leader
-“some_lives” < take a random number, but not all, lives from a leader
+"all_lives" < take all the lives from a leader
+"some_lives" < take a random number, but not all, lives from a leader
 
-“murder” < m_c was murdered by the other cat
+"murder" < m_c was murdered by the other cat
 
-“war” < event only happens during war and ensures o_c in event is warring clan
-“other_clan” < mark event as including another clan
-“rel_down” < event decreases relation with other clan
-“rel_up” < event increases relation with other clan
-“hostile” < event only happens with hostile clans
-“neutral” < event only happens with neutral clans
-“ally” < event only happens with allied clans
+"war" < event only happens during war and ensures o_c in event is warring clan
+"other_clan" < mark event as including another clan
+"rel_down" < event decreases relation with other clan
+"rel_up" < event increases relation with other clan
+"hostile" < event only happens with hostile clans
+"neutral" < event only happens with neutral clans
+"ally" < event only happens with allied clans
 
-“medicine_cat”, “medicine_cat_app” < ensure that m_c is one of these ranks.  All other ranks are separated into their own .jsons
+"medicine_cat", "medicine_cat_app" < ensure that m_c is one of these ranks.  All other ranks are separated into their own .jsons
 
-“other_cat” < there is a second cat in this event
+"other_cat" < there is a second cat in this event
 
-“other_cat_med”, “other_cat_med_app”, “other_cat_warrior”, “other_cat_app”, “other_cat_kit”, “other_cat_lead”, “other_cat_dep”, “other_cat_elder” < mark the other cat as having to be a certain status, if none of these tags are used then other_cat can be anyone
+"other_cat_med", "other_cat_med_app", "other_cat_warrior", "other_cat_app", "other_cat_kit", "other_cat_lead", "other_cat_dep", "other_cat_elder" < mark the other cat as having to be a certain status, if none of these tags are used then other_cat can be anyone
 
-“other_cat_mate” < mark the other cat as having to be the m_c's mate
-“other_cat_child” < mark the other cat as having to be the m_c's kit
-“other_cat_parent” < mark the other cat as having to be m_c's parent
-“other_cat_adult” < mark the other cat as not being able to be a kit or elder
+"other_cat_mate" < mark the other cat as having to be the m_c's mate
+"other_cat_child" < mark the other cat as having to be the m_c's kit
+"other_cat_parent" < mark the other cat as having to be m_c's parent
+"other_cat_adult" < mark the other cat as not being able to be a kit or elder
 
-“other_cat_own_app”, “other_cat_mentor” < mark the other cat has having to be the m_c's mentor or app respectively
+"other_cat_own_app", "other_cat_mentor" < mark the other cat has having to be the m_c's mentor or app respectively
 
-“clan_kits” < clan must have kits for this event to appear
+"clan_kits" < clan must have kits for this event to appear
 
 "yearly" < mark this event to occur 100% of the time on the first month of the tagged season. Not used for injury or death events. 
 
@@ -264,16 +266,16 @@ rc_to_mc < change rc's relationship values towards mc
 to_both < change both cat's relationship values
 
 Tagged relationship parameters are: "romantic", "platonic", "comfort", "respect", "trust", "dislike", "jealousy", 
-Add “neg_” in front of parameter to make it a negative value change (i.e. “neg_romantic”, “neg_platonic”, ect)
+Add "neg_" in front of parameter to make it a negative value change (i.e. "neg_romantic", "neg_platonic", ect)
 
 "single_cat" < marks events that have one version that triggers for a list of cats, and this version that triggers for a single cat
 
 "multi_cat" < marks events triggering for multiple cats e.g many apprentices being named at once
 
 Use these to determine what corruption level the main cat should have, if relevant
-“corruption_low” - main cat generally cares for the wellbeing of others and avoids hurting other cats, even if it benefits them to do so.
-“corruption_mid” - main cat cares more for their own wellbeing.  Does not necessarily want to hurt others, but will not explicitly avoid it if it benefits them.
-“corruption_high” - main cat doesn't care about the wellbeing of others and will happily hurt other cats if it benefits them.
+"corruption_low" - main cat generally cares for the wellbeing of others and avoids hurting other cats, even if it benefits them to do so.
+"corruption_mid" - main cat cares more for their own wellbeing.  Does not necessarily want to hurt others, but will not explicitly avoid it if it benefits them.
+"corruption_high" - main cat doesn't care about the wellbeing of others and will happily hurt other cats if it benefits them.
 You can mix and match corruption tags if you feel an event is on the line between two of them, the code will allow the event for a cat with either of the corruption levels tagged
 
 """

--- a/scripts/patrol.py
+++ b/scripts/patrol.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+# -*- coding: ascii -*-
 from random import choice, randint, choices
 from math import floor
 
@@ -1397,33 +1399,33 @@ class PatrolEvent():
         same for: "gone" (r_c leaves the clan), "disaster_gone" (all leave the clan), "multi_gone" (2-4 cats leave the clan)
 
         #!FOR INJURIES, SEE CONDITIONS LIST FOR TAGGING
-        Tag all injury patrols that should give a scar with “scar” to ensure that classic mode will still scar the cat.
+        Tag all injury patrols that should give a scar with "scar" to ensure that classic mode will still scar the cat.
         If you'd like a patrol to have an injury from one of the injury pools, tag with the pool name
-        If you want to specify a certain condition, tag both with “injury” and the condition
+        If you want to specify a certain condition, tag both with "injury" and the condition
         This will work with any condition whether they are an illness, injury, or perm condition
-        If you want to ensure that a cat cannot die from the condition, tag with “non_lethal”
+        If you want to ensure that a cat cannot die from the condition, tag with "non_lethal"
         Keep in mind that minor injuries are already non lethal by default and permanent conditions will not be affected by this tag.
-        These tags will stack! So you could tag a patrol as “blunt_force_injury”, “injury”, “water in their lungs” to give all the 
+        These tags will stack! So you could tag a patrol as "blunt_force_injury", "injury", "water in their lungs" to give all the 
         conditions from blunt_force_injury AND water in their lungs as possible conditions for that patrol. 
-        Keep in mind that the “non_lethal” tag will apply to ALL the conditions for that patrol.
+        Keep in mind that the "non_lethal" tag will apply to ALL the conditions for that patrol.
         Right now, nonlethal shock is auto applied to all cats present when another cat dies. This may change in the future.
 
         HERB TAGGING:
         herbs are given on successes only
-        “random_herbs” <give a random assortment of herbs
+        "random_herbs" <give a random assortment of herbs
         
-        “herbs” < use to mark that this patrol gives a specific herb, use in conjunction with a herb tag. 
+        "herbs" < use to mark that this patrol gives a specific herb, use in conjunction with a herb tag. 
         
         Herb tags:
          reference herbs.json, you can use any herb name listed there
         
-        “many_herbs#” < to cause the patrol to give a large number of herbs automatically. Replace the # with the 
+        "many_herbs#" < to cause the patrol to give a large number of herbs automatically. Replace the # with the 
         outcome number (i.e. if you want success outcome 3 - which is the skill success - to give lots of herbs, then 
-        use “many_herbs3”)
+        use "many_herbs3")
         
         "no_herbs#" < to cause the patrol to give no herbs on a certain outcome, while still giving herbs on other 
         outcomes. Replace the # with the outcome number (i.e. if you want success outcome 3 - which is the skill 
-        success - to give no herbs, then use “no_herbs3”)
+        success - to give no herbs, then use "no_herbs3")
 
 
 
@@ -1462,16 +1464,16 @@ class PatrolEvent():
         ^^^ On a success, the above tagged values will increase (or if values are dislike and jealousy, 
         they will decrease).  On a fail, the tagged values will decrease (or if values are dislike and jealousy, they will increase)
         
-        “sacrificial” is for fail outcomes where a cat valiantly sacrifices themselves for the clan 
-        (such as the single cat big dog patrol) this will give the tagged for group (“clan_to_r_c”, “patrol_to_r_c”, ect) 
+        "sacrificial" is for fail outcomes where a cat valiantly sacrifices themselves for the clan 
+        (such as the single cat big dog patrol) this will give the tagged for group ("clan_to_r_c", "patrol_to_r_c", ect) 
         a big boost to respect and trust in that cat even though they failed (if the cat survives lol) Other tagged for values 
         will be disregarded for these fail outcomes.
-        “pos_fail” is for if you want the tagged relationship values to still be positive on a failure, rather than negative.
+        "pos_fail" is for if you want the tagged relationship values to still be positive on a failure, rather than negative.
         
-        “big_change” is for if you want the values to increment by a larger number.  This will make all tagged relationship values change by 10 instead of 5
+        "big_change" is for if you want the values to increment by a larger number.  This will make all tagged relationship values change by 10 instead of 5
         
-        “no_change_fail” to set all relationship value changes to 0 on fail outcomes
-        “no_change_success” to set all relationship value changes to 0 on success outcomes
+        "no_change_fail" to set all relationship value changes to 0 on fail outcomes
+        "no_change_success" to set all relationship value changes to 0 on success outcomes
 
         """
 

--- a/scripts/screens/cat_screens.py
+++ b/scripts/screens/cat_screens.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+# -*- coding: ascii -*-
 from random import choice
 
 import pygame
@@ -106,7 +108,7 @@ def bs_blurb_text(cat):
     if backstory == 'kittypet1':
         bs_blurb = "This cat joined the Clan by choice after living life with Twolegs as a kittypet."
     if backstory == 'kittypet2':
-        bs_blurb = "This cat used to live on something called a “boat” with Twolegs, but decided to join the Clan."
+        bs_blurb = "This cat used to live on something called a "boat" with Twolegs, but decided to join the Clan."
     if backstory == 'rogue1':
         bs_blurb = "This cat joined the Clan by choice after living life as a rogue."
     if backstory == 'rogue2':

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -6,37 +6,38 @@ This test isn't because we can't use utf-8 characters, but because we shouldn't
 use them accidentally without explicitly setting the encoding.
 
 Suggested commands to find the offending character:
-file -i file.txt
+file -i old_file.txt
 iconv -cf utf-8 -t ascii -o old_file.txt new_file.txt
 diff old_file.txt new_file.txt"""
 import os
 import sys
+import difflib
 
 
 def test():
     """Iterate through all files in 'resources'
     and verify all characters are ascii decodable."""
+    output = ""
     for (root, _, files) in os.walk("."):
         for file in files:
             if file.endswith(".json") or file.endswith(".py"):
                 path = os.path.join(root, file)
-
                 with open(path, "r", encoding="utf-8") as handle_utf8:
-                    utf_read = handle_utf8.read()
+                    utf_read = handle_utf8.readlines()
+                with open(path, "r", encoding="ascii", errors="replace") as handle_ascii:
+                    ascii_read = handle_ascii.readlines()
 
-                with open(path, "r", encoding="ascii") as handle_ascii:
-                    ascii_read = ""
-                    for _ in range(len(utf_read)):
-                        try:
-                            ascii_read += handle_ascii.read(1)
-                        except UnicodeDecodeError:
-                            line = ascii_read.count("\n")
-                            ascii_len = len(ascii_read)
-                            snippet = ascii_read[ascii_len - 20 : ascii_len + 20]
-                            sys.exit(f"Failed decode line {line} of {path}\n"
-                                     f"Last valid snippet: \"{ascii_read[-50:]}\"")
-
-                print(f"VALID: {path}")
+                # Get difference
+                result = difflib.context_diff(utf_read, ascii_read)
+                if result:
+                    tmp_output = ""
+                    for diff in result:  # Exit if the reads differ
+                        tmp_output += diff
+                    if tmp_output:
+                        output += f"\nFile {path} isn't ascii decodable!!\n"
+                        output += tmp_output
+    if output.strip():
+        sys.exit(output)
 
 
 if __name__ == "__main__":

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# -*- coding: ascii -*-
 """This is not a unittest scripts so mybe this shouldn't be in /tests/...
 Alternatively to Python, the 'file' command on linux can also check encoding.
 

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -1,18 +1,41 @@
 #!/usr/bin/env python3
 """This is not a unittest scripts so mybe this shouldn't be in /tests/...
-Alternatively to Python, the 'file' command on linux can also check encoding."""
+Alternatively to Python, the 'file' command on linux can also check encoding.
+
+This test isn't because we can't use utf-8 characters, but because we shouldn't
+use them accidentally without explicitly setting the encoding.
+
+Suggested commands to find the offending character:
+file -i file.txt
+iconv -cf utf-8 -t ascii -o old_file.txt new_file.txt
+diff old_file.txt new_file.txt"""
 import os
+import sys
 
 
 def test():
     """Iterate through all files in 'resources'
     and verify all characters are ascii decodable."""
-    for (root, _, files) in os.walk("resources"):
+    for (root, _, files) in os.walk("."):
         for file in files:
-            if file.endswith(".json"):
+            if file.endswith(".json") or file.endswith(".py"):
                 path = os.path.join(root, file)
-                with open(path, "r", encoding="ascii") as file_handle:
-                    file_handle.read()
+
+                with open(path, "r", encoding="utf-8") as handle_utf8:
+                    utf_read = handle_utf8.read()
+
+                with open(path, "r", encoding="ascii") as handle_ascii:
+                    ascii_read = ""
+                    for _ in range(len(utf_read)):
+                        try:
+                            ascii_read += handle_ascii.read(1)
+                        except UnicodeDecodeError:
+                            line = ascii_read.count("\n")
+                            ascii_len = len(ascii_read)
+                            snippet = ascii_read[ascii_len - 20 : ascii_len + 20]
+                            sys.exit(f"Failed decode line {line} of {path}\n"
+                                     f"Last valid snippet: \"{ascii_read[-50:]}\"")
+
                 print(f"VALID: {path}")
 
 


### PR DESCRIPTION
- Replaces utf-8 characters with ascii equivalents, mostly “” to "".
- Encoding test now also iterates through python files.
- Encoding test now prints a diff with the non-ascii decodable characters.
- Explicitly defines the encoding as ascii for some files.

I'm not sure if replacing “” in doc strings is actually useful; though it's at least consistent for the test.