### PR TITLE
fixes: typos

### DIFF
--- a/resources/dicts/patrols/med/medcat_beach.json
+++ b/resources/dicts/patrols/med/medcat_beach.json
@@ -1703,7 +1703,7 @@
     "exp": 10,
     "success_text": [
             "Daisies may seem like part of the everyday carpet of greenery, present everywhere from rocks to fields to at the foot of trees, but that doesn't make their leaves any less useful.",
-            "Greenleaf brings a veritable explosion of daisies raising little white and yellow flowers around every corner, and p_l partically doesn't need to even leave camp to gather them.",
+            "Greenleaf brings a veritable explosion of daisies raising little white and yellow flowers around every corner, and p_l practically doesn't need to even leave camp to gather them.",
             "Daisies aren't hard to find in the warmer seasons, and s_c collects enough that they have trouble not dropping any on the way back to camp."
 ],
     "fail_text": [
@@ -1729,7 +1729,7 @@
     "exp": 20,
     "success_text": [
             "Daisies may seem like part of the everyday carpet of greenery, present everywhere from rocks to fields to at the foot of trees, but that doesn't make their leaves any less useful. p_l goes through their common uses with app1.",
-            "Greenleaf brings a veritable explosion of daisies raising little white and yellow flowers around every corner, and p_l partically doesn't need to even leave camp to gather them. It gives them time to let app1 run off and play with their friends, and seeing their apprentice getting to relax makes them smile from their favourite basking spot.",
+            "Greenleaf brings a veritable explosion of daisies raising little white and yellow flowers around every corner, and p_l practically doesn't need to even leave camp to gather them. It gives them time to let app1 run off and play with their friends, and seeing their apprentice getting to relax makes them smile from their favourite basking spot.",
             "Daisies aren't hard to find in the warmer seasons, and s_c collects enough that they have trouble not dropping any on the way back to camp. At least with app1 here with them the load is shared, and they purr in appreciation of the apprentice."
 ],
     "fail_text": [
@@ -1755,7 +1755,7 @@
     "exp": 10,
     "success_text": [
            "Daisies may seem like part of the everyday carpet of greenery, present everywhere from rocks to fields to at the foot of trees, but that doesn't make their leaves any less useful. With a larger patrol, the cats bring back a good haul, and p_l makes sure to thank everyone for their assistance.",
-            "Greenleaf brings a veritable explosion of daisies raising little white and yellow flowers around every corner, and p_l partically doesn't need to even leave camp to gather them. It ends up feeling like an afternoon full of chatting and catching up with their Clanmates that happens to have daisy gathering in it, rather than a typical herb gathering patrol.",
+            "Greenleaf brings a veritable explosion of daisies raising little white and yellow flowers around every corner, and p_l practically doesn't need to even leave camp to gather them. It ends up feeling like an afternoon full of chatting and catching up with their Clanmates that happens to have daisy gathering in it, rather than a typical herb gathering patrol.",
             "Daisies aren't hard to find in the warmer seasons, and s_c collects enough that they have trouble not dropping any on the way back to camp. The patrol, filled with gossip and chatter on the way out and daisy leaves on the trip back, is an easy and enjoyable afternoon."
     ],
     "fail_text": [

--- a/resources/dicts/patrols/med/medcat_beach.json
+++ b/resources/dicts/patrols/med/medcat_beach.json
@@ -1703,7 +1703,7 @@
     "exp": 10,
     "success_text": [
             "Daisies may seem like part of the everyday carpet of greenery, present everywhere from rocks to fields to at the foot of trees, but that doesn't make their leaves any less useful.",
-            "greenleaf brings a veritable explosion of daisies raising little white and yellow flowers around every corner, and p_l partically doesn't need to even leave camp to gather them.",
+            "Greenleaf brings a veritable explosion of daisies raising little white and yellow flowers around every corner, and p_l partically doesn't need to even leave camp to gather them.",
             "Daisies aren't hard to find in the warmer seasons, and s_c collects enough that they have trouble not dropping any on the way back to camp."
 ],
     "fail_text": [
@@ -4444,7 +4444,7 @@
     "biome": "beach",
     "season": "greenleaf",
     "tags": ["med_only", "herb", "oak_leaves", "many_herbs1", "many_herbs2", "med_cat"],
-    "intro_text": "greenleaf encourages the oak to reach its full potential, wide and towering, and p_l goes to collect a harvest of its leaves.",
+    "intro_text": "Greenleaf encourages the oak to reach its full potential, wide and towering, and p_l goes to collect a harvest of its leaves.",
     "decline_text": "They have second thoughts leaving their patients behind and decide to go another day.",
     "chance_of_success": 70,
     "exp": 10,
@@ -4470,7 +4470,7 @@
     "biome": "beach",
     "season": "greenleaf",
     "tags": ["med_only", "med_cat", "herb", "oak_leaves", "many_herbs1", "many_herbs2", "big_change", "platonic", "dislike", "comfort", "respect", "trust", "apprentice"],
-    "intro_text": "greenleaf encourages the oak to reach its full potential, wide and towering, and p_l goes to collect a harvest of its leaves with app1.",
+    "intro_text": "Greenleaf encourages the oak to reach its full potential, wide and towering, and p_l goes to collect a harvest of its leaves with app1.",
     "decline_text": "They have second thoughts leaving their patients behind, especially with their apprentice also out, and decide to go another day.",
     "chance_of_success": 70,
     "exp": 20,

--- a/resources/dicts/patrols/med/medcat_forest.json
+++ b/resources/dicts/patrols/med/medcat_forest.json
@@ -1867,7 +1867,7 @@
     "exp": 10,
     "success_text": [
             "Daisies may seem like part of the everyday carpet of greenery, present everywhere from rocks to fields to at the foot of trees, but that doesn't make their leaves any less useful.",
-            "Greenleaf brings a veritable explosion of daisies raising little white and yellow flowers around every corner, and p_l partically doesn't need to even leave camp to gather them.",
+            "Greenleaf brings a veritable explosion of daisies raising little white and yellow flowers around every corner, and p_l practically doesn't need to even leave camp to gather them.",
             "Daisies aren't hard to find in the warmer seasons, and s_c collects enough that they have trouble not dropping any on the way back to camp."
 ],
     "fail_text": [
@@ -1893,7 +1893,7 @@
     "exp": 20,
     "success_text": [
             "Daisies may seem like part of the everyday carpet of greenery, present everywhere from rocks to fields to at the foot of trees, but that doesn't make their leaves any less useful. p_l goes through their common uses with app1.",
-            "Greenleaf brings a veritable explosion of daisies raising little white and yellow flowers around every corner, and p_l partically doesn't need to even leave camp to gather them. It gives them time to let app1 run off and play with their friends, and seeing their apprentice getting to relax makes them smile from their favourite basking spot.",
+            "Greenleaf brings a veritable explosion of daisies raising little white and yellow flowers around every corner, and p_l practically doesn't need to even leave camp to gather them. It gives them time to let app1 run off and play with their friends, and seeing their apprentice getting to relax makes them smile from their favourite basking spot.",
             "Daisies aren't hard to find in the warmer seasons, and s_c collects enough that they have trouble not dropping any on the way back to camp. At least with app1 here with them the load is shared, and they purr in appreciation of the apprentice."
 ],
     "fail_text": [
@@ -1919,7 +1919,7 @@
     "exp": 10,
     "success_text": [
             "Daisies may seem like part of the everyday carpet of greenery, present everywhere from rocks to fields to at the foot of trees, but that doesn't make their leaves any less useful. With a larger patrol, the cats bring back a good haul, and p_l makes sure to thank everyone for their assistance.",
-            "Greenleaf brings a veritable explosion of daisies raising little white and yellow flowers around every corner, and p_l partically doesn't need to even leave camp to gather them. It ends up feeling like an afternoon full of chatting and catching up with their Clanmates that happens to have daisy gathering in it, rather than a typical herb gathering patrol.",
+            "Greenleaf brings a veritable explosion of daisies raising little white and yellow flowers around every corner, and p_l practically doesn't need to even leave camp to gather them. It ends up feeling like an afternoon full of chatting and catching up with their Clanmates that happens to have daisy gathering in it, rather than a typical herb gathering patrol.",
             "Daisies aren't hard to find in the warmer seasons, and s_c collects enough that they have trouble not dropping any on the way back to camp. The patrol, filled with gossip and chatter on the way out and daisy leaves on the trip back, is an easy and enjoyable afternoon."
     ],
     "fail_text": [

--- a/resources/dicts/patrols/med/medcat_forest.json
+++ b/resources/dicts/patrols/med/medcat_forest.json
@@ -1867,7 +1867,7 @@
     "exp": 10,
     "success_text": [
             "Daisies may seem like part of the everyday carpet of greenery, present everywhere from rocks to fields to at the foot of trees, but that doesn't make their leaves any less useful.",
-            "greenleaf brings a veritable explosion of daisies raising little white and yellow flowers around every corner, and p_l partically doesn't need to even leave camp to gather them.",
+            "Greenleaf brings a veritable explosion of daisies raising little white and yellow flowers around every corner, and p_l partically doesn't need to even leave camp to gather them.",
             "Daisies aren't hard to find in the warmer seasons, and s_c collects enough that they have trouble not dropping any on the way back to camp."
 ],
     "fail_text": [
@@ -1893,7 +1893,7 @@
     "exp": 20,
     "success_text": [
             "Daisies may seem like part of the everyday carpet of greenery, present everywhere from rocks to fields to at the foot of trees, but that doesn't make their leaves any less useful. p_l goes through their common uses with app1.",
-            "greenleaf brings a veritable explosion of daisies raising little white and yellow flowers around every corner, and p_l partically doesn't need to even leave camp to gather them. It gives them time to let app1 run off and play with their friends, and seeing their apprentice getting to relax makes them smile from their favourite basking spot.",
+            "Greenleaf brings a veritable explosion of daisies raising little white and yellow flowers around every corner, and p_l partically doesn't need to even leave camp to gather them. It gives them time to let app1 run off and play with their friends, and seeing their apprentice getting to relax makes them smile from their favourite basking spot.",
             "Daisies aren't hard to find in the warmer seasons, and s_c collects enough that they have trouble not dropping any on the way back to camp. At least with app1 here with them the load is shared, and they purr in appreciation of the apprentice."
 ],
     "fail_text": [
@@ -1919,7 +1919,7 @@
     "exp": 10,
     "success_text": [
             "Daisies may seem like part of the everyday carpet of greenery, present everywhere from rocks to fields to at the foot of trees, but that doesn't make their leaves any less useful. With a larger patrol, the cats bring back a good haul, and p_l makes sure to thank everyone for their assistance.",
-            "greenleaf brings a veritable explosion of daisies raising little white and yellow flowers around every corner, and p_l partically doesn't need to even leave camp to gather them. It ends up feeling like an afternoon full of chatting and catching up with their Clanmates that happens to have daisy gathering in it, rather than a typical herb gathering patrol.",
+            "Greenleaf brings a veritable explosion of daisies raising little white and yellow flowers around every corner, and p_l partically doesn't need to even leave camp to gather them. It ends up feeling like an afternoon full of chatting and catching up with their Clanmates that happens to have daisy gathering in it, rather than a typical herb gathering patrol.",
             "Daisies aren't hard to find in the warmer seasons, and s_c collects enough that they have trouble not dropping any on the way back to camp. The patrol, filled with gossip and chatter on the way out and daisy leaves on the trip back, is an easy and enjoyable afternoon."
     ],
     "fail_text": [
@@ -4634,7 +4634,7 @@
     "biome": "forest",
     "season": "greenleaf",
     "tags": ["med_only", "med_cat", "herb", "oak_leaves", "many_herbs1", "many_herbs2", "big_change", "platonic", "dislike", "comfort", "respect", "trust", "apprentice"],
-    "intro_text": "greenleaf encourages the oak to reach its full potential, wide and towering, and p_l goes to collect a harvest of its leaves with app1.",
+    "intro_text": "Greenleaf encourages the oak to reach its full potential, wide and towering, and p_l goes to collect a harvest of its leaves with app1.",
     "decline_text": "They have second thoughts leaving their patients behind, especially with their apprentice also out, and decide to go another day.",
     "chance_of_success": 70,
     "exp": 20,

--- a/resources/dicts/patrols/med/medcat_plains.json
+++ b/resources/dicts/patrols/med/medcat_plains.json
@@ -1703,7 +1703,7 @@
     "exp": 10,
     "success_text": [
             "Daisies may seem like part of the everyday carpet of greenery, present everywhere from rocks to fields to at the foot of trees, but that doesn't make their leaves any less useful.",
-            "Greenleaf brings a veritable explosion of daisies raising little white and yellow flowers around every corner, and p_l partically doesn't need to even leave camp to gather them.",
+            "Greenleaf brings a veritable explosion of daisies raising little white and yellow flowers around every corner, and p_l practically doesn't need to even leave camp to gather them.",
             "Daisies aren't hard to find in the warmer seasons, and s_c collects enough that they have trouble not dropping any on the way back to camp."
 ],
     "fail_text": [
@@ -1729,7 +1729,7 @@
     "exp": 20,
     "success_text": [
             "Daisies may seem like part of the everyday carpet of greenery, present everywhere from rocks to fields to at the foot of trees, but that doesn't make their leaves any less useful. p_l goes through their common uses with app1.",
-            "Greenleaf brings a veritable explosion of daisies raising little white and yellow flowers around every corner, and p_l partically doesn't need to even leave camp to gather them. It gives them time to let app1 run off and play with their friends, and seeing their apprentice getting to relax makes them smile from their favourite basking spot.",
+            "Greenleaf brings a veritable explosion of daisies raising little white and yellow flowers around every corner, and p_l practically doesn't need to even leave camp to gather them. It gives them time to let app1 run off and play with their friends, and seeing their apprentice getting to relax makes them smile from their favourite basking spot.",
             "Daisies aren't hard to find in the warmer seasons, and s_c collects enough that they have trouble not dropping any on the way back to camp. At least with app1 here with them the load is shared, and they purr in appreciation of the apprentice."
 ],
     "fail_text": [
@@ -1755,7 +1755,7 @@
     "exp": 10,
     "success_text": [
            "Daisies may seem like part of the everyday carpet of greenery, present everywhere from rocks to fields to at the foot of trees, but that doesn't make their leaves any less useful. With a larger patrol, the cats bring back a good haul, and p_l makes sure to thank everyone for their assistance.",
-            "Greenleaf brings a veritable explosion of daisies raising little white and yellow flowers around every corner, and p_l partically doesn't need to even leave camp to gather them. It ends up feeling like an afternoon full of chatting and catching up with their Clanmates that happens to have daisy gathering in it, rather than a typical herb gathering patrol.",
+            "Greenleaf brings a veritable explosion of daisies raising little white and yellow flowers around every corner, and p_l practically doesn't need to even leave camp to gather them. It ends up feeling like an afternoon full of chatting and catching up with their Clanmates that happens to have daisy gathering in it, rather than a typical herb gathering patrol.",
             "Daisies aren't hard to find in the warmer seasons, and s_c collects enough that they have trouble not dropping any on the way back to camp. The patrol, filled with gossip and chatter on the way out and daisy leaves on the trip back, is an easy and enjoyable afternoon."
     ],
     "fail_text": [

--- a/scripts/cat/names.py
+++ b/scripts/cat/names.py
@@ -216,7 +216,7 @@ class Name():
         "Milque", "Mimi", "Minette", "Mini", "Minna", "Minnie", "Mint", "Minty", "Missile Launcher", "Mitski", "Mittens", "Mocha", "Mocha", "Mojo", "Mollie",
         "Molly", "Molly Murder Mittens", "Monika", "Monster", "Monte", "Monzi", "Moon", "Mop", "Moxie", "Mr. Kitty", "Mr. Kitty Whiskers", "Mr. Whiskers",
         "Mr. Wigglebottom", "Mucha", "Murder", "Mushroom", "Mitaine", "Myko", "Neel", "Nagi", "Nakeena", "Neil", "Nemo", "Nessie", "Nick", "Nightmare", "Nikki",
-        "Niles", "Ninja", "Nintendo", "Nisha", "Nitro", "Noodle", "Norman" "Nova", "Nugget", "Nuggets", "Nuka", "Nutella", "O'Leary", "Oakley", "Oapie", "Obi Wan",
+        "Niles", "Ninja", "Nintendo", "Nisha", "Nitro", "Noodle", "Norman", "Nova", "Nugget", "Nuggets", "Nuka", "Nutella", "O'Leary", "Oakley", "Oapie", "Obi Wan",
         "Old Man Sam", "Oleander", "Olga", "Oliver", "Oliva", "Ollie", "Omelet", "Onyx", "Oops", "Ophelia", "Oreo", "Orion", "Oscar", "Owen", "Peach", "Peanut",
         "Peanut Wigglebutt", "Pear", "Pearl", "Pecan", "Penny", "Peony", "Pepper", "Pichi", "Pickles", "Pikachu", "Ping", "Ping Pong",
         "Pip", "Piper", "Pipsqueak", "Pocket", "Poki", "Polly", "Pong", "Poopy", "Porsche", "Potato", "Prickle", "Princess", "Pumpernickel", "Punk", "Purdy",


### PR DESCRIPTION
-capitalized "greenleaf" at the start of a few sentences
-"partically" -> "practically" in a few patrols
-added comma between the loner names "norman" and "nova"