### PR TITLE
Bugfixes

### DIFF
--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -750,6 +750,11 @@ class Cat():
                         game.clan.leader = None
                         game.clan.leader_predecessors += 1
 
+            if game.clan.deputy:
+                if game.clan.deputy.ID == self.ID:
+                    game.clan.deputy = None
+                    game.clan.deputy_predecessors += 1
+
         elif self.status == 'medicine cat':
             self.update_med_mentor()
             self.update_skill()

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -1119,14 +1119,10 @@ class Cat():
                                 possible_skill = self.skill_groups.get(x)
                                 self.skill = choice(possible_skill)
                                 self.mentor_influence.append(self.skill)
-                    # don't give skill from mentor
-                    else:
-                        self.skill = choice(self.skills)
-                        self.mentor_influence.append('None')
-                # if they didn't have a mentor, give random skill
-                else:
-                    self.skill = choice(self.skills)
-                    self.mentor_influence.append('None')
+                                return
+
+                self.skill = choice(self.skills)
+                self.mentor_influence.append('None')
 
             # assign new skill to elder
             elif self.status == 'elder':

--- a/scripts/screens/cat_screens.py
+++ b/scripts/screens/cat_screens.py
@@ -1621,7 +1621,7 @@ class ProfileScreen(Screens):
             else:
                 self.choose_mate_button.enable()
 
-            if self.the_cat.status not in ['apprentice', 'medicine cat apprentice'] or self.the_cat.dead
+            if self.the_cat.status not in ['apprentice', 'medicine cat apprentice'] or self.the_cat.dead \
                     or self.the_cat.outside:
                 self.change_mentor_button.disable()
             else:

--- a/scripts/screens/cat_screens.py
+++ b/scripts/screens/cat_screens.py
@@ -1621,7 +1621,8 @@ class ProfileScreen(Screens):
             else:
                 self.choose_mate_button.enable()
 
-            if self.the_cat.status not in ['apprentice', 'medicine cat apprentice'] or self.the_cat.dead:
+            if self.the_cat.status not in ['apprentice', 'medicine cat apprentice'] or self.the_cat.dead
+                    or self.the_cat.outside:
                 self.change_mentor_button.disable()
             else:
                 self.change_mentor_button.enable()

--- a/scripts/screens/event_screens.py
+++ b/scripts/screens/event_screens.py
@@ -314,6 +314,7 @@ class EventsScreen(Screens):
 
         # Draw and disable the correct menu buttons.
         self.set_disabled_menu_buttons(["events_screen"])
+        self.update_heading_text(f'{game.clan.name}Clan')
         self.show_menu_buttons()
         self.update_events_display()
 

--- a/scripts/screens/world_screens.py
+++ b/scripts/screens/world_screens.py
@@ -423,7 +423,7 @@ class UnknownResScreen(Screens):
                                                                          (220, 60))), manager=MANAGER)  # Text will be filled in later
 
         self.set_disabled_menu_buttons(["starclan_screen"])
-        self.update_heading_text("StarClan")
+        self.update_heading_text("Unknown Residence")
         self.show_menu_buttons()
 
         self.update_search_cats("")  # This will list all the cats, and create the button objects.


### PR DESCRIPTION
- demoting a deputy properly removes them from the deputy variable
- "Starclan" no longer appears as the heading for Unknown Residence. 
- Heading on events screen set properly. 
- Failsafe for warrior apprentices not getting skill at promotion.  (For example, there were apprenticed to an elderly leader)
- You no longer give lost apprentices mentors. 