### PR TITLE
QOL: Additions to prey system

### DIFF
--- a/resources/dicts/patrols/hunting/hunting.json
+++ b/resources/dicts/patrols/hunting/hunting.json
@@ -62,7 +62,8 @@
             "hunting",
             "medium_prey0",
             "medium_prey1",
-            "large_prey2"
+            "large_prey2",
+            "no_fail_prey"
         ],
         "intro_text": "Your patrol comes across a large rat.",
         "success_text": [

--- a/resources/dicts/patrols/hunting/hunting_beach.json
+++ b/resources/dicts/patrols/hunting/hunting_beach.json
@@ -87,7 +87,8 @@
             "medium_prey0",
             "medium_prey1",
             "large_prey2",
-            "large_prey3"
+            "large_prey3",
+            "no_fail_prey"
         ],
         "intro_text": "The patrol looks around for something to disguise their scent while hunting.",
         "decline_text": "On second thought, maybe not.",
@@ -132,7 +133,8 @@
             "clan_to_r_c",
             "minor_injury",
             "scar",
-            "large_prey"
+            "large_prey",
+            "no_fail_prey"
         ],
         "intro_text": "app1's mentor assesses them by sending them on a solo hunt.",
         "decline_text": "app1 asks their mentor to do the assessment some other time.",
@@ -194,7 +196,8 @@
         "tags": [
             "hunting",
             "warrior",
-            "large_prey"
+            "large_prey",
+            "no_fail_prey"
         ],
         "intro_text": "r_c heads out along the coast alone, wanting to sink their teeth into some prey and have some time to themselves.",
         "decline_text": "r_c turns back to camp, deciding that a group hunt would be more effective.",
@@ -250,7 +253,8 @@
         "tags": [
             "hunting",
             "deputy",
-            "large_prey"
+            "large_prey",
+			"no_fail_prey"
         ],
         "intro_text": "r_c heads out along the coast alone, wanting to sink their teeth into some prey and have some time to themselves.",
         "decline_text": "r_c turns back to camp, deciding that a group hunt would be more effective.",
@@ -306,7 +310,8 @@
         "tags": [
             "hunting",
             "leader",
-            "large_prey"
+            "large_prey",
+			"no_fail_prey"
         ],
         "intro_text": "r_c heads out along the coast alone, wanting to sink their teeth into some prey and have some time to themselves.",
         "decline_text": "r_c turns back to camp, deciding that a group hunt would be more effective.",
@@ -1480,500 +1485,824 @@
             null,
             "s_c dances around nervously, but the patrol wants to give this hunt a try. Their anxiety doesn't help, and the deflated octopus manages to grab and bite them with its hooked beak, proving that maybe s_c was right to be cautious."
         ],
-    "min_cats": 2,
-    "max_cats": 6,
-    "antagonize_text": null,
-    "antagonize_fail_text": null
-},
-{
-    "patrol_id": "bch_hunt_eagleswim1",
-    "biome": "beach",
-    "season": "Any",
-    "tags": ["hunting", "large_prey0", "large_prey1", "huge_prey2", "huge_prey3", "warrior", "trust", "scar", "injury", "beak_bite"],
-    "intro_text": "The hunting patrol spots an eagle on the wing overhead, and watches as it swoops to dig its talons through the spine of an impressively huge fish. But then it doesn't take its catch into the air. Perhaps it's too heavy?",
-    "decline_text": "They move on, ignoring the eagle to focus on their own hunt.",
-    "chance_of_success": 30,
-    "exp": 20,
-    "success_text": [
-        "Your patrol uses the eagle as a scout for their own hunt, and eventually manage several smaller catches from the same area that cumulatively are just as impressive as the eagle's massive catch.",
-        "The cats' eyes light up with possibility, watching the eagle swimming to shore awkwardly. p_l leads the patrol yowling threats and insults from the shoreline and making a massive racket. Bewildered, the eagle eventually gives up its catch and takes to the air. The massive fish washes ashore into the paws of c_n.",
-        "As the rest of the patrol discuss whether they can steal the catch, s_c fixates on the bird that caught it. The eagle works its way awkwardly towards shore, and just as it's going to climb out s_c pounces, fighting in the shallows where s_c has the edge over the bird in swimming. They win both the fish and the predator as prey for c_n.",
-        "As the rest of the patrol discuss whether they can steal the catch, s_c fixates on the bird that caught it. The eagle works its way awkwardly towards shore, and just as it's going to climb out s_c pounces, fighting in the shallows where s_c has the edge over the bird in swimming. They win both the fish and the predator as prey for c_n."
-    ],
-    "fail_text": [
-        "The patrol dives into the water, keen to make a play to steal the fish, but even though its talons are occupied keeping grip on its prey, the eagle's huge wings pack a buffeting punch and the cats are driven back, giving up on the idea of scavenging.",
-        null,
-        null,
-        "The patrol decides to fight the eagle in the water for possession of the prey, but while its talons are occupied holding on to its prey, its beak is not, and it takes a nasty chunk out of r_c before the cats retreat."
-    ],
-    "win_skills": ["excellent fighter"],
-    "win_trait": ["ambitious"],
-    "fail_skills": ["None"],
-    "fail_trait": ["None"],
-    "min_cats": 1,
-    "max_cats": 3,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c carries a scar from an eagle's beak.",
-        null
-    ]
-},
-{
-    "patrol_id": "bch_hunt_eagleswim2",
-    "biome": "beach",
-    "season": "Any",
-    "tags": ["hunting", "large_prey0", "large_prey1", "huge_prey2", "huge_prey3", "warrior", "trust", "scar", "injury", "beak_bite"],
-    "intro_text": "The hunting patrol spots an eagle on the wing overhead, and watches as it swoops to dig its talons through the spine of an impressively huge fish. But then it doesn't take its catch into the air. Perhaps it's too heavy?",
-    "decline_text": "They move on, ignoring the eagle to focus on their own hunt.",
-    "chance_of_success": 60,
-    "exp": 20,
-    "success_text": [
-        "Your patrol uses the eagle as a scout for their own hunt, and eventually manage several smaller catches from the same area that cumulatively are just as impressive as the eagle's massive catch.",
-        "The cats' eyes light up with possibility, watching the eagle swimming to shore awkwardly. p_l leads the patrol yowling threats and insults from the shoreline and making a massive racket. Bewildered, the eagle eventually gives up its catch and takes to the air. The massive fish washes ashore into the paws of c_n.",
-        "As the rest of the patrol discuss whether they can steal the catch, s_c fixates on the bird that caught it. The eagle works its way awkwardly towards shore, and just as it's going to climb out s_c pounces, fighting in the shallows where s_c has the edge over the bird in swimming. They win both the fish and the predator as prey for c_n.",
-        "As the rest of the patrol discuss whether they can steal the catch, s_c fixates on the bird that caught it. The eagle works its way awkwardly towards shore, and just as it's going to climb out s_c pounces, fighting in the shallows where s_c has the edge over the bird in swimming. They win both the fish and the predator as prey for c_n."
-    ],
-    "fail_text": [
-        "The patrol dives into the water, keen to make a play to steal the fish, but even though its talons are occupied keeping grip on its prey, the eagle's huge wings pack a buffeting punch and the cats are driven back, giving up on the idea of scavenging.",
-        null,
-        null,
-        "The patrol decides to fight the eagle in the water for possession of the prey, but while its talons are occupied holding on to its prey, its beak is not, and it takes a nasty chunk out of r_c before the cats retreat."
-    ],
-    "win_skills": ["excellent fighter"],
-    "win_trait": ["ambitious"],
-    "fail_skills": ["None"],
-    "fail_trait": ["None"],
-    "min_cats": 4,
-    "max_cats": 6,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c carries a scar from an eagle's beak.",
-        null
-    ]
-},
-{
-    "patrol_id": "bch_hunt_eagleswim3",
-    "biome": "beach",
-    "season": "Any",
-    "tags": ["hunting", "large_prey0", "large_prey1", "huge_prey2", "huge_prey3", "warrior", "trust", "cruel_season", "death", "scar", "injury", "beak_bite"],
-    "intro_text": "The hunting patrol spots an eagle on the wing overhead, and watches as it swoops to dig its talons through the spine of an impressively huge fish. But then it doesn't take its catch into the air. Perhaps it's too heavy?",
-    "decline_text": "They move on, ignoring the eagle to focus on their own hunt.",
-    "chance_of_success": 30,
-    "exp": 20,
-    "success_text": [
-        "Your patrol uses the eagle as a scout for their own hunt, and eventually manage several smaller catches from the same area that cumulatively are just as impressive as the eagle's massive catch.",
-        "The cats' eyes light up with possibility, watching the eagle swimming to shore awkwardly. p_l leads the patrol yowling threats and insults from the shoreline and making a massive racket. Bewildered, the eagle eventually gives up its catch and takes to the air. The massive fish washes ashore into the paws of c_n.",
-        "As the rest of the patrol discuss whether they can steal the catch, s_c fixates on the bird that caught it. The eagle works its way awkwardly towards shore, and just as it's going to climb out s_c pounces, fighting in the shallows where s_c has the edge over the bird in swimming. They win both the fish and the predator as prey for c_n.",
-        "As the rest of the patrol discuss whether they can steal the catch, s_c fixates on the bird that caught it. The eagle works its way awkwardly towards shore, and just as it's going to climb out s_c pounces, fighting in the shallows where s_c has the edge over the bird in swimming. They win both the fish and the predator as prey for c_n."
-    ],
-    "fail_text": [
-        "The patrol dives into the water, keen to make a play to steal the fish, but even though its talons are occupied keeping grip on its prey, the eagle's huge wings pack a buffeting punch and the cats are driven back, giving up on the idea of scavenging.",
-        null,
-        "The patrol decides to fight the eagle in the water for possession of the prey, but the bird drops the prey and a furious haphazard swimming fight ensues. The eagle's talons, wings, and beak flail in an uncoordinated, dangerous tangle that brings r_c below the water. It's hard to say what kills them, the talon wounds or drowning.",
-        "The patrol decides to fight the eagle in the water for possession of the prey, but while its talons are occupied holding on to its prey, its beak is not, and it takes a nasty chunk out of r_c before the cats retreat."
-    ],
-    "win_skills": [
-        "excellent fighter"
-    ],
-    "win_trait": ["ambitious"],
-    "fail_skills": ["None"],
-    "fail_trait": ["None"],
-    "min_cats": 1,
-    "max_cats": 3,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c carries a scar from an eagle's beak.",
-        "r_c was killed by an eagle, scrapping over food.",
-        "were killed by an eagle"
-    ]
-},
-{
-    "patrol_id": "bch_hunt_eagleswim4",
-    "biome": "beach",
-    "season": "Any",
-    "tags": ["hunting", "large_prey0", "large_prey1", "huge_prey2", "huge_prey3", "warrior", "trust", "cruel_season", "death", "scar", "injury", "beak_bite"],
-    "intro_text": "The hunting patrol spots an eagle on the wing overhead, and watches as it swoops to dig its talons through the spine of an impressively huge fish. But then it doesn't take its catch into the air. Perhaps it's too heavy?",
-    "decline_text": "They move on, ignoring the eagle to focus on their own hunt.",
-    "chance_of_success": 60,
-    "exp": 20,
-    "success_text": [
-        "Your patrol uses the eagle as a scout for their own hunt, and eventually manage several smaller catches from the same area that cumulatively are just as impressive as the eagle's massive catch.",
-        "The cats' eyes light up with possibility, watching the eagle swimming to shore awkwardly. p_l leads the patrol yowling threats and insults from the shoreline and making a massive racket. Bewildered, the eagle eventually gives up its catch and takes to the air. The massive fish washes ashore into the paws of c_n.",
-        "As the rest of the patrol discuss whether they can steal the catch, s_c fixates on the bird that caught it. The eagle works its way awkwardly towards shore, and just as it's going to climb out s_c pounces, fighting in the shallows where s_c has the edge over the bird in swimming. They win both the fish and the predator as prey for c_n.",
-        "As the rest of the patrol discuss whether they can steal the catch, s_c fixates on the bird that caught it. The eagle works its way awkwardly towards shore, and just as it's going to climb out s_c pounces, fighting in the shallows where s_c has the edge over the bird in swimming. They win both the fish and the predator as prey for c_n."
-    ],
-    "fail_text": [
-        "The patrol dives into the water, keen to make a play to steal the fish, but even though its talons are occupied keeping grip on its prey, the eagle's huge wings pack a buffeting punch and the cats are driven back, giving up on the idea of scavenging.",
-        null,
-        "The patrol decides to fight the eagle in the water for possession of the prey, but the bird drops the prey and a furious haphazard swimming fight ensues. The eagle's talons, wings, and beak flail in an uncoordinated, dangerous tangle that brings r_c below the water. It's hard to say what kills them, the talon wounds or drowning.",
-        "The patrol decides to fight the eagle in the water for possession of the prey, but while its talons are occupied holding on to its prey, its beak is not, and it takes a nasty chunk out of r_c before the cats retreat."
-    ],
-    "win_skills": [
-        "excellent fighter"
-    ],
-    "win_trait": ["ambitious"],
-    "fail_skills": ["None"],
-    "fail_trait": ["None"],
-    "min_cats": 4,
-    "max_cats": 6,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c carries a scar from an eagle's beak.",
-        "r_c was killed by an eagle, scrapping over food.",
-        "were killed by an eagle"
-    ]
-},
-{
-    "patrol_id":"bch_hunt_twolegsobject1",
-    "biome":"beach",
-    "season": "greenleaf",
-    "tags": ["hunting", "injury", "sprain"],
-    "intro_text" : "As the patrol arrives at a beach, they spot Twolegs and their kits lounging around a brightly colored pelt of some kind, and smell food-scent.",
-    "decline_text": "The patrol decides to avoid the Twolegs.",
-    "chance_of_success" : 50,
-    "exp": 10,
-    "success_text": [
-        "The patrol sneaks closer. It seems the Twolegs are eating, though the open beach shore means the cats don't have any chances of stealing a bite.",
-        null,
-        "s_c is more interested in the strangely-colored pelt than the food-scent, which the Twolegs will undoubtedly be possessive of. They wonder how the odd creature make such things, and why on earth they'd bring them to a beach to sit on pointlessly."
-    ],
-    "fail_text": [
-        "The patrol can't seem to interpret the purpose of the gathering. Twolegs are just mystifying.",
-        null,
-        null,
-        "As the patrol gets close, a Twoleg kit runs at them, screaming unintelligibly. While running away, r_c sprains a leg."
-    ],
-    "win_skills": [
-        "smart",
-        "very smart",
-        "extremely smart"
-    ],
-    "win_trait":["None"],
-    "fail_skills":["None"],
-    "fail_trait":["None"],
-    "min_cats": 2,
-    "max_cats": 6,
-    "antagonize_text": null,
-    "antagonize_fail_text": null
-},
-{
-    "patrol_id": "bch_hunt_leafbaresnowstorm1",
-    "biome": "beach",
-    "season": "leaf-bare",
-    "tags": ["hunting", "large_prey", "comfort", "trust", "patrol_to_p_l", "patrol_to_r_c", "cold_injury"],
-    "intro_text": "It starts snowing soon after the patrol sets out, trying to bring back something nice for the fresh-kill pile.",
-    "decline_text": "They decide to turn back and wait until the snow dies down.",
-    "chance_of_success": 50,
-    "exp" :10,
-    "success_text": [
-        "Despite the snow, the patrol manages to hunt successfully, finding crabs running about on the beach, oblivious to leaf-bare. With the sea to provide there's more than enough to bring a good haul back to c_n, and as p_l leads them home there's a sense of security and competence driving them onwards.",
-        null,
-        "Everyone looks admiringly at s_c by the end of the afternoon. Every cat carries something home, but nearly all of it was caught by s_c.",
-        "s_c really keeps the patrol on task and motivated through the sharp cold of the leaf-bare morning, not through authority or commands, but with a gentle voice and compassionate understanding that encourages every cat to do their best for c_n."
-    ],
-    "fail_text": [
-        "The prey must be hiding; the patrol catches nothing. As a snowstorm descends and visibility drops, the patrol retreats to a sea cave, their pelts and tails and legs all tightly wrapped into one indistinguishable kitty cat ball while they wait for the storm to blow over.",
-        null,
-        null,
-        "The prey must be hiding; the patrol catches nothing. As a snowstorm descends and visibility drops, the patrol retreats to a sea cave, their pelts and tails and legs all tightly wrapped into one indistinguishable kitty cat ball. Still, when they return to camp r_c is cold and chilled."
-    ],
-    "win_skills": ["great hunter", "fantastic hunter"],
-    "win_trait": ["altruistic", "compassionate", "empathetic", "faithful", "loving"],
-    "fail_skills": ["None"],
-    "fail_trait": ["None"],
-    "min_cats": 3,
-    "max_cats": 6,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c caught a chill while hunting in leaf-bare.",
-        null
-    ]
-},
-{
-    "patrol_id": "bch_hunt_leafbaresnowstorm2",
-    "biome": "beach",
-    "season": "leaf-bare",
-    "tags": ["hunting", "small_prey", "cold_injury"],
-    "intro_text": "It starts snowing soon after the patrol sets out, trying to bring back something nice for the fresh-kill pile.",
-    "decline_text": "They decide to turn back and wait until the snow dies down.",
-    "chance_of_success": 40,
-    "exp": 10,
-    "success_text": [
-        "Despite the snow, r_c manages to hunt successfully, finding the normal number of crabs obliviously scurrying about.",
-        null,
-        "s_c really shows their talent, bringing a clutch of crabs back to camp for the fresh-kill pile."
-    ],
-    "fail_text": [
-        null,
-        null,
-        null,
-        "The prey must be hiding; r_c catches nothing. As a snowstorm descends and visibility drops, they hide in a sea cave, shivering and tightly tucked up against the cold. When they return to camp r_c is cold and chilled, but otherwise unharmed."
-    ],
-    "win_skills": ["great hunter", "fantastic hunter"],
-    "win_trait": ["None"],
-    "fail_skills": ["None"],
-    "fail_trait": ["None"],
-    "min_cats": 1,
-    "max_cats": 1,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c caught a chill while hunting in leaf-bare.",
-        null
-    ]
-},
-{
-    "patrol_id": "bch_hunt_leafbaresnowstorm3",
-    "biome": "beach",
-    "season": "leaf-bare",
-    "tags":["hunting", "small_prey", "comfort", "trust", "rel_patrol", "romantic", "no_app", "cold_injury"],
-    "intro_text": "It starts snowing soon after the patrol sets out, trying to bring back something nice for the fresh-kill pile.",
-    "decline_text": "They decide to turn back and wait until the snow dies down.",
-    "chance_of_success": 50,
-    "exp": 10,
-    "success_text": [
-        "A storm descends, sudden and violent, putting an end to any other thoughts but survival. The cats retreat into a sea cave and cuddle together, sharing what little warmth they have. Each cat takes a turn on the most exposed side of the huddle, selflessly risking themselves.",
-        null,
-        "A storm descends, sudden and violent, putting an end to any other thoughts but survival. s_c keeps everyone's spirits up as the patrol hides in the lee of a cliff where the wind can't get them, until everyone is talking, shaky and unhappy, but keeping each other's spirits up.",
-        "A storm descends, sudden and violent, putting an end to any other thoughts but survival. As the cats hide from the wind, s_c keeps an eye out for everyone. It's a long couple of hours, but with gentle understanding and compassion the cats make it though safely, closer than ever afterwards."
-    ],
-    "fail_text": [
-        null,
-        null,
-        null,
-        "A storm descends, sudden and violent, putting an end to any other thoughts but survival. When the snowstorm leaves, finally, and the cats trudge back home, but r_c hasn't escaped unscathed, their body chilled and refusing to warm up properly."
-    ],
-    "win_skills": ["great speaker", "excellent speaker"],
-    "win_trait": ["altruistic", "compassionate", "empathetic", "faithful", "loving"],
-    "fail_skills": ["None"],
-    "fail_trait": ["None"],
-    "min_cats": 2,
-    "max_cats": 6,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c caught a chill while hunting in leaf-bare.",
-        null
-    ]
-},
-{
-    "patrol_id": "bch_hunt_redfox_scavenge1",
-    "biome": "beach",
-    "season": "Any",
-    "tags": ["hunting", "large_prey", "fighting", "scar", "big_bite_injury", "clan_to_patrol", "respect", "rel_patrol"],
-    "intro_text": "Your patrol catches the scent of a red fox. Tracking it, they find the animal feeding on a shark that the waves have washed ashore in the night.",
-    "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
-    "chance_of_success": 50,
-    "exp": 20,
-    "success_text": [
-        "Your cats are smaller but they outnumber the fox, if only by a little, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full of food and unwilling to lose blood over it, is driven off from the kill.",
-        null,
-        "s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until it gives up and runs.",
-        "The patrol launches into battle, but with so few cats it's exhausting trying to keep the fox and its snapping jaws on the defensive. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. It's only one bite, but the fox has had enough and flees."
-    ],
-    "fail_text": [
-        "Your patrol fails to drive away the fox, which keeps possession of the food. However there were no injuries.",
-        null,
-        null,
-        "The patrol launches into battle, but r_c is caught with a nasty bite, and the cats give up on challenging for the food in favor of quickly helping r_c back to the medicine cat den.",
-        null,
-        "s_c means well, but they're overconfident in their attack and the fox manages to sink their teeth into them. The patrol is forced to retreat, forming a defensive ring around the hurt s_c."
-    ],
-    "win_skills": ["good fighter", "great fighter", "excellent fighter"],
-    "win_trait": ["adventurous", "altruistic", "ambitious", "confident", "daring", "fierce", "responsible", "righteous"],
-    "fail_skills": ["None"],
-    "fail_trait": ["troublesome", "vengeful", "bloodthirsty", "bold"],
-    "min_cats": 2,
-    "max_cats": 3,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c carries a scar from a fox fight.",
-        null
-    ]
-},
-{
-    "patrol_id": "bch_hunt_redfox_scavenge2",
-    "biome": "beach",
-    "season": "Any",
-    "tags":["hunting", "large_prey", "fighting", "scar", "big_bite_injury", "clan_to_patrol", "respect", "rel_patrol"],
-    "intro_text": "Your patrol catches the scent of a red fox. Tracking it, they find the animal feeding on a shark that the waves have washed ashore in the night.",
-    "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
-    "chance_of_success": 80,
-    "exp": 20,
-    "success_text": [
-        "Your cats are smaller but heavily outnumber the fox, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full and unwilling to lose blood over it, is driven off from the kill.",
-        null,
-        "s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until s_c lands a crucial blow, snapping a tendon in one of the fox's hindlegs. The fox runs, but there's no way it'll live long with such a crippling injury.",
-        "The patrol launches into battle, keeping the fox on the defensive with teamwork. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. Holding on grimly, s_c's daring move gives the rest of the patrol the opportunity needed to bring the fox down for good."
-    ],
-    "fail_text":[
-        "Your patrol fails to drive away the fox, which keeps possession of the food. However with so many cats to protect each other, there were no injuries.",
-        null,
-        null,
-        "The patrol launches into battle, but r_c is caught with a nasty bite, and the cats give up on challenging for the food in favor of quickly helping r_c back to the medicine cat den.",
-        null,
-        "s_c means well, but they're overconfident in their attack and the fox manages to sink their teeth into them. The patrol is forced to retreat, forming a defensive ring around the hurt s_c."
-    ],
-    "win_skills": ["good fighter", "great fighter", "excellent fighter"],
-    "win_trait": ["adventurous", "altruistic", "ambitious", "confident", "daring", "fierce", "responsible", "righteous"],
-    "fail_skills": ["None"],
-    "fail_trait": ["troublesome", "vengeful", "bloodthirsty", "bold"],
-    "min_cats": 4,
-    "max_cats": 6,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c carries a scar from a fox fight."
-    ]
-},
-{
-    "patrol_id": "bch_hunt_redfox_scavenge3",
-    "biome": "beach",
-    "season": "Any",
-    "tags": ["hunting", "large_prey", "fighting", "scar", "big_bite_injury", "clan_to_patrol", "respect"],
-    "intro_text": "r_c catches the scent of a red fox. Tracking it, they find the animal feeding on a shark that the waves have washed ashore in the night.",
-    "decline_text": "r_c decides not to quarrel with the fox and to find prey elsewhere.",
-    "chance_of_success": 30,
-    "exp": 30,
-    "success_text": [
-        "r_c is smaller, alone, and half its weight, but the fox has a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle. The fox, already stuffed full and unwilling to lose blood over it, leaves the kill with a grumble.",
-        null,
-        "s_c uses every trick in their talented fighting skillset to attack the fox with no one to watch their flank, until the perfect opportunity opens up and they pounce onto the fox's back, digging in their claws. It's a wild ride through the forest until the fox bucks them off, but it wins them the shark carcass.",
-        "In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. But then they're stuck, unwilling to let go and risk being bitten. They're dragged through the forest, over rocks and through bushes, until the fox finally collapses and the battered s_c goes back to proudly claim the shark."
-    ],
-    "fail_text": [
-        "Your patrol fails to drive away the fox, which keeps possession of the food. However there were no injuries.",
-        null,
-        "Fiercely, r_c throws themselves at the fox, determined to win the shark prize. But the fox values it just as dearly, and manages to get a good grip on r_c, shaking them to pieces and killing them.",
-        "r_c launches into battle, but is caught with a nasty bite, and retreats to limp back home. The fox doesn't follow, happy enough to eat the shark instead of the foolish cat.",
-        null,
-        "s_c is overconfident in their attack and the fox manages to sink their teeth into them. They retreat, bleeding and in pain, and the fox settles back down to its meal."
-    ],
-    "win_skills": ["great fighter", "excellent fighter"],
-    "win_trait": ["adventurous", "altruistic", "ambitious", "confident", "daring", "fierce", "responsible", "righteous"],
-    "fail_skills": ["None"],
-    "fail_trait": ["troublesome", "vengeful", "bloodthirsty", "bold"],
-    "min_cats": 1,
-    "max_cats": 1,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c carries a scar from a solo fox fight.",
-        "r_c fell in a solo battle with a fox.",
-        "died fighting a fox"
-    ]
-},
-{
-    "patrol_id": "bch_hunt_foxgray_scavenge1",
-    "biome": "beach",
-    "season": "Any",
-    "tags": ["hunting", "large_prey", "fighting", "scar", "injury", "bite-wound", "clan_to_patrol", "respect", "rel_patrol"],
-    "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? Tracking it, they find a stocky gray fox feeding on an unidentifible but deliciously stinky mound of carrion the sea has washed up onto the shore.",
-    "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
-    "chance_of_success": 70,
-    "exp": 20,
-    "success_text": [
-        "While a gray fox is bigger and far stockier than the cats, the delicious stench of whatever-it-is makes the patrols' eyes go wide, and they leap to claim possession of it. Outnumbered and already full of stinky nonsense, the gray fox leaves the beach, scrambling up a cliff as the cats give in to instinct and roll around in the glorious smell.",
-        "A gray fox is bigger than them, yes... but only just, and that carcass smells divine. The cats creep up on the fox, using the dunes for cover, and wait until the fox has its head buried in the carcass to attack. The ambush sends the competing predator fleeing, and leaves the cats to claim the heavenly stinky food.",
-        "s_c shows their strength, leading the fight against the gray fox. By working together and keeping it distracted, the cats harry and harass the fox until it gives up and runs.",
-        "The patrol launches into battle, but with so few cats it's exhausting trying to keep the fox and its snapping jaws on the defensive. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. It's only one bite, but the fox has had enough and flees."
-    ],
-    "fail_text": [
-        "Your patrol fails to drive away the fox, which keeps possession of the food. However, there were no injuries.",
-        "s_c makes a stupid mistake, too intent on winning the fight to respect their enemy's teeth, and it's only being yanked back by the tail that saves them from injury. The patrol gives up, and settles down to wait a safe distance away until the fox leaves of its own accord.",
-        null,
-        null,
-        null,
-        "s_c means well, but they're overconfident in their attack and the fox manages to sink its teeth into them. The patrol is forced to retreat, forming a defensive ring around the hurt s_c."
-    ],
-    "win_skills": ["good fighter", "great fighter", "excellent fighter"],
-    "win_trait": ["adventurous", "altruistic", "ambitious", "confident", "daring", "fierce", "responsible", "righteous"],
-    "fail_skills": ["None"],
-    "fail_trait": ["troublesome", "vengeful", "bloodthirsty", "bold"],
-    "min_cats": 2,
-    "max_cats": 3,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c carries a scar from a gray fox fight.",
-        null
-    ]
-},
-{
-    "patrol_id": "bch_hunt_foxgray_scavenge2",
-    "biome": "beach",
-    "season": "Any",
-    "tags": ["hunting", "large_prey", "fighting", "clan_to_patrol", "respect", "rel_patrol"],
-    "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? Tracking it, they find a stocky gray fox feeding on an unidentifible but deliciously stinky mound of carrion the sea has washed up onto the shore.",
-    "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
-    "chance_of_success": 90,
-    "exp": 20,
-    "success_text": [
-        "While a gray fox is bigger and far stockier than the cats, the delicious stench of whatever-it-is makes the patrols' eyes go wide, and they leap to claim possession of it. Heavily outnumbered and already full of stinky nonsense, the gray fox leaves the beach, scrambling up a cliff as the cats give in to instinct and roll around in the glorious smell.",
-        "A gray fox is bigger than them, yes... but only just, and that carcass smells divine. The cats creep up on the fox, using the dunes for cover, and wait until the fox has its head buried in the carcass to attack. The ambush sends the competing predator fleeing, and leaves the cats to claim the heavenly stinky food.",
-        "s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until s_c lands a crucial blow, snapping a tendon in one of the fox's hindlegs. The fox runs, but there's no way it'll live long with such a crippling injury.",
-        "The patrol launches into battle, keeping the fox on the defensive with teamwork. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. Holding on grimly, s_c's daring move gives the rest of the patrol the opportunity needed to bring the fox down for good."
-    ],
-    "fail_text": [
-        "Your patrol fails to drive away the fox, which keeps possession of the food. However, with so many cats to protect each other, there were no injuries.",
-        "s_c makes a stupid mistake, too intent on winning the fight to respect their enemy's teeth, and it's only being yanked back by the tail that saves them from injury. The patrol gives up, and settles down to wait a safe distance away until the fox leaves of its own accord."
-    ],
-    "win_skills": ["good fighter", "great fighter", "excellent fighter"],
-    "win_trait": ["adventurous", "altruistic", "ambitious", "confident", "daring", "fierce", "responsible", "righteous"],
-    "fail_skills": ["None"],
-    "fail_trait": ["troublesome", "vengeful", "bloodthirsty", "bold"],
-    "min_cats": 4,
-    "max_cats": 6,
-    "antagonize_text": null,
-    "antagonize_fail_text": null
-},
-{
-    "patrol_id": "bch_hunt_foxgray_scavenge3",
-    "biome": "beach",
-    "season": "Any",
-    "tags": ["hunting", "large_prey", "fighting", "scar", "injury", "bite-wound", "clan_to_patrol", "respect"],
-    "intro_text": "r_c catches the scent of a fox - but is it red, or gray? Tracking it, they find a stocky gray fox feeding on an unidentifible but deliciously stinky mound of carrion the sea has washed up onto the shore.",
-    "decline_text": "r_c decides not to quarrel with the fox and to find prey elsewhere.",
-    "chance_of_success": 50,
-    "exp": 30,
-    "success_text": [
-        "While a gray fox is bigger and far stockier than r_c, the delicious stench of whatever-it-is makes their eyes go wide, and they leap to claim some of it for themselves and c_n. It's such a big lump that the fox doesn't seem to mind sharing.",
-        "A gray fox is bigger than them, yes... but only just, and that carcass smells divine. r_c creeps up on the fox, using the dunes for cover, and waits until the fox has its head buried in the carcass to attack. The ambush sends the competing predator fleeing, and leaves r_c to claim the heavenly stinky food.",
-        "s_c uses every trick in their talented fighting skillset to attack the fox with no one to watch their flank, until the perfect opportunity opens up and they pounce onto the fox's back, digging in their claws. It's enough to convince the gray to back off, and s_c claims a seat at the carcass.",
-        "In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. But then they're stuck, unwilling to let go and risk being bitten. They're dragged along the beach, sand casing their pelt, until the fox finally throws them off and the battered s_c goes back to proudly claim the carcass."
-    ],
-    "fail_text": [
-        "Your patrol fails to drive away the gray fox, which keeps possession of the food. However there were no injuries.",
-        "s_c makes a stupid mistake, too intent on winning the fight to respect their enemy's teeth, and it's tripping over their own feet that saves them. They give up, and settle down to wait a safe distance away until the fox leaves of its own accord.",
-        null,
-        "r_c launches into battle, but is caught with a nasty bite, and retreats to limp back home. The gray fox doesn't follow, happy enough to eat the carcass instead of the foolish cat.",
-        null,
-        "s_c is overconfident in their attack and the fox manages to sink their teeth into them. They retreat, bleeding and in pain, and the gray fox settles back down to its meal."
-    ],
-    "win_skills": ["great fighter", "excellent fighter"],
-    "win_trait": ["adventurous", "altruistic", "ambitious", "confident", "daring", "fierce", "responsible", "righteous"],
-    "fail_skills": ["None"],
-    "fail_trait": ["troublesome", "vengeful", "bloodthirsty", "bold"],
-    "min_cats": 1,
-    "max_cats": 1,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c carries a scar from a solo fight with a gray fox.",
-        null
-    ]
-},
-{
+        "min_cats": 2,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null
+    },
+    {
+        "patrol_id": "bch_hunt_eagleswim1",
+        "biome": "beach",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "large_prey0",
+            "large_prey1",
+            "huge_prey2",
+            "huge_prey3",
+            "warrior",
+            "trust",
+            "scar",
+            "injury",
+            "beak_bite"
+        ],
+        "intro_text": "The hunting patrol spots an eagle on the wing overhead, and watches as it swoops to dig its talons through the spine of an impressively huge fish. But then it doesn't take its catch into the air. Perhaps it's too heavy?",
+        "decline_text": "They move on, ignoring the eagle to focus on their own hunt.",
+        "chance_of_success": 30,
+        "exp": 20,
+        "success_text": [
+            "Your patrol uses the eagle as a scout for their own hunt, and eventually manage several smaller catches from the same area that cumulatively are just as impressive as the eagle's massive catch.",
+            "The cats' eyes light up with possibility, watching the eagle swimming to shore awkwardly. p_l leads the patrol yowling threats and insults from the shoreline and making a massive racket. Bewildered, the eagle eventually gives up its catch and takes to the air. The massive fish washes ashore into the paws of c_n.",
+            "As the rest of the patrol discuss whether they can steal the catch, s_c fixates on the bird that caught it. The eagle works its way awkwardly towards shore, and just as it's going to climb out s_c pounces, fighting in the shallows where s_c has the edge over the bird in swimming. They win both the fish and the predator as prey for c_n.",
+            "As the rest of the patrol discuss whether they can steal the catch, s_c fixates on the bird that caught it. The eagle works its way awkwardly towards shore, and just as it's going to climb out s_c pounces, fighting in the shallows where s_c has the edge over the bird in swimming. They win both the fish and the predator as prey for c_n."
+        ],
+        "fail_text": [
+            "The patrol dives into the water, keen to make a play to steal the fish, but even though its talons are occupied keeping grip on its prey, the eagle's huge wings pack a buffeting punch and the cats are driven back, giving up on the idea of scavenging.",
+            null,
+            null,
+            "The patrol decides to fight the eagle in the water for possession of the prey, but while its talons are occupied holding on to its prey, its beak is not, and it takes a nasty chunk out of r_c before the cats retreat."
+        ],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "ambitious"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 1,
+        "max_cats": 3,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from an eagle's beak.",
+            null
+        ]
+    },
+    {
+        "patrol_id": "bch_hunt_eagleswim2",
+        "biome": "beach",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "large_prey0",
+            "large_prey1",
+            "huge_prey2",
+            "huge_prey3",
+            "warrior",
+            "trust",
+            "scar",
+            "injury",
+            "beak_bite"
+        ],
+        "intro_text": "The hunting patrol spots an eagle on the wing overhead, and watches as it swoops to dig its talons through the spine of an impressively huge fish. But then it doesn't take its catch into the air. Perhaps it's too heavy?",
+        "decline_text": "They move on, ignoring the eagle to focus on their own hunt.",
+        "chance_of_success": 60,
+        "exp": 20,
+        "success_text": [
+            "Your patrol uses the eagle as a scout for their own hunt, and eventually manage several smaller catches from the same area that cumulatively are just as impressive as the eagle's massive catch.",
+            "The cats' eyes light up with possibility, watching the eagle swimming to shore awkwardly. p_l leads the patrol yowling threats and insults from the shoreline and making a massive racket. Bewildered, the eagle eventually gives up its catch and takes to the air. The massive fish washes ashore into the paws of c_n.",
+            "As the rest of the patrol discuss whether they can steal the catch, s_c fixates on the bird that caught it. The eagle works its way awkwardly towards shore, and just as it's going to climb out s_c pounces, fighting in the shallows where s_c has the edge over the bird in swimming. They win both the fish and the predator as prey for c_n.",
+            "As the rest of the patrol discuss whether they can steal the catch, s_c fixates on the bird that caught it. The eagle works its way awkwardly towards shore, and just as it's going to climb out s_c pounces, fighting in the shallows where s_c has the edge over the bird in swimming. They win both the fish and the predator as prey for c_n."
+        ],
+        "fail_text": [
+            "The patrol dives into the water, keen to make a play to steal the fish, but even though its talons are occupied keeping grip on its prey, the eagle's huge wings pack a buffeting punch and the cats are driven back, giving up on the idea of scavenging.",
+            null,
+            null,
+            "The patrol decides to fight the eagle in the water for possession of the prey, but while its talons are occupied holding on to its prey, its beak is not, and it takes a nasty chunk out of r_c before the cats retreat."
+        ],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "ambitious"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 4,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from an eagle's beak.",
+            null
+        ]
+    },
+    {
+        "patrol_id": "bch_hunt_eagleswim3",
+        "biome": "beach",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "large_prey0",
+            "large_prey1",
+            "huge_prey2",
+            "huge_prey3",
+            "warrior",
+            "trust",
+            "cruel_season",
+            "death",
+            "scar",
+            "injury",
+            "beak_bite"
+        ],
+        "intro_text": "The hunting patrol spots an eagle on the wing overhead, and watches as it swoops to dig its talons through the spine of an impressively huge fish. But then it doesn't take its catch into the air. Perhaps it's too heavy?",
+        "decline_text": "They move on, ignoring the eagle to focus on their own hunt.",
+        "chance_of_success": 30,
+        "exp": 20,
+        "success_text": [
+            "Your patrol uses the eagle as a scout for their own hunt, and eventually manage several smaller catches from the same area that cumulatively are just as impressive as the eagle's massive catch.",
+            "The cats' eyes light up with possibility, watching the eagle swimming to shore awkwardly. p_l leads the patrol yowling threats and insults from the shoreline and making a massive racket. Bewildered, the eagle eventually gives up its catch and takes to the air. The massive fish washes ashore into the paws of c_n.",
+            "As the rest of the patrol discuss whether they can steal the catch, s_c fixates on the bird that caught it. The eagle works its way awkwardly towards shore, and just as it's going to climb out s_c pounces, fighting in the shallows where s_c has the edge over the bird in swimming. They win both the fish and the predator as prey for c_n.",
+            "As the rest of the patrol discuss whether they can steal the catch, s_c fixates on the bird that caught it. The eagle works its way awkwardly towards shore, and just as it's going to climb out s_c pounces, fighting in the shallows where s_c has the edge over the bird in swimming. They win both the fish and the predator as prey for c_n."
+        ],
+        "fail_text": [
+            "The patrol dives into the water, keen to make a play to steal the fish, but even though its talons are occupied keeping grip on its prey, the eagle's huge wings pack a buffeting punch and the cats are driven back, giving up on the idea of scavenging.",
+            null,
+            "The patrol decides to fight the eagle in the water for possession of the prey, but the bird drops the prey and a furious haphazard swimming fight ensues. The eagle's talons, wings, and beak flail in an uncoordinated, dangerous tangle that brings r_c below the water. It's hard to say what kills them, the talon wounds or drowning.",
+            "The patrol decides to fight the eagle in the water for possession of the prey, but while its talons are occupied holding on to its prey, its beak is not, and it takes a nasty chunk out of r_c before the cats retreat."
+        ],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "ambitious"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 1,
+        "max_cats": 3,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from an eagle's beak.",
+            "r_c was killed by an eagle, scrapping over food.",
+            "were killed by an eagle"
+        ]
+    },
+    {
+        "patrol_id": "bch_hunt_eagleswim4",
+        "biome": "beach",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "large_prey0",
+            "large_prey1",
+            "huge_prey2",
+            "huge_prey3",
+            "warrior",
+            "trust",
+            "cruel_season",
+            "death",
+            "scar",
+            "injury",
+            "beak_bite"
+        ],
+        "intro_text": "The hunting patrol spots an eagle on the wing overhead, and watches as it swoops to dig its talons through the spine of an impressively huge fish. But then it doesn't take its catch into the air. Perhaps it's too heavy?",
+        "decline_text": "They move on, ignoring the eagle to focus on their own hunt.",
+        "chance_of_success": 60,
+        "exp": 20,
+        "success_text": [
+            "Your patrol uses the eagle as a scout for their own hunt, and eventually manage several smaller catches from the same area that cumulatively are just as impressive as the eagle's massive catch.",
+            "The cats' eyes light up with possibility, watching the eagle swimming to shore awkwardly. p_l leads the patrol yowling threats and insults from the shoreline and making a massive racket. Bewildered, the eagle eventually gives up its catch and takes to the air. The massive fish washes ashore into the paws of c_n.",
+            "As the rest of the patrol discuss whether they can steal the catch, s_c fixates on the bird that caught it. The eagle works its way awkwardly towards shore, and just as it's going to climb out s_c pounces, fighting in the shallows where s_c has the edge over the bird in swimming. They win both the fish and the predator as prey for c_n.",
+            "As the rest of the patrol discuss whether they can steal the catch, s_c fixates on the bird that caught it. The eagle works its way awkwardly towards shore, and just as it's going to climb out s_c pounces, fighting in the shallows where s_c has the edge over the bird in swimming. They win both the fish and the predator as prey for c_n."
+        ],
+        "fail_text": [
+            "The patrol dives into the water, keen to make a play to steal the fish, but even though its talons are occupied keeping grip on its prey, the eagle's huge wings pack a buffeting punch and the cats are driven back, giving up on the idea of scavenging.",
+            null,
+            "The patrol decides to fight the eagle in the water for possession of the prey, but the bird drops the prey and a furious haphazard swimming fight ensues. The eagle's talons, wings, and beak flail in an uncoordinated, dangerous tangle that brings r_c below the water. It's hard to say what kills them, the talon wounds or drowning.",
+            "The patrol decides to fight the eagle in the water for possession of the prey, but while its talons are occupied holding on to its prey, its beak is not, and it takes a nasty chunk out of r_c before the cats retreat."
+        ],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "ambitious"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 4,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from an eagle's beak.",
+            "r_c was killed by an eagle, scrapping over food.",
+            "were killed by an eagle"
+        ]
+    },
+    {
+        "patrol_id": "bch_hunt_twolegsobject1",
+        "biome": "beach",
+        "season": "greenleaf",
+        "tags": [
+            "hunting",
+            "injury",
+            "sprain"
+        ],
+        "intro_text": "As the patrol arrives at a beach, they spot Twolegs and their kits lounging around a brightly colored pelt of some kind, and smell food-scent.",
+        "decline_text": "The patrol decides to avoid the Twolegs.",
+        "chance_of_success": 50,
+        "exp": 10,
+        "success_text": [
+            "The patrol sneaks closer. It seems the Twolegs are eating, though the open beach shore means the cats don't have any chances of stealing a bite.",
+            null,
+            "s_c is more interested in the strangely-colored pelt than the food-scent, which the Twolegs will undoubtedly be possessive of. They wonder how the odd creature make such things, and why on earth they'd bring them to a beach to sit on pointlessly."
+        ],
+        "fail_text": [
+            "The patrol can't seem to interpret the purpose of the gathering. Twolegs are just mystifying.",
+            null,
+            null,
+            "As the patrol gets close, a Twoleg kit runs at them, screaming unintelligibly. While running away, r_c sprains a leg."
+        ],
+        "win_skills": [
+            "smart",
+            "very smart",
+            "extremely smart"
+        ],
+        "win_trait": [
+            "None"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 2,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null
+    },
+    {
+        "patrol_id": "bch_hunt_leafbaresnowstorm1",
+        "biome": "beach",
+        "season": "leaf-bare",
+        "tags": [
+            "hunting",
+            "large_prey",
+            "comfort",
+            "trust",
+            "patrol_to_p_l",
+            "patrol_to_r_c",
+            "cold_injury",
+            "no_fail_prey"
+        ],
+        "intro_text": "It starts snowing soon after the patrol sets out, trying to bring back something nice for the fresh-kill pile.",
+        "decline_text": "They decide to turn back and wait until the snow dies down.",
+        "chance_of_success": 50,
+        "exp": 10,
+        "success_text": [
+            "Despite the snow, the patrol manages to hunt successfully, finding crabs running about on the beach, oblivious to leaf-bare. With the sea to provide there's more than enough to bring a good haul back to c_n, and as p_l leads them home there's a sense of security and competence driving them onwards.",
+            null,
+            "Everyone looks admiringly at s_c by the end of the afternoon. Every cat carries something home, but nearly all of it was caught by s_c.",
+            "s_c really keeps the patrol on task and motivated through the sharp cold of the leaf-bare morning, not through authority or commands, but with a gentle voice and compassionate understanding that encourages every cat to do their best for c_n."
+        ],
+        "fail_text": [
+            "The prey must be hiding; the patrol catches nothing. As a snowstorm descends and visibility drops, the patrol retreats to a sea cave, their pelts and tails and legs all tightly wrapped into one indistinguishable kitty cat ball while they wait for the storm to blow over.",
+            null,
+            null,
+            "The prey must be hiding; the patrol catches nothing. As a snowstorm descends and visibility drops, the patrol retreats to a sea cave, their pelts and tails and legs all tightly wrapped into one indistinguishable kitty cat ball. Still, when they return to camp r_c is cold and chilled."
+        ],
+        "win_skills": [
+            "great hunter",
+            "fantastic hunter"
+        ],
+        "win_trait": [
+            "altruistic",
+            "compassionate",
+            "empathetic",
+            "faithful",
+            "loving"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 3,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c caught a chill while hunting in leaf-bare.",
+            null
+        ]
+    },
+    {
+        "patrol_id": "bch_hunt_leafbaresnowstorm2",
+        "biome": "beach",
+        "season": "leaf-bare",
+        "tags": [
+            "hunting",
+            "small_prey",
+            "cold_injury",
+            "no_fail_prey"
+        ],
+        "intro_text": "It starts snowing soon after the patrol sets out, trying to bring back something nice for the fresh-kill pile.",
+        "decline_text": "They decide to turn back and wait until the snow dies down.",
+        "chance_of_success": 40,
+        "exp": 10,
+        "success_text": [
+            "Despite the snow, r_c manages to hunt successfully, finding the normal number of crabs obliviously scurrying about.",
+            null,
+            "s_c really shows their talent, bringing a clutch of crabs back to camp for the fresh-kill pile."
+        ],
+        "fail_text": [
+            null,
+            null,
+            null,
+            "The prey must be hiding; r_c catches nothing. As a snowstorm descends and visibility drops, they hide in a sea cave, shivering and tightly tucked up against the cold. When they return to camp r_c is cold and chilled, but otherwise unharmed."
+        ],
+        "win_skills": [
+            "great hunter",
+            "fantastic hunter"
+        ],
+        "win_trait": [
+            "None"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c caught a chill while hunting in leaf-bare.",
+            null
+        ]
+    },
+    {
+        "patrol_id": "bch_hunt_leafbaresnowstorm3",
+        "biome": "beach",
+        "season": "leaf-bare",
+        "tags": [
+            "hunting",
+            "small_prey",
+            "comfort",
+            "trust",
+            "rel_patrol",
+            "romantic",
+            "no_app",
+            "cold_injury"
+        ],
+        "intro_text": "It starts snowing soon after the patrol sets out, trying to bring back something nice for the fresh-kill pile.",
+        "decline_text": "They decide to turn back and wait until the snow dies down.",
+        "chance_of_success": 50,
+        "exp": 10,
+        "success_text": [
+            "A storm descends, sudden and violent, putting an end to any other thoughts but survival. The cats retreat into a sea cave and cuddle together, sharing what little warmth they have. Each cat takes a turn on the most exposed side of the huddle, selflessly risking themselves.",
+            null,
+            "A storm descends, sudden and violent, putting an end to any other thoughts but survival. s_c keeps everyone's spirits up as the patrol hides in the lee of a cliff where the wind can't get them, until everyone is talking, shaky and unhappy, but keeping each other's spirits up.",
+            "A storm descends, sudden and violent, putting an end to any other thoughts but survival. As the cats hide from the wind, s_c keeps an eye out for everyone. It's a long couple of hours, but with gentle understanding and compassion the cats make it though safely, closer than ever afterwards."
+        ],
+        "fail_text": [
+            null,
+            null,
+            null,
+            "A storm descends, sudden and violent, putting an end to any other thoughts but survival. When the snowstorm leaves, finally, and the cats trudge back home, but r_c hasn't escaped unscathed, their body chilled and refusing to warm up properly."
+        ],
+        "win_skills": [
+            "great speaker",
+            "excellent speaker"
+        ],
+        "win_trait": [
+            "altruistic",
+            "compassionate",
+            "empathetic",
+            "faithful",
+            "loving"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 2,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c caught a chill while hunting in leaf-bare.",
+            null
+        ]
+    },
+    {
+        "patrol_id": "bch_hunt_redfox_scavenge1",
+        "biome": "beach",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "large_prey",
+            "fighting",
+            "scar",
+            "big_bite_injury",
+            "clan_to_patrol",
+            "respect",
+            "rel_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a red fox. Tracking it, they find the animal feeding on a shark that the waves have washed ashore in the night.",
+        "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 50,
+        "exp": 20,
+        "success_text": [
+            "Your cats are smaller but they outnumber the fox, if only by a little, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full of food and unwilling to lose blood over it, is driven off from the kill.",
+            null,
+            "s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until it gives up and runs.",
+            "The patrol launches into battle, but with so few cats it's exhausting trying to keep the fox and its snapping jaws on the defensive. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. It's only one bite, but the fox has had enough and flees."
+        ],
+        "fail_text": [
+            "Your patrol fails to drive away the fox, which keeps possession of the food. However there were no injuries.",
+            null,
+            null,
+            "The patrol launches into battle, but r_c is caught with a nasty bite, and the cats give up on challenging for the food in favor of quickly helping r_c back to the medicine cat den.",
+            null,
+            "s_c means well, but they're overconfident in their attack and the fox manages to sink their teeth into them. The patrol is forced to retreat, forming a defensive ring around the hurt s_c."
+        ],
+        "win_skills": [
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "troublesome",
+            "vengeful",
+            "bloodthirsty",
+            "bold"
+        ],
+        "min_cats": 2,
+        "max_cats": 3,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a fox fight.",
+            null
+        ]
+    },
+    {
+        "patrol_id": "bch_hunt_redfox_scavenge2",
+        "biome": "beach",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "large_prey",
+            "fighting",
+            "scar",
+            "big_bite_injury",
+            "clan_to_patrol",
+            "respect",
+            "rel_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a red fox. Tracking it, they find the animal feeding on a shark that the waves have washed ashore in the night.",
+        "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 80,
+        "exp": 20,
+        "success_text": [
+            "Your cats are smaller but heavily outnumber the fox, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full and unwilling to lose blood over it, is driven off from the kill.",
+            null,
+            "s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until s_c lands a crucial blow, snapping a tendon in one of the fox's hindlegs. The fox runs, but there's no way it'll live long with such a crippling injury.",
+            "The patrol launches into battle, keeping the fox on the defensive with teamwork. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. Holding on grimly, s_c's daring move gives the rest of the patrol the opportunity needed to bring the fox down for good."
+        ],
+        "fail_text": [
+            "Your patrol fails to drive away the fox, which keeps possession of the food. However with so many cats to protect each other, there were no injuries.",
+            null,
+            null,
+            "The patrol launches into battle, but r_c is caught with a nasty bite, and the cats give up on challenging for the food in favor of quickly helping r_c back to the medicine cat den.",
+            null,
+            "s_c means well, but they're overconfident in their attack and the fox manages to sink their teeth into them. The patrol is forced to retreat, forming a defensive ring around the hurt s_c."
+        ],
+        "win_skills": [
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "troublesome",
+            "vengeful",
+            "bloodthirsty",
+            "bold"
+        ],
+        "min_cats": 4,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a fox fight."
+        ]
+    },
+    {
+        "patrol_id": "bch_hunt_redfox_scavenge3",
+        "biome": "beach",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "large_prey",
+            "fighting",
+            "scar",
+            "big_bite_injury",
+            "clan_to_patrol",
+            "respect"
+        ],
+        "intro_text": "r_c catches the scent of a red fox. Tracking it, they find the animal feeding on a shark that the waves have washed ashore in the night.",
+        "decline_text": "r_c decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 30,
+        "exp": 30,
+        "success_text": [
+            "r_c is smaller, alone, and half its weight, but the fox has a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle. The fox, already stuffed full and unwilling to lose blood over it, leaves the kill with a grumble.",
+            null,
+            "s_c uses every trick in their talented fighting skillset to attack the fox with no one to watch their flank, until the perfect opportunity opens up and they pounce onto the fox's back, digging in their claws. It's a wild ride through the forest until the fox bucks them off, but it wins them the shark carcass.",
+            "In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. But then they're stuck, unwilling to let go and risk being bitten. They're dragged through the forest, over rocks and through bushes, until the fox finally collapses and the battered s_c goes back to proudly claim the shark."
+        ],
+        "fail_text": [
+            "Your patrol fails to drive away the fox, which keeps possession of the food. However there were no injuries.",
+            null,
+            "Fiercely, r_c throws themselves at the fox, determined to win the shark prize. But the fox values it just as dearly, and manages to get a good grip on r_c, shaking them to pieces and killing them.",
+            "r_c launches into battle, but is caught with a nasty bite, and retreats to limp back home. The fox doesn't follow, happy enough to eat the shark instead of the foolish cat.",
+            null,
+            "s_c is overconfident in their attack and the fox manages to sink their teeth into them. They retreat, bleeding and in pain, and the fox settles back down to its meal."
+        ],
+        "win_skills": [
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "troublesome",
+            "vengeful",
+            "bloodthirsty",
+            "bold"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a solo fox fight.",
+            "r_c fell in a solo battle with a fox.",
+            "died fighting a fox"
+        ]
+    },
+    {
+        "patrol_id": "bch_hunt_foxgray_scavenge1",
+        "biome": "beach",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "large_prey",
+            "fighting",
+            "scar",
+            "injury",
+            "bite-wound",
+            "clan_to_patrol",
+            "respect",
+            "rel_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? Tracking it, they find a stocky gray fox feeding on an unidentifible but deliciously stinky mound of carrion the sea has washed up onto the shore.",
+        "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 70,
+        "exp": 20,
+        "success_text": [
+            "While a gray fox is bigger and far stockier than the cats, the delicious stench of whatever-it-is makes the patrols' eyes go wide, and they leap to claim possession of it. Outnumbered and already full of stinky nonsense, the gray fox leaves the beach, scrambling up a cliff as the cats give in to instinct and roll around in the glorious smell.",
+            "A gray fox is bigger than them, yes... but only just, and that carcass smells divine. The cats creep up on the fox, using the dunes for cover, and wait until the fox has its head buried in the carcass to attack. The ambush sends the competing predator fleeing, and leaves the cats to claim the heavenly stinky food.",
+            "s_c shows their strength, leading the fight against the gray fox. By working together and keeping it distracted, the cats harry and harass the fox until it gives up and runs.",
+            "The patrol launches into battle, but with so few cats it's exhausting trying to keep the fox and its snapping jaws on the defensive. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. It's only one bite, but the fox has had enough and flees."
+        ],
+        "fail_text": [
+            "Your patrol fails to drive away the fox, which keeps possession of the food. However, there were no injuries.",
+            "s_c makes a stupid mistake, too intent on winning the fight to respect their enemy's teeth, and it's only being yanked back by the tail that saves them from injury. The patrol gives up, and settles down to wait a safe distance away until the fox leaves of its own accord.",
+            null,
+            null,
+            null,
+            "s_c means well, but they're overconfident in their attack and the fox manages to sink its teeth into them. The patrol is forced to retreat, forming a defensive ring around the hurt s_c."
+        ],
+        "win_skills": [
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "troublesome",
+            "vengeful",
+            "bloodthirsty",
+            "bold"
+        ],
+        "min_cats": 2,
+        "max_cats": 3,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a gray fox fight.",
+            null
+        ]
+    },
+    {
+        "patrol_id": "bch_hunt_foxgray_scavenge2",
+        "biome": "beach",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "large_prey",
+            "fighting",
+            "clan_to_patrol",
+            "respect",
+            "rel_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? Tracking it, they find a stocky gray fox feeding on an unidentifible but deliciously stinky mound of carrion the sea has washed up onto the shore.",
+        "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 90,
+        "exp": 20,
+        "success_text": [
+            "While a gray fox is bigger and far stockier than the cats, the delicious stench of whatever-it-is makes the patrols' eyes go wide, and they leap to claim possession of it. Heavily outnumbered and already full of stinky nonsense, the gray fox leaves the beach, scrambling up a cliff as the cats give in to instinct and roll around in the glorious smell.",
+            "A gray fox is bigger than them, yes... but only just, and that carcass smells divine. The cats creep up on the fox, using the dunes for cover, and wait until the fox has its head buried in the carcass to attack. The ambush sends the competing predator fleeing, and leaves the cats to claim the heavenly stinky food.",
+            "s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until s_c lands a crucial blow, snapping a tendon in one of the fox's hindlegs. The fox runs, but there's no way it'll live long with such a crippling injury.",
+            "The patrol launches into battle, keeping the fox on the defensive with teamwork. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. Holding on grimly, s_c's daring move gives the rest of the patrol the opportunity needed to bring the fox down for good."
+        ],
+        "fail_text": [
+            "Your patrol fails to drive away the fox, which keeps possession of the food. However, with so many cats to protect each other, there were no injuries.",
+            "s_c makes a stupid mistake, too intent on winning the fight to respect their enemy's teeth, and it's only being yanked back by the tail that saves them from injury. The patrol gives up, and settles down to wait a safe distance away until the fox leaves of its own accord."
+        ],
+        "win_skills": [
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "troublesome",
+            "vengeful",
+            "bloodthirsty",
+            "bold"
+        ],
+        "min_cats": 4,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null
+    },
+    {
+        "patrol_id": "bch_hunt_foxgray_scavenge3",
+        "biome": "beach",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "large_prey",
+            "fighting",
+            "scar",
+            "injury",
+            "bite-wound",
+            "clan_to_patrol",
+            "respect"
+        ],
+        "intro_text": "r_c catches the scent of a fox - but is it red, or gray? Tracking it, they find a stocky gray fox feeding on an unidentifible but deliciously stinky mound of carrion the sea has washed up onto the shore.",
+        "decline_text": "r_c decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 50,
+        "exp": 30,
+        "success_text": [
+            "While a gray fox is bigger and far stockier than r_c, the delicious stench of whatever-it-is makes their eyes go wide, and they leap to claim some of it for themselves and c_n. It's such a big lump that the fox doesn't seem to mind sharing.",
+            "A gray fox is bigger than them, yes... but only just, and that carcass smells divine. r_c creeps up on the fox, using the dunes for cover, and waits until the fox has its head buried in the carcass to attack. The ambush sends the competing predator fleeing, and leaves r_c to claim the heavenly stinky food.",
+            "s_c uses every trick in their talented fighting skillset to attack the fox with no one to watch their flank, until the perfect opportunity opens up and they pounce onto the fox's back, digging in their claws. It's enough to convince the gray to back off, and s_c claims a seat at the carcass.",
+            "In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. But then they're stuck, unwilling to let go and risk being bitten. They're dragged along the beach, sand casing their pelt, until the fox finally throws them off and the battered s_c goes back to proudly claim the carcass."
+        ],
+        "fail_text": [
+            "Your patrol fails to drive away the gray fox, which keeps possession of the food. However there were no injuries.",
+            "s_c makes a stupid mistake, too intent on winning the fight to respect their enemy's teeth, and it's tripping over their own feet that saves them. They give up, and settle down to wait a safe distance away until the fox leaves of its own accord.",
+            null,
+            "r_c launches into battle, but is caught with a nasty bite, and retreats to limp back home. The gray fox doesn't follow, happy enough to eat the carcass instead of the foolish cat.",
+            null,
+            "s_c is overconfident in their attack and the fox manages to sink their teeth into them. They retreat, bleeding and in pain, and the gray fox settles back down to its meal."
+        ],
+        "win_skills": [
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "troublesome",
+            "vengeful",
+            "bloodthirsty",
+            "bold"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a solo fight with a gray fox.",
+            null
+        ]
+    },
+    {
         "patrol_id": "bch_hunt_redvixen1",
         "biome": "beach",
         "season": "newleaf",
-        "tags": ["fighting", "death", "scar", "big_bite_injury", "respect", "trust",  "clan_to_r_c", "patrol_to_r_c", "clan_to_patrol"],
+        "tags": [
+            "fighting",
+            "death",
+            "scar",
+            "big_bite_injury",
+            "respect",
+            "trust",
+            "clan_to_r_c",
+            "patrol_to_r_c",
+            "clan_to_patrol"
+        ],
         "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
         "decline_text": "Your patrol decides not to pursue the fox.",
         "chance_of_success": 30,
@@ -1993,10 +2322,29 @@
             "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the red vixen manages to sink her teeth into them. The patrol rallies around s_c, but they have to give up on the fight.",
             "As their hunt descends into a full on battle with the red vixen, p_l takes a blow meant for one of their clanmates, losing a life."
         ],
-        "win_skills": ["excellent fighter"],
-        "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-        "fail_skills": ["good fighter"],
-        "fail_trait": ["None"],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
         "min_cats": 2,
         "max_cats": 3,
         "antagonize_text": null,
@@ -2006,12 +2354,21 @@
             "r_c fell in battle with a red fox.",
             "died while fighting a red vixen"
         ]
-},
-{
+    },
+    {
         "patrol_id": "bch_hunt_redvixen2",
         "biome": "beach",
         "season": "newleaf",
-        "tags": ["fighting", "scar", "big_bite_injury", "respect", "trust",  "clan_to_r_c", "patrol_to_r_c", "clan_to_patrol"],
+        "tags": [
+            "fighting",
+            "scar",
+            "big_bite_injury",
+            "respect",
+            "trust",
+            "clan_to_r_c",
+            "patrol_to_r_c",
+            "clan_to_patrol"
+        ],
         "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
         "decline_text": "Your patrol decides not to pursue the fox.",
         "chance_of_success": 60,
@@ -2030,10 +2387,29 @@
             null,
             "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the red vixen manages to sink her teeth into them. The patrol rallies around s_c, but they have to give up on the fight."
         ],
-        "win_skills": ["excellent fighter"],
-        "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-        "fail_skills": ["good fighter"],
-        "fail_trait": ["None"],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
         "min_cats": 4,
         "max_cats": 6,
         "antagonize_text": null,
@@ -2041,12 +2417,23 @@
         "history_text": [
             "r_c carries a scar from a fight with a red vixen."
         ]
-},
-{
+    },
+    {
         "patrol_id": "bch_hunt_redvixen3",
         "biome": "beach",
         "season": "newleaf",
-        "tags": ["fighting", "death", "scar", "big_bite_injury", "shock", "injury", "respect", "trust", "clan_to_patrol", "no_body"],
+        "tags": [
+            "fighting",
+            "death",
+            "scar",
+            "big_bite_injury",
+            "shock",
+            "injury",
+            "respect",
+            "trust",
+            "clan_to_patrol",
+            "no_body"
+        ],
         "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
         "decline_text": "Your patrol decides not to pursue the fox.",
         "chance_of_success": 20,
@@ -2065,10 +2452,29 @@
             null,
             "s_c is determined to win, but the red vixen is determined to live, and that makes all the difference. s_c ends up pinned in a defensible hiding spot, bleeding and terrified, until the vixen judges them no longer a threat and continues on her way."
         ],
-        "win_skills": ["excellent fighter"],
-        "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-        "fail_skills": ["good fighter"],
-        "fail_trait": ["None"],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
         "min_cats": 1,
         "max_cats": 1,
         "antagonize_text": null,
@@ -2078,12 +2484,22 @@
             "r_c fell in a solo battle with a vixen.",
             "died while fighting a red vixen"
         ]
-},
-{
+    },
+    {
         "patrol_id": "bch_hunt_redvixen4",
         "biome": "beach",
         "season": "greenleaf",
-        "tags": ["fighting", "death", "scar", "big_bite_injury", "respect", "trust",  "clan_to_r_c", "patrol_to_r_c", "clan_to_patrol"],
+        "tags": [
+            "fighting",
+            "death",
+            "scar",
+            "big_bite_injury",
+            "respect",
+            "trust",
+            "clan_to_r_c",
+            "patrol_to_r_c",
+            "clan_to_patrol"
+        ],
         "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
         "decline_text": "Your patrol decides not to pursue the fox.",
         "chance_of_success": 30,
@@ -2103,10 +2519,29 @@
             "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the red vixen manages to sink her teeth into them. The patrol rallies around s_c, but they have to give up on the fight.",
             "As their hunt descends into a full on battle with the red vixen, p_l takes a blow meant for one of their clanmates, losing a life."
         ],
-        "win_skills": ["excellent fighter"],
-        "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-        "fail_skills": ["good fighter"],
-        "fail_trait": ["None"],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
         "min_cats": 2,
         "max_cats": 3,
         "antagonize_text": null,
@@ -2115,13 +2550,22 @@
             "r_c carries a scar from a fight with a red vixen.",
             "r_c fell in battle with a red fox.",
             "died while fighting a red vixen"
-        ]    
-},
-{
+        ]
+    },
+    {
         "patrol_id": "bch_hunt_redvixen5",
         "biome": "beach",
         "season": "greenleaf",
-        "tags": ["fighting", "scar", "big_bite_injury", "respect", "trust",  "clan_to_r_c", "patrol_to_r_c", "clan_to_patrol"],
+        "tags": [
+            "fighting",
+            "scar",
+            "big_bite_injury",
+            "respect",
+            "trust",
+            "clan_to_r_c",
+            "patrol_to_r_c",
+            "clan_to_patrol"
+        ],
         "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
         "decline_text": "Your patrol decides not to pursue the fox.",
         "chance_of_success": 60,
@@ -2140,10 +2584,29 @@
             null,
             "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the red vixen manages to sink her teeth into them. The patrol rallies around s_c, but they have to give up on the fight."
         ],
-        "win_skills": ["excellent fighter"],
-        "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-        "fail_skills": ["good fighter"],
-        "fail_trait": ["None"],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
         "min_cats": 4,
         "max_cats": 6,
         "antagonize_text": null,
@@ -2151,12 +2614,23 @@
         "history_text": [
             "r_c carries a scar from a fight with a red vixen."
         ]
-},
-{
+    },
+    {
         "patrol_id": "bch_hunt_redvixen6",
         "biome": "beach",
         "season": "greenleaf",
-        "tags": ["fighting", "death", "scar", "big_bite_injury", "shock", "injury", "respect", "trust", "clan_to_patrol", "no_body"],
+        "tags": [
+            "fighting",
+            "death",
+            "scar",
+            "big_bite_injury",
+            "shock",
+            "injury",
+            "respect",
+            "trust",
+            "clan_to_patrol",
+            "no_body"
+        ],
         "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
         "decline_text": "Your patrol decides not to pursue the fox.",
         "chance_of_success": 10,
@@ -2175,10 +2649,29 @@
             null,
             "s_c is determined to win, but the red vixen is determined to live, and that makes all the difference. s_c ends up pinned in a defensible hiding spot, bleeding and terrified, until the vixen judges them no longer a threat and continues on her way."
         ],
-        "win_skills": ["excellent fighter"],
-        "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-        "fail_skills": ["good fighter"],
-        "fail_trait": ["None"],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
         "min_cats": 1,
         "max_cats": 1,
         "antagonize_text": null,
@@ -2188,12 +2681,22 @@
             "r_c fell in a solo battle with a vixen.",
             "died while fighting a red vixen"
         ]
-},
-{
+    },
+    {
         "patrol_id": "bch_hunt_redvixen7",
         "biome": "beach",
         "season": "leaf-fall",
-        "tags": ["fighting", "death", "scar", "big_bite_injury", "respect", "trust",  "clan_to_r_c", "patrol_to_r_c", "clan_to_patrol"],
+        "tags": [
+            "fighting",
+            "death",
+            "scar",
+            "big_bite_injury",
+            "respect",
+            "trust",
+            "clan_to_r_c",
+            "patrol_to_r_c",
+            "clan_to_patrol"
+        ],
         "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
         "decline_text": "Your patrol decides not to pursue the fox.",
         "chance_of_success": 30,
@@ -2213,10 +2716,29 @@
             "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the red vixen manages to sink her teeth into them. The patrol rallies around s_c, but they have to give up on the fight.",
             "As their hunt descends into a full on battle with the red vixen, p_l takes a blow meant for one of their clanmates, losing a life."
         ],
-        "win_skills": ["excellent fighter"],
-        "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-        "fail_skills": ["good fighter"],
-        "fail_trait": ["None"],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
         "min_cats": 2,
         "max_cats": 3,
         "antagonize_text": null,
@@ -2226,12 +2748,21 @@
             "r_c fell in battle with a red fox.",
             "died while fighting a red vixen"
         ]
-},
-{
+    },
+    {
         "patrol_id": "bch_hunt_redvixen8",
         "biome": "beach",
         "season": "leaf-fall",
-        "tags": ["fighting", "scar", "big_bite_injury", "respect", "trust",  "clan_to_r_c", "patrol_to_r_c", "clan_to_patrol"],
+        "tags": [
+            "fighting",
+            "scar",
+            "big_bite_injury",
+            "respect",
+            "trust",
+            "clan_to_r_c",
+            "patrol_to_r_c",
+            "clan_to_patrol"
+        ],
         "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
         "decline_text": "Your patrol decides not to pursue the fox.",
         "chance_of_success": 60,
@@ -2248,10 +2779,29 @@
             null,
             "r_c is left wounded as the patrol and the red mother vixen fight to a stalemate. Hopefully they've given the fox mother a reason not to return to this part of the coast."
         ],
-        "win_skills": ["excellent fighter"],
-        "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-        "fail_skills": ["good fighter"],
-        "fail_trait": ["None"],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
         "min_cats": 4,
         "max_cats": 6,
         "antagonize_text": null,
@@ -2259,12 +2809,23 @@
         "history_text": [
             "r_c carries a scar from a red fox fight."
         ]
-},
-{
+    },
+    {
         "patrol_id": "bch_hunt_redvixen9",
         "biome": "beach",
         "season": "leaf-fall",
-        "tags": ["fighting", "death", "scar", "big_bite_injury", "shock", "injury", "respect", "trust", "clan_to_patrol", "no_body"],
+        "tags": [
+            "fighting",
+            "death",
+            "scar",
+            "big_bite_injury",
+            "shock",
+            "injury",
+            "respect",
+            "trust",
+            "clan_to_patrol",
+            "no_body"
+        ],
         "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
         "decline_text": "Your patrol decides not to pursue the fox.",
         "chance_of_success": 20,
@@ -2283,10 +2844,29 @@
             null,
             "s_c is determined to win, but the red vixen is determined to live, and that makes all the difference. s_c ends up pinned in a defensible hiding spot, bleeding and terrified, until the vixen judges them no longer a threat and continues on her way."
         ],
-        "win_skills": ["excellent fighter"],
-        "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-        "fail_skills": ["good fighter"],
-        "fail_trait": ["None"],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
         "min_cats": 1,
         "max_cats": 1,
         "antagonize_text": null,
@@ -2296,12 +2876,19 @@
             "r_c fell in a solo battle with a red vixen.",
             "died while fighting a red vixen"
         ]
-},
-{
+    },
+    {
         "patrol_id": "bch_hunt_grayvixen1",
         "biome": "beach",
         "season": "newleaf",
-        "tags": ["fighting", "minor_injury", "respect", "trust", "rel_patrol", "patrol_to_r_c"],
+        "tags": [
+            "fighting",
+            "minor_injury",
+            "respect",
+            "trust",
+            "rel_patrol",
+            "patrol_to_r_c"
+        ],
         "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
         "decline_text": "Your patrol decides not to pursue the fox.",
         "chance_of_success": 60,
@@ -2320,10 +2907,29 @@
             null,
             "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is all muscle, barging past s_c and knocking them ass over paws as she flees from the patrol."
         ],
-        "win_skills": ["excellent fighter"],
-        "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-        "fail_skills": ["good fighter"],
-        "fail_trait": ["None"],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
         "min_cats": 2,
         "max_cats": 3,
         "antagonize_text": null,
@@ -2332,12 +2938,19 @@
             "r_c carries a scar from a fight with a gray vixen.",
             null
         ]
-},
-{
+    },
+    {
         "patrol_id": "bch_hunt_grayvixen2",
         "biome": "beach",
         "season": "newleaf",
-        "tags": ["fighting", "minor_injury", "respect", "trust", "rel_patrol", "patrol_to_r_c"],
+        "tags": [
+            "fighting",
+            "minor_injury",
+            "respect",
+            "trust",
+            "rel_patrol",
+            "patrol_to_r_c"
+        ],
         "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
         "decline_text": "Your patrol decides not to pursue the fox.",
         "chance_of_success": 90,
@@ -2356,10 +2969,29 @@
             null,
             "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is all muscle, barging past s_c and knocking them ass over paws as she flees from the patrol."
         ],
-        "win_skills": ["excellent fighter"],
-        "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-        "fail_skills": ["good fighter"],
-        "fail_trait": ["None"],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
         "min_cats": 4,
         "max_cats": 6,
         "antagonize_text": null,
@@ -2367,12 +2999,19 @@
         "history_text": [
             "r_c carries a scar from a fight with a gray vixen."
         ]
-},
-{
+    },
+    {
         "patrol_id": "bch_hunt_grayvixen3",
         "biome": "beach",
         "season": "newleaf",
-        "tags": ["fighting", "scar", "big_bite_injury", "respect", "trust", "clan_to_patrol"],
+        "tags": [
+            "fighting",
+            "scar",
+            "big_bite_injury",
+            "respect",
+            "trust",
+            "clan_to_patrol"
+        ],
         "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
         "decline_text": "Your patrol decides not to pursue the fox.",
         "chance_of_success": 50,
@@ -2391,10 +3030,29 @@
             null,
             "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is cunning, sinking her teeth into s_c to distract them as she flees."
         ],
-        "win_skills": ["excellent fighter"],
-        "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-        "fail_skills": ["good fighter"],
-        "fail_trait": ["None"],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
         "min_cats": 1,
         "max_cats": 1,
         "antagonize_text": null,
@@ -2403,12 +3061,19 @@
             "r_c carries a scar from a solo fight with a gray vixen.",
             null
         ]
-},
-{
+    },
+    {
         "patrol_id": "bch_hunt_grayvixen4",
         "biome": "beach",
         "season": "greenleaf",
-        "tags": ["fighting", "minor_injury", "respect", "trust", "rel_patrol", "patrol_to_r_c"],
+        "tags": [
+            "fighting",
+            "minor_injury",
+            "respect",
+            "trust",
+            "rel_patrol",
+            "patrol_to_r_c"
+        ],
         "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
         "decline_text": "Your patrol decides not to pursue the fox.",
         "chance_of_success": 60,
@@ -2427,10 +3092,29 @@
             null,
             "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is all muscle, barging past s_c and knocking them ass over paws as she flees from the patrol."
         ],
-        "win_skills": ["excellent fighter"],
-        "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-        "fail_skills": ["good fighter"],
-        "fail_trait": ["None"],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
         "min_cats": 2,
         "max_cats": 3,
         "antagonize_text": null,
@@ -2438,13 +3122,20 @@
         "history_text": [
             "r_c carries a scar from a fight with a gray vixen.",
             null
-        ]    
-},
-{
+        ]
+    },
+    {
         "patrol_id": "bch_hunt_grayvixen5",
         "biome": "beach",
         "season": "greenleaf",
-        "tags": ["fighting", "minor_injury", "respect", "trust", "rel_patrol", "patrol_to_r_c"],
+        "tags": [
+            "fighting",
+            "minor_injury",
+            "respect",
+            "trust",
+            "rel_patrol",
+            "patrol_to_r_c"
+        ],
         "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
         "decline_text": "Your patrol decides not to pursue the fox.",
         "chance_of_success": 90,
@@ -2463,10 +3154,29 @@
             null,
             "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is all muscle, barging past s_c and knocking them ass over paws as she flees from the patrol."
         ],
-        "win_skills": ["excellent fighter"],
-        "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-        "fail_skills": ["good fighter"],
-        "fail_trait": ["None"],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
         "min_cats": 4,
         "max_cats": 6,
         "antagonize_text": null,
@@ -2474,12 +3184,19 @@
         "history_text": [
             "r_c carries a scar from a fight with a gray vixen."
         ]
-},
-{
+    },
+    {
         "patrol_id": "bch_hunt_grayvixen6",
         "biome": "beach",
         "season": "greenleaf",
-        "tags": ["fighting", "scar", "big_bite_injury", "respect", "trust", "clan_to_patrol"],
+        "tags": [
+            "fighting",
+            "scar",
+            "big_bite_injury",
+            "respect",
+            "trust",
+            "clan_to_patrol"
+        ],
         "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
         "decline_text": "Your patrol decides not to pursue the fox.",
         "chance_of_success": 50,
@@ -2498,10 +3215,29 @@
             null,
             "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is cunning, sinking her teeth into s_c to distract them as she flees."
         ],
-        "win_skills": ["excellent fighter"],
-        "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-        "fail_skills": ["good fighter"],
-        "fail_trait": ["None"],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
         "min_cats": 1,
         "max_cats": 1,
         "antagonize_text": null,
@@ -2509,12 +3245,19 @@
         "history_text": [
             "r_c carries a scar from a solo fight with a gray vixen."
         ]
-},
-{
+    },
+    {
         "patrol_id": "bch_hunt_grayvixen7",
         "biome": "beach",
         "season": "leaf-fall",
-        "tags": ["fighting", "minor_injury", "respect", "trust", "rel_patrol", "patrol_to_r_c"],
+        "tags": [
+            "fighting",
+            "minor_injury",
+            "respect",
+            "trust",
+            "rel_patrol",
+            "patrol_to_r_c"
+        ],
         "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
         "decline_text": "Your patrol decides not to pursue the fox.",
         "chance_of_success": 60,
@@ -2533,10 +3276,29 @@
             null,
             "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is all muscle, barging past s_c and knocking them ass over paws as she flees from the patrol."
         ],
-        "win_skills": ["excellent fighter"],
-        "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-        "fail_skills": ["good fighter"],
-        "fail_trait": ["None"],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
         "min_cats": 2,
         "max_cats": 3,
         "antagonize_text": null,
@@ -2545,12 +3307,19 @@
             "r_c carries a scar from a fight with a gray vixen.",
             null
         ]
-},
-{
+    },
+    {
         "patrol_id": "bch_hunt_grayvixen8",
         "biome": "beach",
         "season": "leaf-fall",
-        "tags": ["fighting", "minor_injury", "respect", "trust", "rel_patrol", "patrol_to_r_c"],
+        "tags": [
+            "fighting",
+            "minor_injury",
+            "respect",
+            "trust",
+            "rel_patrol",
+            "patrol_to_r_c"
+        ],
         "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
         "decline_text": "Your patrol decides not to pursue the fox.",
         "chance_of_success": 90,
@@ -2569,10 +3338,29 @@
             null,
             "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is all muscle, barging past s_c and knocking them ass over paws as she flees from the patrol."
         ],
-        "win_skills": ["excellent fighter"],
-        "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-        "fail_skills": ["good fighter"],
-        "fail_trait": ["None"],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
         "min_cats": 4,
         "max_cats": 6,
         "antagonize_text": null,
@@ -2580,12 +3368,19 @@
         "history_text": [
             "r_c carries a scar from a fight with a gray vixen."
         ]
-},
-{
+    },
+    {
         "patrol_id": "bch_hunt_grayvixen9",
         "biome": "beach",
         "season": "leaf-fall",
-        "tags": ["fighting", "scar", "big_bite_injury", "respect", "trust", "clan_to_patrol"],
+        "tags": [
+            "fighting",
+            "scar",
+            "big_bite_injury",
+            "respect",
+            "trust",
+            "clan_to_patrol"
+        ],
         "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
         "decline_text": "Your patrol decides not to pursue the fox.",
         "chance_of_success": 50,
@@ -2604,10 +3399,29 @@
             null,
             "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is cunning, sinking her teeth into s_c to distract them as she flees."
         ],
-        "win_skills": ["excellent fighter"],
-        "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-        "fail_skills": ["good fighter"],
-        "fail_trait": ["None"],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
         "min_cats": 1,
         "max_cats": 1,
         "antagonize_text": null,
@@ -2615,215 +3429,461 @@
         "history_text": [
             "r_c carries a scar from a solo fight with a gray vixen."
         ]
-},
-{
-    "patrol_id": "bch_hunt_redfox_steal1",
-    "biome": "beach",
-    "season": "Any",
-    "tags": ["hunting", "small_prey", "fighting", "scar", "small_bite_injury", "platonic", "dislike", "respect", "rel_patrol"],
-    "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? And is it worth a fight if they encounter it?",
-    "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
-    "chance_of_success": 50,
-    "exp": 20,
-    "success_text": [
-        "p_l leads the patrol to the end of the scent trail, where a red fox sits plucking the feathers off a plump seagull. With careful signals, the cats set up an ambush. There aren't many of them, but the fox doesn't need to know that - with a massive explosion of yowls, the cats sound like a full battle patrol, and the fox leaps up frightened out of its skin as the cats pounce to take possession of the bird.",
-        null,
-        "They're a small patrol, but a skilled one, and when they track down the red fox at the end of the scent trail they have enough skill and muscle to drive it off from the fish it was gnawing on. The cats gather around it, congraduating each other.",
-        "Tracking the fox trail, s_c reminds the rest of the patrol that things don't always need to end in a fight, using the trail to uncover a food cache of dead fish buried in a dune. They still don't know what kind of fox left the trail, and they don't need to - these fish will make great additions to the fresh-kill pile back home."
-    ],
-    "fail_text": [
-        "The fox's trail vanishes, almost as though the creature has figured out they're tracking it. Grumbling and arguing, the patrol has to head back home disappointed.",
-        "The patrol tracks down a red fox, and spots that it's holding fresh-kill. However, s_c bursts from cover without warning, trying to intimidate the fox. Which they can say sort of worked, but also causes the fox to run off with the food it carries. The other cats aren't particularly pleased with s_c.",
-        null,
-        "p_l leads the patrol to the end of the scent trail, where a red fox sits plucking the feathers off a plump seagull. With careful signals, the cats set up an ambush, but they aren't careful enough, and with a snarl the fox takes a bite at r_c as it flees with its dinner.",
-        null,
-        "The patrol tracks down a red fox, and spots that it's holding fresh-kill. However, s_c bursts from cover without warning, trying to intimidate the fox, and the overconfident attack ends in disaster as the fox bites s_c, leaving the rest of the patrol to rescue their annoying clanmate as the fox runs off with what could've been their dinner."
-    ],
-    "win_skills": ["good hunter", "great hunter", "fantastic hunter", "good fighter", "great fighter", "excellent fighter"],
-    "win_trait": ["altruistic", "calm", "careful", "faithful", "insecure", "loyal", "nervous", "patient", "responsible", "righteous", "thoughtful", "wise"],
-    "fail_skills": ["None"],
-    "fail_trait": ["adventurous", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "playful", "troublesome", "vengeful"],
-    "min_cats": 2,
-    "max_cats": 3,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c carries a scar from a red fox fight.",
-        null
-    ]
-},
-{
-    "patrol_id": "bch_hunt_redfox_steal2",
-    "biome": "beach",
-    "season": "Any",
-    "tags": ["hunting", "small_prey", "fighting", "scar", "small_bite_injury", "platonic", "respect", "rel_patrol"],
-    "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? And is it worth a fight if they encounter it?",
-    "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
-    "chance_of_success": 50,
-    "exp": 20,
-    "success_text": [
-        "p_l leads the patrol to the end of the scent trail, where a red fox sits plucking the feathers off a plump seagull. With careful signals, the cats set up an ambush. While they'd expected having more cats would make it easier, it also makes the patrol far more of a threat to the red fox, and the creature panicks when they reveal themselves. They win the bird, but r_c nearly gets injured, and it's only p_l shoving them both out of the way that saves both their pelts.",
-        null,
-        "With such a big patrol, and with s_c there, when they track down the red fox at the end of the scent trail they have more than enough skill and muscle to drive it off from the fish it was gnawing on. The cats gather around it, congraduating each other.",
-        "Tracking the fox trail, s_c reminds the rest of the patrol that things don't always need to end in a fight, using the trail to uncover a food cache of dead fish buried in a dune. They still don't know what kind of fox left the trail, and they don't need to - these fish will make great additions to the fresh-kill pile back home."
-    ],
-    "fail_text": [
-        "The fox's trail vanishes, almost as though the creature has figured out they're tracking it. Grumbling and arguing, the patrol has to head back home disappointed.",
-        "The patrol tracks down a red fox, and spots that it's holding fresh-kill. However, s_c bursts from cover without warning, trying to intimidate the fox. Which they can say sort of worked, but also causes the fox to run off with the food it carries. The other cats aren't particularly pleased with s_c.",
-        null,
-        "p_l leads the patrol to the end of the scent trail, where a red fox sits plucking the feathers off a plump seagull. With careful signals, the cats set up an ambush, but they aren't careful enough, and with a snarl the fox takes a bite at r_c as it flees with its dinner.",
-        null,
-        "The patrol tracks down a red fox, and spots that it's holding fresh-kill. However, s_c bursts from cover without warning, trying to intimidate the fox, and the overconfident attack ends in disaster as the fox bites s_c, leaving the rest of the patrol to rescue their annoying clanmate as the fox runs off with what could've been their dinner."
-    ],
-    "win_skills": ["good hunter", "great hunter", "fantastic hunter", "good fighter", "great fighter", "excellent fighter"],
-    "win_trait": ["altruistic", "calm", "careful", "faithful", "insecure", "loyal", "nervous", "patient", "responsible", "righteous", "thoughtful", "wise"],
-    "fail_skills": ["None"],
-    "fail_trait": ["adventurous", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "playful", "troublesome", "vengeful"],
-    "min_cats": 4,
-    "max_cats": 6,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c carries a scar from a red fox fight."
-    ]
-},
-{
-    "patrol_id": "bch_hunt_redfox_steal3",
-    "biome": "beach",
-    "season": "Any",
-    "tags": ["hunting", "small_prey", "fighting", "scar", "big_bite_injury",  "clan_to_patrol", "respect"],
-    "intro_text": "r_c catches the scent of a fox - but is it red, or gray? And is it worth a fight if they encounter it?",
-    "decline_text": "r_c decides not to quarrel with the fox and to find prey elsewhere.",
-    "chance_of_success": 30,
-    "exp": 20,
-    "success_text": [
-        "Spotting the red fox they've tracked dipping into a sheltered cove, r_c hangs back, sneaking around until they spot the fox burying a fish for later. They simply wait for it to finish and leave, then creep in to steal the fox's hard work, bringing the prize back to camp for the fresh-kill pile. Sometimes winning a battle doesn't require fighting.",
-        null,
-        "It requires s_c to use some of their best tricks, but they sneak close to the red fox at the end of the scent trail, eyes on the fish the fox carries. The creature puts down its fresh-kill to start digging at a dune, and s_c takes the opportunity, grabbing the fish and running. It's a good prize, and they feel proud to present it to the elders when they pad into camp, tired but satisfied.",
-        "It's a situation that calls for careful calm, not implusive action. s_c tracks down a red fox at the end of the scent trail, holding a young seagull, and waits carefully. Eventually, as the fox starts to hunt at a different beach, it drops its fresh-kill to try win more. s_c carefully snatches it while the fox is distracted, and trots back to camp having successfully outwitted the competing predator."
-    ],
-    "fail_text": [
-        "It embarasses them, but r_c doesn't even manage to find the fox they track, let alone earn anything useful from the afternoon's attempts.",
-        "s_c hones in on the scent, and as soon as they spot the red fox with a dead fish hanging from its jaws, throwes themselves to the attack. The fox hears them coming, and with insulting nonchalance trots off, unwilling to get into a fight.",
-        null,
-        "Finding a red fox holding a fish that would be much appreciated for c_n's fresh-kill pile, r_c goes to attack it. But the fox is just as keen to keep it as r_c is to win it, and they're injured in the resulting fight.",
-        null,
-        "s_c hones in on the scent, and as soon as they spot the red fox with a dead fish hanging from its jaws, recklessly throwes themselves to the attack. But the fox is as desperate to keep its meal as s_c is to win it from them, and s_c has to retreat bleeding, as the fox trots off with its dinner."
-    ],
-    "win_skills": ["good hunter", "great hunter", "fantastic hunter", "good fighter", "great fighter", "excellent fighter"],
-    "win_trait": ["altruistic", "calm", "careful", "faithful", "insecure", "loyal", "nervous", "patient", "responsible", "righteous", "thoughtful", "wise"],
-    "fail_skills": ["None"],
-    "fail_trait": ["adventurous", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "playful", "troublesome", "vengeful"],
-    "min_cats": 1,
-    "max_cats": 1,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c carries a scar from a solo fight with a red fox."
-    ]
-},
-{
-    "patrol_id": "bch_hunt_foxgray_steal1",
-    "biome": "beach",
-    "season": "Any",
-    "tags": ["hunting", "small_prey", "fighting", "scar", "small_bite_injury", "platonic", "respect", "rel_patrol"],
-    "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? And is it worth a fight if they encounter it?",
-    "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
-    "chance_of_success": 50,
-    "exp": 20,
-    "success_text": [
-        "It's a gray fox, which as far as the cats are concerned, means free food. They leap after it, and after a short chase the fox drops the mouse it was holding. That's not enough to satisfy the c_n cats, who drive it out of their territory before collecting the mouse and continuing the afternoon's hunt.",
-        "The scent trail leads to where some kind of fox has cached half a fish in a poorly concealed hole. The cats take it as their due, and leave the fox to wander on.",
-        "The trail leads to a gray fox, and s_c makes sure it both hands over the prey it's poached from c_n land and flees for the border, tail between its legs and yelping. The smaller predator can't stand up to a patrol working together.",
-        "The cats slowly follow the trail, with s_c urging caution. There's no reason to rush into things. Sure enough, they find a grey fox. It's digging at a rotten log, unearthing insects. The patrol uses the presence of the other predator as a distraction to bring down a pump bird, one that was too busy watching the fox to guard from them, and the fox is left unscathed to keep bug hunting."
-    ],
-    "fail_text": [
-        "The fox's trail vanishes, almost as though the creature has figured out they're tracking it. Grumbling and arguing, the patrol has to head back home disappointed.",
-        "The patrol tracks down a gray fox trespassing on c_n land, but s_c runs at it without thinking, and instead of intimidating the fox into fleeing for the border it makes the gray fox skitter up a cliff and start yelping. It takes all afternoon to wait the fox out and then drive it more gently from c_n's hunting grounds, and no one is happy with s_c.",
-        null,
-        "p_l leads the patrol to the end of the scent trail, where a gray fox sits grooming it's fur in the sunshine. With careful signals, the cats set up an ambush, but the small gray panics beyond anything any cat expected, and as it flees, convinced its life is in danger, it bites at r_c.",
-        null,
-        "The patrol tracks down a gray fox trespassing on c_n land, but s_c runs at it without thinking, and instead of intimidating the fox into fleeing for the border it makes the gray fox skitter up a cliff and start yelping. s_c tries to make up for the mistake by following the fox up into the branches, which goes even more poorly and leaves the patrol needing to help them back to the medicine den."
-    ],
-    "win_skills": ["good hunter", "great hunter", "fantastic hunter", "great fighter", "excellent fighter"],
-    "win_trait": ["altruistic", "calm", "careful", "faithful", "insecure", "loyal", "nervous", "patient", "responsible", "righteous", "thoughtful", "wise"],
-    "fail_skills": ["None"],
-    "fail_trait": ["adventurous", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "playful", "troublesome", "vengeful"],
-    "min_cats": 2,
-    "max_cats": 3,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c carries a scar from a gray fox fight.",
-        null
-    ]
-},
-{
-    "patrol_id": "bch_hunt_foxgray_steal2",
-    "biome": "beach",
-    "season": "Any",
-    "tags": ["hunting", "small_prey", "fighting", "scar", "small_bite_injury", "platonic", "respect", "rel_patrol"],
-    "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? And is it worth a fight if they encounter it?",
-    "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
-    "chance_of_success": 70,
-    "exp": 20,
-    "success_text": [
-        "It's a gray fox, which as far as the cats are concerned, means free food. They leap after it, and after a short chase the fox drops the mouse it was holding. That's not enough to satisfy the c_n cats, who drive it out of their territory before collecting the mouse and continuing the afternoon's hunt.",
-        "The scent trail leads to where some kind of fox has cached a wood rat in a poorly concealed hole. The cats take it as their due, and leave the fox to wander on.",
-        "The trail leads to a gray fox, and s_c makes sure it both hands over the prey it's poached from c_n land and flees for the border, tail between its legs and yelping. The smaller predator can't stand up to a patrol working together.",
-        "The cats slowly follow the trail, with s_c urging caution. There's no reason to rush into things. Sure enough, they find a grey fox. It's digging at a rotten log, unearthing insects. The patrol uses the presence of the other predator as a distraction to bring down a pump bird, one that was too busy watching the fox to guard from them, and the fox is left unscathed to keep bug hunting."
-    ],
-    "fail_text": [
-        "The fox's trail vanishes, almost as though the creature has figured out they're tracking it. Grumbling and arguing, the patrol has to head back home disappointed.",
-        "The patrol tracks down a gray fox trespassing on c_n land, but s_c runs at it without thinking, and instead of intimidating the fox into fleeing for the border it makes the gray fox skitter up a cliff and start yelping. It takes all afternoon to wait the fox out and then drive it more gently from c_n's hunting grounds, and no one is happy with s_c.",
-        null,
-        "p_l leads the patrol to the end of the scent trail, where a gray fox sits grooming it's fur in the sunshine. With careful signals, the cats set up an ambush, but the small gray panics beyond anything any cat expected, and as it flees, convinced its life is in danger, it bites at r_c.",
-        null,
-        "The patrol tracks down a gray fox trespassing on c_n land, but s_c runs at it without thinking, and instead of intimidating the fox into fleeing for the border it makes the gray fox skitter up a cliff and start yelping. s_c tries to make up for the mistake by following the fox up into the branches, which goes even more poorly and leaves the patrol needing to help them back to the medicine den."
-    ],
-    "win_skills": ["good hunter", "great hunter", "fantastic hunter", "great fighter", "excellent fighter"],
-    "win_trait": ["altruistic", "calm", "careful", "faithful", "insecure", "loyal", "nervous", "patient", "responsible", "righteous", "thoughtful", "wise"],
-    "fail_skills": ["None"],
-    "fail_trait": ["adventurous", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "playful", "troublesome", "vengeful"],
-    "min_cats": 4,
-    "max_cats": 6,
-    "antagonize_text": null,
-    "antagonize_fail_text": null
-},
-{
-    "patrol_id": "bch_hunt_foxgray_steal3",
-    "biome": "beach",
-    "season": "Any",
-    "tags": ["hunting", "small_prey", "fighting", "scar", "small_bite_injury"],
-    "intro_text": "r_c catches the scent of a fox - but is it red, or gray? And is it worth a fight if they encounter it?",
-    "decline_text": "r_c decides not to quarrel with the fox and to find prey elsewhere.",
-    "chance_of_success": 50,
-    "exp": 15,
-    "success_text": [
-        "Spotting the gray fox they've tracked dipping into a sheltered cove, r_c hangs back, sneaking around until they spot the fox caching a bird kill in an old log a storm washed in moons ago. They simply wait for it to finish and leave, then creep in to steal the fox's hard work, bringing the prize back to camp for the fresh-kill pile. Sometimes winning a battle doesn't require fighting.",
-        null,
-        "s_c tracks down a gray fox, and carefully cosiders it as an opponent. Stocky, yes, but they finally decide they can take it, and burst from cover, using surprise to get in a couple vicious swipes to the fox's face while its jaws are still full of prey. Yelping, the gray fox retreats from the cat, unwilling to risk more split blood, and s_c picks up the rat it carried with a proud grin.",
-        "It's a situation that calls for careful calm, not implusive action. s_c tracks down a gray fox at the end of the scent trail, holding a little plump mouse, and waits carefully. Eventually, the fox tries to cache its fresh-kill in a little hole. s_c picks it up once the fox leaves, strolling back to camp having successfully outwitted the competing predator."
-    ],
-    "fail_text": [
-        "It embarasses them, but r_c doesn't even manage to find the fox they track, let alone earn anything useful from the afternoon's attempts.",
-        "s_c hones in on the scent, and as soon as they spot the gray fox with a dead fish hanging from its jaws, throwes themselves to the attack. The fox hears them coming, and makes a hasty retreat before the fight can start, taking its dinner with it.",
-        null,
-        "Finding a gray fox holding a mouse that would make a nice addition to c_n's fresh-kill pile, r_c goes to attack it. But the fox is just as keen to keep it as r_c is to win it, and they're injured in the resulting fight.",
-        null,
-        "s_c hones in on the scent, and as soon as they spot the gray fox with a dead fish hanging from its jaws, recklessly throwes themselves to the attack. But the fox is a little too desperate to keep itself from harm, and s_c has to retreat bleeding."
-    ],
-    "win_skills": ["good hunter", "great hunter", "fantastic hunter", "good fighter", "great fighter", "excellent fighter"],
-    "win_trait": ["altruistic", "calm", "careful", "faithful", "insecure", "loyal", "nervous", "patient", "responsible", "righteous", "thoughtful", "wise"],
-    "fail_skills": ["None"],
-    "fail_trait": ["adventurous", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "playful", "troublesome", "vengeful"],
-    "min_cats": 1,
-    "max_cats": 1,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c carries a scar from a solo fight with a gray fox."
-    ]
-}
-
+    },
+    {
+        "patrol_id": "bch_hunt_redfox_steal1",
+        "biome": "beach",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "small_prey",
+            "fighting",
+            "scar",
+            "small_bite_injury",
+            "platonic",
+            "dislike",
+            "respect",
+            "rel_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? And is it worth a fight if they encounter it?",
+        "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 50,
+        "exp": 20,
+        "success_text": [
+            "p_l leads the patrol to the end of the scent trail, where a red fox sits plucking the feathers off a plump seagull. With careful signals, the cats set up an ambush. There aren't many of them, but the fox doesn't need to know that - with a massive explosion of yowls, the cats sound like a full battle patrol, and the fox leaps up frightened out of its skin as the cats pounce to take possession of the bird.",
+            null,
+            "They're a small patrol, but a skilled one, and when they track down the red fox at the end of the scent trail they have enough skill and muscle to drive it off from the fish it was gnawing on. The cats gather around it, congraduating each other.",
+            "Tracking the fox trail, s_c reminds the rest of the patrol that things don't always need to end in a fight, using the trail to uncover a food cache of dead fish buried in a dune. They still don't know what kind of fox left the trail, and they don't need to - these fish will make great additions to the fresh-kill pile back home."
+        ],
+        "fail_text": [
+            "The fox's trail vanishes, almost as though the creature has figured out they're tracking it. Grumbling and arguing, the patrol has to head back home disappointed.",
+            "The patrol tracks down a red fox, and spots that it's holding fresh-kill. However, s_c bursts from cover without warning, trying to intimidate the fox. Which they can say sort of worked, but also causes the fox to run off with the food it carries. The other cats aren't particularly pleased with s_c.",
+            null,
+            "p_l leads the patrol to the end of the scent trail, where a red fox sits plucking the feathers off a plump seagull. With careful signals, the cats set up an ambush, but they aren't careful enough, and with a snarl the fox takes a bite at r_c as it flees with its dinner.",
+            null,
+            "The patrol tracks down a red fox, and spots that it's holding fresh-kill. However, s_c bursts from cover without warning, trying to intimidate the fox, and the overconfident attack ends in disaster as the fox bites s_c, leaving the rest of the patrol to rescue their annoying clanmate as the fox runs off with what could've been their dinner."
+        ],
+        "win_skills": [
+            "good hunter",
+            "great hunter",
+            "fantastic hunter",
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "altruistic",
+            "calm",
+            "careful",
+            "faithful",
+            "insecure",
+            "loyal",
+            "nervous",
+            "patient",
+            "responsible",
+            "righteous",
+            "thoughtful",
+            "wise"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "adventurous",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "playful",
+            "troublesome",
+            "vengeful"
+        ],
+        "min_cats": 2,
+        "max_cats": 3,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a red fox fight.",
+            null
+        ]
+    },
+    {
+        "patrol_id": "bch_hunt_redfox_steal2",
+        "biome": "beach",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "small_prey",
+            "fighting",
+            "scar",
+            "small_bite_injury",
+            "platonic",
+            "respect",
+            "rel_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? And is it worth a fight if they encounter it?",
+        "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 50,
+        "exp": 20,
+        "success_text": [
+            "p_l leads the patrol to the end of the scent trail, where a red fox sits plucking the feathers off a plump seagull. With careful signals, the cats set up an ambush. While they'd expected having more cats would make it easier, it also makes the patrol far more of a threat to the red fox, and the creature panicks when they reveal themselves. They win the bird, but r_c nearly gets injured, and it's only p_l shoving them both out of the way that saves both their pelts.",
+            null,
+            "With such a big patrol, and with s_c there, when they track down the red fox at the end of the scent trail they have more than enough skill and muscle to drive it off from the fish it was gnawing on. The cats gather around it, congraduating each other.",
+            "Tracking the fox trail, s_c reminds the rest of the patrol that things don't always need to end in a fight, using the trail to uncover a food cache of dead fish buried in a dune. They still don't know what kind of fox left the trail, and they don't need to - these fish will make great additions to the fresh-kill pile back home."
+        ],
+        "fail_text": [
+            "The fox's trail vanishes, almost as though the creature has figured out they're tracking it. Grumbling and arguing, the patrol has to head back home disappointed.",
+            "The patrol tracks down a red fox, and spots that it's holding fresh-kill. However, s_c bursts from cover without warning, trying to intimidate the fox. Which they can say sort of worked, but also causes the fox to run off with the food it carries. The other cats aren't particularly pleased with s_c.",
+            null,
+            "p_l leads the patrol to the end of the scent trail, where a red fox sits plucking the feathers off a plump seagull. With careful signals, the cats set up an ambush, but they aren't careful enough, and with a snarl the fox takes a bite at r_c as it flees with its dinner.",
+            null,
+            "The patrol tracks down a red fox, and spots that it's holding fresh-kill. However, s_c bursts from cover without warning, trying to intimidate the fox, and the overconfident attack ends in disaster as the fox bites s_c, leaving the rest of the patrol to rescue their annoying clanmate as the fox runs off with what could've been their dinner."
+        ],
+        "win_skills": [
+            "good hunter",
+            "great hunter",
+            "fantastic hunter",
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "altruistic",
+            "calm",
+            "careful",
+            "faithful",
+            "insecure",
+            "loyal",
+            "nervous",
+            "patient",
+            "responsible",
+            "righteous",
+            "thoughtful",
+            "wise"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "adventurous",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "playful",
+            "troublesome",
+            "vengeful"
+        ],
+        "min_cats": 4,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a red fox fight."
+        ]
+    },
+    {
+        "patrol_id": "bch_hunt_redfox_steal3",
+        "biome": "beach",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "small_prey",
+            "fighting",
+            "scar",
+            "big_bite_injury",
+            "clan_to_patrol",
+            "respect"
+        ],
+        "intro_text": "r_c catches the scent of a fox - but is it red, or gray? And is it worth a fight if they encounter it?",
+        "decline_text": "r_c decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 30,
+        "exp": 20,
+        "success_text": [
+            "Spotting the red fox they've tracked dipping into a sheltered cove, r_c hangs back, sneaking around until they spot the fox burying a fish for later. They simply wait for it to finish and leave, then creep in to steal the fox's hard work, bringing the prize back to camp for the fresh-kill pile. Sometimes winning a battle doesn't require fighting.",
+            null,
+            "It requires s_c to use some of their best tricks, but they sneak close to the red fox at the end of the scent trail, eyes on the fish the fox carries. The creature puts down its fresh-kill to start digging at a dune, and s_c takes the opportunity, grabbing the fish and running. It's a good prize, and they feel proud to present it to the elders when they pad into camp, tired but satisfied.",
+            "It's a situation that calls for careful calm, not implusive action. s_c tracks down a red fox at the end of the scent trail, holding a young seagull, and waits carefully. Eventually, as the fox starts to hunt at a different beach, it drops its fresh-kill to try win more. s_c carefully snatches it while the fox is distracted, and trots back to camp having successfully outwitted the competing predator."
+        ],
+        "fail_text": [
+            "It embarasses them, but r_c doesn't even manage to find the fox they track, let alone earn anything useful from the afternoon's attempts.",
+            "s_c hones in on the scent, and as soon as they spot the red fox with a dead fish hanging from its jaws, throwes themselves to the attack. The fox hears them coming, and with insulting nonchalance trots off, unwilling to get into a fight.",
+            null,
+            "Finding a red fox holding a fish that would be much appreciated for c_n's fresh-kill pile, r_c goes to attack it. But the fox is just as keen to keep it as r_c is to win it, and they're injured in the resulting fight.",
+            null,
+            "s_c hones in on the scent, and as soon as they spot the red fox with a dead fish hanging from its jaws, recklessly throwes themselves to the attack. But the fox is as desperate to keep its meal as s_c is to win it from them, and s_c has to retreat bleeding, as the fox trots off with its dinner."
+        ],
+        "win_skills": [
+            "good hunter",
+            "great hunter",
+            "fantastic hunter",
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "altruistic",
+            "calm",
+            "careful",
+            "faithful",
+            "insecure",
+            "loyal",
+            "nervous",
+            "patient",
+            "responsible",
+            "righteous",
+            "thoughtful",
+            "wise"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "adventurous",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "playful",
+            "troublesome",
+            "vengeful"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a solo fight with a red fox."
+        ]
+    },
+    {
+        "patrol_id": "bch_hunt_foxgray_steal1",
+        "biome": "beach",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "small_prey",
+            "fighting",
+            "scar",
+            "small_bite_injury",
+            "platonic",
+            "respect",
+            "rel_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? And is it worth a fight if they encounter it?",
+        "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 50,
+        "exp": 20,
+        "success_text": [
+            "It's a gray fox, which as far as the cats are concerned, means free food. They leap after it, and after a short chase the fox drops the mouse it was holding. That's not enough to satisfy the c_n cats, who drive it out of their territory before collecting the mouse and continuing the afternoon's hunt.",
+            "The scent trail leads to where some kind of fox has cached half a fish in a poorly concealed hole. The cats take it as their due, and leave the fox to wander on.",
+            "The trail leads to a gray fox, and s_c makes sure it both hands over the prey it's poached from c_n land and flees for the border, tail between its legs and yelping. The smaller predator can't stand up to a patrol working together.",
+            "The cats slowly follow the trail, with s_c urging caution. There's no reason to rush into things. Sure enough, they find a grey fox. It's digging at a rotten log, unearthing insects. The patrol uses the presence of the other predator as a distraction to bring down a pump bird, one that was too busy watching the fox to guard from them, and the fox is left unscathed to keep bug hunting."
+        ],
+        "fail_text": [
+            "The fox's trail vanishes, almost as though the creature has figured out they're tracking it. Grumbling and arguing, the patrol has to head back home disappointed.",
+            "The patrol tracks down a gray fox trespassing on c_n land, but s_c runs at it without thinking, and instead of intimidating the fox into fleeing for the border it makes the gray fox skitter up a cliff and start yelping. It takes all afternoon to wait the fox out and then drive it more gently from c_n's hunting grounds, and no one is happy with s_c.",
+            null,
+            "p_l leads the patrol to the end of the scent trail, where a gray fox sits grooming it's fur in the sunshine. With careful signals, the cats set up an ambush, but the small gray panics beyond anything any cat expected, and as it flees, convinced its life is in danger, it bites at r_c.",
+            null,
+            "The patrol tracks down a gray fox trespassing on c_n land, but s_c runs at it without thinking, and instead of intimidating the fox into fleeing for the border it makes the gray fox skitter up a cliff and start yelping. s_c tries to make up for the mistake by following the fox up into the branches, which goes even more poorly and leaves the patrol needing to help them back to the medicine den."
+        ],
+        "win_skills": [
+            "good hunter",
+            "great hunter",
+            "fantastic hunter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "altruistic",
+            "calm",
+            "careful",
+            "faithful",
+            "insecure",
+            "loyal",
+            "nervous",
+            "patient",
+            "responsible",
+            "righteous",
+            "thoughtful",
+            "wise"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "adventurous",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "playful",
+            "troublesome",
+            "vengeful"
+        ],
+        "min_cats": 2,
+        "max_cats": 3,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a gray fox fight.",
+            null
+        ]
+    },
+    {
+        "patrol_id": "bch_hunt_foxgray_steal2",
+        "biome": "beach",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "small_prey",
+            "fighting",
+            "scar",
+            "small_bite_injury",
+            "platonic",
+            "respect",
+            "rel_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? And is it worth a fight if they encounter it?",
+        "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 70,
+        "exp": 20,
+        "success_text": [
+            "It's a gray fox, which as far as the cats are concerned, means free food. They leap after it, and after a short chase the fox drops the mouse it was holding. That's not enough to satisfy the c_n cats, who drive it out of their territory before collecting the mouse and continuing the afternoon's hunt.",
+            "The scent trail leads to where some kind of fox has cached a wood rat in a poorly concealed hole. The cats take it as their due, and leave the fox to wander on.",
+            "The trail leads to a gray fox, and s_c makes sure it both hands over the prey it's poached from c_n land and flees for the border, tail between its legs and yelping. The smaller predator can't stand up to a patrol working together.",
+            "The cats slowly follow the trail, with s_c urging caution. There's no reason to rush into things. Sure enough, they find a grey fox. It's digging at a rotten log, unearthing insects. The patrol uses the presence of the other predator as a distraction to bring down a pump bird, one that was too busy watching the fox to guard from them, and the fox is left unscathed to keep bug hunting."
+        ],
+        "fail_text": [
+            "The fox's trail vanishes, almost as though the creature has figured out they're tracking it. Grumbling and arguing, the patrol has to head back home disappointed.",
+            "The patrol tracks down a gray fox trespassing on c_n land, but s_c runs at it without thinking, and instead of intimidating the fox into fleeing for the border it makes the gray fox skitter up a cliff and start yelping. It takes all afternoon to wait the fox out and then drive it more gently from c_n's hunting grounds, and no one is happy with s_c.",
+            null,
+            "p_l leads the patrol to the end of the scent trail, where a gray fox sits grooming it's fur in the sunshine. With careful signals, the cats set up an ambush, but the small gray panics beyond anything any cat expected, and as it flees, convinced its life is in danger, it bites at r_c.",
+            null,
+            "The patrol tracks down a gray fox trespassing on c_n land, but s_c runs at it without thinking, and instead of intimidating the fox into fleeing for the border it makes the gray fox skitter up a cliff and start yelping. s_c tries to make up for the mistake by following the fox up into the branches, which goes even more poorly and leaves the patrol needing to help them back to the medicine den."
+        ],
+        "win_skills": [
+            "good hunter",
+            "great hunter",
+            "fantastic hunter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "altruistic",
+            "calm",
+            "careful",
+            "faithful",
+            "insecure",
+            "loyal",
+            "nervous",
+            "patient",
+            "responsible",
+            "righteous",
+            "thoughtful",
+            "wise"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "adventurous",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "playful",
+            "troublesome",
+            "vengeful"
+        ],
+        "min_cats": 4,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null
+    },
+    {
+        "patrol_id": "bch_hunt_foxgray_steal3",
+        "biome": "beach",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "small_prey",
+            "fighting",
+            "scar",
+            "small_bite_injury"
+        ],
+        "intro_text": "r_c catches the scent of a fox - but is it red, or gray? And is it worth a fight if they encounter it?",
+        "decline_text": "r_c decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 50,
+        "exp": 15,
+        "success_text": [
+            "Spotting the gray fox they've tracked dipping into a sheltered cove, r_c hangs back, sneaking around until they spot the fox caching a bird kill in an old log a storm washed in moons ago. They simply wait for it to finish and leave, then creep in to steal the fox's hard work, bringing the prize back to camp for the fresh-kill pile. Sometimes winning a battle doesn't require fighting.",
+            null,
+            "s_c tracks down a gray fox, and carefully cosiders it as an opponent. Stocky, yes, but they finally decide they can take it, and burst from cover, using surprise to get in a couple vicious swipes to the fox's face while its jaws are still full of prey. Yelping, the gray fox retreats from the cat, unwilling to risk more split blood, and s_c picks up the rat it carried with a proud grin.",
+            "It's a situation that calls for careful calm, not implusive action. s_c tracks down a gray fox at the end of the scent trail, holding a little plump mouse, and waits carefully. Eventually, the fox tries to cache its fresh-kill in a little hole. s_c picks it up once the fox leaves, strolling back to camp having successfully outwitted the competing predator."
+        ],
+        "fail_text": [
+            "It embarasses them, but r_c doesn't even manage to find the fox they track, let alone earn anything useful from the afternoon's attempts.",
+            "s_c hones in on the scent, and as soon as they spot the gray fox with a dead fish hanging from its jaws, throwes themselves to the attack. The fox hears them coming, and makes a hasty retreat before the fight can start, taking its dinner with it.",
+            null,
+            "Finding a gray fox holding a mouse that would make a nice addition to c_n's fresh-kill pile, r_c goes to attack it. But the fox is just as keen to keep it as r_c is to win it, and they're injured in the resulting fight.",
+            null,
+            "s_c hones in on the scent, and as soon as they spot the gray fox with a dead fish hanging from its jaws, recklessly throwes themselves to the attack. But the fox is a little too desperate to keep itself from harm, and s_c has to retreat bleeding."
+        ],
+        "win_skills": [
+            "good hunter",
+            "great hunter",
+            "fantastic hunter",
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "altruistic",
+            "calm",
+            "careful",
+            "faithful",
+            "insecure",
+            "loyal",
+            "nervous",
+            "patient",
+            "responsible",
+            "righteous",
+            "thoughtful",
+            "wise"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "adventurous",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "playful",
+            "troublesome",
+            "vengeful"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a solo fight with a gray fox."
+        ]
+    }
 ]

--- a/resources/dicts/patrols/hunting/hunting_desert.json
+++ b/resources/dicts/patrols/hunting/hunting_desert.json
@@ -58,7 +58,8 @@
             "medium_prey0",
             "medium_prey1",
             "large_prey2",
-            "large_prey3"
+            "large_prey3",
+            "no_fail_prey"
         ],
         "intro_text": "The patrol looks around for something to disguise their scent while hunting.",
         "decline_text": "On second thought, maybe not.",
@@ -99,7 +100,8 @@
             "medium_prey0",
             "medium_prey1",
             "large_prey2",
-            "large_prey3"
+            "large_prey3",
+            "no_fail_prey"
         ],
         "intro_text": "r_c looks around for something to disguise their scent while hunting.",
         "decline_text": "On second thought, maybe not.",
@@ -142,7 +144,8 @@
             "scar",
             "medium_prey0",
             "large_prey1",
-            "large_prey2"
+            "large_prey2",
+            "no_fail_prey"
         ],
         "intro_text": "r_c's mentor assesses them by sending them on a solo hunt.",
         "decline_text": "r_c asks their mentor to do the assessment some other time.",
@@ -201,7 +204,8 @@
         "season": "Any",
         "tags": [
             "hunting",
-            "medium_prey"
+            "medium_prey",
+			"no_fail_prey"
         ],
         "intro_text": "r_c heads out into the desert alone, wanting to sink their teeth into some prey and have some time to themselves.",
         "decline_text": "r_c turns back to camp, deciding that a group hunt would be more effective.",
@@ -258,7 +262,8 @@
             "hunting",
             "deputy",
             "apprentice",
-            "medium_prey"
+            "medium_prey",
+			"no_fail_prey"
         ],
         "intro_text": "r_c heads out into the desert alone, wanting to sink their teeth into some prey and have some time to themselves.",
         "decline_text": "r_c turns back to camp, deciding that a group hunt would be more effective.",
@@ -314,7 +319,8 @@
         "tags": [
             "hunting",
             "leader",
-            "medium_prey"
+            "medium_prey",
+			"no_fail_prey"
         ],
         "intro_text": "r_c heads out into the desert  alone, wanting to sink their teeth into some prey and have some time to themselves.",
         "decline_text": "r_c turns back to camp, deciding that a group hunt would be more effective.",
@@ -1024,116 +1030,191 @@
         "patrol_id": "dst_hunt_leafbarerainstorm1",
         "biome": "desert",
         "season": "leaf-bare",
-        "tags": ["hunting", "large_prey", "comfort", "trust", "platonic", "rel_patrol", "patrol_to_p_l", "patrol_to_r_c"],
+        "tags": [
+            "hunting",
+            "large_prey",
+            "comfort",
+            "trust",
+            "platonic",
+            "rel_patrol",
+            "patrol_to_p_l",
+            "patrol_to_r_c"
+        ],
         "intro_text": "It starts raining soon after the patrol sets out, trying to bring back something nice for the fresh-kill pile.",
         "decline_text": "They decide to turn back and wait until the rain dies down.",
         "chance_of_success": 50,
         "exp": 20,
         "success_text": [
-                "The desert cats turn their faces to the skies, revelling in the life-giving water. It feels like the very world itself joins them in celebration, insects emerging from hiding and chirping, birds flitting across the sandy scrubland, and the patrol returns to camp with a huge bounty of catches.",
-                null,
-                "s_c leads the patrol to one of their favourite hunting spots, a bounce in everyone's steps as the water promises new life for the desert. The cats are unused to hunting the scrubland in wet, let alone in mud, but thanks to s_c they bring home a mighty haul, laughing at eachother's damp and fluffed out fur.",
-                "The cats slip and slide in a world suddenly damp and wet in the growing rainstorm, but s_c commiserates with those who fall and encourages every cat on, the patrol not only having fun with each other, but also managing to catch a good haul of desert creatures as confused by the slippery ground as they are."
+            "The desert cats turn their faces to the skies, revelling in the life-giving water. It feels like the very world itself joins them in celebration, insects emerging from hiding and chirping, birds flitting across the sandy scrubland, and the patrol returns to camp with a huge bounty of catches.",
+            null,
+            "s_c leads the patrol to one of their favourite hunting spots, a bounce in everyone's steps as the water promises new life for the desert. The cats are unused to hunting the scrubland in wet, let alone in mud, but thanks to s_c they bring home a mighty haul, laughing at eachother's damp and fluffed out fur.",
+            "The cats slip and slide in a world suddenly damp and wet in the growing rainstorm, but s_c commiserates with those who fall and encourages every cat on, the patrol not only having fun with each other, but also managing to catch a good haul of desert creatures as confused by the slippery ground as they are."
         ],
         "fail_text": [
-                "Although the cats rejoice at the rain, after the uptenth time someone slips on the wet rock the hunting trip has to be called off. They'll go out again soon, ready to take advantage of the bounty of Leaf-bare."
+            "Although the cats rejoice at the rain, after the uptenth time someone slips on the wet rock the hunting trip has to be called off. They'll go out again soon, ready to take advantage of the bounty of Leaf-bare."
         ],
-        "win_skills": ["great hunter", "fantastic hunter"],
-        "win_trait": ["altruistic", "compassionate", "empathetic", "faithful", "loving"],
-        "fail_skills": ["None"],
-        "fail_trait": ["None"],
+        "win_skills": [
+            "great hunter",
+            "fantastic hunter"
+        ],
+        "win_trait": [
+            "altruistic",
+            "compassionate",
+            "empathetic",
+            "faithful",
+            "loving"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "None"
+        ],
         "min_cats": 2,
         "max_cats": 6,
         "antagonize_text": null,
         "antagonize_fail_text": null,
         "history_text": [
-                null,
-                null
+            null,
+            null
         ]
     },
     {
         "patrol_id": "dst_hunt_leafbarerainstorm2",
         "biome": "desert",
         "season": "leaf-bare",
-        "tags": ["hunting", "medium_prey"],
+        "tags": [
+            "hunting",
+            "medium_prey"
+        ],
         "intro_text": "It starts raining soon after r_c sets out, trying to bring back something nice for the fresh-kill pile.",
         "decline_text": "They decide to turn back and wait until the rain dies down.",
         "chance_of_success": 40,
         "exp": 10,
         "success_text": [
-                "Despite the rain, and how unfamiliar the desert looks in the gray haze, r_c manages to hunt successfully, finding the normal birds hiding from the downpour. It amuses them that their prey hides in the same places from rain as the birds normally do from sun.",
-                null,
-                "s_c really shows their talent, hunting down a mid-sized tortiose that has overturned itself on the newly slippery ground in the rain storm."
+            "Despite the rain, and how unfamiliar the desert looks in the gray haze, r_c manages to hunt successfully, finding the normal birds hiding from the downpour. It amuses them that their prey hides in the same places from rain as the birds normally do from sun.",
+            null,
+            "s_c really shows their talent, hunting down a mid-sized tortiose that has overturned itself on the newly slippery ground in the rain storm."
         ],
         "fail_text": [
-                "Although r_c rejoices at the rain, after the uptenth time they slip on the wet rock the hunting trip has to be called off. They'll go out again soon, ready to take advantage of the bounty of Leaf-bare."
+            "Although r_c rejoices at the rain, after the uptenth time they slip on the wet rock the hunting trip has to be called off. They'll go out again soon, ready to take advantage of the bounty of Leaf-bare."
         ],
-        "win_skills": ["great hunter", "fantastic hunter"],
-        "win_trait": ["None"],
-        "fail_skills": ["None"],
-        "fail_trait": ["None"],
+        "win_skills": [
+            "great hunter",
+            "fantastic hunter"
+        ],
+        "win_trait": [
+            "None"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "None"
+        ],
         "min_cats": 1,
         "max_cats": 1,
         "antagonize_text": null,
         "antagonize_fail_text": null,
         "history_text": [
-                null,
-                null
+            null,
+            null
         ]
     },
     {
         "patrol_id": "dst_hunt_leafbarerainstorm3",
         "biome": "desert",
         "season": "leaf-bare",
-        "tags": ["hunting", "comfort", "trust", "rel_patrol", "romantic", "no_app"],
+        "tags": [
+            "hunting",
+            "comfort",
+            "trust",
+            "rel_patrol",
+            "romantic",
+            "no_app"
+        ],
         "intro_text": "It starts raining soon after the patrol sets out, trying to bring back something nice for the fresh-kill pile.",
         "decline_text": "They decide to turn back and wait until the rain dies down.",
         "chance_of_success": 50,
         "exp": 10,
         "success_text": [
-                "A storm descends, sudden and violent enough to drive the c_n cats to shelter. The life-giving water is still a relief to witness, but they aren't interested in being as pummeled like the dry ground. The cats shelter in a rocky alcove, sharing stories and laughing occasionally as everyone shares tongues, licking their pelts dry.",
-                null,
-                "A storm descends, sudden and violent enough to drive the c_n cats to shelter. s_c keeps everyone's spirits up as the patrol hides in an abandoned tortoise den where the wind can't get them, until everyone is talking, a little damp but keeping eachother's spirits up.",
-                "A storm descends, sudden and violent enough to drive the c_n cats to shelter. As the cats hide from the wind, s_c keeps an eye out for everyone. There's a lot of restless energy in the shelter as the cats watch Leaf-bare bless c_n, but it's easily redirected to games and friendly debates, perhaps even a little flirting."
+            "A storm descends, sudden and violent enough to drive the c_n cats to shelter. The life-giving water is still a relief to witness, but they aren't interested in being as pummeled like the dry ground. The cats shelter in a rocky alcove, sharing stories and laughing occasionally as everyone shares tongues, licking their pelts dry.",
+            null,
+            "A storm descends, sudden and violent enough to drive the c_n cats to shelter. s_c keeps everyone's spirits up as the patrol hides in an abandoned tortoise den where the wind can't get them, until everyone is talking, a little damp but keeping eachother's spirits up.",
+            "A storm descends, sudden and violent enough to drive the c_n cats to shelter. As the cats hide from the wind, s_c keeps an eye out for everyone. There's a lot of restless energy in the shelter as the cats watch Leaf-bare bless c_n, but it's easily redirected to games and friendly debates, perhaps even a little flirting."
         ],
         "fail_text": [
-                "Although the cats rejoice at the rain, after the uptenth time someone slips on the wet rock the hunting trip has to be called off. They'll go out again soon, ready to take advantage of the bounty of Leaf-bare."
+            "Although the cats rejoice at the rain, after the uptenth time someone slips on the wet rock the hunting trip has to be called off. They'll go out again soon, ready to take advantage of the bounty of Leaf-bare."
         ],
-        "win_skills": ["great speaker", "excellent speaker"],
-        "win_trait": ["altruistic", "compassionate", "empathetic", "faithful", "loving"],
-        "fail_skills": ["None"],
-        "fail_trait": ["None"],
+        "win_skills": [
+            "great speaker",
+            "excellent speaker"
+        ],
+        "win_trait": [
+            "altruistic",
+            "compassionate",
+            "empathetic",
+            "faithful",
+            "loving"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "None"
+        ],
         "min_cats": 2,
         "max_cats": 6,
         "antagonize_text": null,
         "antagonize_fail_text": null,
         "history_text": [
-                null,
-                null
+            null,
+            null
         ]
     },
     {
         "patrol_id": "dst_hunt_swiftfox_anysteal1",
         "biome": "desert",
         "season": "Any",
-        "tags": ["hunting", "small_prey", "comfort", "respect", "rel_patrol"],
+        "tags": [
+            "hunting",
+            "small_prey",
+            "comfort",
+            "respect",
+            "rel_patrol"
+        ],
         "intro_text": "Your patrol spots a swift fox in the distance, trotting through the scrubland with a desert hare in its jaws.",
         "decline_text": "Best not to risk a fight. The patrol watches it go.",
         "chance_of_success": 70,
         "exp": 30,
         "success_text": [
-        "Outraged, your cats charge the poacher, determined to rip its pelt off. No one steals from c_n! The fox jumps, starled, and streaks for the horizon, but with a full patrol your cats chase it until it drops the hare and crosses the border. Hrumph! Though it's only a small haul of prey for a hunting patrol, at least they've gotten rid of the prey thief.",
-        "With many cats, they're able to catch the swift fox, even though it lives up to its name. It might be swift, but its not much else, and your patrol manages to pull it down and kill the intruder, protecting c_n's lands. Oh, and they also win that hare too.",
-        "s_c stops them before the patrol can start haring off after the swift fox. Instead, the cats sneak up on it, not allowing it to deploy its speed to escape. It's a successful strategy, and together they're able to bring down the fox, winning both the prey it poached and the chance to eliminate a thief.",
-        "s_c leads the charge! Their boldness sends the swift fox running, and though they lose the fox in a tumble of blouders the cats can at least bring the hare home for the fresh-kill pile."
+            "Outraged, your cats charge the poacher, determined to rip its pelt off. No one steals from c_n! The fox jumps, starled, and streaks for the horizon, but with a full patrol your cats chase it until it drops the hare and crosses the border. Hrumph! Though it's only a small haul of prey for a hunting patrol, at least they've gotten rid of the prey thief.",
+            "With many cats, they're able to catch the swift fox, even though it lives up to its name. It might be swift, but its not much else, and your patrol manages to pull it down and kill the intruder, protecting c_n's lands. Oh, and they also win that hare too.",
+            "s_c stops them before the patrol can start haring off after the swift fox. Instead, the cats sneak up on it, not allowing it to deploy its speed to escape. It's a successful strategy, and together they're able to bring down the fox, winning both the prey it poached and the chance to eliminate a thief.",
+            "s_c leads the charge! Their boldness sends the swift fox running, and though they lose the fox in a tumble of blouders the cats can at least bring the hare home for the fresh-kill pile."
         ],
         "fail_text": [
-        "The swift fox spots the patrol coming and scarpers, tucking tail and fleeing across the horizon in an example of where the small canivore gets its name."
+            "The swift fox spots the patrol coming and scarpers, tucking tail and fleeing across the horizon in an example of where the small canivore gets its name."
         ],
-        "win_skills": ["smart", "very smart", "extremely smart"],
-        "win_trait": ["bloodthirsty", "fierce", "vengeful", "bold", "confident", "daring"],
-        "fail_skills": ["None"],
-        "fail_trait": ["None"],
+        "win_skills": [
+            "smart",
+            "very smart",
+            "extremely smart"
+        ],
+        "win_trait": [
+            "bloodthirsty",
+            "fierce",
+            "vengeful",
+            "bold",
+            "confident",
+            "daring"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "None"
+        ],
         "min_cats": 2,
         "max_cats": 6,
         "antagonize_text": null,
@@ -1143,27 +1224,51 @@
         "patrol_id": "dst_hunt_swiftfox_anysteal2",
         "biome": "desert",
         "season": "Any",
-        "tags": ["hunting", "large_prey", "fighting", "scar", "small_bite_injury"],
+        "tags": [
+            "hunting",
+            "large_prey",
+            "fighting",
+            "scar",
+            "small_bite_injury"
+        ],
         "intro_text": "r_c spots a swift fox in the distance, trotting through the scrubland with a desert hare in its jaws. It's the biggest of the foxes in c_n's territory, the size of a cat, and r_c is alone. Should they try and take it on?",
         "decline_text": "Best not to risk a fight. r_c watches it go.",
         "chance_of_success": 60,
         "exp": 20,
         "success_text": [
-        "r_c charges the fox, puffed up and snarling! The fox turns tail and runs, dropping the hare in the process, and r_c retreives the poached prey for c_n's fresh-kill pile.",
-        "The swift fox is tired from its hunt, and not capable of living up to its name. r_c catches it in a chase, and claims the hare back for c_n, leaving the fox with a bloodied nose. That'll teach it!",
-        "r_c sneaks up on the fox, approaching through the cover of thornbushes. They burst out, snarling with claws extended, and batter the fox as it screams in surprise, dropping it's stolen prey and jumping backwards. Only it flinches back into more thornbushes, and r_c picks up the dropped hare and pads back to camp, leaving the thief to struggle out of the thorns by itself.",
-        "It makes r_c's blood boil, watching the fox carry away prey it's stolen from c_n's mouths. They creep between the fox and a ravine, waiting until the perfect moment, until they're able to burst from cover, snatching back the hare as the fox tumbles into the steep gash in the ground."
+            "r_c charges the fox, puffed up and snarling! The fox turns tail and runs, dropping the hare in the process, and r_c retreives the poached prey for c_n's fresh-kill pile.",
+            "The swift fox is tired from its hunt, and not capable of living up to its name. r_c catches it in a chase, and claims the hare back for c_n, leaving the fox with a bloodied nose. That'll teach it!",
+            "r_c sneaks up on the fox, approaching through the cover of thornbushes. They burst out, snarling with claws extended, and batter the fox as it screams in surprise, dropping it's stolen prey and jumping backwards. Only it flinches back into more thornbushes, and r_c picks up the dropped hare and pads back to camp, leaving the thief to struggle out of the thorns by itself.",
+            "It makes r_c's blood boil, watching the fox carry away prey it's stolen from c_n's mouths. They creep between the fox and a ravine, waiting until the perfect moment, until they're able to burst from cover, snatching back the hare as the fox tumbles into the steep gash in the ground."
         ],
         "fail_text": [
-        "The swift fox spots r_c coming and scarpers, tucking tail and fleeing across the horizon in an example of where the small canivore gets its name.",
-        null,
-        null,
-        "Puffed up, r_c approaches the swift fox. But there's only one of them, and the fox is their equal in size and weight. instead of running or giving its prey up, it snarls, and attacks. r_c gives just as good as they get, and both animals end up limping away."
+            "The swift fox spots r_c coming and scarpers, tucking tail and fleeing across the horizon in an example of where the small canivore gets its name.",
+            null,
+            null,
+            "Puffed up, r_c approaches the swift fox. But there's only one of them, and the fox is their equal in size and weight. instead of running or giving its prey up, it snarls, and attacks. r_c gives just as good as they get, and both animals end up limping away."
         ],
-        "win_skills": ["smart", "very smart", "extremely smart", "good fighter", "great fighter", "excellent fighter"],
-        "win_trait": ["bloodthirsty", "fierce", "vengeful", "bold", "confident", "daring"],
-        "fail_skills": ["None"],
-        "fail_trait": ["None"],
+        "win_skills": [
+            "smart",
+            "very smart",
+            "extremely smart",
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "bloodthirsty",
+            "fierce",
+            "vengeful",
+            "bold",
+            "confident",
+            "daring"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "None"
+        ],
         "min_cats": 1,
         "max_cats": 1,
         "antagonize_text": null,
@@ -1176,23 +1281,40 @@
         "patrol_id": "dst_hunt_swiftfox_leaf-fallvixen1",
         "biome": "desert",
         "season": "leaf-fall",
-        "tags": ["hunting", "medium_prey1", "medium_prey2", "comfort", "respect", "rel_patrol"],
+        "tags": [
+            "hunting",
+            "medium_prey1",
+            "medium_prey2",
+            "comfort",
+            "respect",
+            "rel_patrol"
+        ],
         "intro_text": "Your patrol spots a swift fox in the distance, behaving weirdly.",
         "decline_text": "Best not to risk a fight. The patrol watches it go.",
         "chance_of_success": 70,
         "exp": 30,
         "success_text": [
-        "Anticipating the coming rains, this fox is checking for a suitable burrow for her litter. And that burrow will not be in c_n's territory. The patrol makes that clear, screaming and charging at her until the fox flees beyond their borders, away from where her cubs could threaten the Clan.",
-        "She's looking for a place to den, and the patrol sets up an ambush. She crossed their borders, but she won't cross back over them again, and with her life ends the threat her cubs would have posed to c_n's kits.",
-        "s_c holds the patrol back until the swift fox's yips bring her mate, than the patrol strikes. While the vixen flees, her mate fights, and against warriors he doesn't stand a chance."
+            "Anticipating the coming rains, this fox is checking for a suitable burrow for her litter. And that burrow will not be in c_n's territory. The patrol makes that clear, screaming and charging at her until the fox flees beyond their borders, away from where her cubs could threaten the Clan.",
+            "She's looking for a place to den, and the patrol sets up an ambush. She crossed their borders, but she won't cross back over them again, and with her life ends the threat her cubs would have posed to c_n's kits.",
+            "s_c holds the patrol back until the swift fox's yips bring her mate, than the patrol strikes. While the vixen flees, her mate fights, and against warriors he doesn't stand a chance."
         ],
         "fail_text": [
-        "The swift fox spots the patrol coming and scarpers, tucking tail and fleeing across the horizon in an example of where the small canivore gets its name."
+            "The swift fox spots the patrol coming and scarpers, tucking tail and fleeing across the horizon in an example of where the small canivore gets its name."
         ],
-        "win_skills": ["smart", "very smart", "extremely smart"],
-        "win_trait": ["None"],
-        "fail_skills": ["None"],
-        "fail_trait": ["None"],
+        "win_skills": [
+            "smart",
+            "very smart",
+            "extremely smart"
+        ],
+        "win_trait": [
+            "None"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "None"
+        ],
         "min_cats": 2,
         "max_cats": 6,
         "antagonize_text": null,
@@ -1202,26 +1324,47 @@
         "patrol_id": "dst_hunt_swiftfox_leaf-fallvixen2",
         "biome": "desert",
         "season": "leaf-fall",
-        "tags": ["hunting", "large_prey2", "fighting", "scar", "respect", "clan_to_r_c", "small_bite_injury"],
+        "tags": [
+            "hunting",
+            "large_prey2",
+            "fighting",
+            "scar",
+            "respect",
+            "clan_to_r_c",
+            "small_bite_injury"
+        ],
         "intro_text": "r_c spots a swift fox in the distance, behaving weirdly. It's the biggest of the foxes in c_n's territory, the size of a cat, and r_c is alone. Should they try and take it on?",
         "decline_text": "Best not to risk a fight. r_c watches it go.",
         "chance_of_success": 60,
         "exp": 20,
         "success_text": [
-        "She's scouting out potential dens for leaf-bare, r_c realises, and rushes to warn her off. Forget about hunting, driving off this vixen before she sets up a den within c_n's borders is more important.",
-        "She's scouting out potential dens for leaf-bare, r_c realises. This could be bad, and r_c gives up on the hunt, instead following the vixen and using tall rocks to bounce their yowls around her, convicning her this patch of desert contains a  thousand cats and warning her off from try to live in it.",
-        "s_c positions themselves down a burrow in the vixen's path, and as the swift fox approaches s_c bursts from it, pinning her down and using surprise to get in a crucial blow to her throat."
+            "She's scouting out potential dens for leaf-bare, r_c realises, and rushes to warn her off. Forget about hunting, driving off this vixen before she sets up a den within c_n's borders is more important.",
+            "She's scouting out potential dens for leaf-bare, r_c realises. This could be bad, and r_c gives up on the hunt, instead following the vixen and using tall rocks to bounce their yowls around her, convicning her this patch of desert contains a  thousand cats and warning her off from try to live in it.",
+            "s_c positions themselves down a burrow in the vixen's path, and as the swift fox approaches s_c bursts from it, pinning her down and using surprise to get in a crucial blow to her throat."
         ],
         "fail_text": [
-        "The swift fox spots r_c coming and scarpers, tucking tail and fleeing across the horizon in an example of where the small canivore gets its name.",
-        null,
-        null,
-        "Puffed up, r_c approaches the swift fox. But there's only one of them, and the fox is their equal in size and weight. instead of running or giving up, it snarls, and attacks. r_c gives just as good as they get, and both animals end up limping away."
+            "The swift fox spots r_c coming and scarpers, tucking tail and fleeing across the horizon in an example of where the small canivore gets its name.",
+            null,
+            null,
+            "Puffed up, r_c approaches the swift fox. But there's only one of them, and the fox is their equal in size and weight. instead of running or giving up, it snarls, and attacks. r_c gives just as good as they get, and both animals end up limping away."
         ],
-        "win_skills": ["smart", "very smart", "extremely smart", "good fighter", "great fighter", "excellent fighter"],
-        "win_trait": ["None"],
-        "fail_skills": ["None"],
-        "fail_trait": ["None"],
+        "win_skills": [
+            "smart",
+            "very smart",
+            "extremely smart",
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "None"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "None"
+        ],
         "min_cats": 1,
         "max_cats": 1,
         "antagonize_text": null,
@@ -1234,26 +1377,49 @@
         "patrol_id": "dst_hunt_swiftfox_leaf-barevixen1",
         "biome": "desert",
         "season": "leaf-bare",
-        "tags": ["hunting", "large_prey1", "large_prey2", "comfort", "respect", "rel_patrol", "fighting", "scar", "big_bite_injury"],
+        "tags": [
+            "hunting",
+            "large_prey1",
+            "large_prey2",
+            "comfort",
+            "respect",
+            "rel_patrol",
+            "fighting",
+            "scar",
+            "big_bite_injury"
+        ],
         "intro_text": "Your patrol spots a swift fox in the distance, behaving weirdly.",
         "decline_text": "Best not to risk a fight. The patrol watches it go.",
         "chance_of_success": 50,
         "exp": 30,
         "success_text": [
-        "The patrol charges the vixen, and she runs, leaving the scent of milk in the air behind her. Though they don't know where her cubs are hidden, without their mother they won't pose a threat to the Clan.",
-        "The patrol sneaks closer, until p_l realises that the vixen is approaching her den - a den when cubs must surely hide. A competitor denning within c_n's borders is an outrage, and the patrol leaps to attack, pinning the vixen in a mess of boulders. Her body, and that of her cubs, will go to the fresh-kill pile tonight.",
-        "s_c holds the patrol back until they spot the vixen's mate, approaching with poached prey in his jaws. Together, the cats ambush the foxes, bursting from cover with claws unshealthed as a vicious fight starts. But warriors fight as a team, and the foxes do not, and one flees, abandoning its mate to the fury of c_n."
+            "The patrol charges the vixen, and she runs, leaving the scent of milk in the air behind her. Though they don't know where her cubs are hidden, without their mother they won't pose a threat to the Clan.",
+            "The patrol sneaks closer, until p_l realises that the vixen is approaching her den - a den when cubs must surely hide. A competitor denning within c_n's borders is an outrage, and the patrol leaps to attack, pinning the vixen in a mess of boulders. Her body, and that of her cubs, will go to the fresh-kill pile tonight.",
+            "s_c holds the patrol back until they spot the vixen's mate, approaching with poached prey in his jaws. Together, the cats ambush the foxes, bursting from cover with claws unshealthed as a vicious fight starts. But warriors fight as a team, and the foxes do not, and one flees, abandoning its mate to the fury of c_n."
         ],
         "fail_text": [
-        "The swift fox spots the patrol coming and scarpers, tucking tail and fleeing across the horizon in an example of where the small canivore gets its name.",
-        null,
-        null,
-        "As the patrol descends on the vixen, her scream of surprise brings in her mate, changing the odds. The male bursts out from cover and sinks his teeth into r_c, both foxes using the patrol switching to r_c's defence as their signal to flee."
+            "The swift fox spots the patrol coming and scarpers, tucking tail and fleeing across the horizon in an example of where the small canivore gets its name.",
+            null,
+            null,
+            "As the patrol descends on the vixen, her scream of surprise brings in her mate, changing the odds. The male bursts out from cover and sinks his teeth into r_c, both foxes using the patrol switching to r_c's defence as their signal to flee."
         ],
-        "win_skills": ["smart", "very smart", "extremely smart", "good fighter", "great fighter", "excellent fighter"],
-        "win_trait": ["None"],
-        "fail_skills": ["None"],
-        "fail_trait": ["None"],
+        "win_skills": [
+            "smart",
+            "very smart",
+            "extremely smart",
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "None"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "None"
+        ],
         "min_cats": 2,
         "max_cats": 6,
         "antagonize_text": null,
@@ -1266,26 +1432,48 @@
         "patrol_id": "dst_hunt_swiftfox_leaf-barevixen2",
         "biome": "desert",
         "season": "leaf-bare",
-        "tags": ["hunting", "medium_prey0", "large_prey2", "fighting", "scar", "respect", "clan_to_r_c", "small_bite_injury"],
+        "tags": [
+            "hunting",
+            "medium_prey0",
+            "large_prey2",
+            "fighting",
+            "scar",
+            "respect",
+            "clan_to_r_c",
+            "small_bite_injury"
+        ],
         "intro_text": "r_c spots a swift fox in the distance, behaving weirdly. It's the biggest of the foxes in c_n's territory, the size of a cat, and r_c is alone. Should they try and take it on?",
         "decline_text": "Best not to risk a fight. r_c watches it go.",
         "chance_of_success": 20,
         "exp": 30,
         "success_text": [
-        "Sneaking closer, r_c realises that the wind carries the scent of milk from the vixen. She has cubs. Eventually she leaves the area, and r_c begins the hunt, checking every burrow, every crevice, every hole until they find the tiny fox cubs. Killing them protects the Clan, they remind themselves.",
-        "She has a den, r_c realises, one perched just under a rocky slope. Once the vixen leaves, r_c uses the rubble around it to bury the den, and it's contents. No swift cubs will be raised within c_n's borders.",
-        "s_c scents the air, following the milk scent of the mother fox from afar. It means they can position themselves for the perfect ambush, leaping from cover to fasten their teeth in her throat."
+            "Sneaking closer, r_c realises that the wind carries the scent of milk from the vixen. She has cubs. Eventually she leaves the area, and r_c begins the hunt, checking every burrow, every crevice, every hole until they find the tiny fox cubs. Killing them protects the Clan, they remind themselves.",
+            "She has a den, r_c realises, one perched just under a rocky slope. Once the vixen leaves, r_c uses the rubble around it to bury the den, and it's contents. No swift cubs will be raised within c_n's borders.",
+            "s_c scents the air, following the milk scent of the mother fox from afar. It means they can position themselves for the perfect ambush, leaping from cover to fasten their teeth in her throat."
         ],
         "fail_text": [
-        "The swift fox spots r_c coming and scarpers, tucking tail and fleeing across the horizon in an example of where the small canivore gets its name.",
-        null,
-        null,
-        "As r_c descends on the vixen, her scream of surprise brings in her mate, changing the odds. The male bursts out from cover and sinks his teeth into r_c, both foxes using the chance to flee."
+            "The swift fox spots r_c coming and scarpers, tucking tail and fleeing across the horizon in an example of where the small canivore gets its name.",
+            null,
+            null,
+            "As r_c descends on the vixen, her scream of surprise brings in her mate, changing the odds. The male bursts out from cover and sinks his teeth into r_c, both foxes using the chance to flee."
         ],
-        "win_skills": ["smart", "very smart", "extremely smart", "good fighter", "great fighter", "excellent fighter"],
-        "win_trait": ["None"],
-        "fail_skills": ["None"],
-        "fail_trait": ["None"],
+        "win_skills": [
+            "smart",
+            "very smart",
+            "extremely smart",
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "None"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "None"
+        ],
         "min_cats": 1,
         "max_cats": 1,
         "antagonize_text": null,
@@ -1298,26 +1486,49 @@
         "patrol_id": "dst_hunt_swiftfox_newleafvixen1",
         "biome": "desert",
         "season": "newleaf",
-        "tags": ["hunting", "large_prey1", "huge_prey2", "comfort", "respect", "rel_patrol", "fighting", "scar", "big_bite_injury"],
+        "tags": [
+            "hunting",
+            "large_prey1",
+            "huge_prey2",
+            "comfort",
+            "respect",
+            "rel_patrol",
+            "fighting",
+            "scar",
+            "big_bite_injury"
+        ],
         "intro_text": "Your patrol spots a swift fox in the distance, behaving weirdly.",
         "decline_text": "Best not to risk a fight. The patrol watches it go.",
         "chance_of_success": 70,
         "exp": 30,
         "success_text": [
-        "The patrol charges the vixen, and she runs, leaving the scent of milk in the air behind her. but they don't know where her cubs might've been hidden, and they'll be old enough to survive without her - this bodes ill for greenleaf.",
-        "The patrol sneaks closer, until p_l realises that the vixen is approaching her den. Her cubs, nearly full grown on prey stolen from c_n's territory, poke their heads out, and the cats yowl in outrage. They charge the den, killing two of the cubs before the vixen runs with her third.",
-        "s_c holds the patrol back until they spot the vixen's mate, approaching with poached prey in his jaws. Together, the cats ambush the foxes, bursting from cover with claws unshealthed as a vicious fight starts. But warriors fight as a team, and the foxes do not, and one flees, abandoning its mate and cubs to the fury of c_n."
+            "The patrol charges the vixen, and she runs, leaving the scent of milk in the air behind her. but they don't know where her cubs might've been hidden, and they'll be old enough to survive without her - this bodes ill for greenleaf.",
+            "The patrol sneaks closer, until p_l realises that the vixen is approaching her den. Her cubs, nearly full grown on prey stolen from c_n's territory, poke their heads out, and the cats yowl in outrage. They charge the den, killing two of the cubs before the vixen runs with her third.",
+            "s_c holds the patrol back until they spot the vixen's mate, approaching with poached prey in his jaws. Together, the cats ambush the foxes, bursting from cover with claws unshealthed as a vicious fight starts. But warriors fight as a team, and the foxes do not, and one flees, abandoning its mate and cubs to the fury of c_n."
         ],
         "fail_text": [
-        "The swift fox spots the patrol coming and scarpers, tucking tail and fleeing across the horizon in an example of where the small canivore gets its name.",
-        null,
-        null,
-        "As the patrol descends on the vixen, her scream of surprise brings in her mate, changing the odds. The male bursts out from cover and sinks his teeth into r_c, both foxes using the patrol switching to r_c's defence as their signal to flee."
+            "The swift fox spots the patrol coming and scarpers, tucking tail and fleeing across the horizon in an example of where the small canivore gets its name.",
+            null,
+            null,
+            "As the patrol descends on the vixen, her scream of surprise brings in her mate, changing the odds. The male bursts out from cover and sinks his teeth into r_c, both foxes using the patrol switching to r_c's defence as their signal to flee."
         ],
-        "win_skills": ["smart", "very smart", "extremely smart", "good fighter", "great fighter", "excellent fighter"],
-        "win_trait": ["None"],
-        "fail_skills": ["None"],
-        "fail_trait": ["None"],
+        "win_skills": [
+            "smart",
+            "very smart",
+            "extremely smart",
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "None"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "None"
+        ],
         "min_cats": 2,
         "max_cats": 6,
         "antagonize_text": null,
@@ -1330,26 +1541,48 @@
         "patrol_id": "dst_hunt_swiftfox_newleafvixen2",
         "biome": "desert",
         "season": "newleaf",
-        "tags": ["hunting", "medium_prey0", "large_prey2", "fighting", "scar", "respect", "clan_to_r_c", "small_bite_injury"],
+        "tags": [
+            "hunting",
+            "medium_prey0",
+            "large_prey2",
+            "fighting",
+            "scar",
+            "respect",
+            "clan_to_r_c",
+            "small_bite_injury"
+        ],
         "intro_text": "r_c spots a swift fox in the distance, behaving weirdly. It's the biggest of the foxes in c_n's territory, the size of a cat, and r_c is alone. Should they try and take it on?",
         "decline_text": "Best not to risk a fight. r_c watches it go.",
         "chance_of_success": 40,
         "exp": 30,
         "success_text": [
-        "Sneaking closer, r_c realises that the wind carries the scent of milk from the vixen. She has cubs. Eventually she leaves the area, and r_c begins the hunt, checking every burrow, every crevice, every hole until they stumble over the den. Two of the cubs flee into the desert, while the third falls to r_c's claws.",
-        "She has a den, r_c realises, one perched just under a rocky slope. Once the vixen leaves, r_c uses the rubble around it to bury the den and its contents. No swift cubs will be raised within c_n's borders.",
-        "s_c scents the air, following the milk scent of the mother fox from afar. It means they can position themselves for the perfect ambush, leaping from cover to fasten their teeth in her throat. Her cubs will be old enough to survive without her, but this vixen will never raise kitten killers again."
+            "Sneaking closer, r_c realises that the wind carries the scent of milk from the vixen. She has cubs. Eventually she leaves the area, and r_c begins the hunt, checking every burrow, every crevice, every hole until they stumble over the den. Two of the cubs flee into the desert, while the third falls to r_c's claws.",
+            "She has a den, r_c realises, one perched just under a rocky slope. Once the vixen leaves, r_c uses the rubble around it to bury the den and its contents. No swift cubs will be raised within c_n's borders.",
+            "s_c scents the air, following the milk scent of the mother fox from afar. It means they can position themselves for the perfect ambush, leaping from cover to fasten their teeth in her throat. Her cubs will be old enough to survive without her, but this vixen will never raise kitten killers again."
         ],
         "fail_text": [
-        "The swift fox spots r_c coming and scarpers, tucking tail and fleeing across the horizon in an example of where the small canivore gets its name.",
-        null,
-        null,
-        "As r_c descends on the vixen, her scream of surprise brings in her mate, changing the odds. The male bursts out from cover and sinks his teeth into r_c, both foxes using the chance to flee."
+            "The swift fox spots r_c coming and scarpers, tucking tail and fleeing across the horizon in an example of where the small canivore gets its name.",
+            null,
+            null,
+            "As r_c descends on the vixen, her scream of surprise brings in her mate, changing the odds. The male bursts out from cover and sinks his teeth into r_c, both foxes using the chance to flee."
         ],
-        "win_skills": ["smart", "very smart", "extremely smart", "good fighter", "great fighter", "excellent fighter"],
-        "win_trait": ["None"],
-        "fail_skills": ["None"],
-        "fail_trait": ["None"],
+        "win_skills": [
+            "smart",
+            "very smart",
+            "extremely smart",
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "None"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "None"
+        ],
         "min_cats": 1,
         "max_cats": 1,
         "antagonize_text": null,
@@ -1358,159 +1591,307 @@
             "r_c was marked by a fight with a swift fox vixen."
         ]
     },
-	{
-    	"patrol_id": "dst_hunt_kitfox_scavenge1",
-    	"biome": "desert",
-    	"season": "Any",
-    	"tags": ["hunting", "huge_prey", "fighting", "injury", "sprain", "clan_to_patrol", "respect", "rel_patrol"],
-    	"intro_text": "Your patrol catches the scent of a fox. Tracking it, they find a kit fox feeding on a young collared peccary, a bit too big to be called a piglet. It looks like this youngster got on the wrong side of the dominant boar of its group. The kit fox is barely strong enough to open the carcass.",
-    	"decline_text": "Your patrol decides the boar is probably coming back, and they don't want to be here when it arrives to feed on its victim.",
-    	"chance_of_success": 70,
-    	"exp": 20,
-    	"success_text": [
-    	"One tiny kit fox against your cats? No contest, and the fox knows it. As soon as it sees them it trots off, leaving the cats to bring as much of the peccary back to camp as they can possibly carry.",
-    	"The kit fox gives way to the bigger cats, melting away into the scrubby dry bush as your cats bring as much of this feast as they can back to the Clan. It knows that the patrol will leave more than enough scraps behind to fill its belly full of pork.",
-    	"s_c is smart enough to stop anyone from pursuing the kit fox as it melts away before them. There's no point - the peccary carcass is the real prize here, and the patrol should focused on bringing its meat back for the Clan.",
-    	"The kit fox is irrelevant, and vanishes as soon as it sees the bigger predators coming to claim the carcass. Instead s_c focuses on maintaining a watch for other challengers, and their vigilence means the patrol sees the boar coming to cannibalise its victim from far off, making off with as much of the carcass as they can carry before it spots them."
-    	],
-    	"fail_text": [
-    	"One tiny kit fox against your cats? No contest. Your cats against the boar coming snuffling back? Also no contest, and the patrol wisely backs off as the boar begins to cannibalise its victim.",
-    	null,
-    	null,
-    	"One tiny kit fox against your cats? No contest. Your cats against the boar coming snuffling back? Also no contest, and as the patrol flees r_c feels something pull painfully in their leg."
-    	],
-    	"win_skills": ["smart", "very smart", "extremely smart"],
-    	"win_trait": ["adventurous", "altruistic", "ambitious", "confident", "daring", "fierce", "responsible", "righteous"],
-        "fail_skills": ["None"],
-        "fail_trait": ["None"],
-    	"min_cats": 2,
-    	"max_cats": 3,
-    	"antagonize_text": null,
-    	"antagonize_fail_text": null
-	},
-	{
-    	"patrol_id": "dst_hunt_kitfox_scavenge2",
-    	"biome": "desert",
-    	"season": "Any",
-    	"tags": ["hunting", "huge_prey", "fighting", "injury", "sprain", "clan_to_patrol", "respect", "rel_patrol"],
-    	"intro_text": "Your patrol catches the scent of a fox. Tracking it, they find a kit fox feeding on a young collared peccary, a bit too big to be called a piglet. It looks like this youngster got on the wrong side of the dominant boar of its group. The kit fox is barely strong enough to open the carcass.",
-    	"decline_text": "Your patrol decides the boar is probably coming back, and they don't want to be here when it arrives to feed on its victim.",
-    	"chance_of_success": 90,
-    	"exp": 20,
-    	"success_text": [
-        "One tiny kit fox against your cats? No contest, and the fox knows it. As soon as it sees them it trots off, leaving the cats to bring as much of the peccary back to camp as they can possibly carry.",
-    	"The kit fox gives way to the bigger cats, melting away into the scrubby dry bush as your cats bring as much of this feast as they can back to the Clan. It knows that the patrol will leave more than enough scraps behind to fill its belly full of pork.",
-    	"s_c is smart enough to stop anyone from pursuing the kit fox as it melts away before them. There's no point - the peccary carcass is the real prize here, and the patrol should focused on bringing its meat back for the Clan.",
-    	"The kit fox is irrelevant, and vanishes as soon as it sees the bigger predators coming to claim the carcass. Instead s_c focuses on maintaining a watch for other challengers, and their vigilence means the patrol sees the boar coming to cannibalise its victim from far off, making off with as much of the carcass as they can carry before it spots them."
-    	],
-    	"fail_text": [
-    	"One tiny kit fox against your cats? No contest. Your cats against the boar coming snuffling back? Also no contest, and the patrol wisely backs off as the boar begins to cannibalise its victim.",
-    	null,
-    	null,
-    	"One tiny kit fox against your cats? No contest. Your cats against the boar coming snuffling back? Also no contest, and as the patrol flees r_c feels something pull painfully in their leg."
-    	],
-    	"win_skills": ["smart", "very smart", "extremely smart"],
-    	"win_trait": ["adventurous", "altruistic", "ambitious", "confident", "daring", "fierce", "responsible", "righteous"],
-        "fail_skills": ["None"],
-        "fail_trait": ["troublesome", "vengeful", "bloodthirsty", "bold"],
-    	"min_cats": 4,
-    	"max_cats": 6,
-    	"antagonize_text": null,
-    	"antagonize_fail_text": null
-	},
-	{
-    	"patrol_id": "dst_hunt_kitfox_scavenge3",
-    	"biome": "desert",
-    	"season": "Any",
-    	"tags": ["hunting", "huge_prey", "fighting", "death", "no_body", "all_lives", "injury", "sprain", "clan_to_patrol", "respect"],
-    	"intro_text": "r_c catches the scent of a fox. Tracking it, they find a kit fox feeding on a young collared peccary, a bit too big to be called a piglet. It looks like this youngster got on the wrong side of the dominant boar of its group. The kit fox is barely strong enough to open the carcass.",
-    	"decline_text": "r_c decides the boar is probably coming back, and they don't want to be here when it arrives to feed on its victim.",
-    	"chance_of_success": 30,
-    	"exp": 30,
-    	"success_text": [
+    {
+        "patrol_id": "dst_hunt_kitfox_scavenge1",
+        "biome": "desert",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "huge_prey",
+            "fighting",
+            "injury",
+            "sprain",
+            "clan_to_patrol",
+            "respect",
+            "rel_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox. Tracking it, they find a kit fox feeding on a young collared peccary, a bit too big to be called a piglet. It looks like this youngster got on the wrong side of the dominant boar of its group. The kit fox is barely strong enough to open the carcass.",
+        "decline_text": "Your patrol decides the boar is probably coming back, and they don't want to be here when it arrives to feed on its victim.",
+        "chance_of_success": 70,
+        "exp": 20,
+        "success_text": [
+            "One tiny kit fox against your cats? No contest, and the fox knows it. As soon as it sees them it trots off, leaving the cats to bring as much of the peccary back to camp as they can possibly carry.",
+            "The kit fox gives way to the bigger cats, melting away into the scrubby dry bush as your cats bring as much of this feast as they can back to the Clan. It knows that the patrol will leave more than enough scraps behind to fill its belly full of pork.",
+            "s_c is smart enough to stop anyone from pursuing the kit fox as it melts away before them. There's no point - the peccary carcass is the real prize here, and the patrol should focused on bringing its meat back for the Clan.",
+            "The kit fox is irrelevant, and vanishes as soon as it sees the bigger predators coming to claim the carcass. Instead s_c focuses on maintaining a watch for other challengers, and their vigilence means the patrol sees the boar coming to cannibalise its victim from far off, making off with as much of the carcass as they can carry before it spots them."
+        ],
+        "fail_text": [
+            "One tiny kit fox against your cats? No contest. Your cats against the boar coming snuffling back? Also no contest, and the patrol wisely backs off as the boar begins to cannibalise its victim.",
+            null,
+            null,
+            "One tiny kit fox against your cats? No contest. Your cats against the boar coming snuffling back? Also no contest, and as the patrol flees r_c feels something pull painfully in their leg."
+        ],
+        "win_skills": [
+            "smart",
+            "very smart",
+            "extremely smart"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 2,
+        "max_cats": 3,
+        "antagonize_text": null,
+        "antagonize_fail_text": null
+    },
+    {
+        "patrol_id": "dst_hunt_kitfox_scavenge2",
+        "biome": "desert",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "huge_prey",
+            "fighting",
+            "injury",
+            "sprain",
+            "clan_to_patrol",
+            "respect",
+            "rel_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox. Tracking it, they find a kit fox feeding on a young collared peccary, a bit too big to be called a piglet. It looks like this youngster got on the wrong side of the dominant boar of its group. The kit fox is barely strong enough to open the carcass.",
+        "decline_text": "Your patrol decides the boar is probably coming back, and they don't want to be here when it arrives to feed on its victim.",
+        "chance_of_success": 90,
+        "exp": 20,
+        "success_text": [
+            "One tiny kit fox against your cats? No contest, and the fox knows it. As soon as it sees them it trots off, leaving the cats to bring as much of the peccary back to camp as they can possibly carry.",
+            "The kit fox gives way to the bigger cats, melting away into the scrubby dry bush as your cats bring as much of this feast as they can back to the Clan. It knows that the patrol will leave more than enough scraps behind to fill its belly full of pork.",
+            "s_c is smart enough to stop anyone from pursuing the kit fox as it melts away before them. There's no point - the peccary carcass is the real prize here, and the patrol should focused on bringing its meat back for the Clan.",
+            "The kit fox is irrelevant, and vanishes as soon as it sees the bigger predators coming to claim the carcass. Instead s_c focuses on maintaining a watch for other challengers, and their vigilence means the patrol sees the boar coming to cannibalise its victim from far off, making off with as much of the carcass as they can carry before it spots them."
+        ],
+        "fail_text": [
+            "One tiny kit fox against your cats? No contest. Your cats against the boar coming snuffling back? Also no contest, and the patrol wisely backs off as the boar begins to cannibalise its victim.",
+            null,
+            null,
+            "One tiny kit fox against your cats? No contest. Your cats against the boar coming snuffling back? Also no contest, and as the patrol flees r_c feels something pull painfully in their leg."
+        ],
+        "win_skills": [
+            "smart",
+            "very smart",
+            "extremely smart"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "troublesome",
+            "vengeful",
+            "bloodthirsty",
+            "bold"
+        ],
+        "min_cats": 4,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null
+    },
+    {
+        "patrol_id": "dst_hunt_kitfox_scavenge3",
+        "biome": "desert",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "huge_prey",
+            "fighting",
+            "death",
+            "no_body",
+            "all_lives",
+            "injury",
+            "sprain",
+            "clan_to_patrol",
+            "respect"
+        ],
+        "intro_text": "r_c catches the scent of a fox. Tracking it, they find a kit fox feeding on a young collared peccary, a bit too big to be called a piglet. It looks like this youngster got on the wrong side of the dominant boar of its group. The kit fox is barely strong enough to open the carcass.",
+        "decline_text": "r_c decides the boar is probably coming back, and they don't want to be here when it arrives to feed on its victim.",
+        "chance_of_success": 30,
+        "exp": 30,
+        "success_text": [
             "One tiny kit fox? r-c sees it off with a pawswipe, not interested in trying to take the fox as prey when the peccary carcass exists. They try to bring as much of the peccary back to camp as they can possibly carry.",
             "The kit fox gives way to the bigger cat, melting away into the scrubby dry bush as r_c brings as much of the feast as they can back to the Clan. It knows that the cat will leave more than enough scraps behind to fill its belly full of pork.",
             "s_c is smart enough to stop themselves from pursuing the kit fox as it melts away before them. There's no point - the peccary carcass is the real prize here, and s_c is focused on bringing its meat back for the Clan.",
             "The kit fox is irrelevant, and vanishes as soon as it sees the bigger predators coming to claim the carcass. Instead s_c focuses on maintaining a watch for other challengers, and their vigilence means they see the boar coming to cannibalise its victim from far off, making off with as much of the carcass as they can carry before it spots them."
-    	],
-    	"fail_text": [
-    	"Your patrol fails to drive away the fox, which keeps possession of the food. However there were no injuries.",
-        null,
-    	"One tiny kit fox against r_c? No contest. r_c settles in to open the carcass, but is caught unawares by the boar returning to reclaim it, and is killed and eaten by the boar.",
-    	"One tiny kit fox against your cats? No contest. r_c against the boar coming snuffling back? Also no contest, and as the patrol flees r_c feels something pull painfully in their leg."
-    	],
-    	"win_skills": ["smart", "very smart", "extremely smart", "good fighter", "great fighter", "excellent fighter"],
-    	"win_trait": ["adventurous", "altruistic", "ambitious", "confident", "daring", "fierce", "responsible", "righteous"],
-        "fail_skills": ["None"],
-        "fail_trait": ["troublesome", "vengeful", "bloodthirsty", "bold"],
-    	"min_cats": 1,
-    	"max_cats": 1,
-    	"antagonize_text": null,
-    	"antagonize_fail_text": null,
-    	"history_text": [
-        	null,
-        	"r_c fell when they were surprised by a peccary boar.",
+        ],
+        "fail_text": [
+            "Your patrol fails to drive away the fox, which keeps possession of the food. However there were no injuries.",
+            null,
+            "One tiny kit fox against r_c? No contest. r_c settles in to open the carcass, but is caught unawares by the boar returning to reclaim it, and is killed and eaten by the boar.",
+            "One tiny kit fox against your cats? No contest. r_c against the boar coming snuffling back? Also no contest, and as the patrol flees r_c feels something pull painfully in their leg."
+        ],
+        "win_skills": [
+            "smart",
+            "very smart",
+            "extremely smart",
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "troublesome",
+            "vengeful",
+            "bloodthirsty",
+            "bold"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            null,
+            "r_c fell when they were surprised by a peccary boar.",
             "were gored and eaten by a peccary boar"
-    	]
-	},
+        ]
+    },
     {
         "patrol_id": "dst_hunt_kitfox_steal1",
         "biome": "desert",
         "season": "Any",
-        "tags": ["hunting", "fighting", "scar", "small_bite_injury", "medium_prey", "trust"],
+        "tags": [
+            "hunting",
+            "fighting",
+            "scar",
+            "small_bite_injury",
+            "medium_prey",
+            "trust"
+        ],
         "intro_text": "r_c catches the scent of a fox. Tracking it down, the cats spot a kit fox wandering through their territory, carrying a mouse in its jaws.",
         "decline_text": "That's an insignificant amount of fresh-kill to start a fight over.",
         "chance_of_success": 70,
         "exp": 15,
         "success_text": [
-        "The hunters melt into the thorny scrubland and surround the smaller predator. By the time it scents them, it's too late. While the hunters will happily accept the mouse it carried, the fox was the prey they were actually after.",
-        "The kit fox isn't crazy, and immediately drops the mouse, running for its life from the patrol. But your patrol is fster, though it exhausts them, and together they bring down the small fox for the fresh-kill pile.",
-        "s_c pounces, snarling, and the fox turns tail with a yelp. Only s_c isn't alone, and cats circle the fox as it turns and snarls, darting in to finish it off without mercy. Kit foxes not only steal prey, for c_n, they are prey.",
-        "It takes a certain level of swagger to take on another predator, but s_c has that swagger in spades, and they take the lead hunting down the kit fox, fearless as they win not just the mouse it stole, but the kit fox itself for c_n's fresh-kill pile."
+            "The hunters melt into the thorny scrubland and surround the smaller predator. By the time it scents them, it's too late. While the hunters will happily accept the mouse it carried, the fox was the prey they were actually after.",
+            "The kit fox isn't crazy, and immediately drops the mouse, running for its life from the patrol. But your patrol is fster, though it exhausts them, and together they bring down the small fox for the fresh-kill pile.",
+            "s_c pounces, snarling, and the fox turns tail with a yelp. Only s_c isn't alone, and cats circle the fox as it turns and snarls, darting in to finish it off without mercy. Kit foxes not only steal prey, for c_n, they are prey.",
+            "It takes a certain level of swagger to take on another predator, but s_c has that swagger in spades, and they take the lead hunting down the kit fox, fearless as they win not just the mouse it stole, but the kit fox itself for c_n's fresh-kill pile."
         ],
         "fail_text": [
-        "The patrol approaches the kit fox, who spots them and sets off at full speed. It's not worth following them, not with the fox having a headstart.",
-        null,
-        null,
-        "With a massive yowl, r_c charges the fox. It bares its teeth, unwilling to give up its hard won prey without a fight, and one wrong step puts r_c's pelt in range of those little jaws, as the small kit fox tries to live up to the reputation of its bigger and stronger relatives."
+            "The patrol approaches the kit fox, who spots them and sets off at full speed. It's not worth following them, not with the fox having a headstart.",
+            null,
+            null,
+            "With a massive yowl, r_c charges the fox. It bares its teeth, unwilling to give up its hard won prey without a fight, and one wrong step puts r_c's pelt in range of those little jaws, as the small kit fox tries to live up to the reputation of its bigger and stronger relatives."
         ],
-        "win_skills": ["good fighter", "great fighter", "excellent fighter"],
-        "win_trait": ["adventurous", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "loyal", "playful", "righteous", "shameless", "strict", "troublesome", "vengeful"],
-        "fail_skills": ["None"],
-        "fail_trait": ["None"],
+        "win_skills": [
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "loyal",
+            "playful",
+            "righteous",
+            "shameless",
+            "strict",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "None"
+        ],
         "min_cats": 2,
         "max_cats": 4,
         "antagonize_text": null,
         "antagonize_fail_text": null,
-    	"history_text": [
-        	"r_c was scarred by a kit fox."
-    	]
+        "history_text": [
+            "r_c was scarred by a kit fox."
+        ]
     },
     {
         "patrol_id": "dst_hunt_kitfox_steal2",
         "biome": "desert",
         "season": "Any",
-        "tags": ["hunting", "large_prey", "fighting", "scar", "small_bite_injury"],
+        "tags": [
+            "hunting",
+            "large_prey",
+            "fighting",
+            "scar",
+            "small_bite_injury"
+        ],
         "intro_text": "r_c catches the scent of a fox. Tracking it down, they spot a kit fox wandering through their territory, carrying a mouse in its jaws.",
         "decline_text": "That's an insignificant amount of fresh-kill to start a fight over.",
         "chance_of_success": 50,
         "exp": 25,
         "success_text": [
-        "The hunter melts into the thorny scrubland and sneaks towards the smaller predator. By the time it scents them, it's too late. While r_c will happily accept the mouse it carried, the fox was the prey they were actually after.",
-        "The kit fox locks eyes with r_c as they emerge from the grass, weighing up its options against the bigger cat. r_c doesn't hesitate, leaps to attack it, and with their skill they're able to bring down the kit fox. It should have run from them - trying to keep its mouse means r_c will be able to add both to the fresh-kill pile." ,
-        "s_c pounces, snarling, and the fox turns tail with a yelp. But they're prepared for the fox trying to flee, and leap fast and low to the gorund, slamming their teeth into the fox's throat. Kit foxes not only steal prey, for c_n, they are prey.",
-        "It takes a certain level of swagger to take on another predator, but s_c has that swagger in spades, fearless as they win not just the mouse it stole, but the kit fox itself for c_n's fresh-kill pile."
+            "The hunter melts into the thorny scrubland and sneaks towards the smaller predator. By the time it scents them, it's too late. While r_c will happily accept the mouse it carried, the fox was the prey they were actually after.",
+            "The kit fox locks eyes with r_c as they emerge from the grass, weighing up its options against the bigger cat. r_c doesn't hesitate, leaps to attack it, and with their skill they're able to bring down the kit fox. It should have run from them - trying to keep its mouse means r_c will be able to add both to the fresh-kill pile.",
+            "s_c pounces, snarling, and the fox turns tail with a yelp. But they're prepared for the fox trying to flee, and leap fast and low to the gorund, slamming their teeth into the fox's throat. Kit foxes not only steal prey, for c_n, they are prey.",
+            "It takes a certain level of swagger to take on another predator, but s_c has that swagger in spades, fearless as they win not just the mouse it stole, but the kit fox itself for c_n's fresh-kill pile."
         ],
         "fail_text": [
-        "The patrol approaches the kit fox, who spots them and sets off at full speed. It's not worth following them, not with the fox having a headstart.",
-        null,
-        null,
-        "With a massive yowl, r_c charges the fox. It bares its teeth, unwilling to give up its hard won prey without a fight, and one wrong step puts r_c's pelt in range of those little jaws, as the small kit fox tries to live up to the reputation of its bigger and stronger relatives."
+            "The patrol approaches the kit fox, who spots them and sets off at full speed. It's not worth following them, not with the fox having a headstart.",
+            null,
+            null,
+            "With a massive yowl, r_c charges the fox. It bares its teeth, unwilling to give up its hard won prey without a fight, and one wrong step puts r_c's pelt in range of those little jaws, as the small kit fox tries to live up to the reputation of its bigger and stronger relatives."
         ],
-        "win_skills": ["good fighter", "great fighter", "excellent fighter"],
-        "win_trait": ["adventurous", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "loyal", "playful", "righteous", "shameless", "strict", "troublesome", "vengeful"],
-        "fail_skills": ["None"],
-        "fail_trait": ["None"],
+        "win_skills": [
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "loyal",
+            "playful",
+            "righteous",
+            "shameless",
+            "strict",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "None"
+        ],
         "min_cats": 1,
         "max_cats": 1,
         "antagonize_text": null,
@@ -1524,28 +1905,54 @@
         "patrol_id": "dst_hunt_kitfox_steal3",
         "biome": "desert",
         "season": "Any",
-        "tags": ["hunting", "small_prey", "trust"],
+        "tags": [
+            "hunting",
+            "small_prey",
+            "trust"
+        ],
         "intro_text": "r_c catches the scent of a fox. Tracking it down, the cats spot a kit fox wandering through their territory, carrying a mouse in its jaws.",
         "decline_text": "That's an insignificant amount of fresh-kill to start a fight over.",
         "chance_of_success": 90,
         "exp": 15,
         "success_text": [
-        "The hunters melt into the thorny scrubland and surround the smaller predator. By the time it scents them, it's too late. While the hunters will happily accept the mouse it carried, the fox was the prey they were actually after.",
-        "The kit fox isn't crazy, and immediately drops the mouse, running for its life from the patrol. But your patrol is fster, though it exhausts them, and together they bring down the small fox for the fresh-kill pile.",
-        "s_c pounces, snarling, and the fox turns tail with a yelp. Only s_c isn't alone, and cats circle the fox as it turns and snarls, darting in to finish it off without mercy. Kit foxes not only steal prey, for c_n, they are prey.",
-        "It takes a certain level of swagger to take on another predator, but s_c has that swagger in spades, and they take the lead hunting down the kit fox, fearless as they win not just the mouse it stole, but the kit fox itself for c_n's fresh-kill pile."
+            "The hunters melt into the thorny scrubland and surround the smaller predator. By the time it scents them, it's too late. While the hunters will happily accept the mouse it carried, the fox was the prey they were actually after.",
+            "The kit fox isn't crazy, and immediately drops the mouse, running for its life from the patrol. But your patrol is fster, though it exhausts them, and together they bring down the small fox for the fresh-kill pile.",
+            "s_c pounces, snarling, and the fox turns tail with a yelp. Only s_c isn't alone, and cats circle the fox as it turns and snarls, darting in to finish it off without mercy. Kit foxes not only steal prey, for c_n, they are prey.",
+            "It takes a certain level of swagger to take on another predator, but s_c has that swagger in spades, and they take the lead hunting down the kit fox, fearless as they win not just the mouse it stole, but the kit fox itself for c_n's fresh-kill pile."
         ],
         "fail_text": [
-        "The patrol approaches the kit fox, who spots them and sets off at full speed. It's not worth following them, not with the fox having a headstart."
+            "The patrol approaches the kit fox, who spots them and sets off at full speed. It's not worth following them, not with the fox having a headstart."
         ],
-        "win_skills": ["good fighter", "great fighter", "excellent fighter"],
-        "win_trait": ["adventurous", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "loyal", "playful", "righteous", "shameless", "strict", "troublesome", "vengeful"],
-        "fail_skills": ["None"],
-        "fail_trait": ["None"],
+        "win_skills": [
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "loyal",
+            "playful",
+            "righteous",
+            "shameless",
+            "strict",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "None"
+        ],
         "min_cats": 5,
         "max_cats": 6,
         "antagonize_text": null,
         "antagonize_fail_text": null
     }
-
 ]

--- a/resources/dicts/patrols/hunting/hunting_forest.json
+++ b/resources/dicts/patrols/hunting/hunting_forest.json
@@ -1,5306 +1,5341 @@
 [
-	{
-		"patrol_id": "fst_hunt_vole1",
-		"biome": "forest",
-		"season": "Any",
-		"tags": [
-			"hunting",
-			"medium_prey"
-		],
-		"intro_text": "Your patrol comes across a vole nibbling at a seed.",
-		"success_text": [
-			"r_c drops into a crouch and lightly stalks towards the vole. They pause, waggling their haunches before pouncing. They catch the vole easily and deliver a killing bite to the back of its head.",
-			"r_c drops into a crouch and begins stalking forward. When they get close, the vole suddenly stops chewing and r_c takes the opportunity to pounce. They kill the prey quickly and lick the blood from their lips with satisfaction.",
-			"s_c drops into a crouch and has to consciously stop their tail from swaying in excitement as they stalk the prey. Once they think they're close enough, they give their haunches a little wiggle and leap. They catch the vole squarely between their paws and kill it quickly."
-		],
-		"fail_text": [
-			"r_c drops into a crouch and begins to stalk forward. They're preparing to pounce when their paw lightly brushes a twig and the vole immediately takes off. They give chase, but the critter disappears into a burrow. Mousedung!"
-		],
-		"decline_text": "Your patrol decides to look for other prey.",
-		"chance_of_success": 50,
-		"exp": 10,
-		"win_skills": [
-			"great hunter",
-			"fantastic hunter"
-		],
-		"min_cats": 1,
-		"max_cats": 3,
-		"antagonize_text": null,
-		"antagonize_fail_text": null
-	},
-	{
-		"patrol_id": "fst_hunt_porcupine1",
-		"biome": "forest",
-		"season": "Any",
-		"tags": [
-			"hunting",
-			"injury",
-			"quilled by a porcupine",
-			"scar",
-			"death",
-			"huge_prey2"
-		],
-		"intro_text": "r_c encounters a porcupine, bristling with quills.",
-		"decline_text": "The patrol steers clear of the porcupine.",
-		"chance_of_success": 40,
-		"exp": 10,
-		"success_text": [
-			"The patrol examines the porcupine, eventually deciding that they shouldn't risk the potential injury it could cause.",
-			"The porcupine rattles its quills viciously, the patrol heeds its warning and gives it space.",
-			"s_c sets up an ambush, devising a clever plan to take the porcupine by surprise and attack it before it can whip its quills into anyone's pelt.  The Clan will be impressed by this hefty fresh-kill.",
-			"s_c has the ingenious idea to follow the porcupine from a distance and collect dropped quills to bring back to camp. The quills could be woven into the Clan's defenses to strengthen them."
-		],
-		"fail_text": [
-			"r_c leaps back just as the porcupine whips its tail towards them! That was close! The patrol gives the porcupine a wide berth.",
-			"s_c gets closer to the porcupine, intending to impress the rest of the patrol with their bravery. All the cats recoil as a horrible smell comes from the porcupine and they back off before it can charge at them.  The patrol returns to camp, the smelly evidence of their encounter still clinging to s_c's pelt.",
-			"r_c doesn't react quickly enough to the porcupine's warning. It charges sideways at them, its quills ready to impale! r_c is badly injured and dies a few days later from the wounds.",
-			"The porcupine whips around, digging the quills of its tail into r_c! The patrol bolts away and returns to camp, r_c with a nose full of quills."
-		],
-		"win_skills": [
-			"great hunter",
-			"fantastic hunter",
-			"very smart",
-			"extremely smart"
-		],
-		"win_trait": [
-			"calm",
-			"careful",
-			"strange",
-			"thoughtful",
-			"wise"
-		],
-		"fail_trait": [
-			"bold",
-			"daring",
-			"confident",
-			"adventurous"
-		],
-		"min_cats": 3,
-		"max_cats": 6,
-		"history_text": [
-			"r_c was scarred by a porcupine while on patrol.",
-			"r_c was killed by an angry porcupine while on patrol.",
-			"killed by a porcupine"
-		],
-		"antagonize_text": null,
-		"antagonize_fail_text": null
-	},
-	{
-		"patrol_id": "fst_hunt_porcupine2",
-		"biome": "forest",
-		"season": "Any",
-		"tags": [
-			"hunting",
-			"injury",
-			"quilled by a porcupine",
-			"scar",
-			"death",
-			"huge_prey2",
-			"huge_prey3"
-		],
-		"intro_text": "r_c encounters a porcupine, bristling with quills.",
-		"decline_text": "The patrol steers clear of the porcupine, they don't have enough cats to confront this creature safely.",
-		"chance_of_success": 10,
-		"exp": 30,
-		"success_text": [
-			"The patrol examines the porcupine, eventually deciding that they shouldn't risk the potential injury it could cause.",
-			"The porcupine rattles its quills viciously, the patrol heeds its warning and gives it space.",
-			"s_c sets up an ambush, devising a clever plan to take the porcupine by surprise and attack it before it can whip its quills into anyone's pelt.  The Clan will be impressed by this hefty fresh-kill.",
-			"s_c has the ingenious idea to follow the porcupine from a distance and collect dropped quills to bring back to camp.  The quills could be woven into the Clan's defenses to strengthen them."
-		],
-		"fail_text": [
-			"r_c leaps back just as the porcupine whips its tail towards them! That was close! They decide to give the porcupine a wide berth.",
-			null,
-			"r_c doesn't react quickly enough to the porcupine's warning. It charges sideways at them, its quills ready to impale! r_c is badly injured and dies a few days later from the wounds.",
-			"The porcupine whips around, digging the quills of its tail into r_c! r_c returns to camp with a nose full of quills and a wounded pride."
-		],
-		"win_skills": [
-			"fantastic hunter",
-			"extremely smart"
-		],
-		"win_trait": [
-			"calm",
-			"careful",
-			"strange",
-			"thoughtful",
-			"wise"
-		],
-		"min_cats": 1,
-		"max_cats": 2,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			"r_c was scarred by a porcupine while on patrol.",
-			"r_c was killed by an angry porcupine while on patrol.",
-			"killed by a porcupine"
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_rabbit1",
-		"biome": "forest",
-		"season": "Any",
-		"tags": [
-			"hunting",
-			"large_prey"
-		],
-		"intro_text": "While hunting, r_c comes across a rabbit burrow.",
-		"success_text": [
-			"r_c catches the rabbit hiding in its burrow."
-		],
-		"fail_text": [
-			"The burrow is abandoned, with no prey to be found in there."
-		],
-		"decline_text": "r_c decides to ignore the burrow.",
-		"chance_of_success": 50,
-		"exp": 10,
-		"win_skills": [
-			"great hunter",
-			"fantastic hunter"
-		],
-		"min_cats": 1,
-		"max_cats": 6,
-		"antagonize_text": null,
-		"antagonize_fail_text": null
-	},
-	{
-		"patrol_id": "fst_hunt_twolegplace1",
-		"biome": "forest",
-		"season": "Any",
-		"tags": [
-			"hunting",
-			"medium_prey0",
-			"large_prey1"
-		],
-		"intro_text": "The patrol approaches a Twoleg nest in the woods while hunting.",
-		"decline_text": "The patrol decides to hunt elsewhere.",
-		"chance_of_success": 40,
-		"exp": 10,
-		"success_text": [
-			"The patrol has a successful hunt, avoiding any Twolegs.",
-			"The patrol finds some astonishingly fat chickens running around the Twoleg nest, and helps themselves to one."
-		],
-		"fail_text": [
-			"Twoleg kits scare the patrol away."
-		],
-		"min_cats": 1,
-		"max_cats": 3,
-		"antagonize_text": "A Twoleg kit approaches the patrol, and they send it away squawking with it's blood on their claws.",
-		"antagonize_fail_text": "The Twoleg kits wandering around are unimpressed by the patrol and chase the cats for fun."
-	},
-	{
-		"patrol_id": "fst_hunt_twolegplace2",
-		"biome": "forest",
-		"season": "Any",
-		"tags": [
-			"hunting",
-			"medium_prey0",
-			"large_prey1"
-		],
-		"intro_text": "The patrol approaches a Twoleg nest in the woods while hunting.",
-		"decline_text": "The patrol decides to hunt elsewhere.",
-		"chance_of_success": 60,
-		"exp": 10,
-		"success_text": [
-			"The patrol cats split up, using sentries to ensure that the Twolegs don't disturb their hunts.",
-			"The patrol finds some astonishingly fat chickens running around the Twoleg nest, and helps themselves to as many as they can carry."
-		],
-		"fail_text": [
-			"Twoleg kits stomp through the woods, scaring away prey and ruining the hunt."
-		],
-		"min_cats": 4,
-		"max_cats": 6,
-		"antagonize_text": "Finding a Twoleg kit wandering alone, the cats harass it until it flees squawking, it's blood on their claws.",
-		"antagonize_fail_text": "The Twoleg kits wandering around are unimpressed by the patrol and chase the cats for fun."
-	},
-	{
-		"patrol_id": "fst_hunt_squirrel1",
-		"biome": "forest",
-		"season": "Any",
-		"tags": [
-			"hunting",
-			"injury",
-			"sprain",
-			"scar",
-			"medium_prey0",
-			"medium_prey1",
-			"large_prey2"
-		],
-		"intro_text": "The patrol notices a commotion and finds two squirrels chasing each other across the forest floor.",
-		"decline_text": "The patrol decides there's probably easier prey to find elsewhere.",
-		"chance_of_success": 50,
-		"exp": 10,
-		"success_text": [
-			"The squirrels are so distracted that the patrol is able to quickly catch them both.",
-			"The patrol springs onto the squirrels without a second thought, easily dispatching them.",
-			"s_c is quick on the jump! Though the squirrels notice the cats and begin scampering away, s_c easily cuts them off and kills both squirrels."
-		],
-		"fail_text": [
-			"The squirrels are far too excited and quick - they slip right out from between the patrol's claws.",
-			"s_c runs at the squirrels before anyone else can pounce, laughing at the prey's antics and playfully jumping into the middle of their game.  The squirrels scatter away at the disturbance and disappear into the canopy.",
-			null,
-			"r_c tries to climb up after them but slips and falls, twisting their paw."
-		],
-		"win_skills": [
-			"good hunter",
-			"great hunter",
-			"fantastic hunter"
-		],
-		"fail_trait": [
-			"troublesome",
-			"childish",
-			"playful"
-		],
-		"min_cats": 1,
-		"max_cats": 6,
-		"history_text": [
-			"r_c gained a scar after trying to chase some squirrels up a tree."
-		],
-		"antagonize_text": null,
-		"antagonize_fail_text": null
-	},
-	{
-		"patrol_id": "fst_hunt_burrow1",
-		"biome": "forest",
-		"season": "Any",
-		"tags": [
-			"hunting",
-			"big_bite_injury",
-			"scar",
-			"fighting",
-			"medium_prey"
-		],
-		"intro_text": "The patrol finds a small burrow in the ground with a strange scent. They hesitate, unsure if this is worth checking.",
-		"decline_text": "The patrol decides to avoid the burrow. There's no telling what could await inside.",
-		"chance_of_success": 60,
-		"exp": 10,
-		"success_text": [
-			"The patrol flushes a gopher out of the burrow! More fresh-kill!",
-			"Inside the burrow is a rabbit, curled up and alone. Perhaps a buck recently kicked from his birth warren? Whatever the case, this rabbit will feed the Clan now."
-		],
-		"fail_text": [
-			"The burrow turns out to be empty, the smell nothing but stale air and a slight tang of sickness. Whatever used to live here is gone now.  Checking the burrow was a waste of time.",
-			"s_c sticks their nose into the hole only to come face to face with a skunk! The whole patrol is sprayed!",
-			null,
-			"Oh no! The burrow was home to a wolverine, now angry at the disturbance. The patrol bolts away to escape its wrath, but r_c doesn't quite move fast enough and is caught in its claws until another cat turns back to help."
-		],
-		"fail_trait": [
-			"bold",
-			"ambitious",
-			"childish",
-			"impulsive"
-		],
-		"min_cats": 2,
-		"max_cats": 6,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			"r_c was scarred after an unfortunate encounter with a wolverine."
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_burrow2",
-		"biome": "forest",
-		"season": "Any",
-		"tags": [
-			"hunting",
-			"death",
-			"fighting",
-			"medium_prey"
-		],
-		"intro_text": "The patrol finds a small burrow in the ground with a strange scent. They hesitate, unsure if this is worth checking.",
-		"decline_text": "The patrol decides to avoid the burrow. There's no telling what could await inside.",
-		"chance_of_success": 40,
-		"exp": 10,
-		"success_text": [
-			"r_c flushes a gopher out of the burrow! More fresh-kill!",
-			"Inside the burrow is a rabbit, curled up and alone. Perhaps a buck recently kicked from his birth warren? Whatever the case, this rabbit will feed the Clan now."
-		],
-		"fail_text": [
-			"The burrow turns out to be empty, the smell nothing but stale air and a slight tang of sickness. Whatever used to live here is gone now.  Checking the burrow was a waste of time.",
-			"s_c sticks their nose into the hole only to come face to face with a skunk! The whole patrol is sprayed!",
-			"Oh no! The burrow was home to a wolverine, now angry at the disturbance. r_c bolts away to escape its wrath, but doesn't quite move fast enough and is caught in its claws.  With no other cats around to help, r_c is quickly killed by the predator."
-		],
-		"fail_trait": [
-			"bold",
-			"ambitious",
-			"childish",
-			"impulsive"
-		],
-		"min_cats": 1,
-		"max_cats": 1,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			null,
-			"r_c was killed after an unfortunate experience with a wolverine.",
-			"killed by a wolverine"
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_howl1",
-		"biome": "forest",
-		"season": "Any",
-		"tags": [
-			"hunting",
-			"scar",
-			"big_bite_injury",
-			"fighting",
-			"death",
-			"no_leader",
-			"medium_prey1",
-			"large_prey2",
-			"large_prey3"
-		],
-		"intro_text": "The patrol hears distant howling and wonders whether to investigate the noise.",
-		"decline_text": "The patrol decides not to investigate the source of the noise.  Whatever is making it will not be friendly to them.",
-		"chance_of_success": 50,
-		"exp": 30,
-		"success_text": [
-			"The patrol tracks the noise and discovers a coyote scavenging off a carcass. This is a predator they cannot fight, the patrol decides to return to camp and report the intruder to the leader. Perhaps they can return later to take what the coyote leaves behind.",
-			"The patrol tracks the noise and finds a mostly stripped carcass covered in the scent of coyote. They quickly scavenge what little is left and leave before the predator can return.",
-			"The patrol follows the noise to a coyote who quickly spots them in the brush. A fight ensues and thanks to the skills of s_c, the coyote eventually runs away, deeming the carcass they had been scavenging from to not be worth the hassle.  Your patrol brings back what meat had still been left.",
-			"The noise leads them to a coyote, scavenging from a carcass. s_c instructs them to wait in the brush, downwind from the canine, until it leaves. Eventually the coyote eats its fill and disappears into the forest. When s_c deems it safe, the patrol takes their turn stripping the leftover meat from the bones."
-		],
-		"fail_text": [
-			"The noise leads them to a coyote that's busy stripping the last of the meat from a carcass. The patrol waits till the coyote leaves, hoping to pick up any leftovers, but unfortunately the bones have been thoroughly cleaned.",
-			"They track the noise to a coyote. Before the patrol can investigate further, s_c whimpers in terror at the sight of the beast and dashes away.  The patrol follows anxiously, not wanting to lose sight of their Clanmate while a coyote is about.",
-			"The patrol finds a coyote at the source of the noise. It seems to be scavenging from an old carcass and upon seeing the cats, proves to be fiercely protective of its meal.  The patrol doesn't move fast enough and r_c is killed before they can run.",
-			"The sound leads them to a coyote, scavenging from a carcass. The coyote notices them before they can hide and lunges, making it clear that this food has been claimed.  r_c is momentarily caught in its jaws before the patrol retaliates and drives it off their Clanmate."
-		],
-		"win_skills": [
-			"excellent fighter"
-		],
-		"win_trait": [
-			"careful",
-			"calm",
-			"patient",
-			"responsible",
-			"sneaky",
-			"thoughtful",
-			"wise"
-		],
-		"fail_trait": [
-			"nervous",
-			"insecure"
-		],
-		"min_cats": 4,
-		"max_cats": 6,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			"r_c was scarred by a coyote protecting its scavenged meal.",
-			"r_c was killed by a coyote protecting its scavenged meal.",
-			"killed by a coyote"
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_howl2",
-		"biome": "forest",
-		"season": "Any",
-		"tags": [
-			"hunting",
-			"scar",
-			"big_bite_injury",
-			"fighting",
-			"death",
-			"no_leader",
-			"medium_prey1",
-			"large_prey2",
-			"large_prey3"
-		],
-		"intro_text": "The patrol hears distant howling and wonders whether to investigate the noise.",
-		"decline_text": "The patrol decides not to investigate the source of the noise. Whatever is making it will not be friendly to them.",
-		"chance_of_success": 30,
-		"exp": 30,
-		"success_text": [
-			"The patrol tracks the noise and discovers a coyote scavenging off a carcass. This is a predator they cannot fight, the patrol decides to return to camp and report the intruder to the leader. Perhaps they can return later to take what the coyote leaves behind.",
-			"The patrol tracks the noise and finds a mostly stripped carcass covered in the scent of coyote. They quickly scavenge what little is left and leave before the predator can return.",
-			"The noise leads them to a coyote, scavenging from a carcass. s_c instructs them to wait in the brush, downwind from the canine, until it leaves. Eventually the coyote eats its fill and disappears into the forest. When s_c deems it safe, the patrol takes their turn stripping the leftover meat from the bones.",
-			"The noise leads them to a coyote, scavenging from a carcass. s_c instructs them to wait in the brush, downwind from the canine, until it leaves. Eventually the coyote eats its fill and disappears into the forest. When s_c deems it safe, the patrol takes their turn stripping the leftover meat from the bones."
-		],
-		"fail_text": [
-			"The noise leads them to a coyote that's busy stripping the last of the meat from a carcass. The patrol waits till the coyote leaves, hoping to pick up any leftovers, but unfortunately the bones have been thoroughly cleaned.",
-			"They track the noise to a coyote. Before the patrol can investigate further, s_c whimpers in terror at the sight of the beast and dashes away.  The patrol follows anxiously, not wanting to lose sight of their Clanmate while a coyote is about.",
-			"The patrol finds a coyote at the source of the noise. It seems to be scavenging from an old carcass and upon seeing the cats, proves to be fiercely protective of its meal.  The patrol doesn't move fast enough and r_c is killed before they can run.",
-			"The sound leads them to a coyote, scavenging from a carcass. The coyote notices them before they can hide and lunges, making it clear that this food has been claimed.  r_c is momentarily caught in its jaws before the patrol retaliates and drives it off their Clanmate."
-		],
-		"win_skills": [
-			"very smart",
-			"extremely smart"
-		],
-		"win_trait": [
-			"careful",
-			"calm",
-			"patient",
-			"responsible",
-			"sneaky",
-			"thoughtful",
-			"wise"
-		],
-		"fail_trait": [
-			"nervous",
-			"insecure"
-		],
-		"min_cats": 2,
-		"max_cats": 4,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			"r_c was scarred by a coyote protecting its scavenged meal.",
-			"r_c was killed by a coyote protecting its scavenged meal.",
-			"killed by a coyote"
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_howl3",
-		"biome": "forest",
-		"season": "Any",
-		"tags": [
-			"hunting",
-			"fighting",
-			"death",
-			"no_leader",
-			"medium_prey1",
-			"large_prey2",
-			"large_prey3"
-		],
-		"intro_text": "r_c hears distant howling and wonders whether to investigate the noise.",
-		"decline_text": "r_c decides not to investigate the source of the noise. Whatever is making it will not be friendly to them and they are only one cat.",
-		"chance_of_success": 10,
-		"exp": 30,
-		"success_text": [
-			"r_c tracks the noise and discovers a coyote scavenging off a carcass. This is a predator they cannot fight, they decide to return to camp and report the intruder to the leader, perhaps a patrol can return later to take what the coyote leaves behind.",
-			"r_c tracks the noise and finds a mostly stripped carcass covered in the scent of coyote. They quickly scavenge what little is left and leave before the predator can return.",
-			"The noise leads them to a coyote, scavenging from a carcass. s_c decides to wait in the brush, downwind from the canine, until it leaves. Eventually the coyote eats its fill and disappears into the forest. s_c waits a while longer, ensuring the coyote has truly left, and takes their turn stripping the leftover meat from the bones.",
-			"The noise leads them to a coyote, scavenging from a carcass. s_c decides to wait in the brush, downwind from the canine, until it leaves. Eventually the coyote eats its fill and disappears into the forest. s_c waits a while longer, ensuring the coyote has truly left, and takes their turn stripping the leftover meat from the bones."
-		],
-		"fail_text": [
-			"The noise leads them to a coyote that's busy stripping the last of the meat from a carcass. They wait till the coyote leaves, hoping to pick up any leftovers, but unfortunately the bones have been thoroughly cleaned.",
-			"They track the noise to a coyote. s_c whimpers in terror at the sight of the beast and dashes away, running straight back to camp...",
-			"r_c finds a coyote at the source of the noise. It seems to be scavenging from an old carcass and upon seeing the cat, proves to be fiercely protective of its meal.  They doesn't move fast enough and with no Clanmates to save them, r_c is quickly killed."
-		],
-		"win_skills": [
-			"very smart",
-			"extremely smart"
-		],
-		"win_trait": [
-			"careful",
-			"calm",
-			"patient",
-			"responsible",
-			"sneaky",
-			"thoughtful",
-			"wise"
-		],
-		"fail_trait": [
-			"nervous",
-			"insecure"
-		],
-		"min_cats": 1,
-		"max_cats": 1,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			null,
-			"r_c was killed by a coyote protecting its scavenged meal.",
-			"killed by a coyote"
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_howl4",
-		"biome": "forest",
-		"season": "Any",
-		"tags": [
-			"hunting",
-			"scar",
-			"big_bite_injury",
-			"fighting",
-			"death",
-			"no_leader",
-			"medium_prey1",
-			"large_prey2",
-			"large_prey3"
-		],
-		"intro_text": "The patrol hears distant howling and wonders whether to investigate the noise.",
-		"decline_text": "The patrol decides not to investigate the source of the noise.  Whatever is making it will not be friendly to them.",
-		"chance_of_success": 40,
-		"exp": 30,
-		"success_text": [
-			"The patrol tracks the noise and discovers a wolf eating from its kill. This is a predator they cannot fight and more wolves may be nearby, the patrol decides to return to camp and report the intruder to the leader. Perhaps they can return later to take what fresh-kill is left behind.",
-			"The patrol tracks the noise and finds a mostly stripped carcass covered in the scent of wolves. They quickly scavenge what little is left and leave before the predators can return.",
-			"The noise leads them to a wolf, eating from its kill. s_c instructs them to wait in the brush, downwind from the canine, until it leaves. Eventually the wolf eats its fill and disappears into the forest. When s_c deems it safe, the patrol takes their turn stripping the leftover meat from the bones.",
-			"The noise leads them to a wolf, eating from its kill. s_c instructs them to wait in the brush, downwind from the canine, until it leaves. Eventually the wolf eats its fill and disappears into the forest. When s_c deems it safe, the patrol takes their turn stripping the leftover meat from the bones."
-		],
-		"fail_text": [
-			"The noise leads them to a wolf that's busy stripping the last of the meat from a carcass. The patrol waits till the wolf leaves, hoping to pick up any leftovers, but unfortunately the bones have been thoroughly cleaned.",
-			"They track the noise to a wolf. Before the patrol can investigate further, s_c whimpers in terror at the sight of the beast and dashes away. The patrol follows anxiously, not wanting to lose sight of their Clanmate while a wolf is about.",
-			"The patrol finds a wolf pack at the source of the noise. The wolves are tearing into a dead deer and upon seeing the cats, proves to be fiercely protective of their meal. The patrol doesn't move fast enough and r_c is killed before they can run.",
-			"The sound leads them to a wolf, scavenging from a carcass. The wolf notices them before they can hide and lunges, making it clear that this food has been claimed. r_c is momentarily caught in its jaws before the patrol retaliates and drives it off their Clanmate."
-		],
-		"win_skills": [
-			"very smart",
-			"extremely smart"
-		],
-		"win_trait": [
-			"careful",
-			"calm",
-			"patient",
-			"responsible",
-			"sneaky",
-			"thoughtful",
-			"wise"
-		],
-		"fail_trait": [
-			"nervous",
-			"insecure"
-		],
-		"min_cats": 5,
-		"max_cats": 6,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			"r_c was scarred by a wolf protecting its scavenged meal.",
-			"r_c was killed by a wolf pack protecting its meal.",
-			"killed by a wolf pack"
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_howl5",
-		"biome": "forest",
-		"season": "Any",
-		"tags": [
-			"hunting",
-			"fighting",
-			"death",
-			"no_leader",
-			"medium_prey1",
-			"large_prey2",
-			"large_prey3"
-		],
-		"intro_text": "The patrol hears distant howling and wonders whether to investigate the noise.",
-		"decline_text": "The patrol decides not to investigate the source of the noise. Whatever is making it will not be friendly to them.",
-		"chance_of_success": 20,
-		"exp": 30,
-		"success_text": [
-			"The patrol tracks the noise and discovers a wolf eating from its kill. This is a predator they cannot fight and more wolves may be nearby, the patrol decides to return to camp and report the intruder to the leader. Perhaps they can return later to take what little fresh-kill is left behind.",
-			"The patrol tracks the noise and finds a mostly stripped carcass covered in the scent of wolves. They quickly scavenge what little is left and leave before the predators can return.",
-			"The noise leads them to a wolf, scavenging from a carcass. s_c instructs them to wait in the brush, downwind from the canine, until it leaves. Eventually the wolf eats its fill and disappears into the forest. When s_c deems it safe, the patrol takes their turn stripping the leftover meat from the bones.",
-			"The noise leads them to a wolf, scavenging from a carcass. s_c instructs them to wait in the brush, downwind from the canine, until it leaves. Eventually the wolf eats its fill and disappears into the forest. When s_c deems it safe, the patrol takes their turn stripping the leftover meat from the bones."
-		],
-		"fail_text": [
-			"The noise leads them to a wolf that's busy stripping the last of the meat from a carcass. The patrol waits till the wolf leaves, hoping to pick up any leftovers, but unfortunately the bones have been thoroughly cleaned.",
-			"They track the noise to a wolf. Before the patrol can investigate further, s_c whimpers in terror at the sight of the beast and dashes away.  The patrol follows anxiously, not wanting to lose sight of their Clanmate while a wolf is about.",
-			"The patrol finds a wolf pack at the source of the noise. The wolves are busy eating from the carcass of a deer, and upon seeing the cats, prove to be fiercely protective of their meal.  The patrol doesn't move fast enough and r_c is killed before they can run."
-		],
-		"win_skills": [
-			"very smart",
-			"extremely smart"
-		],
-		"win_trait": [
-			"careful",
-			"calm",
-			"patient",
-			"responsible",
-			"sneaky",
-			"thoughtful",
-			"wise"
-		],
-		"fail_trait": [
-			"nervous",
-			"insecure"
-		],
-		"min_cats": 2,
-		"max_cats": 4,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			null,
-			"r_c was killed by a wolf protecting its meal.",
-			"killed by a wolf"
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_howl6",
-		"biome": "forest",
-		"season": "Any",
-		"tags": [
-			"hunting",
-			"fighting",
-			"death",
-			"no_leader",
-			"medium_prey1",
-			"large_prey2",
-			"large_prey3"
-		],
-		"intro_text": "r_c hears distant howling and wonders whether to investigate the noise.",
-		"decline_text": "r_c decides not to investigate the source of the noise.  Whatever is making it will not be friendly to them and they are only one cat.",
-		"chance_of_success": 10,
-		"exp": 40,
-		"success_text": [
-			"r_c tracks the noise and discovers a wolf eating from its kill. This is a predator they cannot fight, they decide to return to camp and report the intruder to the leader, perhaps a patrol can return later to take what the wolf leaves behind.",
-			"r_c tracks the noise and finds a mostly stripped carcass covered in the scent of wolf. They quickly scavenge what little is left and leave before the predator can return.",
-			"The noise leads them to a wolf, tearing into the carcass of a deer. s_c decides to wait in the brush, downwind from the canine, until it leaves. Eventually the wolf eats its fill and disappears into the forest. s_c waits a while longer, ensuring the wolf has truly left, and takes their turn stripping the leftover meat from the bones.",
-			"The noise leads them to a wolf, tearing into the carcass of a deer. s_c decides to wait in the brush, downwind from the canine, until it leaves. Eventually the wolf eats its fill and disappears into the forest. s_c waits a while longer, ensuring the wolf has truly left, and takes their turn stripping the leftover meat from the bones."
-		],
-		"fail_text": [
-			"The noise leads them to a wolf that's busy stripping the last of the meat from a carcass. They wait till the wolf leaves, hoping to pick up any leftovers, but unfortunately the bones have been thoroughly cleaned.",
-			"They track the noise to a wolf. s_c whimpers in terror at the sight of the beast and dashes away, running straight back to camp.",
-			"r_c finds a wolf pack at the source of the noise. The pack is tearing into a deer carcass and upon seeing the cat, prove to be fiercely protective of their meal. r_c doesn't move fast enough and with no Clanmates to save them, is quickly killed."
-		],
-		"win_skills": [
-			"very smart",
-			"extremely smart"
-		],
-		"win_trait": [
-			"careful",
-			"calm",
-			"patient",
-			"responsible",
-			"sneaky",
-			"thoughtful",
-			"wise"
-		],
-		"fail_trait": [
-			"nervous",
-			"insecure"
-		],
-		"min_cats": 1,
-		"max_cats": 1,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			null,
-			"r_c was killed by a wolf protecting its meal.",
-			"killed by a wolf"
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_strange1",
-		"biome": "forest",
-		"season": "Any",
-		"tags": [
-			"hunting",
-			"medium_prey0",
-			"medium_prey1",
-			"large_prey2",
-			"large_prey3"
-		],
-		"intro_text": "The patrol looks around for something to disguise their scent while hunting.",
-		"decline_text": "On second thought, maybe not.",
-		"chance_of_success": 50,
-		"exp": 20,
-		"success_text": [
-			"They can't think of anything that would work, but their hunt goes well regardless.",
-			"A stinky bush will do! The plan works and their hunt goes well.",
-			"s_c leads them to some deer droppings in the forest - it's not clean, but it's extremely effective, and the patrol hunts well.",
-			"s_c tells the patrol to roll in a patch of garlic to disguise their scent, which works perfectly. It's a funny taste to wash off their pelts though."
-		],
-		"fail_text": [
-			"The patrol finds nothing to disguise their scent, and no prey either.",
-			"The patrol finds no prey; it seems like all the prey was scared off because of their stench!"
-		],
-		"win_skills": [
-			"very smart",
-			"extremely smart"
-		],
-		"win_trait": [
-			"strange"
-		],
-		"fail_skills": [
-			"None"
-		],
-		"fail_trait": [
-			"None"
-		],
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"min_cats": 2,
-		"max_cats": 6
-	},
-	{
-		"patrol_id": "fst_hunt_strange2",
-		"biome": "forest",
-		"season": "Any",
-		"tags": [
-			"hunting",
-			"medium_prey0",
-			"medium_prey1",
-			"large_prey2",
-			"large_prey3"
-		],
-		"intro_text": "r_c looks around for something to disguise their scent while hunting.",
-		"decline_text": "On second thought, maybe not.",
-		"chance_of_success": 50,
-		"exp": 20,
-		"success_text": [
-			"They can't think of anything that would work, but their hunt goes well regardless.",
-			null,
-			"s_c finds some deer droppings in the forest - it's not clean, but it's extremely effective, and the hunt goes well.",
-			"s_c rolls in a patch of garlic to disguise their scent, which works perfectly. It's a funny taste to wash off their pelt though."
-		],
-		"fail_text": [
-			"The patrol finds nothing to disguise their scent, and no prey either.",
-			"r_c finds no prey; it seems like all the prey was scared off because of their stench!"
-		],
-		"win_skills": [
-			"very smart",
-			"extremely smart"
-		],
-		"win_trait": [
-			"strange"
-		],
-		"fail_skills": [
-			"None"
-		],
-		"fail_trait": [
-			"None"
-		],
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"min_cats": 1,
-		"max_cats": 1
-	},
-	{
-		"patrol_id": "fst_hunt_solo1",
-		"biome": "forest",
-		"season": "Any",
-		"tags": [
-			"hunting",
-			"apprentice",
-			"minor_injury",
-			"scar",
-			"medium_prey0",
-			"large_prey1",
-			"large_prey2",
-			"large_prey3"
-		],
-		"intro_text": "r_c's mentor assesses them by sending them on a solo hunt.",
-		"decline_text": "r_c asks their mentor to do the assessment some other time.",
-		"chance_of_success": 40,
-		"exp": 20,
-		"success_text": [
-			"r_c manages a skillful catch, and brings it back to the camp to show everyone!",
-			"r_c focuses completely on their test, slipping into a cleareyed, razor focused routine of catch and stash, catch and stash. Eventually they've caught enough to need their mentor's help carrying it back to camp, and the feeling seeing their prey stock the fresh-kill pile - they feel ready to burst with happiness!",
-			null,
-			"It's a terrible day for hunting, the prey running sparse and alert. But s_c takes their time and doesn't let the conditions discourage them, until eventually the perfect opportunity falls into place and they pull off a perfect catch!"
-		],
-		"fail_text": [
-			"Hunting is poor, and while r_c's mentor is disappointed, they don't expect r_c to be able to catch what isn't there.",
-			"s_c is too hasty, bouncing after first one prey, then another, and it ends with them empty-pawed and exhausted. Their mentor is disappointed - they clearly need more training.",
-			null,
-			"While on the hunt, r_c tumbles right down a steep slope while their attention is elsewhere. Bruised and sore, r_c has to report to the medicine cat den when they return to camp."
-		],
-		"win_skills": [
-			"None"
-		],
-		"win_trait": [
-			"calm",
-			"careful",
-			"insecure",
-			"lonesome",
-			"loyal",
-			"nervous",
-			"sneaky",
-			"strange",
-			"patient",
-			"thoughtful",
-			"wise"
-		],
-		"fail_skills": [
-			"None"
-		],
-		"fail_trait": [
-			"adventurous",
-			"bold",
-			"charismatic",
-			"childish",
-			"confident",
-			"daring",
-			"playful",
-			"righteous"
-		],
-		"min_cats": 1,
-		"max_cats": 1,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			"r_c got injured as an apprentice, exploring alone."
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_solo2",
-		"biome": "forest",
-		"season": "Any",
-		"tags": [
-			"hunting",
-			"medium_prey0",
-			"medium_prey1",
-			"large_prey2",
-			"large_prey3"
-		],
-		"intro_text": "r_c heads out into the forest alone, wanting to sink their teeth into some prey and have some time to themselves.",
-		"decline_text": "r_c turns back to camp, deciding that a group hunt would be more effective.",
-		"chance_of_success": 40,
-		"exp": 20,
-		"success_text": [
-			"r_c heads off to one of their favorite spots in the forest, a grove of spread out trees with thick underbrush providing excellent ambush chances. And what do you know, they are bush! Or they were as far as that squirrel thought.",
-			"r_c finds a fat, dumb, slow rabbit, and they can barely drag the thing back to camp, but by the stars it's juicy when they sit down to eat it with their Clanmates.",
-			"s_c gets the chance to try out an idea they've been sitting on for a while. There's a rabbit warren that they've spotted that's particularly badly built, and they manage to dig down into one of the dens, fishing baby rabbits out by the pawful.",
-			"The prey is running terribly today. But s_c has patience, and wisely waits for the perfect opportunity instead of getting frustrated. They come back to camp with a good contribution to the Clan's stores, having had a relaxing day sitting with their thoughts while waiting for the prey to come to them."
-		],
-		"fail_text": [
-			"You can't catch what isn't there, and the prey today is very not there.",
-			"s_c starts the day with endless energy, but as one hunt fails after another, it very quickly runs dry. The come back to camp, empty pawed and prickling with frustration.",
-			null,
-			null
-		],
-		"win_skills": [
-			"smart",
-			"very smart",
-			"extremely smart"
-		],
-		"win_trait": [
-			"calm",
-			"careful",
-			"insecure",
-			"lonesome",
-			"loyal",
-			"nervous",
-			"sneaky",
-			"strange",
-			"patient",
-			"thoughtful",
-			"wise"
-		],
-		"fail_skills": [
-			"None"
-		],
-		"fail_trait": [
-			"bold",
-			"childish",
-			"confident",
-			"daring",
-			"playful"
-		],
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"min_cats": 1,
-		"max_cats": 1
-	},
-	{
-		"patrol_id": "fst_hunt_solo3",
-		"biome": "forest",
-		"season": "Any",
-		"tags": [
-			"hunting",
-			"deputy",
-			"medium_prey0",
-			"medium_prey1",
-			"large_prey2",
-			"large_prey3"
-		],
-		"intro_text": "r_c heads out into the forest alone, wanting to sink their teeth into some prey and have some time to themselves.",
-		"decline_text": "r_c turns back to camp, deciding that a group hunt would be more effective.",
-		"chance_of_success": 40,
-		"exp": 20,
-		"success_text": [
-			"r_c heads off to one of their favorite spots in the forest, a grove of spread out trees with thick underbrush providing excellent ambush chances. And what do you know, they are bush! Or they were as far as that squirrel thought. They snicker to themselves as they pad back to camp.",
-			"r_c finds a fat, dumb, slow rabbit, and they can barely drag the thing back to camp, but by the stars it's juicy when they sit down to eat it with their Clanmates. Purring, they take the opportunity for a small moment of peace, relaxing with their friends.",
-			"s_c gets the chance to try out an idea they've been sitting on for a while. There's a rabbit warren that they've spotted that's particularly badly built, and they manage to dig down into one of the dens, fishing a couple baby rabbits out. This is a good spot to remember if c_n hits hard times.",
-			"The prey is running terribly today. But s_c has patience, and wisely waits for the perfect opportunity instead of getting frustrated. They come back to camp with a good contribution to the Clan's stores, having had a relaxing day sitting with their thoughts while waiting for the prey to come to them."
-		],
-		"fail_text": [
-			"You can't catch what isn't there, and the prey today is very not there.",
-			"s_c starts the day with endless energy, but as one hunt fails after another, it very quickly runs dry. They give up and return to camp, to try and at least make progress on all the work piling up there.",
-			null,
-			null
-		],
-		"win_skills": [
-			"smart",
-			"very smart",
-			"extremely smart"
-		],
-		"win_trait": [
-			"calm",
-			"careful",
-			"insecure",
-			"lonesome",
-			"loyal",
-			"nervous",
-			"sneaky",
-			"strange",
-			"patient",
-			"thoughtful",
-			"wise"
-		],
-		"fail_skills": [
-			"None"
-		],
-		"fail_trait": [
-			"bold",
-			"childish",
-			"confident",
-			"daring",
-			"playful"
-		],
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"min_cats": 1,
-		"max_cats": 1
-	},
-	{
-		"patrol_id": "fst_hunt_solo4",
-		"biome": "forest",
-		"season": "Any",
-		"tags": [
-			"hunting",
-			"leader",
-			"medium_prey0",
-			"medium_prey1",
-			"large_prey2",
-			"large_prey3"
-		],
-		"intro_text": "r_c heads out into the forest alone, wanting to sink their teeth into some prey and have some time to themselves.",
-		"decline_text": "r_c turns back to camp, deciding that a group hunt would be more effective.",
-		"chance_of_success": 40,
-		"exp": 20,
-		"success_text": [
-			"r_c heads off to one of their favorite spots in the forest, a grove of spread out trees with thick underbrush providing excellent ambush chances. And what do you know, they are bush! Or they were as far as that squirrel thought. They snicker to themselves as they pad back to camp.",
-			"r_c finds a fat, dumb, slow rabbit, and they can barely drag the thing back to camp, but by the stars it's juicy when they sit down to eat it with their Clanmates. Purring, they take the opportunity for a small moment of peace, relaxing with their friends.",
-			"s_c gets the chance to try out an idea they've been sitting on for a while. There's a rabbit warren that they've spotted that's particularly badly built, and they manage to dig down into one of the dens, fishing a couple baby rabbits out. This is a good spot to remember if c_n hits hard times.",
-			"The prey is running terribly today. But s_c has patience, and wisely waits for the perfect opportunity instead of getting frustrated. They come back to camp with a good contribution to the Clan's stores, having had a relaxing day sitting with their thoughts while waiting for the prey to come to them."
-		],
-		"fail_text": [
-			"You can't catch what isn't there, and the prey today is very not there.",
-			"s_c starts the day with endless energy, but as one hunt fails after another, it very quickly runs dry. They give up and return to camp, to try and at least make progress on all the work piling up there.",
-			null,
-			null
-		],
-		"win_skills": [
-			"smart",
-			"very smart",
-			"extremely smart"
-		],
-		"win_trait": [
-			"calm",
-			"careful",
-			"insecure",
-			"lonesome",
-			"loyal",
-			"nervous",
-			"sneaky",
-			"strange",
-			"patient",
-			"thoughtful",
-			"wise"
-		],
-		"fail_skills": [
-			"None"
-		],
-		"fail_trait": [
-			"bold",
-			"childish",
-			"confident",
-			"daring",
-			"playful"
-		],
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"min_cats": 1,
-		"max_cats": 1
-	},
-	{
-		"patrol_id": "fst_hunt_noise1",
-		"biome": "forest",
-		"season": "Any",
-		"tags": [
-			"hunting",
-			"big_bite_injury",
-			"scar",
-			"small_prey0",
-			"small_prey1",
-			"medium_prey2"
-		],
-		"intro_text": "As the patrol is checking the border lines, they hear an odd sound coming from a nearby bush.",
-		"decline_text": "It's probably nothing. The patrol leaves the noise alone and continues on their way.",
-		"chance_of_success": 80,
-		"exp": 10,
-		"success_text": [
-			"r_c drops down into a hunting crouch, certain that a mouse must be the source of the noise.  They find themselves to be correct when they pounce into the bush and return to the patrol with the tasty morsel dangling from their mouth.",
-			null,
-			"p_l pads towards the bush to check on the noise when a rabbit suddenly bursts out!  s_c is quick to react and manages to snag the rabbit before it can disappear."
-		],
-		"fail_text": [
-			"p_l pads closer to the bush, intent on finding the source of the noise, only to come face to face with a skunk!  The poor cat ends up stinking for days after the unfortunate incident.",
-			"s_c doesn't even hesitate before splitting from the patrol to check on the source of the noise. They quickly regret their impulsivity, however, when an angry raccoon bursts from the bush!  s_c gets quite the scare, but thankfully the raccoon only wanted to get away from them and quickly runs off back into the undergrowth.",
-			null,
-			"r_c takes the lead in checking the source of the noise and comes face to face with an angry fox! Though they backpedal rapidly, the fox still manages to take a bite out of them before the rest of the patrol can back them up."
-		],
-		"other_clan": [
-			"None"
-		],
-		"win_skills": [
-			"good hunter",
-			"great hunter",
-			"excellent hunter"
-		],
-		"win_trait": [
-			"None"
-		],
-		"fail_skills": [
-			"None"
-		],
-		"fail_trait": [
-			"daring",
-			"bold",
-			"ambitious"
-		],
-		"min_cats": 5,
-		"max_cats": 6,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			"r_c gained a scar from a fox."
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_noise2",
-		"biome": "forest",
-		"season": "Any",
-		"tags": [
-			"hunting",
-			"big_bite_injury",
-			"scar",
-			"death",
-			"small_prey0",
-			"small_prey1",
-			"medium_prey2"
-		],
-		"intro_text": "As the patrol is checking the border lines, they hear an odd sound coming from a nearby bush.",
-		"decline_text": "It's probably nothing. The patrol leaves the noise alone and continues on their way.",
-		"chance_of_success": 60,
-		"exp": 10,
-		"success_text": [
-			"r_c drops down into a hunting crouch, certain that a mouse must be the source of the noise. They find themselves to be correct when they pounce into the bush and return to the patrol with the tasty morsel dangling from their mouth.",
-			null,
-			"p_l pads towards the bush to check on the noise when a rabbit suddenly bursts out! s_c is quick to react and manages to snag the rabbit before it can disappear."
-		],
-		"fail_text": [
-			"p_l pads closer to the bush, intent on finding the source of the noise, only to come face to face with a skunk! The poor cat ends up stinking for days after the unfortunate incident.",
-			"s_c doesn't even hesitate before splitting from the patrol to check on the source of the noise. They quickly regret their impulsivity, however, when an angry raccoon bursts from the bush! s_c gets quite the scare, but thankfully the raccoon only wanted to get away from them and quickly runs off back into the undergrowth.",
-			"r_c takes the lead in checking the source of the noise and comes face to face with a snarling wolverine! r_c yowls for their patrol but the other cats aren't quick enough to stop the wolverine from killing r_c in one quick and deadly swipe.",
-			"r_c takes the lead in checking the source of the noise and comes face to face with an angry fox! Though they backpedal rapidly, the fox still manages to take a bite out of them before the rest of the patrol can back them up."
-		],
-		"other_clan": [
-			"None"
-		],
-		"win_skills": [
-			"good hunter",
-			"great hunter",
-			"excellent hunter"
-		],
-		"win_trait": [
-			"None"
-		],
-		"fail_skills": [
-			"None"
-		],
-		"fail_trait": [
-			"daring",
-			"bold",
-			"ambitious"
-		],
-		"min_cats": 2,
-		"max_cats": 4,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			"p_l gained a scar from a fox.",
-			"p_l was killed by a wolverine.",
-			"killed by a wolverine"
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_gonetnr1",
-		"biome": "forest",
-		"season": "Any",
-		"tags": [
-			"hunting",
-			"gone",
-			"small_prey0",
-			"small_prey1"
-		],
-		"intro_text": "Your patrol encounters a clearing where a lot of Twolegs linger.",
-		"decline_text": "Your patrol decides to hunt elsewhere.",
-		"chance_of_success": 60,
-		"exp": 20,
-		"success_text": [
-			"They continue hunting undetected.",
-			"Slyly, r_c uses the chance to get food, practicing their best kittypet impression until just the right moment, before darting forward and making off with a sandwich in their mouth.",
-			"s_c spots the Twolegs unloading metal boxes from their monsters, and abruptly tells the patrol to leave. Now.",
-			"A Twoleg spots s_c and crouches down, clicking softly. s_c hisses and flees."
-		],
-		"fail_text": [
-			null,
-			null,
-			"The patrol mostly ignores the Twolegs. As they hunt they hear a yelp from r_c. They've crawled into a metal Twolegs box, and there's nothing they or the rest of the patrol can do to get them out - eventually the Twolegs notice, and r_c is taken by them.",
-			null,
-			"A Twoleg spots s_c and crouches down, clicking softly. s_c pauses - are they hurt? Do they want to make friends? Before they can decide whether to step closer, there's a swoosh, and a net falls around them. s_c fights desperately, but the Twolegs take them away in the monster."
-		],
-		"win_skills": [
-			"extremely smart"
-		],
-		"win_trait": [
-			"ambitious",
-			"bloodthirsty",
-			"cold",
-			"fierce",
-			"shameless",
-			"strict",
-			"troublesome",
-			"vengeful"
-		],
-		"fail_skills": [
-			"None"
-		],
-		"fail_trait": [
-			"altruistic",
-			"compassionate",
-			"empathetic",
-			"faithful",
-			"loving",
-			"patient",
-			"responsible",
-			"thoughtful",
-			"wise"
-		],
-		"min_cats": 1,
-		"max_cats": 3,
-		"antagonize_text": null,
-		"antagonize_fail_text": null
-	},
-	{
-		"patrol_id": "fst_hunt_gonetnr2",
-		"biome": "forest",
-		"season": "Any",
-		"tags": [
-			"hunting",
-			"gone",
-			"medium_prey0",
-			"large_prey1"
-		],
-		"intro_text": "Your patrol encounters a clearing where a lot of Twolegs linger.",
-		"decline_text": "Your patrol decides to hunt elsewhere.",
-		"chance_of_success": 60,
-		"exp": 20,
-		"success_text": [
-			"They continue hunting undetected, using the presence of the Twolegs startling the local wildlife to bring back a good haul.",
-			"Slyly, r_c uses the chance to get food, practicing their best kittypet impression until just the right moment, before darting forward and making off with a large lump of meat in their mouth.",
-			"s_c spots the Twolegs unloading metal boxes from their monsters, and abruptly tells the patrol to leave. Now.",
-			"A Twoleg spots s_c and crouches down, clicking softly. s_c hisses and flees."
-		],
-		"fail_text": [
-			null,
-			null,
-			"The patrol mostly ignores the Twolegs. As they hunt they hear a yelp from r_c. They've crawled into a metal Twolegs box, and there's nothing they or the rest of the patrol can do to get them out - eventually the Twolegs notice, and r_c is taken by them.",
-			null,
-			"A Twoleg spots s_c and crouches down, clicking softly. s_c pauses - are they hurt? Do they want to make friends? Before they can decide whether to step closer, there's a swoosh, and a net falls around them. s_c fights desperately, but the Twolegs take them away in the monster."
-		],
-		"win_skills": [
-			"extremely smart"
-		],
-		"win_trait": [
-			"ambitious",
-			"bloodthirsty",
-			"cold",
-			"fierce",
-			"shameless",
-			"strict",
-			"troublesome",
-			"vengeful"
-		],
-		"fail_skills": [
-			"None"
-		],
-		"fail_trait": [
-			"altruistic",
-			"compassionate",
-			"empathetic",
-			"faithful",
-			"loving",
-			"patient",
-			"responsible",
-			"thoughtful",
-			"wise"
-		],
-		"min_cats": 4,
-		"max_cats": 6,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			null,
-			null
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_gonetnr3",
-		"biome": "forest",
-		"season": "Any",
-		"tags": [
-			"hunting",
-			"multi_gone",
-			"small_prey0",
-			"small_prey1"
-		],
-		"intro_text": "Your patrol encounters a clearing where a lot of Twolegs linger.",
-		"decline_text": "Your patrol decides to hunt elsewhere.",
-		"chance_of_success": 60,
-		"exp": 20,
-		"success_text": [
-			"They continue hunting undetected.",
-			"Slyly, r_c uses the chance to get food, practicing their best kittypet impression until just the right moment, before darting forward and making off with a sandwich in their mouth.",
-			"s_c spots the Twolegs unloading metal boxes from their monsters, and abruptly tells the patrol to leave. Now.",
-			"A Twoleg spots s_c and crouches down, clicking softly. s_c hisses and flees."
-		],
-		"fail_text": [
-			null,
-			null,
-			"The patrol mostly ignores the Twolegs. But as they hunt, the cats encounter appealing, delicious smelling mush in little burrows. Some of the patrol investigates, and doors slam down behind them. There's nothing they or the rest of the patrol can do to get them out - eventually the Twolegs notice, and the trapped cats are taken.",
-			null,
-			"A Twoleg spots s_c and crouches down, clicking softly. s_c pauses - are they hurt? Do they want to make friends? They wander closer, drawing more of the patrol in with them. Before they can decide whether to step away, there's a swoosh, and a net falls around the cats. They fight desperately, but the Twolegs take them away in the monster."
-		],
-		"win_skills": [
-			"extremely smart"
-		],
-		"win_trait": [
-			"ambitious",
-			"bloodthirsty",
-			"cold",
-			"fierce",
-			"shameless",
-			"strict",
-			"troublesome",
-			"vengeful"
-		],
-		"fail_skills": [
-			"None"
-		],
-		"fail_trait": [
-			"altruistic",
-			"compassionate",
-			"empathetic",
-			"faithful",
-			"loving",
-			"patient",
-			"responsible",
-			"thoughtful",
-			"wise"
-		],
-		"min_cats": 4,
-		"max_cats": 6,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			null,
-			null
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_gonetwolegden1",
-		"biome": "forest",
-		"season": "Any",
-		"tags": [
-			"hunting",
-			"gone",
-			"scar",
-			"injury",
-			"torn pelt",
-			"medium_prey0",
-			"medium_prey2",
-			"large_prey3"
-		],
-		"intro_text": "r_c decides to hunt out near the Twoleg dens.",
-		"decline_text": "On second thought, they decide to reline their nest today instead.",
-		"chance_of_success": 50,
-		"exp": 20,
-		"success_text": [
-			"They're interrupted by Twolegs wandering through the woods a couple times, but it's a successful hunt.",
-			"A friendly Twoleg makes a psspsspss noise, and pours kittypet food on the ground for r_c. They've always wondered what it might taste like... dry, is the answer. Very odd.",
-			"s_c gets distracted from hunting by strange Twoleg activity around one of their dens. They appear to be hauling all their many, many varieties of nest lining out and into a big monster. s_c take the opportunity to grab a little soft thing, something that's almost shaped like prey. It'll be good for the nursery.",
-			"Calmly, s_c weaves around the Twoleg dens, picking out the mice from the tunnels and the birds off the strange metal hanging fruit. A successful, sneaky hunt."
-		],
-		"fail_text": [
-			null,
-			"The Twolegs here are friendly, and a little carelessly, s_c goes to hunt in their garden. But there's a new thing there, a box, suspicious and strange. Wisely, s_c avoids it, and returns to c_n territory.",
-			"Carelessly, r_c is seen by Twolegs, and taken from c_n.",
-			"Carelessly, r_c is seen by Twolegs, and is taken hissing and spitting to be locked in a monster's den. Overnight, they discover that a broken window is just wide enough to push themselves out to safety through, but the glass leaves them bleeding as they run back to c_n."
-		],
-		"win_skills": [
-			"smart",
-			"very smart",
-			"extremely smart"
-		],
-		"win_trait": [
-			"calm",
-			"careful",
-			"insecure",
-			"lonesome",
-			"loyal",
-			"nervous",
-			"sneaky",
-			"strange"
-		],
-		"fail_skills": [
-			"None"
-		],
-		"fail_trait": [
-			"altruistic",
-			"compassionate",
-			"empathetic",
-			"faithful",
-			"loving",
-			"patient",
-			"responsible",
-			"thoughtful",
-			"wise"
-		],
-		"min_cats": 1,
-		"max_cats": 1,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			null,
-			null
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_gonetwolegden2",
-		"biome": "forest",
-		"season": "Any",
-		"tags": [
-			"hunting",
-			"gone",
-			"small_prey",
-			"apprentice",
-			"medium_prey0",
-			"medium_prey2",
-			"large_prey3"
-		],
-		"intro_text": "app1 decides to hunt out near the Twoleg dens.",
-		"decline_text": "On second thought, they decide to reline their nest today instead.",
-		"chance_of_success": 50,
-		"exp": 20,
-		"success_text": [
-			"They're interrupted by Twolegs wandering through the woods a couple times, so they miss a couple catches, but overall it works out.",
-			"A friendly Twolegs makes a psspsspss noise, and pours kittypet food on the ground for app1. They've always wondered what it might taste like... dry, is the answer. It's strangely appealing.",
-			null,
-			"Tail lashing excitedly, app1 hunts in the strange, forbidden land, ducking around corners and crawling over gardens with their belly low to the ground. A successful, sneaky hunt."
-		],
-		"fail_text": [
-			null,
-			"A little carelessly, s_c jumps a fence to hunt in a den's garden. But there's a new thing there, a box, suspicious and strange. Wisely, s_c avoids it, and returns to c_n territory.",
-			"Carelessly, app1 is seen by Twolegs, and taken from c_n.",
-			"Carelessly, app1 is seen by Twolegs, and is taken hissing and spitting to be locked in a monster's den. Overnight, they discover that a broken window is just wide enough to push themselves out to safety through, but the glass leaves them bleeding as they run back to c_n."
-		],
-		"win_skills": [
-			"None"
-		],
-		"win_trait": [
-			"calm",
-			"careful",
-			"insecure",
-			"lonesome",
-			"loyal",
-			"nervous",
-			"sneaky",
-			"strange"
-		],
-		"fail_skills": [
-			"None"
-		],
-		"fail_trait": [
-			"altruistic",
-			"compassionate",
-			"empathetic",
-			"faithful",
-			"loving",
-			"patient",
-			"responsible",
-			"thoughtful",
-			"wise"
-		],
-		"min_cats": 1,
-		"max_cats": 1,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			null,
-			null
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_gonetwolegden3",
-		"biome": "forest",
-		"season": "Any",
-		"tags": [
-			"hunting",
-			"gone",
-			"small_prey",
-			"romantic",
-			"platonic",
-			"no_app",
-			"medium_prey0"
-		],
-		"intro_text": "Boldly, eyes daring p_l to say no, r_c suggests hunting by the Twoleg dens.",
-		"decline_text": "On second thought, they decide to reline their nests today instead.",
-		"chance_of_success": 50,
-		"exp": 20,
-		"success_text": [
-			"They're interrupted by Twolegs wandering through the woods a couple times, but it's a successful hunt.",
-			"A friendly Twolegs makes a psspsspss noise, and pours kittypet food on the ground for r_c. They fetch p_l, and both cats investigate the food, loudly proclaiming how much better fresh-kill is, but both a little thrilled by the experience.",
-			"s_c shows the other cat all around the outskirts of the Twoleg dens, showing off how much they know about the strange animals and their weird behavior, and enjoying getting to feel clever.",
-			"It's a strange adventure, odd and weird and a little thrilling. s_c takes the lead, but both s_c and r_c are wide eyed and a little scared, in a fun way."
-		],
-		"fail_text": [
-			"Carelessly, r_c is seen by Twolegs, and is taken hissing and spitting to be locked in a monster's den. Overnight, they hear p_l yowling from outside, and the two cats manage to craft an escape plan through a broken window. Shivering, r_c presses their pelt against p_l on the way back to c_n.",
-			"The Twolegs here are friendly, and a little carelessly, s_c goes to hunt in their garden. But there's a new thing there, a box, suspicious and strange. Wisely, s_c avoids it, and returns to c_n territory.",
-			"Carelessly, r_c is seen by Twolegs, and taken from c_n.",
-			null
-		],
-		"win_skills": [
-			"smart",
-			"very smart",
-			"extremely smart"
-		],
-		"win_trait": [
-			"calm",
-			"careful",
-			"insecure",
-			"lonesome",
-			"loyal",
-			"nervous",
-			"sneaky",
-			"strange"
-		],
-		"fail_skills": [
-			"None"
-		],
-		"fail_trait": [
-			"altruistic",
-			"compassionate",
-			"empathetic",
-			"faithful",
-			"loving",
-			"patient",
-			"responsible",
-			"thoughtful",
-			"wise"
-		],
-		"min_cats": 2,
-		"max_cats": 2,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			null,
-			null
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_gonetwolegden4",
-		"biome": "forest",
-		"season": "Any",
-		"tags": [
-			"hunting",
-			"gone",
-			"small_prey",
-			"apprentice",
-			"romantic",
-			"platonic",
-			"two_apprentices",
-			"medium_prey0"
-		],
-		"intro_text": "Boldly, eyes daring app1 to say no, app2 suggests hunting by the Twoleg dens. Where apprentices are definitely not allowed.",
-		"decline_text": "On second thought, they decide to reline their nests today instead.",
-		"chance_of_success": 50,
-		"exp": 20,
-		"success_text": [
-			"They're interrupted by Twolegs wandering through the woods a couple times, so they miss a couple catches, but overall it works out.",
-			"A friendly Twolegs makes a psspsspss noise, and pours kittypet food on the ground for app2. They fetch app1, and both apprentices loudly proclaim how much better fresh-kill is, but both are also wide eyed and thrilled by the experience.",
-			null,
-			"Tail lashing excitedly, app1 hunts in the strange, forbidden land, ducking around corners and crawling over gardens with their belly low to the ground. app2 tries to be even sneakier, and so app1 ups their game, until they're both probably the most obvious pair of cats in the neighborhood."
-		],
-		"fail_text": [
-			"Carelessly, app2 is seen by Twolegs, and is taken hissing and spitting to be locked in a monster's den. Overnight, they hear app1 yowling from outside, and the two cats manage to craft an escape plan through a broken window. Shivering, app2 presses their pelt against app1 as they pad home.",
-			"A little carelessly, s_c jumps a fence to hunt in a den's garden. But there's a new thing there, a box, suspicious and strange. Wisely, s_c avoids it, and returns to c_n territory.",
-			"Carelessly, app1 is seen by Twolegs, and taken from c_n.",
-			null
-		],
-		"win_skills": [
-			"None"
-		],
-		"win_trait": [
-			"calm",
-			"careful",
-			"insecure",
-			"lonesome",
-			"loyal",
-			"nervous",
-			"sneaky",
-			"strange"
-		],
-		"fail_skills": [
-			"None"
-		],
-		"fail_trait": [
-			"altruistic",
-			"compassionate",
-			"empathetic",
-			"faithful",
-			"loving",
-			"patient",
-			"responsible",
-			"thoughtful",
-			"wise"
-		],
-		"min_cats": 2,
-		"max_cats": 2,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			null,
-			null
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_gonetwolegtrap1",
-		"biome": "forest",
-		"season": "Any",
-		"tags": [
-			"hunting",
-			"gone"
-		],
-		"intro_text": "The smell of food lures r_c into what looks like a tunnel between some bushes.",
-		"decline_text": "Turning their nose up at the temptation, they continue on their way.",
-		"chance_of_success": 50,
-		"exp": 20,
-		"success_text": [
-			"Darting through quickly, they see that the lovely smell is Twoleg mush, and keep running.",
-			"The lovely smell leads to Twoleg mush. Puzzled, r_c checks around them, only for their fur to stand on end as they realize they're standing in a metal tunnel, cloaked in rust and camouflage. It's to their great fortune that this trap seems to be broken, but whatever Twoleg restocked the bait might still be around. They leave quickly.",
-			"Something about this situation sets all of s_c's instincts off. They investigate, carefully, and strip the cover of the bushes away from a Twoleg trap underneath.",
-			"Something isn't right. Nervously pawing at the bushes, s_c thinks that the smell is too good to be true. They leave it, deciding to return to camp and report it to the deputy instead."
-		],
-		"fail_text": [
-			null,
-			"Easily swayed by the delicious smell, s_c wanders recklessly into the sheltered space, only to smack into a metal wall. Inside the trap, a young fox starts up a distressed wail, and s_c feels sympathy for it they never expected to feel for a fox, as well as the heart stopping realization that it could easily have been them.",
-			"r_c is caught in a trap hidden in the bushes and is taken by Twolegs shortly after.",
-			null
-		],
-		"win_skills": [
-			"smart",
-			"very smart",
-			"extremely smart"
-		],
-		"win_trait": [
-			"calm",
-			"careful",
-			"insecure",
-			"lonesome",
-			"loyal",
-			"nervous",
-			"sneaky",
-			"strange"
-		],
-		"fail_skills": [
-			"None"
-		],
-		"fail_trait": [
-			"adventurous",
-			"bold",
-			"confident",
-			"daring",
-			"playful"
-		],
-		"min_cats": 1,
-		"max_cats": 1,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			null,
-			null
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_gonetwolegtrap2",
-		"biome": "forest",
-		"season": "Any",
-		"tags": [
-			"hunting",
-			"gone"
-		],
-		"intro_text": "The smell of food lures r_c into what looks like a tunnel between some bushes.",
-		"decline_text": "Turning their nose up at the temptation, the patrol continues on their way.",
-		"chance_of_success": 50,
-		"exp": 20,
-		"success_text": [
-			"Darting through quickly, r_c sees that the lovely smell is Twoleg mush, and keeps running.",
-			"The lovely smell leads to Twoleg mush. Puzzled, r_c checks around them, only for their fur to stand on end as they realize they're standing in a metal tunnel, cloaked in rust and camouflage. It's to their great fortune that this trap seems to be broken, but whatever Twoleg restocked the bait might still be around. They leave quickly.",
-			"Something about this situation sets all of s_c's instincts off. They investigate, carefully, and the patrol helps them strip the cover of the bushes away from a Twoleg trap underneath.",
-			"Something isn't right. Nervously pawing at the bushes, s_c thinks that the smell is too good to be true. They leave it, convincing the patrol to return to camp and report it to the deputy instead."
-		],
-		"fail_text": [
-			null,
-			"Easily swayed by the delicious smell, s_c wanders recklessly into the sheltered space, only to smack into a metal wall. Inside the trap, a young fox starts up a distressed wail, and s_c feels sympathy for it they never expected to feel for a fox, as well as the heart stopping realization that it could easily have been them.",
-			"r_c is caught in a trap hidden in the bushes! There's nothing the patrol is able to do to help them, and r_c is taken by Twolegs shortly after.",
-			null
-		],
-		"win_skills": [
-			"smart",
-			"very smart",
-			"extremely smart"
-		],
-		"win_trait": [
-			"calm",
-			"careful",
-			"insecure",
-			"lonesome",
-			"loyal",
-			"nervous",
-			"sneaky",
-			"strange"
-		],
-		"fail_skills": [
-			"None"
-		],
-		"fail_trait": [
-			"adventurous",
-			"bold",
-			"confident",
-			"daring",
-			"playful"
-		],
-		"min_cats": 2,
-		"max_cats": 6,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			null,
-			null
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_thunderpath1",
-		"biome": "forest",
-		"season": "Any",
-		"tags": [
-			"death",
-			"scar",
-			"retirement",
-			"blunt_force_injury",
-			"hunting",
-			"medium_prey"
-		],
-		"intro_text": "The patrol comes across a thunderpath running through the forest.",
-		"decline_text": "They decide it is better not to cross.",
-		"chance_of_success": 50,
-		"exp": 10,
-		"success_text": [
-			"Your patrol crosses the thunderpath and can hunt on the other side.",
-			"Your patrol finds a pipe running under the thunderpath and uses it to cross. They end up with slightly damp paws, but a successful haul of prey.",
-			"Your patrol stops on the edge of the thunderpath, and s_c organizes a thorough search that finds a flattened squirrel. It's a reminder of the danger of the thunderpath, and a good source of scavenged meat.",
-			"s_c is patient enough to wait until the thunderpath is completely clear, then trots across calmly to hunt on the other side."
-		],
-		"fail_text": [
-			"r_c hears a monster thundering towards them, but it screeches to a halt just in time. That was close! Maybe it's best to go back to camp.",
-			null,
-			"r_c is hit by a monster while crossing and dies instantly.",
-			"r_c is hit by a monster and seems quite injured, but miraculously still alive."
-		],
-		"win_skills": [
-			"smart",
-			"very smart",
-			"extremely smart"
-		],
-		"win_trait": [
-			"calm",
-			"careful",
-			"insecure",
-			"nervous",
-			"sneaky",
-			"strange",
-			"patient",
-			"responsible",
-			"thoughtful",
-			"wise"
-		],
-		"fail_skills": [
-			"None"
-		],
-		"fail_trait": [
-			"None"
-		],
-		"min_cats": 1,
-		"max_cats": 6,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			"r_c was heavily injured by a monster, and carries the scars from it.",
-			"r_c was hit by a monster and killed.",
-			"were hit by a monster"
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_thunderpath2",
-		"biome": "forest",
-		"season": "Any",
-		"tags": [
-			"death",
-			"scar",
-			"retirement",
-			"blunt_force_injury",
-			"hunting",
-			"cruel_season",
-			"medium_prey"
-		],
-		"intro_text": "The patrol comes across a thunderpath running through the forest.",
-		"decline_text": "They decide it is better not to cross.",
-		"chance_of_success": 30,
-		"exp": 10,
-		"success_text": [
-			"Your patrol crosses the thunderpath and can hunt on the other side.",
-			"Your patrol finds a pipe running under the thunderpath and uses it to cross. They end up with slightly damp paws, but a successful haul of prey.",
-			"Your patrol stops on the edge of the thunderpath, and s_c organizes a thorough search that finds a flattened squirrel. It's a reminder of the danger of the thunderpath, and a good source of scavenged meat.",
-			"s_c is patient enough to wait until the thunderpath is completely clear, then trots across calmly to hunt on the other side."
-		],
-		"fail_text": [
-			"r_c hears a monster thundering towards them, but it screeches to a halt just in time. That was close! Maybe it's best to go back to camp.",
-			null,
-			"r_c is crossing the thunderpath and hears a monster thundering towards them. They freeze, and the monster swerves to hit them deliberately, killing them instantly.",
-			"r_c is hit by a monster and seems quite injured, but miraculously still alive."
-		],
-		"win_skills": [
-			"smart",
-			"very smart",
-			"extremely smart"
-		],
-		"win_trait": [
-			"calm",
-			"careful",
-			"insecure",
-			"nervous",
-			"sneaky",
-			"strange",
-			"patient",
-			"responsible",
-			"thoughtful",
-			"wise"
-		],
-		"fail_skills": [
-			"None"
-		],
-		"fail_trait": [
-			"None"
-		],
-		"min_cats": 1,
-		"max_cats": 6,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			"r_c was heavily injured by a monster, and carries the scars from it.",
-			"r_c was hit by a monster and killed.",
-			"were hit by a monster"
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_thunderpath3",
-		"biome": "forest",
-		"season": "Any",
-		"tags": [
-			"multi_deaths",
-			"scar",
-			"retirement",
-			"blunt_force_injury",
-			"hunting",
-			"medium_prey0",
-			"large_prey1",
-			"large_prey2",
-			"large_prey3"
-		],
-		"intro_text": "The patrol comes across a thunderpath running through the forest.",
-		"decline_text": "They decide it is better not to cross.",
-		"chance_of_success": 50,
-		"exp": 10,
-		"success_text": [
-			"Your patrol crosses the thunderpath and can hunt on the other side.",
-			"Your patrol finds a pipe running under the thunderpath and uses it to cross. They end up with slightly damp paws, but a successful haul of lots of prey.",
-			"Your patrol stops on the edge of the thunderpath, and s_c organizes a thorough search that finds several flattened pieces of roadkill. It's a reminder of the danger of the thunderpath, and a good source of scavenged meat.",
-			"s_c is patient enough to wait until the thunderpath is completely clear, then trots across calmly with the patrol to hunt on the other side."
-		],
-		"fail_text": [
-			null,
-			null,
-			"As the group crosses the thunderpath, a speeding monster appears out of nowhere. The cats run panicked in all directions, and several of them get hit and die.",
-			"r_c is hit by a monster and seems quite injured, but miraculously still alive."
-		],
-		"win_skills": [
-			"smart",
-			"very smart",
-			"extremely smart"
-		],
-		"win_trait": [
-			"calm",
-			"careful",
-			"insecure",
-			"nervous",
-			"sneaky",
-			"strange",
-			"patient",
-			"responsible",
-			"thoughtful",
-			"wise"
-		],
-		"fail_skills": [
-			"None"
-		],
-		"fail_trait": [
-			"None"
-		],
-		"min_cats": 5,
-		"max_cats": 6,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			"r_c was heavily injured by a monster, and carries the scars from it.",
-			"This cat was hit by a monster and killed.",
-			"were hit by a monster"
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_thunderpath4",
-		"biome": "forest",
-		"season": "Any",
-		"tags": [
-			"multi_deaths",
-			"scar",
-			"retirement",
-			"blunt_force_injury",
-			"hunting",
-			"cruel_season",
-			"medium_prey"
-		],
-		"intro_text": "The patrol comes across a thunderpath running through the forest.",
-		"decline_text": "They decide it is better not to cross.",
-		"chance_of_success": 30,
-		"exp": 10,
-		"success_text": [
-			"Your patrol crosses the thunderpath and can hunt on the other side.",
-			"Your patrol finds a pipe running under the thunderpath and uses it to cross. They end up with slightly damp paws, but a successful haul of lots of prey.",
-			"Your patrol stops on the edge of the thunderpath, and s_c organizes a thorough search that finds a flattened squirrel. It's a reminder of the danger of the thunderpath, and a good source of scavenged meat.",
-			"s_c is patient enough to wait until the thunderpath is completely clear, then trots across calmly with the patrol to hunt on the other side."
-		],
-		"fail_text": [
-			"r_c hears a monster thundering towards them, but it screeches to a halt just in time. That was close! Maybe it's best to go back to camp.",
-			null,
-			"As the group crosses the thunderpath, a speeding monster appears out of nowhere. The cats run panicked in all directions, and several of them get hit as the monster swerves to hit them deliberately, killing them instantly.",
-			"r_c is hit by a monster and seems quite injured, but miraculously still alive."
-		],
-		"win_skills": [
-			"smart",
-			"very smart",
-			"extremely smart"
-		],
-		"win_trait": [
-			"calm",
-			"careful",
-			"insecure",
-			"nervous",
-			"sneaky",
-			"strange",
-			"patient",
-			"responsible",
-			"thoughtful",
-			"wise"
-		],
-		"fail_skills": [
-			"None"
-		],
-		"fail_trait": [
-			"None"
-		],
-		"min_cats": 5,
-		"max_cats": 6,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			"r_c was heavily injured by a monster, and carries the scars from it.",
-			"r_c was hit by a monster and killed.",
-			"were hit by a monster"
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_fun1",
-		"biome": "forest",
-		"season": "Any",
-		"tags": [
-			"hunting",
-			"small_prey0",
-			"small_prey1",
-			"medium_prey2"
-		],
-		"intro_text": "As r_c tears through the forest, stretching their legs on a run, they spot movement out of the corner of their eye.",
-		"decline_text": "They keep going, not wanting to slow down.",
-		"chance_of_success": 50,
-		"exp": 10,
-		"success_text": [
-			"With a huge leap, they dart sideways and pull a blackbird out of the air. What a great catch!",
-			"Laughing, they bounce gleefully off a tree trunk, redirecting their momentum to slam into a very surprised mouse.",
-			"Nothing's going to escape their claws! r_c skids to a halt and then leaps into action, claw just barely catching in the tail of the squirrel they saw and bringing it down. They purr with satisfaction and trot back to camp with their prize."
-		],
-		"fail_text": [
-			"r_c darts to the side, but wherever made the flash of movement is long gone. How frustrating!",
-			"r_c skids to a halt and tries to sprint after it, but the bird they saw escapes their paws. They chatter angrily at it, and it tries to poop on them. Such is life."
-		],
-		"win_skills": [
-			"good hunter",
-			"great hunter",
-			"fantastic hunter"
-		],
-		"win_trait": [
-			"None"
-		],
-		"fail_skills": [
-			"None"
-		],
-		"fail_trait": [
-			"None"
-		],
-		"min_cats": 1,
-		"max_cats": 1,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			null,
-			null
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_fun2",
-		"biome": "forest",
-		"season": "Any",
-		"tags": [
-			"hunting",
-			"apprentice",
-			"small_prey"
-		],
-		"intro_text": "As app1 tears through the forest, stretching their legs on a run, they spot movement out of the corner of their eye.",
-		"decline_text": "They keep going, not wanting to slow down.",
-		"chance_of_success": 50,
-		"exp": 10,
-		"success_text": [
-			"With a huge leap, they dart sideways and pull the tail off a taking flight into blackbird the air. A missed catch, but new nest lining?",
-			"Laughing, they bounce gleefully off a tree trunk. It redirects their momentum far better than they were expecting, and it's difficult to say who's more surprised - the mouse, or the apprentice slamming into it! Not a very clean catch, but one they're proud of anyway."
-		],
-		"fail_text": [
-			"app1 darts to the side, but wherever made the flash of movement is long gone. How frustrating!",
-			"app1 skids to a halt and tries to sprint after it, but the bird they saw escapes their paws. They chatter angrily at it, and it tries to poop on them. Such is life."
-		],
-		"win_skills": [
-			"None"
-		],
-		"win_trait": [
-			"None"
-		],
-		"fail_skills": [
-			"None"
-		],
-		"fail_trait": [
-			"None"
-		],
-		"min_cats": 1,
-		"max_cats": 1,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			null,
-			null
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_fun3",
-		"biome": "forest",
-		"season": "Any",
-		"tags": [
-			"hunting",
-			"no_app",
-			"romantic",
-			"platonic",
-			"respect",
-			"small_prey0",
-			"small_prey1",
-			"medium_prey2"
-		],
-		"intro_text": "As r_c tears through the forest with p_l, stretching their legs on a run, they spot movement out of the corner of their eye.",
-		"decline_text": "They keep going, not wanting to slow down.",
-		"chance_of_success": 50,
-		"exp": 10,
-		"success_text": [
-			"With a huge leap, r_c darts sideways and pulls a blackbird out of the air. p_l trots over to congratulate them on the fantastic catch, purring.",
-			"Laughing, they bounce gleefully off a tree trunk, redirecting their momentum to slam into a very surprised mouse. p_l skids to a halt, gasping over their beautiful catch with their eyes shining.",
-			"Nothing's going to escape their claws! s_c skids to a halt and then leaps into action, claw just barely catching in the tail of the squirrel they saw and bringing it down. They purr with satisfaction and pad back to r_c, sharing in the excitement of the hunt with them."
-		],
-		"fail_text": [
-			"r_c darts to the side, but wherever made the flash of movement is long gone. How frustrating!",
-			"r_c skids to a halt and tries to sprint after it, but the bird they saw escapes their paws. They chatter angrily at it, and it tries to poop on them. Such is life. p_l snickers at them a bit too, but it's all in good fun."
-		],
-		"win_skills": [
-			"good hunter",
-			"great hunter",
-			"fantastic hunter"
-		],
-		"win_trait": [
-			"None"
-		],
-		"fail_skills": [
-			"None"
-		],
-		"fail_trait": [
-			"None"
-		],
-		"min_cats": 2,
-		"max_cats": 2,
-		"antagonize_text": null,
-		"antagonize_fail_text": null
-	},
-	{
-		"patrol_id": "fst_hunt_fun4",
-		"biome": "forest",
-		"season": "Any",
-		"tags": [
-			"hunting",
-			"apprentice",
-			"romantic",
-			"platonic",
-			"respect",
-			"two_apprentices",
-			"small_prey"
-		],
-		"intro_text": "As app1 tears through the forest with app2, stretching their legs on a run, they spot movement out of the corner of their eye.",
-		"decline_text": "They keep going, not wanting to slow down.",
-		"chance_of_success": 50,
-		"exp": 10,
-		"success_text": [
-			"With a huge leap, app1 darts sideways and pulls the tail off a blackbird taking flight into the air. A missed catch, but new nest lining? They toss some of the feathers at app2, and the two apprentices end up scuffling like kits.",
-			"Laughing, app1 bounces gleefully off a tree trunk. It redirects their momentum far better than they were expecting, and it's difficult to say who's more surprised - the mouse, or the apprentice slamming into it! Not a very clean catch, but the look on app2's face, so shocked and impressed, makes them blush."
-		],
-		"fail_text": [
-			"app1 darts to the side, but wherever made the flash of movement is long gone. How frustrating!",
-			"app1 skids to a halt and tries to sprint after it, but the bird they saw escapes their paws. They chatter angrily at it, and it tries to poop on them. Such is life. app2 snickers at them too, but in a lighthearted way, and soon both apprentices are giggling about it as they continue their run."
-		],
-		"win_skills": [
-			"None"
-		],
-		"win_trait": [
-			"None"
-		],
-		"fail_skills": [
-			"None"
-		],
-		"fail_trait": [
-			"None"
-		],
-		"min_cats": 2,
-		"max_cats": 2,
-		"antagonize_text": null,
-		"antagonize_fail_text": null
-	},
-	{
-		"patrol_id": "fst_hunt_heat1",
-		"biome": "forest",
-		"season": "greenleaf",
-		"tags": [
-			"hunting",
-			"small_prey",
-			"heat_illness",
-			"medium_prey0",
-			"huge_prey1"
-		],
-		"intro_text": "It is extremely hot out today, and the hunting patrol is having a hard time staying on task. r_c debates turning back home.",
-		"decline_text": "The patrol decides to head back to camp. They can hunt a different day.",
-		"chance_of_success": 50,
-		"exp": 15,
-		"success_text": [
-			"They decide to power through the weather and the patrol eventually has a successful, if exhausting, hunt.",
-			"The patrol stops to cool off in the shade of a tree for a heartbeat before continuing on their way. As they do, they notice a half-grown deer fawn tottering about in the distance. It's confused by the heat and underweight, and by working together the cats manage to bring it down, a huge prize for the Clan."
-		],
-		"fail_text": [
-			"No way, it's too hot for this. They can try to hunt again later.",
-			null,
-			null,
-			"r_c collapses from heat exhaustion. p_l carries them back to camp."
-		],
-		"min_cats": 2,
-		"max_cats": 6,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			"This cat got heatstroke while on a patrol.",
-			"This cat died from heat stroke.",
-			"died from heat stroke"
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_lillizard1",
-		"biome": "forest",
-		"season": "Any",
-		"tags": [
-			"hunting",
-			"platonic",
-			"comfort",
-			"small_prey"
-		],
-		"intro_text": "Something skitters across the leaf litter, catching the patrols eyes. A little lizard!",
-		"decline_text": "Startled by the lizard, the patrol watches it scurry away.",
-		"chance_of_success": 60,
-		"exp": 15,
-		"success_text": [
-			"r_c pounces on the little creature and carries the nice mouthful home.",
-			"The lizard drops its tail, and r_c dives for it, while p_l pounces for the lizard. Surely this counts for two catches? Neither of them cares much, and it's a happy afternoon hunting together.",
-			"s_c is basically on top of the skittering lizard, and ends up doing a ridiculous hop to come down on it with claws extended. r_c compliments them on the catch with a laugh in their meow, and s_c has to agree with them, purring with laughter."
-		],
-		"fail_text": [
-			"The patrol is unable to catch the small reptile quick enough and the little lizard lives another day.",
-			"r_c and p_l go for the prey at the same time, bonking their heads together. Not a bad collision, and both of them are mature enough to let it go, but neither is pleased to have missed an easy catch."
-		],
-		"win_skills": [
-			"good hunter",
-			"great hunter",
-			"fantastic hunter"
-		],
-		"win_trait": [
-			"None"
-		],
-		"fail_skills": [
-			"None"
-		],
-		"fail_trait": [
-			"None"
-		],
-		"min_cats": 2,
-		"max_cats": 3,
-		"antagonize_text": null,
-		"antagonize_fail_text": null
-	},
-	{
-		"patrol_id": "fst_hunt_lillizard2",
-		"biome": "forest",
-		"season": "Any",
-		"tags": [
-			"hunting",
-			"rel_two_apps",
-			"platonic",
-			"comfort",
-			"romantic",
-			"two_apprentices",
-			"apprentice",
-			"small_prey"
-		],
-		"intro_text": "Something skitters across the leaf litter, catching the patrol's eyes. A little lizard!",
-		"decline_text": "Startled by the lizard, the patrol watches it scurry away.",
-		"chance_of_success": 60,
-		"exp": 15,
-		"success_text": [
-			"app1 pounces on the little creature and misses, but they don't seem overly concerned, stopping nearly every step to chat to app2, who's just as keen to talk.",
-			"app1 and app2 go for the prey at the same time, bonking their heads together. It makes both of them laugh while apologizing, and they don't leave each other's side for the rest of the patrol, apologies turning to chatting turning to whispered conversations."
-		],
-		"fail_text": [
-			"The patrol is unable to catch the small reptile quick enough and the little lizard lives another day."
-		],
-		"win_skills": [
-			"None"
-		],
-		"win_trait": [
-			"None"
-		],
-		"fail_skills": [
-			"None"
-		],
-		"fail_trait": [
-			"None"
-		],
-		"min_cats": 2,
-		"max_cats": 3,
-		"antagonize_text": null,
-		"antagonize_fail_text": null
-	},
-	{
-		"patrol_id": "fst_hunt_twolegsobject1",
-		"biome": "forest",
-		"season": "greenleaf",
-		"tags": [
-			"hunting",
-			"injury",
-			"burn"
-		],
-		"intro_text": "The patrol comes across a strange Twolegs object smelling slightly of smoke and prey. Intriguing, but also sort of terrifying. Don't the Twolegs know the danger of fire?",
-		"decline_text": "The patrol decides to avoid the Twoleg object.",
-		"chance_of_success": 50,
-		"exp": 10,
-		"success_text": [
-			"The patrol interprets the purpose of the object. It seems like Twolegs light their fresh-kill on fire before eating it! How strange.",
-			null,
-			"s_c looks closely at the Twoleg object, studying it, wondering how specifically the Twolegs harness and contain the power of fire without it escaping. Wouldn't it be wonderful if c_n could do that?"
-		],
-		"fail_text": [
-			"The patrol can't seem to interpret the purpose of the object. Twolegs are just mystifying.",
-			null,
-			null,
-			"As r_c pokes around the strange smelling whatever-it-is, they poke a piece of metal still holding the heat of fire in it, and skitter backwards with a yelp."
-		],
-		"win_skills": [
-			"smart",
-			"very smart",
-			"extremely smart"
-		],
-		"win_trait": [
-			"None"
-		],
-		"fail_skills": [
-			"None"
-		],
-		"fail_trait": [
-			"None"
-		],
-		"min_cats": 1,
-		"max_cats": 6,
-		"antagonize_text": null,
-		"antagonize_fail_text": null
-	},
-	{
-		"patrol_id": "fst_hunt_leafbaresnowstorm1",
-		"biome": "forest",
-		"season": "leaf-bare",
-		"tags": [
-			"hunting",
-			"comfort",
-			"trust",
-			"patrol_to_p_l",
-			"patrol_to_r_c",
-			"cold_injury",
-			"small_prey0",
-			"small_prey1",
-			"medium_prey2",
-			"large_prey3"
-		],
-		"intro_text": "It starts snowing soon after the patrol sets out, trying to bring back something, anything, for the fresh-kill pile.",
-		"decline_text": "They decide to turn back and wait until the snow dies down.",
-		"chance_of_success": 50,
-		"exp": 10,
-		"success_text": [
-			"Despite the snow, the patrol manages to hunt successfully, finding mice underneath the leaf litter. Only a couple, but in this season, that's more than enough to count as a success, and as p_l leads them home there's a sense of security and competence driving them onwards.",
-			null,
-			"Everyone looks admiringly at s_c by the end of the afternoon. Every cat carries something home, but nearly all of it was caught by s_c.",
-			"s_c really keeps the patrol on task and motivated through the sharp cold of the leaf-bare morning, not through authority or commands, but with a gentle voice and compassionate understanding that encourages every cat to do their best for c_n."
-		],
-		"fail_text": [
-			"The prey must be hiding; the patrol catches nothing. As a snowstorm descends and visibility drops, the patrol clumps together under a bush, their pelts and tails and legs all tightly wrapped into one indistinguishable kitty cat ball.",
-			null,
-			null,
-			"The prey must be hiding; the patrol catches nothing. As a snowstorm descends and visibility drops, the patrol clumps together under a bush, their pelts and tails and legs all tightly wrapped into one indistinguishable kitty cat ball. Still, when they return to camp r_c is cold and chilled."
-		],
-		"win_skills": [
-			"great hunter",
-			"fantastic hunter"
-		],
-		"win_trait": [
-			"altruistic",
-			"compassionate",
-			"empathetic",
-			"faithful",
-			"loving"
-		],
-		"fail_skills": [
-			"None"
-		],
-		"fail_trait": [
-			"None"
-		],
-		"min_cats": 2,
-		"max_cats": 6,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			"r_c caught a chill while hunting in leaf-bare.",
-			null
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_leafbaresnowstorm2",
-		"biome": "forest",
-		"season": "leaf-bare",
-		"tags": [
-			"hunting",
-			"cold_injury",
-			"small_prey0",
-			"medium_prey1",
-			"large_prey2"
-		],
-		"intro_text": "It starts snowing soon after r_c sets out, trying to bring back something, anything, for the fresh-kill pile.",
-		"decline_text": "They decide to turn back and wait until the snow dies down.",
-		"chance_of_success": 40,
-		"exp": 10,
-		"success_text": [
-			"Despite the snow, r_c manages to hunt successfully, finding a mouse underneath the leaf litter. Only one, but in this season, that's more than enough to count as a success.",
-			null,
-			"s_c really shows their talent, bringing a clutch of mice back to camp for the fresh-kill pile."
-		],
-		"fail_text": [
-			null,
-			null,
-			null,
-			"The prey must be hiding; r_c catches nothing. As a snowstorm descends and visibility drops, they hide under a bush, shivering and tightly tucked up against the cold. When they return to camp r_c is cold and chilled, their paws and tail prickling with the danger of frostbite."
-		],
-		"win_skills": [
-			"great hunter",
-			"fantastic hunter"
-		],
-		"win_trait": [
-			"None"
-		],
-		"fail_skills": [
-			"None"
-		],
-		"fail_trait": [
-			"None"
-		],
-		"min_cats": 1,
-		"max_cats": 1,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			"r_c caught a chill while hunting in leaf-bare.",
-			null
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_leafbaresnowstorm3",
-		"biome": "forest",
-		"season": "leaf-bare",
-		"tags": [
-			"hunting",
-			"comfort",
-			"trust",
-			"rel_patrol",
-			"romantic",
-			"no_app",
-			"death",
-			"cold_injury",
-			"small_prey"
-		],
-		"intro_text": "It starts snowing soon after the patrol sets out, trying to bring back something, anything, for the fresh-kill pile.",
-		"decline_text": "They decide to turn back and wait until the snow dies down.",
-		"chance_of_success": 50,
-		"exp": 10,
-		"success_text": [
-			"A storm descends, sudden and violent, putting an end to any other thoughts but survival. The cats retreat under some evergreen underbrush and cuddle together, sharing what little warmth they have. Each cat takes a turn on the most exposed side of the huddle, selflessly risking themselves.",
-			null,
-			"A storm descends, sudden and violent, putting an end to any other thoughts but survival. s_c keeps everyone's spirits up as the patrol hides inside a hollow log, until everyone is talking, shaky and unhappy, but keeping each other's spirits up.",
-			"A storm descends, sudden and violent, putting an end to any other thoughts but survival. As the cats hide under the low hanging branches of a pine, s_c keeps an eye out for everyone. It's a long couple of hours, but with gentle understanding and compassion the cats make it though safely, closer than ever afterwards."
-		],
-		"fail_text": [
-			null,
-			null,
-			"A storm descends, sudden and violent, putting an end to any other thoughts but survival. As the cats huddle together, desperately trying to conserve warmth, no one notices that r_c has stopped responding. At some point in the storm, their life slips away, and their distraught Clanmates are left to carry their body home.",
-			"A storm descends, sudden and violent, putting an end to any other thoughts but survival. When the snowstorm leaves, finally, and the cats trudge back home, but r_c hasn't escaped unscathed, their body chilled and refusing to warm up properly."
-		],
-		"win_skills": [
-			"great speaker",
-			"excellent speaker"
-		],
-		"win_trait": [
-			"altruistic",
-			"compassionate",
-			"empathetic",
-			"faithful",
-			"loving"
-		],
-		"fail_skills": [
-			"None"
-		],
-		"fail_trait": [
-			"None"
-		],
-		"min_cats": 2,
-		"max_cats": 6,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			"r_c caught a chill while hunting in leaf-bare.",
-			"r_c froze to death while hunting in a storm.",
-    		"froze to death while hunting"
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_fox_newleafscavenge1",
-		"biome": "forest",
-		"season": "newleaf",
-		"tags": [
-			"hunting",
-			"fighting",
-			"scar",
-			"injury",
-			"bite-wound",
-			"clan_to_patrol",
-			"respect",
-			"rel_patrol",
-			"medium_prey0",
-			"medium_prey1",
-			"large_prey2",
-			"large_prey3"
-		],
-		"intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? Tracking it, they find their red enemy feeding on a deer fawn carcass. It's impossible to say whether the fox killed it or found it.",
-		"decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
-		"chance_of_success": 50,
-		"exp": 20,
-		"success_text": [
-			"Your cats are smaller but they outnumber the fox, if only by a little, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full of venison and unwilling to lose blood over it, is driven off from the kill.",
-			null,
-			"s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until it gives up and runs.",
-			"The patrol launches into battle, but with so few cats it's exhausting trying to keep the fox and its snapping jaws on the defensive. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. It's only one bite, but the fox has had enough and flees."
-		],
-		"fail_text": [
-			"Your patrol fails to drive away the fox, which keeps possession of the food. However there were no injuries.",
-			null,
-			null,
-			"The patrol launches into battle, but r_c is caught with a nasty bite, and the cats give up on challenging for the food in favor of quickly helping r_c back to the medicine cat den.",
-			null,
-			"s_c means well, but they're overconfident in their attack and the fox manages to sink their teeth into them. The patrol is forced to retreat, forming a defensive ring around the hurt s_c."
-		],
-		"win_skills": [
-			"good fighter",
-			"great fighter",
-			"excellent fighter"
-		],
-		"win_trait": [
-			"adventurous",
-			"altruistic",
-			"ambitious",
-			"confident",
-			"daring",
-			"fierce",
-			"responsible",
-			"righteous"
-		],
-		"fail_skills": [
-			"None"
-		],
-		"fail_trait": [
-			"troublesome",
-			"vengeful",
-			"bloodthirsty",
-			"bold"
-		],
-		"min_cats": 2,
-		"max_cats": 3,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			"r_c carries a scar from a fox fight.",
-			null
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_fox_newleafscavenge2",
-		"biome": "forest",
-		"season": "newleaf",
-		"tags": [
-			"hunting",
-			"fighting",
-			"scar",
-			"injury",
-			"bite-wound",
-			"clan_to_patrol",
-			"respect",
-			"rel_patrol",
-			"medium_prey0",
-			"medium_prey1",
-			"large_prey2",
-			"large_prey3"
-		],
-		"intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? Tracking it, they find their red enemy feeding on a deer fawn carcass. It's impossible to say whether the fox killed it or found it.",
-		"decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
-		"chance_of_success": 80,
-		"exp": 20,
-		"success_text": [
-			"Your cats are smaller but heavily outnumber the fox, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full of venison and unwilling to lose blood over it, is driven off from the kill.",
-			null,
-			"s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until s_c lands a crucial blow, snapping a tendon in one of the fox's hindlegs. The fox runs, but there's no way it'll live long with such a crippling injury.",
-			"The patrol launches into battle, keeping the fox on the defensive with teamwork. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. Holding on grimly, s_c's daring move gives the rest of the patrol the opportunity needed to bring the fox down for good."
-		],
-		"fail_text": [
-			"Your patrol fails to drive away the fox, which keeps possession of the food. However with so many cats to protect each other, there were no injuries.",
-			null,
-			null,
-			"The patrol launches into battle, but r_c is caught with a nasty bite, and the cats give up on challenging for the food in favor of quickly helping r_c back to the medicine cat den.",
-			null,
-			"s_c means well, but they're overconfident in their attack and the fox manages to sink their teeth into them. The patrol is forced to retreat, forming a defensive ring around the hurt s_c."
-		],
-		"win_skills": [
-			"good fighter",
-			"great fighter",
-			"excellent fighter"
-		],
-		"win_trait": [
-			"adventurous",
-			"altruistic",
-			"ambitious",
-			"confident",
-			"daring",
-			"fierce",
-			"responsible",
-			"righteous"
-		],
-		"fail_skills": [
-			"None"
-		],
-		"fail_trait": [
-			"troublesome",
-			"vengeful",
-			"bloodthirsty",
-			"bold"
-		],
-		"min_cats": 4,
-		"max_cats": 6,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			"r_c carries a scar from a fox fight."
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_fox_newleafscavenge3",
-		"biome": "forest",
-		"season": "newleaf",
-		"tags": [
-			"hunting",
-			"fighting",
-			"death",
-			"scar",
-			"injury",
-			"bite-wound",
-			"clan_to_patrol",
-			"respect",
-			"medium_prey0",
-			"medium_prey1",
-			"large_prey2",
-			"large_prey3"
-		],
-		"intro_text": "r_c catches the scent of a fox - but is it red, or gray? Tracking it, they find their red enemy feeding on a deer fawn carcass. It's impossible to say whether the fox killed it or found it.",
-		"decline_text": "r_c decides not to quarrel with the fox and to find prey elsewhere.",
-		"chance_of_success": 30,
-		"exp": 30,
-		"success_text": [
-			"r_c may be smaller, alone, and half its weight, but the fox has a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle. The fox, already stuffed full of venison and unwilling to lose blood over it, leaves the kill with a grumble.",
-			null,
-			"s_c uses every trick in their talented fighting skillset to attack the fox with no one to watch their flank, until the perfect opportunity opens up and they pounce onto the fox's back, digging in their claws. It's a wild ride through the forest until the fox bucks them off, but it wins them the fawn carcass.",
-			"In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. But then they're stuck, unwilling to let go and risk being bitten. They're dragged through the forest, over rocks and through bushes, until the fox finally collapses and the battered s_c goes back to proudly claim the fawn."
-		],
-		"fail_text": [
-			"Your patrol fails to drive away the fox, which keeps possession of the food. However there were no injuries.",
-			null,
-			"Fiercely, r_c throws themselves at the fox, determined to win the fawn prize. But the fox values it just as dearly, and manages to get a good grip on r_c, shaking them to pieces and killing them.",
-			"r_c launches into battle, but is caught with a nasty bite, and retreats to limp back home. The fox doesn't follow, happy enough to eat the fawn instead of the foolish cat.",
-			null,
-			"s_c is overconfident in their attack and the fox manages to sink their teeth into them. They retreat, bleeding and in pain, and the fox settles back down to its meal."
-		],
-		"win_skills": [
-			"great fighter",
-			"excellent fighter"
-		],
-		"win_trait": [
-			"adventurous",
-			"altruistic",
-			"ambitious",
-			"confident",
-			"daring",
-			"fierce",
-			"responsible",
-			"righteous"
-		],
-		"fail_skills": [
-			"None"
-		],
-		"fail_trait": [
-			"troublesome",
-			"vengeful",
-			"bloodthirsty",
-			"bold"
-		],
-		"min_cats": 1,
-		"max_cats": 1,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			"r_c carries a scar from a solo fox fight.",
-			"r_c fell in a solo battle with a fox.",
-			"died while fighting a fox"
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_fox_greenleafscavenge1",
-		"biome": "forest",
-		"season": "greenleaf",
-		"tags": [
-			"hunting",
-			"fighting",
-			"scar",
-			"injury",
-			"bite-wound",
-			"clan_to_patrol",
-			"respect",
-			"rel_patrol",
-			"medium_prey0",
-			"medium_prey1",
-			"large_prey2",
-			"large_prey3"
-		],
-		"intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? Tracking it, they find their red enemy feeding on a deer fawn carcass. It's impossible to say whether the fox killed it or found it.",
-		"decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
-		"chance_of_success": 50,
-		"exp": 20,
-		"success_text": [
-			"Your cats are smaller but they outnumber the fox, if only by a little, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full of venison and unwilling to lose blood over it, is driven off from the kill.",
-			null,
-			"s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until it gives up and runs.",
-			"The patrol launches into battle, but with so few cats it's exhausting trying to keep the fox and it's snapping jaws on the defensive. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. It's only one bite, but the fox has had enough and flees."
-		],
-		"fail_text": [
-			"Your patrol fails to drive away the fox, which keeps possession of the food. However there were no injuries.",
-			null,
-			null,
-			"The patrol launches into battle, but r_c is caught with a nasty bite, and the cats give up on challenging for the food in favor of quickly helping r_c back to the medicine cat den.",
-			null,
-			"s_c means well, but they're overconfident in their attack and the fox manages to sink their teeth into them. The patrol is forced to retreat, forming a defensive ring around the hurt s_c."
-		],
-		"win_skills": [
-			"good fighter",
-			"great fighter",
-			"excellent fighter"
-		],
-		"win_trait": [
-			"adventurous",
-			"altruistic",
-			"ambitious",
-			"confident",
-			"daring",
-			"fierce",
-			"responsible",
-			"righteous"
-		],
-		"fail_skills": [
-			"None"
-		],
-		"fail_trait": [
-			"troublesome",
-			"vengeful",
-			"bloodthirsty",
-			"bold"
-		],
-		"min_cats": 2,
-		"max_cats": 3,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			"r_c carries a scar from a fox fight.",
-			null
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_fox_greenleafleafscavenge2",
-		"biome": "forest",
-		"season": "greenleaf",
-		"tags": [
-			"hunting",
-			"fighting",
-			"scar",
-			"injury",
-			"bite-wound",
-			"clan_to_patrol",
-			"respect",
-			"rel_patrol",
-			"medium_prey0",
-			"medium_prey1",
-			"large_prey2",
-			"large_prey3"
-		],
-		"intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? Tracking it, they find their red enemy feeding on a deer fawn carcass. It's impossible to say whether the fox killed it or found it.",
-		"decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
-		"chance_of_success": 80,
-		"exp": 20,
-		"success_text": [
-			"Your cats are smaller but heavily outnumber the fox, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full of venison and unwilling to lose blood over it, is driven off from the kill.",
-			null,
-			"s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until s_c lands a crucial blow, snapping a tendon in one of the fox's hindlegs. The fox runs, but there's no way it'll live long with such a crippling injury.",
-			"The patrol launches into battle, keeping the fox on the defensive with teamwork. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. Holding on grimly, s_c's daring move gives the rest of the patrol the opportunity needed to bring the fox down for good."
-		],
-		"fail_text": [
-			"Your patrol fails to drive away the fox, which keeps possession of the food. However with so many cats to protect each other, there were no injuries.",
-			null,
-			null,
-			"The patrol launches into battle, but r_c is caught with a nasty bite, and the cats give up on challenging for the food in favor of quickly helping r_c back to the medicine cat den.",
-			null,
-			"s_c means well, but they're overconfident in their attack and the fox manages to sink their teeth into them. The patrol is forced to retreat, forming a defensive ring around the hurt s_c."
-		],
-		"win_skills": [
-			"good fighter",
-			"great fighter",
-			"excellent fighter"
-		],
-		"win_trait": [
-			"adventurous",
-			"altruistic",
-			"ambitious",
-			"confident",
-			"daring",
-			"fierce",
-			"responsible",
-			"righteous"
-		],
-		"fail_skills": [
-			"None"
-		],
-		"fail_trait": [
-			"troublesome",
-			"vengeful",
-			"bloodthirsty",
-			"bold"
-		],
-		"min_cats": 4,
-		"max_cats": 6,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			"r_c carries a scar from a fox fight."
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_fox_greenleafscavenge3",
-		"biome": "forest",
-		"season": "greenleaf",
-		"tags": [
-			"hunting",
-			"fighting",
-			"death",
-			"scar",
-			"injury",
-			"bite-wound",
-			"clan_to_patrol",
-			"respect",
-			"medium_prey0",
-			"medium_prey1",
-			"large_prey2",
-			"large_prey3"
-		],
-		"intro_text": "r_c catches the scent of a fox - but is it red, or gray? Tracking it, they find their red enemy feeding on a deer fawn carcass. It's impossible to say whether the fox killed it or found it.",
-		"decline_text": "r_c decides not to quarrel with the fox and to find prey elsewhere.",
-		"chance_of_success": 30,
-		"exp": 30,
-		"success_text": [
-			"r_c may be smaller, alone, and half its weight, but the fox has a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle. The fox, already stuffed full of venison and unwilling to lose blood over it, leaves the kill with a grumble.",
-			null,
-			"s_c uses every trick in their talented fighting skillset to attack the fox with no one to watch their flank, until the perfect opportunity opens up and they pounce onto the fox's back, digging in their claws. It's a wild ride through the forest until the fox bucks them off, but it wins them the fawn carcass.",
-			"In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. But then they're stuck, unwilling to let go and risk being bitten. They're dragged through the forest, over rocks and through bushes, until the fox finally collapses and the battered s_c goes back to proudly claim the fawn."
-		],
-		"fail_text": [
-			"Your patrol fails to drive away the fox, which keeps possession of the food. However there were no injuries.",
-			null,
-			"Fiercely, r_c throws themselves at the fox, determined to win the fawn prize. But the fox values it just as dearly, and manages to get a good grip on r_c, shaking them to pieces and killing them.",
-			"r_c launches into battle, but is caught with a nasty bite, and retreats to limp back home. The fox doesn't follow, happy enough to eat the fawn instead of the foolish cat.",
-			null,
-			"s_c is overconfident in their attack and the fox manages to sink their teeth into them. They retreat, bleeding and in pain, and the fox settles back down to its meal."
-		],
-		"win_skills": [
-			"great fighter",
-			"excellent fighter"
-		],
-		"win_trait": [
-			"adventurous",
-			"altruistic",
-			"ambitious",
-			"confident",
-			"daring",
-			"fierce",
-			"responsible",
-			"righteous"
-		],
-		"fail_skills": [
-			"None"
-		],
-		"fail_trait": [
-			"troublesome",
-			"vengeful",
-			"bloodthirsty",
-			"bold"
-		],
-		"min_cats": 1,
-		"max_cats": 1,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			"r_c carries a scar from a solo fox fight.",
-			"r_c fell in a solo battle with a fox.",
-			"died while fighting a fox"
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_fox_leaf-fallscavenge1",
-		"biome": "forest",
-		"season": "leaf-fall",
-		"tags": [
-			"hunting",
-			"fighting",
-			"scar",
-			"injury",
-			"bite-wound",
-			"clan_to_patrol",
-			"respect",
-			"rel_patrol",
-			"medium_prey0",
-			"medium_prey1",
-			"large_prey2",
-			"large_prey3"
-		],
-		"intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? Tracking it, they find their red enemy feeding on a deer fawn carcass. It's impossible to say whether the fox killed it or found it.",
-		"decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
-		"chance_of_success": 50,
-		"exp": 20,
-		"success_text": [
-			"Your cats are smaller but they outnumber the fox, if only by a little, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full of venison and unwilling to lose blood over it, is driven off from the kill.",
-			null,
-			"s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until it gives up and runs.",
-			"The patrol launches into battle, but with so few cats it's exhausting trying to keep the fox and its snapping jaws on the defensive. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. It's only one bite, but the fox has had enough and flees."
-		],
-		"fail_text": [
-			"Your patrol fails to drive away the fox, which keeps possession of the food. However there were no injuries.",
-			null,
-			null,
-			"The patrol launches into battle, but r_c is caught with a nasty bite, and the cats give up on challenging for the food in favor of quickly helping r_c back to the medicine cat den.",
-			null,
-			"s_c means well, but they're overconfident in their attack and the fox manages to sink their teeth into them. The patrol is forced to retreat, forming a defensive ring around the hurt s_c."
-		],
-		"win_skills": [
-			"good fighter",
-			"great fighter",
-			"excellent fighter"
-		],
-		"win_trait": [
-			"adventurous",
-			"altruistic",
-			"ambitious",
-			"confident",
-			"daring",
-			"fierce",
-			"responsible",
-			"righteous"
-		],
-		"fail_skills": [
-			"None"
-		],
-		"fail_trait": [
-			"troublesome",
-			"vengeful",
-			"bloodthirsty",
-			"bold"
-		],
-		"min_cats": 2,
-		"max_cats": 3,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			"r_c carries a scar from a fox fight.",
-			null
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_fox_leaf-fallscavenge2",
-		"biome": "forest",
-		"season": "leaf-fall",
-		"tags": [
-			"hunting",
-			"fighting",
-			"scar",
-			"injury",
-			"bite-wound",
-			"clan_to_patrol",
-			"respect",
-			"rel_patrol",
-			"medium_prey0",
-			"medium_prey1",
-			"large_prey2",
-			"large_prey3"
-		],
-		"intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? Tracking it, they find their red enemy feeding on a deer fawn carcass. It's impossible to say whether the fox killed it or found it.",
-		"decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
-		"chance_of_success": 80,
-		"exp": 20,
-		"success_text": [
-			"Your cats are smaller but heavily outnumber the fox, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full of venison and unwilling to lose blood over it, is driven off from the kill.",
-			null,
-			"s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until s_c lands a crucial blow, snapping a tendon in one of the fox's hindlegs. The fox runs, but there's no way it'll live long with such a crippling injury.",
-			"The patrol launches into battle, keeping the fox on the defensive with teamwork. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. Holding on grimly, s_c's daring move gives the rest of the patrol the opportunity needed to bring the fox down for good."
-		],
-		"fail_text": [
-			"Your patrol fails to drive away the fox, which keeps possession of the food. However with so many cats to protect each other, there were no injuries.",
-			null,
-			null,
-			"The patrol launches into battle, but r_c is caught with a nasty bite, and the cats give up on challenging for the food in favor of quickly helping r_c back to the medicine cat den.",
-			null,
-			"s_c means well, but they're overconfident in their attack and the fox manages to sink their teeth into them. The patrol is forced to retreat, forming a defensive ring around the hurt s_c."
-		],
-		"win_skills": [
-			"good fighter",
-			"great fighter",
-			"excellent fighter"
-		],
-		"win_trait": [
-			"adventurous",
-			"altruistic",
-			"ambitious",
-			"confident",
-			"daring",
-			"fierce",
-			"responsible",
-			"righteous"
-		],
-		"fail_skills": [
-			"None"
-		],
-		"fail_trait": [
-			"troublesome",
-			"vengeful",
-			"bloodthirsty",
-			"bold"
-		],
-		"min_cats": 4,
-		"max_cats": 6,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			"r_c carries a scar from a fox fight."
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_fox_leaf-fallscavenge3",
-		"biome": "forest",
-		"season": "leaf-fall",
-		"tags": [
-			"hunting",
-			"fighting",
-			"death",
-			"scar",
-			"injury",
-			"bite-wound",
-			"clan_to_patrol",
-			"respect",
-			"medium_prey0",
-			"medium_prey1",
-			"large_prey2",
-			"large_prey3"
-		],
-		"intro_text": "r_c catches the scent of a fox - but is it red, or gray? Tracking it, they find their red enemy feeding on a deer fawn carcass. It's impossible to say whether the fox killed it or found it.",
-		"decline_text": "r_c decides not to quarrel with the fox and to find prey elsewhere.",
-		"chance_of_success": 30,
-		"exp": 30,
-		"success_text": [
-			"r_c may be smaller, alone, and half its weight, but the fox has a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle. The fox, already stuffed full of venison and unwilling to lose blood over it, leaves the kill with a grumble.",
-			null,
-			"s_c uses every trick in their talented fighting skillset to attack the fox with no one to watch their flank, until the perfect opportunity opens up and they pounce onto the fox's back, digging in their claws. It's a wild ride through the forest until the fox bucks them off, but it wins them the fawn carcass.",
-			"In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. But then they're stuck, unwilling to let go and risk being bitten. They're dragged through the forest, over rocks and through bushes, until the fox finally collapses and the battered s_c goes back to proudly claim the fawn."
-		],
-		"fail_text": [
-			"Your patrol fails to drive away the fox, which keeps possession of the food. However there were no injuries.",
-			null,
-			"Fiercely, r_c throws themselves at the fox, determined to win the fawn prize. But the fox values it just as dearly, and manages to get a good grip on r_c, shaking them to pieces and killing them.",
-			"r_c launches into battle, but is caught with a nasty bite, and retreats to limp back home. The fox doesn't follow, happy enough to eat the fawn instead of the foolish cat.",
-			null,
-			"s_c is overconfident in their attack and the fox manages to sink their teeth into them. They retreat, bleeding and in pain, and the fox settles back down to its meal."
-		],
-		"win_skills": [
-			"great fighter",
-			"excellent fighter"
-		],
-		"win_trait": [
-			"adventurous",
-			"altruistic",
-			"ambitious",
-			"confident",
-			"daring",
-			"fierce",
-			"responsible",
-			"righteous"
-		],
-		"fail_skills": [
-			"None"
-		],
-		"fail_trait": [
-			"troublesome",
-			"vengeful",
-			"bloodthirsty",
-			"bold"
-		],
-		"min_cats": 1,
-		"max_cats": 1,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			"r_c carries a scar from a solo fox fight.",
-			"r_c fell in a solo battle with a fox.",
-			"died while fighting a fox"
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_fox_leaf-barescavenge1",
-		"biome": "forest",
-		"season": "leaf-bare",
-		"tags": [
-			"hunting",
-			"fighting",
-			"scar",
-			"injury",
-			"bite-wound",
-			"clan_to_patrol",
-			"respect",
-			"rel_patrol",
-			"medium_prey0",
-			"medium_prey1",
-			"large_prey2",
-			"large_prey3"
-		],
-		"intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? Tracking it, they find their red enemy feeding on a deer carcass, either a small doe or one of last newleaf's fawns. It's impossible to say whether the fox killed it or found it.",
-		"decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
-		"chance_of_success": 30,
-		"exp": 20,
-		"success_text": [
-			"Your cats are smaller but they outnumber the fox, if only by a little, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full of venison and unwilling to lose blood over it, is driven off from the kill.",
-			null,
-			"s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until it gives up and runs.",
-			"The patrol launches into battle, but with so few cats it's exhausting trying to keep the fox and its snapping jaws on the defensive. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. It's only one bite, but the fox has had enough and flees."
-		],
-		"fail_text": [
-			"Your patrol fails to drive away the fox, which keeps possession of the food. However there were no injuries.",
-			null,
-			null,
-			"The patrol launches into battle, but r_c is caught with a nasty bite, and the cats give up on challenging for the food in favor of quickly helping r_c back to the medicine cat den.",
-			null,
-			"s_c means well, but they're overconfident in their attack and the fox manages to sink their teeth into them. The patrol is forced to retreat, forming a defensive ring around the hurt s_c."
-		],
-		"win_skills": [
-			"good fighter",
-			"great fighter",
-			"excellent fighter"
-		],
-		"win_trait": [
-			"adventurous",
-			"altruistic",
-			"ambitious",
-			"confident",
-			"daring",
-			"fierce",
-			"responsible",
-			"righteous"
-		],
-		"fail_skills": [
-			"None"
-		],
-		"fail_trait": [
-			"troublesome",
-			"vengeful",
-			"bloodthirsty",
-			"bold"
-		],
-		"min_cats": 2,
-		"max_cats": 3,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			"r_c carries a scar from a fox fight.",
-			null
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_fox_leaf-barescavenge2",
-		"biome": "forest",
-		"season": "leaf-bare",
-		"tags": [
-			"hunting",
-			"fighting",
-			"scar",
-			"injury",
-			"bite-wound",
-			"clan_to_patrol",
-			"respect",
-			"rel_patrol",
-			"medium_prey0",
-			"medium_prey1",
-			"large_prey2",
-			"large_prey3"
-		],
-		"intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? Tracking it, they find their red enemy feeding on a deer carcass, either a small doe or one of last newleaf's fawns. It's impossible to say whether the fox killed it or found it.",
-		"decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
-		"chance_of_success": 60,
-		"exp": 20,
-		"success_text": [
-			"Your cats are smaller but heavily outnumber the fox, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full of venison and unwilling to lose blood over it, is driven off from the kill.",
-			null,
-			"s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until s_c lands a crucial blow, snapping a tendon in one of the fox's hindlegs. The fox runs, but there's no way it'll live long with such a crippling injury.",
-			"The patrol launches into battle, keeping the fox on the defensive with teamwork. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. Holding on grimly, s_c's daring move gives the rest of the patrol the opportunity needed to bring the fox down for good."
-		],
-		"fail_text": [
-			"Your patrol fails to drive away the fox, which keeps possession of the food. However with so many cats to protect each other, there were no injuries.",
-			null,
-			null,
-			"The patrol launches into battle, but r_c is caught with a nasty bite, and the cats give up on challenging for the food in favor of quickly helping r_c back to the medicine cat den.",
-			null,
-			"s_c means well, but they're overconfident in their attack and the fox manages to sink their teeth into them. The patrol is forced to retreat, forming a defensive ring around the hurt s_c."
-		],
-		"win_skills": [
-			"good fighter",
-			"great fighter",
-			"excellent fighter"
-		],
-		"win_trait": [
-			"adventurous",
-			"altruistic",
-			"ambitious",
-			"confident",
-			"daring",
-			"fierce",
-			"responsible",
-			"righteous"
-		],
-		"fail_skills": [
-			"None"
-		],
-		"fail_trait": [
-			"troublesome",
-			"vengeful",
-			"bloodthirsty",
-			"bold"
-		],
-		"min_cats": 4,
-		"max_cats": 6,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			"r_c carries a scar from a fox fight."
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_fox_leaf-barescavenge3",
-		"biome": "forest",
-		"season": "leaf-bare",
-		"tags": [
-			"hunting",
-			"fighting",
-			"death",
-			"scar",
-			"injury",
-			"bite-wound",
-			"clan_to_patrol",
-			"respect",
-			"medium_prey0",
-			"medium_prey1",
-			"large_prey2",
-			"large_prey3"
-		],
-		"intro_text": "r_c catches the scent of a fox - but is it red, or gray? Tracking it, they find their red enemy feeding on a deer carcass, either a small doe or one of last newleaf's fawns. It's impossible to say whether the fox killed it or found it.",
-		"decline_text": "r_c decides not to quarrel with the fox and to find prey elsewhere.",
-		"chance_of_success": 10,
-		"exp": 30,
-		"success_text": [
-			"r_c may be smaller, alone, and half its weight, but the fox has a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle. The fox, already stuffed full of venison and unwilling to lose blood over it, leaves the kill with a grumble.",
-			null,
-			"s_c uses every trick in their talented fighting skillset to attack the fox with no one to watch their flank, until the perfect opportunity opens up and they pounce onto the fox's back, digging in their claws. It's a wild ride through the forest until the fox bucks them off, but it wins them the fawn carcass.",
-			"In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. But then they're stuck, unwilling to let go and risk being bitten. They're dragged through the forest, over rocks and through bushes, until the fox finally collapses and the battered s_c goes back to proudly claim the fawn."
-		],
-		"fail_text": [
-			"Your patrol fails to drive away the fox, which keeps possession of the food. However there were no injuries.",
-			null,
-			"Fiercely, r_c throws themselves at the fox, determined to win the fawn prize. But the fox values it just as dearly, and manages to get a good grip on r_c, shaking them to pieces and killing them.",
-			"r_c launches into battle, but is caught with a nasty bite, and retreats to limp back home. The fox doesn't follow, happy enough to eat the fawn instead of the foolish cat.",
-			null,
-			"s_c is overconfident in their attack and the fox manages to sink their teeth into them. They retreat, bleeding and in pain, and the fox settles back down to its meal."
-		],
-		"win_skills": [
-			"great fighter",
-			"excellent fighter"
-		],
-		"win_trait": [
-			"adventurous",
-			"altruistic",
-			"ambitious",
-			"confident",
-			"daring",
-			"fierce",
-			"responsible",
-			"righteous"
-		],
-		"fail_skills": [
-			"None"
-		],
-		"fail_trait": [
-			"troublesome",
-			"vengeful",
-			"bloodthirsty",
-			"bold"
-		],
-		"min_cats": 1,
-		"max_cats": 1,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			"r_c carries a scar from a solo fox fight.",
-			"r_c fell in a solo battle with a fox.",
-			"died while fighting a fox"
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_foxgray_newleafscavenge1",
-		"biome": "forest",
-		"season": "newleaf",
-		"tags": [
-			"hunting",
-			"fighting",
-			"scar",
-			"injury",
-			"bite-wound",
-			"clan_to_patrol",
-			"respect",
-			"rel_patrol",
-			"medium_prey0",
-			"medium_prey1",
-			"large_prey2",
-			"large_prey3"
-		],
-		"intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? Tracking it, they find a stocky gray fox feeding on a deer fawn carcass. A gray fox is unlikely to have killed a fawn this size.",
-		"decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
-		"chance_of_success": 70,
-		"exp": 20,
-		"success_text": [
-			"The cats are only just smaller and outnumber the fox, if only by a little, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full of venison and unwilling to lose blood over it, is driven off from the kill.",
-			null,
-			"s_c shows their strength, leading the fight against the gray fox. By working together and keeping it distracted, the cats harry and harass the fox until it gives up and runs.",
-			"The patrol launches into battle, but with so few cats it's exhausting trying to keep the fox and it's snapping jaws on the defensive. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. It's only one bite, but the fox has had enough and flees."
-		],
-		"fail_text": [
-			"Your patrol fails to drive away the fox, which keeps possession of the food. However there were no injuries.",
-			"s_c makes a stupid mistake, too intent on winning the fight to respect their enemy's teeth, and it's only being yanked back by the tail that saves them from injury. The patrol gives up, and settles down to wait a safe distance away until the fox leaves of its own accord.",
-			null,
-			null,
-			null,
-			"s_c means well, but they're overconfident in their attack and the fox manages to sink their teeth into them. The patrol is forced to retreat, forming a defensive ring around the hurt s_c."
-		],
-		"win_skills": [
-			"good fighter",
-			"great fighter",
-			"excellent fighter"
-		],
-		"win_trait": [
-			"adventurous",
-			"altruistic",
-			"ambitious",
-			"confident",
-			"daring",
-			"fierce",
-			"responsible",
-			"righteous"
-		],
-		"fail_skills": [
-			"None"
-		],
-		"fail_trait": [
-			"troublesome",
-			"vengeful",
-			"bloodthirsty",
-			"bold"
-		],
-		"min_cats": 2,
-		"max_cats": 3,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			"r_c carries a scar from a fox fight.",
-			null
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_foxgray_newleafscavenge2",
-		"biome": "forest",
-		"season": "newleaf",
-		"tags": [
-			"hunting",
-			"fighting",
-			"clan_to_patrol",
-			"respect",
-			"rel_patrol",
-			"medium_prey0",
-			"medium_prey1",
-			"large_prey2",
-			"large_prey3"
-		],
-		"intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? Tracking it, they find a stocky gray fox feeding on a deer fawn carcass. A gray fox is unlikely to have killed a fawn this size.",
-		"decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
-		"chance_of_success": 90,
-		"exp": 20,
-		"success_text": [
-			"Your cats are only just smaller and heavily outnumber the fox, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full of venison and unwilling to lose blood over it, is driven off from the kill.",
-			null,
-			"s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until s_c lands a crucial blow, snapping a tendon in one of the fox's hindlegs. The fox runs, but there's no way it'll live long with such a crippling injury.",
-			"The patrol launches into battle, keeping the fox on the defensive with teamwork. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. Holding on grimly, s_c's daring move gives the rest of the patrol the opportunity needed to bring the fox down for good."
-		],
-		"fail_text": [
-			"Your patrol fails to drive away the fox, which keeps possession of the food. However with so many cats to protect each other, there were no injuries.",
-			"s_c makes a stupid mistake, too intent on winning the fight to respect their enemy's teeth, and it's only being yanked back by the tail that saves them from injury. The patrol gives up, and settles down to wait a safe distance away until the fox leaves of its own accord."
-		],
-		"win_skills": [
-			"good fighter",
-			"great fighter",
-			"excellent fighter"
-		],
-		"win_trait": [
-			"adventurous",
-			"altruistic",
-			"ambitious",
-			"confident",
-			"daring",
-			"fierce",
-			"responsible",
-			"righteous"
-		],
-		"fail_skills": [
-			"None"
-		],
-		"fail_trait": [
-			"troublesome",
-			"vengeful",
-			"bloodthirsty",
-			"bold"
-		],
-		"min_cats": 4,
-		"max_cats": 6,
-		"antagonize_text": null,
-		"antagonize_fail_text": null
-	},
-	{
-		"patrol_id": "fst_hunt_foxgray_newleafscavenge3",
-		"biome": "forest",
-		"season": "newleaf",
-		"tags": [
-			"hunting",
-			"fighting",
-			"scar",
-			"injury",
-			"bite-wound",
-			"clan_to_patrol",
-			"respect",
-			"medium_prey0",
-			"medium_prey1",
-			"large_prey2",
-			"large_prey3"
-		],
-		"intro_text": "r_c catches the scent of a fox - but is it red, or gray? Tracking it, they find a stocky gray fox feeding on a deer fawn carcass. A gray fox is unlikely to have killed a fawn this size.",
-		"decline_text": "r_c decides not to quarrel with the fox and to find prey elsewhere.",
-		"chance_of_success": 50,
-		"exp": 30,
-		"success_text": [
-			"r_c may be smaller, alone, and half its weight, but the fox has a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle. The fox, already stuffed full of venison and unwilling to lose blood over it, leaves the kill with a grumble.",
-			null,
-			"s_c uses every trick in their talented fighting skillset to attack the fox with no one to watch their flank, until the perfect opportunity opens up and they pounce onto the fox's back, digging in their claws. It's a wild ride through the forest until the fox bucks them off, but it wins them the fawn carcass.",
-			"In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. But then they're stuck, unwilling to let go and risk being bitten. They're dragged through the forest, over rocks and through bushes, until the fox finally collapses and the battered s_c goes back to proudly claim the fawn."
-		],
-		"fail_text": [
-			"Your patrol fails to drive away the gray fox, which keeps possession of the food. However there were no injuries.",
-			"s_c makes a stupid mistake, too intent on winning the fight to respect their enemy's teeth, and it's tripping over their own feet that saves them. They give up, and settle down to wait a safe distance away until the fox leaves of its own accord.",
-			null,
-			"r_c launches into battle, but is caught with a nasty bite, and retreats to limp back home. The gray fox doesn't follow, happy enough to eat the fawn instead of the foolish cat.",
-			null,
-			"s_c is overconfident in their attack and the fox manages to sink their teeth into them. They retreat, bleeding and in pain, and the gray fox settles back down to its meal."
-		],
-		"win_skills": [
-			"great fighter",
-			"excellent fighter"
-		],
-		"win_trait": [
-			"adventurous",
-			"altruistic",
-			"ambitious",
-			"confident",
-			"daring",
-			"fierce",
-			"responsible",
-			"righteous"
-		],
-		"fail_skills": [
-			"None"
-		],
-		"fail_trait": [
-			"troublesome",
-			"vengeful",
-			"bloodthirsty",
-			"bold"
-		],
-		"min_cats": 1,
-		"max_cats": 1,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			"r_c carries a scar from a solo fox fight.",
-			null
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_foxgray_greenleafscavenge1",
-		"biome": "forest",
-		"season": "greenleaf",
-		"tags": [
-			"hunting",
-			"fighting",
-			"scar",
-			"injury",
-			"bite-wound",
-			"clan_to_patrol",
-			"respect",
-			"rel_patrol",
-			"medium_prey0",
-			"medium_prey1",
-			"large_prey2",
-			"large_prey3"
-		],
-		"intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? Tracking it, they find a stocky gray fox feeding on a deer fawn carcass. A gray fox is unlikely to have killed a fawn this size.",
-		"decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
-		"chance_of_success": 70,
-		"exp": 20,
-		"success_text": [
-			"The cats are only just smaller and outnumber the fox, if only by a little, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full of venison and unwilling to lose blood over it, is driven off from the kill.",
-			null,
-			"s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until it gives up and runs.",
-			"The patrol launches into battle, but with so few cats it's exhausting trying to keep the fox and its snapping jaws on the defensive. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. It's only one bite, but the fox has had enough and flees."
-		],
-		"fail_text": [
-			"Your patrol fails to drive away the fox, which keeps possession of the food. However there were no injuries.",
-			"s_c makes a stupid mistake, too intent on winning the fight to respect their enemy's teeth, and it's only being yanked back by the tail that saves them from injury. The patrol gives up, and settles down to wait a safe distance away until the fox leaves of its own accord.",
-			null,
-			null,
-			null,
-			"s_c means well, but they're overconfident in their attack and the fox manages to sink their teeth into them. The patrol is forced to retreat, forming a defensive ring around the hurt s_c."
-		],
-		"win_skills": [
-			"good fighter",
-			"great fighter",
-			"excellent fighter"
-		],
-		"win_trait": [
-			"adventurous",
-			"altruistic",
-			"ambitious",
-			"confident",
-			"daring",
-			"fierce",
-			"responsible",
-			"righteous"
-		],
-		"fail_skills": [
-			"None"
-		],
-		"fail_trait": [
-			"troublesome",
-			"vengeful",
-			"bloodthirsty",
-			"bold"
-		],
-		"min_cats": 2,
-		"max_cats": 3,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			"r_c carries a scar from a fox fight.",
-			null
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_foxgray_greenleafscavenge2",
-		"biome": "forest",
-		"season": "greenleaf",
-		"tags": [
-			"hunting",
-			"fighting",
-			"scar",
-			"injury",
-			"clan_to_patrol",
-			"respect",
-			"rel_patrol",
-			"medium_prey0",
-			"medium_prey1",
-			"large_prey2",
-			"large_prey3"
-		],
-		"intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? Tracking it, they find a stocky gray fox feeding on a deer fawn carcass. A gray fox is unlikely to have killed a fawn this size.",
-		"decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
-		"chance_of_success": 90,
-		"exp": 20,
-		"success_text": [
-			"Your cats are only just smaller and heavily outnumber the fox, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full of venison and unwilling to lose blood over it, is driven off from the kill.",
-			null,
-			"s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until s_c lands a crucial blow, snapping a tendon in one of the fox's hindlegs. The fox runs, but there's no way it'll live long with such a crippling injury.",
-			"The patrol launches into battle, keeping the fox on the defensive with teamwork. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. Holding on grimly, s_c's daring move gives the rest of the patrol the opportunity needed to bring the fox down for good."
-		],
-		"fail_text": [
-			"Your patrol fails to drive away the fox, which keeps possession of the food. However with so many cats to protect each other, there were no injuries.",
-			"s_c makes a stupid mistake, too intent on winning the fight to respect their enemy's teeth, and it's only being janked back by the tail that saves them from injury. The patrol gives up, and settles down to wait a safe distance away until the fox leaves of its own accord."
-		],
-		"win_skills": [
-			"good fighter",
-			"great fighter",
-			"excellent fighter"
-		],
-		"win_trait": [
-			"adventurous",
-			"altruistic",
-			"ambitious",
-			"confident",
-			"daring",
-			"fierce",
-			"responsible",
-			"righteous"
-		],
-		"fail_skills": [
-			"None"
-		],
-		"fail_trait": [
-			"troublesome",
-			"vengeful",
-			"bloodthirsty",
-			"bold"
-		],
-		"min_cats": 4,
-		"max_cats": 6,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			"r_c carries a scar from a fox fight."
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_foxgray_greenleafscavenge3",
-		"biome": "forest",
-		"season": "greenleaf",
-		"tags": [
-			"hunting",
-			"fighting",
-			"scar",
-			"injury",
-			"bite-wound",
-			"clan_to_patrol",
-			"respect",
-			"medium_prey0",
-			"medium_prey1",
-			"large_prey2",
-			"large_prey3"
-		],
-		"intro_text": "r_c catches the scent of a fox - but is it red, or gray? Tracking it, they find a stocky gray fox feeding on a deer fawn carcass. A gray fox is unlikely to have killed a fawn this size.",
-		"decline_text": "r_c decides not to quarrel with the fox and to find prey elsewhere.",
-		"chance_of_success": 50,
-		"exp": 30,
-		"success_text": [
-			"r_c may be smaller, alone, and half its weight, but the fox has a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle. The fox, already stuffed full of venison and unwilling to lose blood over it, leaves the kill with a grumble.",
-			null,
-			"s_c uses every trick in their talented fighting skillset to attack the fox with no one to watch their flank, until the perfect opportunity opens up and they pounce onto the fox's back, digging in their claws. It's a wild ride through the forest until the fox bucks them off, but it wins them the fawn carcass.",
-			"In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. But then they're stuck, unwilling to let go and risk being bitten. They're dragged through the forest, over rocks and through bushes, until the fox finally collapses and the battered s_c goes back to proudly claim the fawn."
-		],
-		"fail_text": [
-			"Your patrol fails to drive away the gray fox, which keeps possession of the food. However there were no injuries.",
-			"s_c makes a stupid mistake, too intent on winning the fight to respect their enemy's teeth, and it's tripping over their own feet that saves them. They give up, and settle down to wait a safe distance away until the fox leaves of its own accord.",
-			null,
-			"r_c launches into battle, but is caught with a nasty bite, and retreats to limp back home. The gray fox doesn't follow, happy enough to eat the fawn instead of the foolish cat.",
-			null,
-			"s_c is overconfident in their attack and the fox manages to sink their teeth into them. They retreat, bleeding and in pain, and the gray fox settles back down to its meal."
-		],
-		"win_skills": [
-			"great fighter",
-			"excellent fighter"
-		],
-		"win_trait": [
-			"adventurous",
-			"altruistic",
-			"ambitious",
-			"confident",
-			"daring",
-			"fierce",
-			"responsible",
-			"righteous"
-		],
-		"fail_skills": [
-			"None"
-		],
-		"fail_trait": [
-			"troublesome",
-			"vengeful",
-			"bloodthirsty",
-			"bold"
-		],
-		"min_cats": 1,
-		"max_cats": 1,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			"r_c carries a scar from a solo fox fight.",
-			null
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_foxgray_leaf-fallscavenge1",
-		"biome": "forest",
-		"season": "leaf-fall",
-		"tags": [
-			"hunting",
-			"fighting",
-			"scar",
-			"injury",
-			"bite-wound",
-			"clan_to_patrol",
-			"respect",
-			"rel_patrol",
-			"medium_prey0",
-			"medium_prey1",
-			"large_prey2",
-			"large_prey3"
-		],
-		"intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? Tracking it, they find a stocky gray fox feeding on a deer fawn carcass. A gray fox is unlikely to have killed a fawn this size.",
-		"decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
-		"chance_of_success": 70,
-		"exp": 20,
-		"success_text": [
-			"The cats are only just smaller and outnumber the fox, if only by a little, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full of venison and unwilling to lose blood over it, is driven off from the kill.",
-			null,
-			"s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until it gives up and runs.",
-			"The patrol launches into battle, but with so few cats it's exhausting trying to keep the fox and its snapping jaws on the defensive. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. It's only one bite, but the fox has had enough and flees."
-		],
-		"fail_text": [
-			"Your patrol fails to drive away the fox, which keeps possession of the food. However there were no injuries.",
-			"s_c makes a stupid mistake, too intent on winning the fight to respect their enemy's teeth, and it's only being janked back by the tail that saves them from injury. The patrol gives up, and settles down to wait a safe distance away until the fox leaves of its own accord.",
-			null,
-			null,
-			null,
-			"s_c means well, but they're overconfident in their attack and the fox manages to sink their teeth into them. The patrol is forced to retreat, forming a defensive ring around the hurt s_c."
-		],
-		"win_skills": [
-			"good fighter",
-			"great fighter",
-			"excellent fighter"
-		],
-		"win_trait": [
-			"adventurous",
-			"altruistic",
-			"ambitious",
-			"confident",
-			"daring",
-			"fierce",
-			"responsible",
-			"righteous"
-		],
-		"fail_skills": [
-			"None"
-		],
-		"fail_trait": [
-			"troublesome",
-			"vengeful",
-			"bloodthirsty",
-			"bold"
-		],
-		"min_cats": 2,
-		"max_cats": 3,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			"r_c carries a scar from a fox fight.",
-			null
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_foxgray_leaf-fallscavenge2",
-		"biome": "forest",
-		"season": "leaf-fall",
-		"tags": [
-			"hunting",
-			"fighting",
-			"scar",
-			"injury",
-			"clan_to_patrol",
-			"respect",
-			"rel_patrol",
-			"medium_prey0",
-			"medium_prey1",
-			"large_prey2",
-			"large_prey3"
-		],
-		"intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? Tracking it, they find a stocky gray fox feeding on a deer fawn carcass. A gray fox is unlikely to have killed a fawn this size.",
-		"decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
-		"chance_of_success": 90,
-		"exp": 20,
-		"success_text": [
-			"Your cats are only just smaller and heavily outnumber the fox, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full of venison and unwilling to lose blood over it, is driven off from the kill.",
-			null,
-			"s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until s_c lands a crucial blow, snapping a tendon in one of the fox's hindlegs. The fox runs, but there's no way it'll live long with such a crippling injury.",
-			"The patrol launches into battle, keeping the fox on the defensive with teamwork. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. Holding on grimly, s_c's daring move gives the rest of the patrol the opportunity needed to bring the fox down for good."
-		],
-		"fail_text": [
-			"Your patrol fails to drive away the fox, which keeps possession of the food. However with so many cats to protect each other, there were no injuries.",
-			"s_c makes a stupid mistake, too intent on winning the fight to respect their enemy's teeth, and it's only being yanked back by the tail that saves them from injury. The patrol gives up, and settles down to wait a safe distance away until the fox leaves of its own accord."
-		],
-		"win_skills": [
-			"good fighter",
-			"great fighter",
-			"excellent fighter"
-		],
-		"win_trait": [
-			"adventurous",
-			"altruistic",
-			"ambitious",
-			"confident",
-			"daring",
-			"fierce",
-			"responsible",
-			"righteous"
-		],
-		"fail_skills": [
-			"None"
-		],
-		"fail_trait": [
-			"troublesome",
-			"vengeful",
-			"bloodthirsty",
-			"bold"
-		],
-		"min_cats": 4,
-		"max_cats": 6,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			"r_c carries a scar from a fox fight."
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_foxgray_leaf-fallscavenge3",
-		"biome": "forest",
-		"season": "leaf-fall",
-		"tags": [
-			"hunting",
-			"fighting",
-			"scar",
-			"injury",
-			"bite-wound",
-			"clan_to_patrol",
-			"respect",
-			"medium_prey0",
-			"medium_prey1",
-			"large_prey2",
-			"large_prey3"
-		],
-		"intro_text": "r_c catches the scent of a fox - but is it red, or gray? Tracking it, they find a stocky gray fox feeding on a deer fawn carcass. A gray fox is unlikely to have killed a fawn this size.",
-		"decline_text": "r_c decides not to quarrel with the fox and to find prey elsewhere.",
-		"chance_of_success": 50,
-		"exp": 30,
-		"success_text": [
-			"r_c may be smaller, alone, and half its weight, but the fox has a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle. The fox, already stuffed full of venison and unwilling to lose blood over it, leaves the kill with a grumble.",
-			null,
-			"s_c uses every trick in their talented fighting skillset to attack the fox with no one to watch their flank, until the perfect opportunity opens up and they pounce onto the fox's back, digging in their claws. It's a wild ride through the forest until the fox bucks them off, but it wins them the fawn carcass.",
-			"In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. But then they're stuck, unwilling to let go and risk being bitten. They're dragged through the forest, over rocks and through bushes, until the fox finally collapses and the battered s_c goes back to proudly claim the fawn."
-		],
-		"fail_text": [
-			"Your patrol fails to drive away the gray fox, which keeps possession of the food. However there were no injuries.",
-			"s_c makes a stupid mistake, too intent on winning the fight to respect their enemy's teeth, and it's tripping over their own feet that saves them. They give up, and settle down to wait a safe distance away until the fox leaves of its own accord.",
-			null,
-			"r_c launches into battle, but is caught with a nasty bite, and retreats to limp back home. The gray fox doesn't follow, happy enough to eat the fawn instead of the foolish cat.",
-			null,
-			"s_c is overconfident in their attack and the fox manages to sink their teeth into them. They retreat, bleeding and in pain, and the gray fox settles back down to its meal."
-		],
-		"win_skills": [
-			"great fighter",
-			"excellent fighter"
-		],
-		"win_trait": [
-			"adventurous",
-			"altruistic",
-			"ambitious",
-			"confident",
-			"daring",
-			"fierce",
-			"responsible",
-			"righteous"
-		],
-		"fail_skills": [
-			"None"
-		],
-		"fail_trait": [
-			"troublesome",
-			"vengeful",
-			"bloodthirsty",
-			"bold"
-		],
-		"min_cats": 1,
-		"max_cats": 1,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			"r_c carries a scar from a solo fox fight.",
-			null
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_foxgray_leaf-barescavenge1",
-		"biome": "forest",
-		"season": "leaf-bare",
-		"tags": [
-			"hunting",
-			"fighting",
-			"scar",
-			"injury",
-			"bite-wound",
-			"clan_to_patrol",
-			"respect",
-			"rel_patrol",
-			"medium_prey0",
-			"medium_prey1",
-			"large_prey2",
-			"large_prey3"
-		],
-		"intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? Tracking it, they find a stocky gray fox feeding on a deer carcass, either a small doe or one of last newleaf's fawns. A gray fox could never take on prey this size, it must have found the carcass, and now c_n has too.",
-		"decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
-		"chance_of_success": 50,
-		"exp": 20,
-		"success_text": [
-			"The cats are only just smaller and outnumber the fox, if only by a little, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full of venison and unwilling to lose blood over it, is driven off from the kill.",
-			null,
-			"s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until it gives up and runs.",
-			"The patrol launches into battle, but with so few cats it's exhausting trying to keep the fox and its snapping jaws on the defensive. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. It's only one bite, but the fox has had enough and flees."
-		],
-		"fail_text": [
-			"Your patrol fails to drive away the fox, which keeps possession of the food. However there were no injuries.",
-			"s_c makes a stupid mistake, too intent on winning the fight to respect their enemy's teeth, and it's only being yanked back by the tail that saves them from injury. The patrol gives up, and settles down to wait a safe distance away until the fox leaves of its own accord.",
-			null,
-			null,
-			null,
-			"s_c means well, but they're overconfident in their attack and the fox manages to sink their teeth into them. The patrol is forced to retreat, forming a defensive ring around the hurt s_c."
-		],
-		"win_skills": [
-			"good fighter",
-			"great fighter",
-			"excellent fighter"
-		],
-		"win_trait": [
-			"adventurous",
-			"altruistic",
-			"ambitious",
-			"confident",
-			"daring",
-			"fierce",
-			"responsible",
-			"righteous"
-		],
-		"fail_skills": [
-			"None"
-		],
-		"fail_trait": [
-			"troublesome",
-			"vengeful",
-			"bloodthirsty",
-			"bold"
-		],
-		"min_cats": 2,
-		"max_cats": 3,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			"r_c carries a scar from a fox fight.",
-			null
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_foxgray_leaf-barescavenge2",
-		"biome": "forest",
-		"season": "leaf-bare",
-		"tags": [
-			"hunting",
-			"fighting",
-			"scar",
-			"injury",
-			"clan_to_patrol",
-			"respect",
-			"rel_patrol",
-			"medium_prey0",
-			"medium_prey1",
-			"large_prey2",
-			"large_prey3"
-		],
-		"intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? Tracking it, they find a stocky gray fox feeding on a deer carcass, either a small doe or one of last newleaf's fawns. A gray fox could never take on prey this size, it must have found the carcass, and now c_n has too.",
-		"decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
-		"chance_of_success": 70,
-		"exp": 20,
-		"success_text": [
-			"Your cats are only just smaller and heavily outnumber the fox, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full of venison and unwilling to lose blood over it, is driven off from the kill.",
-			null,
-			"s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until s_c lands a crucial blow, snapping a tendon in one of the fox's hindlegs. The fox runs, but there's no way it'll live long with such a crippling injury.",
-			"The patrol launches into battle, keeping the fox on the defensive with teamwork. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. Holding on grimly, s_c's daring move gives the rest of the patrol the opportunity needed to bring the fox down for good."
-		],
-		"fail_text": [
-			"Your patrol fails to drive away the fox, which keeps possession of the food. However with so many cats to protect each other, there were no injuries.",
-			"s_c makes a stupid mistake, too intent on winning the fight to respect their enemy's teeth, and it's only being yanked back by the tail that saves them from injury. The patrol gives up, and settles down to wait a safe distance away until the fox leaves of its own accord."
-		],
-		"win_skills": [
-			"good fighter",
-			"great fighter",
-			"excellent fighter"
-		],
-		"win_trait": [
-			"adventurous",
-			"altruistic",
-			"ambitious",
-			"confident",
-			"daring",
-			"fierce",
-			"responsible",
-			"righteous"
-		],
-		"fail_skills": [
-			"None"
-		],
-		"fail_trait": [
-			"troublesome",
-			"vengeful",
-			"bloodthirsty",
-			"bold"
-		],
-		"min_cats": 4,
-		"max_cats": 6,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			"r_c carries a scar from a fox fight."
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_foxgray_leaf-barescavenge3",
-		"biome": "forest",
-		"season": "leaf-bare",
-		"tags": [
-			"hunting",
-			"fighting",
-			"scar",
-			"injury",
-			"bite-wound",
-			"clan_to_patrol",
-			"respect",
-			"medium_prey0",
-			"medium_prey1",
-			"large_prey2",
-			"large_prey3"
-		],
-		"intro_text": "r_c catches the scent of a fox - but is it red, or gray? Tracking it, they find a stocky gray fox feeding on a deer carcass, either a small doe or one of last newleaf's fawns. A gray fox could never take on prey this size, it must have found the carcass, and now c_n has too.",
-		"decline_text": "r_c decides not to quarrel with the fox and to find prey elsewhere.",
-		"chance_of_success": 30,
-		"exp": 30,
-		"success_text": [
-			"r_c may be smaller, alone, and half its weight, but the fox has a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle. The fox, already stuffed full of venison and unwilling to lose blood over it, leaves the kill with a grumble.",
-			null,
-			"s_c uses every trick in their talented fighting skillset to attack the fox with no one to watch their flank, until the perfect opportunity opens up and they pounce onto the fox's back, digging in their claws. It's a wild ride through the forest until the fox bucks them off, but it wins them the fawn carcass.",
-			"In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. But then they're stuck, unwilling to let go and risk being bitten. They're dragged through the forest, over rocks and through bushes, until the fox finally collapses and the battered s_c goes back to proudly claim the fawn."
-		],
-		"fail_text": [
-			"Your patrol fails to drive away the gray fox, which keeps possession of the food. However there were no injuries.",
-			"s_c makes a stupid mistake, too intent on winning the fight to respect their enemy's teeth, and it's tripping over their own feet that saves them. They give up, and settle down to wait a safe distance away until the fox leaves of its own accord.",
-			null,
-			"r_c launches into battle, but is caught with a nasty bite, and retreats to limp back home. The gray fox doesn't follow, happy enough to eat the fawn instead of the foolish cat.",
-			null,
-			"s_c is overconfident in their attack and the fox manages to sink their teeth into them. They retreat, bleeding and in pain, and the gray fox settles back down to its meal."
-		],
-		"win_skills": [
-			"great fighter",
-			"excellent fighter"
-		],
-		"win_trait": [
-			"adventurous",
-			"altruistic",
-			"ambitious",
-			"confident",
-			"daring",
-			"fierce",
-			"responsible",
-			"righteous"
-		],
-		"fail_skills": [
-			"None"
-		],
-		"fail_trait": [
-			"troublesome",
-			"vengeful",
-			"bloodthirsty",
-			"bold"
-		],
-		"min_cats": 1,
-		"max_cats": 1,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			"r_c carries a scar from a solo fox fight.",
-			null
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_redvixen1",
-		"biome": "forest",
-		"season": "newleaf",
-		"tags": [
-			"fighting",
-			"death",
-			"scar",
-			"big_bite_injury",
-			"respect",
-			"trust",
-			"clan_to_r_c",
-			"patrol_to_r_c",
-			"clan_to_patrol"
-		],
-		"intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
-		"decline_text": "Your patrol decides not to pursue the fox.",
-		"chance_of_success": 30,
-		"exp": 30,
-		"success_text": [
-			"The red vixen smells of milk, and hopefully by driving her out of the territory, her litter this newleaf won't be a threat to the Clan. If they don't starve, c_n will hunt them down - they do not share territory with foxes.",
-			"Your patrol drives away the red fox, seeks out her den, and kills her young cubs. It's brutal, but these fluffy baby foxes would one day have grown to be kit-killers and thieves.",
-			"s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the red fox nor her cubs pose a threat to the Clan. It truly proves s_c's place as one of c_n's most talented and skillful fighters.",
-			"The patrol overcomes the red vixen and drives her off thanks to a brilliant battle move by s_c at a critical moment. Their bravery ensures the patrol's success, and the cats arrive back at camp singing their praises to make sure the Clan knows it."
-		],
-		"fail_text": [
-			"The mother red fox is vicious and determined, and the small patrol is beaten back. But this forest is c_n's and they haven't given up. They may have lost this battle, but c_n will win this war.",
-			"s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarasses them deeply the rest of the patrol have to rescue them from the red vixen.",
-			"Never threaten a mother's young - the red vixen kills r_c in the skirmish.",
-			"The mother red fox's snapping jaws leave r_c dripping blood onto the leaf litter, forcing the patrol to back off.",
-			null,
-			"s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the red vixen manages to sink her teeth into them. The patrol rallies around s_c, but they have to give up on the fight.",
-			"As their hunt descends into a full on battle with the red vixen, p_l takes a blow meant for one of their Clanmates, losing a life."
-		],
-		"win_skills": [
-			"excellent fighter"
-		],
-		"win_trait": [
-			"adventurous",
-			"altruistic",
-			"ambitious",
-			"bloodthirsty",
-			"bold",
-			"confident",
-			"daring",
-			"fierce",
-			"responsible",
-			"righteous",
-			"troublesome",
-			"vengeful"
-		],
-		"fail_skills": [
-			"good fighter"
-		],
-		"fail_trait": [
-			"None"
-		],
-		"min_cats": 2,
-		"max_cats": 3,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			"r_c carries a scar from a fox fight.",
-			"r_c fell in battle with a fox.",
-			"died while fighting a fox"
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_redvixen2",
-		"biome": "forest",
-		"season": "newleaf",
-		"tags": [
-			"fighting",
-			"scar",
-			"big_bite_injury",
-			"respect",
-			"trust",
-			"clan_to_r_c",
-			"patrol_to_r_c",
-			"clan_to_patrol"
-		],
-		"intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
-		"decline_text": "Your patrol decides not to pursue the fox.",
-		"chance_of_success": 60,
-		"exp": 30,
-		"success_text": [
-			"Led by p_l, and with a heap of cooperation and teamwork, the patrol drives away the red fox, seeks out her den, and kills her young cubs. The forest will be safe from both the threat the vixen posed this season, and the threat her cubs would've given c_n in the seasons to come.",
-			"With so many cats working together in tight coordination, they manage to accomplish the near-impossible, killing the red mother vixen and ending the threat to the Clan that she and her cubs pose.",
-			"s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the red fox nor her dependent cubs pose a threat to the Clan. It truly proves s_c's place as one of c_n's most talented and skillful fighters.",
-			"The patrol overcomes the red vixen and drives her off thanks to a brilliant battle move by s_c at a critical moment. Their bravery ensures the patrol's success, and the cats arrive back at camp singing their praises to make sure the Clan knows it."
-		],
-		"fail_text": [
-			"The mother red fox is vicious and determined. Although they lose this battle, through teamwork the cats manage to retreat without injury.",
-			"s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarasses them deeply the rest of the patrol have to rescue them from the red vixen.",
-			null,
-			"r_c is left wounded as the patrol and the red mother vixen fight to a stalemate. Hopefully they've given the fox mother a reason not to return to this part of the forest.",
-			null,
-			"s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the red vixen manages to sink her teeth into them. The patrol rallies around s_c, but they have to give up on the fight."
-		],
-		"win_skills": [
-			"excellent fighter"
-		],
-		"win_trait": [
-			"adventurous",
-			"altruistic",
-			"ambitious",
-			"bloodthirsty",
-			"bold",
-			"confident",
-			"daring",
-			"fierce",
-			"responsible",
-			"righteous",
-			"troublesome",
-			"vengeful"
-		],
-		"fail_skills": [
-			"good fighter"
-		],
-		"fail_trait": [
-			"None"
-		],
-		"min_cats": 4,
-		"max_cats": 6,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			"r_c carries a scar from a fox fight."
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_redvixen3",
-		"biome": "forest",
-		"season": "newleaf",
-		"tags": [
-			"fighting",
-			"death",
-			"scar",
-			"big_bite_injury",
-			"shock",
-			"injury",
-			"respect",
-			"trust",
-			"clan_to_patrol",
-			"no_body"
-		],
-		"intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
-		"decline_text": "Your patrol decides not to pursue the fox.",
-		"chance_of_success": 20,
-		"exp": 50,
-		"success_text": [
-			"The red vixen smells of milk, and hopefully by driving her out of the territory, her litter this newleaf won't be a threat to the Clan. If they don't starve, c_n will hunt them down - they do not share territory with foxes.",
-			null,
-			"s_c displays incredible skill, driving the mother vixen and her brood out of the forest all by themselves. Now neither the red fox nor her dependent cubs pose a threat to the Clan. They swell with pride, feeling the confidence of knowing that they're truly one of the best fighters c_n has ever produced.",
-			"A brilliant battle move by s_c knocks the red vixen off balance, and s_c manages to drive her out of c_n territory, though it takes every spark of strength in their pelt to do it alone."
-		],
-		"fail_text": [
-			null,
-			null,
-			"Never threaten a mother's young - the red vixen kills r_c in the skirmish, and carries off the body to feed her litter.",
-			"The mother red fox's snapping jaws leave r_c dripping blood onto the leaf litter, and barely able to escape further injury.",
-			null,
-			"s_c is determined to win, but the red vixen is determined to live, and that makes all the difference. s_c ends up pinned in a defensible hiding spot, bleeding and terrified, until the vixen judges them no longer a threat and continues on her way."
-		],
-		"win_skills": [
-			"excellent fighter"
-		],
-		"win_trait": [
-			"adventurous",
-			"altruistic",
-			"ambitious",
-			"bloodthirsty",
-			"bold",
-			"confident",
-			"daring",
-			"fierce",
-			"responsible",
-			"righteous",
-			"troublesome",
-			"vengeful"
-		],
-		"fail_skills": [
-			"good fighter"
-		],
-		"fail_trait": [
-			"None"
-		],
-		"min_cats": 1,
-		"max_cats": 1,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			"r_c carries a scar from a solo fight with a vixen.",
-			"r_c fell in a solo battle with a vixen.",
-			"died while fighting a vixen"
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_redvixen4",
-		"biome": "forest",
-		"season": "greenleaf",
-		"tags": [
-			"fighting",
-			"death",
-			"scar",
-			"big_bite_injury",
-			"respect",
-			"trust",
-			"clan_to_r_c",
-			"patrol_to_r_c",
-			"clan_to_patrol"
-		],
-		"intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
-		"decline_text": "Your patrol decides not to pursue the fox.",
-		"chance_of_success": 30,
-		"exp": 30,
-		"success_text": [
-			"The red vixen smells of milk and blood. Hopefully by driving her out of the territory, the litter she has been raising this greenleaf won't be a threat to the Clan. If they don't starve, c_n will hunt them down - they do not share with foxes.",
-			"Your patrol drives away the red fox, seeks out her den, and kills her cubs. It's brutal, but these fluffy small foxes would one day have grown to be kit-killers and thieves.",
-			"s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the red fox nor her dependent cubs pose a threat to the Clan. It truly proves s_c's place as one of c_n's most talented and skillful fighters.",
-			"The patrol overcomes the red vixen and drives her off thanks to a brilliant battle move by s_c at a critical moment. Their bravery ensures the patrol's success, and the cats arrive back at camp singing their praises to make sure the Clan knows it."
-		],
-		"fail_text": [
-			"The mother red fox is vicious and determined, and the small patrol is beaten back. But this forest is c_n's and they haven't given up. They may have lost this battle, but c_n will win this war.",
-			"s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarasses them deeply the rest of the patrol have to rescue them from the red vixen.",
-			"Never threaten a mother's young - the red vixen kills r_c in the skirmish.",
-			"The mother red fox's snapping jaws leave r_c dripping blood onto the leaf litter, forcing the patrol to back off.",
-			null,
-			"s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the red vixen manages to sink her teeth into them. The patrol rallies around s_c, but they have to give up on the fight.",
-			"As their hunt descends into a full on battle with the red vixen, p_l takes a blow meant for one of their Clanmates, losing a life."
-		],
-		"win_skills": [
-			"excellent fighter"
-		],
-		"win_trait": [
-			"adventurous",
-			"altruistic",
-			"ambitious",
-			"bloodthirsty",
-			"bold",
-			"confident",
-			"daring",
-			"fierce",
-			"responsible",
-			"righteous",
-			"troublesome",
-			"vengeful"
-		],
-		"fail_skills": [
-			"good fighter"
-		],
-		"fail_trait": [
-			"None"
-		],
-		"min_cats": 2,
-		"max_cats": 3,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			"r_c carries a scar from a fox fight.",
-			"r_c fell in battle with a fox.",
-			"died while fighting a fox"
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_redvixen5",
-		"biome": "forest",
-		"season": "greenleaf",
-		"tags": [
-			"fighting",
-			"scar",
-			"big_bite_injury",
-			"respect",
-			"trust",
-			"clan_to_r_c",
-			"patrol_to_r_c",
-			"clan_to_patrol"
-		],
-		"intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
-		"decline_text": "Your patrol decides not to pursue the fox.",
-		"chance_of_success": 60,
-		"exp": 30,
-		"success_text": [
-			"Led by p_l, and with a heap of cooperation and teamwork, the patrol drives away the red fox, seeks out her den, and kills her growing cubs. The forest will be safe from both the threat the vixen posed this season, and the threat her cubs would've given c_n in the seasons to come.",
-			"With so many cats working together in tight coordination, they manage to accomplish the near-impossible, killing the red mother vixen and ending the threat to the Clan that she and her cubs pose.",
-			"s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the red fox nor her dependent cubs pose a threat to the Clan. It truly proves s_c's place as one of c_n's most talented and skillful fighters.",
-			"The patrol overcomes the red vixen and drives her off thanks to a brilliant battle move by s_c at a critical moment. Their bravery ensures the patrol's success, and the cats arrive back at camp singing their praises to make sure the Clan knows it."
-		],
-		"fail_text": [
-			"The mother red fox is vicious and determined. Although they lose this battle, through teamwork the cats manage to retreat without injury.",
-			"s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarasses them deeply the rest of the patrol have to rescue them from the red vixen.",
-			null,
-			"r_c is left wounded as the patrol and the red mother vixen fight to a stalemate. Hopefully they've given the fox mother a reason not to return to this part of the forest.",
-			null,
-			"s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the red vixen manages to sink her teeth into them. The patrol rallies around s_c, but they have to give up on the fight."
-		],
-		"win_skills": [
-			"excellent fighter"
-		],
-		"win_trait": [
-			"adventurous",
-			"altruistic",
-			"ambitious",
-			"bloodthirsty",
-			"bold",
-			"confident",
-			"daring",
-			"fierce",
-			"responsible",
-			"righteous",
-			"troublesome",
-			"vengeful"
-		],
-		"fail_skills": [
-			"good fighter"
-		],
-		"fail_trait": [
-			"None"
-		],
-		"min_cats": 4,
-		"max_cats": 6,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			"r_c carries a scar from a fox fight."
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_redvixen6",
-		"biome": "forest",
-		"season": "greenleaf",
-		"tags": [
-			"fighting",
-			"death",
-			"scar",
-			"big_bite_injury",
-			"shock",
-			"injury",
-			"respect",
-			"trust",
-			"clan_to_patrol",
-			"no_body"
-		],
-		"intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
-		"decline_text": "Your patrol decides not to pursue the fox.",
-		"chance_of_success": 10,
-		"exp": 50,
-		"success_text": [
-			"The red vixen smells of milk and blood. Hopefully by driving her out of the territory, the litter she has been raising this greenleaf won't be a threat to the Clan.",
-			null,
-			"s_c displays incredible skill, driving the mother vixen and her brood out of the forest all by themselves. Now neither the red fox nor her dependent cubs pose a threat to the Clan. They swell with pride, feeling the confidence of knowing that they're truly one of the best fighters c_n has ever produced.",
-			"A brilliant battle move by s_c at a critical moment knocks the red vixen off balance, and s_c manages to drive her out of c_n territory, though it takes every spark of strength in their pelt to do it alone."
-		],
-		"fail_text": [
-			null,
-			null,
-			"Never threaten a mother's young - the red vixen kills r_c in the skirmish, and carries off the body to feed her litter.",
-			"The mother red fox's snapping jaws leave r_c dripping blood onto the leaf litter, and barely able to escape further injury.",
-			null,
-			"s_c is determined to win, but the red vixen is determined to live, and that makes all the difference. s_c ends up pinned in a defensible hiding spot, bleeding and terrified, until the vixen judges them no longer a threat and continues on her way."
-		],
-		"win_skills": [
-			"excellent fighter"
-		],
-		"win_trait": [
-			"adventurous",
-			"altruistic",
-			"ambitious",
-			"bloodthirsty",
-			"bold",
-			"confident",
-			"daring",
-			"fierce",
-			"responsible",
-			"righteous",
-			"troublesome",
-			"vengeful"
-		],
-		"fail_skills": [
-			"good fighter"
-		],
-		"fail_trait": [
-			"None"
-		],
-		"min_cats": 1,
-		"max_cats": 1,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			"r_c carries a scar from a solo fight with a vixen.",
-			"r_c fell in a solo battle with a vixen.",
-			"died while fighting a vixen"
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_redvixen7",
-		"biome": "forest",
-		"season": "leaf-fall",
-		"tags": [
-			"fighting",
-			"death",
-			"scar",
-			"big_bite_injury",
-			"respect",
-			"trust",
-			"clan_to_r_c",
-			"patrol_to_r_c",
-			"clan_to_patrol"
-		],
-		"intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
-		"decline_text": "Your patrol decides not to pursue the fox.",
-		"chance_of_success": 30,
-		"exp": 30,
-		"success_text": [
-			"The red vixen smells like the prey she's been poaching to feed her litter. She's stolen from c_n for the last time, and the patrol drives her from their territory, yowling their anger and fury.",
-			"Your patrol drives away the red fox, and seeks out her den, but her leaf-fall cubs are near full-grown and scatter into the wilderness. Hopefully leaf-bare takes care of them.",
-			"s_c displays incredible skill, driving the red mother vixen out of the territory almost by themselves. It truly proves s_c's place as one of c_n's most talented and skillful fighters.",
-			"The patrol overcomes the red vixen and drives her off thanks to a brilliant battle move by s_c at a critical moment. Their bravery ensures the patrol's success, and the cats arrive back at camp singing their praises to make sure the Clan knows it."
-		],
-		"fail_text": [
-			"The mother red fox is vicious and determined, and the small patrol is beaten back. But this forest is c_n's and they haven't given up. They may have lost this battle, but c_n will win this war.",
-			"s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarasses them deeply the rest of the patrol have to rescue them from the red vixen.",
-			"Never threaten a mother's young - the red vixen kills r_c in the skirmish.",
-			"The mother red fox's snapping jaws leave r_c dripping blood onto the leaf litter, forcing the patrol to back off.",
-			null,
-			"s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the red vixen manages to sink her teeth into them. The patrol rallies around s_c, but they have to give up on the fight.",
-			"As their hunt descends into a full on battle with the red vixen, p_l takes a blow meant for one of their Clanmates, losing a life."
-		],
-		"win_skills": [
-			"excellent fighter"
-		],
-		"win_trait": [
-			"adventurous",
-			"altruistic",
-			"ambitious",
-			"bloodthirsty",
-			"bold",
-			"confident",
-			"daring",
-			"fierce",
-			"responsible",
-			"righteous",
-			"troublesome",
-			"vengeful"
-		],
-		"fail_skills": [
-			"good fighter"
-		],
-		"fail_trait": [
-			"None"
-		],
-		"min_cats": 2,
-		"max_cats": 3,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			"r_c carries a scar from a fox fight.",
-			"r_c fell in battle with a fox.",
-			"died while fighting a vixen"
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_redvixen8",
-		"biome": "forest",
-		"season": "leaf-fall",
-		"tags": [
-			"fighting",
-			"scar",
-			"big_bite_injury",
-			"respect",
-			"trust",
-			"clan_to_r_c",
-			"patrol_to_r_c",
-			"clan_to_patrol"
-		],
-		"intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
-		"decline_text": "Your patrol decides not to pursue the fox.",
-		"chance_of_success": 60,
-		"exp": 30,
-		"success_text": [
-			"Led by p_l and with a heap of cooperation and teamwork, the patrol drives away the red fox, and seeks out her den. But her cubs are near full-grown with the bounty of leaf-fall, and scatter from the patrol into the wilderness. Hopefully leaf-bare takes care of them.",
-			"With so many cats working together in tight coordination, they manage to accomplish the near-impossible, killing the red mother vixen and ending the threat to the Clan that she poses. The patrol drives her near-full grown litter of fox cubs out from the territory. Hopefully the coming leaf-bare will take care of them.",
-			"s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the red fox nor her cubs pose a threat to c_n.",
-			"The patrol overcomes the red vixen and drives her off thanks to a brilliant battle move by s_c at a critical moment. Their bravery ensures the patrol's success, and the cats arrive back at camp singing their praises to make sure the Clan knows it."
-		],
-		"fail_text": [
-			"The mother red fox is vicious and determined. Although they lose this battle, through teamwork the cats manage to retreat without injury.",
-			"s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the red vixen manages to sink her teeth into them. The patrol rallies around s_c, but they have to give up the fight.",
-			null,
-			"r_c is left wounded as the patrol and the red mother vixen fight to a stalemate. Hopefully they've given the fox mother a reason not to return to this part of the forest."
-		],
-		"win_skills": [
-			"excellent fighter"
-		],
-		"win_trait": [
-			"adventurous",
-			"altruistic",
-			"ambitious",
-			"bloodthirsty",
-			"bold",
-			"confident",
-			"daring",
-			"fierce",
-			"responsible",
-			"righteous",
-			"troublesome",
-			"vengeful"
-		],
-		"fail_skills": [
-			"good fighter"
-		],
-		"fail_trait": [
-			"None"
-		],
-		"min_cats": 4,
-		"max_cats": 6,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			"r_c carries a scar from a red fox fight."
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_redvixen9",
-		"biome": "forest",
-		"season": "leaf-fall",
-		"tags": [
-			"fighting",
-			"death",
-			"scar",
-			"big_bite_injury",
-			"shock",
-			"injury",
-			"respect",
-			"trust",
-			"clan_to_patrol",
-			"no_body"
-		],
-		"intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
-		"decline_text": "Your patrol decides not to pursue the fox.",
-		"chance_of_success": 20,
-		"exp": 50,
-		"success_text": [
-			"It takes r_c's every scrap of bravery and strength to drive away the red vixen - her near grown litter, fat on the bounty of leaf-fall, is a challenge for another day. c_n will have to deal with the young foxes now roaming motherless in their woods, before they start to compete for prey in leaf-bare.",
-			null,
-			"s_c displays incredible skill, driving the mother vixen and her brood out of the forest all by themselves. Now neither the red fox nor her cubs pose a threat to the Clan. They swell with pride, feeling the confidence of knowing that they're truly one of the best fighters c_n has ever produced.",
-			"A brilliant battle move by s_c at a critical moment knocks the red vixen off balance, and s_c manages to drive her out of c_n territory, though it takes every spark of strength in their pelt to do it alone."
-		],
-		"fail_text": [
-			null,
-			null,
-			"Never threaten a mother's young - the red vixen kills r_c in the skirmish, and carries off the body to feed her litter.",
-			"The mother red fox's snapping jaws leave r_c dripping blood onto the leaf litter, and barely able to escape further injury.",
-			null,
-			"s_c is determined to win, but the red vixen is determined to live, and that makes all the difference. s_c ends up pinned in a defensible hiding spot, bleeding and terrified, until the vixen judges them no longer a threat and continues on her way."
-		],
-		"win_skills": [
-			"excellent fighter"
-		],
-		"win_trait": [
-			"adventurous",
-			"altruistic",
-			"ambitious",
-			"bloodthirsty",
-			"bold",
-			"confident",
-			"daring",
-			"fierce",
-			"responsible",
-			"righteous",
-			"troublesome",
-			"vengeful"
-		],
-		"fail_skills": [
-			"good fighter"
-		],
-		"fail_trait": [
-			"None"
-		],
-		"min_cats": 1,
-		"max_cats": 1,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			"r_c carries a scar from a solo fight with a red vixen.",
-			"r_c fell in a solo battle with a red vixen.",
-			"died while fighting a vixen"
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_grayvixen1",
-		"biome": "forest",
-		"season": "newleaf",
-		"tags": [
-			"fighting",
-			"minor_injury",
-			"respect",
-			"trust",
-			"rel_patrol",
-			"patrol_to_r_c"
-		],
-		"intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
-		"decline_text": "Your patrol decides not to pursue the fox.",
-		"chance_of_success": 60,
-		"exp": 30,
-		"success_text": [
-			"The stocky gray vixen they track down smells of milk, and though she's nearly double the weight of any of the patrol and all of it muscle, they meet her eyes squarely, and leap to attack. c_n does not tolerate sharing their territory with foxes, and they work together to drive her off.",
-			"Your patrol drives away the gray fox, seeks out her den, and kills her young cubs. It's brutal, but these fluffy baby foxes would one day have grown to be kit-killers and thieves. Better to deal with them now than when they're the height and nearly double the weight of a cat, though a gray fox will always be easier than a bigger red one.",
-			"s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the gray fox nor her cubs pose a threat to the Clan. It places s_c as one of c_n's most talented and skillful fighters, a gray fox is a dangerous competitor.",
-			"The patrol overcomes the gray vixen they find and drives her off thanks to a brilliant battle move by s_c. The cats swirl around s_c afterwards, congratulating them on their bravery and skill."
-		],
-		"fail_text": [
-			"The patrol comes across a gray vixen at the end of the scent trail. She spots them too, measures herself up against them, then flees, scrambling into the trees in a move that completely surprises the cats. This round goes to the gray fox.",
-			"s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarasses them deeply the gray vixen slips past them and flees further into the forest.",
-			null,
-			"The patrol finds a stocky gray vixen wandering their forest, and drives her out in a scene that mostly involves yowling and screaming and yapping at each other until she gives in. r_c gets a little battered, but everyone is mostly fine.",
-			null,
-			"s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is all muscle, barging past s_c and knocking them ass over paws as she flees from the patrol."
-		],
-		"win_skills": [
-			"excellent fighter"
-		],
-		"win_trait": [
-			"adventurous",
-			"altruistic",
-			"ambitious",
-			"bloodthirsty",
-			"bold",
-			"confident",
-			"daring",
-			"fierce",
-			"responsible",
-			"righteous",
-			"troublesome",
-			"vengeful"
-		],
-		"fail_skills": [
-			"good fighter"
-		],
-		"fail_trait": [
-			"None"
-		],
-		"min_cats": 2,
-		"max_cats": 3,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			"r_c carries a scar from a fox fight.",
-			null
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_grayvixen2",
-		"biome": "forest",
-		"season": "newleaf",
-		"tags": [
-			"fighting",
-			"minor_injury",
-			"respect",
-			"trust",
-			"rel_patrol",
-			"patrol_to_r_c"
-		],
-		"intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
-		"decline_text": "Your patrol decides not to pursue the fox.",
-		"chance_of_success": 90,
-		"exp": 30,
-		"success_text": [
-			"The stocky gray vixen they track down smells of milk, and though she's nearly double the weight of any of the patrol and all of it muscle, they meet her eyes squarely, and leap to attack. c_n does not tolerate sharing their territory with foxes, and they work together to drive her off.",
-			"With so many cats working together in tight coordination, they're able to keep the gray vixen they find pinned and distracted as they wear her down. The fox eventually flees for her den, and the patrol follows to take care of the cubs she's raising.",
-			"s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the gray fox nor her cubs pose a threat to the Clan. It places s_c as one of c_n's most talented and skillful fighters, a gray fox is a dangerous competitor.",
-			"Bravely, s_c charges the gray fox, yowling threats. The vixen spooks and skitters up a tree, growling and barking in a squeaky tone, and s_c follows her up into the branches. As the rest of the patrol backs them up from the ground, s_c screams until the fox is cowering and afraid, then lets her flee."
-		],
-		"fail_text": [
-			"The patrol comes across a gray vixen at the end of the scent trail. She spots them too, measures herself up against them, then flees, scrambling into the trees in a move that completely surprises the cats. This round goes to the gray fox.",
-			"s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarasses them deeply the gray vixen slips past them and flees further into the forest.",
-			null,
-			"The patrol finds a stocky gray vixen wandering their forest, and drives her out in a scene that mostly involves yowling and screaming and yapping at each other until she gives in. r_c gets a little battered, but everyone is mostly fine.",
-			null,
-			"s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is all muscle, barging past s_c and knocking them ass over paws as she flees from the patrol."
-		],
-		"win_skills": [
-			"excellent fighter"
-		],
-		"win_trait": [
-			"adventurous",
-			"altruistic",
-			"ambitious",
-			"bloodthirsty",
-			"bold",
-			"confident",
-			"daring",
-			"fierce",
-			"responsible",
-			"righteous",
-			"troublesome",
-			"vengeful"
-		],
-		"fail_skills": [
-			"good fighter"
-		],
-		"fail_trait": [
-			"None"
-		],
-		"min_cats": 4,
-		"max_cats": 6,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			"r_c carries a scar from a fox fight."
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_grayvixen3",
-		"biome": "forest",
-		"season": "newleaf",
-		"tags": [
-			"fighting",
-			"scar",
-			"big_bite_injury",
-			"respect",
-			"trust",
-			"clan_to_patrol"
-		],
-		"intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
-		"decline_text": "Your patrol decides not to pursue the fox.",
-		"chance_of_success": 50,
-		"exp": 50,
-		"success_text": [
-			"The stocky gray vixen they track down smells of milk, and though she's near double r_c's weight and all of it muscle, they meet her eyes squarely, and leap to attack. c_n does not tolerate sharing their territory with foxes.",
-			null,
-			"s_c displays incredible skill, driving the mother vixen and her brood out of the forest all by themselves. Now neither the gray fox nor her dependent cubs pose a threat to the Clan. They swell with pride, returning to camp knowing there's one less competitor poaching c_n's prey.",
-			"They're nearly of equal height, with s_c's bold aggression making up for the weight that the gray vixen has on them, and the stand off is resolved when s_c charges the gray fox and she chooses flight over fight."
-		],
-		"fail_text": [
-			"r_c comes across a gray vixen at the end of the scent trail. She spots them too, measures herself up against them, then flees, scrambling into the trees in a move that completely surprises r_c. This round goes to the gray fox.",
-			"s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarasses them deeply the gray vixen slips past them and flees further into the forest.",
-			null,
-			"r_c nearly managed to pin the gray vixen they found into a thorn ticket, but snapping jaws leave r_c dripping blood onto the leaf litter. Today this round goes to the gray fox.",
-			null,
-			"s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is cunning, sinking her teeth into s_c to distract them as she flees."
-		],
-		"win_skills": [
-			"excellent fighter"
-		],
-		"win_trait": [
-			"adventurous",
-			"altruistic",
-			"ambitious",
-			"bloodthirsty",
-			"bold",
-			"confident",
-			"daring",
-			"fierce",
-			"responsible",
-			"righteous",
-			"troublesome",
-			"vengeful"
-		],
-		"fail_skills": [
-			"good fighter"
-		],
-		"fail_trait": [
-			"None"
-		],
-		"min_cats": 1,
-		"max_cats": 1,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			"r_c carries a scar from a solo fight with a vixen.",
-			null
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_grayvixen4",
-		"biome": "forest",
-		"season": "greenleaf",
-		"tags": [
-			"fighting",
-			"minor_injury",
-			"respect",
-			"trust",
-			"rel_patrol",
-			"patrol_to_r_c"
-		],
-		"intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
-		"decline_text": "Your patrol decides not to pursue the fox.",
-		"chance_of_success": 60,
-		"exp": 30,
-		"success_text": [
-			"The stocky gray vixen they track down smells of milk, and though she's nearly double the weight of any of the patrol and all of it muscle, they meet her eyes squarely, and leap to attack. c_n does not tolerate sharing their territory with foxes, and they work together to drive her off.",
-			"Your patrol drives away the gray fox, seeks out her den, and kills her young cubs. It's brutal, but these fluffy small foxes would one day have grown to be kit-killers and thieves. Better to deal with them now than when they're the height and nearly double the weight of a cat, though a gray fox will always be easier than a bigger red one.",
-			"s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the gray fox nor her cubs pose a threat to the Clan. It places s_c as one of c_n's most talented and skillful fighters, a gray fox is a dangerous competitor.",
-			"The patrol overcomes the gray vixen they find and drives her off thanks to a brilliant battle move by s_c. The cats swirl around s_c afterwards, congratulating them on their bravery and skill."
-		],
-		"fail_text": [
-			"The patrol comes across a gray vixen at the end of the scent trail. She spots them too, measures herself up against them, then flees, scrambling into the trees in a move that completely surprises the cats. This round goes to the gray fox.",
-			"s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarasses them deeply the gray vixen slips past them and flees further into the forest.",
-			null,
-			"The patrol finds a stocky gray vixen wandering their forest, and drives her out in a scene that mostly involves yowling and screaming and yapping at each other until she gives in. r_c gets a little battered, but everyone is mostly fine.",
-			null,
-			"s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is all muscle, barging past s_c and knocking them ass over paws as she flees from the patrol."
-		],
-		"win_skills": [
-			"excellent fighter"
-		],
-		"win_trait": [
-			"adventurous",
-			"altruistic",
-			"ambitious",
-			"bloodthirsty",
-			"bold",
-			"confident",
-			"daring",
-			"fierce",
-			"responsible",
-			"righteous",
-			"troublesome",
-			"vengeful"
-		],
-		"fail_skills": [
-			"good fighter"
-		],
-		"fail_trait": [
-			"None"
-		],
-		"min_cats": 2,
-		"max_cats": 3,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			"r_c carries a scar from a fox fight.",
-			null
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_grayvixen5",
-		"biome": "forest",
-		"season": "greenleaf",
-		"tags": [
-			"fighting",
-			"minor_injury",
-			"respect",
-			"trust",
-			"rel_patrol",
-			"patrol_to_r_c"
-		],
-		"intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
-		"decline_text": "Your patrol decides not to pursue the fox.",
-		"chance_of_success": 90,
-		"exp": 30,
-		"success_text": [
-			"Led by p_l, and with a heap of cooperation and teamwork, the patrol drives away the gray fox, seeks out her den, and kills her growing cubs. The forest will be safe from both the competition the vixen posed this season, and the threat her cubs would've given c_n in the seasons to come.",
-			"With so many cats working together in tight coordination, they're able to keep the gray vixen they find pinned and distracted as they wear her down. The fox eventually flees for her den, and the patrol follows to take care of the cubs she's raising.",
-			"s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the gray fox nor her cubs pose a threat to the Clan. It places s_c as one of c_n's most talented and skillful fighters, a gray fox is a dangerous competitor.",
-			"Bravely, s_c charges the gray fox, yowling threats. The vixen spooks and skitters up a tree, growling and barking in a squeaky tone, and s_c follows her up into the branches. As the rest of the patrol backs them up from the ground, s_c screams until the fox is cowering and afraid, then lets her flee."
-		],
-		"fail_text": [
-			"The patrol comes across a gray vixen at the end of the scent trail. She spots them too, measures herself up against them, then flees, scrambling into the trees in a move that completely surprises the cats. This round goes to the gray fox.",
-			"s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarasses them deeply the gray vixen slips past them and flees further into the forest.",
-			null,
-			"The patrol finds a stocky gray vixen wandering their forest, and drives her out in a scene that mostly involves yowling and screaming and yapping at each other until she gives in. r_c gets a little battered, but everyone is mostly fine.",
-			null,
-			"s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is all muscle, barging past s_c and knocking them ass over paws as she flees from the patrol."
-		],
-		"win_skills": [
-			"excellent fighter"
-		],
-		"win_trait": [
-			"adventurous",
-			"altruistic",
-			"ambitious",
-			"bloodthirsty",
-			"bold",
-			"confident",
-			"daring",
-			"fierce",
-			"responsible",
-			"righteous",
-			"troublesome",
-			"vengeful"
-		],
-		"fail_skills": [
-			"good fighter"
-		],
-		"fail_trait": [
-			"None"
-		],
-		"min_cats": 4,
-		"max_cats": 6,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			"r_c carries a scar from a fox fight."
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_grayvixen6",
-		"biome": "forest",
-		"season": "greenleaf",
-		"tags": [
-			"fighting",
-			"scar",
-			"big_bite_injury",
-			"respect",
-			"trust",
-			"clan_to_patrol"
-		],
-		"intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
-		"decline_text": "Your patrol decides not to pursue the fox.",
-		"chance_of_success": 50,
-		"exp": 50,
-		"success_text": [
-			"r_c finds a gray vixen smelling of milk and blood. Hopefully by driving her out of the territory, the litter she has been raising this greenleaf won't be a threat to the Clan.",
-			null,
-			"s_c displays incredible skill, driving the mother vixen and her brood out of the forest all by themselves. Now neither the gray fox nor her dependent cubs pose a threat to the Clan. They swell with pride, returning to camp knowing there's one less competitor poaching c_n's prey.",
-			"They're nearly of equal height, with s_c's bold aggression making up for the weight that the gray vixen has on them, and the stand off is resolved when s_c charges the gray fox and she chooses flight over fight."
-		],
-		"fail_text": [
-			"r_c comes across a gray vixen at the end of the scent trail. She spots them too, measures herself up against them, then flees, scrambling into the trees in a move that completely surprises r_c. This round goes to the gray fox.",
-			"s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarasses them deeply the gray vixen slips past them and flees further into the forest.",
-			null,
-			"r_c nearly managed to pin the gray vixen they found into a thorn ticket, but snapping jaws leave r_c dripping blood onto the leaf litter. Today this round goes to the gray fox.",
-			null,
-			"s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is cunning, sinking her teeth into s_c to distract them as she flees."
-		],
-		"win_skills": [
-			"excellent fighter"
-		],
-		"win_trait": [
-			"adventurous",
-			"altruistic",
-			"ambitious",
-			"bloodthirsty",
-			"bold",
-			"confident",
-			"daring",
-			"fierce",
-			"responsible",
-			"righteous",
-			"troublesome",
-			"vengeful"
-		],
-		"fail_skills": [
-			"good fighter"
-		],
-		"fail_trait": [
-			"None"
-		],
-		"min_cats": 1,
-		"max_cats": 1,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			"r_c carries a scar from a solo fight with a vixen."
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_grayvixen7",
-		"biome": "forest",
-		"season": "leaf-fall",
-		"tags": [
-			"fighting",
-			"minor_injury",
-			"respect",
-			"trust",
-			"rel_patrol",
-			"patrol_to_r_c"
-		],
-		"intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
-		"decline_text": "Your patrol decides not to pursue the fox.",
-		"chance_of_success": 60,
-		"exp": 30,
-		"success_text": [
-			"The gray vixen smells like the prey she's been poaching to feed her litter. She's stolen from c_n for the last time, and the patrol drives her from their territory, yowling their anger and fury.",
-			"Your patrol drives away the gray fox, and seeks out her den, but her leaf-fall cubs are near full-grown and scatter into the wilderness. Hopefully leaf-bare takes care of them, but if c_n spots them, they won't hesitate.",
-			"s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the gray fox nor her scattered cubs pose a threat to the Clan. It places s_c as one of c_n's most talented and skillful fighters, a gray fox is a dangerous competitor.",
-			"The patrol overcomes the gray vixen they find and drives her off thanks to a brilliant battle move by s_c. The cats swirl around s_c afterwards, congratulating them on their bravery and skill."
-		],
-		"fail_text": [
-			"The patrol comes across a gray vixen at the end of the scent trail. She spots them too, measures herself up against them, then flees, scrambling into the trees in a move that completely surprises the cats. This round goes to the gray fox.",
-			"s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarasses them deeply the gray vixen slips past them and flees further into the forest.",
-			null,
-			"The patrol finds a stocky gray vixen wandering their forest, and drives her out in a scene that mostly involves yowling and screaming and yapping at each other until she gives in. r_c gets a little battered, but everyone is mostly fine.",
-			null,
-			"s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is all muscle, barging past s_c and knocking them ass over paws as she flees from the patrol."
-		],
-		"win_skills": [
-			"excellent fighter"
-		],
-		"win_trait": [
-			"adventurous",
-			"altruistic",
-			"ambitious",
-			"bloodthirsty",
-			"bold",
-			"confident",
-			"daring",
-			"fierce",
-			"responsible",
-			"righteous",
-			"troublesome",
-			"vengeful"
-		],
-		"fail_skills": [
-			"good fighter"
-		],
-		"fail_trait": [
-			"None"
-		],
-		"min_cats": 2,
-		"max_cats": 3,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			"r_c carries a scar from a fox fight.",
-			null
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_grayvixen8",
-		"biome": "forest",
-		"season": "leaf-fall",
-		"tags": [
-			"fighting",
-			"minor_injury",
-			"respect",
-			"trust",
-			"rel_patrol",
-			"patrol_to_r_c"
-		],
-		"intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
-		"decline_text": "Your patrol decides not to pursue the fox.",
-		"chance_of_success": 90,
-		"exp": 30,
-		"success_text": [
-			"Led by p_l and with a heap of cooperation and teamwork, the patrol drives away the gray fox, and seeks out her den. But her cubs are near full-grown with the bounty of leaf-fall, and scatter from the patrol into the wilderness. Hopefully leaf-bare takes care of them.",
-			"With so many cats working together in tight coordination, they're able to keep the gray vixen they find pinned and distracted as they wear her down. The fox eventually flees for her den, and the patrol follows to drive her near-full grown litter of fox cubs out from the territory. Hopefully the coming leaf-bare will take care of them.",
-			"s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the gray fox nor her scattered cubs pose a threat to the Clan. It places s_c as one of c_n's most talented and skillful fighters, a gray fox is a dangerous competitor.",
-			"Bravely, s_c charges the gray fox, yowling threats. The vixen spooks and skitters up a tree, growling and barking in a squeaky tone, and s_c follows her up into the branches. As the rest of the patrol backs them up from the ground, s_c screams until the fox is cowering and afraid, then lets her flee."
-		],
-		"fail_text": [
-			"The patrol comes across a gray vixen at the end of the scent trail. She spots them too, measures herself up against them, then flees, scrambling into the trees in a move that completely surprises the cats. This round goes to the gray fox.",
-			"s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarasses them deeply the gray vixen slips past them and flees further into the forest.",
-			null,
-			"The patrol finds a stocky gray vixen wandering their forest, and drives her out in a scene that mostly involves yowling and screaming and yapping at each other until she gives in. r_c gets a little battered, but everyone is mostly fine.",
-			null,
-			"s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is all muscle, barging past s_c and knocking them ass over paws as she flees from the patrol."
-		],
-		"win_skills": [
-			"excellent fighter"
-		],
-		"win_trait": [
-			"adventurous",
-			"altruistic",
-			"ambitious",
-			"bloodthirsty",
-			"bold",
-			"confident",
-			"daring",
-			"fierce",
-			"responsible",
-			"righteous",
-			"troublesome",
-			"vengeful"
-		],
-		"fail_skills": [
-			"good fighter"
-		],
-		"fail_trait": [
-			"None"
-		],
-		"min_cats": 4,
-		"max_cats": 6,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			"r_c carries a scar from a red fox fight."
-		]
-	},
-	{
-		"patrol_id": "fst_hunt_grayvixen9",
-		"biome": "forest",
-		"season": "leaf-fall",
-		"tags": [
-			"fighting",
-			"scar",
-			"big_bite_injury",
-			"respect",
-			"trust",
-			"clan_to_patrol"
-		],
-		"intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
-		"decline_text": "Your patrol decides not to pursue the fox.",
-		"chance_of_success": 50,
-		"exp": 50,
-		"success_text": [
-			"In an exhausting fight, r_c manages to bring down and kill the gray vixen they've tracked. Her near grown litter, fat on the bounty of leaf-fall, is a challenge for another day. c_n will have to deal with the young foxes now roaming motherless in their woods, before they start to compete for prey in leaf-bare.",
-			null,
-			"s_c displays incredible skill, driving the mother vixen and her brood out of the forest all by themselves. Now neither the gray fox nor her cubs pose a threat to the Clan. They swell with pride, returning to camp knowing there's one less competitor poaching c_n's prey.",
-			"They're nearly of equal height, with s_c's bold aggression making up for the weight that the gray vixen has on them, and the stand off is resolved when s_c charges the gray fox and she chooses flight over fight."
-		],
-		"fail_text": [
-			"r_c comes across a gray vixen at the end of the scent trail. She spots them too, measures herself up against them, then flees, scrambling into the trees in a move that completely surprises r_c. This round goes to the gray fox.",
-			"s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarasses them deeply the gray vixen slips past them and flees further into the forest.",
-			null,
-			"r_c nearly managed to pin the gray vixen they found into a thorn ticket, but snapping jaws leave r_c dripping blood onto the leaf litter. Today this round goes to the gray fox.",
-			null,
-			"s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is cunning, sinking her teeth into s_c to distract them as she flees."
-		],
-		"win_skills": [
-			"excellent fighter"
-		],
-		"win_trait": [
-			"adventurous",
-			"altruistic",
-			"ambitious",
-			"bloodthirsty",
-			"bold",
-			"confident",
-			"daring",
-			"fierce",
-			"responsible",
-			"righteous",
-			"troublesome",
-			"vengeful"
-		],
-		"fail_skills": [
-			"good fighter"
-		],
-		"fail_trait": [
-			"None"
-		],
-		"min_cats": 1,
-		"max_cats": 1,
-		"antagonize_text": null,
-		"antagonize_fail_text": null,
-		"history_text": [
-			"r_c carries a scar from a solo fight with a gray vixen."
-		]
-	},
-	{
+    {
+        "patrol_id": "fst_hunt_vole1",
+        "biome": "forest",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "medium_prey"
+        ],
+        "intro_text": "Your patrol comes across a vole nibbling at a seed.",
+        "success_text": [
+            "r_c drops into a crouch and lightly stalks towards the vole. They pause, waggling their haunches before pouncing. They catch the vole easily and deliver a killing bite to the back of its head.",
+            "r_c drops into a crouch and begins stalking forward. When they get close, the vole suddenly stops chewing and r_c takes the opportunity to pounce. They kill the prey quickly and lick the blood from their lips with satisfaction.",
+            "s_c drops into a crouch and has to consciously stop their tail from swaying in excitement as they stalk the prey. Once they think they're close enough, they give their haunches a little wiggle and leap. They catch the vole squarely between their paws and kill it quickly."
+        ],
+        "fail_text": [
+            "r_c drops into a crouch and begins to stalk forward. They're preparing to pounce when their paw lightly brushes a twig and the vole immediately takes off. They give chase, but the critter disappears into a burrow. Mousedung!"
+        ],
+        "decline_text": "Your patrol decides to look for other prey.",
+        "chance_of_success": 50,
+        "exp": 10,
+        "win_skills": [
+            "great hunter",
+            "fantastic hunter"
+        ],
+        "min_cats": 1,
+        "max_cats": 3,
+        "antagonize_text": null,
+        "antagonize_fail_text": null
+    },
+    {
+        "patrol_id": "fst_hunt_porcupine1",
+        "biome": "forest",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "injury",
+            "quilled by a porcupine",
+            "scar",
+            "death",
+            "huge_prey2"
+        ],
+        "intro_text": "r_c encounters a porcupine, bristling with quills.",
+        "decline_text": "The patrol steers clear of the porcupine.",
+        "chance_of_success": 40,
+        "exp": 10,
+        "success_text": [
+            "The patrol examines the porcupine, eventually deciding that they shouldn't risk the potential injury it could cause.",
+            "The porcupine rattles its quills viciously, the patrol heeds its warning and gives it space.",
+            "s_c sets up an ambush, devising a clever plan to take the porcupine by surprise and attack it before it can whip its quills into anyone's pelt.  The Clan will be impressed by this hefty fresh-kill.",
+            "s_c has the ingenious idea to follow the porcupine from a distance and collect dropped quills to bring back to camp. The quills could be woven into the Clan's defenses to strengthen them."
+        ],
+        "fail_text": [
+            "r_c leaps back just as the porcupine whips its tail towards them! That was close! The patrol gives the porcupine a wide berth.",
+            "s_c gets closer to the porcupine, intending to impress the rest of the patrol with their bravery. All the cats recoil as a horrible smell comes from the porcupine and they back off before it can charge at them.  The patrol returns to camp, the smelly evidence of their encounter still clinging to s_c's pelt.",
+            "r_c doesn't react quickly enough to the porcupine's warning. It charges sideways at them, its quills ready to impale! r_c is badly injured and dies a few days later from the wounds.",
+            "The porcupine whips around, digging the quills of its tail into r_c! The patrol bolts away and returns to camp, r_c with a nose full of quills."
+        ],
+        "win_skills": [
+            "great hunter",
+            "fantastic hunter",
+            "very smart",
+            "extremely smart"
+        ],
+        "win_trait": [
+            "calm",
+            "careful",
+            "strange",
+            "thoughtful",
+            "wise"
+        ],
+        "fail_trait": [
+            "bold",
+            "daring",
+            "confident",
+            "adventurous"
+        ],
+        "min_cats": 3,
+        "max_cats": 6,
+        "history_text": [
+            "r_c was scarred by a porcupine while on patrol.",
+            "r_c was killed by an angry porcupine while on patrol.",
+            "killed by a porcupine"
+        ],
+        "antagonize_text": null,
+        "antagonize_fail_text": null
+    },
+    {
+        "patrol_id": "fst_hunt_porcupine2",
+        "biome": "forest",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "injury",
+            "quilled by a porcupine",
+            "scar",
+            "death",
+            "huge_prey2",
+            "huge_prey3"
+        ],
+        "intro_text": "r_c encounters a porcupine, bristling with quills.",
+        "decline_text": "The patrol steers clear of the porcupine, they don't have enough cats to confront this creature safely.",
+        "chance_of_success": 10,
+        "exp": 30,
+        "success_text": [
+            "The patrol examines the porcupine, eventually deciding that they shouldn't risk the potential injury it could cause.",
+            "The porcupine rattles its quills viciously, the patrol heeds its warning and gives it space.",
+            "s_c sets up an ambush, devising a clever plan to take the porcupine by surprise and attack it before it can whip its quills into anyone's pelt.  The Clan will be impressed by this hefty fresh-kill.",
+            "s_c has the ingenious idea to follow the porcupine from a distance and collect dropped quills to bring back to camp.  The quills could be woven into the Clan's defenses to strengthen them."
+        ],
+        "fail_text": [
+            "r_c leaps back just as the porcupine whips its tail towards them! That was close! They decide to give the porcupine a wide berth.",
+            null,
+            "r_c doesn't react quickly enough to the porcupine's warning. It charges sideways at them, its quills ready to impale! r_c is badly injured and dies a few days later from the wounds.",
+            "The porcupine whips around, digging the quills of its tail into r_c! r_c returns to camp with a nose full of quills and a wounded pride."
+        ],
+        "win_skills": [
+            "fantastic hunter",
+            "extremely smart"
+        ],
+        "win_trait": [
+            "calm",
+            "careful",
+            "strange",
+            "thoughtful",
+            "wise"
+        ],
+        "min_cats": 1,
+        "max_cats": 2,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c was scarred by a porcupine while on patrol.",
+            "r_c was killed by an angry porcupine while on patrol.",
+            "killed by a porcupine"
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_rabbit1",
+        "biome": "forest",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "large_prey",
+            "no_fail_prey"
+        ],
+        "intro_text": "While hunting, r_c comes across a rabbit burrow.",
+        "success_text": [
+            "r_c catches the rabbit hiding in its burrow."
+        ],
+        "fail_text": [
+            "The burrow is abandoned, with no prey to be found in there."
+        ],
+        "decline_text": "r_c decides to ignore the burrow.",
+        "chance_of_success": 50,
+        "exp": 10,
+        "win_skills": [
+            "great hunter",
+            "fantastic hunter"
+        ],
+        "min_cats": 1,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null
+    },
+    {
+        "patrol_id": "fst_hunt_twolegplace1",
+        "biome": "forest",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "medium_prey0",
+            "large_prey1"
+        ],
+        "intro_text": "The patrol approaches a Twoleg nest in the woods while hunting.",
+        "decline_text": "The patrol decides to hunt elsewhere.",
+        "chance_of_success": 40,
+        "exp": 10,
+        "success_text": [
+            "The patrol has a successful hunt, avoiding any Twolegs.",
+            "The patrol finds some astonishingly fat chickens running around the Twoleg nest, and helps themselves to one."
+        ],
+        "fail_text": [
+            "Twoleg kits scare the patrol away."
+        ],
+        "min_cats": 1,
+        "max_cats": 3,
+        "antagonize_text": "A Twoleg kit approaches the patrol, and they send it away squawking with it's blood on their claws.",
+        "antagonize_fail_text": "The Twoleg kits wandering around are unimpressed by the patrol and chase the cats for fun."
+    },
+    {
+        "patrol_id": "fst_hunt_twolegplace2",
+        "biome": "forest",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "medium_prey0",
+            "large_prey1"
+        ],
+        "intro_text": "The patrol approaches a Twoleg nest in the woods while hunting.",
+        "decline_text": "The patrol decides to hunt elsewhere.",
+        "chance_of_success": 60,
+        "exp": 10,
+        "success_text": [
+            "The patrol cats split up, using sentries to ensure that the Twolegs don't disturb their hunts.",
+            "The patrol finds some astonishingly fat chickens running around the Twoleg nest, and helps themselves to as many as they can carry."
+        ],
+        "fail_text": [
+            "Twoleg kits stomp through the woods, scaring away prey and ruining the hunt."
+        ],
+        "min_cats": 4,
+        "max_cats": 6,
+        "antagonize_text": "Finding a Twoleg kit wandering alone, the cats harass it until it flees squawking, it's blood on their claws.",
+        "antagonize_fail_text": "The Twoleg kits wandering around are unimpressed by the patrol and chase the cats for fun."
+    },
+    {
+        "patrol_id": "fst_hunt_squirrel1",
+        "biome": "forest",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "injury",
+            "sprain",
+            "scar",
+            "medium_prey0",
+            "medium_prey1",
+            "large_prey2"
+        ],
+        "intro_text": "The patrol notices a commotion and finds two squirrels chasing each other across the forest floor.",
+        "decline_text": "The patrol decides there's probably easier prey to find elsewhere.",
+        "chance_of_success": 50,
+        "exp": 10,
+        "success_text": [
+            "The squirrels are so distracted that the patrol is able to quickly catch them both.",
+            "The patrol springs onto the squirrels without a second thought, easily dispatching them.",
+            "s_c is quick on the jump! Though the squirrels notice the cats and begin scampering away, s_c easily cuts them off and kills both squirrels."
+        ],
+        "fail_text": [
+            "The squirrels are far too excited and quick - they slip right out from between the patrol's claws.",
+            "s_c runs at the squirrels before anyone else can pounce, laughing at the prey's antics and playfully jumping into the middle of their game.  The squirrels scatter away at the disturbance and disappear into the canopy.",
+            null,
+            "r_c tries to climb up after them but slips and falls, twisting their paw."
+        ],
+        "win_skills": [
+            "good hunter",
+            "great hunter",
+            "fantastic hunter"
+        ],
+        "fail_trait": [
+            "troublesome",
+            "childish",
+            "playful"
+        ],
+        "min_cats": 1,
+        "max_cats": 6,
+        "history_text": [
+            "r_c gained a scar after trying to chase some squirrels up a tree."
+        ],
+        "antagonize_text": null,
+        "antagonize_fail_text": null
+    },
+    {
+        "patrol_id": "fst_hunt_burrow1",
+        "biome": "forest",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "big_bite_injury",
+            "scar",
+            "fighting",
+            "medium_prey"
+        ],
+        "intro_text": "The patrol finds a small burrow in the ground with a strange scent. They hesitate, unsure if this is worth checking.",
+        "decline_text": "The patrol decides to avoid the burrow. There's no telling what could await inside.",
+        "chance_of_success": 60,
+        "exp": 10,
+        "success_text": [
+            "The patrol flushes a gopher out of the burrow! More fresh-kill!",
+            "Inside the burrow is a rabbit, curled up and alone. Perhaps a buck recently kicked from his birth warren? Whatever the case, this rabbit will feed the Clan now."
+        ],
+        "fail_text": [
+            "The burrow turns out to be empty, the smell nothing but stale air and a slight tang of sickness. Whatever used to live here is gone now.  Checking the burrow was a waste of time.",
+            "s_c sticks their nose into the hole only to come face to face with a skunk! The whole patrol is sprayed!",
+            null,
+            "Oh no! The burrow was home to a wolverine, now angry at the disturbance. The patrol bolts away to escape its wrath, but r_c doesn't quite move fast enough and is caught in its claws until another cat turns back to help."
+        ],
+        "fail_trait": [
+            "bold",
+            "ambitious",
+            "childish",
+            "impulsive"
+        ],
+        "min_cats": 2,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c was scarred after an unfortunate encounter with a wolverine."
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_burrow2",
+        "biome": "forest",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "death",
+            "fighting",
+            "medium_prey"
+        ],
+        "intro_text": "The patrol finds a small burrow in the ground with a strange scent. They hesitate, unsure if this is worth checking.",
+        "decline_text": "The patrol decides to avoid the burrow. There's no telling what could await inside.",
+        "chance_of_success": 40,
+        "exp": 10,
+        "success_text": [
+            "r_c flushes a gopher out of the burrow! More fresh-kill!",
+            "Inside the burrow is a rabbit, curled up and alone. Perhaps a buck recently kicked from his birth warren? Whatever the case, this rabbit will feed the Clan now."
+        ],
+        "fail_text": [
+            "The burrow turns out to be empty, the smell nothing but stale air and a slight tang of sickness. Whatever used to live here is gone now.  Checking the burrow was a waste of time.",
+            "s_c sticks their nose into the hole only to come face to face with a skunk! The whole patrol is sprayed!",
+            "Oh no! The burrow was home to a wolverine, now angry at the disturbance. r_c bolts away to escape its wrath, but doesn't quite move fast enough and is caught in its claws.  With no other cats around to help, r_c is quickly killed by the predator."
+        ],
+        "fail_trait": [
+            "bold",
+            "ambitious",
+            "childish",
+            "impulsive"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            null,
+            "r_c was killed after an unfortunate experience with a wolverine.",
+            "killed by a wolverine"
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_howl1",
+        "biome": "forest",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "scar",
+            "big_bite_injury",
+            "fighting",
+            "death",
+            "no_leader",
+            "medium_prey1",
+            "large_prey2",
+            "large_prey3"
+        ],
+        "intro_text": "The patrol hears distant howling and wonders whether to investigate the noise.",
+        "decline_text": "The patrol decides not to investigate the source of the noise.  Whatever is making it will not be friendly to them.",
+        "chance_of_success": 50,
+        "exp": 30,
+        "success_text": [
+            "The patrol tracks the noise and discovers a coyote scavenging off a carcass. This is a predator they cannot fight, the patrol decides to return to camp and report the intruder to the leader. Perhaps they can return later to take what the coyote leaves behind.",
+            "The patrol tracks the noise and finds a mostly stripped carcass covered in the scent of coyote. They quickly scavenge what little is left and leave before the predator can return.",
+            "The patrol follows the noise to a coyote who quickly spots them in the brush. A fight ensues and thanks to the skills of s_c, the coyote eventually runs away, deeming the carcass they had been scavenging from to not be worth the hassle.  Your patrol brings back what meat had still been left.",
+            "The noise leads them to a coyote, scavenging from a carcass. s_c instructs them to wait in the brush, downwind from the canine, until it leaves. Eventually the coyote eats its fill and disappears into the forest. When s_c deems it safe, the patrol takes their turn stripping the leftover meat from the bones."
+        ],
+        "fail_text": [
+            "The noise leads them to a coyote that's busy stripping the last of the meat from a carcass. The patrol waits till the coyote leaves, hoping to pick up any leftovers, but unfortunately the bones have been thoroughly cleaned.",
+            "They track the noise to a coyote. Before the patrol can investigate further, s_c whimpers in terror at the sight of the beast and dashes away.  The patrol follows anxiously, not wanting to lose sight of their Clanmate while a coyote is about.",
+            "The patrol finds a coyote at the source of the noise. It seems to be scavenging from an old carcass and upon seeing the cats, proves to be fiercely protective of its meal.  The patrol doesn't move fast enough and r_c is killed before they can run.",
+            "The sound leads them to a coyote, scavenging from a carcass. The coyote notices them before they can hide and lunges, making it clear that this food has been claimed.  r_c is momentarily caught in its jaws before the patrol retaliates and drives it off their Clanmate."
+        ],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "careful",
+            "calm",
+            "patient",
+            "responsible",
+            "sneaky",
+            "thoughtful",
+            "wise"
+        ],
+        "fail_trait": [
+            "nervous",
+            "insecure"
+        ],
+        "min_cats": 4,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c was scarred by a coyote protecting its scavenged meal.",
+            "r_c was killed by a coyote protecting its scavenged meal.",
+            "killed by a coyote"
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_howl2",
+        "biome": "forest",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "scar",
+            "big_bite_injury",
+            "fighting",
+            "death",
+            "no_leader",
+            "medium_prey1",
+            "large_prey2",
+            "large_prey3"
+        ],
+        "intro_text": "The patrol hears distant howling and wonders whether to investigate the noise.",
+        "decline_text": "The patrol decides not to investigate the source of the noise. Whatever is making it will not be friendly to them.",
+        "chance_of_success": 30,
+        "exp": 30,
+        "success_text": [
+            "The patrol tracks the noise and discovers a coyote scavenging off a carcass. This is a predator they cannot fight, the patrol decides to return to camp and report the intruder to the leader. Perhaps they can return later to take what the coyote leaves behind.",
+            "The patrol tracks the noise and finds a mostly stripped carcass covered in the scent of coyote. They quickly scavenge what little is left and leave before the predator can return.",
+            "The noise leads them to a coyote, scavenging from a carcass. s_c instructs them to wait in the brush, downwind from the canine, until it leaves. Eventually the coyote eats its fill and disappears into the forest. When s_c deems it safe, the patrol takes their turn stripping the leftover meat from the bones.",
+            "The noise leads them to a coyote, scavenging from a carcass. s_c instructs them to wait in the brush, downwind from the canine, until it leaves. Eventually the coyote eats its fill and disappears into the forest. When s_c deems it safe, the patrol takes their turn stripping the leftover meat from the bones."
+        ],
+        "fail_text": [
+            "The noise leads them to a coyote that's busy stripping the last of the meat from a carcass. The patrol waits till the coyote leaves, hoping to pick up any leftovers, but unfortunately the bones have been thoroughly cleaned.",
+            "They track the noise to a coyote. Before the patrol can investigate further, s_c whimpers in terror at the sight of the beast and dashes away.  The patrol follows anxiously, not wanting to lose sight of their Clanmate while a coyote is about.",
+            "The patrol finds a coyote at the source of the noise. It seems to be scavenging from an old carcass and upon seeing the cats, proves to be fiercely protective of its meal.  The patrol doesn't move fast enough and r_c is killed before they can run.",
+            "The sound leads them to a coyote, scavenging from a carcass. The coyote notices them before they can hide and lunges, making it clear that this food has been claimed.  r_c is momentarily caught in its jaws before the patrol retaliates and drives it off their Clanmate."
+        ],
+        "win_skills": [
+            "very smart",
+            "extremely smart"
+        ],
+        "win_trait": [
+            "careful",
+            "calm",
+            "patient",
+            "responsible",
+            "sneaky",
+            "thoughtful",
+            "wise"
+        ],
+        "fail_trait": [
+            "nervous",
+            "insecure"
+        ],
+        "min_cats": 2,
+        "max_cats": 4,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c was scarred by a coyote protecting its scavenged meal.",
+            "r_c was killed by a coyote protecting its scavenged meal.",
+            "killed by a coyote"
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_howl3",
+        "biome": "forest",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "fighting",
+            "death",
+            "no_leader",
+            "medium_prey1",
+            "large_prey2",
+            "large_prey3"
+        ],
+        "intro_text": "r_c hears distant howling and wonders whether to investigate the noise.",
+        "decline_text": "r_c decides not to investigate the source of the noise. Whatever is making it will not be friendly to them and they are only one cat.",
+        "chance_of_success": 10,
+        "exp": 30,
+        "success_text": [
+            "r_c tracks the noise and discovers a coyote scavenging off a carcass. This is a predator they cannot fight, they decide to return to camp and report the intruder to the leader, perhaps a patrol can return later to take what the coyote leaves behind.",
+            "r_c tracks the noise and finds a mostly stripped carcass covered in the scent of coyote. They quickly scavenge what little is left and leave before the predator can return.",
+            "The noise leads them to a coyote, scavenging from a carcass. s_c decides to wait in the brush, downwind from the canine, until it leaves. Eventually the coyote eats its fill and disappears into the forest. s_c waits a while longer, ensuring the coyote has truly left, and takes their turn stripping the leftover meat from the bones.",
+            "The noise leads them to a coyote, scavenging from a carcass. s_c decides to wait in the brush, downwind from the canine, until it leaves. Eventually the coyote eats its fill and disappears into the forest. s_c waits a while longer, ensuring the coyote has truly left, and takes their turn stripping the leftover meat from the bones."
+        ],
+        "fail_text": [
+            "The noise leads them to a coyote that's busy stripping the last of the meat from a carcass. They wait till the coyote leaves, hoping to pick up any leftovers, but unfortunately the bones have been thoroughly cleaned.",
+            "They track the noise to a coyote. s_c whimpers in terror at the sight of the beast and dashes away, running straight back to camp...",
+            "r_c finds a coyote at the source of the noise. It seems to be scavenging from an old carcass and upon seeing the cat, proves to be fiercely protective of its meal.  They doesn't move fast enough and with no Clanmates to save them, r_c is quickly killed."
+        ],
+        "win_skills": [
+            "very smart",
+            "extremely smart"
+        ],
+        "win_trait": [
+            "careful",
+            "calm",
+            "patient",
+            "responsible",
+            "sneaky",
+            "thoughtful",
+            "wise"
+        ],
+        "fail_trait": [
+            "nervous",
+            "insecure"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            null,
+            "r_c was killed by a coyote protecting its scavenged meal.",
+            "killed by a coyote"
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_howl4",
+        "biome": "forest",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "scar",
+            "big_bite_injury",
+            "fighting",
+            "death",
+            "no_leader",
+            "medium_prey1",
+            "large_prey2",
+            "large_prey3"
+        ],
+        "intro_text": "The patrol hears distant howling and wonders whether to investigate the noise.",
+        "decline_text": "The patrol decides not to investigate the source of the noise.  Whatever is making it will not be friendly to them.",
+        "chance_of_success": 40,
+        "exp": 30,
+        "success_text": [
+            "The patrol tracks the noise and discovers a wolf eating from its kill. This is a predator they cannot fight and more wolves may be nearby, the patrol decides to return to camp and report the intruder to the leader. Perhaps they can return later to take what fresh-kill is left behind.",
+            "The patrol tracks the noise and finds a mostly stripped carcass covered in the scent of wolves. They quickly scavenge what little is left and leave before the predators can return.",
+            "The noise leads them to a wolf, eating from its kill. s_c instructs them to wait in the brush, downwind from the canine, until it leaves. Eventually the wolf eats its fill and disappears into the forest. When s_c deems it safe, the patrol takes their turn stripping the leftover meat from the bones.",
+            "The noise leads them to a wolf, eating from its kill. s_c instructs them to wait in the brush, downwind from the canine, until it leaves. Eventually the wolf eats its fill and disappears into the forest. When s_c deems it safe, the patrol takes their turn stripping the leftover meat from the bones."
+        ],
+        "fail_text": [
+            "The noise leads them to a wolf that's busy stripping the last of the meat from a carcass. The patrol waits till the wolf leaves, hoping to pick up any leftovers, but unfortunately the bones have been thoroughly cleaned.",
+            "They track the noise to a wolf. Before the patrol can investigate further, s_c whimpers in terror at the sight of the beast and dashes away. The patrol follows anxiously, not wanting to lose sight of their Clanmate while a wolf is about.",
+            "The patrol finds a wolf pack at the source of the noise. The wolves are tearing into a dead deer and upon seeing the cats, proves to be fiercely protective of their meal. The patrol doesn't move fast enough and r_c is killed before they can run.",
+            "The sound leads them to a wolf, scavenging from a carcass. The wolf notices them before they can hide and lunges, making it clear that this food has been claimed. r_c is momentarily caught in its jaws before the patrol retaliates and drives it off their Clanmate."
+        ],
+        "win_skills": [
+            "very smart",
+            "extremely smart"
+        ],
+        "win_trait": [
+            "careful",
+            "calm",
+            "patient",
+            "responsible",
+            "sneaky",
+            "thoughtful",
+            "wise"
+        ],
+        "fail_trait": [
+            "nervous",
+            "insecure"
+        ],
+        "min_cats": 5,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c was scarred by a wolf protecting its scavenged meal.",
+            "r_c was killed by a wolf pack protecting its meal.",
+            "killed by a wolf pack"
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_howl5",
+        "biome": "forest",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "fighting",
+            "death",
+            "no_leader",
+            "medium_prey1",
+            "large_prey2",
+            "large_prey3"
+        ],
+        "intro_text": "The patrol hears distant howling and wonders whether to investigate the noise.",
+        "decline_text": "The patrol decides not to investigate the source of the noise. Whatever is making it will not be friendly to them.",
+        "chance_of_success": 20,
+        "exp": 30,
+        "success_text": [
+            "The patrol tracks the noise and discovers a wolf eating from its kill. This is a predator they cannot fight and more wolves may be nearby, the patrol decides to return to camp and report the intruder to the leader. Perhaps they can return later to take what little fresh-kill is left behind.",
+            "The patrol tracks the noise and finds a mostly stripped carcass covered in the scent of wolves. They quickly scavenge what little is left and leave before the predators can return.",
+            "The noise leads them to a wolf, scavenging from a carcass. s_c instructs them to wait in the brush, downwind from the canine, until it leaves. Eventually the wolf eats its fill and disappears into the forest. When s_c deems it safe, the patrol takes their turn stripping the leftover meat from the bones.",
+            "The noise leads them to a wolf, scavenging from a carcass. s_c instructs them to wait in the brush, downwind from the canine, until it leaves. Eventually the wolf eats its fill and disappears into the forest. When s_c deems it safe, the patrol takes their turn stripping the leftover meat from the bones."
+        ],
+        "fail_text": [
+            "The noise leads them to a wolf that's busy stripping the last of the meat from a carcass. The patrol waits till the wolf leaves, hoping to pick up any leftovers, but unfortunately the bones have been thoroughly cleaned.",
+            "They track the noise to a wolf. Before the patrol can investigate further, s_c whimpers in terror at the sight of the beast and dashes away.  The patrol follows anxiously, not wanting to lose sight of their Clanmate while a wolf is about.",
+            "The patrol finds a wolf pack at the source of the noise. The wolves are busy eating from the carcass of a deer, and upon seeing the cats, prove to be fiercely protective of their meal.  The patrol doesn't move fast enough and r_c is killed before they can run."
+        ],
+        "win_skills": [
+            "very smart",
+            "extremely smart"
+        ],
+        "win_trait": [
+            "careful",
+            "calm",
+            "patient",
+            "responsible",
+            "sneaky",
+            "thoughtful",
+            "wise"
+        ],
+        "fail_trait": [
+            "nervous",
+            "insecure"
+        ],
+        "min_cats": 2,
+        "max_cats": 4,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            null,
+            "r_c was killed by a wolf protecting its meal.",
+            "killed by a wolf"
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_howl6",
+        "biome": "forest",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "fighting",
+            "death",
+            "no_leader",
+            "medium_prey1",
+            "large_prey2",
+            "large_prey3"
+        ],
+        "intro_text": "r_c hears distant howling and wonders whether to investigate the noise.",
+        "decline_text": "r_c decides not to investigate the source of the noise.  Whatever is making it will not be friendly to them and they are only one cat.",
+        "chance_of_success": 10,
+        "exp": 40,
+        "success_text": [
+            "r_c tracks the noise and discovers a wolf eating from its kill. This is a predator they cannot fight, they decide to return to camp and report the intruder to the leader, perhaps a patrol can return later to take what the wolf leaves behind.",
+            "r_c tracks the noise and finds a mostly stripped carcass covered in the scent of wolf. They quickly scavenge what little is left and leave before the predator can return.",
+            "The noise leads them to a wolf, tearing into the carcass of a deer. s_c decides to wait in the brush, downwind from the canine, until it leaves. Eventually the wolf eats its fill and disappears into the forest. s_c waits a while longer, ensuring the wolf has truly left, and takes their turn stripping the leftover meat from the bones.",
+            "The noise leads them to a wolf, tearing into the carcass of a deer. s_c decides to wait in the brush, downwind from the canine, until it leaves. Eventually the wolf eats its fill and disappears into the forest. s_c waits a while longer, ensuring the wolf has truly left, and takes their turn stripping the leftover meat from the bones."
+        ],
+        "fail_text": [
+            "The noise leads them to a wolf that's busy stripping the last of the meat from a carcass. They wait till the wolf leaves, hoping to pick up any leftovers, but unfortunately the bones have been thoroughly cleaned.",
+            "They track the noise to a wolf. s_c whimpers in terror at the sight of the beast and dashes away, running straight back to camp.",
+            "r_c finds a wolf pack at the source of the noise. The pack is tearing into a deer carcass and upon seeing the cat, prove to be fiercely protective of their meal. r_c doesn't move fast enough and with no Clanmates to save them, is quickly killed."
+        ],
+        "win_skills": [
+            "very smart",
+            "extremely smart"
+        ],
+        "win_trait": [
+            "careful",
+            "calm",
+            "patient",
+            "responsible",
+            "sneaky",
+            "thoughtful",
+            "wise"
+        ],
+        "fail_trait": [
+            "nervous",
+            "insecure"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            null,
+            "r_c was killed by a wolf protecting its meal.",
+            "killed by a wolf"
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_strange1",
+        "biome": "forest",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "medium_prey0",
+            "medium_prey1",
+            "large_prey2",
+            "large_prey3",
+            "no_fail_prey"
+        ],
+        "intro_text": "The patrol looks around for something to disguise their scent while hunting.",
+        "decline_text": "On second thought, maybe not.",
+        "chance_of_success": 50,
+        "exp": 20,
+        "success_text": [
+            "They can't think of anything that would work, but their hunt goes well regardless.",
+            "A stinky bush will do! The plan works and their hunt goes well.",
+            "s_c leads them to some deer droppings in the forest - it's not clean, but it's extremely effective, and the patrol hunts well.",
+            "s_c tells the patrol to roll in a patch of garlic to disguise their scent, which works perfectly. It's a funny taste to wash off their pelts though."
+        ],
+        "fail_text": [
+            "The patrol finds nothing to disguise their scent, and no prey either.",
+            "The patrol finds no prey; it seems like all the prey was scared off because of their stench!"
+        ],
+        "win_skills": [
+            "very smart",
+            "extremely smart"
+        ],
+        "win_trait": [
+            "strange"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "min_cats": 2,
+        "max_cats": 6
+    },
+    {
+        "patrol_id": "fst_hunt_strange2",
+        "biome": "forest",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "medium_prey0",
+            "medium_prey1",
+            "large_prey2",
+            "large_prey3",
+            "no_fail_prey"
+        ],
+        "intro_text": "r_c looks around for something to disguise their scent while hunting.",
+        "decline_text": "On second thought, maybe not.",
+        "chance_of_success": 50,
+        "exp": 20,
+        "success_text": [
+            "They can't think of anything that would work, but their hunt goes well regardless.",
+            null,
+            "s_c finds some deer droppings in the forest - it's not clean, but it's extremely effective, and the hunt goes well.",
+            "s_c rolls in a patch of garlic to disguise their scent, which works perfectly. It's a funny taste to wash off their pelt though."
+        ],
+        "fail_text": [
+            "The patrol finds nothing to disguise their scent, and no prey either.",
+            "r_c finds no prey; it seems like all the prey was scared off because of their stench!"
+        ],
+        "win_skills": [
+            "very smart",
+            "extremely smart"
+        ],
+        "win_trait": [
+            "strange"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "min_cats": 1,
+        "max_cats": 1
+    },
+    {
+        "patrol_id": "fst_hunt_solo1",
+        "biome": "forest",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "apprentice",
+            "minor_injury",
+            "scar",
+            "medium_prey0",
+            "large_prey1",
+            "large_prey2",
+            "large_prey3",
+            "no_fail_prey"
+        ],
+        "intro_text": "r_c's mentor assesses them by sending them on a solo hunt.",
+        "decline_text": "r_c asks their mentor to do the assessment some other time.",
+        "chance_of_success": 40,
+        "exp": 20,
+        "success_text": [
+            "r_c manages a skillful catch, and brings it back to the camp to show everyone!",
+            "r_c focuses completely on their test, slipping into a cleareyed, razor focused routine of catch and stash, catch and stash. Eventually they've caught enough to need their mentor's help carrying it back to camp, and the feeling seeing their prey stock the fresh-kill pile - they feel ready to burst with happiness!",
+            null,
+            "It's a terrible day for hunting, the prey running sparse and alert. But s_c takes their time and doesn't let the conditions discourage them, until eventually the perfect opportunity falls into place and they pull off a perfect catch!"
+        ],
+        "fail_text": [
+            "Hunting is poor, and while r_c's mentor is disappointed, they don't expect r_c to be able to catch what isn't there.",
+            "s_c is too hasty, bouncing after first one prey, then another, and it ends with them empty pawed and exhausted. Their mentor is disappointed - they clearly need more training.",
+            null,
+            "While on the hunt, r_c tumbles right down a steep slope while their attention is elsewhere. Bruised and sore, r_c has to report to the medicine cat den when they return to camp."
+        ],
+        "win_skills": [
+            "None"
+        ],
+        "win_trait": [
+            "calm",
+            "careful",
+            "insecure",
+            "lonesome",
+            "loyal",
+            "nervous",
+            "sneaky",
+            "strange",
+            "patient",
+            "thoughtful",
+            "wise"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "adventurous",
+            "bold",
+            "charismatic",
+            "childish",
+            "confident",
+            "daring",
+            "playful",
+            "righteous"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c got injured as an apprentice, exploring alone."
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_solo2",
+        "biome": "forest",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "medium_prey0",
+            "medium_prey1",
+            "large_prey2",
+            "large_prey3",
+            "no_fail_prey"
+        ],
+        "intro_text": "r_c heads out into the forest alone, wanting to sink their teeth into some prey and have some time to themselves.",
+        "decline_text": "r_c turns back to camp, deciding that a group hunt would be more effective.",
+        "chance_of_success": 40,
+        "exp": 20,
+        "success_text": [
+            "r_c heads off to one of their favorite spots in the forest, a grove of spread out trees with thick underbrush providing excellent ambush chances. And what do you know, they are bush! Or they were as far as that squirrel thought.",
+            "r_c finds a fat, dumb, slow rabbit, and they can barely drag the thing back to camp, but by the stars it's juicy when they sit down to eat it with their Clanmates.",
+            "s_c gets the chance to try out an idea they've been sitting on for a while. There's a rabbit warren that they've spotted that's particularly badly built, and they manage to dig down into one of the dens, fishing baby rabbits out by the pawful.",
+            "The prey is running terribly today. But s_c has patience, and wisely waits for the perfect opportunity instead of getting frustrated. They come back to camp with a good contribution to the Clan's stores, having had a relaxing day sitting with their thoughts while waiting for the prey to come to them."
+        ],
+        "fail_text": [
+            "You can't catch what isn't there, and the prey today is very not there.",
+            "s_c starts the day with endless energy, but as one hunt fails after another, it very quickly runs dry. The come back to camp, empty pawed and prickling with frustration.",
+            null,
+            null
+        ],
+        "win_skills": [
+            "smart",
+            "very smart",
+            "extremely smart"
+        ],
+        "win_trait": [
+            "calm",
+            "careful",
+            "insecure",
+            "lonesome",
+            "loyal",
+            "nervous",
+            "sneaky",
+            "strange",
+            "patient",
+            "thoughtful",
+            "wise"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "bold",
+            "childish",
+            "confident",
+            "daring",
+            "playful"
+        ],
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "min_cats": 1,
+        "max_cats": 1
+    },
+    {
+        "patrol_id": "fst_hunt_solo3",
+        "biome": "forest",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "deputy",
+            "medium_prey0",
+            "medium_prey1",
+            "large_prey2",
+            "large_prey3",
+			"no_fail_prey"
+        ],
+        "intro_text": "r_c heads out into the forest alone, wanting to sink their teeth into some prey and have some time to themselves.",
+        "decline_text": "r_c turns back to camp, deciding that a group hunt would be more effective.",
+        "chance_of_success": 40,
+        "exp": 20,
+        "success_text": [
+            "r_c heads off to one of their favorite spots in the forest, a grove of spread out trees with thick underbrush providing excellent ambush chances. And what do you know, they are bush! Or they were as far as that squirrel thought. They snicker to themselves as they pad back to camp.",
+            "r_c finds a fat, dumb, slow rabbit, and they can barely drag the thing back to camp, but by the stars it's juicy when they sit down to eat it with their Clanmates. Purring, they take the opportunity for a small moment of peace, relaxing with their friends.",
+            "s_c gets the chance to try out an idea they've been sitting on for a while. There's a rabbit warren that they've spotted that's particularly badly built, and they manage to dig down into one of the dens, fishing a couple baby rabbits out. This is a good spot to remember if c_n hits hard times.",
+            "The prey is running terribly today. But s_c has patience, and wisely waits for the perfect opportunity instead of getting frustrated. They come back to camp with a good contribution to the Clan's stores, having had a relaxing day sitting with their thoughts while waiting for the prey to come to them."
+        ],
+        "fail_text": [
+            "You can't catch what isn't there, and the prey today is very not there.",
+            "s_c starts the day with endless energy, but as one hunt fails after another, it very quickly runs dry. They give up and return to camp, to try and at least make progress on all the work piling up there.",
+            null,
+            null
+        ],
+        "win_skills": [
+            "smart",
+            "very smart",
+            "extremely smart"
+        ],
+        "win_trait": [
+            "calm",
+            "careful",
+            "insecure",
+            "lonesome",
+            "loyal",
+            "nervous",
+            "sneaky",
+            "strange",
+            "patient",
+            "thoughtful",
+            "wise"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "bold",
+            "childish",
+            "confident",
+            "daring",
+            "playful"
+        ],
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "min_cats": 1,
+        "max_cats": 1
+    },
+    {
+        "patrol_id": "fst_hunt_solo4",
+        "biome": "forest",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "leader",
+            "medium_prey0",
+            "medium_prey1",
+            "large_prey2",
+            "large_prey3",
+			"no_fail_prey"
+        ],
+        "intro_text": "r_c heads out into the forest alone, wanting to sink their teeth into some prey and have some time to themselves.",
+        "decline_text": "r_c turns back to camp, deciding that a group hunt would be more effective.",
+        "chance_of_success": 40,
+        "exp": 20,
+        "success_text": [
+            "r_c heads off to one of their favorite spots in the forest, a grove of spread out trees with thick underbrush providing excellent ambush chances. And what do you know, they are bush! Or they were as far as that squirrel thought. They snicker to themselves as they pad back to camp.",
+            "r_c finds a fat, dumb, slow rabbit, and they can barely drag the thing back to camp, but by the stars it's juicy when they sit down to eat it with their Clanmates. Purring, they take the opportunity for a small moment of peace, relaxing with their friends.",
+            "s_c gets the chance to try out an idea they've been sitting on for a while. There's a rabbit warren that they've spotted that's particularly badly built, and they manage to dig down into one of the dens, fishing a couple baby rabbits out. This is a good spot to remember if c_n hits hard times.",
+            "The prey is running terribly today. But s_c has patience, and wisely waits for the perfect opportunity instead of getting frustrated. They come back to camp with a good contribution to the Clan's stores, having had a relaxing day sitting with their thoughts while waiting for the prey to come to them."
+        ],
+        "fail_text": [
+            "You can't catch what isn't there, and the prey today is very not there.",
+            "s_c starts the day with endless energy, but as one hunt fails after another, it very quickly runs dry. They give up and return to camp, to try and at least make progress on all the work piling up there.",
+            null,
+            null
+        ],
+        "win_skills": [
+            "smart",
+            "very smart",
+            "extremely smart"
+        ],
+        "win_trait": [
+            "calm",
+            "careful",
+            "insecure",
+            "lonesome",
+            "loyal",
+            "nervous",
+            "sneaky",
+            "strange",
+            "patient",
+            "thoughtful",
+            "wise"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "bold",
+            "childish",
+            "confident",
+            "daring",
+            "playful"
+        ],
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "min_cats": 1,
+        "max_cats": 1
+    },
+    {
+        "patrol_id": "fst_hunt_noise1",
+        "biome": "forest",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "big_bite_injury",
+            "scar",
+            "small_prey0",
+            "small_prey1",
+            "medium_prey2"
+        ],
+        "intro_text": "As the patrol is checking the border lines, they hear an odd sound coming from a nearby bush.",
+        "decline_text": "It's probably nothing. The patrol leaves the noise alone and continues on their way.",
+        "chance_of_success": 80,
+        "exp": 10,
+        "success_text": [
+            "r_c drops down into a hunting crouch, certain that a mouse must be the source of the noise.  They find themselves to be correct when they pounce into the bush and return to the patrol with the tasty morsel dangling from their mouth.",
+            null,
+            "p_l pads towards the bush to check on the noise when a rabbit suddenly bursts out!  s_c is quick to react and manages to snag the rabbit before it can disappear."
+        ],
+        "fail_text": [
+            "p_l pads closer to the bush, intent on finding the source of the noise, only to come face to face with a skunk!  The poor cat ends up stinking for days after the unfortunate incident.",
+            "s_c doesn't even hesitate before splitting from the patrol to check on the source of the noise. They quickly regret their impulsivity, however, when an angry raccoon bursts from the bush!  s_c gets quite the scare, but thankfully the raccoon only wanted to get away from them and quickly runs off back into the undergrowth.",
+            null,
+            "r_c takes the lead in checking the source of the noise and comes face to face with an angry fox! Though they backpedal rapidly, the fox still manages to take a bite out of them before the rest of the patrol can back them up."
+        ],
+        "other_clan": [
+            "None"
+        ],
+        "win_skills": [
+            "good hunter",
+            "great hunter",
+            "excellent hunter"
+        ],
+        "win_trait": [
+            "None"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "daring",
+            "bold",
+            "ambitious"
+        ],
+        "min_cats": 5,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c gained a scar from a fox."
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_noise2",
+        "biome": "forest",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "big_bite_injury",
+            "scar",
+            "death",
+            "small_prey0",
+            "small_prey1",
+            "medium_prey2"
+        ],
+        "intro_text": "As the patrol is checking the border lines, they hear an odd sound coming from a nearby bush.",
+        "decline_text": "It's probably nothing. The patrol leaves the noise alone and continues on their way.",
+        "chance_of_success": 60,
+        "exp": 10,
+        "success_text": [
+            "r_c drops down into a hunting crouch, certain that a mouse must be the source of the noise. They find themselves to be correct when they pounce into the bush and return to the patrol with the tasty morsel dangling from their mouth.",
+            null,
+            "p_l pads towards the bush to check on the noise when a rabbit suddenly bursts out! s_c is quick to react and manages to snag the rabbit before it can disappear."
+        ],
+        "fail_text": [
+            "p_l pads closer to the bush, intent on finding the source of the noise, only to come face to face with a skunk! The poor cat ends up stinking for days after the unfortunate incident.",
+            "s_c doesn't even hesitate before splitting from the patrol to check on the source of the noise. They quickly regret their impulsivity, however, when an angry raccoon bursts from the bush! s_c gets quite the scare, but thankfully the raccoon only wanted to get away from them and quickly runs off back into the undergrowth.",
+            "r_c takes the lead in checking the source of the noise and comes face to face with a snarling wolverine! r_c yowls for their patrol but the other cats aren't quick enough to stop the wolverine from killing r_c in one quick and deadly swipe.",
+            "r_c takes the lead in checking the source of the noise and comes face to face with an angry fox! Though they backpedal rapidly, the fox still manages to take a bite out of them before the rest of the patrol can back them up."
+        ],
+        "other_clan": [
+            "None"
+        ],
+        "win_skills": [
+            "good hunter",
+            "great hunter",
+            "excellent hunter"
+        ],
+        "win_trait": [
+            "None"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "daring",
+            "bold",
+            "ambitious"
+        ],
+        "min_cats": 2,
+        "max_cats": 4,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "p_l gained a scar from a fox.",
+            "p_l was killed by a wolverine.",
+            "killed by a wolverine"
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_gonetnr1",
+        "biome": "forest",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "gone",
+            "small_prey0",
+            "small_prey1"
+        ],
+        "intro_text": "Your patrol encounters a clearing where a lot of Twolegs linger.",
+        "decline_text": "Your patrol decides to hunt elsewhere.",
+        "chance_of_success": 60,
+        "exp": 20,
+        "success_text": [
+            "They continue hunting undetected.",
+            "Slyly, r_c uses the chance to get food, practicing their best kittypet impression until just the right moment, before darting forward and making off with a sandwich in their mouth.",
+            "s_c spots the Twolegs unloading metal boxes from their monsters, and abruptly tells the patrol to leave. Now.",
+            "A Twoleg spots s_c and crouches down, clicking softly. s_c hisses and flees."
+        ],
+        "fail_text": [
+            null,
+            null,
+            "The patrol mostly ignores the Twolegs. As they hunt they hear a yelp from r_c. They've crawled into a metal Twolegs box, and there's nothing they or the rest of the patrol can do to get them out - eventually the Twolegs notice, and r_c is taken by them.",
+            null,
+            "A Twoleg spots s_c and crouches down, clicking softly. s_c pauses - are they hurt? Do they want to make friends? Before they can decide whether to step closer, there's a swoosh, and a net falls around them. s_c fights desperately, but the Twolegs take them away in the monster."
+        ],
+        "win_skills": [
+            "extremely smart"
+        ],
+        "win_trait": [
+            "ambitious",
+            "bloodthirsty",
+            "cold",
+            "fierce",
+            "shameless",
+            "strict",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "altruistic",
+            "compassionate",
+            "empathetic",
+            "faithful",
+            "loving",
+            "patient",
+            "responsible",
+            "thoughtful",
+            "wise"
+        ],
+        "min_cats": 1,
+        "max_cats": 3,
+        "antagonize_text": null,
+        "antagonize_fail_text": null
+    },
+    {
+        "patrol_id": "fst_hunt_gonetnr2",
+        "biome": "forest",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "gone",
+            "medium_prey0",
+            "large_prey1"
+        ],
+        "intro_text": "Your patrol encounters a clearing where a lot of Twolegs linger.",
+        "decline_text": "Your patrol decides to hunt elsewhere.",
+        "chance_of_success": 60,
+        "exp": 20,
+        "success_text": [
+            "They continue hunting undetected, using the presence of the Twolegs startling the local wildlife to bring back a good haul.",
+            "Slyly, r_c uses the chance to get food, practicing their best kittypet impression until just the right moment, before darting forward and making off with a large lump of meat in their mouth.",
+            "s_c spots the Twolegs unloading metal boxes from their monsters, and abruptly tells the patrol to leave. Now.",
+            "A Twoleg spots s_c and crouches down, clicking softly. s_c hisses and flees."
+        ],
+        "fail_text": [
+            null,
+            null,
+            "The patrol mostly ignores the Twolegs. As they hunt they hear a yelp from r_c. They've crawled into a metal Twolegs box, and there's nothing they or the rest of the patrol can do to get them out - eventually the Twolegs notice, and r_c is taken by them.",
+            null,
+            "A Twoleg spots s_c and crouches down, clicking softly. s_c pauses - are they hurt? Do they want to make friends? Before they can decide whether to step closer, there's a swoosh, and a net falls around them. s_c fights desperately, but the Twolegs take them away in the monster."
+        ],
+        "win_skills": [
+            "extremely smart"
+        ],
+        "win_trait": [
+            "ambitious",
+            "bloodthirsty",
+            "cold",
+            "fierce",
+            "shameless",
+            "strict",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "altruistic",
+            "compassionate",
+            "empathetic",
+            "faithful",
+            "loving",
+            "patient",
+            "responsible",
+            "thoughtful",
+            "wise"
+        ],
+        "min_cats": 4,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            null,
+            null
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_gonetnr3",
+        "biome": "forest",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "multi_gone",
+            "small_prey0",
+            "small_prey1"
+        ],
+        "intro_text": "Your patrol encounters a clearing where a lot of Twolegs linger.",
+        "decline_text": "Your patrol decides to hunt elsewhere.",
+        "chance_of_success": 60,
+        "exp": 20,
+        "success_text": [
+            "They continue hunting undetected.",
+            "Slyly, r_c uses the chance to get food, practicing their best kittypet impression until just the right moment, before darting forward and making off with a sandwich in their mouth.",
+            "s_c spots the Twolegs unloading metal boxes from their monsters, and abruptly tells the patrol to leave. Now.",
+            "A Twoleg spots s_c and crouches down, clicking softly. s_c hisses and flees."
+        ],
+        "fail_text": [
+            null,
+            null,
+            "The patrol mostly ignores the Twolegs. But as they hunt, the cats encounter appealing, delicious smelling mush in little burrows. Some of the patrol investigates, and doors slam down behind them. There's nothing they or the rest of the patrol can do to get them out - eventually the Twolegs notice, and the trapped cats are taken.",
+            null,
+            "A Twoleg spots s_c and crouches down, clicking softly. s_c pauses - are they hurt? Do they want to make friends? They wander closer, drawing more of the patrol in with them. Before they can decide whether to step away, there's a swoosh, and a net falls around the cats. They fight desperately, but the Twolegs take them away in the monster."
+        ],
+        "win_skills": [
+            "extremely smart"
+        ],
+        "win_trait": [
+            "ambitious",
+            "bloodthirsty",
+            "cold",
+            "fierce",
+            "shameless",
+            "strict",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "altruistic",
+            "compassionate",
+            "empathetic",
+            "faithful",
+            "loving",
+            "patient",
+            "responsible",
+            "thoughtful",
+            "wise"
+        ],
+        "min_cats": 4,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            null,
+            null
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_gonetwolegden1",
+        "biome": "forest",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "gone",
+            "scar",
+            "injury",
+            "torn pelt",
+            "medium_prey0",
+            "medium_prey2",
+            "large_prey3"
+        ],
+        "intro_text": "r_c decides to hunt out near the Twoleg dens.",
+        "decline_text": "On second thought, they decide to reline their nest today instead.",
+        "chance_of_success": 50,
+        "exp": 20,
+        "success_text": [
+            "They're interrupted by Twolegs wandering through the woods a couple times, but it's a successful hunt.",
+            "A friendly Twoleg makes a psspsspss noise, and pours kittypet food on the ground for r_c. They've always wondered what it might taste like... dry, is the answer. Very odd.",
+            "s_c gets distracted from hunting by strange Twoleg activity around one of their dens. They appear to be hauling all their many, many varieties of nest lining out and into a big monster. s_c take the opportunity to grab a little soft thing, something that's almost shaped like prey. It'll be good for the nursery.",
+            "Calmly, s_c weaves around the Twoleg dens, picking out the mice from the tunnels and the birds off the strange metal hanging fruit. A successful, sneaky hunt."
+        ],
+        "fail_text": [
+            null,
+            "The Twolegs here are friendly, and a little carelessly, s_c goes to hunt in their garden. But there's a new thing there, a box, suspicious and strange. Wisely, s_c avoids it, and returns to c_n territory.",
+            "Carelessly, r_c is seen by Twolegs, and taken from c_n.",
+            "Carelessly, r_c is seen by Twolegs, and is taken hissing and spitting to be locked in a monster's den. Overnight, they discover that a broken window is just wide enough to push themselves out to safety through, but the glass leaves them bleeding as they run back to c_n."
+        ],
+        "win_skills": [
+            "smart",
+            "very smart",
+            "extremely smart"
+        ],
+        "win_trait": [
+            "calm",
+            "careful",
+            "insecure",
+            "lonesome",
+            "loyal",
+            "nervous",
+            "sneaky",
+            "strange"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "altruistic",
+            "compassionate",
+            "empathetic",
+            "faithful",
+            "loving",
+            "patient",
+            "responsible",
+            "thoughtful",
+            "wise"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            null,
+            null
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_gonetwolegden2",
+        "biome": "forest",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "gone",
+            "small_prey",
+            "apprentice",
+            "medium_prey0",
+            "medium_prey2",
+            "large_prey3"
+        ],
+        "intro_text": "app1 decides to hunt out near the Twoleg dens.",
+        "decline_text": "On second thought, they decide to reline their nest today instead.",
+        "chance_of_success": 50,
+        "exp": 20,
+        "success_text": [
+            "They're interrupted by Twolegs wandering through the woods a couple times, so they miss a couple catches, but overall it works out.",
+            "A friendly Twolegs makes a psspsspss noise, and pours kittypet food on the ground for app1. They've always wondered what it might taste like... dry, is the answer. It's strangely appealing.",
+            null,
+            "Tail lashing excitedly, app1 hunts in the strange, forbidden land, ducking around corners and crawling over gardens with their belly low to the ground. A successful, sneaky hunt."
+        ],
+        "fail_text": [
+            null,
+            "A little carelessly, s_c jumps a fence to hunt in a den's garden. But there's a new thing there, a box, suspicious and strange. Wisely, s_c avoids it, and returns to c_n territory.",
+            "Carelessly, app1 is seen by Twolegs, and taken from c_n.",
+            "Carelessly, app1 is seen by Twolegs, and is taken hissing and spitting to be locked in a monster's den. Overnight, they discover that a broken window is just wide enough to push themselves out to safety through, but the glass leaves them bleeding as they run back to c_n."
+        ],
+        "win_skills": [
+            "None"
+        ],
+        "win_trait": [
+            "calm",
+            "careful",
+            "insecure",
+            "lonesome",
+            "loyal",
+            "nervous",
+            "sneaky",
+            "strange"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "altruistic",
+            "compassionate",
+            "empathetic",
+            "faithful",
+            "loving",
+            "patient",
+            "responsible",
+            "thoughtful",
+            "wise"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            null,
+            null
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_gonetwolegden3",
+        "biome": "forest",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "gone",
+            "small_prey",
+            "romantic",
+            "platonic",
+            "no_app",
+            "medium_prey0"
+        ],
+        "intro_text": "Boldly, eyes daring p_l to say no, r_c suggests hunting by the Twoleg dens.",
+        "decline_text": "On second thought, they decide to reline their nests today instead.",
+        "chance_of_success": 50,
+        "exp": 20,
+        "success_text": [
+            "They're interrupted by Twolegs wandering through the woods a couple times, but it's a successful hunt.",
+            "A friendly Twolegs makes a psspsspss noise, and pours kittypet food on the ground for r_c. They fetch p_l, and both cats investigate the food, loudly proclaiming how much better fresh-kill is, but both a little thrilled by the experience.",
+            "s_c shows the other cat all around the outskirts of the Twoleg dens, showing off how much they know about the strange animals and their weird behavior, and enjoying getting to feel clever.",
+            "It's a strange adventure, odd and weird and a little thrilling. s_c takes the lead, but both s_c and r_c are wide eyed and a little scared, in a fun way."
+        ],
+        "fail_text": [
+            "Carelessly, r_c is seen by Twolegs, and is taken hissing and spitting to be locked in a monster's den. Overnight, they hear p_l yowling from outside, and the two cats manage to craft an escape plan through a broken window. Shivering, r_c presses their pelt against p_l on the way back to c_n.",
+            "The Twolegs here are friendly, and a little carelessly, s_c goes to hunt in their garden. But there's a new thing there, a box, suspicious and strange. Wisely, s_c avoids it, and returns to c_n territory.",
+            "Carelessly, r_c is seen by Twolegs, and taken from c_n.",
+            null
+        ],
+        "win_skills": [
+            "smart",
+            "very smart",
+            "extremely smart"
+        ],
+        "win_trait": [
+            "calm",
+            "careful",
+            "insecure",
+            "lonesome",
+            "loyal",
+            "nervous",
+            "sneaky",
+            "strange"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "altruistic",
+            "compassionate",
+            "empathetic",
+            "faithful",
+            "loving",
+            "patient",
+            "responsible",
+            "thoughtful",
+            "wise"
+        ],
+        "min_cats": 2,
+        "max_cats": 2,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            null,
+            null
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_gonetwolegden4",
+        "biome": "forest",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "gone",
+            "small_prey",
+            "apprentice",
+            "romantic",
+            "platonic",
+            "two_apprentices",
+            "medium_prey0"
+        ],
+        "intro_text": "Boldly, eyes daring app1 to say no, app2 suggests hunting by the Twoleg dens. Where apprentices are definitely not allowed.",
+        "decline_text": "On second thought, they decide to reline their nests today instead.",
+        "chance_of_success": 50,
+        "exp": 20,
+        "success_text": [
+            "They're interrupted by Twolegs wandering through the woods a couple times, so they miss a couple catches, but overall it works out.",
+            "A friendly Twolegs makes a psspsspss noise, and pours kittypet food on the ground for app2. They fetch app1, and both apprentices loudly proclaim how much better fresh-kill is, but both are also wide eyed and thrilled by the experience.",
+            null,
+            "Tail lashing excitedly, app1 hunts in the strange, forbidden land, ducking around corners and crawling over gardens with their belly low to the ground. app2 tries to be even sneakier, and so app1 ups their game, until they're both probably the most obvious pair of cats in the neighborhood."
+        ],
+        "fail_text": [
+            "Carelessly, app2 is seen by Twolegs, and is taken hissing and spitting to be locked in a monster's den. Overnight, they hear app1 yowling from outside, and the two cats manage to craft an escape plan through a broken window. Shivering, app2 presses their pelt against app1 as they pad home.",
+            "A little carelessly, s_c jumps a fence to hunt in a den's garden. But there's a new thing there, a box, suspicious and strange. Wisely, s_c avoids it, and returns to c_n territory.",
+            "Carelessly, app1 is seen by Twolegs, and taken from c_n.",
+            null
+        ],
+        "win_skills": [
+            "None"
+        ],
+        "win_trait": [
+            "calm",
+            "careful",
+            "insecure",
+            "lonesome",
+            "loyal",
+            "nervous",
+            "sneaky",
+            "strange"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "altruistic",
+            "compassionate",
+            "empathetic",
+            "faithful",
+            "loving",
+            "patient",
+            "responsible",
+            "thoughtful",
+            "wise"
+        ],
+        "min_cats": 2,
+        "max_cats": 2,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            null,
+            null
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_gonetwolegtrap1",
+        "biome": "forest",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "gone"
+        ],
+        "intro_text": "The smell of food lures r_c into what looks like a tunnel between some bushes.",
+        "decline_text": "Turning their nose up at the temptation, they continue on their way.",
+        "chance_of_success": 50,
+        "exp": 20,
+        "success_text": [
+            "Darting through quickly, they see that the lovely smell is Twoleg mush, and keep running.",
+            "The lovely smell leads to Twoleg mush. Puzzled, r_c checks around them, only for their fur to stand on end as they realize they're standing in a metal tunnel, cloaked in rust and camouflage. It's to their great fortune that this trap seems to be broken, but whatever Twoleg restocked the bait might still be around. They leave quickly.",
+            "Something about this situation sets all of s_c's instincts off. They investigate, carefully, and strip the cover of the bushes away from a Twoleg trap underneath.",
+            "Something isn't right. Nervously pawing at the bushes, s_c thinks that the smell is too good to be true. They leave it, deciding to return to camp and report it to the deputy instead."
+        ],
+        "fail_text": [
+            null,
+            "Easily swayed by the delicious smell, s_c wanders recklessly into the sheltered space, only to smack into a metal wall. Inside the trap, a young fox starts up a distressed wail, and s_c feels sympathy for it they never expected to feel for a fox, as well as the heart stopping realization that it could easily have been them.",
+            "r_c is caught in a trap hidden in the bushes and is taken by Twolegs shortly after.",
+            null
+        ],
+        "win_skills": [
+            "smart",
+            "very smart",
+            "extremely smart"
+        ],
+        "win_trait": [
+            "calm",
+            "careful",
+            "insecure",
+            "lonesome",
+            "loyal",
+            "nervous",
+            "sneaky",
+            "strange"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "adventurous",
+            "bold",
+            "confident",
+            "daring",
+            "playful"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            null,
+            null
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_gonetwolegtrap2",
+        "biome": "forest",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "gone"
+        ],
+        "intro_text": "The smell of food lures r_c into what looks like a tunnel between some bushes.",
+        "decline_text": "Turning their nose up at the temptation, the patrol continues on their way.",
+        "chance_of_success": 50,
+        "exp": 20,
+        "success_text": [
+            "Darting through quickly, r_c sees that the lovely smell is Twoleg mush, and keeps running.",
+            "The lovely smell leads to Twoleg mush. Puzzled, r_c checks around them, only for their fur to stand on end as they realize they're standing in a metal tunnel, cloaked in rust and camouflage. It's to their great fortune that this trap seems to be broken, but whatever Twoleg restocked the bait might still be around. They leave quickly.",
+            "Something about this situation sets all of s_c's instincts off. They investigate, carefully, and the patrol helps them strip the cover of the bushes away from a Twoleg trap underneath.",
+            "Something isn't right. Nervously pawing at the bushes, s_c thinks that the smell is too good to be true. They leave it, convincing the patrol to return to camp and report it to the deputy instead."
+        ],
+        "fail_text": [
+            null,
+            "Easily swayed by the delicious smell, s_c wanders recklessly into the sheltered space, only to smack into a metal wall. Inside the trap, a young fox starts up a distressed wail, and s_c feels sympathy for it they never expected to feel for a fox, as well as the heart stopping realization that it could easily have been them.",
+            "r_c is caught in a trap hidden in the bushes! There's nothing the patrol is able to do to help them, and r_c is taken by Twolegs shortly after.",
+            null
+        ],
+        "win_skills": [
+            "smart",
+            "very smart",
+            "extremely smart"
+        ],
+        "win_trait": [
+            "calm",
+            "careful",
+            "insecure",
+            "lonesome",
+            "loyal",
+            "nervous",
+            "sneaky",
+            "strange"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "adventurous",
+            "bold",
+            "confident",
+            "daring",
+            "playful"
+        ],
+        "min_cats": 2,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            null,
+            null
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_thunderpath1",
+        "biome": "forest",
+        "season": "Any",
+        "tags": [
+            "death",
+            "scar",
+            "retirement",
+            "blunt_force_injury",
+            "hunting",
+            "medium_prey"
+        ],
+        "intro_text": "The patrol comes across a thunderpath running through the forest.",
+        "decline_text": "They decide it is better not to cross.",
+        "chance_of_success": 50,
+        "exp": 10,
+        "success_text": [
+            "Your patrol crosses the thunderpath and can hunt on the other side.",
+            "Your patrol finds a pipe running under the thunderpath and uses it to cross. They end up with slightly damp paws, but a successful haul of prey.",
+            "Your patrol stops on the edge of the thunderpath, and s_c organizes a thorough search that finds a flattened squirrel. It's a reminder of the danger of the thunderpath, and a good source of scavenged meat.",
+            "s_c is patient enough to wait until the thunderpath is completely clear, then trots across calmly to hunt on the other side."
+        ],
+        "fail_text": [
+            "r_c hears a monster thundering towards them, but it screeches to a halt just in time. That was close! Maybe it's best to go back to camp.",
+            null,
+            "r_c is hit by a monster while crossing and dies instantly.",
+            "r_c is hit by a monster and seems quite injured, but miraculously still alive."
+        ],
+        "win_skills": [
+            "smart",
+            "very smart",
+            "extremely smart"
+        ],
+        "win_trait": [
+            "calm",
+            "careful",
+            "insecure",
+            "nervous",
+            "sneaky",
+            "strange",
+            "patient",
+            "responsible",
+            "thoughtful",
+            "wise"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 1,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c was heavily injured by a monster, and carries the scars from it.",
+            "r_c was hit by a monster and killed.",
+            "were hit by a monster"
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_thunderpath2",
+        "biome": "forest",
+        "season": "Any",
+        "tags": [
+            "death",
+            "scar",
+            "retirement",
+            "blunt_force_injury",
+            "hunting",
+            "cruel_season",
+            "medium_prey"
+        ],
+        "intro_text": "The patrol comes across a thunderpath running through the forest.",
+        "decline_text": "They decide it is better not to cross.",
+        "chance_of_success": 30,
+        "exp": 10,
+        "success_text": [
+            "Your patrol crosses the thunderpath and can hunt on the other side.",
+            "Your patrol finds a pipe running under the thunderpath and uses it to cross. They end up with slightly damp paws, but a successful haul of prey.",
+            "Your patrol stops on the edge of the thunderpath, and s_c organizes a thorough search that finds a flattened squirrel. It's a reminder of the danger of the thunderpath, and a good source of scavenged meat.",
+            "s_c is patient enough to wait until the thunderpath is completely clear, then trots across calmly to hunt on the other side."
+        ],
+        "fail_text": [
+            "r_c hears a monster thundering towards them, but it screeches to a halt just in time. That was close! Maybe it's best to go back to camp.",
+            null,
+            "r_c is crossing the thunderpath and hears a monster thundering towards them. They freeze, and the monster swerves to hit them deliberately, killing them instantly.",
+            "r_c is hit by a monster and seems quite injured, but miraculously still alive."
+        ],
+        "win_skills": [
+            "smart",
+            "very smart",
+            "extremely smart"
+        ],
+        "win_trait": [
+            "calm",
+            "careful",
+            "insecure",
+            "nervous",
+            "sneaky",
+            "strange",
+            "patient",
+            "responsible",
+            "thoughtful",
+            "wise"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 1,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c was heavily injured by a monster, and carries the scars from it.",
+            "r_c was hit by a monster and killed.",
+            "were hit by a monster"
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_thunderpath3",
+        "biome": "forest",
+        "season": "Any",
+        "tags": [
+            "multi_deaths",
+            "scar",
+            "retirement",
+            "blunt_force_injury",
+            "hunting",
+            "medium_prey0",
+            "large_prey1",
+            "large_prey2",
+            "large_prey3"
+        ],
+        "intro_text": "The patrol comes across a thunderpath running through the forest.",
+        "decline_text": "They decide it is better not to cross.",
+        "chance_of_success": 50,
+        "exp": 10,
+        "success_text": [
+            "Your patrol crosses the thunderpath and can hunt on the other side.",
+            "Your patrol finds a pipe running under the thunderpath and uses it to cross. They end up with slightly damp paws, but a successful haul of lots of prey.",
+            "Your patrol stops on the edge of the thunderpath, and s_c organizes a thorough search that finds several flattened pieces of roadkill. It's a reminder of the danger of the thunderpath, and a good source of scavenged meat.",
+            "s_c is patient enough to wait until the thunderpath is completely clear, then trots across calmly with the patrol to hunt on the other side."
+        ],
+        "fail_text": [
+            null,
+            null,
+            "As the group crosses the thunderpath, a speeding monster appears out of nowhere. The cats run panicked in all directions, and several of them get hit and die.",
+            "r_c is hit by a monster and seems quite injured, but miraculously still alive."
+        ],
+        "win_skills": [
+            "smart",
+            "very smart",
+            "extremely smart"
+        ],
+        "win_trait": [
+            "calm",
+            "careful",
+            "insecure",
+            "nervous",
+            "sneaky",
+            "strange",
+            "patient",
+            "responsible",
+            "thoughtful",
+            "wise"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 5,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c was heavily injured by a monster, and carries the scars from it.",
+            "This cat was hit by a monster and killed.",
+            "were hit by a monster"
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_thunderpath4",
+        "biome": "forest",
+        "season": "Any",
+        "tags": [
+            "multi_deaths",
+            "scar",
+            "retirement",
+            "blunt_force_injury",
+            "hunting",
+            "cruel_season",
+            "medium_prey"
+        ],
+        "intro_text": "The patrol comes across a thunderpath running through the forest.",
+        "decline_text": "They decide it is better not to cross.",
+        "chance_of_success": 30,
+        "exp": 10,
+        "success_text": [
+            "Your patrol crosses the thunderpath and can hunt on the other side.",
+            "Your patrol finds a pipe running under the thunderpath and uses it to cross. They end up with slightly damp paws, but a successful haul of lots of prey.",
+            "Your patrol stops on the edge of the thunderpath, and s_c organizes a thorough search that finds a flattened squirrel. It's a reminder of the danger of the thunderpath, and a good source of scavenged meat.",
+            "s_c is patient enough to wait until the thunderpath is completely clear, then trots across calmly with the patrol to hunt on the other side."
+        ],
+        "fail_text": [
+            "r_c hears a monster thundering towards them, but it screeches to a halt just in time. That was close! Maybe it's best to go back to camp.",
+            null,
+            "As the group crosses the thunderpath, a speeding monster appears out of nowhere. The cats run panicked in all directions, and several of them get hit as the monster swerves to hit them deliberately, killing them instantly.",
+            "r_c is hit by a monster and seems quite injured, but miraculously still alive."
+        ],
+        "win_skills": [
+            "smart",
+            "very smart",
+            "extremely smart"
+        ],
+        "win_trait": [
+            "calm",
+            "careful",
+            "insecure",
+            "nervous",
+            "sneaky",
+            "strange",
+            "patient",
+            "responsible",
+            "thoughtful",
+            "wise"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 5,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c was heavily injured by a monster, and carries the scars from it.",
+            "r_c was hit by a monster and killed.",
+            "were hit by a monster"
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_fun1",
+        "biome": "forest",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "small_prey0",
+            "small_prey1",
+            "medium_prey2"
+        ],
+        "intro_text": "As r_c tears through the forest, stretching their legs on a run, they spot movement out of the corner of their eye.",
+        "decline_text": "They keep going, not wanting to slow down.",
+        "chance_of_success": 50,
+        "exp": 10,
+        "success_text": [
+            "With a huge leap, they dart sideways and pull a blackbird out of the air. What a great catch!",
+            "Laughing, they bounce gleefully off a tree trunk, redirecting their momentum to slam into a very surprised mouse.",
+            "Nothing's going to escape their claws! r_c skids to a halt and then leaps into action, claw just barely catching in the tail of the squirrel they saw and bringing it down. They purr with satisfaction and trot back to camp with their prize."
+        ],
+        "fail_text": [
+            "r_c darts to the side, but wherever made the flash of movement is long gone. How frustrating!",
+            "r_c skids to a halt and tries to sprint after it, but the bird they saw escapes their paws. They chatter angrily at it, and it tries to poop on them. Such is life."
+        ],
+        "win_skills": [
+            "good hunter",
+            "great hunter",
+            "fantastic hunter"
+        ],
+        "win_trait": [
+            "None"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            null,
+            null
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_fun2",
+        "biome": "forest",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "apprentice",
+            "small_prey"
+        ],
+        "intro_text": "As app1 tears through the forest, stretching their legs on a run, they spot movement out of the corner of their eye.",
+        "decline_text": "They keep going, not wanting to slow down.",
+        "chance_of_success": 50,
+        "exp": 10,
+        "success_text": [
+            "With a huge leap, they dart sideways and pull the tail off a taking flight into blackbird the air. A missed catch, but new nest lining?",
+            "Laughing, they bounce gleefully off a tree trunk. It redirects their momentum far better than they were expecting, and it's difficult to say who's more surprised - the mouse, or the apprentice slamming into it! Not a very clean catch, but one they're proud of anyway."
+        ],
+        "fail_text": [
+            "app1 darts to the side, but wherever made the flash of movement is long gone. How frustrating!",
+            "app1 skids to a halt and tries to sprint after it, but the bird they saw escapes their paws. They chatter angrily at it, and it tries to poop on them. Such is life."
+        ],
+        "win_skills": [
+            "None"
+        ],
+        "win_trait": [
+            "None"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            null,
+            null
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_fun3",
+        "biome": "forest",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "no_app",
+            "romantic",
+            "platonic",
+            "respect",
+            "small_prey0",
+            "small_prey1",
+            "medium_prey2"
+        ],
+        "intro_text": "As r_c tears through the forest with p_l, stretching their legs on a run, they spot movement out of the corner of their eye.",
+        "decline_text": "They keep going, not wanting to slow down.",
+        "chance_of_success": 50,
+        "exp": 10,
+        "success_text": [
+            "With a huge leap, r_c darts sideways and pulls a blackbird out of the air. p_l trots over to congratulate them on the fantastic catch, purring.",
+            "Laughing, they bounce gleefully off a tree trunk, redirecting their momentum to slam into a very surprised mouse. p_l skids to a halt, gasping over their beautiful catch with their eyes shining.",
+            "Nothing's going to escape their claws! s_c skids to a halt and then leaps into action, claw just barely catching in the tail of the squirrel they saw and bringing it down. They purr with satisfaction and pad back to r_c, sharing in the excitement of the hunt with them."
+        ],
+        "fail_text": [
+            "r_c darts to the side, but wherever made the flash of movement is long gone. How frustrating!",
+            "r_c skids to a halt and tries to sprint after it, but the bird they saw escapes their paws. They chatter angrily at it, and it tries to poop on them. Such is life. p_l snickers at them a bit too, but it's all in good fun."
+        ],
+        "win_skills": [
+            "good hunter",
+            "great hunter",
+            "fantastic hunter"
+        ],
+        "win_trait": [
+            "None"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 2,
+        "max_cats": 2,
+        "antagonize_text": null,
+        "antagonize_fail_text": null
+    },
+    {
+        "patrol_id": "fst_hunt_fun4",
+        "biome": "forest",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "apprentice",
+            "romantic",
+            "platonic",
+            "respect",
+            "two_apprentices",
+            "small_prey"
+        ],
+        "intro_text": "As app1 tears through the forest with app2, stretching their legs on a run, they spot movement out of the corner of their eye.",
+        "decline_text": "They keep going, not wanting to slow down.",
+        "chance_of_success": 50,
+        "exp": 10,
+        "success_text": [
+            "With a huge leap, app1 darts sideways and pulls the tail off a blackbird taking flight into the air. A missed catch, but new nest lining? They toss some of the feathers at app2, and the two apprentices end up scuffling like kits.",
+            "Laughing, app1 bounces gleefully off a tree trunk. It redirects their momentum far better than they were expecting, and it's difficult to say who's more surprised - the mouse, or the apprentice slamming into it! Not a very clean catch, but the look on app2's face, so shocked and impressed, makes them blush."
+        ],
+        "fail_text": [
+            "app1 darts to the side, but wherever made the flash of movement is long gone. How frustrating!",
+            "app1 skids to a halt and tries to sprint after it, but the bird they saw escapes their paws. They chatter angrily at it, and it tries to poop on them. Such is life. app2 snickers at them too, but in a lighthearted way, and soon both apprentices are giggling about it as they continue their run."
+        ],
+        "win_skills": [
+            "None"
+        ],
+        "win_trait": [
+            "None"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 2,
+        "max_cats": 2,
+        "antagonize_text": null,
+        "antagonize_fail_text": null
+    },
+    {
+        "patrol_id": "fst_hunt_heat1",
+        "biome": "forest",
+        "season": "greenleaf",
+        "tags": [
+            "hunting",
+            "small_prey",
+            "heat_illness",
+            "medium_prey0",
+            "huge_prey1"
+        ],
+        "intro_text": "It is extremely hot out today, and the hunting patrol is having a hard time staying on task. r_c debates turning back home.",
+        "decline_text": "The patrol decides to head back to camp. They can hunt a different day.",
+        "chance_of_success": 50,
+        "exp": 15,
+        "success_text": [
+            "They decide to power through the weather and the patrol eventually has a successful, if exhausting, hunt.",
+            "The patrol stops to cool off in the shade of a tree for a heartbeat before continuing on their way. As they do, they notice a half-grown deer fawn tottering about in the distance. It's confused by the heat and underweight, and by working together the cats manage to bring it down, a huge prize for the Clan."
+        ],
+        "fail_text": [
+            "No way, it's too hot for this. They can try to hunt again later.",
+            null,
+            null,
+            "r_c collapses from heat exhaustion. p_l carries them back to camp."
+        ],
+        "min_cats": 2,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "This cat got heatstroke while on a patrol.",
+            "This cat died from heat stroke.",
+            "died from heat stroke"
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_lillizard1",
+        "biome": "forest",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "platonic",
+            "comfort",
+            "small_prey"
+        ],
+        "intro_text": "Something skitters across the leaf litter, catching the patrols eyes. A little lizard!",
+        "decline_text": "Startled by the lizard, the patrol watches it scurry away.",
+        "chance_of_success": 60,
+        "exp": 15,
+        "success_text": [
+            "r_c pounces on the little creature and carries the nice mouthful home.",
+            "The lizard drops its tail, and r_c dives for it, while p_l pounces for the lizard. Surely this counts for two catches? Neither of them cares much, and it's a happy afternoon hunting together.",
+            "s_c is basically on top of the skittering lizard, and ends up doing a ridiculous hop to come down on it with claws extended. r_c compliments them on the catch with a laugh in their meow, and s_c has to agree with them, purring with laughter."
+        ],
+        "fail_text": [
+            "The patrol is unable to catch the small reptile quick enough and the little lizard lives another day.",
+            "r_c and p_l go for the prey at the same time, bonking their heads together. Not a bad collision, and both of them are mature enough to let it go, but neither is pleased to have missed an easy catch."
+        ],
+        "win_skills": [
+            "good hunter",
+            "great hunter",
+            "fantastic hunter"
+        ],
+        "win_trait": [
+            "None"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 2,
+        "max_cats": 3,
+        "antagonize_text": null,
+        "antagonize_fail_text": null
+    },
+    {
+        "patrol_id": "fst_hunt_lillizard2",
+        "biome": "forest",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "rel_two_apps",
+            "platonic",
+            "comfort",
+            "romantic",
+            "two_apprentices",
+            "apprentice",
+            "small_prey"
+        ],
+        "intro_text": "Something skitters across the leaf litter, catching the patrol's eyes. A little lizard!",
+        "decline_text": "Startled by the lizard, the patrol watches it scurry away.",
+        "chance_of_success": 60,
+        "exp": 15,
+        "success_text": [
+            "app1 pounces on the little creature and misses, but they don't seem overly concerned, stopping nearly every step to chat to app2, who's just as keen to talk.",
+            "app1 and app2 go for the prey at the same time, bonking their heads together. It makes both of them laugh while apologizing, and they don't leave each other's side for the rest of the patrol, apologies turning to chatting turning to whispered conversations."
+        ],
+        "fail_text": [
+            "The patrol is unable to catch the small reptile quick enough and the little lizard lives another day."
+        ],
+        "win_skills": [
+            "None"
+        ],
+        "win_trait": [
+            "None"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 2,
+        "max_cats": 3,
+        "antagonize_text": null,
+        "antagonize_fail_text": null
+    },
+    {
+        "patrol_id": "fst_hunt_twolegsobject1",
+        "biome": "forest",
+        "season": "greenleaf",
+        "tags": [
+            "hunting",
+            "injury",
+            "burn"
+        ],
+        "intro_text": "The patrol comes across a strange Twolegs object smelling slightly of smoke and prey. Intriguing, but also sort of terrifying. Don't the Twolegs know the danger of fire?",
+        "decline_text": "The patrol decides to avoid the Twoleg object.",
+        "chance_of_success": 50,
+        "exp": 10,
+        "success_text": [
+            "The patrol interprets the purpose of the object. It seems like Twolegs light their fresh-kill on fire before eating it! How strange.",
+            null,
+            "s_c looks closely at the Twoleg object, studying it, wondering how specifically the Twolegs harness and contain the power of fire without it escaping. Wouldn't it be wonderful if c_n could do that?"
+        ],
+        "fail_text": [
+            "The patrol can't seem to interpret the purpose of the object. Twolegs are just mystifying.",
+            null,
+            null,
+            "As r_c pokes around the strange smelling whatever-it-is, they poke a piece of metal still holding the heat of fire in it, and skitter backwards with a yelp."
+        ],
+        "win_skills": [
+            "smart",
+            "very smart",
+            "extremely smart"
+        ],
+        "win_trait": [
+            "None"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 1,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null
+    },
+    {
+        "patrol_id": "fst_hunt_leafbaresnowstorm1",
+        "biome": "forest",
+        "season": "leaf-bare",
+        "tags": [
+            "hunting",
+            "comfort",
+            "trust",
+            "patrol_to_p_l",
+            "patrol_to_r_c",
+            "cold_injury",
+            "small_prey0",
+            "small_prey1",
+            "medium_prey2",
+            "large_prey3",
+            "no_fail_prey"
+        ],
+        "intro_text": "It starts snowing soon after the patrol sets out, trying to bring back something, anything, for the fresh-kill pile.",
+        "decline_text": "They decide to turn back and wait until the snow dies down.",
+        "chance_of_success": 50,
+        "exp": 10,
+        "success_text": [
+            "Despite the snow, the patrol manages to hunt successfully, finding mice underneath the leaf litter. Only a couple, but in this season, that's more than enough to count as a success, and as p_l leads them home there's a sense of security and competence driving them onwards.",
+            null,
+            "Everyone looks admiringly at s_c by the end of the afternoon. Every cat carries something home, but nearly all of it was caught by s_c.",
+            "s_c really keeps the patrol on task and motivated through the sharp cold of the leaf-bare morning, not through authority or commands, but with a gentle voice and compassionate understanding that encourages every cat to do their best for c_n."
+        ],
+        "fail_text": [
+            "The prey must be hiding; the patrol catches nothing. As a snowstorm descends and visibility drops, the patrol clumps together under a bush, their pelts and tails and legs all tightly wrapped into one indistinguishable kitty cat ball.",
+            null,
+            null,
+            "The prey must be hiding; the patrol catches nothing. As a snowstorm descends and visibility drops, the patrol clumps together under a bush, their pelts and tails and legs all tightly wrapped into one indistinguishable kitty cat ball. Still, when they return to camp r_c is cold and chilled."
+        ],
+        "win_skills": [
+            "great hunter",
+            "fantastic hunter"
+        ],
+        "win_trait": [
+            "altruistic",
+            "compassionate",
+            "empathetic",
+            "faithful",
+            "loving"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 2,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c caught a chill while hunting in leaf-bare.",
+            null
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_leafbaresnowstorm2",
+        "biome": "forest",
+        "season": "leaf-bare",
+        "tags": [
+            "hunting",
+            "cold_injury",
+            "small_prey0",
+            "medium_prey1",
+            "large_prey2",
+            "no_fail_prey"
+        ],
+        "intro_text": "It starts snowing soon after r_c sets out, trying to bring back something, anything, for the fresh-kill pile.",
+        "decline_text": "They decide to turn back and wait until the snow dies down.",
+        "chance_of_success": 40,
+        "exp": 10,
+        "success_text": [
+            "Despite the snow, r_c manages to hunt successfully, finding a mouse underneath the leaf litter. Only one, but in this season, that's more than enough to count as a success.",
+            null,
+            "s_c really shows their talent, bringing a clutch of mice back to camp for the fresh-kill pile."
+        ],
+        "fail_text": [
+            null,
+            null,
+            null,
+            "The prey must be hiding; r_c catches nothing. As a snowstorm descends and visibility drops, they hide under a bush, shivering and tightly tucked up against the cold. When they return to camp r_c is cold and chilled, their paws and tail prickling with the danger of frostbite."
+        ],
+        "win_skills": [
+            "great hunter",
+            "fantastic hunter"
+        ],
+        "win_trait": [
+            "None"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c caught a chill while hunting in leaf-bare.",
+            null
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_leafbaresnowstorm3",
+        "biome": "forest",
+        "season": "leaf-bare",
+        "tags": [
+            "hunting",
+            "comfort",
+            "trust",
+            "rel_patrol",
+            "romantic",
+            "no_app",
+            "death",
+            "cold_injury",
+            "small_prey"
+        ],
+        "intro_text": "It starts snowing soon after the patrol sets out, trying to bring back something, anything, for the fresh-kill pile.",
+        "decline_text": "They decide to turn back and wait until the snow dies down.",
+        "chance_of_success": 50,
+        "exp": 10,
+        "success_text": [
+            "A storm descends, sudden and violent, putting an end to any other thoughts but survival. The cats retreat under some evergreen underbrush and cuddle together, sharing what little warmth they have. Each cat takes a turn on the most exposed side of the huddle, selflessly risking themselves.",
+            null,
+            "A storm descends, sudden and violent, putting an end to any other thoughts but survival. s_c keeps everyone's spirits up as the patrol hides inside a hollow log, until everyone is talking, shaky and unhappy, but keeping each other's spirits up.",
+            "A storm descends, sudden and violent, putting an end to any other thoughts but survival. As the cats hide under the low hanging branches of a pine, s_c keeps an eye out for everyone. It's a long couple of hours, but with gentle understanding and compassion the cats make it though safely, closer than ever afterwards."
+        ],
+        "fail_text": [
+            null,
+            null,
+            "A storm descends, sudden and violent, putting an end to any other thoughts but survival. As the cats huddle together, desperately trying to conserve warmth, no one notices that r_c has stopped responding. At some point in the storm, their life slips away, and their distraught Clanmates are left to carry their body home.",
+            "A storm descends, sudden and violent, putting an end to any other thoughts but survival. When the snowstorm leaves, finally, and the cats trudge back home, but r_c hasn't escaped unscathed, their body chilled and refusing to warm up properly."
+        ],
+        "win_skills": [
+            "great speaker",
+            "excellent speaker"
+        ],
+        "win_trait": [
+            "altruistic",
+            "compassionate",
+            "empathetic",
+            "faithful",
+            "loving"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 2,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c caught a chill while hunting in leaf-bare.",
+            "r_c froze to death while hunting in a storm.",
+            "froze to death while hunting"
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_fox_newleafscavenge1",
+        "biome": "forest",
+        "season": "newleaf",
+        "tags": [
+            "hunting",
+            "fighting",
+            "scar",
+            "injury",
+            "bite-wound",
+            "clan_to_patrol",
+            "respect",
+            "rel_patrol",
+            "medium_prey0",
+            "medium_prey1",
+            "large_prey2",
+            "large_prey3"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? Tracking it, they find their red enemy feeding on a deer fawn carcass. It's impossible to say whether the fox killed it or found it.",
+        "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 50,
+        "exp": 20,
+        "success_text": [
+            "Your cats are smaller but they outnumber the fox, if only by a little, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full of venison and unwilling to lose blood over it, is driven off from the kill.",
+            null,
+            "s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until it gives up and runs.",
+            "The patrol launches into battle, but with so few cats it's exhausting trying to keep the fox and its snapping jaws on the defensive. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. It's only one bite, but the fox has had enough and flees."
+        ],
+        "fail_text": [
+            "Your patrol fails to drive away the fox, which keeps possession of the food. However there were no injuries.",
+            null,
+            null,
+            "The patrol launches into battle, but r_c is caught with a nasty bite, and the cats give up on challenging for the food in favor of quickly helping r_c back to the medicine cat den.",
+            null,
+            "s_c means well, but they're overconfident in their attack and the fox manages to sink their teeth into them. The patrol is forced to retreat, forming a defensive ring around the hurt s_c."
+        ],
+        "win_skills": [
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "troublesome",
+            "vengeful",
+            "bloodthirsty",
+            "bold"
+        ],
+        "min_cats": 2,
+        "max_cats": 3,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a fox fight.",
+            null
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_fox_newleafscavenge2",
+        "biome": "forest",
+        "season": "newleaf",
+        "tags": [
+            "hunting",
+            "fighting",
+            "scar",
+            "injury",
+            "bite-wound",
+            "clan_to_patrol",
+            "respect",
+            "rel_patrol",
+            "medium_prey0",
+            "medium_prey1",
+            "large_prey2",
+            "large_prey3"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? Tracking it, they find their red enemy feeding on a deer fawn carcass. It's impossible to say whether the fox killed it or found it.",
+        "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 80,
+        "exp": 20,
+        "success_text": [
+            "Your cats are smaller but heavily outnumber the fox, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full of venison and unwilling to lose blood over it, is driven off from the kill.",
+            null,
+            "s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until s_c lands a crucial blow, snapping a tendon in one of the fox's hindlegs. The fox runs, but there's no way it'll live long with such a crippling injury.",
+            "The patrol launches into battle, keeping the fox on the defensive with teamwork. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. Holding on grimly, s_c's daring move gives the rest of the patrol the opportunity needed to bring the fox down for good."
+        ],
+        "fail_text": [
+            "Your patrol fails to drive away the fox, which keeps possession of the food. However with so many cats to protect each other, there were no injuries.",
+            null,
+            null,
+            "The patrol launches into battle, but r_c is caught with a nasty bite, and the cats give up on challenging for the food in favor of quickly helping r_c back to the medicine cat den.",
+            null,
+            "s_c means well, but they're overconfident in their attack and the fox manages to sink their teeth into them. The patrol is forced to retreat, forming a defensive ring around the hurt s_c."
+        ],
+        "win_skills": [
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "troublesome",
+            "vengeful",
+            "bloodthirsty",
+            "bold"
+        ],
+        "min_cats": 4,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a fox fight."
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_fox_newleafscavenge3",
+        "biome": "forest",
+        "season": "newleaf",
+        "tags": [
+            "hunting",
+            "fighting",
+            "death",
+            "scar",
+            "injury",
+            "bite-wound",
+            "clan_to_patrol",
+            "respect",
+            "medium_prey0",
+            "medium_prey1",
+            "large_prey2",
+            "large_prey3"
+        ],
+        "intro_text": "r_c catches the scent of a fox - but is it red, or gray? Tracking it, they find their red enemy feeding on a deer fawn carcass. It's impossible to say whether the fox killed it or found it.",
+        "decline_text": "r_c decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 30,
+        "exp": 30,
+        "success_text": [
+            "r_c may be smaller, alone, and half its weight, but the fox has a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle. The fox, already stuffed full of venison and unwilling to lose blood over it, leaves the kill with a grumble.",
+            null,
+            "s_c uses every trick in their talented fighting skillset to attack the fox with no one to watch their flank, until the perfect opportunity opens up and they pounce onto the fox's back, digging in their claws. It's a wild ride through the forest until the fox bucks them off, but it wins them the fawn carcass.",
+            "In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. But then they're stuck, unwilling to let go and risk being bitten. They're dragged through the forest, over rocks and through bushes, until the fox finally collapses and the battered s_c goes back to proudly claim the fawn."
+        ],
+        "fail_text": [
+            "Your patrol fails to drive away the fox, which keeps possession of the food. However there were no injuries.",
+            null,
+            "Fiercely, r_c throws themselves at the fox, determined to win the fawn prize. But the fox values it just as dearly, and manages to get a good grip on r_c, shaking them to pieces and killing them.",
+            "r_c launches into battle, but is caught with a nasty bite, and retreats to limp back home. The fox doesn't follow, happy enough to eat the fawn instead of the foolish cat.",
+            null,
+            "s_c is overconfident in their attack and the fox manages to sink their teeth into them. They retreat, bleeding and in pain, and the fox settles back down to its meal."
+        ],
+        "win_skills": [
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "troublesome",
+            "vengeful",
+            "bloodthirsty",
+            "bold"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a solo fox fight.",
+            "r_c fell in a solo battle with a fox.",
+            "died while fighting a fox"
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_fox_greenleafscavenge1",
+        "biome": "forest",
+        "season": "greenleaf",
+        "tags": [
+            "hunting",
+            "fighting",
+            "scar",
+            "injury",
+            "bite-wound",
+            "clan_to_patrol",
+            "respect",
+            "rel_patrol",
+            "medium_prey0",
+            "medium_prey1",
+            "large_prey2",
+            "large_prey3"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? Tracking it, they find their red enemy feeding on a deer fawn carcass. It's impossible to say whether the fox killed it or found it.",
+        "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 50,
+        "exp": 20,
+        "success_text": [
+            "Your cats are smaller but they outnumber the fox, if only by a little, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full of venison and unwilling to lose blood over it, is driven off from the kill.",
+            null,
+            "s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until it gives up and runs.",
+            "The patrol launches into battle, but with so few cats it's exhausting trying to keep the fox and it's snapping jaws on the defensive. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. It's only one bite, but the fox has had enough and flees."
+        ],
+        "fail_text": [
+            "Your patrol fails to drive away the fox, which keeps possession of the food. However there were no injuries.",
+            null,
+            null,
+            "The patrol launches into battle, but r_c is caught with a nasty bite, and the cats give up on challenging for the food in favor of quickly helping r_c back to the medicine cat den.",
+            null,
+            "s_c means well, but they're overconfident in their attack and the fox manages to sink their teeth into them. The patrol is forced to retreat, forming a defensive ring around the hurt s_c."
+        ],
+        "win_skills": [
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "troublesome",
+            "vengeful",
+            "bloodthirsty",
+            "bold"
+        ],
+        "min_cats": 2,
+        "max_cats": 3,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a fox fight.",
+            null
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_fox_greenleafleafscavenge2",
+        "biome": "forest",
+        "season": "greenleaf",
+        "tags": [
+            "hunting",
+            "fighting",
+            "scar",
+            "injury",
+            "bite-wound",
+            "clan_to_patrol",
+            "respect",
+            "rel_patrol",
+            "medium_prey0",
+            "medium_prey1",
+            "large_prey2",
+            "large_prey3"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? Tracking it, they find their red enemy feeding on a deer fawn carcass. It's impossible to say whether the fox killed it or found it.",
+        "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 80,
+        "exp": 20,
+        "success_text": [
+            "Your cats are smaller but heavily outnumber the fox, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full of venison and unwilling to lose blood over it, is driven off from the kill.",
+            null,
+            "s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until s_c lands a crucial blow, snapping a tendon in one of the fox's hindlegs. The fox runs, but there's no way it'll live long with such a crippling injury.",
+            "The patrol launches into battle, keeping the fox on the defensive with teamwork. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. Holding on grimly, s_c's daring move gives the rest of the patrol the opportunity needed to bring the fox down for good."
+        ],
+        "fail_text": [
+            "Your patrol fails to drive away the fox, which keeps possession of the food. However with so many cats to protect each other, there were no injuries.",
+            null,
+            null,
+            "The patrol launches into battle, but r_c is caught with a nasty bite, and the cats give up on challenging for the food in favor of quickly helping r_c back to the medicine cat den.",
+            null,
+            "s_c means well, but they're overconfident in their attack and the fox manages to sink their teeth into them. The patrol is forced to retreat, forming a defensive ring around the hurt s_c."
+        ],
+        "win_skills": [
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "troublesome",
+            "vengeful",
+            "bloodthirsty",
+            "bold"
+        ],
+        "min_cats": 4,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a fox fight."
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_fox_greenleafscavenge3",
+        "biome": "forest",
+        "season": "greenleaf",
+        "tags": [
+            "hunting",
+            "fighting",
+            "death",
+            "scar",
+            "injury",
+            "bite-wound",
+            "clan_to_patrol",
+            "respect",
+            "medium_prey0",
+            "medium_prey1",
+            "large_prey2",
+            "large_prey3"
+        ],
+        "intro_text": "r_c catches the scent of a fox - but is it red, or gray? Tracking it, they find their red enemy feeding on a deer fawn carcass. It's impossible to say whether the fox killed it or found it.",
+        "decline_text": "r_c decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 30,
+        "exp": 30,
+        "success_text": [
+            "r_c may be smaller, alone, and half its weight, but the fox has a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle. The fox, already stuffed full of venison and unwilling to lose blood over it, leaves the kill with a grumble.",
+            null,
+            "s_c uses every trick in their talented fighting skillset to attack the fox with no one to watch their flank, until the perfect opportunity opens up and they pounce onto the fox's back, digging in their claws. It's a wild ride through the forest until the fox bucks them off, but it wins them the fawn carcass.",
+            "In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. But then they're stuck, unwilling to let go and risk being bitten. They're dragged through the forest, over rocks and through bushes, until the fox finally collapses and the battered s_c goes back to proudly claim the fawn."
+        ],
+        "fail_text": [
+            "Your patrol fails to drive away the fox, which keeps possession of the food. However there were no injuries.",
+            null,
+            "Fiercely, r_c throws themselves at the fox, determined to win the fawn prize. But the fox values it just as dearly, and manages to get a good grip on r_c, shaking them to pieces and killing them.",
+            "r_c launches into battle, but is caught with a nasty bite, and retreats to limp back home. The fox doesn't follow, happy enough to eat the fawn instead of the foolish cat.",
+            null,
+            "s_c is overconfident in their attack and the fox manages to sink their teeth into them. They retreat, bleeding and in pain, and the fox settles back down to its meal."
+        ],
+        "win_skills": [
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "troublesome",
+            "vengeful",
+            "bloodthirsty",
+            "bold"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a solo fox fight.",
+            "r_c fell in a solo battle with a fox.",
+            "died while fighting a fox"
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_fox_leaf-fallscavenge1",
+        "biome": "forest",
+        "season": "leaf-fall",
+        "tags": [
+            "hunting",
+            "fighting",
+            "scar",
+            "injury",
+            "bite-wound",
+            "clan_to_patrol",
+            "respect",
+            "rel_patrol",
+            "medium_prey0",
+            "medium_prey1",
+            "large_prey2",
+            "large_prey3"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? Tracking it, they find their red enemy feeding on a deer fawn carcass. It's impossible to say whether the fox killed it or found it.",
+        "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 50,
+        "exp": 20,
+        "success_text": [
+            "Your cats are smaller but they outnumber the fox, if only by a little, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full of venison and unwilling to lose blood over it, is driven off from the kill.",
+            null,
+            "s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until it gives up and runs.",
+            "The patrol launches into battle, but with so few cats it's exhausting trying to keep the fox and its snapping jaws on the defensive. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. It's only one bite, but the fox has had enough and flees."
+        ],
+        "fail_text": [
+            "Your patrol fails to drive away the fox, which keeps possession of the food. However there were no injuries.",
+            null,
+            null,
+            "The patrol launches into battle, but r_c is caught with a nasty bite, and the cats give up on challenging for the food in favor of quickly helping r_c back to the medicine cat den.",
+            null,
+            "s_c means well, but they're overconfident in their attack and the fox manages to sink their teeth into them. The patrol is forced to retreat, forming a defensive ring around the hurt s_c."
+        ],
+        "win_skills": [
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "troublesome",
+            "vengeful",
+            "bloodthirsty",
+            "bold"
+        ],
+        "min_cats": 2,
+        "max_cats": 3,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a fox fight.",
+            null
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_fox_leaf-fallscavenge2",
+        "biome": "forest",
+        "season": "leaf-fall",
+        "tags": [
+            "hunting",
+            "fighting",
+            "scar",
+            "injury",
+            "bite-wound",
+            "clan_to_patrol",
+            "respect",
+            "rel_patrol",
+            "medium_prey0",
+            "medium_prey1",
+            "large_prey2",
+            "large_prey3"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? Tracking it, they find their red enemy feeding on a deer fawn carcass. It's impossible to say whether the fox killed it or found it.",
+        "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 80,
+        "exp": 20,
+        "success_text": [
+            "Your cats are smaller but heavily outnumber the fox, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full of venison and unwilling to lose blood over it, is driven off from the kill.",
+            null,
+            "s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until s_c lands a crucial blow, snapping a tendon in one of the fox's hindlegs. The fox runs, but there's no way it'll live long with such a crippling injury.",
+            "The patrol launches into battle, keeping the fox on the defensive with teamwork. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. Holding on grimly, s_c's daring move gives the rest of the patrol the opportunity needed to bring the fox down for good."
+        ],
+        "fail_text": [
+            "Your patrol fails to drive away the fox, which keeps possession of the food. However with so many cats to protect each other, there were no injuries.",
+            null,
+            null,
+            "The patrol launches into battle, but r_c is caught with a nasty bite, and the cats give up on challenging for the food in favor of quickly helping r_c back to the medicine cat den.",
+            null,
+            "s_c means well, but they're overconfident in their attack and the fox manages to sink their teeth into them. The patrol is forced to retreat, forming a defensive ring around the hurt s_c."
+        ],
+        "win_skills": [
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "troublesome",
+            "vengeful",
+            "bloodthirsty",
+            "bold"
+        ],
+        "min_cats": 4,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a fox fight."
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_fox_leaf-fallscavenge3",
+        "biome": "forest",
+        "season": "leaf-fall",
+        "tags": [
+            "hunting",
+            "fighting",
+            "death",
+            "scar",
+            "injury",
+            "bite-wound",
+            "clan_to_patrol",
+            "respect",
+            "medium_prey0",
+            "medium_prey1",
+            "large_prey2",
+            "large_prey3"
+        ],
+        "intro_text": "r_c catches the scent of a fox - but is it red, or gray? Tracking it, they find their red enemy feeding on a deer fawn carcass. It's impossible to say whether the fox killed it or found it.",
+        "decline_text": "r_c decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 30,
+        "exp": 30,
+        "success_text": [
+            "r_c may be smaller, alone, and half its weight, but the fox has a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle. The fox, already stuffed full of venison and unwilling to lose blood over it, leaves the kill with a grumble.",
+            null,
+            "s_c uses every trick in their talented fighting skillset to attack the fox with no one to watch their flank, until the perfect opportunity opens up and they pounce onto the fox's back, digging in their claws. It's a wild ride through the forest until the fox bucks them off, but it wins them the fawn carcass.",
+            "In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. But then they're stuck, unwilling to let go and risk being bitten. They're dragged through the forest, over rocks and through bushes, until the fox finally collapses and the battered s_c goes back to proudly claim the fawn."
+        ],
+        "fail_text": [
+            "Your patrol fails to drive away the fox, which keeps possession of the food. However there were no injuries.",
+            null,
+            "Fiercely, r_c throws themselves at the fox, determined to win the fawn prize. But the fox values it just as dearly, and manages to get a good grip on r_c, shaking them to pieces and killing them.",
+            "r_c launches into battle, but is caught with a nasty bite, and retreats to limp back home. The fox doesn't follow, happy enough to eat the fawn instead of the foolish cat.",
+            null,
+            "s_c is overconfident in their attack and the fox manages to sink their teeth into them. They retreat, bleeding and in pain, and the fox settles back down to its meal."
+        ],
+        "win_skills": [
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "troublesome",
+            "vengeful",
+            "bloodthirsty",
+            "bold"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a solo fox fight.",
+            "r_c fell in a solo battle with a fox.",
+            "died while fighting a fox"
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_fox_leaf-barescavenge1",
+        "biome": "forest",
+        "season": "leaf-bare",
+        "tags": [
+            "hunting",
+            "fighting",
+            "scar",
+            "injury",
+            "bite-wound",
+            "clan_to_patrol",
+            "respect",
+            "rel_patrol",
+            "medium_prey0",
+            "medium_prey1",
+            "large_prey2",
+            "large_prey3"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? Tracking it, they find their red enemy feeding on a deer carcass, either a small doe or one of last newleaf's fawns. It's impossible to say whether the fox killed it or found it.",
+        "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 30,
+        "exp": 20,
+        "success_text": [
+            "Your cats are smaller but they outnumber the fox, if only by a little, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full of venison and unwilling to lose blood over it, is driven off from the kill.",
+            null,
+            "s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until it gives up and runs.",
+            "The patrol launches into battle, but with so few cats it's exhausting trying to keep the fox and its snapping jaws on the defensive. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. It's only one bite, but the fox has had enough and flees."
+        ],
+        "fail_text": [
+            "Your patrol fails to drive away the fox, which keeps possession of the food. However there were no injuries.",
+            null,
+            null,
+            "The patrol launches into battle, but r_c is caught with a nasty bite, and the cats give up on challenging for the food in favor of quickly helping r_c back to the medicine cat den.",
+            null,
+            "s_c means well, but they're overconfident in their attack and the fox manages to sink their teeth into them. The patrol is forced to retreat, forming a defensive ring around the hurt s_c."
+        ],
+        "win_skills": [
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "troublesome",
+            "vengeful",
+            "bloodthirsty",
+            "bold"
+        ],
+        "min_cats": 2,
+        "max_cats": 3,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a fox fight.",
+            null
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_fox_leaf-barescavenge2",
+        "biome": "forest",
+        "season": "leaf-bare",
+        "tags": [
+            "hunting",
+            "fighting",
+            "scar",
+            "injury",
+            "bite-wound",
+            "clan_to_patrol",
+            "respect",
+            "rel_patrol",
+            "medium_prey0",
+            "medium_prey1",
+            "large_prey2",
+            "large_prey3"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? Tracking it, they find their red enemy feeding on a deer carcass, either a small doe or one of last newleaf's fawns. It's impossible to say whether the fox killed it or found it.",
+        "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 60,
+        "exp": 20,
+        "success_text": [
+            "Your cats are smaller but heavily outnumber the fox, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full of venison and unwilling to lose blood over it, is driven off from the kill.",
+            null,
+            "s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until s_c lands a crucial blow, snapping a tendon in one of the fox's hindlegs. The fox runs, but there's no way it'll live long with such a crippling injury.",
+            "The patrol launches into battle, keeping the fox on the defensive with teamwork. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. Holding on grimly, s_c's daring move gives the rest of the patrol the opportunity needed to bring the fox down for good."
+        ],
+        "fail_text": [
+            "Your patrol fails to drive away the fox, which keeps possession of the food. However with so many cats to protect each other, there were no injuries.",
+            null,
+            null,
+            "The patrol launches into battle, but r_c is caught with a nasty bite, and the cats give up on challenging for the food in favor of quickly helping r_c back to the medicine cat den.",
+            null,
+            "s_c means well, but they're overconfident in their attack and the fox manages to sink their teeth into them. The patrol is forced to retreat, forming a defensive ring around the hurt s_c."
+        ],
+        "win_skills": [
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "troublesome",
+            "vengeful",
+            "bloodthirsty",
+            "bold"
+        ],
+        "min_cats": 4,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a fox fight."
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_fox_leaf-barescavenge3",
+        "biome": "forest",
+        "season": "leaf-bare",
+        "tags": [
+            "hunting",
+            "fighting",
+            "death",
+            "scar",
+            "injury",
+            "bite-wound",
+            "clan_to_patrol",
+            "respect",
+            "medium_prey0",
+            "medium_prey1",
+            "large_prey2",
+            "large_prey3"
+        ],
+        "intro_text": "r_c catches the scent of a fox - but is it red, or gray? Tracking it, they find their red enemy feeding on a deer carcass, either a small doe or one of last newleaf's fawns. It's impossible to say whether the fox killed it or found it.",
+        "decline_text": "r_c decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 10,
+        "exp": 30,
+        "success_text": [
+            "r_c may be smaller, alone, and half its weight, but the fox has a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle. The fox, already stuffed full of venison and unwilling to lose blood over it, leaves the kill with a grumble.",
+            null,
+            "s_c uses every trick in their talented fighting skillset to attack the fox with no one to watch their flank, until the perfect opportunity opens up and they pounce onto the fox's back, digging in their claws. It's a wild ride through the forest until the fox bucks them off, but it wins them the fawn carcass.",
+            "In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. But then they're stuck, unwilling to let go and risk being bitten. They're dragged through the forest, over rocks and through bushes, until the fox finally collapses and the battered s_c goes back to proudly claim the fawn."
+        ],
+        "fail_text": [
+            "Your patrol fails to drive away the fox, which keeps possession of the food. However there were no injuries.",
+            null,
+            "Fiercely, r_c throws themselves at the fox, determined to win the fawn prize. But the fox values it just as dearly, and manages to get a good grip on r_c, shaking them to pieces and killing them.",
+            "r_c launches into battle, but is caught with a nasty bite, and retreats to limp back home. The fox doesn't follow, happy enough to eat the fawn instead of the foolish cat.",
+            null,
+            "s_c is overconfident in their attack and the fox manages to sink their teeth into them. They retreat, bleeding and in pain, and the fox settles back down to its meal."
+        ],
+        "win_skills": [
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "troublesome",
+            "vengeful",
+            "bloodthirsty",
+            "bold"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a solo fox fight.",
+            "r_c fell in a solo battle with a fox.",
+            "died while fighting a fox"
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_foxgray_newleafscavenge1",
+        "biome": "forest",
+        "season": "newleaf",
+        "tags": [
+            "hunting",
+            "fighting",
+            "scar",
+            "injury",
+            "bite-wound",
+            "clan_to_patrol",
+            "respect",
+            "rel_patrol",
+            "medium_prey0",
+            "medium_prey1",
+            "large_prey2",
+            "large_prey3"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? Tracking it, they find a stocky gray fox feeding on a deer fawn carcass. A gray fox is unlikely to have killed a fawn this size.",
+        "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 70,
+        "exp": 20,
+        "success_text": [
+            "The cats are only just smaller and outnumber the fox, if only by a little, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full of venison and unwilling to lose blood over it, is driven off from the kill.",
+            null,
+            "s_c shows their strength, leading the fight against the gray fox. By working together and keeping it distracted, the cats harry and harass the fox until it gives up and runs.",
+            "The patrol launches into battle, but with so few cats it's exhausting trying to keep the fox and it's snapping jaws on the defensive. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. It's only one bite, but the fox has had enough and flees."
+        ],
+        "fail_text": [
+            "Your patrol fails to drive away the fox, which keeps possession of the food. However there were no injuries.",
+            "s_c makes a stupid mistake, too intent on winning the fight to respect their enemy's teeth, and it's only being yanked back by the tail that saves them from injury. The patrol gives up, and settles down to wait a safe distance away until the fox leaves of its own accord.",
+            null,
+            null,
+            null,
+            "s_c means well, but they're overconfident in their attack and the fox manages to sink their teeth into them. The patrol is forced to retreat, forming a defensive ring around the hurt s_c."
+        ],
+        "win_skills": [
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "troublesome",
+            "vengeful",
+            "bloodthirsty",
+            "bold"
+        ],
+        "min_cats": 2,
+        "max_cats": 3,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a fox fight.",
+            null
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_foxgray_newleafscavenge2",
+        "biome": "forest",
+        "season": "newleaf",
+        "tags": [
+            "hunting",
+            "fighting",
+            "clan_to_patrol",
+            "respect",
+            "rel_patrol",
+            "medium_prey0",
+            "medium_prey1",
+            "large_prey2",
+            "large_prey3"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? Tracking it, they find a stocky gray fox feeding on a deer fawn carcass. A gray fox is unlikely to have killed a fawn this size.",
+        "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 90,
+        "exp": 20,
+        "success_text": [
+            "Your cats are only just smaller and heavily outnumber the fox, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full of venison and unwilling to lose blood over it, is driven off from the kill.",
+            null,
+            "s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until s_c lands a crucial blow, snapping a tendon in one of the fox's hindlegs. The fox runs, but there's no way it'll live long with such a crippling injury.",
+            "The patrol launches into battle, keeping the fox on the defensive with teamwork. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. Holding on grimly, s_c's daring move gives the rest of the patrol the opportunity needed to bring the fox down for good."
+        ],
+        "fail_text": [
+            "Your patrol fails to drive away the fox, which keeps possession of the food. However with so many cats to protect each other, there were no injuries.",
+            "s_c makes a stupid mistake, too intent on winning the fight to respect their enemy's teeth, and it's only being yanked back by the tail that saves them from injury. The patrol gives up, and settles down to wait a safe distance away until the fox leaves of its own accord."
+        ],
+        "win_skills": [
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "troublesome",
+            "vengeful",
+            "bloodthirsty",
+            "bold"
+        ],
+        "min_cats": 4,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null
+    },
+    {
+        "patrol_id": "fst_hunt_foxgray_newleafscavenge3",
+        "biome": "forest",
+        "season": "newleaf",
+        "tags": [
+            "hunting",
+            "fighting",
+            "scar",
+            "injury",
+            "bite-wound",
+            "clan_to_patrol",
+            "respect",
+            "medium_prey0",
+            "medium_prey1",
+            "large_prey2",
+            "large_prey3"
+        ],
+        "intro_text": "r_c catches the scent of a fox - but is it red, or gray? Tracking it, they find a stocky gray fox feeding on a deer fawn carcass. A gray fox is unlikely to have killed a fawn this size.",
+        "decline_text": "r_c decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 50,
+        "exp": 30,
+        "success_text": [
+            "r_c may be smaller, alone, and half its weight, but the fox has a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle. The fox, already stuffed full of venison and unwilling to lose blood over it, leaves the kill with a grumble.",
+            null,
+            "s_c uses every trick in their talented fighting skillset to attack the fox with no one to watch their flank, until the perfect opportunity opens up and they pounce onto the fox's back, digging in their claws. It's a wild ride through the forest until the fox bucks them off, but it wins them the fawn carcass.",
+            "In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. But then they're stuck, unwilling to let go and risk being bitten. They're dragged through the forest, over rocks and through bushes, until the fox finally collapses and the battered s_c goes back to proudly claim the fawn."
+        ],
+        "fail_text": [
+            "Your patrol fails to drive away the gray fox, which keeps possession of the food. However there were no injuries.",
+            "s_c makes a stupid mistake, too intent on winning the fight to respect their enemy's teeth, and it's tripping over their own feet that saves them. They give up, and settle down to wait a safe distance away until the fox leaves of its own accord.",
+            null,
+            "r_c launches into battle, but is caught with a nasty bite, and retreats to limp back home. The gray fox doesn't follow, happy enough to eat the fawn instead of the foolish cat.",
+            null,
+            "s_c is overconfident in their attack and the fox manages to sink their teeth into them. They retreat, bleeding and in pain, and the gray fox settles back down to its meal."
+        ],
+        "win_skills": [
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "troublesome",
+            "vengeful",
+            "bloodthirsty",
+            "bold"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a solo fox fight.",
+            null
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_foxgray_greenleafscavenge1",
+        "biome": "forest",
+        "season": "greenleaf",
+        "tags": [
+            "hunting",
+            "fighting",
+            "scar",
+            "injury",
+            "bite-wound",
+            "clan_to_patrol",
+            "respect",
+            "rel_patrol",
+            "medium_prey0",
+            "medium_prey1",
+            "large_prey2",
+            "large_prey3"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? Tracking it, they find a stocky gray fox feeding on a deer fawn carcass. A gray fox is unlikely to have killed a fawn this size.",
+        "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 70,
+        "exp": 20,
+        "success_text": [
+            "The cats are only just smaller and outnumber the fox, if only by a little, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full of venison and unwilling to lose blood over it, is driven off from the kill.",
+            null,
+            "s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until it gives up and runs.",
+            "The patrol launches into battle, but with so few cats it's exhausting trying to keep the fox and its snapping jaws on the defensive. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. It's only one bite, but the fox has had enough and flees."
+        ],
+        "fail_text": [
+            "Your patrol fails to drive away the fox, which keeps possession of the food. However there were no injuries.",
+            "s_c makes a stupid mistake, too intent on winning the fight to respect their enemy's teeth, and it's only being yanked back by the tail that saves them from injury. The patrol gives up, and settles down to wait a safe distance away until the fox leaves of its own accord.",
+            null,
+            null,
+            null,
+            "s_c means well, but they're overconfident in their attack and the fox manages to sink their teeth into them. The patrol is forced to retreat, forming a defensive ring around the hurt s_c."
+        ],
+        "win_skills": [
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "troublesome",
+            "vengeful",
+            "bloodthirsty",
+            "bold"
+        ],
+        "min_cats": 2,
+        "max_cats": 3,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a fox fight.",
+            null
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_foxgray_greenleafscavenge2",
+        "biome": "forest",
+        "season": "greenleaf",
+        "tags": [
+            "hunting",
+            "fighting",
+            "scar",
+            "injury",
+            "clan_to_patrol",
+            "respect",
+            "rel_patrol",
+            "medium_prey0",
+            "medium_prey1",
+            "large_prey2",
+            "large_prey3"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? Tracking it, they find a stocky gray fox feeding on a deer fawn carcass. A gray fox is unlikely to have killed a fawn this size.",
+        "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 90,
+        "exp": 20,
+        "success_text": [
+            "Your cats are only just smaller and heavily outnumber the fox, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full of venison and unwilling to lose blood over it, is driven off from the kill.",
+            null,
+            "s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until s_c lands a crucial blow, snapping a tendon in one of the fox's hindlegs. The fox runs, but there's no way it'll live long with such a crippling injury.",
+            "The patrol launches into battle, keeping the fox on the defensive with teamwork. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. Holding on grimly, s_c's daring move gives the rest of the patrol the opportunity needed to bring the fox down for good."
+        ],
+        "fail_text": [
+            "Your patrol fails to drive away the fox, which keeps possession of the food. However with so many cats to protect each other, there were no injuries.",
+            "s_c makes a stupid mistake, too intent on winning the fight to respect their enemy's teeth, and it's only being janked back by the tail that saves them from injury. The patrol gives up, and settles down to wait a safe distance away until the fox leaves of its own accord."
+        ],
+        "win_skills": [
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "troublesome",
+            "vengeful",
+            "bloodthirsty",
+            "bold"
+        ],
+        "min_cats": 4,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a fox fight."
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_foxgray_greenleafscavenge3",
+        "biome": "forest",
+        "season": "greenleaf",
+        "tags": [
+            "hunting",
+            "fighting",
+            "scar",
+            "injury",
+            "bite-wound",
+            "clan_to_patrol",
+            "respect",
+            "medium_prey0",
+            "medium_prey1",
+            "large_prey2",
+            "large_prey3"
+        ],
+        "intro_text": "r_c catches the scent of a fox - but is it red, or gray? Tracking it, they find a stocky gray fox feeding on a deer fawn carcass. A gray fox is unlikely to have killed a fawn this size.",
+        "decline_text": "r_c decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 50,
+        "exp": 30,
+        "success_text": [
+            "r_c may be smaller, alone, and half its weight, but the fox has a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle. The fox, already stuffed full of venison and unwilling to lose blood over it, leaves the kill with a grumble.",
+            null,
+            "s_c uses every trick in their talented fighting skillset to attack the fox with no one to watch their flank, until the perfect opportunity opens up and they pounce onto the fox's back, digging in their claws. It's a wild ride through the forest until the fox bucks them off, but it wins them the fawn carcass.",
+            "In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. But then they're stuck, unwilling to let go and risk being bitten. They're dragged through the forest, over rocks and through bushes, until the fox finally collapses and the battered s_c goes back to proudly claim the fawn."
+        ],
+        "fail_text": [
+            "Your patrol fails to drive away the gray fox, which keeps possession of the food. However there were no injuries.",
+            "s_c makes a stupid mistake, too intent on winning the fight to respect their enemy's teeth, and it's tripping over their own feet that saves them. They give up, and settle down to wait a safe distance away until the fox leaves of its own accord.",
+            null,
+            "r_c launches into battle, but is caught with a nasty bite, and retreats to limp back home. The gray fox doesn't follow, happy enough to eat the fawn instead of the foolish cat.",
+            null,
+            "s_c is overconfident in their attack and the fox manages to sink their teeth into them. They retreat, bleeding and in pain, and the gray fox settles back down to its meal."
+        ],
+        "win_skills": [
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "troublesome",
+            "vengeful",
+            "bloodthirsty",
+            "bold"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a solo fox fight.",
+            null
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_foxgray_leaf-fallscavenge1",
+        "biome": "forest",
+        "season": "leaf-fall",
+        "tags": [
+            "hunting",
+            "fighting",
+            "scar",
+            "injury",
+            "bite-wound",
+            "clan_to_patrol",
+            "respect",
+            "rel_patrol",
+            "medium_prey0",
+            "medium_prey1",
+            "large_prey2",
+            "large_prey3"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? Tracking it, they find a stocky gray fox feeding on a deer fawn carcass. A gray fox is unlikely to have killed a fawn this size.",
+        "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 70,
+        "exp": 20,
+        "success_text": [
+            "The cats are only just smaller and outnumber the fox, if only by a little, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full of venison and unwilling to lose blood over it, is driven off from the kill.",
+            null,
+            "s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until it gives up and runs.",
+            "The patrol launches into battle, but with so few cats it's exhausting trying to keep the fox and its snapping jaws on the defensive. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. It's only one bite, but the fox has had enough and flees."
+        ],
+        "fail_text": [
+            "Your patrol fails to drive away the fox, which keeps possession of the food. However there were no injuries.",
+            "s_c makes a stupid mistake, too intent on winning the fight to respect their enemy's teeth, and it's only being janked back by the tail that saves them from injury. The patrol gives up, and settles down to wait a safe distance away until the fox leaves of its own accord.",
+            null,
+            null,
+            null,
+            "s_c means well, but they're overconfident in their attack and the fox manages to sink their teeth into them. The patrol is forced to retreat, forming a defensive ring around the hurt s_c."
+        ],
+        "win_skills": [
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "troublesome",
+            "vengeful",
+            "bloodthirsty",
+            "bold"
+        ],
+        "min_cats": 2,
+        "max_cats": 3,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a fox fight.",
+            null
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_foxgray_leaf-fallscavenge2",
+        "biome": "forest",
+        "season": "leaf-fall",
+        "tags": [
+            "hunting",
+            "fighting",
+            "scar",
+            "injury",
+            "clan_to_patrol",
+            "respect",
+            "rel_patrol",
+            "medium_prey0",
+            "medium_prey1",
+            "large_prey2",
+            "large_prey3"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? Tracking it, they find a stocky gray fox feeding on a deer fawn carcass. A gray fox is unlikely to have killed a fawn this size.",
+        "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 90,
+        "exp": 20,
+        "success_text": [
+            "Your cats are only just smaller and heavily outnumber the fox, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full of venison and unwilling to lose blood over it, is driven off from the kill.",
+            null,
+            "s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until s_c lands a crucial blow, snapping a tendon in one of the fox's hindlegs. The fox runs, but there's no way it'll live long with such a crippling injury.",
+            "The patrol launches into battle, keeping the fox on the defensive with teamwork. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. Holding on grimly, s_c's daring move gives the rest of the patrol the opportunity needed to bring the fox down for good."
+        ],
+        "fail_text": [
+            "Your patrol fails to drive away the fox, which keeps possession of the food. However with so many cats to protect each other, there were no injuries.",
+            "s_c makes a stupid mistake, too intent on winning the fight to respect their enemy's teeth, and it's only being yanked back by the tail that saves them from injury. The patrol gives up, and settles down to wait a safe distance away until the fox leaves of its own accord."
+        ],
+        "win_skills": [
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "troublesome",
+            "vengeful",
+            "bloodthirsty",
+            "bold"
+        ],
+        "min_cats": 4,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a fox fight."
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_foxgray_leaf-fallscavenge3",
+        "biome": "forest",
+        "season": "leaf-fall",
+        "tags": [
+            "hunting",
+            "fighting",
+            "scar",
+            "injury",
+            "bite-wound",
+            "clan_to_patrol",
+            "respect",
+            "medium_prey0",
+            "medium_prey1",
+            "large_prey2",
+            "large_prey3"
+        ],
+        "intro_text": "r_c catches the scent of a fox - but is it red, or gray? Tracking it, they find a stocky gray fox feeding on a deer fawn carcass. A gray fox is unlikely to have killed a fawn this size.",
+        "decline_text": "r_c decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 50,
+        "exp": 30,
+        "success_text": [
+            "r_c may be smaller, alone, and half its weight, but the fox has a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle. The fox, already stuffed full of venison and unwilling to lose blood over it, leaves the kill with a grumble.",
+            null,
+            "s_c uses every trick in their talented fighting skillset to attack the fox with no one to watch their flank, until the perfect opportunity opens up and they pounce onto the fox's back, digging in their claws. It's a wild ride through the forest until the fox bucks them off, but it wins them the fawn carcass.",
+            "In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. But then they're stuck, unwilling to let go and risk being bitten. They're dragged through the forest, over rocks and through bushes, until the fox finally collapses and the battered s_c goes back to proudly claim the fawn."
+        ],
+        "fail_text": [
+            "Your patrol fails to drive away the gray fox, which keeps possession of the food. However there were no injuries.",
+            "s_c makes a stupid mistake, too intent on winning the fight to respect their enemy's teeth, and it's tripping over their own feet that saves them. They give up, and settle down to wait a safe distance away until the fox leaves of its own accord.",
+            null,
+            "r_c launches into battle, but is caught with a nasty bite, and retreats to limp back home. The gray fox doesn't follow, happy enough to eat the fawn instead of the foolish cat.",
+            null,
+            "s_c is overconfident in their attack and the fox manages to sink their teeth into them. They retreat, bleeding and in pain, and the gray fox settles back down to its meal."
+        ],
+        "win_skills": [
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "troublesome",
+            "vengeful",
+            "bloodthirsty",
+            "bold"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a solo fox fight.",
+            null
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_foxgray_leaf-barescavenge1",
+        "biome": "forest",
+        "season": "leaf-bare",
+        "tags": [
+            "hunting",
+            "fighting",
+            "scar",
+            "injury",
+            "bite-wound",
+            "clan_to_patrol",
+            "respect",
+            "rel_patrol",
+            "medium_prey0",
+            "medium_prey1",
+            "large_prey2",
+            "large_prey3"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? Tracking it, they find a stocky gray fox feeding on a deer carcass, either a small doe or one of last newleaf's fawns. A gray fox could never take on prey this size, it must have found the carcass, and now c_n has too.",
+        "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 50,
+        "exp": 20,
+        "success_text": [
+            "The cats are only just smaller and outnumber the fox, if only by a little, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full of venison and unwilling to lose blood over it, is driven off from the kill.",
+            null,
+            "s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until it gives up and runs.",
+            "The patrol launches into battle, but with so few cats it's exhausting trying to keep the fox and its snapping jaws on the defensive. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. It's only one bite, but the fox has had enough and flees."
+        ],
+        "fail_text": [
+            "Your patrol fails to drive away the fox, which keeps possession of the food. However there were no injuries.",
+            "s_c makes a stupid mistake, too intent on winning the fight to respect their enemy's teeth, and it's only being yanked back by the tail that saves them from injury. The patrol gives up, and settles down to wait a safe distance away until the fox leaves of its own accord.",
+            null,
+            null,
+            null,
+            "s_c means well, but they're overconfident in their attack and the fox manages to sink their teeth into them. The patrol is forced to retreat, forming a defensive ring around the hurt s_c."
+        ],
+        "win_skills": [
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "troublesome",
+            "vengeful",
+            "bloodthirsty",
+            "bold"
+        ],
+        "min_cats": 2,
+        "max_cats": 3,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a fox fight.",
+            null
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_foxgray_leaf-barescavenge2",
+        "biome": "forest",
+        "season": "leaf-bare",
+        "tags": [
+            "hunting",
+            "fighting",
+            "scar",
+            "injury",
+            "clan_to_patrol",
+            "respect",
+            "rel_patrol",
+            "medium_prey0",
+            "medium_prey1",
+            "large_prey2",
+            "large_prey3"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? Tracking it, they find a stocky gray fox feeding on a deer carcass, either a small doe or one of last newleaf's fawns. A gray fox could never take on prey this size, it must have found the carcass, and now c_n has too.",
+        "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 70,
+        "exp": 20,
+        "success_text": [
+            "Your cats are only just smaller and heavily outnumber the fox, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full of venison and unwilling to lose blood over it, is driven off from the kill.",
+            null,
+            "s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until s_c lands a crucial blow, snapping a tendon in one of the fox's hindlegs. The fox runs, but there's no way it'll live long with such a crippling injury.",
+            "The patrol launches into battle, keeping the fox on the defensive with teamwork. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. Holding on grimly, s_c's daring move gives the rest of the patrol the opportunity needed to bring the fox down for good."
+        ],
+        "fail_text": [
+            "Your patrol fails to drive away the fox, which keeps possession of the food. However with so many cats to protect each other, there were no injuries.",
+            "s_c makes a stupid mistake, too intent on winning the fight to respect their enemy's teeth, and it's only being yanked back by the tail that saves them from injury. The patrol gives up, and settles down to wait a safe distance away until the fox leaves of its own accord."
+        ],
+        "win_skills": [
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "troublesome",
+            "vengeful",
+            "bloodthirsty",
+            "bold"
+        ],
+        "min_cats": 4,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a fox fight."
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_foxgray_leaf-barescavenge3",
+        "biome": "forest",
+        "season": "leaf-bare",
+        "tags": [
+            "hunting",
+            "fighting",
+            "scar",
+            "injury",
+            "bite-wound",
+            "clan_to_patrol",
+            "respect",
+            "medium_prey0",
+            "medium_prey1",
+            "large_prey2",
+            "large_prey3"
+        ],
+        "intro_text": "r_c catches the scent of a fox - but is it red, or gray? Tracking it, they find a stocky gray fox feeding on a deer carcass, either a small doe or one of last newleaf's fawns. A gray fox could never take on prey this size, it must have found the carcass, and now c_n has too.",
+        "decline_text": "r_c decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 30,
+        "exp": 30,
+        "success_text": [
+            "r_c may be smaller, alone, and half its weight, but the fox has a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle. The fox, already stuffed full of venison and unwilling to lose blood over it, leaves the kill with a grumble.",
+            null,
+            "s_c uses every trick in their talented fighting skillset to attack the fox with no one to watch their flank, until the perfect opportunity opens up and they pounce onto the fox's back, digging in their claws. It's a wild ride through the forest until the fox bucks them off, but it wins them the fawn carcass.",
+            "In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. But then they're stuck, unwilling to let go and risk being bitten. They're dragged through the forest, over rocks and through bushes, until the fox finally collapses and the battered s_c goes back to proudly claim the fawn."
+        ],
+        "fail_text": [
+            "Your patrol fails to drive away the gray fox, which keeps possession of the food. However there were no injuries.",
+            "s_c makes a stupid mistake, too intent on winning the fight to respect their enemy's teeth, and it's tripping over their own feet that saves them. They give up, and settle down to wait a safe distance away until the fox leaves of its own accord.",
+            null,
+            "r_c launches into battle, but is caught with a nasty bite, and retreats to limp back home. The gray fox doesn't follow, happy enough to eat the fawn instead of the foolish cat.",
+            null,
+            "s_c is overconfident in their attack and the fox manages to sink their teeth into them. They retreat, bleeding and in pain, and the gray fox settles back down to its meal."
+        ],
+        "win_skills": [
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "troublesome",
+            "vengeful",
+            "bloodthirsty",
+            "bold"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a solo fox fight.",
+            null
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_redvixen1",
+        "biome": "forest",
+        "season": "newleaf",
+        "tags": [
+            "fighting",
+            "death",
+            "scar",
+            "big_bite_injury",
+            "respect",
+            "trust",
+            "clan_to_r_c",
+            "patrol_to_r_c",
+            "clan_to_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
+        "decline_text": "Your patrol decides not to pursue the fox.",
+        "chance_of_success": 30,
+        "exp": 30,
+        "success_text": [
+            "The red vixen smells of milk, and hopefully by driving her out of the territory, her litter this newleaf won't be a threat to the Clan. If they don't starve, c_n will hunt them down - they do not share territory with foxes.",
+            "Your patrol drives away the red fox, seeks out her den, and kills her young cubs. It's brutal, but these fluffy baby foxes would one day have grown to be kit-killers and thieves.",
+            "s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the red fox nor her cubs pose a threat to the Clan. It truly proves s_c's place as one of c_n's most talented and skillful fighters.",
+            "The patrol overcomes the red vixen and drives her off thanks to a brilliant battle move by s_c at a critical moment. Their bravery ensures the patrol's success, and the cats arrive back at camp singing their praises to make sure the Clan knows it."
+        ],
+        "fail_text": [
+            "The mother red fox is vicious and determined, and the small patrol is beaten back. But this forest is c_n's and they haven't given up. They may have lost this battle, but c_n will win this war.",
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarasses them deeply the rest of the patrol have to rescue them from the red vixen.",
+            "Never threaten a mother's young - the red vixen kills r_c in the skirmish.",
+            "The mother red fox's snapping jaws leave r_c dripping blood onto the leaf litter, forcing the patrol to back off.",
+            null,
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the red vixen manages to sink her teeth into them. The patrol rallies around s_c, but they have to give up on the fight.",
+            "As their hunt descends into a full on battle with the red vixen, p_l takes a blow meant for one of their Clanmates, losing a life."
+        ],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 2,
+        "max_cats": 3,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a fox fight.",
+            "r_c fell in battle with a fox.",
+            "died while fighting a fox"
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_redvixen2",
+        "biome": "forest",
+        "season": "newleaf",
+        "tags": [
+            "fighting",
+            "scar",
+            "big_bite_injury",
+            "respect",
+            "trust",
+            "clan_to_r_c",
+            "patrol_to_r_c",
+            "clan_to_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
+        "decline_text": "Your patrol decides not to pursue the fox.",
+        "chance_of_success": 60,
+        "exp": 30,
+        "success_text": [
+            "Led by p_l, and with a heap of cooperation and teamwork, the patrol drives away the red fox, seeks out her den, and kills her young cubs. The forest will be safe from both the threat the vixen posed this season, and the threat her cubs would've given c_n in the seasons to come.",
+            "With so many cats working together in tight coordination, they manage to accomplish the near-impossible, killing the red mother vixen and ending the threat to the Clan that she and her cubs pose.",
+            "s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the red fox nor her dependent cubs pose a threat to the Clan. It truly proves s_c's place as one of c_n's most talented and skillful fighters.",
+            "The patrol overcomes the red vixen and drives her off thanks to a brilliant battle move by s_c at a critical moment. Their bravery ensures the patrol's success, and the cats arrive back at camp singing their praises to make sure the Clan knows it."
+        ],
+        "fail_text": [
+            "The mother red fox is vicious and determined. Although they lose this battle, through teamwork the cats manage to retreat without injury.",
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarasses them deeply the rest of the patrol have to rescue them from the red vixen.",
+            null,
+            "r_c is left wounded as the patrol and the red mother vixen fight to a stalemate. Hopefully they've given the fox mother a reason not to return to this part of the forest.",
+            null,
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the red vixen manages to sink her teeth into them. The patrol rallies around s_c, but they have to give up on the fight."
+        ],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 4,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a fox fight."
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_redvixen3",
+        "biome": "forest",
+        "season": "newleaf",
+        "tags": [
+            "fighting",
+            "death",
+            "scar",
+            "big_bite_injury",
+            "shock",
+            "injury",
+            "respect",
+            "trust",
+            "clan_to_patrol",
+            "no_body"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
+        "decline_text": "Your patrol decides not to pursue the fox.",
+        "chance_of_success": 20,
+        "exp": 50,
+        "success_text": [
+            "The red vixen smells of milk, and hopefully by driving her out of the territory, her litter this newleaf won't be a threat to the Clan. If they don't starve, c_n will hunt them down - they do not share territory with foxes.",
+            null,
+            "s_c displays incredible skill, driving the mother vixen and her brood out of the forest all by themselves. Now neither the red fox nor her dependent cubs pose a threat to the Clan. They swell with pride, feeling the confidence of knowing that they're truly one of the best fighters c_n has ever produced.",
+            "A brilliant battle move by s_c knocks the red vixen off balance, and s_c manages to drive her out of c_n territory, though it takes every spark of strength in their pelt to do it alone."
+        ],
+        "fail_text": [
+            null,
+            null,
+            "Never threaten a mother's young - the red vixen kills r_c in the skirmish, and carries off the body to feed her litter.",
+            "The mother red fox's snapping jaws leave r_c dripping blood onto the leaf litter, and barely able to escape further injury.",
+            null,
+            "s_c is determined to win, but the red vixen is determined to live, and that makes all the difference. s_c ends up pinned in a defensible hiding spot, bleeding and terrified, until the vixen judges them no longer a threat and continues on her way."
+        ],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a solo fight with a vixen.",
+            "r_c fell in a solo battle with a vixen.",
+            "died while fighting a vixen"
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_redvixen4",
+        "biome": "forest",
+        "season": "greenleaf",
+        "tags": [
+            "fighting",
+            "death",
+            "scar",
+            "big_bite_injury",
+            "respect",
+            "trust",
+            "clan_to_r_c",
+            "patrol_to_r_c",
+            "clan_to_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
+        "decline_text": "Your patrol decides not to pursue the fox.",
+        "chance_of_success": 30,
+        "exp": 30,
+        "success_text": [
+            "The red vixen smells of milk and blood. Hopefully by driving her out of the territory, the litter she has been raising this greenleaf won't be a threat to the Clan. If they don't starve, c_n will hunt them down - they do not share with foxes.",
+            "Your patrol drives away the red fox, seeks out her den, and kills her cubs. It's brutal, but these fluffy small foxes would one day have grown to be kit-killers and thieves.",
+            "s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the red fox nor her dependent cubs pose a threat to the Clan. It truly proves s_c's place as one of c_n's most talented and skillful fighters.",
+            "The patrol overcomes the red vixen and drives her off thanks to a brilliant battle move by s_c at a critical moment. Their bravery ensures the patrol's success, and the cats arrive back at camp singing their praises to make sure the Clan knows it."
+        ],
+        "fail_text": [
+            "The mother red fox is vicious and determined, and the small patrol is beaten back. But this forest is c_n's and they haven't given up. They may have lost this battle, but c_n will win this war.",
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarasses them deeply the rest of the patrol have to rescue them from the red vixen.",
+            "Never threaten a mother's young - the red vixen kills r_c in the skirmish.",
+            "The mother red fox's snapping jaws leave r_c dripping blood onto the leaf litter, forcing the patrol to back off.",
+            null,
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the red vixen manages to sink her teeth into them. The patrol rallies around s_c, but they have to give up on the fight.",
+            "As their hunt descends into a full on battle with the red vixen, p_l takes a blow meant for one of their Clanmates, losing a life."
+        ],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 2,
+        "max_cats": 3,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a fox fight.",
+            "r_c fell in battle with a fox.",
+            "died while fighting a fox"
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_redvixen5",
+        "biome": "forest",
+        "season": "greenleaf",
+        "tags": [
+            "fighting",
+            "scar",
+            "big_bite_injury",
+            "respect",
+            "trust",
+            "clan_to_r_c",
+            "patrol_to_r_c",
+            "clan_to_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
+        "decline_text": "Your patrol decides not to pursue the fox.",
+        "chance_of_success": 60,
+        "exp": 30,
+        "success_text": [
+            "Led by p_l, and with a heap of cooperation and teamwork, the patrol drives away the red fox, seeks out her den, and kills her growing cubs. The forest will be safe from both the threat the vixen posed this season, and the threat her cubs would've given c_n in the seasons to come.",
+            "With so many cats working together in tight coordination, they manage to accomplish the near-impossible, killing the red mother vixen and ending the threat to the Clan that she and her cubs pose.",
+            "s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the red fox nor her dependent cubs pose a threat to the Clan. It truly proves s_c's place as one of c_n's most talented and skillful fighters.",
+            "The patrol overcomes the red vixen and drives her off thanks to a brilliant battle move by s_c at a critical moment. Their bravery ensures the patrol's success, and the cats arrive back at camp singing their praises to make sure the Clan knows it."
+        ],
+        "fail_text": [
+            "The mother red fox is vicious and determined. Although they lose this battle, through teamwork the cats manage to retreat without injury.",
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarasses them deeply the rest of the patrol have to rescue them from the red vixen.",
+            null,
+            "r_c is left wounded as the patrol and the red mother vixen fight to a stalemate. Hopefully they've given the fox mother a reason not to return to this part of the forest.",
+            null,
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the red vixen manages to sink her teeth into them. The patrol rallies around s_c, but they have to give up on the fight."
+        ],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 4,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a fox fight."
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_redvixen6",
+        "biome": "forest",
+        "season": "greenleaf",
+        "tags": [
+            "fighting",
+            "death",
+            "scar",
+            "big_bite_injury",
+            "shock",
+            "injury",
+            "respect",
+            "trust",
+            "clan_to_patrol",
+            "no_body"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
+        "decline_text": "Your patrol decides not to pursue the fox.",
+        "chance_of_success": 10,
+        "exp": 50,
+        "success_text": [
+            "The red vixen smells of milk and blood. Hopefully by driving her out of the territory, the litter she has been raising this greenleaf won't be a threat to the Clan.",
+            null,
+            "s_c displays incredible skill, driving the mother vixen and her brood out of the forest all by themselves. Now neither the red fox nor her dependent cubs pose a threat to the Clan. They swell with pride, feeling the confidence of knowing that they're truly one of the best fighters c_n has ever produced.",
+            "A brilliant battle move by s_c at a critical moment knocks the red vixen off balance, and s_c manages to drive her out of c_n territory, though it takes every spark of strength in their pelt to do it alone."
+        ],
+        "fail_text": [
+            null,
+            null,
+            "Never threaten a mother's young - the red vixen kills r_c in the skirmish, and carries off the body to feed her litter.",
+            "The mother red fox's snapping jaws leave r_c dripping blood onto the leaf litter, and barely able to escape further injury.",
+            null,
+            "s_c is determined to win, but the red vixen is determined to live, and that makes all the difference. s_c ends up pinned in a defensible hiding spot, bleeding and terrified, until the vixen judges them no longer a threat and continues on her way."
+        ],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a solo fight with a vixen.",
+            "r_c fell in a solo battle with a vixen.",
+            "died while fighting a vixen"
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_redvixen7",
+        "biome": "forest",
+        "season": "leaf-fall",
+        "tags": [
+            "fighting",
+            "death",
+            "scar",
+            "big_bite_injury",
+            "respect",
+            "trust",
+            "clan_to_r_c",
+            "patrol_to_r_c",
+            "clan_to_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
+        "decline_text": "Your patrol decides not to pursue the fox.",
+        "chance_of_success": 30,
+        "exp": 30,
+        "success_text": [
+            "The red vixen smells like the prey she's been poaching to feed her litter. She's stolen from c_n for the last time, and the patrol drives her from their territory, yowling their anger and fury.",
+            "Your patrol drives away the red fox, and seeks out her den, but her leaf-fall cubs are near full-grown and scatter into the wilderness. Hopefully leaf-bare takes care of them.",
+            "s_c displays incredible skill, driving the red mother vixen out of the territory almost by themselves. It truly proves s_c's place as one of c_n's most talented and skillful fighters.",
+            "The patrol overcomes the red vixen and drives her off thanks to a brilliant battle move by s_c at a critical moment. Their bravery ensures the patrol's success, and the cats arrive back at camp singing their praises to make sure the Clan knows it."
+        ],
+        "fail_text": [
+            "The mother red fox is vicious and determined, and the small patrol is beaten back. But this forest is c_n's and they haven't given up. They may have lost this battle, but c_n will win this war.",
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarasses them deeply the rest of the patrol have to rescue them from the red vixen.",
+            "Never threaten a mother's young - the red vixen kills r_c in the skirmish.",
+            "The mother red fox's snapping jaws leave r_c dripping blood onto the leaf litter, forcing the patrol to back off.",
+            null,
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the red vixen manages to sink her teeth into them. The patrol rallies around s_c, but they have to give up on the fight.",
+            "As their hunt descends into a full on battle with the red vixen, p_l takes a blow meant for one of their Clanmates, losing a life."
+        ],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 2,
+        "max_cats": 3,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a fox fight.",
+            "r_c fell in battle with a fox.",
+            "died while fighting a vixen"
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_redvixen8",
+        "biome": "forest",
+        "season": "leaf-fall",
+        "tags": [
+            "fighting",
+            "scar",
+            "big_bite_injury",
+            "respect",
+            "trust",
+            "clan_to_r_c",
+            "patrol_to_r_c",
+            "clan_to_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
+        "decline_text": "Your patrol decides not to pursue the fox.",
+        "chance_of_success": 60,
+        "exp": 30,
+        "success_text": [
+            "Led by p_l and with a heap of cooperation and teamwork, the patrol drives away the red fox, and seeks out her den. But her cubs are near full-grown with the bounty of leaf-fall, and scatter from the patrol into the wilderness. Hopefully leaf-bare takes care of them.",
+            "With so many cats working together in tight coordination, they manage to accomplish the near-impossible, killing the red mother vixen and ending the threat to the Clan that she poses. The patrol drives her near-full grown litter of fox cubs out from the territory. Hopefully the coming leaf-bare will take care of them.",
+            "s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the red fox nor her cubs pose a threat to c_n.",
+            "The patrol overcomes the red vixen and drives her off thanks to a brilliant battle move by s_c at a critical moment. Their bravery ensures the patrol's success, and the cats arrive back at camp singing their praises to make sure the Clan knows it."
+        ],
+        "fail_text": [
+            "The mother red fox is vicious and determined. Although they lose this battle, through teamwork the cats manage to retreat without injury.",
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the red vixen manages to sink her teeth into them. The patrol rallies around s_c, but they have to give up the fight.",
+            null,
+            "r_c is left wounded as the patrol and the red mother vixen fight to a stalemate. Hopefully they've given the fox mother a reason not to return to this part of the forest."
+        ],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 4,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a red fox fight."
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_redvixen9",
+        "biome": "forest",
+        "season": "leaf-fall",
+        "tags": [
+            "fighting",
+            "death",
+            "scar",
+            "big_bite_injury",
+            "shock",
+            "injury",
+            "respect",
+            "trust",
+            "clan_to_patrol",
+            "no_body"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
+        "decline_text": "Your patrol decides not to pursue the fox.",
+        "chance_of_success": 20,
+        "exp": 50,
+        "success_text": [
+            "It takes r_c's every scrap of bravery and strength to drive away the red vixen - her near grown litter, fat on the bounty of leaf-fall, is a challenge for another day. c_n will have to deal with the young foxes now roaming motherless in their woods, before they start to compete for prey in leaf-bare.",
+            null,
+            "s_c displays incredible skill, driving the mother vixen and her brood out of the forest all by themselves. Now neither the red fox nor her cubs pose a threat to the Clan. They swell with pride, feeling the confidence of knowing that they're truly one of the best fighters c_n has ever produced.",
+            "A brilliant battle move by s_c at a critical moment knocks the red vixen off balance, and s_c manages to drive her out of c_n territory, though it takes every spark of strength in their pelt to do it alone."
+        ],
+        "fail_text": [
+            null,
+            null,
+            "Never threaten a mother's young - the red vixen kills r_c in the skirmish, and carries off the body to feed her litter.",
+            "The mother red fox's snapping jaws leave r_c dripping blood onto the leaf litter, and barely able to escape further injury.",
+            null,
+            "s_c is determined to win, but the red vixen is determined to live, and that makes all the difference. s_c ends up pinned in a defensible hiding spot, bleeding and terrified, until the vixen judges them no longer a threat and continues on her way."
+        ],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a solo fight with a red vixen.",
+            "r_c fell in a solo battle with a red vixen.",
+            "died while fighting a vixen"
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_grayvixen1",
+        "biome": "forest",
+        "season": "newleaf",
+        "tags": [
+            "fighting",
+            "minor_injury",
+            "respect",
+            "trust",
+            "rel_patrol",
+            "patrol_to_r_c"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
+        "decline_text": "Your patrol decides not to pursue the fox.",
+        "chance_of_success": 60,
+        "exp": 30,
+        "success_text": [
+            "The stocky gray vixen they track down smells of milk, and though she's nearly double the weight of any of the patrol and all of it muscle, they meet her eyes squarely, and leap to attack. c_n does not tolerate sharing their territory with foxes, and they work together to drive her off.",
+            "Your patrol drives away the gray fox, seeks out her den, and kills her young cubs. It's brutal, but these fluffy baby foxes would one day have grown to be kit-killers and thieves. Better to deal with them now than when they're the height and nearly double the weight of a cat, though a gray fox will always be easier than a bigger red one.",
+            "s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the gray fox nor her cubs pose a threat to the Clan. It places s_c as one of c_n's most talented and skillful fighters, a gray fox is a dangerous competitor.",
+            "The patrol overcomes the gray vixen they find and drives her off thanks to a brilliant battle move by s_c. The cats swirl around s_c afterwards, congratulating them on their bravery and skill."
+        ],
+        "fail_text": [
+            "The patrol comes across a gray vixen at the end of the scent trail. She spots them too, measures herself up against them, then flees, scrambling into the trees in a move that completely surprises the cats. This round goes to the gray fox.",
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarasses them deeply the gray vixen slips past them and flees further into the forest.",
+            null,
+            "The patrol finds a stocky gray vixen wandering their forest, and drives her out in a scene that mostly involves yowling and screaming and yapping at each other until she gives in. r_c gets a little battered, but everyone is mostly fine.",
+            null,
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is all muscle, barging past s_c and knocking them ass over paws as she flees from the patrol."
+        ],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 2,
+        "max_cats": 3,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a fox fight.",
+            null
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_grayvixen2",
+        "biome": "forest",
+        "season": "newleaf",
+        "tags": [
+            "fighting",
+            "minor_injury",
+            "respect",
+            "trust",
+            "rel_patrol",
+            "patrol_to_r_c"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
+        "decline_text": "Your patrol decides not to pursue the fox.",
+        "chance_of_success": 90,
+        "exp": 30,
+        "success_text": [
+            "The stocky gray vixen they track down smells of milk, and though she's nearly double the weight of any of the patrol and all of it muscle, they meet her eyes squarely, and leap to attack. c_n does not tolerate sharing their territory with foxes, and they work together to drive her off.",
+            "With so many cats working together in tight coordination, they're able to keep the gray vixen they find pinned and distracted as they wear her down. The fox eventually flees for her den, and the patrol follows to take care of the cubs she's raising.",
+            "s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the gray fox nor her cubs pose a threat to the Clan. It places s_c as one of c_n's most talented and skillful fighters, a gray fox is a dangerous competitor.",
+            "Bravely, s_c charges the gray fox, yowling threats. The vixen spooks and skitters up a tree, growling and barking in a squeaky tone, and s_c follows her up into the branches. As the rest of the patrol backs them up from the ground, s_c screams until the fox is cowering and afraid, then lets her flee."
+        ],
+        "fail_text": [
+            "The patrol comes across a gray vixen at the end of the scent trail. She spots them too, measures herself up against them, then flees, scrambling into the trees in a move that completely surprises the cats. This round goes to the gray fox.",
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarasses them deeply the gray vixen slips past them and flees further into the forest.",
+            null,
+            "The patrol finds a stocky gray vixen wandering their forest, and drives her out in a scene that mostly involves yowling and screaming and yapping at each other until she gives in. r_c gets a little battered, but everyone is mostly fine.",
+            null,
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is all muscle, barging past s_c and knocking them ass over paws as she flees from the patrol."
+        ],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 4,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a fox fight."
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_grayvixen3",
+        "biome": "forest",
+        "season": "newleaf",
+        "tags": [
+            "fighting",
+            "scar",
+            "big_bite_injury",
+            "respect",
+            "trust",
+            "clan_to_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
+        "decline_text": "Your patrol decides not to pursue the fox.",
+        "chance_of_success": 50,
+        "exp": 50,
+        "success_text": [
+            "The stocky gray vixen they track down smells of milk, and though she's near double r_c's weight and all of it muscle, they meet her eyes squarely, and leap to attack. c_n does not tolerate sharing their territory with foxes.",
+            null,
+            "s_c displays incredible skill, driving the mother vixen and her brood out of the forest all by themselves. Now neither the gray fox nor her dependent cubs pose a threat to the Clan. They swell with pride, returning to camp knowing there's one less competitor poaching c_n's prey.",
+            "They're nearly of equal height, with s_c's bold aggression making up for the weight that the gray vixen has on them, and the stand off is resolved when s_c charges the gray fox and she chooses flight over fight."
+        ],
+        "fail_text": [
+            "r_c comes across a gray vixen at the end of the scent trail. She spots them too, measures herself up against them, then flees, scrambling into the trees in a move that completely surprises r_c. This round goes to the gray fox.",
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarasses them deeply the gray vixen slips past them and flees further into the forest.",
+            null,
+            "r_c nearly managed to pin the gray vixen they found into a thorn ticket, but snapping jaws leave r_c dripping blood onto the leaf litter. Today this round goes to the gray fox.",
+            null,
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is cunning, sinking her teeth into s_c to distract them as she flees."
+        ],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a solo fight with a vixen.",
+            null
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_grayvixen4",
+        "biome": "forest",
+        "season": "greenleaf",
+        "tags": [
+            "fighting",
+            "minor_injury",
+            "respect",
+            "trust",
+            "rel_patrol",
+            "patrol_to_r_c"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
+        "decline_text": "Your patrol decides not to pursue the fox.",
+        "chance_of_success": 60,
+        "exp": 30,
+        "success_text": [
+            "The stocky gray vixen they track down smells of milk, and though she's nearly double the weight of any of the patrol and all of it muscle, they meet her eyes squarely, and leap to attack. c_n does not tolerate sharing their territory with foxes, and they work together to drive her off.",
+            "Your patrol drives away the gray fox, seeks out her den, and kills her young cubs. It's brutal, but these fluffy small foxes would one day have grown to be kit-killers and thieves. Better to deal with them now than when they're the height and nearly double the weight of a cat, though a gray fox will always be easier than a bigger red one.",
+            "s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the gray fox nor her cubs pose a threat to the Clan. It places s_c as one of c_n's most talented and skillful fighters, a gray fox is a dangerous competitor.",
+            "The patrol overcomes the gray vixen they find and drives her off thanks to a brilliant battle move by s_c. The cats swirl around s_c afterwards, congratulating them on their bravery and skill."
+        ],
+        "fail_text": [
+            "The patrol comes across a gray vixen at the end of the scent trail. She spots them too, measures herself up against them, then flees, scrambling into the trees in a move that completely surprises the cats. This round goes to the gray fox.",
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarasses them deeply the gray vixen slips past them and flees further into the forest.",
+            null,
+            "The patrol finds a stocky gray vixen wandering their forest, and drives her out in a scene that mostly involves yowling and screaming and yapping at each other until she gives in. r_c gets a little battered, but everyone is mostly fine.",
+            null,
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is all muscle, barging past s_c and knocking them ass over paws as she flees from the patrol."
+        ],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 2,
+        "max_cats": 3,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a fox fight.",
+            null
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_grayvixen5",
+        "biome": "forest",
+        "season": "greenleaf",
+        "tags": [
+            "fighting",
+            "minor_injury",
+            "respect",
+            "trust",
+            "rel_patrol",
+            "patrol_to_r_c"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
+        "decline_text": "Your patrol decides not to pursue the fox.",
+        "chance_of_success": 90,
+        "exp": 30,
+        "success_text": [
+            "Led by p_l, and with a heap of cooperation and teamwork, the patrol drives away the gray fox, seeks out her den, and kills her growing cubs. The forest will be safe from both the competition the vixen posed this season, and the threat her cubs would've given c_n in the seasons to come.",
+            "With so many cats working together in tight coordination, they're able to keep the gray vixen they find pinned and distracted as they wear her down. The fox eventually flees for her den, and the patrol follows to take care of the cubs she's raising.",
+            "s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the gray fox nor her cubs pose a threat to the Clan. It places s_c as one of c_n's most talented and skillful fighters, a gray fox is a dangerous competitor.",
+            "Bravely, s_c charges the gray fox, yowling threats. The vixen spooks and skitters up a tree, growling and barking in a squeaky tone, and s_c follows her up into the branches. As the rest of the patrol backs them up from the ground, s_c screams until the fox is cowering and afraid, then lets her flee."
+        ],
+        "fail_text": [
+            "The patrol comes across a gray vixen at the end of the scent trail. She spots them too, measures herself up against them, then flees, scrambling into the trees in a move that completely surprises the cats. This round goes to the gray fox.",
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarasses them deeply the gray vixen slips past them and flees further into the forest.",
+            null,
+            "The patrol finds a stocky gray vixen wandering their forest, and drives her out in a scene that mostly involves yowling and screaming and yapping at each other until she gives in. r_c gets a little battered, but everyone is mostly fine.",
+            null,
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is all muscle, barging past s_c and knocking them ass over paws as she flees from the patrol."
+        ],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 4,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a fox fight."
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_grayvixen6",
+        "biome": "forest",
+        "season": "greenleaf",
+        "tags": [
+            "fighting",
+            "scar",
+            "big_bite_injury",
+            "respect",
+            "trust",
+            "clan_to_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
+        "decline_text": "Your patrol decides not to pursue the fox.",
+        "chance_of_success": 50,
+        "exp": 50,
+        "success_text": [
+            "r_c finds a gray vixen smelling of milk and blood. Hopefully by driving her out of the territory, the litter she has been raising this greenleaf won't be a threat to the Clan.",
+            null,
+            "s_c displays incredible skill, driving the mother vixen and her brood out of the forest all by themselves. Now neither the gray fox nor her dependent cubs pose a threat to the Clan. They swell with pride, returning to camp knowing there's one less competitor poaching c_n's prey.",
+            "They're nearly of equal height, with s_c's bold aggression making up for the weight that the gray vixen has on them, and the stand off is resolved when s_c charges the gray fox and she chooses flight over fight."
+        ],
+        "fail_text": [
+            "r_c comes across a gray vixen at the end of the scent trail. She spots them too, measures herself up against them, then flees, scrambling into the trees in a move that completely surprises r_c. This round goes to the gray fox.",
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarasses them deeply the gray vixen slips past them and flees further into the forest.",
+            null,
+            "r_c nearly managed to pin the gray vixen they found into a thorn ticket, but snapping jaws leave r_c dripping blood onto the leaf litter. Today this round goes to the gray fox.",
+            null,
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is cunning, sinking her teeth into s_c to distract them as she flees."
+        ],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a solo fight with a vixen."
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_grayvixen7",
+        "biome": "forest",
+        "season": "leaf-fall",
+        "tags": [
+            "fighting",
+            "minor_injury",
+            "respect",
+            "trust",
+            "rel_patrol",
+            "patrol_to_r_c"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
+        "decline_text": "Your patrol decides not to pursue the fox.",
+        "chance_of_success": 60,
+        "exp": 30,
+        "success_text": [
+            "The gray vixen smells like the prey she's been poaching to feed her litter. She's stolen from c_n for the last time, and the patrol drives her from their territory, yowling their anger and fury.",
+            "Your patrol drives away the gray fox, and seeks out her den, but her leaf-fall cubs are near full-grown and scatter into the wilderness. Hopefully leaf-bare takes care of them, but if c_n spots them, they won't hesitate.",
+            "s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the gray fox nor her scattered cubs pose a threat to the Clan. It places s_c as one of c_n's most talented and skillful fighters, a gray fox is a dangerous competitor.",
+            "The patrol overcomes the gray vixen they find and drives her off thanks to a brilliant battle move by s_c. The cats swirl around s_c afterwards, congratulating them on their bravery and skill."
+        ],
+        "fail_text": [
+            "The patrol comes across a gray vixen at the end of the scent trail. She spots them too, measures herself up against them, then flees, scrambling into the trees in a move that completely surprises the cats. This round goes to the gray fox.",
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarasses them deeply the gray vixen slips past them and flees further into the forest.",
+            null,
+            "The patrol finds a stocky gray vixen wandering their forest, and drives her out in a scene that mostly involves yowling and screaming and yapping at each other until she gives in. r_c gets a little battered, but everyone is mostly fine.",
+            null,
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is all muscle, barging past s_c and knocking them ass over paws as she flees from the patrol."
+        ],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 2,
+        "max_cats": 3,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a fox fight.",
+            null
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_grayvixen8",
+        "biome": "forest",
+        "season": "leaf-fall",
+        "tags": [
+            "fighting",
+            "minor_injury",
+            "respect",
+            "trust",
+            "rel_patrol",
+            "patrol_to_r_c"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
+        "decline_text": "Your patrol decides not to pursue the fox.",
+        "chance_of_success": 90,
+        "exp": 30,
+        "success_text": [
+            "Led by p_l and with a heap of cooperation and teamwork, the patrol drives away the gray fox, and seeks out her den. But her cubs are near full-grown with the bounty of leaf-fall, and scatter from the patrol into the wilderness. Hopefully leaf-bare takes care of them.",
+            "With so many cats working together in tight coordination, they're able to keep the gray vixen they find pinned and distracted as they wear her down. The fox eventually flees for her den, and the patrol follows to drive her near-full grown litter of fox cubs out from the territory. Hopefully the coming leaf-bare will take care of them.",
+            "s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the gray fox nor her scattered cubs pose a threat to the Clan. It places s_c as one of c_n's most talented and skillful fighters, a gray fox is a dangerous competitor.",
+            "Bravely, s_c charges the gray fox, yowling threats. The vixen spooks and skitters up a tree, growling and barking in a squeaky tone, and s_c follows her up into the branches. As the rest of the patrol backs them up from the ground, s_c screams until the fox is cowering and afraid, then lets her flee."
+        ],
+        "fail_text": [
+            "The patrol comes across a gray vixen at the end of the scent trail. She spots them too, measures herself up against them, then flees, scrambling into the trees in a move that completely surprises the cats. This round goes to the gray fox.",
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarasses them deeply the gray vixen slips past them and flees further into the forest.",
+            null,
+            "The patrol finds a stocky gray vixen wandering their forest, and drives her out in a scene that mostly involves yowling and screaming and yapping at each other until she gives in. r_c gets a little battered, but everyone is mostly fine.",
+            null,
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is all muscle, barging past s_c and knocking them ass over paws as she flees from the patrol."
+        ],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 4,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a red fox fight."
+        ]
+    },
+    {
+        "patrol_id": "fst_hunt_grayvixen9",
+        "biome": "forest",
+        "season": "leaf-fall",
+        "tags": [
+            "fighting",
+            "scar",
+            "big_bite_injury",
+            "respect",
+            "trust",
+            "clan_to_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
+        "decline_text": "Your patrol decides not to pursue the fox.",
+        "chance_of_success": 50,
+        "exp": 50,
+        "success_text": [
+            "In an exhausting fight, r_c manages to bring down and kill the gray vixen they've tracked. Her near grown litter, fat on the bounty of leaf-fall, is a challenge for another day. c_n will have to deal with the young foxes now roaming motherless in their woods, before they start to compete for prey in leaf-bare.",
+            null,
+            "s_c displays incredible skill, driving the mother vixen and her brood out of the forest all by themselves. Now neither the gray fox nor her cubs pose a threat to the Clan. They swell with pride, returning to camp knowing there's one less competitor poaching c_n's prey.",
+            "They're nearly of equal height, with s_c's bold aggression making up for the weight that the gray vixen has on them, and the stand off is resolved when s_c charges the gray fox and she chooses flight over fight."
+        ],
+        "fail_text": [
+            "r_c comes across a gray vixen at the end of the scent trail. She spots them too, measures herself up against them, then flees, scrambling into the trees in a move that completely surprises r_c. This round goes to the gray fox.",
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarasses them deeply the gray vixen slips past them and flees further into the forest.",
+            null,
+            "r_c nearly managed to pin the gray vixen they found into a thorn ticket, but snapping jaws leave r_c dripping blood onto the leaf litter. Today this round goes to the gray fox.",
+            null,
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is cunning, sinking her teeth into s_c to distract them as she flees."
+        ],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a solo fight with a gray vixen."
+        ]
+    },
+    {
         "patrol_id": "fst_hunt_genmouse1",
         "biome": "forest",
         "season": "newleaf",
         "tags": [
-            "hunting", "no_app", "medium_prey"
+            "hunting",
+            "no_app",
+            "medium_prey"
         ],
         "intro_text": "r_c catches scent of a mouse nearby. A perfect opportunity to pick up one of the first bounties newleaf brings to the forest.",
         "decline_text": "Your patrol ignores the mouse.",
         "success_text": [
             "r_c locates the mouse and begins to stalk. The mouse nibbles on a seed, unaware of the hunting cat. r_c waggles their haunches and leaps, pinning the mouse beneath a paw as they make the killing bite.",
             "r_c pinpoints the location of the prey and begins creeping forward. They're almost within pouncing distance when the mouse suddenly bolts. With a lash of their tail, r_c leaps after the mouse, barely snagging it before it reaches a burrow. They purr in satisfaction as prey-blood hits their tongue.",
-			"s_c immediately drops into a practised crouch, shimmying flawlessly along the ground and taking the perfectly plump mouse completely by surprise."
+            "s_c immediately drops into a practised crouch, shimmying flawlessly along the ground and taking the perfectly plump mouse completely by surprise."
         ],
         "fail_text": [
             "r_c narrowly misses the mouse."
         ],
         "chance_of_success": 60,
         "exp": 10,
-        "win_skills": ["good hunter", "great hunter", "fantastic hunter"],
+        "win_skills": [
+            "good hunter",
+            "great hunter",
+            "fantastic hunter"
+        ],
         "min_cats": 1,
         "max_cats": 1,
         "antagonize_text": null,
         "antagonize_fail_text": null
     },
-	{
+    {
         "patrol_id": "fst_hunt_genmouse2",
         "biome": "forest",
         "season": "greenleaf",
         "tags": [
-            "hunting", "no_app", "medium_prey"
+            "hunting",
+            "no_app",
+            "medium_prey"
         ],
         "intro_text": "r_c catches scent of a mouse nearby, and feels themselves drool at the idea of greenleaf fresh-kill. It's a great day for hunting, too, greenleaf bringing life to c_n's woods.",
         "decline_text": "Your patrol ignores the mouse.",
         "success_text": [
             "r_c locates the mouse and begins to stalk. The mouse nibbles on a seed, unaware of the hunting cat. r_c waggles their haunches and leaps, pinning the mouse beneath a paw as they make the killing bite.",
             "r_c pinpoints the location of the prey and begins creeping forward. They're almost within pouncing distance when the mouse suddenly bolts. With a lash of their tail, r_c leaps after the mouse, barely snagging it before it reaches a burrow. They purr in satisfaction as prey-blood hits their tongue.",
-			"s_c immediately drops into a practised crouch, shimmying flawlessly along the ground and taking the perfectly plump mouse completely by surprise."
+            "s_c immediately drops into a practised crouch, shimmying flawlessly along the ground and taking the perfectly plump mouse completely by surprise."
         ],
         "fail_text": [
             "r_c narrowly misses the mouse."
         ],
         "chance_of_success": 60,
         "exp": 10,
-        "win_skills": ["good hunter", "great hunter", "fantastic hunter"],
+        "win_skills": [
+            "good hunter",
+            "great hunter",
+            "fantastic hunter"
+        ],
         "min_cats": 1,
         "max_cats": 1,
         "antagonize_text": null,
         "antagonize_fail_text": null
     },
-	{
+    {
         "patrol_id": "fst_hunt_genmouse3",
         "biome": "forest",
         "season": "leaf-fall",
         "tags": [
-            "hunting", "no_app", "medium_prey"
+            "hunting",
+            "no_app",
+            "medium_prey"
         ],
         "intro_text": "r_c catches scent of a mouse nearby. It'll be fat on the nuts and acorns leaf-fall scatters through the forest, and if r_c can only avoid the leaves crunching under their paws it's as good as caught.",
         "decline_text": "Your patrol ignores the mouse.",
         "success_text": [
             "r_c locates the mouse and begins to stalk. The mouse nibbles on a seed, unaware of the hunting cat. r_c waggles their haunches and leaps, pinning the mouse beneath a paw as they make the killing bite.",
             "r_c pinpoints the location of the prey and begins creeping forward. They're almost within pouncing distance when the mouse suddenly bolts. With a lash of their tail, r_c leaps after the mouse, barely snagging it before it reaches a burrow. They purr in satisfaction as prey-blood hits their tongue.",
-			"s_c immediately drops into a practiced crouch, shimmying flawlessly along the ground and taking the perfectly plump mouse completely by surprise."
+            "s_c immediately drops into a practiced crouch, shimmying flawlessly along the ground and taking the perfectly plump mouse completely by surprise."
         ],
         "fail_text": [
             "r_c narrowly misses the mouse."
         ],
         "chance_of_success": 50,
         "exp": 10,
-        "win_skills": ["good hunter", "great hunter", "fantastic hunter"],
+        "win_skills": [
+            "good hunter",
+            "great hunter",
+            "fantastic hunter"
+        ],
         "min_cats": 1,
         "max_cats": 1,
         "antagonize_text": null,
         "antagonize_fail_text": null
     },
-	{
+    {
         "patrol_id": "fst_hunt_genmouse4",
         "biome": "forest",
         "season": "leaf-bare",
         "tags": [
-            "hunting", "no_app", "medium_prey"
+            "hunting",
+            "no_app",
+            "medium_prey"
         ],
         "intro_text": "r_c catches scent of a mouse nearby, one that would be greatly appreciated for the fresh-kill pile.",
         "decline_text": "Your patrol ignores the mouse.",
         "success_text": [
             "r_c locates the mouse and begins to stalk. The mouse nibbles on a seed, unaware of the hunting cat. r_c waggles their haunches and leaps, pinning the mouse beneath a paw as they make the killing bite.",
             "r_c pinpoints the location of the prey and begins creeping forward. They're almost within pouncing distance when the mouse suddenly bolts. With a lash of their tail, r_c leaps after the mouse, barely snagging it before it reaches a burrow. They purr in satisfaction as prey-blood hits their tongue.",
-			"s_c immediately drops into a practised crouch, shimmying flawlessly along the ground and taking the perfectly plump mouse completely by surprise."
+            "s_c immediately drops into a practised crouch, shimmying flawlessly along the ground and taking the perfectly plump mouse completely by surprise."
         ],
         "fail_text": [
             "r_c narrowly misses the mouse."
         ],
         "chance_of_success": 30,
         "exp": 10,
-        "win_skills": ["good hunter", "great hunter", "fantastic hunter"],
+        "win_skills": [
+            "good hunter",
+            "great hunter",
+            "fantastic hunter"
+        ],
         "min_cats": 1,
         "max_cats": 1,
         "antagonize_text": null,
         "antagonize_fail_text": null
     },
-	{
+    {
         "patrol_id": "fst_hunt_genappmouse1",
         "biome": "forest",
         "season": "newleaf",
         "tags": [
-            "hunting", "apprentice", "medium_prey"
+            "hunting",
+            "apprentice",
+            "medium_prey"
         ],
         "intro_text": "app1 catches scent of a mouse nearby. A perfect opportunity to pick up one of the first bounties newleaf brings to the forest.",
         "decline_text": "Your patrol ignores the mouse.",
@@ -5318,12 +5353,14 @@
         "antagonize_text": null,
         "antagonize_fail_text": null
     },
-	{
+    {
         "patrol_id": "fst_hunt_genappmouse2",
         "biome": "forest",
         "season": "greenleaf",
         "tags": [
-            "hunting", "apprentice", "medium_prey"
+            "hunting",
+            "apprentice",
+            "medium_prey"
         ],
         "intro_text": "app1 catches scent of a mouse nearby. Surely greenleaf is the perfect time to try solo-hunting, everyone always says that this is when the prey wanders right into a cat's jaws.",
         "decline_text": "Your patrol ignores the mouse.",
@@ -5341,12 +5378,14 @@
         "antagonize_text": null,
         "antagonize_fail_text": null
     },
-	{
+    {
         "patrol_id": "fst_hunt_genappmouse3",
         "biome": "forest",
         "season": "leaf-fall",
         "tags": [
-            "hunting", "apprentice", "medium_prey"
+            "hunting",
+            "apprentice",
+            "medium_prey"
         ],
         "intro_text": "app1 catches scent of a mouse nearby. They look at the leaf litter on the ground - are they good enough to stalk without being heard?",
         "decline_text": "Your patrol ignores the mouse.",
@@ -5364,12 +5403,14 @@
         "antagonize_text": null,
         "antagonize_fail_text": null
     },
-	{
+    {
         "patrol_id": "fst_hunt_genappmouse4",
         "biome": "forest",
         "season": "leaf-bare",
         "tags": [
-            "hunting", "apprentice", "medium_prey"
+            "hunting",
+            "apprentice",
+            "medium_prey"
         ],
         "intro_text": "app1 catches scent of a mouse nearby. But they're by themselves, and the chill of leaf-bare has stripped the forest of it's green cloak, can they managed the catch?",
         "decline_text": "Your patrol ignores the mouse.",
@@ -5387,12 +5428,17 @@
         "antagonize_text": null,
         "antagonize_fail_text": null
     },
-	{
+    {
         "patrol_id": "gen_hunt_genmentormouse1",
         "biome": "forest",
         "season": "newleaf",
         "tags": [
-            "hunting", "apprentice", "small_prey", "comfort", "trust", "warrior"
+            "hunting",
+            "apprentice",
+            "small_prey",
+            "comfort",
+            "trust",
+            "warrior"
         ],
         "intro_text": "app1 catches scent of a mouse nearby. p_l tells them it might be the perfect opportunity to pick up one of the first bounties newleaf brings to the forest, and whispers some stalking tips to app1.",
         "decline_text": "Your patrol ignores the mouse.",
@@ -5410,12 +5456,17 @@
         "antagonize_text": null,
         "antagonize_fail_text": null
     },
-	{
+    {
         "patrol_id": "gen_hunt_genmentormouse2",
         "biome": "forest",
         "season": "greenleaf",
         "tags": [
-            "hunting", "apprentice", "small_prey", "comfort", "trust", "warrior"
+            "hunting",
+            "apprentice",
+            "small_prey",
+            "comfort",
+            "trust",
+            "warrior"
         ],
         "intro_text": "app1 catches scent of a mouse nearby. p_l congratulates them, and gives them some tips on where the mouse might be headed. With the heat of greenleaf, their prey is probably headed to a damp gully ahead.",
         "decline_text": "Your patrol ignores the mouse.",
@@ -5433,12 +5484,17 @@
         "antagonize_text": null,
         "antagonize_fail_text": null
     },
-	{
+    {
         "patrol_id": "gen_hunt_genmentormouse3",
         "biome": "forest",
         "season": "leaf-fall",
         "tags": [
-            "hunting", "apprentice", "small_prey", "comfort", "trust", "warrior"
+            "hunting",
+            "apprentice",
+            "small_prey",
+            "comfort",
+            "trust",
+            "warrior"
         ],
         "intro_text": "app1 catches scent of a mouse nearby. p_l nods, and asks them if app1 remembers their tips on stalking on leaf-fall's, well, fallen leaves.",
         "decline_text": "Your patrol ignores the mouse.",
@@ -5456,12 +5512,17 @@
         "antagonize_text": null,
         "antagonize_fail_text": null
     },
-	{
+    {
         "patrol_id": "gen_hunt_genmentormouse4",
         "biome": "forest",
         "season": "leaf-bare",
         "tags": [
-            "hunting", "apprentice", "small_prey", "comfort", "trust", "warrior"
+            "hunting",
+            "apprentice",
+            "small_prey",
+            "comfort",
+            "trust",
+            "warrior"
         ],
         "intro_text": "app1 catches scent of a mouse nearby. p_l congratulates them, and tries to prepare app1 for the stalk as best they can - if app1 can catch this mouse, this is the season where it will be most valuable for the Clan.",
         "decline_text": "Your patrol ignores the mouse.",
@@ -5479,12 +5540,18 @@
         "antagonize_text": null,
         "antagonize_fail_text": null
     },
-	{
+    {
         "patrol_id": "fst_hunt_mice_ohnotheyrehot1",
         "biome": "forest",
         "season": "newleaf",
         "tags": [
-            "hunting", "romantic", "respect", "pos_jealous", "pos_dislike", "p_l_to_r_c", "medium_prey"
+            "hunting",
+            "romantic",
+            "respect",
+            "pos_jealous",
+            "pos_dislike",
+            "p_l_to_r_c",
+            "medium_prey"
         ],
         "intro_text": "As the patrol heads out into the forest to hunt, r_c seems to be absolutely unconcerned with their duties, instead ambling along as through the prey is going to waltz into their paws.",
         "decline_text": "The cats are called back to camp - there's something the deputy needs to discuss with them.",
@@ -5493,25 +5560,44 @@
         "success_text": [
             "r_c makes it look easy, and when the patrol is done mousing everyone else ends up carrying catches mostly brought down by them. They lead the way back to camp, sauntering with a distinctly smug sway of their hips.",
             null,
-			"Of course s_c is unconcerned, s_c knows their own skills well, and mice? not a challenge. After their fifth catch the rest of the patrol is forced to admit they might have a point about not needing to worry.",
+            "Of course s_c is unconcerned, s_c knows their own skills well, and mice? not a challenge. After their fifth catch the rest of the patrol is forced to admit they might have a point about not needing to worry.",
             "As the patrol settles in, tracking mouse scent mostly, s_c wanders back, and as they put a paw down the ground squeaks. They lean down, jaws snapping, and meet the eyes of the rest of the patrol with an insolent smirk."
         ],
         "fail_text": [
             "r_c doesn't bring much home, impressing nobody."
         ],
-        "win_skills": ["good hunter", "great hunter", "fantastic hunter"],
-		"win_trait": ["bold", "charismatic", "childish", "confident", "daring", "fierce", "shameless", "troublesome"],
+        "win_skills": [
+            "good hunter",
+            "great hunter",
+            "fantastic hunter"
+        ],
+        "win_trait": [
+            "bold",
+            "charismatic",
+            "childish",
+            "confident",
+            "daring",
+            "fierce",
+            "shameless",
+            "troublesome"
+        ],
         "min_cats": 3,
         "max_cats": 6,
         "antagonize_text": null,
         "antagonize_fail_text": null
     },
-	{
+    {
         "patrol_id": "fst_hunt_mice_ohnotheyrehot2",
         "biome": "forest",
         "season": "greenleaf",
         "tags": [
-            "hunting", "romantic", "respect", "pos_jealous", "pos_dislike", "p_l_to_r_c", "medium_prey"
+            "hunting",
+            "romantic",
+            "respect",
+            "pos_jealous",
+            "pos_dislike",
+            "p_l_to_r_c",
+            "medium_prey"
         ],
         "intro_text": "As the patrol heads out into the forest to hunt, r_c seems to be absolutely unconcerned with their duties, instead ambling along as through the prey is going to waltz into their paws.",
         "decline_text": "The cats are called back to camp - there's something the deputy needs to discuss with them.",
@@ -5520,25 +5606,44 @@
         "success_text": [
             "r_c makes it look easy, and when the patrol is done mousing everyone else ends up carrying catches mostly brought down by them. They lead the way back to camp, sauntering with a distinctly smug sway of their hips.",
             null,
-			"Of course s_c is unconcerned, s_c knows their own skills well, and mice? not a challenge. After their fifth catch the rest of the patrol is forced to admit they might have a point about not needing to worry.",
+            "Of course s_c is unconcerned, s_c knows their own skills well, and mice? not a challenge. After their fifth catch the rest of the patrol is forced to admit they might have a point about not needing to worry.",
             "As the patrol settles in, tracking mouse scent mostly, s_c wanders back, and as they put a paw down the ground squeaks. They lean down, jaws snapping, and meet the eyes of the rest of the patrol with an insolent smirk."
         ],
         "fail_text": [
             "r_c doesn't bring much home, impressing nobody."
         ],
-        "win_skills": ["good hunter", "great hunter", "fantastic hunter"],
-		"win_trait": ["bold", "charismatic", "childish", "confident", "daring", "fierce", "shameless", "troublesome"],
+        "win_skills": [
+            "good hunter",
+            "great hunter",
+            "fantastic hunter"
+        ],
+        "win_trait": [
+            "bold",
+            "charismatic",
+            "childish",
+            "confident",
+            "daring",
+            "fierce",
+            "shameless",
+            "troublesome"
+        ],
         "min_cats": 3,
         "max_cats": 6,
         "antagonize_text": null,
         "antagonize_fail_text": null
     },
-	{
+    {
         "patrol_id": "fst_hunt_mice_ohnotheyrehot3",
         "biome": "forest",
         "season": "leaf-fall",
         "tags": [
-            "hunting", "romantic", "respect", "pos_jealous", "pos_dislike", "p_l_to_r_c", "medium_prey"
+            "hunting",
+            "romantic",
+            "respect",
+            "pos_jealous",
+            "pos_dislike",
+            "p_l_to_r_c",
+            "medium_prey"
         ],
         "intro_text": "As the patrol heads out into the forest to hunt, r_c seems to be absolutely unconcerned with their duties, instead ambling along as through the prey is going to waltz into their paws.",
         "decline_text": "The cats are called back to camp - there's something the deputy needs to discuss with them.",
@@ -5547,25 +5652,44 @@
         "success_text": [
             "r_c makes it look easy, and when the patrol is done mousing everyone else ends up carrying catches mostly brought down by them. They lead the way back to camp, sauntering with a distinctly smug sway of their hips.",
             null,
-			"Of course s_c is unconcerned, s_c knows their own skills well, and mice? not a challenge. After their fifth catch the rest of the patrol is forced to admit they might have a point about not needing to worry.",
+            "Of course s_c is unconcerned, s_c knows their own skills well, and mice? not a challenge. After their fifth catch the rest of the patrol is forced to admit they might have a point about not needing to worry.",
             "As the patrol settles in, tracking mouse scent mostly, s_c wanders back, and as they put a paw down the ground squeaks. They lean down, jaws snapping, and meet the eyes of the rest of the patrol with an insolent smirk."
         ],
         "fail_text": [
             "r_c doesn't bring much home, impressing nobody."
         ],
-        "win_skills": ["good hunter", "great hunter", "fantastic hunter"],
-		"win_trait": ["bold", "charismatic", "childish", "confident", "daring", "fierce", "shameless", "troublesome"],
+        "win_skills": [
+            "good hunter",
+            "great hunter",
+            "fantastic hunter"
+        ],
+        "win_trait": [
+            "bold",
+            "charismatic",
+            "childish",
+            "confident",
+            "daring",
+            "fierce",
+            "shameless",
+            "troublesome"
+        ],
         "min_cats": 3,
         "max_cats": 6,
         "antagonize_text": null,
         "antagonize_fail_text": null
     },
-	{
+    {
         "patrol_id": "fst_hunt_mice_ohnotheyrehot4",
         "biome": "forest",
         "season": "leaf-bare",
         "tags": [
-            "hunting", "romantic", "respect", "pos_jealous", "pos_dislike", "p_l_to_r_c", "medium_prey"
+            "hunting",
+            "romantic",
+            "respect",
+            "pos_jealous",
+            "pos_dislike",
+            "p_l_to_r_c",
+            "medium_prey"
         ],
         "intro_text": "As the patrol heads out into the forest to hunt, r_c seems to be absolutely unconcerned with their duties, instead ambling along as through the prey is going to waltz into their paws.",
         "decline_text": "The cats are called back to camp - there's something the deputy needs to discuss with them.",
@@ -5574,25 +5698,43 @@
         "success_text": [
             "r_c makes it look easy, and when the patrol is done mousing everyone else ends up carrying catches mostly brought down by them. They lead the way back to camp, sauntering with a distinctly smug sway of their hips.",
             null,
-			"Of course s_c is unconcerned, s_c knows their own skills well, and mice? not a challenge. After their fifth catch the rest of the patrol is forced to admit they might have a point about not needing to worry.",
+            "Of course s_c is unconcerned, s_c knows their own skills well, and mice? not a challenge. After their fifth catch the rest of the patrol is forced to admit they might have a point about not needing to worry.",
             "As the patrol settles in, tracking mouse scent mostly, s_c wanders back, and as they put a paw down the ground squeaks. They lean down, jaws snapping, and meet the eyes of the rest of the patrol with an insolent smirk."
         ],
         "fail_text": [
             "r_c doesn't bring much home, impressing nobody."
         ],
-        "win_skills": ["good hunter", "great hunter", "fantastic hunter"],
-		"win_trait": ["bold", "charismatic", "childish", "confident", "daring", "fierce", "shameless", "troublesome"],
+        "win_skills": [
+            "good hunter",
+            "great hunter",
+            "fantastic hunter"
+        ],
+        "win_trait": [
+            "bold",
+            "charismatic",
+            "childish",
+            "confident",
+            "daring",
+            "fierce",
+            "shameless",
+            "troublesome"
+        ],
         "min_cats": 3,
         "max_cats": 6,
         "antagonize_text": null,
         "antagonize_fail_text": null
     },
-	{
+    {
         "patrol_id": "fst_hunt_mice1",
         "biome": "forest",
         "season": "newleaf",
         "tags": [
-            "hunting", "respect", "patrol_to_r_c", "medium_prey0", "large_prey1", "large_prey2"
+            "hunting",
+            "respect",
+            "patrol_to_r_c",
+            "medium_prey0",
+            "large_prey1",
+            "large_prey2"
         ],
         "intro_text": "As the patrol heads out into the forest to hunt, r_c suggests a good sheltered gully. It's a little far from camp, but the hunting around there is good, particularly for mice.",
         "decline_text": "The cats are called back to camp - there's something the deputy needs to discuss with them.",
@@ -5601,23 +5743,32 @@
         "success_text": [
             "As they arrive, the patrol startles two mice, and r_c manages to react quick enough with an inelegant pounce to kill one. It's a good omen for the rest of the morning's work, which proves to be a productive and satisfying hunt.",
             "Your cats sneak into the hunting grounds, ears rotating as different spots catch their interest. r_c's suggestion proves to be a fruitful hunting ground, one that c_n hasn't used for a while and whose creatures (as predicted, nearly all mice) have lost their edge of wariness. It's a good hunt.",
-			"These are the times that it really pays to have a hunter of s_c's caliber on the patrol - they really go above and beyond, impressing everyone and leaving a trail of terror among the local mice."
+            "These are the times that it really pays to have a hunter of s_c's caliber on the patrol - they really go above and beyond, impressing everyone and leaving a trail of terror among the local mice."
         ],
         "fail_text": [
             "Ah. r_c's suggested hunting grounds don't work out, not that anyone blames them for it."
         ],
-        "win_skills": ["good hunter", "great hunter", "fantastic hunter"],
+        "win_skills": [
+            "good hunter",
+            "great hunter",
+            "fantastic hunter"
+        ],
         "min_cats": 3,
         "max_cats": 6,
         "antagonize_text": null,
         "antagonize_fail_text": null
     },
-	{
+    {
         "patrol_id": "fst_hunt_mice2",
         "biome": "forest",
         "season": "greenleaf",
         "tags": [
-            "hunting", "respect", "patrol_to_r_c", "medium_prey0", "large_prey1", "large_prey2"
+            "hunting",
+            "respect",
+            "patrol_to_r_c",
+            "medium_prey0",
+            "large_prey1",
+            "large_prey2"
         ],
         "intro_text": "As the patrol heads out into the forest to hunt, r_c suggests a good sheltered gully. It's a little far from camp, but the hunting around there is good, particularly for mice.",
         "decline_text": "The cats are called back to camp - there's something the deputy needs to discuss with them.",
@@ -5626,23 +5777,32 @@
         "success_text": [
             "As they arrive, the patrol startles two mice, and r_c manages to react quick enough with an inelegant pounce to kill one. It's a good omen for the rest of the morning's work, which proves to be a productive and satisfying hunt.",
             "Your cats sneak into the hunting grounds, ears rotating as different spots catch their interest. r_c's suggestion proves to be a fruitful hunting ground, one that c_n hasn't used for a while and whose creatures (as predicted, nearly all mice) have lost their edge of wariness. It's a good hunt.",
-			"These are the times that it really pays to have a hunter of s_c's caliber on the patrol - they really go above and beyond, impressing everyone and leaving a trail of terror among the local mice."
+            "These are the times that it really pays to have a hunter of s_c's caliber on the patrol - they really go above and beyond, impressing everyone and leaving a trail of terror among the local mice."
         ],
         "fail_text": [
             "Ah. r_c's suggested hunting grounds don't work out, not that anyone blames them for it."
         ],
-        "win_skills": ["good hunter", "great hunter", "fantastic hunter"],
+        "win_skills": [
+            "good hunter",
+            "great hunter",
+            "fantastic hunter"
+        ],
         "min_cats": 3,
         "max_cats": 6,
         "antagonize_text": null,
         "antagonize_fail_text": null
     },
-	{
+    {
         "patrol_id": "fst_hunt_mice3",
         "biome": "forest",
         "season": "leaf-fall",
         "tags": [
-            "hunting", "respect", "patrol_to_r_c", "medium_prey0", "large_prey1", "large_prey2"
+            "hunting",
+            "respect",
+            "patrol_to_r_c",
+            "medium_prey0",
+            "large_prey1",
+            "large_prey2"
         ],
         "intro_text": "As the patrol heads out into the forest to hunt, r_c suggests a good sheltered gully. It's a little far from camp, but the hunting around there is good, particularly for mice.",
         "decline_text": "The cats are called back to camp - there's something the deputy needs to discuss with them.",
@@ -5651,23 +5811,32 @@
         "success_text": [
             "As they arrive, the patrol startles two mice, and r_c manages to react quick enough with an inelegant pounce to kill one. It's a good omen for the rest of the morning's work, which proves to be a productive and satisfying hunt.",
             "Your cats sneak into the hunting grounds, ears rotating as different spots catch their interest. r_c's suggestion proves to be a fruitful hunting ground, one that c_n hasn't used for a while and whose creatures (as predicted, nearly all mice) have lost their edge of wariness. It's a good hunt.",
-			"These are the times that it really pays to have a hunter of s_c's caliber on the patrol - they really go above and beyond, impressing everyone and leaving a trail of terror among the local mice."
+            "These are the times that it really pays to have a hunter of s_c's caliber on the patrol - they really go above and beyond, impressing everyone and leaving a trail of terror among the local mice."
         ],
         "fail_text": [
             "Ah. r_c's suggested hunting grounds don't work out, not that anyone blames them for it."
         ],
-        "win_skills": ["good hunter", "great hunter", "fantastic hunter"],
+        "win_skills": [
+            "good hunter",
+            "great hunter",
+            "fantastic hunter"
+        ],
         "min_cats": 3,
         "max_cats": 6,
         "antagonize_text": null,
         "antagonize_fail_text": null
     },
-	{
+    {
         "patrol_id": "fst_hunt_mice4",
         "biome": "forest",
         "season": "leaf-bare",
         "tags": [
-            "hunting", "respect", "patrol_to_r_c", "medium_prey0", "large_prey1", "large_prey2"
+            "hunting",
+            "respect",
+            "patrol_to_r_c",
+            "medium_prey0",
+            "large_prey1",
+            "large_prey2"
         ],
         "intro_text": "As the patrol heads out into the forest to hunt, r_c suggests a good sheltered gully. It's a little far from camp, and the walk will be chilly, but the hunting around there is good, particularly for mice.",
         "decline_text": "The cats are called back to camp - there's something the deputy needs to discuss with them.",
@@ -5676,12 +5845,16 @@
         "success_text": [
             "As they arrive, the patrol startles two mice, and r_c manages to react quick enough with an inelegant pounce to kill one. It's a good omen for the rest of the morning's work, which proves to be a productive and satisfying hunt.",
             "Your cats sneak into the hunting grounds, ears rotating as different spots catch their interest. r_c's suggestion proves to be a fruitful hunting ground, one that c_n hasn't used for a while and whose creatures (as predicted, nearly all mice) have lost their edge of wariness. It's a good hunt.",
-			"These are the times that it really pays to have a hunter of s_c's caliber on the patrol - they really go above and beyond, impressing everyone and leaving a trail of terror among the local mice."
+            "These are the times that it really pays to have a hunter of s_c's caliber on the patrol - they really go above and beyond, impressing everyone and leaving a trail of terror among the local mice."
         ],
         "fail_text": [
             "Ah. r_c's suggested hunting grounds don't work out, not that anyone blames them for it."
         ],
-        "win_skills": ["good hunter", "great hunter", "fantastic hunter"],
+        "win_skills": [
+            "good hunter",
+            "great hunter",
+            "fantastic hunter"
+        ],
         "min_cats": 3,
         "max_cats": 6,
         "antagonize_text": null,

--- a/resources/dicts/patrols/hunting/hunting_mountains.json
+++ b/resources/dicts/patrols/hunting/hunting_mountains.json
@@ -37,7 +37,8 @@
             "medium_prey0",
             "medium_prey1",
             "large_prey2",
-            "large_prey3"
+            "large_prey3",
+            "no_fail_prey"
         ],
         "intro_text": "The patrol looks around for something to disguise their scent while hunting.",
         "decline_text": "On second thought, maybe not.",
@@ -74,7 +75,8 @@
             "medium_prey0",
             "medium_prey1",
             "large_prey2",
-            "large_prey3"
+            "large_prey3",
+            "no_fail_prey"
         ],
         "intro_text": "r_c looks around for something to disguise their scent while hunting.",
         "decline_text": "On second thought, maybe not.",
@@ -120,7 +122,8 @@
             "medium_prey0",
             "medium_prey1",
             "large_prey2",
-            "large_prey3"
+            "large_prey3",
+            "no_fail_prey"
         ],
         "intro_text": "r_c's mentor assesses them by sending them on a solo hunt.",
         "decline_text": "r_c asks their mentor to do the assessment some other time.",
@@ -178,7 +181,8 @@
             "medium_prey0",
             "medium_prey1",
             "large_prey2",
-            "large_prey3"
+            "large_prey3",
+            "no_fail_prey"
         ],
         "intro_text": "r_c heads out onto the mountains alone, wanting to sink their teeth into some prey and have some time to themselves.",
         "decline_text": "r_c turns back to camp, deciding that a group hunt would be more effective.",
@@ -234,7 +238,8 @@
             "medium_prey0",
             "medium_prey1",
             "large_prey2",
-            "large_prey3"
+            "large_prey3",
+            "no_fail_prey"
         ],
         "intro_text": "r_c heads out onto the mountains alone, wanting to sink their teeth into some prey and have some time to themselves.",
         "decline_text": "r_c turns back to camp, deciding that a group hunt would be more effective.",
@@ -293,7 +298,8 @@
             "medium_prey0",
             "medium_prey1",
             "large_prey2",
-            "large_prey3"
+            "large_prey3",
+            "no_fail_prey"
         ],
         "intro_text": "r_c heads out onto the mountains alone, wanting to sink their teeth into some prey and have some time to themselves.",
         "decline_text": "r_c turns back to camp, deciding that a group hunt would be more effective.",
@@ -347,9 +353,9 @@
             "hunting",
             "big_bite_injury",
             "scar",
-			"medium_prey0",
-			"medium_prey1",
-			"large_prey3"
+            "medium_prey0",
+            "medium_prey1",
+            "large_prey3"
         ],
         "intro_text": "As the patrol is checking the border lines, they hear an odd sound coming from just beyond a rock fall.",
         "decline_text": "It's probably nothing. The patrol leaves the noise alone and continues on their way.",
@@ -393,9 +399,9 @@
             "big_bite_injury",
             "scar",
             "death",
-			"medium_prey0",
-			"medium_prey1",
-			"large_prey3"
+            "medium_prey0",
+            "medium_prey1",
+            "large_prey3"
         ],
         "intro_text": "As the patrol is checking the border lines, they hear an odd sound coming from just beyond a rock fall.",
         "decline_text": "It's probably nothing. The patrol leaves the noise alone and continues on their way.",
@@ -1703,8 +1709,18 @@
         "biome": "mountainous",
         "season": "leaf-bare",
         "tags": [
-            "hunting", "comfort", "trust", "patrol_to_p_l", "patrol_to_r_c", "cold_injury", "scar", "small_prey0", "medium_prey1", "medium_prey2",
-            "large_prey3"
+            "hunting",
+            "comfort",
+            "trust",
+            "patrol_to_p_l",
+            "patrol_to_r_c",
+            "cold_injury",
+            "scar",
+            "small_prey0",
+            "medium_prey1",
+            "medium_prey2",
+            "large_prey3",
+            "no_fail_prey"
         ],
         "intro_text": "It starts snowing soon after the patrol sets out, trying to bring back something, anything, for the fresh-kill pile.",
         "decline_text": "They decide to turn back and wait until the snow dies down.",
@@ -1760,7 +1776,8 @@
             "scar",
             "small_prey0",
             "medium_prey1",
-            "medium_prey2"
+            "medium_prey2",
+            "no_fail_prey"
         ],
         "intro_text": "It starts snowing soon after r_c sets out, trying to bring back something, anything, for the fresh-kill pile.",
         "decline_text": "They decide to turn back and wait until the snow dies down.",
@@ -1874,7 +1891,8 @@
             "small_prey0",
             "medium_prey1",
             "medium_prey2",
-            "large_prey3"
+            "large_prey3",
+            "no_fail_prey"
         ],
         "intro_text": "It starts snowing soon after the patrol sets out, trying to bring back something for the fresh-kill pile.",
         "decline_text": "They decide to turn back and wait until the snow dies down.",
@@ -1928,7 +1946,8 @@
             "scar",
             "small_prey0",
             "small_prey1",
-            "medium_prey2"
+            "medium_prey2",
+            "no_fail_prey"
         ],
         "intro_text": "It starts snowing soon after r_c sets out, trying to bring back something for the fresh-kill pile.",
         "decline_text": "They decide to turn back and wait until the snow dies down.",
@@ -2039,7 +2058,8 @@
             "small_prey0",
             "medium_prey1",
             "medium_prey2",
-            "large_prey3"
+            "large_prey3",
+            "no_fail_prey"
         ],
         "intro_text": "It starts snowing soon after the patrol sets out, trying to bring back something for the fresh-kill pile.",
         "decline_text": "They decide to turn back and wait until the snow dies down.",
@@ -2093,7 +2113,8 @@
             "scar",
             "small_prey0",
             "medium_prey1",
-            "medium_prey2"
+            "medium_prey2",
+            "no_fail_prey"
         ],
         "intro_text": "It starts snowing soon after r_c sets out, trying to bring back something for the fresh-kill pile.",
         "decline_text": "They decide to turn back and wait until the snow dies down.",

--- a/resources/dicts/patrols/hunting/hunting_plains.json
+++ b/resources/dicts/patrols/hunting/hunting_plains.json
@@ -193,7 +193,8 @@
             "medium_prey0",
             "medium_prey1",
             "large_prey2",
-            "large_prey3"
+            "large_prey3",
+            "no_fail_prey"
         ],
         "intro_text": "The patrol looks around for something to disguise their scent while hunting.",
         "decline_text": "On second thought, maybe not.",
@@ -236,7 +237,8 @@
             "medium_prey0",
             "medium_prey1",
             "large_prey2",
-            "large_prey3"
+            "large_prey3",
+            "no_fail_prey"
         ],
         "intro_text": "r_c looks around for something to disguise their scent while hunting.",
         "decline_text": "On second thought, maybe not.",
@@ -279,7 +281,8 @@
             "apprentice",
             "minor_injury",
             "scar",
-            "medium_prey"
+            "medium_prey",
+            "no_fail_prey"
         ],
         "intro_text": "r_c's mentor assesses them by sending them on a solo hunt.",
         "decline_text": "r_c asks their mentor to do the assessment some other time.",
@@ -344,7 +347,8 @@
             "medium_prey0",
             "medium_prey1",
             "large_prey2",
-            "large_prey3"
+            "large_prey3",
+            "no_fail_prey"
         ],
         "intro_text": "r_c heads out onto the plains alone, wanting to sink their teeth into some prey and have some time to themselves.",
         "decline_text": "r_c turns back to camp, deciding that a group hunt would be more effective.",
@@ -403,7 +407,8 @@
             "medium_prey0",
             "medium_prey1",
             "large_prey2",
-            "large_prey3"
+            "large_prey3",
+            "no_fail_prey"
         ],
         "intro_text": "r_c heads out onto the plains alone, wanting to sink their teeth into some prey and have some time to themselves.",
         "decline_text": "r_c turns back to camp, deciding that a group hunt would be more effective.",
@@ -462,7 +467,8 @@
             "medium_prey0",
             "medium_prey1",
             "large_prey2",
-            "large_prey3"
+            "large_prey3",
+            "no_fail_prey"
         ],
         "intro_text": "r_c heads out onto the plains alone, wanting to sink their teeth into some prey and have some time to themselves.",
         "decline_text": "r_c turns back to camp, deciding that a group hunt would be more effective.",
@@ -1547,7 +1553,8 @@
             "small_prey0",
             "medium_prey1",
             "medium_prey2",
-            "large_prey3"
+            "large_prey3",
+            "no_fail_prey"
         ],
         "intro_text": "It starts snowing soon after the patrol sets out, trying to bring back something, anything, for the fresh-kill pile.",
         "decline_text": "They decide to turn back and wait until the snow dies down.",
@@ -1600,7 +1607,8 @@
             "cold_injury",
             "medium_prey0",
             "medium_prey1",
-            "large_prey2"
+            "large_prey2",
+            "no_fail_prey"
         ],
         "intro_text": "It starts snowing soon after r_c sets out, trying to bring back something, anything, for the fresh-kill pile.",
         "decline_text": "They decide to turn back and wait until the snow dies down.",
@@ -1694,1398 +1702,2523 @@
             "r_c caught a chill while hunting in leaf-bare.",
             "r_c froze to death while hunting in a storm.",
             "froze to death while hunting"
-    ]
-},
-{
-    "patrol_id": "pln_hunt_redfox_newleafscavenge1",
-    "biome": "plains",
-    "season": "newleaf",
-    "tags": ["hunting", "large_prey", "fighting", "scar", "big_bite_injury", "clan_to_patrol", "respect", "rel_patrol"],
-    "intro_text": "Your patrol catches the scent of a red fox. Tracking it, they find the animal feeding on a pronghorn fawn carcass. It's impossible to say whether the fox killed it or found it.",
-    "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
-    "chance_of_success": 50,
-    "exp": 20,
-    "success_text": [
-    "Your cats are smaller but they outnumber the fox, if only by a little, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full of food and unwilling to lose blood over it, is driven off from the kill.",
-    null,
-    "s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until it gives up and runs.",
-    "The patrol launches into battle, but with so few cats it's exhausting trying to keep the fox and its snapping jaws on the defensive. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. It's only one bite, but the fox has had enough and flees."
-    ],
-    "fail_text": [
-    "Your patrol fails to drive away the fox, which keeps possession of the food. However there were no injuries.",
-    null,
-    null,
-    "The patrol launches into battle, but r_c is caught with a nasty bite, and the cats give up on challenging for the food in favor of quickly helping r_c back to the medicine cat den.",
-    null,
-    "s_c means well, but they're overconfident in their attack and the fox manages to sink their teeth into them. The patrol is forced to retreat, forming a defensive ring around the hurt s_c."
-    ],
-    "win_skills": ["good fighter", "great fighter", "excellent fighter"],
-    "win_trait": ["adventurous", "altruistic", "ambitious", "confident", "daring", "fierce", "responsible", "righteous"],
-    "fail_skills": ["None"],
-    "fail_trait": ["troublesome", "vengeful", "bloodthirsty", "bold"],
-    "min_cats": 2,
-    "max_cats": 3,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c carries a scar from a fox fight.",
-        null
-    ]
-},
-{
-    "patrol_id": "pln_hunt_redfox_newleafscavenge2",
-    "biome": "plains",
-    "season": "newleaf",
-    "tags": ["hunting", "large_prey", "fighting", "scar", "big_bite_injury", "clan_to_patrol", "respect", "rel_patrol"],
-    "intro_text": "Your patrol catches the scent of a red fox. Tracking it, they find the animal feeding on a pronghorn fawn carcass. It's impossible to say whether the fox killed it or found it.",
-    "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
-    "chance_of_success": 80,
-    "exp": 20,
-    "success_text": [
-    "Your cats are smaller but heavily outnumber the fox, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full and unwilling to lose blood over it, is driven off from the kill.",
-    null,
-    "s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until s_c lands a crucial blow, snapping a tendon in one of the fox's hindlegs. The fox runs, but there's no way it'll live long with such a crippling injury.",
-    "The patrol launches into battle, keeping the fox on the defensive with teamwork. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. Holding on grimly, s_c's daring move gives the rest of the patrol the opportunity needed to bring the fox down for good."
-    ],
-    "fail_text": [
-    "Your patrol fails to drive away the fox, which keeps possession of the food. However with so many cats to protect each other, there were no injuries.",
-    null,
-    null,
-    "The patrol launches into battle, but r_c is caught with a nasty bite, and the cats give up on challenging for the food in favor of quickly helping r_c back to the medicine cat den.",
-    null,
-    "s_c means well, but they're overconfident in their attack and the fox manages to sink their teeth into them. The patrol is forced to retreat, forming a defensive ring around the hurt s_c."
-    ],
-    "win_skills": ["good fighter", "great fighter", "excellent fighter"],
-    "win_trait": ["adventurous", "altruistic", "ambitious", "confident", "daring", "fierce", "responsible", "righteous"],
-    "fail_skills": ["None"],
-    "fail_trait": ["troublesome", "vengeful", "bloodthirsty", "bold"],
-    "min_cats": 4,
-    "max_cats": 6,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c carries a scar from a fox fight."
-    ]
-},
-{
-    "patrol_id": "pln_hunt_redfox_newleafscavenge3",
-    "biome": "plains",
-    "season": "newleaf",
-    "tags": ["hunting", "large_prey", "fighting", "scar", "big_bite_injury", "clan_to_patrol", "respect"],
-    "intro_text": "r_c catches the scent of a red fox. Tracking it, they find the animal feeding on a pronghorn fawn carcass. It's impossible to say whether the fox killed it or found it.",
-    "decline_text": "r_c decides not to quarrel with the fox and to find prey elsewhere.",
-    "chance_of_success": 30,
-    "exp": 30,
-    "success_text": [
-        "r_c may be smaller, alone, and half its weight, but the fox has a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle. The fox, already stuffed full and unwilling to lose blood over it, leaves the kill with a grumble.",
-        null,
-        "s_c uses every trick in their talented fighting skillset to attack the fox with no one to watch their flank, until the perfect opportunity opens up and they pounce onto the fox's back, digging in their claws. It's a wild ride through the forest until the fox bucks them off, but it wins them the fawn carcass.",
-        "In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. But then they're stuck, unwilling to let go and risk being bitten. They're dragged through the forest, over rocks and through bushes, until the fox finally collapses and the battered s_c goes back to proudly claim the fawn."
-    ],
-    "fail_text": [
-        "Your patrol fails to drive away the fox, which keeps possession of the food. However there were no injuries.",
-        null,
-        "Fiercely, r_c throws themselves at the fox, determined to win the fawn prize. But the fox values it just as dearly, and manages to get a good grip on r_c, shaking them to pieces and killing them.",
-        "r_c launches into battle, but is caught with a nasty bite, and retreats to limp back home. The fox doesn't follow, happy enough to eat the fawn instead of the foolish cat.",
-        null,
-        "s_c is overconfident in their attack and the fox manages to sink their teeth into them. They retreat, bleeding and in pain, and the fox settles back down to its meal."
-    ],
-    "win_skills": ["great fighter", "excellent fighter"],
-    "win_trait": ["adventurous", "altruistic", "ambitious", "confident", "daring", "fierce", "responsible", "righteous"],
-    "fail_skills": ["None"],
-    "fail_trait": ["troublesome", "vengeful", "bloodthirsty", "bold"],
-    "min_cats": 1,
-    "max_cats": 1,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c carries a scar from a solo fox fight.",
-        "r_c fell in a solo battle with a fox.",
-        "died in battle with a fox"
-    ]
-},
-{
-    "patrol_id": "pln_hunt_redfox_greenleafscavenge1",
-    "biome": "plains",
-    "season": "greenleaf",
-    "tags": ["hunting", "large_prey", "fighting", "scar", "big_bite_injury", "clan_to_patrol", "respect", "rel_patrol"],
-    "intro_text": "Your patrol catches the scent of a red fox. Tracking it, they find the animal feeding on a pronghorn fawn carcass. It's impossible to say whether the fox killed it or found it.",
-    "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
-    "chance_of_success": 50,
-    "exp": 20,
-    "success_text": [
-        "Your cats are smaller but they outnumber the fox, if only by a little, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full and unwilling to lose blood over it, is driven off from the kill.",
-        null,
-        "s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until it gives up and runs.",
-        "The patrol launches into battle, but with so few cats it's exhausting trying to keep the fox and its snapping jaws on the defensive. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. It's only one bite, but the fox has had enough and flees."
-    ],
-    "fail_text": [
-        "Your patrol fails to drive away the fox, which keeps possession of the food. However there were no injuries.",
-        null,
-        null,
-        "The patrol launches into battle, but r_c is caught with a nasty bite, and the cats give up on challenging for the food in favor of quickly helping r_c back to the medicine cat den.",
-        null,
-        "s_c means well, but they're overconfident in their attack and the fox manages to sink their teeth into them. The patrol is forced to retreat, forming a defensive ring around the hurt s_c."
-    ],
-    "win_skills": ["good fighter", "great fighter", "excellent fighter"],
-    "win_trait": ["adventurous", "altruistic", "ambitious", "confident", "daring", "fierce", "responsible", "righteous"],
-    "fail_skills": ["None"],
-    "fail_trait": ["troublesome", "vengeful", "bloodthirsty", "bold"],
-    "min_cats": 2,
-    "max_cats": 3,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c carries a scar from a fox fight.",
-        null
-    ]
-},
-{
-    "patrol_id": "pln_hunt_redfox_greenleafleafscavenge2",
-    "biome": "plains",
-    "season": "greenleaf",
-    "tags": ["hunting", "large_prey", "fighting", "scar", "injury", "big_bite_injury", "clan_to_patrol", "respect", "rel_patrol"],
-    "intro_text": "Your patrol catches the scent of a red fox. Tracking it, they find the animal feeding on a pronghorn fawn carcass. It's impossible to say whether the fox killed it or found it.",
-    "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
-    "chance_of_success": 80,
-    "exp": 20,
-    "success_text": [
-        "Your cats are smaller but heavily outnumber the fox, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full and unwilling to lose blood over it, is driven off from the kill.",
-        null,
-        "s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until s_c lands a crucial blow, snapping a tendon in one of the fox's hindlegs. The fox runs, but there's no way it'll live long with such a crippling injury.",
-        "The patrol launches into battle, keeping the fox on the defensive with teamwork. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. Holding on grimly, s_c's daring move gives the rest of the patrol the opportunity needed to bring the fox down for good."
-    ],
-    "fail_text": [
-        "Your patrol fails to drive away the fox, which keeps possession of the food. However with so many cats to protect each other, there were no injuries.",
-        null,
-        null,
-        "The patrol launches into battle, but r_c is caught with a nasty bite, and the cats give up on challenging for the food in favor of quickly helping r_c back to the medicine cat den.",
-        null,
-        "s_c means well, but they're overconfident in their attack and the fox manages to sink their teeth into them. The patrol is forced to retreat, forming a defensive ring around the hurt s_c."
-    ],
-    "win_skills": ["good fighter", "great fighter", "excellent fighter"],
-    "win_trait": ["adventurous", "altruistic", "ambitious", "confident", "daring", "fierce", "responsible", "righteous"],
-    "fail_skills": ["None"],
-    "fail_trait": ["troublesome", "vengeful", "bloodthirsty", "bold"],
-    "min_cats": 4,
-    "max_cats": 6,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c carries a scar from a fox fight."
-    ]
-},
-{
-    "patrol_id": "pln_hunt_redfox_greenleafscavenge3",
-    "biome": "plains",
-    "season": "greenleaf",
-    "tags": ["hunting", "large_prey", "fighting", "scar", "big_bite_injury", "clan_to_patrol", "respect"],
-    "intro_text": "r_c catches the scent of a red fox. Tracking it, they find the animal feeding on a pronghorn fawn carcass. It's impossible to say whether the fox killed it or found it.",
-    "decline_text": "r_c decides not to quarrel with the fox and to find prey elsewhere.",
-    "chance_of_success": 30,
-    "exp": 30,
-    "success_text": [
-        "r_c may be smaller, alone, and half its weight, but the fox has a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle. The fox, already stuffed full and unwilling to lose blood over it, leaves the kill with a grumble.",
-        null,
-        "s_c uses every trick in their talented fighting skillset to attack the fox with no one to watch their flank, until the perfect opportunity opens up and they pounce onto the fox's back, digging in their claws. It's a wild ride through the forest until the fox bucks them off, but it wins them the fawn carcass.",
-        "In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. But then they're stuck, unwilling to let go and risk being bitten. They're dragged through the forest, over rocks and through bushes, until the fox finally collapses and the battered s_c goes back to proudly claim the fawn."
-    ],
-    "fail_text": [
-        "Your patrol fails to drive away the fox, which keeps possession of the food. However there were no injuries.",
-        null,
-        "Fiercely, r_c throws themselves at the fox, determined to win the fawn prize. But the fox values it just as dearly, and manages to get a good grip on r_c, shaking them to pieces and killing them.",
-        "r_c launches into battle, but is caught with a nasty bite, and retreats to limp back home. The fox doesn't follow, happy enough to eat the fawn instead of the foolish cat.",
-        null,
-        "s_c is overconfident in their attack and the fox manages to sink their teeth into them. They retreat, bleeding and in pain, and the fox settles back down to its meal."
-    ],
-    "win_skills": ["great fighter", "excellent fighter"],
-    "win_trait": ["adventurous", "altruistic", "ambitious", "confident", "daring", "fierce", "responsible", "righteous"],
-    "fail_skills": ["None"],
-    "fail_trait": ["troublesome", "vengeful", "bloodthirsty", "bold"],
-    "min_cats": 1,
-    "max_cats": 1,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c carries a scar from a solo fox fight.",
-        "r_c fell in a solo battle with a fox.",
-        "died in battle with a fox"
-    ]
-},
-{
-    "patrol_id": "pln_hunt_redfox_leaf-fallscavenge1",
-    "biome": "plains",
-    "season": "leaf-fall",
-    "tags": ["hunting", "large_prey", "fighting", "scar", "big_bite_injury", "clan_to_patrol", "respect", "rel_patrol"],
-    "intro_text": "Your patrol catches the scent of a red fox. Tracking it, they find the animal feeding on a pronghorn fawn carcass. It's impossible to say whether the fox killed it or found it.",
-    "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
-    "chance_of_success": 50,
-    "exp": 20,
-    "success_text": [
-        "Your cats are smaller but they outnumber the fox, if only by a little, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full of venison and unwilling to lose blood over it, is driven off from the kill.",
-        null,
-        "s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until it gives up and runs.",
-        "The patrol launches into battle, but with so few cats it's exhausting trying to keep the fox and its snapping jaws on the defensive. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. It's only one bite, but the fox has had enough and flees."
-    ],
-    "fail_text": [
-        "Your patrol fails to drive away the fox, which keeps possession of the food. However there were no injuries.",
-        null,
-        null,
-        "The patrol launches into battle, but r_c is caught with a nasty bite, and the cats give up on challenging for the food in favor of quickly helping r_c back to the medicine cat den.",
-        null,
-        "s_c means well, but they're overconfident in their attack and the fox manages to sink their teeth into them. The patrol is forced to retreat, forming a defensive ring around the hurt s_c."
-    ],
-    "win_skills": ["good fighter", "great fighter", "excellent fighter"],
-    "win_trait": ["adventurous", "altruistic", "ambitious", "confident", "daring", "fierce", "responsible", "righteous"],
-    "fail_skills": ["None"],
-    "fail_trait": ["troublesome", "vengeful", "bloodthirsty", "bold"],
-    "min_cats": 2,
-    "max_cats": 3,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c carries a scar from a fox fight.",
-        null
-    ]
-},
-{
-    "patrol_id": "pln_hunt_redfox_leaf-fallscavenge2",
-    "biome": "plains",
-    "season": "leaf-fall",
-    "tags": ["hunting", "large_prey", "fighting", "scar", "big_bite_injury", "clan_to_patrol", "respect", "rel_patrol"],
-    "intro_text": "Your patrol catches the scent of a red fox. Tracking it, they find the animal feeding on a pronghorn fawn carcass. It's impossible to say whether the fox killed it or found it.",
-    "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
-    "chance_of_success": 80,
-    "exp": 20,
-    "success_text": [
-        "Your cats are smaller but heavily outnumber the fox, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full of venison and unwilling to lose blood over it, is driven off from the kill.",
-        null,
-        "s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until s_c lands a crucial blow, snapping a tendon in one of the fox's hindlegs. The fox runs, but there's no way it'll live long with such a crippling injury.",
-        "The patrol launches into battle, keeping the fox on the defensive with teamwork. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. Holding on grimly, s_c's daring move gives the rest of the patrol the opportunity needed to bring the fox down for good."
-    ],
-    "fail_text": [
-        "Your patrol fails to drive away the fox, which keeps possession of the food. However with so many cats to protect each other, there were no injuries.",
-        null,
-        null,
-        "The patrol launches into battle, but r_c is caught with a nasty bite, and the cats give up on challenging for the food in favor of quickly helping r_c back to the medicine cat den.",
-        null,
-        "s_c means well, but they're overconfident in their attack and the fox manages to sink their teeth into them. The patrol is forced to retreat, forming a defensive ring around the hurt s_c."
-    ],
-    "win_skills": ["good fighter", "great fighter", "excellent fighter"],
-    "win_trait": ["adventurous", "altruistic", "ambitious", "confident", "daring", "fierce", "responsible", "righteous"],
-    "fail_skills": ["None"],
-    "fail_trait": ["troublesome", "vengeful", "bloodthirsty", "bold"],
-    "min_cats": 4,
-    "max_cats": 6,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c carries a scar from a fox fight."
-    ]
-},
-{
-    "patrol_id": "pln_hunt_redfox_leaf-fallscavenge3",
-    "biome": "plains",
-    "season": "leaf-fall",
-    "tags": ["hunting", "large_prey", "fighting", "scar", "big_bite_injury", "clan_to_patrol", "respect"],
-    "intro_text": "r_c catches the scent of a red fox. Tracking it, they find the animal feeding on a pronghorn fawn carcass. It's impossible to say whether the fox killed it or found it.",
-    "decline_text": "r_c decides not to quarrel with the fox and to find prey elsewhere.",
-    "chance_of_success": 30,
-    "exp": 30,
-    "success_text": [
-        "r_c may be smaller, alone, and half its weight, but the fox has a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle. The fox, already stuffed full of venison and unwilling to lose blood over it, leaves the kill with a grumble.",
-        null,
-        "s_c uses every trick in their talented fighting skillset to attack the fox with no one to watch their flank, until the perfect opportunity opens up and they pounce onto the fox's back, digging in their claws. It's a wild ride through the forest until the fox bucks them off, but it wins them the fawn carcass.",
-        "In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. But then they're stuck, unwilling to let go and risk being bitten. They're dragged through the forest, over rocks and through bushes, until the fox finally collapses and the battered s_c goes back to proudly claim the fawn."
-    ],
-    "fail_text": [
-        "Your patrol fails to drive away the fox, which keeps possession of the food. However there were no injuries.",
-        null,
-        "Fiercely, r_c throws themselves at the fox, determined to win the fawn prize. But the fox values it just as dearly, and manages to get a good grip on r_c, shaking them to pieces and killing them.",
-        "r_c launches into battle, but is caught with a nasty bite, and retreats to limp back home. The fox doesn't follow, happy enough to eat the fawn instead of the foolish cat.",
-        null,
-        "s_c is overconfident in their attack and the fox manages to sink their teeth into them. They retreat, bleeding and in pain, and the fox settles back down to its meal."
-    ],
-    "win_skills": ["great fighter", "excellent fighter"],
-    "win_trait": ["adventurous", "altruistic", "ambitious", "confident", "daring", "fierce", "responsible", "righteous"],
-    "fail_skills": ["None"],
-    "fail_trait": ["troublesome", "vengeful", "bloodthirsty", "bold"],
-    "min_cats": 1,
-    "max_cats": 1,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c carries a scar from a solo fox fight.",
-        "r_c fell in a solo battle with a fox.",
-        "died in battle with a fox"
-    ]
-},
-{
-    "patrol_id": "pln_hunt_redfox_leaf-barescavenge1",
-    "biome": "plains",
-    "season": "leaf-bare",
-    "tags": ["hunting", "large_prey", "fighting", "scar", "big_bite_injury", "clan_to_patrol", "respect", "rel_patrol"],
-    "intro_text": "Your patrol catches the scent of a red fox. Tracking it, they find the animal feeding on a pronghorn carcass, either a small doe or one of last newleaf's fawns. It's impossible to say whether the fox killed it or found it.",
-    "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
-    "chance_of_success": 30,
-    "exp": 20,
-    "success_text": [
-        "Your cats are smaller but they outnumber the fox, if only by a little, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full of venison and unwilling to lose blood over it, is driven off from the kill.",
-        null,
-        "s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until it gives up and runs.",
-        "The patrol launches into battle, but with so few cats it's exhausting trying to keep the fox and its snapping jaws on the defensive. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. It's only one bite, but the fox has had enough and flees."
-    ],
-    "fail_text": [
-        "Your patrol fails to drive away the fox, which keeps possession of the food. However there were no injuries.",
-        null,
-        null,
-        "The patrol launches into battle, but r_c is caught with a nasty bite, and the cats give up on challenging for the food in favor of quickly helping r_c back to the medicine cat den.",
-        null,
-        "s_c means well, but they're overconfident in their attack and the fox manages to sink their teeth into them. The patrol is forced to retreat, forming a defensive ring around the hurt s_c."
-    ],
-    "win_skills": ["good fighter", "great fighter", "excellent fighter"],
-    "win_trait": ["adventurous", "altruistic", "ambitious", "confident", "daring", "fierce", "responsible", "righteous"],
-    "fail_skills": ["None"],
-    "fail_trait": ["troublesome", "vengeful", "bloodthirsty", "bold"],
-    "min_cats": 2,
-    "max_cats": 3,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c carries a scar from a fox fight.",
-        null
-    ]
-},
-{
-    "patrol_id": "pln_hunt_redfox_leaf-barescavenge2",
-    "biome": "plains",
-    "season": "leaf-bare",
-    "tags": ["hunting", "large_prey", "fighting", "scar", "big_bite_injury", "clan_to_patrol", "respect", "rel_patrol"],
-    "intro_text": "Your patrol catches the scent of a red fox. Tracking it, they find the animal feeding on a pronghorn carcass, either a small doe or one of last newleaf's fawns. It's impossible to say whether the fox killed it or found it.",
-    "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
-    "chance_of_success": 60,
-    "exp": 20,
-    "success_text": [
-        "Your cats are smaller but heavily outnumber the fox, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full of venison and unwilling to lose blood over it, is driven off from the kill.",
-        null,
-        "s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until s_c lands a crucial blow, snapping a tendon in one of the fox's hindlegs. The fox runs, but there's no way it'll live long with such a crippling injury.",
-        "The patrol launches into battle, keeping the fox on the defensive with teamwork. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. Holding on grimly, s_c's daring move gives the rest of the patrol the opportunity needed to bring the fox down for good."
-    ],
-    "fail_text": [
-        "Your patrol fails to drive away the fox, which keeps possession of the food. However with so many cats to protect each other, there were no injuries.",
-        null,
-        null,
-        "The patrol launches into battle, but r_c is caught with a nasty bite, and the cats give up on challenging for the food in favor of quickly helping r_c back to the medicine cat den.",
-        null,
-        "s_c means well, but they're overconfident in their attack and the fox manages to sink their teeth into them. The patrol is forced to retreat, forming a defensive ring around the hurt s_c."
-    ],
-    "win_skills": ["good fighter", "great fighter", "excellent fighter"],
-    "win_trait": ["adventurous", "altruistic", "ambitious", "confident", "daring", "fierce", "responsible", "righteous"],
-    "fail_skills": ["None"],
-    "fail_trait": ["troublesome", "vengeful", "bloodthirsty", "bold"],
-    "min_cats": 4,
-    "max_cats": 6,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c carries a scar from a fox fight."
-    ]
-},
-{
-    "patrol_id": "pln_hunt_redfox_leaf-barescavenge3",
-    "biome": "plains",
-    "season": "leaf-bare",
-    "tags": ["hunting", "large_prey", "fighting", "scar", "big_bite_injury", "clan_to_patrol", "respect"],
-    "intro_text": "r_c catches the scent of a red fox. Tracking it, they find the animal feeding on a pronghorn carcass, either a small doe or one of last newleaf's fawns. It's impossible to say whether the fox killed it or found it.",
-    "decline_text": "r_c decides not to quarrel with the fox and to find prey elsewhere.",
-    "chance_of_success": 10,
-    "exp": 30,
-    "success_text": [
-        "r_c may be smaller, alone, and half its weight, but the fox has a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle. The fox, already stuffed full of venison and unwilling to lose blood over it, leaves the kill with a grumble.",
-        null,
-        "s_c uses every trick in their talented fighting skillset to attack the fox with no one to watch their flank, until the perfect opportunity opens up and they pounce onto the fox's back, digging in their claws. It's a wild ride through the forest until the fox bucks them off, but it wins them the fawn carcass.",
-        "In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. But then they're stuck, unwilling to let go and risk being bitten. They're dragged through the forest, over rocks and through bushes, until the fox finally collapses and the battered s_c goes back to proudly claim the fawn."
-    ],
-    "fail_text": [
-        "Your patrol fails to drive away the fox, which keeps possession of the food. However there were no injuries.",
-        null,
-        "Fiercely, r_c throws themselves at the fox, determined to win the fawn prize. But the fox values it just as dearly, and manages to get a good grip on r_c, shaking them to pieces and killing them.",
-        "r_c launches into battle, but is caught with a nasty bite, and retreats to limp back home. The fox doesn't follow, happy enough to eat the fawn instead of the foolish cat.",
-        null,
-        "s_c is overconfident in their attack and the fox manages to sink their teeth into them. They retreat, bleeding and in pain, and the fox settles back down to its meal."
-    ],
-    "win_skills": ["great fighter", "excellent fighter"],
-    "win_trait": ["adventurous", "altruistic", "ambitious", "confident", "daring", "fierce", "responsible", "righteous"],
-    "fail_skills": ["None"],
-    "fail_trait": ["troublesome", "vengeful", "bloodthirsty", "bold"],
-    "min_cats": 1,
-    "max_cats": 1,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c carries a scar from a solo fox fight.",
-        "r_c fell in a solo battle with a fox.",
-        "died in battle with a fox"
-    ]
-},
-{
-    "patrol_id": "pln_hunt_redvixen1",
-    "biome": "plains",
-    "season": "newleaf",
-    "tags": ["fighting", "death", "scar", "big_bite_injury", "respect", "trust",  "clan_to_r_c", "patrol_to_r_c", "clan_to_patrol"],
-    "intro_text": "Your patrol catches the scent of a fox - but is it red, or swift?",
-    "decline_text": "Your patrol decides not to pursue the fox.",
-    "chance_of_success": 30,
-    "exp": 30,
-    "success_text": [
-        "The red vixen smells of milk, and hopefully by driving her out of the territory, her litter this newleaf won't be a threat to the Clan. If they don't starve, c_n will hunt them down - they do not share territory with foxes.",
-        "Your patrol drives away the red fox, seeks out her den, and kills her young cubs. It's brutal, but these fluffy baby foxes would one day have grown to be kit-killers and thieves.",
-        "s_c displays incredible skill, driving the mother red vixen out of the territory almost by themselves. Now neither the fox nor her cubs pose a threat to the Clan. It truly proves s_c's place as one of c_n's most talented and skillful fighters.",
-        "The patrol overcomes the red vixen and drives her off thanks to a brilliant battle move by s_c at a critical moment. Their bravery ensures the patrol's success, and the cats arrive back at camp singing their praises to make sure the Clan knows it."
-    ],
-    "fail_text": [
-        "The mother red fox is vicious and determined, and the small patrol is beaten back. But these plains is c_n's and they haven't given up. They may have lost this battle, but c_n will win this war.",
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the rest of the patrol have to rescue them from the red vixen.",
-        "Never threaten a mother's young - the red vixen kills r_c in the skirmish.",
-        "The mother red fox's snapping jaws leave r_c dripping blood onto the grass, forcing the patrol to back off.",
-        null,
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the red vixen manages to sink her teeth into them. The patrol rallies around s_c, but they have to give up on the fight.",
-        "As their hunt descends into a full on battle with a red vixen determined to protect her young, p_l takes a blow meant for one of their Clanmates, losing a life."
-    ],
-    "win_skills": ["excellent fighter"],
-    "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-    "fail_skills": ["good fighter"],
-    "fail_trait": ["None"],
-    "min_cats": 2,
-    "max_cats": 3,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c carries a scar from a fox fight.",
-        "r_c fell in battle with a fox.",
-        "died in battle with a fox"
-    ]
-},
-{
-    "patrol_id": "pln_hunt_redvixen2",
-    "biome": "plains",
-    "season": "newleaf",
-    "tags": ["fighting", "scar", "big_bite_injury", "respect", "trust",  "clan_to_r_c", "patrol_to_r_c", "clan_to_patrol"],
-    "intro_text": "Your patrol catches the scent of a fox - but is it red, or swift?",
-    "decline_text": "Your patrol decides not to pursue the fox.",
-    "chance_of_success": 60,
-    "exp": 30,
-    "success_text": [
-        "Led by p_l, and with a heap of cooperation and teamwork, the patrol drives away a red fox vixen, seeking out her den and killing her young cubs. The plains will be safe from both the threat the vixen posed this season, and the threat her cubs would've given c_n in the seasons to come.",
-        "With so many cats working together in tight coordination, they manage to accomplish the near-impossible, finding and killing a mother red vixen and ending the threat to the Clan that she and her cubs pose.",
-        "s_c displays incredible skill, driving the mother red vixen they track down out of the territory almost by themselves. Now neither the fox nor her dependent cubs pose a threat to the Clan. It truly proves s_c's place as one of c_n's most talented and skillful fighters.",
-        "The patrol hunts down and overcomes the red vixen they discover, driving her off thanks to a brilliant battle move by s_c at a critical moment. Their bravery ensures the patrol's success, and the cats arrive back at camp singing their praises to make sure the Clan knows it."
-    ],
-    "fail_text": [
-        "The mother red fox is vicious and determined. Although they lose this battle, through teamwork the cats manage to retreat without injury.",
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the rest of the patrol have to rescue them from the red vixen.",
-        null,
-        "r_c is left wounded as the patrol and the mother red vixen fight to a stalemate. Hopefully they've given the fox mother a reason not to return to this part of the forest.",
-        null,
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the red vixen manages to sink her teeth into them. The patrol rallies around s_c, but they have to give up on the fight."
-    ],
-    "win_skills": ["excellent fighter"],
-    "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-    "fail_skills": ["good fighter"],
-    "fail_trait": ["None"],
-    "min_cats": 4,
-    "max_cats": 6,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-    "r_c carries a scar from a fox fight."
-    ]
-},
-{
-    "patrol_id": "pln_hunt_redvixen3",
-    "biome": "plains",
-    "season": "newleaf",
-    "tags": ["fighting", "death", "scar", "big_bite_injury", "respect", "trust", "clan_to_patrol", "no_body"],
-    "intro_text": "Your patrol catches the scent of a fox - but is it red, or swift?",
-    "decline_text": "Your patrol decides not to pursue the fox.",
-    "chance_of_success": 20,
-    "exp": 50,
-    "success_text": [
-        "The red vixen smells of milk, and hopefully by driving her out of the territory, her litter this newleaf won't be a threat to the Clan. If they don't starve, c_n will hunt them down - they do not share territory with foxes.",
-        null,
-        "s_c displays incredible skill, driving the mother red vixen and her brood out of c_n's plains all by themselves. Now neither the fox nor her dependent cubs pose a threat to the Clan. They swell with pride, feeling the confidence of knowing that they're truly one of the best fighters c_n has ever produced.",
-        "A brilliant battle move by s_c knocks the red vixen they find off balance, and s_c manages to drive her out of c_n territory, though it takes every spark of strength in their pelt to do it alone."
-    ],
-    "fail_text": [
-        null,
-        null,
-        "Never threaten a mother's young - the red vixen kills r_c in the skirmish, and carries off the body to feed her litter.",
-        "The mother red fox's snapping jaws leave r_c dripping blood onto the leaf litter, and barely able to escape further injury.",
-        null,
-        "s_c is determined to win, but the vixen is determined to live, and that makes all the difference. s_c ends up pinned in a defensible hiding spot, bleeding and terrified, until the vixen judges them no longer a threat and continues on her way."
-    ],
-    "win_skills": ["excellent fighter"],
-    "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-    "fail_skills": ["good fighter"],
-    "fail_trait": ["None"],
-    "min_cats": 1,
-    "max_cats": 1,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c carries a scar from a solo fight with a vixen.",
-        "r_c fell in a solo battle with a vixen.",
-        "died in battle with a fox"
-    ]
-},
-{
-    "patrol_id": "pln_hunt_redvixen4",
-    "biome": "plains",
-    "season": "greenleaf",
-    "tags": ["fighting", "death", "scar", "big_bite_injury", "respect", "trust",  "clan_to_r_c", "patrol_to_r_c", "clan_to_patrol"],
-    "intro_text": "Your patrol catches the scent of a fox - but is it red, or swift?",
-    "decline_text": "Your patrol decides not to pursue the fox.",
-    "chance_of_success": 30,
-    "exp": 30,
-    "success_text": [
-        "The red vixen smells of milk and blood. Hopefully by driving her out of the territory, the litter she has been raising this greenleaf won't be a threat to the Clan. If they don't starve, c_n will hunt them down - they do not share with foxes.",
-        "Your patrol drives away the fox, seeks out her den, and kills her cubs. It's brutal, but these fluffy small foxes would one day have grown to be kit-killers and thieves.",
-        "s_c displays incredible skill, driving the mother red vixen they track down out of the territory almost by themselves. Now neither the fox nor her dependent cubs pose a threat to the Clan. It truly proves s_c's place as one of c_n's most talented and skillful fighters.",
-        "The patrol hunts down and overcomes the red vixen they discover, driving her off thanks to a brilliant battle move by s_c at a critical moment. Their bravery ensures the patrol's success, and the cats arrive back at camp singing their praises to make sure the Clan knows it."
-    ],
-    "fail_text": [
-        "The mother red fox is vicious and determined, and the small patrol is beaten back. But this forest is c_n's and they haven't given up. They may have lost this battle, but c_n will win this war.",
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the rest of the patrol have to rescue them from the red vixen.",
-        "Never threaten a mother's young - the red vixen kills r_c in the skirmish.",
-        "The mother red fox's snapping jaws leave r_c dripping blood onto the grass, forcing the patrol to back off.",
-        null,
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the red vixen manages to sink her teeth into them. The patrol rallies around s_c, but they have to give up on the fight.",
-        "As their hunt descends into a full on battle with a red vixen determined to protect her young, p_l takes a blow meant for one of their Clanmates, losing a life."
-    ],
-    "win_skills": ["excellent fighter"],
-    "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-    "fail_skills": ["good fighter"],
-    "fail_trait": ["None"],
-    "min_cats": 2,
-    "max_cats": 3,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c carries a scar from a fox fight.",
-        "r_c fell in battle with a fox.",
-        "died in battle with a fox"
-    ]    
-},
-{
-    "patrol_id": "pln_hunt_redvixen5",
-    "biome": "plains",
-    "season": "greenleaf",
-    "tags": ["fighting", "scar", "big_bite_injury", "respect", "trust",  "clan_to_r_c", "patrol_to_r_c", "clan_to_patrol"],
-    "intro_text": "Your patrol catches the scent of a fox - but is it red, or swift?",
-    "decline_text": "Your patrol decides not to pursue the fox.",
-    "chance_of_success": 60,
-    "exp": 30,
-    "success_text": [
-        "Led by p_l, and with a heap of cooperation and teamwork, the patrol drives away the fox, seeks out her den, and kills her growing cubs. The forest will be safe from both the threat the vixen posed this season, and the threat her cubs would've given c_n in the seasons to come.",
-        "With so many cats working together in tight coordination, they manage to accomplish the near-impossible, finding and killing a mother red vixen and ending the threat to the Clan that she and her cubs pose.",
-        "s_c displays incredible skill, driving the mother red vixen they track down out of the territory almost by themselves. Now neither the fox nor her dependent cubs pose a threat to the Clan. It truly proves s_c's place as one of c_n's most talented and skillful fighters.",
-        "The patrol hunts down and overcomes the red vixen they discover, driving her off thanks to a brilliant battle move by s_c at a critical moment. Their bravery ensures the patrol's success, and the cats arrive back at camp singing their praises to make sure the Clan knows it."
-    ],
-    "fail_text": [
-        "The mother red fox is vicious and determined. Although they lose this battle, through teamwork the cats manage to retreat without injury.",
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the rest of the patrol have to rescue them from the red vixen.",
-        null,
-        "r_c is left wounded as the patrol and the mother red vixen fight to a stalemate. Hopefully they've given the fox mother a reason not to return to this part of the forest.",
-        null,
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the red vixen manages to sink her teeth into them. The patrol rallies around s_c, but they have to give up on the fight."
-    ],
-    "win_skills": ["excellent fighter"],
-    "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-    "fail_skills": ["good fighter"],
-    "fail_trait": ["None"],
-    "min_cats": 4,
-    "max_cats": 6,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-    "r_c carries a scar from a fox fight."
-    ]
-},
-{
-    "patrol_id": "pln_hunt_redvixen6",
-    "biome": "plains",
-    "season": "greenleaf",
-    "tags": ["fighting", "death", "scar", "big_bite_injury", "respect", "trust", "clan_to_patrol", "no_body"],
-    "intro_text": "Your patrol catches the scent of a fox - but is it red, or swift?",
-    "decline_text": "Your patrol decides not to pursue the fox.",
-    "chance_of_success": 10,
-    "exp": 50,
-    "success_text": [
-        "The red vixen smells of milk and blood. Hopefully by driving her out of the territory, the litter she has been raising this greenleaf won't be a threat to the Clan.",
-        null,
-        "s_c displays incredible skill, driving the mother red vixen and her brood out of c_n's plains all by themselves. Now neither the fox nor her dependent cubs pose a threat to the Clan. They swell with pride, feeling the confidence of knowing that they're truly one of the best fighters c_n has ever produced.",
-        "A brilliant battle move by s_c at a critical moment knocks the red vixen they find off balance, and s_c manages to drive her out of c_n territory, though it takes every spark of strength in their pelt to do it alone."
-    ],
-    "fail_text": [
-        null,
-        null,
-        "Never threaten a mother's young - the red vixen kills r_c in the skirmish, and carries off the body to feed her litter.",
-        "The mother red fox's snapping jaws leave r_c dripping blood onto the leaf litter, and barely able to escape further injury.",
-        null,
-        "s_c is determined to win, but the vixen is determined to live, and that makes all the difference. s_c ends up pinned in a defensible hiding spot, bleeding and terrified, until the vixen judges them no longer a threat and continues on her way."
-    ],
-    "win_skills": ["excellent fighter"],
-    "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-        "fail_skills": ["good fighter"],
-        "fail_trait": ["None"],
-    "min_cats": 1,
-    "max_cats": 1,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c carries a scar from a solo fight with a vixen.",
-        "r_c fell in a solo battle with a vixen.",
-        "died in battle with a fox"
-    ]
-},
-{
-    "patrol_id": "pln_hunt_redvixen7",
-    "biome": "plains",
-    "season": "leaf-fall",
-    "tags": ["fighting", "death", "scar", "big_bite_injury", "respect", "trust",  "clan_to_r_c", "patrol_to_r_c", "clan_to_patrol"],
-    "intro_text": "Your patrol catches the scent of a fox - but is it red, or swift?",
-    "decline_text": "Your patrol decides not to pursue the fox.",
-    "chance_of_success": 30,
-    "exp": 30,
-    "success_text": [
-        "The red vixen smells like the prey she's been poaching to feed her litter. She's stolen from c_n for the last time, and the patrol drives her from their territory, yowling their anger and fury.",
-        "Your patrol drives away the red fox, and seeks out her den, but her leaf-fall cubs are near full-grown and scatter into the wilderness. Hopefully leaf-bare takes care of them.",
-        "s_c displays incredible skill, driving the mother red vixen they track down out of the territory almost by themselves. It truly proves s_c's place as one of c_n's most talented and skillful fighters.",
-        "The patrol hunts down and overcomes the red vixen they discover, driving her off thanks to a brilliant battle move by s_c at a critical moment. Their bravery ensures the patrol's success, and the cats arrive back at camp singing their praises to make sure the Clan knows it."
-    ],
-    "fail_text": [
-        "The mother red fox is vicious and determined, and the small patrol is beaten back. But this forest is c_n's and they haven't given up. They may have lost this battle, but c_n will win this war.",
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the rest of the patrol have to rescue them from the red vixen.",
-        "Never threaten a mother's young - the red vixen kills r_c in the skirmish.",
-        "The mother red fox's snapping jaws leave r_c dripping blood onto the grass, forcing the patrol to back off.",
-        null,
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the red vixen manages to sink her teeth into them. The patrol rallies around s_c, but they have to give up on the fight.",
-        "As their hunt descends into a full on battle with a red vixen determined to protect her young, p_l takes a blow meant for one of their Clanmates, losing a life."
-    ],
-    "win_skills": ["excellent fighter"],
-    "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-    "fail_skills": ["good fighter"],
-    "fail_trait": ["None"],
-    "min_cats": 2,
-    "max_cats": 3,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-    "r_c carries a scar from a fox fight.",
-    "r_c fell in battle with a fox.",
-        "died in battle with a fox"
-    ]
-},
-{
-    "patrol_id": "pln_hunt_redvixen8",
-    "biome": "plains",
-    "season": "leaf-fall",
-    "tags": ["fighting", "scar", "big_bite_injury", "respect", "trust",  "clan_to_r_c", "patrol_to_r_c", "clan_to_patrol"],
-    "intro_text": "Your patrol catches the scent of a fox - but is it red, or swift?",
-    "decline_text": "Your patrol decides not to pursue the fox.",
-    "chance_of_success": 60,
-    "exp": 30,
-    "success_text": [
-        "Led by p_l and with a heap of cooperation and teamwork, the patrol drives away the fox, and seeks out her den. But her cubs are near full-grown with the bounty of leaf-fall, and scatter from the patrol into the wilderness. Hopefully leaf-bare takes care of them.",
-        "With so many cats working together in tight coordination, they manage to accomplish the near-impossible, killing the mother vixen and ending the threat to the Clan that she poses. The patrol drives her near-full grown litter of fox cubs out from the territory. Hopefully the coming leaf-bare will take care of them.",
-        "s_c displays incredible skill, driving the mother red vixen they track down out of the territory almost by themselves. Now neither the fox nor her cubs pose a threat to c_n.",
-        "The patrol hunts down and overcomes the red vixen they discover, driving her off thanks to a brilliant battle move by s_c at a critical moment. Their bravery ensures the patrol's success, and the cats arrive back at camp singing their praises to make sure the Clan knows it."
-    ],
-    "fail_text": [
-        "The mother red fox is vicious and determined. Although they lose this battle, through teamwork the cats manage to retreat without injury.",
-        null,
-        "r_c is left wounded as the patrol and the mother red vixen fight to a stalemate. Hopefully they've given the fox mother a reason not to return to this part of the forest.",
-        null,
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the red vixen manages to sink her teeth into them. The patrol rallies around s_c, but they have to give up the fight."
-    ],
-    "win_skills": ["excellent fighter"],
-    "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-        "fail_skills": ["good fighter"],
-        "fail_trait": ["None"],
-    "min_cats": 4,
-    "max_cats": 6,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-    "r_c carries a scar from a fox fight."
-    ]
-},
-{
-    "patrol_id": "pln_hunt_redvixen9",
-    "biome": "plains",
-    "season": "leaf-fall",
-    "tags": ["fighting", "death", "scar", "big_bite_injury", "respect", "trust", "clan_to_patrol", "no_body"],
-    "intro_text": "Your patrol catches the scent of a fox - but is it red, or swift?",
-    "decline_text": "Your patrol decides not to pursue the fox.",
-    "chance_of_success": 20,
-    "exp": 50,
-    "success_text": [
-        "It takes r_c's every scrap of bravery and strength to drive away the red vixen - her near grown litter, fat on the bounty of leaf-fall, is a challenge for another day. c_n will have to deal with the young foxes now roaming motherless in their woods, before they start to compete for prey in leaf-bare.",
-        null,
-        "s_c displays incredible skill, driving the mother red vixen and her brood out of c_n's plains all by themselves. Now neither the fox nor her cubs pose a threat to the Clan. They swell with pride, feeling the confidence of knowing that they're truly one of the best fighters c_n has ever produced.",
-        "A brilliant battle move by s_c at a critical moment knocks the red vixen they find off balance, and s_c manages to drive her out of c_n territory, though it takes every spark of strength in their pelt to do it alone."
-    ],
-    "fail_text": [
-        null,
-        null,
-        "Never threaten a mother's young - the red vixen kills r_c in the skirmish, and carries off the body to feed her litter.",
-        "The mother red fox's snapping jaws leave r_c dripping blood onto the leaf litter, and barely able to escape further injury.",
-        null,
-        "s_c is determined to win, but the vixen is determined to live, and that makes all the difference. s_c ends up pinned in a defensible hiding spot, bleeding and terrified, until the vixen judges them no longer a threat and continues on her way."
-    ],
-    "win_skills": ["excellent fighter"],
-    "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-    "fail_skills": ["good fighter"],
-    "fail_trait": ["None"],
-    "min_cats": 1,
-    "max_cats": 1,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-    "r_c carries a scar from a solo fight with a red vixen.",
-    "r_c fell in a solo battle with a red vixen.",
-        "died in battle with a fox"
-    ]
-},
-{
-    "patrol_id": "pln_hunt_swiftfox_newleafvixen1",
-    "biome": "plains",
-    "season": "newleaf",
-    "tags": ["hunting", "comfort", "respect", "rel_patrol"],
-    "intro_text": "Your patrol catches the scent of a fox - but is it red, or swift?",
-    "decline_text": "Your patrol decides not to pursue the fox.",
-    "chance_of_success": 70,
-    "exp": 30,
-    "success_text": [
-    "Anticipating the coming greenleaf, this swift fox is checking for a suitable burrow for her litter. And that burrow will not be in c_n's territory. The patrol makes that clear, screaming and charging at her until the fox flees beyond their borders, away from where her cubs could threaten the Clan.",
-    "This swift vixen is looking for a place to den, and the patrol sets up an ambush. She crossed their borders, but she won't cross back over them again, and with her life ends the threat her cubs would have posed to c_n's kits.",
-    "s_c holds the patrol back until the swift fox's yips bring her mate, than the patrol strikes. While the vixen flees, her mate fights, and against warriors he doesn't stand a chance."
-    ],
-    "fail_text": [
-    "The swift fox spots the patrol coming and scarpers, tucking tail and fleeing across the horizon in an example of where the small canivore gets its name."
-    ],
-    "win_skills": ["smart", "very smart", "extremely smart"],
-    "win_trait": ["None"],
-    "fail_skills": ["None"],
-    "fail_trait": ["None"],
-    "min_cats": 2,
-    "max_cats": 6,
-    "antagonize_text": null,
-    "antagonize_fail_text": null
-},
-{
-    "patrol_id": "pln_hunt_swiftfox_newleafvixen2",
-    "biome": "plains",
-    "season": "newleaf",
-    "tags": ["hunting", "fighting", "scar", "respect", "clan_to_r_c", "small_bite_injury"],
-    "intro_text": "r_c catches the scent of a fox - but is it red, or swift?",
-    "decline_text": "Your patrol decides not to pursue the fox.",
-    "chance_of_success": 60,
-    "exp": 20,
-    "success_text": [
-    "This swift vixen is scouting out potential dens for greenleaf, r_c realises, and rushes to warn her off. Forget about hunting, driving off this vixen before she sets up a den within c_n's borders is more important.",
-    "This swift vixen is scouting out potential dens for greenleaf, r_c realises. This could be bad, and r_c gives up on the hunt, instead following the vixen, yowling and hissing, using their persistance to warn her off from trying to live here.",
-    "s_c positions themselves down a burrow in the vixen's path, and as the swift fox approaches s_c bursts from it, pinning her down and using surprise to get in a crucial blow to her throat."
-    ],
-    "fail_text": [
-    "The swift fox spots r_c coming and scarpers, tucking tail and fleeing across the horizon in an example of where the small canivore gets its name.",
-    null,
-    null,
-    "Puffed up, r_c approaches the swift fox. But there's only one of them, and the fox is their equal in size and weight. instead of running or giving up, it snarls, and attacks. r_c gives just as good as they get, and both animals end up limping away."
-    ],
-    "win_skills": ["smart", "very smart", "extremely smart", "good fighter", "great fighter", "excellent fighter"],
-    "win_trait": ["None"],
-    "fail_skills": ["None"],
-    "fail_trait": ["None"],
-    "min_cats": 1,
-    "max_cats": 1,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c carries a scar from fighting with a swift fox."
-    ]
-},
-{
-    "patrol_id": "pln_hunt_swiftfox_greenleafvixen1",
-    "biome": "plains",
-    "season": "greenleaf",
-    "tags": ["hunting", "comfort", "respect", "rel_patrol", "fighting", "scar", "big_bite_injury"],
-    "intro_text": "Your patrol catches the scent of a fox - but is it red, or swift?",
-    "decline_text": "Your patrol decides not to pursue the fox.",
-    "chance_of_success": 50,
-    "exp": 30,
-    "success_text": [
-    "The patrol charges the vixen, and she runs, leaving the scent of milk in the air behind her. Though they don't know where her cubs are hidden, without their mother they won't pose a threat to the Clan.",
-    "The patrol sneaks closer, until p_l realises that the vixen is approaching her den - a den when cubs must surely hide. A competitor denning within c_n's borders is an outrage, and the patrol leaps to attack, pinning the vixen in a mess of boulders.",
-    "s_c holds the patrol back until they spot the vixen's mate, approaching with poached prey in his jaws. Together, the cats ambush the foxes, bursting from cover with claws unshealthed as a vicious fight starts. But warriors fight as a team, and the foxes do not, and one flees, abandoning its mate to the fury of c_n."
-    ],
-    "fail_text": [
-    "The swift fox spots the patrol coming and scarpers, tucking tail and fleeing across the horizon in an example of where the small canivore gets its name.",
-    null,
-    null,
-    "As the patrol descends on the swift vixen, her scream of surprise brings in her mate, changing the odds. The male bursts out from cover and sinks his teeth into r_c, both foxes using the patrol switching to r_c's defence as their signal to flee."
-    ],
-    "win_skills": ["smart", "very smart", "extremely smart", "good fighter", "great fighter", "excellent fighter"],
-    "win_trait": ["None"],
-    "fail_skills": ["None"],
-    "fail_trait": ["None"],
-    "min_cats": 2,
-    "max_cats": 6,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c was marked by a fight with a swift fox vixen."
-    ]
-},
-{
-    "patrol_id": "pln_hunt_swiftfox_greenleafvixen2",
-    "biome": "plains",
-    "season": "greenleaf",
-    "tags": ["hunting", "fighting", "scar", "respect", "clan_to_r_c", "small_bite_injury"],
-    "intro_text": "r_c catches the scent of a fox - but is it red, or swift?",
-    "decline_text": "Your patrol decides not to pursue the fox.",
-    "chance_of_success": 20,
-    "exp": 30,
-    "success_text": [
-    "Sneaking closer, r_c realises that the wind carries the scent of milk from the vixen. It's a swift fox - and she has cubs. Eventually she leaves the area, and r_c begins the hunt, checking every burrow, every crevice, every hole until they find the tiny fox cubs. Killing them protects the Clan, they remind themselves.",
-    "This swift vixen has a den, r_c realises, one perched just under a lone tree. Once the vixen leaves, r_c digs around it to bury the den and its contents. No swift cubs will be raised within c_n's borders.",
-    "s_c scents the air, following the milk scent of the mother swift fox from afar. It means they can position themselves for the perfect ambush, leaping from cover to fasten their teeth in her throat."
-    ],
-    "fail_text": [
-    "The swift fox spots r_c coming and scarpers, tucking tail and fleeing across the horizon in an example of where the small canivore gets its name.",
-    null,
-    null,
-    "As r_c descends on the swift vixen, her scream of surprise brings in her mate, changing the odds. The male bursts out from cover and sinks his teeth into r_c, both foxes using the chance to flee."
-    ],
-    "win_skills": ["smart", "very smart", "extremely smart", "good fighter", "great fighter", "excellent fighter"],
-    "win_trait": ["None"],
-    "fail_skills": ["None"],
-    "fail_trait": ["None"],
-    "min_cats": 1,
-    "max_cats": 1,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c was marked by a fight with a swift fox vixen."
-    ]
-},
-{
-    "patrol_id": "pln_hunt_swiftfox_leaf-fallvixen1",
-    "biome": "plains",
-    "season": "leaf-fall",
-    "tags": ["hunting", "large_prey1", "huge_prey2", "comfort", "respect", "rel_patrol", "fighting", "scar", "big_bite_injury"],
-    "intro_text": "Your patrol catches the scent of a fox - but is it red, or swift?",
-    "decline_text": "Your patrol decides not to pursue the fox.",
-    "chance_of_success": 70,
-    "exp": 30,
-    "success_text": [
-    "The patrol charges the swift vixen, and she runs, leaving the scent of milk in the air behind her. But they don't know where her cubs might've been hidden, and they'll be old enough to survive without her - this bodes ill for leaf-bare.",
-    "The patrol sneaks closer, until p_l realises that the swift vixen is approaching her den. Her cubs, nearly full grown on prey stolen from c_n's territory, poke their heads out, and the cats yowl in outrage. They charge the den, killing two of the cubs before the vixen runs with her third.",
-    "s_c holds the patrol back until they spot the swift vixen's mate, approaching with poached prey in his jaws. Together, the cats ambush the foxes, bursting from cover with claws unshealthed as a vicious fight starts. But warriors fight as a team, and the foxes do not, and one flees, abandoning its mate and cubs to the fury of c_n."
-    ],
-    "fail_text": [
-    "The swift fox spots the patrol coming and scarpers, tucking tail and fleeing across the horizon in an example of where the small canivore gets its name.",
-    null,
-    null,
-    "As the patrol descends on the swift vixen, her scream of surprise brings in her mate, changing the odds. The male bursts out from cover and sinks his teeth into r_c, both foxes using the patrol switching to r_c's defence as their signal to flee."
-    ],
-    "win_skills": ["smart", "very smart", "extremely smart", "good fighter", "great fighter", "excellent fighter"],
-    "win_trait": ["None"],
-    "fail_skills": ["None"],
-    "fail_trait": ["None"],
-    "min_cats": 2,
-    "max_cats": 6,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c was marked by a fight with a swift fox vixen."
-    ]
-},
-{
-    "patrol_id": "pln_hunt_swiftfox_leaf-fallvixen2",
-    "biome": "plains",
-    "season": "leaf-fall",
-    "tags": ["hunting", "medium_prey0", "large_prey2", "fighting", "scar", "respect", "clan_to_r_c", "small_bite_injury"],
-    "intro_text": "r_c catches the scent of a fox - but is it red, or swift?",
-    "decline_text": "Your patrol decides not to pursue the fox.",
-    "chance_of_success": 40,
-    "exp": 30,
-    "success_text": [
-    "Sneaking closer, r_c realises that the wind carries the scent of milk from the vixen. It's a swift fox - and she has cubs. Eventually she leaves the area, and r_c begins the hunt, checking every burrow, every crevice, every hole until they stumble over the den. Two of the cubs flee into the grasslands, while the third falls to r_c's claws.",
-    "This swift vixen has a den, r_c realises, one perched just under a lone tree. Once the vixen leaves, r_c digs around it to bury the den and its contents. No swift cubs will be raised within c_n's borders.",
-    "s_c scents the air, following the milk scent of the mother swift fox from afar. It means they can position themselves for the perfect ambush, leaping from cover to fasten their teeth in her throat. Her cubs will be old enough to survive without her, but this vixen will never raise kitten killers again."
-    ],
-    "fail_text": [
-    "The swift fox spots r_c coming and scarpers, tucking tail and fleeing across the horizon in an example of where the small canivore gets its name.",
-    null,
-    null,
-    "As r_c descends on the swift vixen, her scream of surprise brings in her mate, changing the odds. The male bursts out from cover and sinks his teeth into r_c, both foxes using the chance to flee."
-    ],
-    "win_skills": ["smart", "very smart", "extremely smart", "good fighter", "great fighter", "excellent fighter"],
-    "win_trait": ["None"],
-    "fail_skills": ["None"],
-    "fail_trait": ["None"],
-    "min_cats": 1,
-    "max_cats": 1,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c was marked by a fight with a swift fox vixen."
-    ]
-},
-{
-	"patrol_id": "pln_hunt_kitfox_steal1",
-	"biome": "plains",
-	"season": "Any",
-	"tags": ["hunting", "small_prey"],
-	"intro_text": "r_c catches the scent of a fox. Tracking it down, the cats spot a kit fox wandering through the grass, carrying a mouse in its jaws.",
-	"decline_text": "That's an insignificant amount of fresh-kill to start a fight over.",
-	"chance_of_success": 70,
-	"exp": 10,
-	"success_text": [
-	"Your hunters chase after it, spitting and hissing as the smaller predator tries to run. But a patrol full of cats is faster, and the fox soon decides that it'd prefer to give up the mouse rather than fight. It's an insignificant amount of fresh-kill, but hopefully a permanent lesson for a fox on stealing from c_n.",
-	"The kit fox isn't crazy, and immediately drops the mouse, running for its life from the patrol." ,
-	"s_c pounces, snarling, and the fox turns tail with a yelp. Only s_c isn't alone, and cats circle the fox as it turns and snarls and yelps for mercy, holding it their until they're very sure it will never dare sneak across c_n's borders again.",
-	"s_c wanders up to the kit fox, swagger in their step as they take the opportunity to be the bigger predator for once in their life. The kit fox takes one look at the patrol backing s_c up and decides it's time to be elsewhere as fast as its legs can take it, leaving the single skinny mouse it stole behind."
-	],
-	"fail_text": [
-	"The patrol approaches the kit fox, who spots them and sets off at full speed. It's not worth following them, not over a single mouse."
-	],
-	"win_skills": ["good fighter", "great fighter", "excellent fighter"],
-	"win_trait": ["adventurous", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "loyal", "playful", "righteous", "shameless", "strict", "troublesome", "vengeful"],
-	"fail_skills": ["None"],
-	"fail_trait": ["None"],
-	"min_cats": 2,
-	"max_cats": 6,
-	"antagonize_text": null,
-	"antagonize_fail_text": null
-},
-{
-	"patrol_id": "pln_hunt_kitfox_steal2",
-	"biome": "plains",
-	"season": "Any",
-	"tags": ["hunting", "small_prey", "fighting", "scar", "small_bite_injury"],
-	"intro_text": "r_c catches the scent of a fox. Tracking it down, they spot a kit fox wandering through the grass, carrying a mouse in its jaws.",
-	"decline_text": "That's an insignificant amount of fresh-kill to start a fight over.",
-	"chance_of_success": 70,
-	"exp": 10,
-	"success_text": [
-	"r_c chases after it, spitting and hissing as the smaller predator tries to run. But r_c is faster, and the fox soon decides that it'd prefer to give up the mouse rather than fight. Puffed up and proud, r_c trots back to camp with the addition for the fresh-kill pile.",
-	"The kit fox locks eyes with r_c as they emerge from the grass, weighing up its options against the bigger cat. There's a long, tense moment as both puff up, ready for a fight, but the fox's nerve breaks first and it runs, leaving r_c with the mouse." ,
-	"s_c pounces, snarling, and the fox turns tail with a yelp. Only s_c uses that moment to grab that fluffy tail and shake, until the fox gives up its prey and turns to bite. They dart backwards, and that's as much fight as the fox had in them - the fox runs, and s_c has won the mouse.",
-	"s_c wanders up to the kit fox, swagger in their step as they take the opportunity to be the bigger predator for once in their life. It looks like it's going to fight for a second, but s_c's confidence intimidates it into dropping the mouse and fleeing back into the long grass."
-	],
-	"fail_text": [
-	"r_c approaches the kit fox, who spots them and sets off at full speed. It's not worth following them, not over a single mouse.",
-	null,
-	null,
-	"With a massive yowl, r_c charges the fox. It bares its teeth, unwilling to give up its hard won prey without a fight, and one wrong step puts r_c's pelt in range of those little jaws, as the small kit fox tries to live up to the reputation of its bigger and stronger relatives."
-	],
-	"win_skills": ["good fighter", "great fighter", "excellent fighter"],
-	"win_trait": ["adventurous", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "loyal", "playful", "righteous", "shameless", "strict", "troublesome", "vengeful"],
-	"fail_skills": ["None"],
-	"fail_trait": ["None"],
-	"min_cats": 1,
-	"max_cats": 1,
-	"antagonize_text": null,
-	"antagonize_fail_text": null,
-	"history_text": [
-    	"r_c carries a scar from a fight with a kit fox.",
-    	null
-	]
-},
-{
-	"patrol_id": "pln_hunt_swiftfox_newleafscavenge1",
-	"biome": "plains",
-	"season": "newleaf",
-	"tags": ["hunting", "large_prey", "comfort", "respect", "rel_patrol"],
-	"intro_text": "Your patrol catches the scent of a fox. Tracking it, they find a swift fox feeding on a calf carcass. The cat-sized predator definitely didn't kill this massive hunk of fresh-kill.",
-	"decline_text": "Your patrol decides not to quarrel with the fox - bigger predators will be attracted here. Best to leave sooner rather than later.",
-	"chance_of_success": 70,
-	"exp": 20,
-	"success_text": [
-	"As the patrol approaches, the swift fox spots them and backs off from the carcass with a whine. Your cats can feed in peace for now, but larger predators will surely soon come to throw them off the kill. By cooperating together, the patrol is able to at least drag some of the intestines home to camp.",
-	null,
-	"s_c sits and watches the swift fox as the patrol takes over the kill without a fight. It wanders the area, grabbing pieces of gristle and meat and caching them in little holes, giving s_c an idea. Together the Clan cats gnaw off a leg, and take their bony prize back to camp for c_n.",
-	"While the rest of the patrol feeds on the kill, the swift fox gnawing on the head at the other end in uneasy truce, s_c keeps watch. It turns out to have been a wise move, as they spot a cougar's ears sticking up out of the grass. The kill's original owner is coming back, and the cats vacate with speed."
-	],
-	"fail_text": [
-	"The swift fox gives up on the kill with a snarl, but a coyote yip in the distance sends both the smaller predator species running, the cats puffed up and uncomfortable.",
-	"The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth. s_c calls the rest of the patrol for backup and no one is injured, but by the time they get back to the kill ravens are circling overhead. The patrol gives it up, knowing bigger predators will arrive soon."
-	],
-	"win_skills": ["smart", "very smart", "extremely smart"],
-	"win_trait": ["altruistic", "patient", "responsible", "thoughtful", "wise", "calm", "careful", "insecure", "nervous", "sneaky"],
-	"fail_skills": ["None"],
-	"fail_trait": ["bold", "childish", "confident", "daring", "playful", "shameless"],
-	"min_cats": 2,
-	"max_cats": 6,
-	"antagonize_text": null,
-	"antagonize_fail_text": null
-},
-{
-	"patrol_id": "pln_hunt_swiftfox_newleafscavenge2",
-	"biome": "plains",
-	"season": "newleaf",
-	"tags": ["hunting", "small_prey", "fighting", "scar", "death", "no_body", "small_bite_injury"],
-	"intro_text": "r_c catches the scent of a fox. Tracking it, they find a swift fox feeding on a calf carcass. The cat-sized predator definitely didn't kill this massive hunk of fresh-kill.",
-	"decline_text": "r_c decides not to quarrel with the fox - bigger predators will be attracted here. Best to leave sooner rather than later.",
-	"chance_of_success": 70,
-	"exp": 10,
-	"success_text": [
-	"r_c approaches the kill, fur puffed up. The swift fox grumbles, but with a hiss both animals agree to disagree, feeding from opposite ends of the calf without further trouble. r_c is able to find some decent scraps to carry back to camp, though with only them there they can't bring back as much meat as they'd like.",
-	null,
-	"Watching the swift fox at the carcass, s_c notices it stripping meat from the calf and caching it in little holes, and starts to copy it. The bigger predators will return to claim the calf soon, but by the time they do s_c will have hidden away the choicest morsels to fetch later.",
-	"With great care, aware that the kill's original owner must be somewhere about, s_c snatches the first large scrap they find and leaves the swift fox to risk the wrath of the bigger predators."
-	],
-	"fail_text": [
-	"A coyote yip in the distance sends both the smaller predator species running before r_c can muscle in on the feeding opportunity.",
-	"The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth. s_c dances out of the way, but hears the caw of ravens descending on the carcass, and knows it would be too dangerous to return.",
-	"r_c happily tucks into the massive calf - there's more than enough room for both them and the small fox to feed. They hear a massive, outraged yowl, and a blow from behind sends them to StarClan with a single hit. They never saw what did it.",
-	"Puffed up, r_c approaches the swift fox. But there's only one of them, and the fox is their equal in size and weight. instead of running or giving it, it snarls, and attacks. r_c gives just as good as they get, and both animals end up limping away from the kill.",
-	null,
-	"The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth, sinking them into s_c and giving s_c a bigger concern than scavenging from the calf carcass."
-	],
-	"win_skills": ["good fighter", "great fighter", "excellent fighter"],
-	"win_trait": ["altruistic", "patient", "responsible", "thoughtful", "wise", "calm", "careful", "insecure", "nervous", "sneaky"],
-	"fail_skills": ["None"],
-	"fail_trait": ["bold", "childish", "confident", "daring", "playful", "shameless"],
-	"min_cats": 1,
-	"max_cats": 1,
-	"antagonize_text": null,
-	"antagonize_fail_text": null,
-	"history_text": [
-    	"r_c carries a scar from fighting with a swift fox.",
-    	"While scavenging alone, r_c was killed by a predator they didn't see.",
-        "were killed by a predator"
-	]
-},
-{
-	"patrol_id": "pln_hunt_swiftfox_greenleafscavenge1",
-	"biome": "plains",
-	"season": "greenleaf",
-	"tags": ["hunting", "large_prey", "comfort", "respect", "rel_patrol"],
-	"intro_text": "Your patrol catches the scent of a fox. Tracking it, they find a swift fox feeding on a calf carcass. The cat-sized predator definitely didn't kill this massive hunk of fresh-kill.",
-	"decline_text": "Your patrol decides not to quarrel with the fox - bigger predators will be attracted here. Best to leave sooner rather than later.",
-	"chance_of_success": 70,
-	"exp": 20,
-	"success_text": [
-	"As the patrol approaches, the swift fox spots them and backs off from the carcass with a whine. Your cats can feed in peace for now, but larger predators will surely soon come to throw them off the kill. By cooperating together, the patrol is able to at least drag some of the intestines home to camp.",
-	null,
-	"s_c sits and watches the swift fox as the patrol takes over the kill without a fight. It wanders the area, grabbing pieces of gristle and meat and caching them in little holes, giving s_c an idea. Together the Clan cats gnaw off a leg, and take their bony prize back to camp for c_n.",
-	"While the rest of the patrol feeds on the kill, the swift fox gnawing on the head at the other end in uneasy truce, s_c keeps watch. It turns out to have been a wise move, as they spot a cougar's ears sticking up out of the grass. The kill's original owner is coming back, and the cats vacate with speed."
-	],
-	"fail_text": [
-	"The swift fox gives up on the kill with a snarl, but a coyote yip in the distance sends both the smaller predator species running, the cats puffed up and uncomfortable.",
-	"The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth. s_c calls the rest of the patrol for backup and no one is injured, but by the time they get back to the kill ravens are circling overhead. The patrol gives it up, knowing bigger predators will arrive soon."
-	],
-	"win_skills": ["smart", "very smart", "extremely smart"],
-	"win_trait": ["altruistic", "patient", "responsible", "thoughtful", "wise", "calm", "careful", "insecure", "nervous", "sneaky"],
-	"fail_skills": ["None"],
-	"fail_trait": ["bold", "childish", "confident", "daring", "playful", "shameless"],
-	"min_cats": 2,
-	"max_cats": 6,
-	"antagonize_text": null,
-	"antagonize_fail_text": null
-},
-{
-	"patrol_id": "pln_hunt_swiftfox_greenleafscavenge2",
-	"biome": "plains",
-	"season": "greenleaf",
-	"tags": ["hunting", "small_prey", "fighting", "scar", "death", "no_body", "small_bite_injury"],
-	"intro_text": "r_c catches the scent of a fox. Tracking it, they find a swift fox feeding on a calf carcass. The cat-sized predator definitely didn't kill this massive hunk of fresh-kill.",
-	"decline_text": "r_c decides not to quarrel with the fox - bigger predators will be attracted here. Best to leave sooner rather than later.",
-	"chance_of_success": 70,
-	"exp": 10,
-	"success_text": [
-	"r_c smaller, alone, and half its weight, but the fox has a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle. The fox, already stuffed full and unwilling to lose blood over it, leaves the kill with a grumble.",
-    	null,
-    	"s_c uses every trick in their talented fighting skillset to attack the fox with no one to watch their flank, until the perfect opportunity opens up and they pounce onto the fox's back, digging in their claws. It's a wild ride through the forest until the fox bucks them off, but it wins them the fawn carcass.",
-	"In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. But then they're stuck, unwilling to let go and risk being bitten. They're dragged through the forest, over rocks and through bushes, until the fox finally collapses and the battered s_c goes back to proudly claim the fawn."
-	],
-	"fail_text": [
-"A coyote yip in the distance sends both the smaller predator species running before r_c can muscle in on the feeding opportunity.",
-	"The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth. s_c dances out of the way, but hears the caw of ravens descending on the carcass, and knows it would be too dangerous to return.",
-	"r_c happily tucks into the massive calf - there's more than enough room for both them and the small fox to feed. They hear a massive, outraged yowl, and a blow from behind sends them to StarClan with a single hit. They never saw what did it.",
-	"Puffed up, r_c approaches the swift fox. But there's only one of them, and the fox is their equal in size and weight. instead of running or giving it, it snarls, and attacks. r_c gives just as good as they get, and both animals end up limping away from the kill.",
-	null,
-	"The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth, sinking them into s_c and giving s_c a bigger concern than scavenging from the calf carcass."
-	],
-	"win_skills": ["good fighter", "great fighter", "excellent fighter"],
-	"win_trait": ["altruistic", "patient", "responsible", "thoughtful", "wise", "calm", "careful", "insecure", "nervous", "sneaky"],
-	"fail_skills": ["None"],
-	"fail_trait": ["bold", "childish", "confident", "daring", "playful", "shameless"],
-	"min_cats": 1,
-	"max_cats": 1,
-	"antagonize_text": null,
-	"antagonize_fail_text": null,
-	"history_text": [
-    	"r_c carries a scar from fighting with a swift fox.",
-    	"While scavenging alone, r_c was killed by a predator they didn't see.",
-        "were killed by a predator"
-	]
-},
-{
-	"patrol_id": "pln_hunt_swiftfox_leaf-fallscavenge1",
-	"biome": "plains",
-	"season": "leaf-fall",
-	"tags": ["hunting", "large_prey", "comfort", "respect", "rel_patrol"],
-	"intro_text": "Your patrol catches the scent of a fox. Tracking it, they find a swift fox feeding on a calf carcass. The cat-sized predator definitely didn't kill this massive hunk of fresh-kill.",
-	"decline_text": "Your patrol decides not to quarrel with the fox - bigger predators will be attracted here. Best to leave sooner rather than later.",
-	"chance_of_success": 70,
-	"exp": 20,
-	"success_text": [
-	"As the patrol approaches, the swift fox spots them and backs off from the carcass with a whine. Your cats can feed in peace for now, but larger predators will surely soon come to throw them off the kill. By cooperating together, the patrol is able to at least drag some of the intestines home to camp.",
-	null,
-	"s_c sits and watches the swift fox as the patrol takes over the kill without a fight. It wanders the area, grabbing pieces of gristle and meat and caching them in little holes, giving s_c an idea. Together the Clan cats gnaw off a leg, and take their bony prize back to camp for c_n.",
-	"While the rest of the patrol feeds on the kill, the swift fox gnawing on the head at the other end in uneasy truce, s_c keeps watch. It turns out to have been a wise move, as they spot a cougar's ears sticking up out of the grass. The kill's original owner is coming back, and the cats vacate with speed."
-	],
-	"fail_text": [
-	"The swift fox gives up on the kill with a snarl, but a coyote yip in the distance sends both the smaller predator species running, the cats puffed up and uncomfortable.",
-	"The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth. s_c calls the rest of the patrol for backup and no one is injured, but by the time they get back to the kill ravens are circling overhead. The patrol gives it up, knowing bigger predators will arrive soon."
-	],
-	"win_skills": ["smart", "very smart", "extremely smart"],
-	"win_trait": ["altruistic", "patient", "responsible", "thoughtful", "wise", "calm", "careful", "insecure", "nervous", "sneaky"],
-	"fail_skills": ["None"],
-	"fail_trait": ["bold", "childish", "confident", "daring", "playful", "shameless"],
-	"min_cats": 2,
-	"max_cats": 6,
-	"antagonize_text": null,
-	"antagonize_fail_text": null
-},
-{
-	"patrol_id": "pln_hunt_swiftfox_leaf-fallscavenge2",
-	"biome": "plains",
-	"season": "leaf-fall",
-	"tags": ["hunting", "small_prey", "fighting", "scar", "death", "no_body", "small_bite_injury"],
-	"intro_text": "r_c catches the scent of a fox. Tracking it, they find a swift fox feeding on a calf carcass. The cat-sized predator definitely didn't kill this massive hunk of fresh-kill.",
-	"decline_text": "r_c decides not to quarrel with the fox - bigger predators will be attracted here. Best to leave sooner rather than later.",
-	"chance_of_success": 70,
-	"exp": 10,
-	"success_text": [
-	"r_c smaller, alone, and half its weight, but the fox has a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle. The fox, already stuffed full of venison and unwilling to lose blood over it, leaves the kill with a grumble.",
-    	null,
-    	"s_c uses every trick in their talented fighting skillset to attack the fox with no one to watch their flank, until the perfect opportunity opens up and they pounce onto the fox's back, digging in their claws. It's a wild ride through the forest until the fox bucks them off, but it wins them the fawn carcass.",
-	"In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. But then they're stuck, unwilling to let go and risk being bitten. They're dragged through the forest, over rocks and through bushes, until the fox finally collapses and the battered s_c goes back to proudly claim the fawn."
-	],
-	"fail_text": [
-"A coyote yip in the distance sends both the smaller predator species running before r_c can muscle in on the feeding opportunity.",
-	"The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth. s_c dances out of the way, but hears the caw of ravens descending on the carcass, and knows it would be too dangerous to return.",
-	"r_c happily tucks into the massive calf - there's more than enough room for both them and the small fox to feed. They hear a massive, outraged yowl, and a blow from behind sends them to StarClan with a single hit. They never saw what did it.",
-	"Puffed up, r_c approaches the swift fox. But there's only one of them, and the fox is their equal in size and weight. instead of running or giving it, it snarls, and attacks. r_c gives just as good as they get, and both animals end up limping away from the kill.",
-	null,
-	"The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth, sinking them into s_c and giving s_c a bigger concern than scavenging from the calf carcass."
-	],
-	"win_skills": ["good fighter", "great fighter", "excellent fighter"],
-	"win_trait": ["altruistic", "patient", "responsible", "thoughtful", "wise", "calm", "careful", "insecure", "nervous", "sneaky"],
-	"fail_skills": ["None"],
-	"fail_trait": ["bold", "childish", "confident", "daring", "playful", "shameless"],
-	"min_cats": 1,
-	"max_cats": 1,
-	"antagonize_text": null,
-	"antagonize_fail_text": null,
-	"history_text": [
-    	"r_c carries a scar from fighting with a swift fox.",
-    	"While scavenging alone, r_c was killed by a predator they didn't see.",
-        "were killed by a predator"
-	]
-},
-{
-	"patrol_id": "pln_hunt_swiftfox_leaf-barescavenge1",
-	"biome": "plains",
-	"season": "leaf-bare",
-	"tags": ["hunting", "large_prey", "comfort", "respect", "rel_patrol"],
-	"intro_text": "Your patrol catches the scent of a fox. Tracking it, they find a swift fox feeding on a cow carcass, either a small female or one of last Newleaf's calves. The cat-sized predator definitely didn't kill this massive hunk of fresh-kill.",
-	"decline_text": "Your patrol decides not to quarrel with the fox - bigger predators will be attracted here. Best to leave sooner rather than later.",
-	"chance_of_success": 60,
-	"exp": 20,
-	"success_text": [
-	"As the patrol approaches, the swift fox spots them and backs off from the carcass with a whine. Your cats can feed in peace for now, but larger predators will surely soon come to throw them off the kill. By cooperating together, the patrol is able to at least drag some of the intestines home to camp.",
-	null,
-	"s_c sits and watches the swift fox as the patrol takes over the kill without a fight. It wanders the area, grabbing pieces of gristle and meat and caching them in little holes, giving s_c an idea. Together the Clan cats gnaw off a leg, and take their bony prize back to camp for c_n.",
-	"While the rest of the patrol feeds on the kill, the swift fox gnawing on the head at the other end in uneasy truce, s_c keeps watch. It turns out to have been a wise move, as they spot a cougar's ears sticking up out of the grass. The kill's original owner is coming back, and the cats vacate with speed."
-	],
-	"fail_text": [
-	"The swift fox gives up on the kill with a snarl, but a coyote yip in the distance sends both the smaller predator species running, the cats puffed up and uncomfortable.",
-	"The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth. s_c calls the rest of the patrol for backup and no one is injured, but by the time they get back to the kill ravens are circling overhead. The patrol gives it up, knowing bigger predators will arrive soon."
-	],
-	"win_skills": ["smart", "very smart", "extremely smart"],
-	"win_trait": ["altruistic", "patient", "responsible", "thoughtful", "wise", "calm", "careful", "insecure", "nervous", "sneaky"],
-	"fail_skills": ["None"],
-	"fail_trait": ["bold", "childish", "confident", "daring", "playful", "shameless"],
-	"min_cats": 2,
-	"max_cats": 6,
-	"antagonize_text": null,
-	"antagonize_fail_text": null
-},
-{
-	"patrol_id": "pln_hunt_swiftfox_leaf-barescavenge2",
-	"biome": "plains",
-	"season": "leaf-bare",
-	"tags": ["hunting", "small_prey", "fighting", "scar", "death", "no_body", "small_bite_injury"],
-	"intro_text": "r_c catches the scent of a fox. Tracking it, they find a swift fox feeding on a cow carcass, either a small female or one of last Newleaf's calves. Roughly equal in size to r_c, the swift fox definitely didn't bring down this feast themselves.",
-	"decline_text": "r_c decides not to quarrel with the fox - bigger predators will be attracted here. Best to leave sooner rather than later.",
-	"chance_of_success": 50,
-	"exp": 10,
-	"success_text": [
-	"r_c smaller, alone, and half its weight, but the fox has a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle. The fox, already stuffed full of venison and unwilling to lose blood over it, leaves the kill with a grumble.",
-    	null,
-    	"s_c uses every trick in their talented fighting skillset to attack the fox with no one to watch their flank, until the perfect opportunity opens up and they pounce onto the fox's back, digging in their claws. It's a wild ride through the forest until the fox bucks them off, but it wins them the fawn carcass.",
-	"In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. But then they're stuck, unwilling to let go and risk being bitten. They're dragged through the forest, over rocks and through bushes, until the fox finally collapses and the battered s_c goes back to proudly claim the fawn."
-	],
-	"fail_text": [
-"A coyote yip in the distance sends both the smaller predator species running before r_c can muscle in on the feeding opportunity.",
-	"The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth. s_c dances out of the way, but hears the caw of ravens descending on the carcass, and knows it would be too dangerous to return.",
-	"r_c happily tucks into the massive calf - there's more than enough room for both them and the small fox to feed. They hear a massive, outraged yowl, and a blow from behind sends them to StarClan with a single hit. They never saw what did it.",
-	"Puffed up, r_c approaches the swift fox. But there's only one of them, and the fox is their equal in size and weight. instead of running or giving it, it snarls, and attacks. r_c gives just as good as they get, and both animals end up limping away from the kill.",
-	null,
-	"The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth, sinking them into s_c and giving s_c a bigger concern than scavenging from the calf carcass."
-	],
-	"win_skills": ["good fighter", "great fighter", "excellent fighter"],
-	"win_trait": ["altruistic", "patient", "responsible", "thoughtful", "wise", "calm", "careful", "insecure", "nervous", "sneaky"],
-	"fail_skills": ["None"],
-	"fail_trait": ["bold", "childish", "confident", "daring", "playful", "shameless"],
-	"min_cats": 1,
-	"max_cats": 1,
-	"antagonize_text": null,
-	"antagonize_fail_text": null,
-	"history_text": [
-    	"r_c carries a scar from fighting with a swift fox.",
-    	"While scavenging alone, r_c was killed by a predator they didn't see.",
-        "were killed by a predator"
-	]
-},
-{
+        ]
+    },
+    {
+        "patrol_id": "pln_hunt_redfox_newleafscavenge1",
+        "biome": "plains",
+        "season": "newleaf",
+        "tags": [
+            "hunting",
+            "large_prey",
+            "fighting",
+            "scar",
+            "big_bite_injury",
+            "clan_to_patrol",
+            "respect",
+            "rel_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a red fox. Tracking it, they find the animal feeding on a pronghorn fawn carcass. It's impossible to say whether the fox killed it or found it.",
+        "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 50,
+        "exp": 20,
+        "success_text": [
+            "Your cats are smaller but they outnumber the fox, if only by a little, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full of food and unwilling to lose blood over it, is driven off from the kill.",
+            null,
+            "s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until it gives up and runs.",
+            "The patrol launches into battle, but with so few cats it's exhausting trying to keep the fox and its snapping jaws on the defensive. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. It's only one bite, but the fox has had enough and flees."
+        ],
+        "fail_text": [
+            "Your patrol fails to drive away the fox, which keeps possession of the food. However there were no injuries.",
+            null,
+            null,
+            "The patrol launches into battle, but r_c is caught with a nasty bite, and the cats give up on challenging for the food in favor of quickly helping r_c back to the medicine cat den.",
+            null,
+            "s_c means well, but they're overconfident in their attack and the fox manages to sink their teeth into them. The patrol is forced to retreat, forming a defensive ring around the hurt s_c."
+        ],
+        "win_skills": [
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "troublesome",
+            "vengeful",
+            "bloodthirsty",
+            "bold"
+        ],
+        "min_cats": 2,
+        "max_cats": 3,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a fox fight.",
+            null
+        ]
+    },
+    {
+        "patrol_id": "pln_hunt_redfox_newleafscavenge2",
+        "biome": "plains",
+        "season": "newleaf",
+        "tags": [
+            "hunting",
+            "large_prey",
+            "fighting",
+            "scar",
+            "big_bite_injury",
+            "clan_to_patrol",
+            "respect",
+            "rel_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a red fox. Tracking it, they find the animal feeding on a pronghorn fawn carcass. It's impossible to say whether the fox killed it or found it.",
+        "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 80,
+        "exp": 20,
+        "success_text": [
+            "Your cats are smaller but heavily outnumber the fox, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full and unwilling to lose blood over it, is driven off from the kill.",
+            null,
+            "s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until s_c lands a crucial blow, snapping a tendon in one of the fox's hindlegs. The fox runs, but there's no way it'll live long with such a crippling injury.",
+            "The patrol launches into battle, keeping the fox on the defensive with teamwork. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. Holding on grimly, s_c's daring move gives the rest of the patrol the opportunity needed to bring the fox down for good."
+        ],
+        "fail_text": [
+            "Your patrol fails to drive away the fox, which keeps possession of the food. However with so many cats to protect each other, there were no injuries.",
+            null,
+            null,
+            "The patrol launches into battle, but r_c is caught with a nasty bite, and the cats give up on challenging for the food in favor of quickly helping r_c back to the medicine cat den.",
+            null,
+            "s_c means well, but they're overconfident in their attack and the fox manages to sink their teeth into them. The patrol is forced to retreat, forming a defensive ring around the hurt s_c."
+        ],
+        "win_skills": [
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "troublesome",
+            "vengeful",
+            "bloodthirsty",
+            "bold"
+        ],
+        "min_cats": 4,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a fox fight."
+        ]
+    },
+    {
+        "patrol_id": "pln_hunt_redfox_newleafscavenge3",
+        "biome": "plains",
+        "season": "newleaf",
+        "tags": [
+            "hunting",
+            "large_prey",
+            "fighting",
+            "scar",
+            "big_bite_injury",
+            "clan_to_patrol",
+            "respect"
+        ],
+        "intro_text": "r_c catches the scent of a red fox. Tracking it, they find the animal feeding on a pronghorn fawn carcass. It's impossible to say whether the fox killed it or found it.",
+        "decline_text": "r_c decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 30,
+        "exp": 30,
+        "success_text": [
+            "r_c may be smaller, alone, and half its weight, but the fox has a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle. The fox, already stuffed full and unwilling to lose blood over it, leaves the kill with a grumble.",
+            null,
+            "s_c uses every trick in their talented fighting skillset to attack the fox with no one to watch their flank, until the perfect opportunity opens up and they pounce onto the fox's back, digging in their claws. It's a wild ride through the forest until the fox bucks them off, but it wins them the fawn carcass.",
+            "In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. But then they're stuck, unwilling to let go and risk being bitten. They're dragged through the forest, over rocks and through bushes, until the fox finally collapses and the battered s_c goes back to proudly claim the fawn."
+        ],
+        "fail_text": [
+            "Your patrol fails to drive away the fox, which keeps possession of the food. However there were no injuries.",
+            null,
+            "Fiercely, r_c throws themselves at the fox, determined to win the fawn prize. But the fox values it just as dearly, and manages to get a good grip on r_c, shaking them to pieces and killing them.",
+            "r_c launches into battle, but is caught with a nasty bite, and retreats to limp back home. The fox doesn't follow, happy enough to eat the fawn instead of the foolish cat.",
+            null,
+            "s_c is overconfident in their attack and the fox manages to sink their teeth into them. They retreat, bleeding and in pain, and the fox settles back down to its meal."
+        ],
+        "win_skills": [
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "troublesome",
+            "vengeful",
+            "bloodthirsty",
+            "bold"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a solo fox fight.",
+            "r_c fell in a solo battle with a fox.",
+            "died in battle with a fox"
+        ]
+    },
+    {
+        "patrol_id": "pln_hunt_redfox_greenleafscavenge1",
+        "biome": "plains",
+        "season": "greenleaf",
+        "tags": [
+            "hunting",
+            "large_prey",
+            "fighting",
+            "scar",
+            "big_bite_injury",
+            "clan_to_patrol",
+            "respect",
+            "rel_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a red fox. Tracking it, they find the animal feeding on a pronghorn fawn carcass. It's impossible to say whether the fox killed it or found it.",
+        "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 50,
+        "exp": 20,
+        "success_text": [
+            "Your cats are smaller but they outnumber the fox, if only by a little, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full and unwilling to lose blood over it, is driven off from the kill.",
+            null,
+            "s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until it gives up and runs.",
+            "The patrol launches into battle, but with so few cats it's exhausting trying to keep the fox and its snapping jaws on the defensive. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. It's only one bite, but the fox has had enough and flees."
+        ],
+        "fail_text": [
+            "Your patrol fails to drive away the fox, which keeps possession of the food. However there were no injuries.",
+            null,
+            null,
+            "The patrol launches into battle, but r_c is caught with a nasty bite, and the cats give up on challenging for the food in favor of quickly helping r_c back to the medicine cat den.",
+            null,
+            "s_c means well, but they're overconfident in their attack and the fox manages to sink their teeth into them. The patrol is forced to retreat, forming a defensive ring around the hurt s_c."
+        ],
+        "win_skills": [
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "troublesome",
+            "vengeful",
+            "bloodthirsty",
+            "bold"
+        ],
+        "min_cats": 2,
+        "max_cats": 3,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a fox fight.",
+            null
+        ]
+    },
+    {
+        "patrol_id": "pln_hunt_redfox_greenleafleafscavenge2",
+        "biome": "plains",
+        "season": "greenleaf",
+        "tags": [
+            "hunting",
+            "large_prey",
+            "fighting",
+            "scar",
+            "injury",
+            "big_bite_injury",
+            "clan_to_patrol",
+            "respect",
+            "rel_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a red fox. Tracking it, they find the animal feeding on a pronghorn fawn carcass. It's impossible to say whether the fox killed it or found it.",
+        "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 80,
+        "exp": 20,
+        "success_text": [
+            "Your cats are smaller but heavily outnumber the fox, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full and unwilling to lose blood over it, is driven off from the kill.",
+            null,
+            "s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until s_c lands a crucial blow, snapping a tendon in one of the fox's hindlegs. The fox runs, but there's no way it'll live long with such a crippling injury.",
+            "The patrol launches into battle, keeping the fox on the defensive with teamwork. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. Holding on grimly, s_c's daring move gives the rest of the patrol the opportunity needed to bring the fox down for good."
+        ],
+        "fail_text": [
+            "Your patrol fails to drive away the fox, which keeps possession of the food. However with so many cats to protect each other, there were no injuries.",
+            null,
+            null,
+            "The patrol launches into battle, but r_c is caught with a nasty bite, and the cats give up on challenging for the food in favor of quickly helping r_c back to the medicine cat den.",
+            null,
+            "s_c means well, but they're overconfident in their attack and the fox manages to sink their teeth into them. The patrol is forced to retreat, forming a defensive ring around the hurt s_c."
+        ],
+        "win_skills": [
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "troublesome",
+            "vengeful",
+            "bloodthirsty",
+            "bold"
+        ],
+        "min_cats": 4,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a fox fight."
+        ]
+    },
+    {
+        "patrol_id": "pln_hunt_redfox_greenleafscavenge3",
+        "biome": "plains",
+        "season": "greenleaf",
+        "tags": [
+            "hunting",
+            "large_prey",
+            "fighting",
+            "scar",
+            "big_bite_injury",
+            "clan_to_patrol",
+            "respect"
+        ],
+        "intro_text": "r_c catches the scent of a red fox. Tracking it, they find the animal feeding on a pronghorn fawn carcass. It's impossible to say whether the fox killed it or found it.",
+        "decline_text": "r_c decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 30,
+        "exp": 30,
+        "success_text": [
+            "r_c may be smaller, alone, and half its weight, but the fox has a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle. The fox, already stuffed full and unwilling to lose blood over it, leaves the kill with a grumble.",
+            null,
+            "s_c uses every trick in their talented fighting skillset to attack the fox with no one to watch their flank, until the perfect opportunity opens up and they pounce onto the fox's back, digging in their claws. It's a wild ride through the forest until the fox bucks them off, but it wins them the fawn carcass.",
+            "In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. But then they're stuck, unwilling to let go and risk being bitten. They're dragged through the forest, over rocks and through bushes, until the fox finally collapses and the battered s_c goes back to proudly claim the fawn."
+        ],
+        "fail_text": [
+            "Your patrol fails to drive away the fox, which keeps possession of the food. However there were no injuries.",
+            null,
+            "Fiercely, r_c throws themselves at the fox, determined to win the fawn prize. But the fox values it just as dearly, and manages to get a good grip on r_c, shaking them to pieces and killing them.",
+            "r_c launches into battle, but is caught with a nasty bite, and retreats to limp back home. The fox doesn't follow, happy enough to eat the fawn instead of the foolish cat.",
+            null,
+            "s_c is overconfident in their attack and the fox manages to sink their teeth into them. They retreat, bleeding and in pain, and the fox settles back down to its meal."
+        ],
+        "win_skills": [
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "troublesome",
+            "vengeful",
+            "bloodthirsty",
+            "bold"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a solo fox fight.",
+            "r_c fell in a solo battle with a fox.",
+            "died in battle with a fox"
+        ]
+    },
+    {
+        "patrol_id": "pln_hunt_redfox_leaf-fallscavenge1",
+        "biome": "plains",
+        "season": "leaf-fall",
+        "tags": [
+            "hunting",
+            "large_prey",
+            "fighting",
+            "scar",
+            "big_bite_injury",
+            "clan_to_patrol",
+            "respect",
+            "rel_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a red fox. Tracking it, they find the animal feeding on a pronghorn fawn carcass. It's impossible to say whether the fox killed it or found it.",
+        "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 50,
+        "exp": 20,
+        "success_text": [
+            "Your cats are smaller but they outnumber the fox, if only by a little, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full of venison and unwilling to lose blood over it, is driven off from the kill.",
+            null,
+            "s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until it gives up and runs.",
+            "The patrol launches into battle, but with so few cats it's exhausting trying to keep the fox and its snapping jaws on the defensive. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. It's only one bite, but the fox has had enough and flees."
+        ],
+        "fail_text": [
+            "Your patrol fails to drive away the fox, which keeps possession of the food. However there were no injuries.",
+            null,
+            null,
+            "The patrol launches into battle, but r_c is caught with a nasty bite, and the cats give up on challenging for the food in favor of quickly helping r_c back to the medicine cat den.",
+            null,
+            "s_c means well, but they're overconfident in their attack and the fox manages to sink their teeth into them. The patrol is forced to retreat, forming a defensive ring around the hurt s_c."
+        ],
+        "win_skills": [
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "troublesome",
+            "vengeful",
+            "bloodthirsty",
+            "bold"
+        ],
+        "min_cats": 2,
+        "max_cats": 3,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a fox fight.",
+            null
+        ]
+    },
+    {
+        "patrol_id": "pln_hunt_redfox_leaf-fallscavenge2",
+        "biome": "plains",
+        "season": "leaf-fall",
+        "tags": [
+            "hunting",
+            "large_prey",
+            "fighting",
+            "scar",
+            "big_bite_injury",
+            "clan_to_patrol",
+            "respect",
+            "rel_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a red fox. Tracking it, they find the animal feeding on a pronghorn fawn carcass. It's impossible to say whether the fox killed it or found it.",
+        "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 80,
+        "exp": 20,
+        "success_text": [
+            "Your cats are smaller but heavily outnumber the fox, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full of venison and unwilling to lose blood over it, is driven off from the kill.",
+            null,
+            "s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until s_c lands a crucial blow, snapping a tendon in one of the fox's hindlegs. The fox runs, but there's no way it'll live long with such a crippling injury.",
+            "The patrol launches into battle, keeping the fox on the defensive with teamwork. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. Holding on grimly, s_c's daring move gives the rest of the patrol the opportunity needed to bring the fox down for good."
+        ],
+        "fail_text": [
+            "Your patrol fails to drive away the fox, which keeps possession of the food. However with so many cats to protect each other, there were no injuries.",
+            null,
+            null,
+            "The patrol launches into battle, but r_c is caught with a nasty bite, and the cats give up on challenging for the food in favor of quickly helping r_c back to the medicine cat den.",
+            null,
+            "s_c means well, but they're overconfident in their attack and the fox manages to sink their teeth into them. The patrol is forced to retreat, forming a defensive ring around the hurt s_c."
+        ],
+        "win_skills": [
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "troublesome",
+            "vengeful",
+            "bloodthirsty",
+            "bold"
+        ],
+        "min_cats": 4,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a fox fight."
+        ]
+    },
+    {
+        "patrol_id": "pln_hunt_redfox_leaf-fallscavenge3",
+        "biome": "plains",
+        "season": "leaf-fall",
+        "tags": [
+            "hunting",
+            "large_prey",
+            "fighting",
+            "scar",
+            "big_bite_injury",
+            "clan_to_patrol",
+            "respect"
+        ],
+        "intro_text": "r_c catches the scent of a red fox. Tracking it, they find the animal feeding on a pronghorn fawn carcass. It's impossible to say whether the fox killed it or found it.",
+        "decline_text": "r_c decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 30,
+        "exp": 30,
+        "success_text": [
+            "r_c may be smaller, alone, and half its weight, but the fox has a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle. The fox, already stuffed full of venison and unwilling to lose blood over it, leaves the kill with a grumble.",
+            null,
+            "s_c uses every trick in their talented fighting skillset to attack the fox with no one to watch their flank, until the perfect opportunity opens up and they pounce onto the fox's back, digging in their claws. It's a wild ride through the forest until the fox bucks them off, but it wins them the fawn carcass.",
+            "In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. But then they're stuck, unwilling to let go and risk being bitten. They're dragged through the forest, over rocks and through bushes, until the fox finally collapses and the battered s_c goes back to proudly claim the fawn."
+        ],
+        "fail_text": [
+            "Your patrol fails to drive away the fox, which keeps possession of the food. However there were no injuries.",
+            null,
+            "Fiercely, r_c throws themselves at the fox, determined to win the fawn prize. But the fox values it just as dearly, and manages to get a good grip on r_c, shaking them to pieces and killing them.",
+            "r_c launches into battle, but is caught with a nasty bite, and retreats to limp back home. The fox doesn't follow, happy enough to eat the fawn instead of the foolish cat.",
+            null,
+            "s_c is overconfident in their attack and the fox manages to sink their teeth into them. They retreat, bleeding and in pain, and the fox settles back down to its meal."
+        ],
+        "win_skills": [
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "troublesome",
+            "vengeful",
+            "bloodthirsty",
+            "bold"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a solo fox fight.",
+            "r_c fell in a solo battle with a fox.",
+            "died in battle with a fox"
+        ]
+    },
+    {
+        "patrol_id": "pln_hunt_redfox_leaf-barescavenge1",
+        "biome": "plains",
+        "season": "leaf-bare",
+        "tags": [
+            "hunting",
+            "large_prey",
+            "fighting",
+            "scar",
+            "big_bite_injury",
+            "clan_to_patrol",
+            "respect",
+            "rel_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a red fox. Tracking it, they find the animal feeding on a pronghorn carcass, either a small doe or one of last newleaf's fawns. It's impossible to say whether the fox killed it or found it.",
+        "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 30,
+        "exp": 20,
+        "success_text": [
+            "Your cats are smaller but they outnumber the fox, if only by a little, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full of venison and unwilling to lose blood over it, is driven off from the kill.",
+            null,
+            "s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until it gives up and runs.",
+            "The patrol launches into battle, but with so few cats it's exhausting trying to keep the fox and its snapping jaws on the defensive. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. It's only one bite, but the fox has had enough and flees."
+        ],
+        "fail_text": [
+            "Your patrol fails to drive away the fox, which keeps possession of the food. However there were no injuries.",
+            null,
+            null,
+            "The patrol launches into battle, but r_c is caught with a nasty bite, and the cats give up on challenging for the food in favor of quickly helping r_c back to the medicine cat den.",
+            null,
+            "s_c means well, but they're overconfident in their attack and the fox manages to sink their teeth into them. The patrol is forced to retreat, forming a defensive ring around the hurt s_c."
+        ],
+        "win_skills": [
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "troublesome",
+            "vengeful",
+            "bloodthirsty",
+            "bold"
+        ],
+        "min_cats": 2,
+        "max_cats": 3,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a fox fight.",
+            null
+        ]
+    },
+    {
+        "patrol_id": "pln_hunt_redfox_leaf-barescavenge2",
+        "biome": "plains",
+        "season": "leaf-bare",
+        "tags": [
+            "hunting",
+            "large_prey",
+            "fighting",
+            "scar",
+            "big_bite_injury",
+            "clan_to_patrol",
+            "respect",
+            "rel_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a red fox. Tracking it, they find the animal feeding on a pronghorn carcass, either a small doe or one of last newleaf's fawns. It's impossible to say whether the fox killed it or found it.",
+        "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 60,
+        "exp": 20,
+        "success_text": [
+            "Your cats are smaller but heavily outnumber the fox, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full of venison and unwilling to lose blood over it, is driven off from the kill.",
+            null,
+            "s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until s_c lands a crucial blow, snapping a tendon in one of the fox's hindlegs. The fox runs, but there's no way it'll live long with such a crippling injury.",
+            "The patrol launches into battle, keeping the fox on the defensive with teamwork. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. Holding on grimly, s_c's daring move gives the rest of the patrol the opportunity needed to bring the fox down for good."
+        ],
+        "fail_text": [
+            "Your patrol fails to drive away the fox, which keeps possession of the food. However with so many cats to protect each other, there were no injuries.",
+            null,
+            null,
+            "The patrol launches into battle, but r_c is caught with a nasty bite, and the cats give up on challenging for the food in favor of quickly helping r_c back to the medicine cat den.",
+            null,
+            "s_c means well, but they're overconfident in their attack and the fox manages to sink their teeth into them. The patrol is forced to retreat, forming a defensive ring around the hurt s_c."
+        ],
+        "win_skills": [
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "troublesome",
+            "vengeful",
+            "bloodthirsty",
+            "bold"
+        ],
+        "min_cats": 4,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a fox fight."
+        ]
+    },
+    {
+        "patrol_id": "pln_hunt_redfox_leaf-barescavenge3",
+        "biome": "plains",
+        "season": "leaf-bare",
+        "tags": [
+            "hunting",
+            "large_prey",
+            "fighting",
+            "scar",
+            "big_bite_injury",
+            "clan_to_patrol",
+            "respect"
+        ],
+        "intro_text": "r_c catches the scent of a red fox. Tracking it, they find the animal feeding on a pronghorn carcass, either a small doe or one of last newleaf's fawns. It's impossible to say whether the fox killed it or found it.",
+        "decline_text": "r_c decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 10,
+        "exp": 30,
+        "success_text": [
+            "r_c may be smaller, alone, and half its weight, but the fox has a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle. The fox, already stuffed full of venison and unwilling to lose blood over it, leaves the kill with a grumble.",
+            null,
+            "s_c uses every trick in their talented fighting skillset to attack the fox with no one to watch their flank, until the perfect opportunity opens up and they pounce onto the fox's back, digging in their claws. It's a wild ride through the forest until the fox bucks them off, but it wins them the fawn carcass.",
+            "In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. But then they're stuck, unwilling to let go and risk being bitten. They're dragged through the forest, over rocks and through bushes, until the fox finally collapses and the battered s_c goes back to proudly claim the fawn."
+        ],
+        "fail_text": [
+            "Your patrol fails to drive away the fox, which keeps possession of the food. However there were no injuries.",
+            null,
+            "Fiercely, r_c throws themselves at the fox, determined to win the fawn prize. But the fox values it just as dearly, and manages to get a good grip on r_c, shaking them to pieces and killing them.",
+            "r_c launches into battle, but is caught with a nasty bite, and retreats to limp back home. The fox doesn't follow, happy enough to eat the fawn instead of the foolish cat.",
+            null,
+            "s_c is overconfident in their attack and the fox manages to sink their teeth into them. They retreat, bleeding and in pain, and the fox settles back down to its meal."
+        ],
+        "win_skills": [
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "troublesome",
+            "vengeful",
+            "bloodthirsty",
+            "bold"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a solo fox fight.",
+            "r_c fell in a solo battle with a fox.",
+            "died in battle with a fox"
+        ]
+    },
+    {
+        "patrol_id": "pln_hunt_redvixen1",
+        "biome": "plains",
+        "season": "newleaf",
+        "tags": [
+            "fighting",
+            "death",
+            "scar",
+            "big_bite_injury",
+            "respect",
+            "trust",
+            "clan_to_r_c",
+            "patrol_to_r_c",
+            "clan_to_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or swift?",
+        "decline_text": "Your patrol decides not to pursue the fox.",
+        "chance_of_success": 30,
+        "exp": 30,
+        "success_text": [
+            "The red vixen smells of milk, and hopefully by driving her out of the territory, her litter this newleaf won't be a threat to the Clan. If they don't starve, c_n will hunt them down - they do not share territory with foxes.",
+            "Your patrol drives away the red fox, seeks out her den, and kills her young cubs. It's brutal, but these fluffy baby foxes would one day have grown to be kit-killers and thieves.",
+            "s_c displays incredible skill, driving the mother red vixen out of the territory almost by themselves. Now neither the fox nor her cubs pose a threat to the Clan. It truly proves s_c's place as one of c_n's most talented and skillful fighters.",
+            "The patrol overcomes the red vixen and drives her off thanks to a brilliant battle move by s_c at a critical moment. Their bravery ensures the patrol's success, and the cats arrive back at camp singing their praises to make sure the Clan knows it."
+        ],
+        "fail_text": [
+            "The mother red fox is vicious and determined, and the small patrol is beaten back. But these plains is c_n's and they haven't given up. They may have lost this battle, but c_n will win this war.",
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the rest of the patrol have to rescue them from the red vixen.",
+            "Never threaten a mother's young - the red vixen kills r_c in the skirmish.",
+            "The mother red fox's snapping jaws leave r_c dripping blood onto the grass, forcing the patrol to back off.",
+            null,
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the red vixen manages to sink her teeth into them. The patrol rallies around s_c, but they have to give up on the fight.",
+            "As their hunt descends into a full on battle with a red vixen determined to protect her young, p_l takes a blow meant for one of their Clanmates, losing a life."
+        ],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 2,
+        "max_cats": 3,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a fox fight.",
+            "r_c fell in battle with a fox.",
+            "died in battle with a fox"
+        ]
+    },
+    {
+        "patrol_id": "pln_hunt_redvixen2",
+        "biome": "plains",
+        "season": "newleaf",
+        "tags": [
+            "fighting",
+            "scar",
+            "big_bite_injury",
+            "respect",
+            "trust",
+            "clan_to_r_c",
+            "patrol_to_r_c",
+            "clan_to_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or swift?",
+        "decline_text": "Your patrol decides not to pursue the fox.",
+        "chance_of_success": 60,
+        "exp": 30,
+        "success_text": [
+            "Led by p_l, and with a heap of cooperation and teamwork, the patrol drives away a red fox vixen, seeking out her den and killing her young cubs. The plains will be safe from both the threat the vixen posed this season, and the threat her cubs would've given c_n in the seasons to come.",
+            "With so many cats working together in tight coordination, they manage to accomplish the near-impossible, finding and killing a mother red vixen and ending the threat to the Clan that she and her cubs pose.",
+            "s_c displays incredible skill, driving the mother red vixen they track down out of the territory almost by themselves. Now neither the fox nor her dependent cubs pose a threat to the Clan. It truly proves s_c's place as one of c_n's most talented and skillful fighters.",
+            "The patrol hunts down and overcomes the red vixen they discover, driving her off thanks to a brilliant battle move by s_c at a critical moment. Their bravery ensures the patrol's success, and the cats arrive back at camp singing their praises to make sure the Clan knows it."
+        ],
+        "fail_text": [
+            "The mother red fox is vicious and determined. Although they lose this battle, through teamwork the cats manage to retreat without injury.",
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the rest of the patrol have to rescue them from the red vixen.",
+            null,
+            "r_c is left wounded as the patrol and the mother red vixen fight to a stalemate. Hopefully they've given the fox mother a reason not to return to this part of the forest.",
+            null,
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the red vixen manages to sink her teeth into them. The patrol rallies around s_c, but they have to give up on the fight."
+        ],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 4,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a fox fight."
+        ]
+    },
+    {
+        "patrol_id": "pln_hunt_redvixen3",
+        "biome": "plains",
+        "season": "newleaf",
+        "tags": [
+            "fighting",
+            "death",
+            "scar",
+            "big_bite_injury",
+            "respect",
+            "trust",
+            "clan_to_patrol",
+            "no_body"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or swift?",
+        "decline_text": "Your patrol decides not to pursue the fox.",
+        "chance_of_success": 20,
+        "exp": 50,
+        "success_text": [
+            "The red vixen smells of milk, and hopefully by driving her out of the territory, her litter this newleaf won't be a threat to the Clan. If they don't starve, c_n will hunt them down - they do not share territory with foxes.",
+            null,
+            "s_c displays incredible skill, driving the mother red vixen and her brood out of c_n's plains all by themselves. Now neither the fox nor her dependent cubs pose a threat to the Clan. They swell with pride, feeling the confidence of knowing that they're truly one of the best fighters c_n has ever produced.",
+            "A brilliant battle move by s_c knocks the red vixen they find off balance, and s_c manages to drive her out of c_n territory, though it takes every spark of strength in their pelt to do it alone."
+        ],
+        "fail_text": [
+            null,
+            null,
+            "Never threaten a mother's young - the red vixen kills r_c in the skirmish, and carries off the body to feed her litter.",
+            "The mother red fox's snapping jaws leave r_c dripping blood onto the leaf litter, and barely able to escape further injury.",
+            null,
+            "s_c is determined to win, but the vixen is determined to live, and that makes all the difference. s_c ends up pinned in a defensible hiding spot, bleeding and terrified, until the vixen judges them no longer a threat and continues on her way."
+        ],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a solo fight with a vixen.",
+            "r_c fell in a solo battle with a vixen.",
+            "died in battle with a fox"
+        ]
+    },
+    {
+        "patrol_id": "pln_hunt_redvixen4",
+        "biome": "plains",
+        "season": "greenleaf",
+        "tags": [
+            "fighting",
+            "death",
+            "scar",
+            "big_bite_injury",
+            "respect",
+            "trust",
+            "clan_to_r_c",
+            "patrol_to_r_c",
+            "clan_to_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or swift?",
+        "decline_text": "Your patrol decides not to pursue the fox.",
+        "chance_of_success": 30,
+        "exp": 30,
+        "success_text": [
+            "The red vixen smells of milk and blood. Hopefully by driving her out of the territory, the litter she has been raising this greenleaf won't be a threat to the Clan. If they don't starve, c_n will hunt them down - they do not share with foxes.",
+            "Your patrol drives away the fox, seeks out her den, and kills her cubs. It's brutal, but these fluffy small foxes would one day have grown to be kit-killers and thieves.",
+            "s_c displays incredible skill, driving the mother red vixen they track down out of the territory almost by themselves. Now neither the fox nor her dependent cubs pose a threat to the Clan. It truly proves s_c's place as one of c_n's most talented and skillful fighters.",
+            "The patrol hunts down and overcomes the red vixen they discover, driving her off thanks to a brilliant battle move by s_c at a critical moment. Their bravery ensures the patrol's success, and the cats arrive back at camp singing their praises to make sure the Clan knows it."
+        ],
+        "fail_text": [
+            "The mother red fox is vicious and determined, and the small patrol is beaten back. But this forest is c_n's and they haven't given up. They may have lost this battle, but c_n will win this war.",
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the rest of the patrol have to rescue them from the red vixen.",
+            "Never threaten a mother's young - the red vixen kills r_c in the skirmish.",
+            "The mother red fox's snapping jaws leave r_c dripping blood onto the grass, forcing the patrol to back off.",
+            null,
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the red vixen manages to sink her teeth into them. The patrol rallies around s_c, but they have to give up on the fight.",
+            "As their hunt descends into a full on battle with a red vixen determined to protect her young, p_l takes a blow meant for one of their Clanmates, losing a life."
+        ],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 2,
+        "max_cats": 3,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a fox fight.",
+            "r_c fell in battle with a fox.",
+            "died in battle with a fox"
+        ]
+    },
+    {
+        "patrol_id": "pln_hunt_redvixen5",
+        "biome": "plains",
+        "season": "greenleaf",
+        "tags": [
+            "fighting",
+            "scar",
+            "big_bite_injury",
+            "respect",
+            "trust",
+            "clan_to_r_c",
+            "patrol_to_r_c",
+            "clan_to_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or swift?",
+        "decline_text": "Your patrol decides not to pursue the fox.",
+        "chance_of_success": 60,
+        "exp": 30,
+        "success_text": [
+            "Led by p_l, and with a heap of cooperation and teamwork, the patrol drives away the fox, seeks out her den, and kills her growing cubs. The forest will be safe from both the threat the vixen posed this season, and the threat her cubs would've given c_n in the seasons to come.",
+            "With so many cats working together in tight coordination, they manage to accomplish the near-impossible, finding and killing a mother red vixen and ending the threat to the Clan that she and her cubs pose.",
+            "s_c displays incredible skill, driving the mother red vixen they track down out of the territory almost by themselves. Now neither the fox nor her dependent cubs pose a threat to the Clan. It truly proves s_c's place as one of c_n's most talented and skillful fighters.",
+            "The patrol hunts down and overcomes the red vixen they discover, driving her off thanks to a brilliant battle move by s_c at a critical moment. Their bravery ensures the patrol's success, and the cats arrive back at camp singing their praises to make sure the Clan knows it."
+        ],
+        "fail_text": [
+            "The mother red fox is vicious and determined. Although they lose this battle, through teamwork the cats manage to retreat without injury.",
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the rest of the patrol have to rescue them from the red vixen.",
+            null,
+            "r_c is left wounded as the patrol and the mother red vixen fight to a stalemate. Hopefully they've given the fox mother a reason not to return to this part of the forest.",
+            null,
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the red vixen manages to sink her teeth into them. The patrol rallies around s_c, but they have to give up on the fight."
+        ],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 4,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a fox fight."
+        ]
+    },
+    {
+        "patrol_id": "pln_hunt_redvixen6",
+        "biome": "plains",
+        "season": "greenleaf",
+        "tags": [
+            "fighting",
+            "death",
+            "scar",
+            "big_bite_injury",
+            "respect",
+            "trust",
+            "clan_to_patrol",
+            "no_body"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or swift?",
+        "decline_text": "Your patrol decides not to pursue the fox.",
+        "chance_of_success": 10,
+        "exp": 50,
+        "success_text": [
+            "The red vixen smells of milk and blood. Hopefully by driving her out of the territory, the litter she has been raising this greenleaf won't be a threat to the Clan.",
+            null,
+            "s_c displays incredible skill, driving the mother red vixen and her brood out of c_n's plains all by themselves. Now neither the fox nor her dependent cubs pose a threat to the Clan. They swell with pride, feeling the confidence of knowing that they're truly one of the best fighters c_n has ever produced.",
+            "A brilliant battle move by s_c at a critical moment knocks the red vixen they find off balance, and s_c manages to drive her out of c_n territory, though it takes every spark of strength in their pelt to do it alone."
+        ],
+        "fail_text": [
+            null,
+            null,
+            "Never threaten a mother's young - the red vixen kills r_c in the skirmish, and carries off the body to feed her litter.",
+            "The mother red fox's snapping jaws leave r_c dripping blood onto the leaf litter, and barely able to escape further injury.",
+            null,
+            "s_c is determined to win, but the vixen is determined to live, and that makes all the difference. s_c ends up pinned in a defensible hiding spot, bleeding and terrified, until the vixen judges them no longer a threat and continues on her way."
+        ],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a solo fight with a vixen.",
+            "r_c fell in a solo battle with a vixen.",
+            "died in battle with a fox"
+        ]
+    },
+    {
+        "patrol_id": "pln_hunt_redvixen7",
+        "biome": "plains",
+        "season": "leaf-fall",
+        "tags": [
+            "fighting",
+            "death",
+            "scar",
+            "big_bite_injury",
+            "respect",
+            "trust",
+            "clan_to_r_c",
+            "patrol_to_r_c",
+            "clan_to_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or swift?",
+        "decline_text": "Your patrol decides not to pursue the fox.",
+        "chance_of_success": 30,
+        "exp": 30,
+        "success_text": [
+            "The red vixen smells like the prey she's been poaching to feed her litter. She's stolen from c_n for the last time, and the patrol drives her from their territory, yowling their anger and fury.",
+            "Your patrol drives away the red fox, and seeks out her den, but her leaf-fall cubs are near full-grown and scatter into the wilderness. Hopefully leaf-bare takes care of them.",
+            "s_c displays incredible skill, driving the mother red vixen they track down out of the territory almost by themselves. It truly proves s_c's place as one of c_n's most talented and skillful fighters.",
+            "The patrol hunts down and overcomes the red vixen they discover, driving her off thanks to a brilliant battle move by s_c at a critical moment. Their bravery ensures the patrol's success, and the cats arrive back at camp singing their praises to make sure the Clan knows it."
+        ],
+        "fail_text": [
+            "The mother red fox is vicious and determined, and the small patrol is beaten back. But this forest is c_n's and they haven't given up. They may have lost this battle, but c_n will win this war.",
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the rest of the patrol have to rescue them from the red vixen.",
+            "Never threaten a mother's young - the red vixen kills r_c in the skirmish.",
+            "The mother red fox's snapping jaws leave r_c dripping blood onto the grass, forcing the patrol to back off.",
+            null,
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the red vixen manages to sink her teeth into them. The patrol rallies around s_c, but they have to give up on the fight.",
+            "As their hunt descends into a full on battle with a red vixen determined to protect her young, p_l takes a blow meant for one of their Clanmates, losing a life."
+        ],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 2,
+        "max_cats": 3,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a fox fight.",
+            "r_c fell in battle with a fox.",
+            "died in battle with a fox"
+        ]
+    },
+    {
+        "patrol_id": "pln_hunt_redvixen8",
+        "biome": "plains",
+        "season": "leaf-fall",
+        "tags": [
+            "fighting",
+            "scar",
+            "big_bite_injury",
+            "respect",
+            "trust",
+            "clan_to_r_c",
+            "patrol_to_r_c",
+            "clan_to_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or swift?",
+        "decline_text": "Your patrol decides not to pursue the fox.",
+        "chance_of_success": 60,
+        "exp": 30,
+        "success_text": [
+            "Led by p_l and with a heap of cooperation and teamwork, the patrol drives away the fox, and seeks out her den. But her cubs are near full-grown with the bounty of leaf-fall, and scatter from the patrol into the wilderness. Hopefully leaf-bare takes care of them.",
+            "With so many cats working together in tight coordination, they manage to accomplish the near-impossible, killing the mother vixen and ending the threat to the Clan that she poses. The patrol drives her near-full grown litter of fox cubs out from the territory. Hopefully the coming leaf-bare will take care of them.",
+            "s_c displays incredible skill, driving the mother red vixen they track down out of the territory almost by themselves. Now neither the fox nor her cubs pose a threat to c_n.",
+            "The patrol hunts down and overcomes the red vixen they discover, driving her off thanks to a brilliant battle move by s_c at a critical moment. Their bravery ensures the patrol's success, and the cats arrive back at camp singing their praises to make sure the Clan knows it."
+        ],
+        "fail_text": [
+            "The mother red fox is vicious and determined. Although they lose this battle, through teamwork the cats manage to retreat without injury.",
+            null,
+            "r_c is left wounded as the patrol and the mother red vixen fight to a stalemate. Hopefully they've given the fox mother a reason not to return to this part of the forest.",
+            null,
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the red vixen manages to sink her teeth into them. The patrol rallies around s_c, but they have to give up the fight."
+        ],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 4,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a fox fight."
+        ]
+    },
+    {
+        "patrol_id": "pln_hunt_redvixen9",
+        "biome": "plains",
+        "season": "leaf-fall",
+        "tags": [
+            "fighting",
+            "death",
+            "scar",
+            "big_bite_injury",
+            "respect",
+            "trust",
+            "clan_to_patrol",
+            "no_body"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or swift?",
+        "decline_text": "Your patrol decides not to pursue the fox.",
+        "chance_of_success": 20,
+        "exp": 50,
+        "success_text": [
+            "It takes r_c's every scrap of bravery and strength to drive away the red vixen - her near grown litter, fat on the bounty of leaf-fall, is a challenge for another day. c_n will have to deal with the young foxes now roaming motherless in their woods, before they start to compete for prey in leaf-bare.",
+            null,
+            "s_c displays incredible skill, driving the mother red vixen and her brood out of c_n's plains all by themselves. Now neither the fox nor her cubs pose a threat to the Clan. They swell with pride, feeling the confidence of knowing that they're truly one of the best fighters c_n has ever produced.",
+            "A brilliant battle move by s_c at a critical moment knocks the red vixen they find off balance, and s_c manages to drive her out of c_n territory, though it takes every spark of strength in their pelt to do it alone."
+        ],
+        "fail_text": [
+            null,
+            null,
+            "Never threaten a mother's young - the red vixen kills r_c in the skirmish, and carries off the body to feed her litter.",
+            "The mother red fox's snapping jaws leave r_c dripping blood onto the leaf litter, and barely able to escape further injury.",
+            null,
+            "s_c is determined to win, but the vixen is determined to live, and that makes all the difference. s_c ends up pinned in a defensible hiding spot, bleeding and terrified, until the vixen judges them no longer a threat and continues on her way."
+        ],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a solo fight with a red vixen.",
+            "r_c fell in a solo battle with a red vixen.",
+            "died in battle with a fox"
+        ]
+    },
+    {
+        "patrol_id": "pln_hunt_swiftfox_newleafvixen1",
+        "biome": "plains",
+        "season": "newleaf",
+        "tags": [
+            "hunting",
+            "comfort",
+            "respect",
+            "rel_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or swift?",
+        "decline_text": "Your patrol decides not to pursue the fox.",
+        "chance_of_success": 70,
+        "exp": 30,
+        "success_text": [
+            "Anticipating the coming greenleaf, this swift fox is checking for a suitable burrow for her litter. And that burrow will not be in c_n's territory. The patrol makes that clear, screaming and charging at her until the fox flees beyond their borders, away from where her cubs could threaten the Clan.",
+            "This swift vixen is looking for a place to den, and the patrol sets up an ambush. She crossed their borders, but she won't cross back over them again, and with her life ends the threat her cubs would have posed to c_n's kits.",
+            "s_c holds the patrol back until the swift fox's yips bring her mate, than the patrol strikes. While the vixen flees, her mate fights, and against warriors he doesn't stand a chance."
+        ],
+        "fail_text": [
+            "The swift fox spots the patrol coming and scarpers, tucking tail and fleeing across the horizon in an example of where the small canivore gets its name."
+        ],
+        "win_skills": [
+            "smart",
+            "very smart",
+            "extremely smart"
+        ],
+        "win_trait": [
+            "None"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 2,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null
+    },
+    {
+        "patrol_id": "pln_hunt_swiftfox_newleafvixen2",
+        "biome": "plains",
+        "season": "newleaf",
+        "tags": [
+            "hunting",
+            "fighting",
+            "scar",
+            "respect",
+            "clan_to_r_c",
+            "small_bite_injury"
+        ],
+        "intro_text": "r_c catches the scent of a fox - but is it red, or swift?",
+        "decline_text": "Your patrol decides not to pursue the fox.",
+        "chance_of_success": 60,
+        "exp": 20,
+        "success_text": [
+            "This swift vixen is scouting out potential dens for greenleaf, r_c realises, and rushes to warn her off. Forget about hunting, driving off this vixen before she sets up a den within c_n's borders is more important.",
+            "This swift vixen is scouting out potential dens for greenleaf, r_c realises. This could be bad, and r_c gives up on the hunt, instead following the vixen, yowling and hissing, using their persistance to warn her off from trying to live here.",
+            "s_c positions themselves down a burrow in the vixen's path, and as the swift fox approaches s_c bursts from it, pinning her down and using surprise to get in a crucial blow to her throat."
+        ],
+        "fail_text": [
+            "The swift fox spots r_c coming and scarpers, tucking tail and fleeing across the horizon in an example of where the small canivore gets its name.",
+            null,
+            null,
+            "Puffed up, r_c approaches the swift fox. But there's only one of them, and the fox is their equal in size and weight. instead of running or giving up, it snarls, and attacks. r_c gives just as good as they get, and both animals end up limping away."
+        ],
+        "win_skills": [
+            "smart",
+            "very smart",
+            "extremely smart",
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "None"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from fighting with a swift fox."
+        ]
+    },
+    {
+        "patrol_id": "pln_hunt_swiftfox_greenleafvixen1",
+        "biome": "plains",
+        "season": "greenleaf",
+        "tags": [
+            "hunting",
+            "comfort",
+            "respect",
+            "rel_patrol",
+            "fighting",
+            "scar",
+            "big_bite_injury"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or swift?",
+        "decline_text": "Your patrol decides not to pursue the fox.",
+        "chance_of_success": 50,
+        "exp": 30,
+        "success_text": [
+            "The patrol charges the vixen, and she runs, leaving the scent of milk in the air behind her. Though they don't know where her cubs are hidden, without their mother they won't pose a threat to the Clan.",
+            "The patrol sneaks closer, until p_l realises that the vixen is approaching her den - a den when cubs must surely hide. A competitor denning within c_n's borders is an outrage, and the patrol leaps to attack, pinning the vixen in a mess of boulders.",
+            "s_c holds the patrol back until they spot the vixen's mate, approaching with poached prey in his jaws. Together, the cats ambush the foxes, bursting from cover with claws unshealthed as a vicious fight starts. But warriors fight as a team, and the foxes do not, and one flees, abandoning its mate to the fury of c_n."
+        ],
+        "fail_text": [
+            "The swift fox spots the patrol coming and scarpers, tucking tail and fleeing across the horizon in an example of where the small canivore gets its name.",
+            null,
+            null,
+            "As the patrol descends on the swift vixen, her scream of surprise brings in her mate, changing the odds. The male bursts out from cover and sinks his teeth into r_c, both foxes using the patrol switching to r_c's defence as their signal to flee."
+        ],
+        "win_skills": [
+            "smart",
+            "very smart",
+            "extremely smart",
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "None"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 2,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c was marked by a fight with a swift fox vixen."
+        ]
+    },
+    {
+        "patrol_id": "pln_hunt_swiftfox_greenleafvixen2",
+        "biome": "plains",
+        "season": "greenleaf",
+        "tags": [
+            "hunting",
+            "fighting",
+            "scar",
+            "respect",
+            "clan_to_r_c",
+            "small_bite_injury"
+        ],
+        "intro_text": "r_c catches the scent of a fox - but is it red, or swift?",
+        "decline_text": "Your patrol decides not to pursue the fox.",
+        "chance_of_success": 20,
+        "exp": 30,
+        "success_text": [
+            "Sneaking closer, r_c realises that the wind carries the scent of milk from the vixen. It's a swift fox - and she has cubs. Eventually she leaves the area, and r_c begins the hunt, checking every burrow, every crevice, every hole until they find the tiny fox cubs. Killing them protects the Clan, they remind themselves.",
+            "This swift vixen has a den, r_c realises, one perched just under a lone tree. Once the vixen leaves, r_c digs around it to bury the den and its contents. No swift cubs will be raised within c_n's borders.",
+            "s_c scents the air, following the milk scent of the mother swift fox from afar. It means they can position themselves for the perfect ambush, leaping from cover to fasten their teeth in her throat."
+        ],
+        "fail_text": [
+            "The swift fox spots r_c coming and scarpers, tucking tail and fleeing across the horizon in an example of where the small canivore gets its name.",
+            null,
+            null,
+            "As r_c descends on the swift vixen, her scream of surprise brings in her mate, changing the odds. The male bursts out from cover and sinks his teeth into r_c, both foxes using the chance to flee."
+        ],
+        "win_skills": [
+            "smart",
+            "very smart",
+            "extremely smart",
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "None"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c was marked by a fight with a swift fox vixen."
+        ]
+    },
+    {
+        "patrol_id": "pln_hunt_swiftfox_leaf-fallvixen1",
+        "biome": "plains",
+        "season": "leaf-fall",
+        "tags": [
+            "hunting",
+            "large_prey1",
+            "huge_prey2",
+            "comfort",
+            "respect",
+            "rel_patrol",
+            "fighting",
+            "scar",
+            "big_bite_injury"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or swift?",
+        "decline_text": "Your patrol decides not to pursue the fox.",
+        "chance_of_success": 70,
+        "exp": 30,
+        "success_text": [
+            "The patrol charges the swift vixen, and she runs, leaving the scent of milk in the air behind her. But they don't know where her cubs might've been hidden, and they'll be old enough to survive without her - this bodes ill for leaf-bare.",
+            "The patrol sneaks closer, until p_l realises that the swift vixen is approaching her den. Her cubs, nearly full grown on prey stolen from c_n's territory, poke their heads out, and the cats yowl in outrage. They charge the den, killing two of the cubs before the vixen runs with her third.",
+            "s_c holds the patrol back until they spot the swift vixen's mate, approaching with poached prey in his jaws. Together, the cats ambush the foxes, bursting from cover with claws unshealthed as a vicious fight starts. But warriors fight as a team, and the foxes do not, and one flees, abandoning its mate and cubs to the fury of c_n."
+        ],
+        "fail_text": [
+            "The swift fox spots the patrol coming and scarpers, tucking tail and fleeing across the horizon in an example of where the small canivore gets its name.",
+            null,
+            null,
+            "As the patrol descends on the swift vixen, her scream of surprise brings in her mate, changing the odds. The male bursts out from cover and sinks his teeth into r_c, both foxes using the patrol switching to r_c's defence as their signal to flee."
+        ],
+        "win_skills": [
+            "smart",
+            "very smart",
+            "extremely smart",
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "None"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 2,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c was marked by a fight with a swift fox vixen."
+        ]
+    },
+    {
+        "patrol_id": "pln_hunt_swiftfox_leaf-fallvixen2",
+        "biome": "plains",
+        "season": "leaf-fall",
+        "tags": [
+            "hunting",
+            "medium_prey0",
+            "large_prey2",
+            "fighting",
+            "scar",
+            "respect",
+            "clan_to_r_c",
+            "small_bite_injury"
+        ],
+        "intro_text": "r_c catches the scent of a fox - but is it red, or swift?",
+        "decline_text": "Your patrol decides not to pursue the fox.",
+        "chance_of_success": 40,
+        "exp": 30,
+        "success_text": [
+            "Sneaking closer, r_c realises that the wind carries the scent of milk from the vixen. It's a swift fox - and she has cubs. Eventually she leaves the area, and r_c begins the hunt, checking every burrow, every crevice, every hole until they stumble over the den. Two of the cubs flee into the grasslands, while the third falls to r_c's claws.",
+            "This swift vixen has a den, r_c realises, one perched just under a lone tree. Once the vixen leaves, r_c digs around it to bury the den and its contents. No swift cubs will be raised within c_n's borders.",
+            "s_c scents the air, following the milk scent of the mother swift fox from afar. It means they can position themselves for the perfect ambush, leaping from cover to fasten their teeth in her throat. Her cubs will be old enough to survive without her, but this vixen will never raise kitten killers again."
+        ],
+        "fail_text": [
+            "The swift fox spots r_c coming and scarpers, tucking tail and fleeing across the horizon in an example of where the small canivore gets its name.",
+            null,
+            null,
+            "As r_c descends on the swift vixen, her scream of surprise brings in her mate, changing the odds. The male bursts out from cover and sinks his teeth into r_c, both foxes using the chance to flee."
+        ],
+        "win_skills": [
+            "smart",
+            "very smart",
+            "extremely smart",
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "None"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c was marked by a fight with a swift fox vixen."
+        ]
+    },
+    {
+        "patrol_id": "pln_hunt_kitfox_steal1",
+        "biome": "plains",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "small_prey"
+        ],
+        "intro_text": "r_c catches the scent of a fox. Tracking it down, the cats spot a kit fox wandering through the grass, carrying a mouse in its jaws.",
+        "decline_text": "That's an insignificant amount of fresh-kill to start a fight over.",
+        "chance_of_success": 70,
+        "exp": 10,
+        "success_text": [
+            "Your hunters chase after it, spitting and hissing as the smaller predator tries to run. But a patrol full of cats is faster, and the fox soon decides that it'd prefer to give up the mouse rather than fight. It's an insignificant amount of fresh-kill, but hopefully a permanent lesson for a fox on stealing from c_n.",
+            "The kit fox isn't crazy, and immediately drops the mouse, running for its life from the patrol.",
+            "s_c pounces, snarling, and the fox turns tail with a yelp. Only s_c isn't alone, and cats circle the fox as it turns and snarls and yelps for mercy, holding it their until they're very sure it will never dare sneak across c_n's borders again.",
+            "s_c wanders up to the kit fox, swagger in their step as they take the opportunity to be the bigger predator for once in their life. The kit fox takes one look at the patrol backing s_c up and decides it's time to be elsewhere as fast as its legs can take it, leaving the single skinny mouse it stole behind."
+        ],
+        "fail_text": [
+            "The patrol approaches the kit fox, who spots them and sets off at full speed. It's not worth following them, not over a single mouse."
+        ],
+        "win_skills": [
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "loyal",
+            "playful",
+            "righteous",
+            "shameless",
+            "strict",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 2,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null
+    },
+    {
+        "patrol_id": "pln_hunt_kitfox_steal2",
+        "biome": "plains",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "small_prey",
+            "fighting",
+            "scar",
+            "small_bite_injury"
+        ],
+        "intro_text": "r_c catches the scent of a fox. Tracking it down, they spot a kit fox wandering through the grass, carrying a mouse in its jaws.",
+        "decline_text": "That's an insignificant amount of fresh-kill to start a fight over.",
+        "chance_of_success": 70,
+        "exp": 10,
+        "success_text": [
+            "r_c chases after it, spitting and hissing as the smaller predator tries to run. But r_c is faster, and the fox soon decides that it'd prefer to give up the mouse rather than fight. Puffed up and proud, r_c trots back to camp with the addition for the fresh-kill pile.",
+            "The kit fox locks eyes with r_c as they emerge from the grass, weighing up its options against the bigger cat. There's a long, tense moment as both puff up, ready for a fight, but the fox's nerve breaks first and it runs, leaving r_c with the mouse.",
+            "s_c pounces, snarling, and the fox turns tail with a yelp. Only s_c uses that moment to grab that fluffy tail and shake, until the fox gives up its prey and turns to bite. They dart backwards, and that's as much fight as the fox had in them - the fox runs, and s_c has won the mouse.",
+            "s_c wanders up to the kit fox, swagger in their step as they take the opportunity to be the bigger predator for once in their life. It looks like it's going to fight for a second, but s_c's confidence intimidates it into dropping the mouse and fleeing back into the long grass."
+        ],
+        "fail_text": [
+            "r_c approaches the kit fox, who spots them and sets off at full speed. It's not worth following them, not over a single mouse.",
+            null,
+            null,
+            "With a massive yowl, r_c charges the fox. It bares its teeth, unwilling to give up its hard won prey without a fight, and one wrong step puts r_c's pelt in range of those little jaws, as the small kit fox tries to live up to the reputation of its bigger and stronger relatives."
+        ],
+        "win_skills": [
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "loyal",
+            "playful",
+            "righteous",
+            "shameless",
+            "strict",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a fight with a kit fox.",
+            null
+        ]
+    },
+    {
+        "patrol_id": "pln_hunt_swiftfox_newleafscavenge1",
+        "biome": "plains",
+        "season": "newleaf",
+        "tags": [
+            "hunting",
+            "large_prey",
+            "comfort",
+            "respect",
+            "rel_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox. Tracking it, they find a swift fox feeding on a calf carcass. The cat-sized predator definitely didn't kill this massive hunk of fresh-kill.",
+        "decline_text": "Your patrol decides not to quarrel with the fox - bigger predators will be attracted here. Best to leave sooner rather than later.",
+        "chance_of_success": 70,
+        "exp": 20,
+        "success_text": [
+            "As the patrol approaches, the swift fox spots them and backs off from the carcass with a whine. Your cats can feed in peace for now, but larger predators will surely soon come to throw them off the kill. By cooperating together, the patrol is able to at least drag some of the intestines home to camp.",
+            null,
+            "s_c sits and watches the swift fox as the patrol takes over the kill without a fight. It wanders the area, grabbing pieces of gristle and meat and caching them in little holes, giving s_c an idea. Together the Clan cats gnaw off a leg, and take their bony prize back to camp for c_n.",
+            "While the rest of the patrol feeds on the kill, the swift fox gnawing on the head at the other end in uneasy truce, s_c keeps watch. It turns out to have been a wise move, as they spot a cougar's ears sticking up out of the grass. The kill's original owner is coming back, and the cats vacate with speed."
+        ],
+        "fail_text": [
+            "The swift fox gives up on the kill with a snarl, but a coyote yip in the distance sends both the smaller predator species running, the cats puffed up and uncomfortable.",
+            "The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth. s_c calls the rest of the patrol for backup and no one is injured, but by the time they get back to the kill ravens are circling overhead. The patrol gives it up, knowing bigger predators will arrive soon."
+        ],
+        "win_skills": [
+            "smart",
+            "very smart",
+            "extremely smart"
+        ],
+        "win_trait": [
+            "altruistic",
+            "patient",
+            "responsible",
+            "thoughtful",
+            "wise",
+            "calm",
+            "careful",
+            "insecure",
+            "nervous",
+            "sneaky"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "bold",
+            "childish",
+            "confident",
+            "daring",
+            "playful",
+            "shameless"
+        ],
+        "min_cats": 2,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null
+    },
+    {
+        "patrol_id": "pln_hunt_swiftfox_newleafscavenge2",
+        "biome": "plains",
+        "season": "newleaf",
+        "tags": [
+            "hunting",
+            "small_prey",
+            "fighting",
+            "scar",
+            "death",
+            "no_body",
+            "small_bite_injury"
+        ],
+        "intro_text": "r_c catches the scent of a fox. Tracking it, they find a swift fox feeding on a calf carcass. The cat-sized predator definitely didn't kill this massive hunk of fresh-kill.",
+        "decline_text": "r_c decides not to quarrel with the fox - bigger predators will be attracted here. Best to leave sooner rather than later.",
+        "chance_of_success": 70,
+        "exp": 10,
+        "success_text": [
+            "r_c approaches the kill, fur puffed up. The swift fox grumbles, but with a hiss both animals agree to disagree, feeding from opposite ends of the calf without further trouble. r_c is able to find some decent scraps to carry back to camp, though with only them there they can't bring back as much meat as they'd like.",
+            null,
+            "Watching the swift fox at the carcass, s_c notices it stripping meat from the calf and caching it in little holes, and starts to copy it. The bigger predators will return to claim the calf soon, but by the time they do s_c will have hidden away the choicest morsels to fetch later.",
+            "With great care, aware that the kill's original owner must be somewhere about, s_c snatches the first large scrap they find and leaves the swift fox to risk the wrath of the bigger predators."
+        ],
+        "fail_text": [
+            "A coyote yip in the distance sends both the smaller predator species running before r_c can muscle in on the feeding opportunity.",
+            "The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth. s_c dances out of the way, but hears the caw of ravens descending on the carcass, and knows it would be too dangerous to return.",
+            "r_c happily tucks into the massive calf - there's more than enough room for both them and the small fox to feed. They hear a massive, outraged yowl, and a blow from behind sends them to StarClan with a single hit. They never saw what did it.",
+            "Puffed up, r_c approaches the swift fox. But there's only one of them, and the fox is their equal in size and weight. instead of running or giving it, it snarls, and attacks. r_c gives just as good as they get, and both animals end up limping away from the kill.",
+            null,
+            "The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth, sinking them into s_c and giving s_c a bigger concern than scavenging from the calf carcass."
+        ],
+        "win_skills": [
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "altruistic",
+            "patient",
+            "responsible",
+            "thoughtful",
+            "wise",
+            "calm",
+            "careful",
+            "insecure",
+            "nervous",
+            "sneaky"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "bold",
+            "childish",
+            "confident",
+            "daring",
+            "playful",
+            "shameless"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from fighting with a swift fox.",
+            "While scavenging alone, r_c was killed by a predator they didn't see.",
+            "were killed by a predator"
+        ]
+    },
+    {
+        "patrol_id": "pln_hunt_swiftfox_greenleafscavenge1",
+        "biome": "plains",
+        "season": "greenleaf",
+        "tags": [
+            "hunting",
+            "large_prey",
+            "comfort",
+            "respect",
+            "rel_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox. Tracking it, they find a swift fox feeding on a calf carcass. The cat-sized predator definitely didn't kill this massive hunk of fresh-kill.",
+        "decline_text": "Your patrol decides not to quarrel with the fox - bigger predators will be attracted here. Best to leave sooner rather than later.",
+        "chance_of_success": 70,
+        "exp": 20,
+        "success_text": [
+            "As the patrol approaches, the swift fox spots them and backs off from the carcass with a whine. Your cats can feed in peace for now, but larger predators will surely soon come to throw them off the kill. By cooperating together, the patrol is able to at least drag some of the intestines home to camp.",
+            null,
+            "s_c sits and watches the swift fox as the patrol takes over the kill without a fight. It wanders the area, grabbing pieces of gristle and meat and caching them in little holes, giving s_c an idea. Together the Clan cats gnaw off a leg, and take their bony prize back to camp for c_n.",
+            "While the rest of the patrol feeds on the kill, the swift fox gnawing on the head at the other end in uneasy truce, s_c keeps watch. It turns out to have been a wise move, as they spot a cougar's ears sticking up out of the grass. The kill's original owner is coming back, and the cats vacate with speed."
+        ],
+        "fail_text": [
+            "The swift fox gives up on the kill with a snarl, but a coyote yip in the distance sends both the smaller predator species running, the cats puffed up and uncomfortable.",
+            "The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth. s_c calls the rest of the patrol for backup and no one is injured, but by the time they get back to the kill ravens are circling overhead. The patrol gives it up, knowing bigger predators will arrive soon."
+        ],
+        "win_skills": [
+            "smart",
+            "very smart",
+            "extremely smart"
+        ],
+        "win_trait": [
+            "altruistic",
+            "patient",
+            "responsible",
+            "thoughtful",
+            "wise",
+            "calm",
+            "careful",
+            "insecure",
+            "nervous",
+            "sneaky"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "bold",
+            "childish",
+            "confident",
+            "daring",
+            "playful",
+            "shameless"
+        ],
+        "min_cats": 2,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null
+    },
+    {
+        "patrol_id": "pln_hunt_swiftfox_greenleafscavenge2",
+        "biome": "plains",
+        "season": "greenleaf",
+        "tags": [
+            "hunting",
+            "small_prey",
+            "fighting",
+            "scar",
+            "death",
+            "no_body",
+            "small_bite_injury"
+        ],
+        "intro_text": "r_c catches the scent of a fox. Tracking it, they find a swift fox feeding on a calf carcass. The cat-sized predator definitely didn't kill this massive hunk of fresh-kill.",
+        "decline_text": "r_c decides not to quarrel with the fox - bigger predators will be attracted here. Best to leave sooner rather than later.",
+        "chance_of_success": 70,
+        "exp": 10,
+        "success_text": [
+            "r_c smaller, alone, and half its weight, but the fox has a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle. The fox, already stuffed full and unwilling to lose blood over it, leaves the kill with a grumble.",
+            null,
+            "s_c uses every trick in their talented fighting skillset to attack the fox with no one to watch their flank, until the perfect opportunity opens up and they pounce onto the fox's back, digging in their claws. It's a wild ride through the forest until the fox bucks them off, but it wins them the fawn carcass.",
+            "In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. But then they're stuck, unwilling to let go and risk being bitten. They're dragged through the forest, over rocks and through bushes, until the fox finally collapses and the battered s_c goes back to proudly claim the fawn."
+        ],
+        "fail_text": [
+            "A coyote yip in the distance sends both the smaller predator species running before r_c can muscle in on the feeding opportunity.",
+            "The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth. s_c dances out of the way, but hears the caw of ravens descending on the carcass, and knows it would be too dangerous to return.",
+            "r_c happily tucks into the massive calf - there's more than enough room for both them and the small fox to feed. They hear a massive, outraged yowl, and a blow from behind sends them to StarClan with a single hit. They never saw what did it.",
+            "Puffed up, r_c approaches the swift fox. But there's only one of them, and the fox is their equal in size and weight. instead of running or giving it, it snarls, and attacks. r_c gives just as good as they get, and both animals end up limping away from the kill.",
+            null,
+            "The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth, sinking them into s_c and giving s_c a bigger concern than scavenging from the calf carcass."
+        ],
+        "win_skills": [
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "altruistic",
+            "patient",
+            "responsible",
+            "thoughtful",
+            "wise",
+            "calm",
+            "careful",
+            "insecure",
+            "nervous",
+            "sneaky"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "bold",
+            "childish",
+            "confident",
+            "daring",
+            "playful",
+            "shameless"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from fighting with a swift fox.",
+            "While scavenging alone, r_c was killed by a predator they didn't see.",
+            "were killed by a predator"
+        ]
+    },
+    {
+        "patrol_id": "pln_hunt_swiftfox_leaf-fallscavenge1",
+        "biome": "plains",
+        "season": "leaf-fall",
+        "tags": [
+            "hunting",
+            "large_prey",
+            "comfort",
+            "respect",
+            "rel_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox. Tracking it, they find a swift fox feeding on a calf carcass. The cat-sized predator definitely didn't kill this massive hunk of fresh-kill.",
+        "decline_text": "Your patrol decides not to quarrel with the fox - bigger predators will be attracted here. Best to leave sooner rather than later.",
+        "chance_of_success": 70,
+        "exp": 20,
+        "success_text": [
+            "As the patrol approaches, the swift fox spots them and backs off from the carcass with a whine. Your cats can feed in peace for now, but larger predators will surely soon come to throw them off the kill. By cooperating together, the patrol is able to at least drag some of the intestines home to camp.",
+            null,
+            "s_c sits and watches the swift fox as the patrol takes over the kill without a fight. It wanders the area, grabbing pieces of gristle and meat and caching them in little holes, giving s_c an idea. Together the Clan cats gnaw off a leg, and take their bony prize back to camp for c_n.",
+            "While the rest of the patrol feeds on the kill, the swift fox gnawing on the head at the other end in uneasy truce, s_c keeps watch. It turns out to have been a wise move, as they spot a cougar's ears sticking up out of the grass. The kill's original owner is coming back, and the cats vacate with speed."
+        ],
+        "fail_text": [
+            "The swift fox gives up on the kill with a snarl, but a coyote yip in the distance sends both the smaller predator species running, the cats puffed up and uncomfortable.",
+            "The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth. s_c calls the rest of the patrol for backup and no one is injured, but by the time they get back to the kill ravens are circling overhead. The patrol gives it up, knowing bigger predators will arrive soon."
+        ],
+        "win_skills": [
+            "smart",
+            "very smart",
+            "extremely smart"
+        ],
+        "win_trait": [
+            "altruistic",
+            "patient",
+            "responsible",
+            "thoughtful",
+            "wise",
+            "calm",
+            "careful",
+            "insecure",
+            "nervous",
+            "sneaky"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "bold",
+            "childish",
+            "confident",
+            "daring",
+            "playful",
+            "shameless"
+        ],
+        "min_cats": 2,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null
+    },
+    {
+        "patrol_id": "pln_hunt_swiftfox_leaf-fallscavenge2",
+        "biome": "plains",
+        "season": "leaf-fall",
+        "tags": [
+            "hunting",
+            "small_prey",
+            "fighting",
+            "scar",
+            "death",
+            "no_body",
+            "small_bite_injury"
+        ],
+        "intro_text": "r_c catches the scent of a fox. Tracking it, they find a swift fox feeding on a calf carcass. The cat-sized predator definitely didn't kill this massive hunk of fresh-kill.",
+        "decline_text": "r_c decides not to quarrel with the fox - bigger predators will be attracted here. Best to leave sooner rather than later.",
+        "chance_of_success": 70,
+        "exp": 10,
+        "success_text": [
+            "r_c smaller, alone, and half its weight, but the fox has a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle. The fox, already stuffed full of venison and unwilling to lose blood over it, leaves the kill with a grumble.",
+            null,
+            "s_c uses every trick in their talented fighting skillset to attack the fox with no one to watch their flank, until the perfect opportunity opens up and they pounce onto the fox's back, digging in their claws. It's a wild ride through the forest until the fox bucks them off, but it wins them the fawn carcass.",
+            "In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. But then they're stuck, unwilling to let go and risk being bitten. They're dragged through the forest, over rocks and through bushes, until the fox finally collapses and the battered s_c goes back to proudly claim the fawn."
+        ],
+        "fail_text": [
+            "A coyote yip in the distance sends both the smaller predator species running before r_c can muscle in on the feeding opportunity.",
+            "The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth. s_c dances out of the way, but hears the caw of ravens descending on the carcass, and knows it would be too dangerous to return.",
+            "r_c happily tucks into the massive calf - there's more than enough room for both them and the small fox to feed. They hear a massive, outraged yowl, and a blow from behind sends them to StarClan with a single hit. They never saw what did it.",
+            "Puffed up, r_c approaches the swift fox. But there's only one of them, and the fox is their equal in size and weight. instead of running or giving it, it snarls, and attacks. r_c gives just as good as they get, and both animals end up limping away from the kill.",
+            null,
+            "The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth, sinking them into s_c and giving s_c a bigger concern than scavenging from the calf carcass."
+        ],
+        "win_skills": [
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "altruistic",
+            "patient",
+            "responsible",
+            "thoughtful",
+            "wise",
+            "calm",
+            "careful",
+            "insecure",
+            "nervous",
+            "sneaky"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "bold",
+            "childish",
+            "confident",
+            "daring",
+            "playful",
+            "shameless"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from fighting with a swift fox.",
+            "While scavenging alone, r_c was killed by a predator they didn't see.",
+            "were killed by a predator"
+        ]
+    },
+    {
+        "patrol_id": "pln_hunt_swiftfox_leaf-barescavenge1",
+        "biome": "plains",
+        "season": "leaf-bare",
+        "tags": [
+            "hunting",
+            "large_prey",
+            "comfort",
+            "respect",
+            "rel_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox. Tracking it, they find a swift fox feeding on a cow carcass, either a small female or one of last Newleaf's calves. The cat-sized predator definitely didn't kill this massive hunk of fresh-kill.",
+        "decline_text": "Your patrol decides not to quarrel with the fox - bigger predators will be attracted here. Best to leave sooner rather than later.",
+        "chance_of_success": 60,
+        "exp": 20,
+        "success_text": [
+            "As the patrol approaches, the swift fox spots them and backs off from the carcass with a whine. Your cats can feed in peace for now, but larger predators will surely soon come to throw them off the kill. By cooperating together, the patrol is able to at least drag some of the intestines home to camp.",
+            null,
+            "s_c sits and watches the swift fox as the patrol takes over the kill without a fight. It wanders the area, grabbing pieces of gristle and meat and caching them in little holes, giving s_c an idea. Together the Clan cats gnaw off a leg, and take their bony prize back to camp for c_n.",
+            "While the rest of the patrol feeds on the kill, the swift fox gnawing on the head at the other end in uneasy truce, s_c keeps watch. It turns out to have been a wise move, as they spot a cougar's ears sticking up out of the grass. The kill's original owner is coming back, and the cats vacate with speed."
+        ],
+        "fail_text": [
+            "The swift fox gives up on the kill with a snarl, but a coyote yip in the distance sends both the smaller predator species running, the cats puffed up and uncomfortable.",
+            "The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth. s_c calls the rest of the patrol for backup and no one is injured, but by the time they get back to the kill ravens are circling overhead. The patrol gives it up, knowing bigger predators will arrive soon."
+        ],
+        "win_skills": [
+            "smart",
+            "very smart",
+            "extremely smart"
+        ],
+        "win_trait": [
+            "altruistic",
+            "patient",
+            "responsible",
+            "thoughtful",
+            "wise",
+            "calm",
+            "careful",
+            "insecure",
+            "nervous",
+            "sneaky"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "bold",
+            "childish",
+            "confident",
+            "daring",
+            "playful",
+            "shameless"
+        ],
+        "min_cats": 2,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null
+    },
+    {
+        "patrol_id": "pln_hunt_swiftfox_leaf-barescavenge2",
+        "biome": "plains",
+        "season": "leaf-bare",
+        "tags": [
+            "hunting",
+            "small_prey",
+            "fighting",
+            "scar",
+            "death",
+            "no_body",
+            "small_bite_injury"
+        ],
+        "intro_text": "r_c catches the scent of a fox. Tracking it, they find a swift fox feeding on a cow carcass, either a small female or one of last Newleaf's calves. Roughly equal in size to r_c, the swift fox definitely didn't bring down this feast themselves.",
+        "decline_text": "r_c decides not to quarrel with the fox - bigger predators will be attracted here. Best to leave sooner rather than later.",
+        "chance_of_success": 50,
+        "exp": 10,
+        "success_text": [
+            "r_c smaller, alone, and half its weight, but the fox has a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle. The fox, already stuffed full of venison and unwilling to lose blood over it, leaves the kill with a grumble.",
+            null,
+            "s_c uses every trick in their talented fighting skillset to attack the fox with no one to watch their flank, until the perfect opportunity opens up and they pounce onto the fox's back, digging in their claws. It's a wild ride through the forest until the fox bucks them off, but it wins them the fawn carcass.",
+            "In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. But then they're stuck, unwilling to let go and risk being bitten. They're dragged through the forest, over rocks and through bushes, until the fox finally collapses and the battered s_c goes back to proudly claim the fawn."
+        ],
+        "fail_text": [
+            "A coyote yip in the distance sends both the smaller predator species running before r_c can muscle in on the feeding opportunity.",
+            "The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth. s_c dances out of the way, but hears the caw of ravens descending on the carcass, and knows it would be too dangerous to return.",
+            "r_c happily tucks into the massive calf - there's more than enough room for both them and the small fox to feed. They hear a massive, outraged yowl, and a blow from behind sends them to StarClan with a single hit. They never saw what did it.",
+            "Puffed up, r_c approaches the swift fox. But there's only one of them, and the fox is their equal in size and weight. instead of running or giving it, it snarls, and attacks. r_c gives just as good as they get, and both animals end up limping away from the kill.",
+            null,
+            "The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth, sinking them into s_c and giving s_c a bigger concern than scavenging from the calf carcass."
+        ],
+        "win_skills": [
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "altruistic",
+            "patient",
+            "responsible",
+            "thoughtful",
+            "wise",
+            "calm",
+            "careful",
+            "insecure",
+            "nervous",
+            "sneaky"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "bold",
+            "childish",
+            "confident",
+            "daring",
+            "playful",
+            "shameless"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from fighting with a swift fox.",
+            "While scavenging alone, r_c was killed by a predator they didn't see.",
+            "were killed by a predator"
+        ]
+    },
+    {
         "patrol_id": "pln_hunt_BIGFOX1",
         "biome": "plains",
         "season": "Any",
-        "tags": ["hunting", "warrior", "no_app"],
+        "tags": [
+            "hunting",
+            "warrior",
+            "no_app"
+        ],
         "intro_text": "As r_c jumps up onto a rock to survey the plains, they spot the blood red pelt of a truly massive red fox.",
         "decline_text": "Not today, thank you - they'll go back to camp.",
         "chance_of_success": 60,
         "exp": 20,
         "success_text": [
-                "Swallowing their instinctive terror, r_c instead crouches to the rock and takes the time to assess the situation. Massive body, huge ruff of fur, legs towering daintily above the grass - this is too big to be a red fox, but ironically is less dangerous then it's smaller fox counterpart.",
-                "No way, these things are barely ever seen! The hunting around here will already be ruined by the other predator, so r_c feels no guilt in hanging around to watch the maned wolf, thinking of the stories they'll tell back at camp.",
-                "With a huff, r_c accepts that this hunt has failed - the massive maned wolf, despite every appearance, hunts nearly identical prey to c_n. Still, they're not one to give up on an opportunity to learn, and sit and watch the wolf pounce for mice in case there might be tips to pick up."
+            "Swallowing their instinctive terror, r_c instead crouches to the rock and takes the time to assess the situation. Massive body, huge ruff of fur, legs towering daintily above the grass - this is too big to be a red fox, but ironically is less dangerous then it's smaller fox counterpart.",
+            "No way, these things are barely ever seen! The hunting around here will already be ruined by the other predator, so r_c feels no guilt in hanging around to watch the maned wolf, thinking of the stories they'll tell back at camp.",
+            "With a huff, r_c accepts that this hunt has failed - the massive maned wolf, despite every appearance, hunts nearly identical prey to c_n. Still, they're not one to give up on an opportunity to learn, and sit and watch the wolf pounce for mice in case there might be tips to pick up."
         ],
         "fail_text": [
-                "Their jolt of fear gives them strength, and r_c is most of the way home before it occurs to them that the huge maned creature might have been too big to be a red fox.",
-                "r_c doesn't know what that monster is, and isn't sticking around to find out! They run home, tail between their legs."
+            "Their jolt of fear gives them strength, and r_c is most of the way home before it occurs to them that the huge maned creature might have been too big to be a red fox.",
+            "r_c doesn't know what that monster is, and isn't sticking around to find out! They run home, tail between their legs."
         ],
-        "win_skills": ["smart", "very smart", "extremely smart", "good teacher", "great teacher", "fantastic teacher"],
-        "win_trait": ["None"],
-        "fail_skills": ["None"],
-        "fail_trait": ["childish", "nervous"],
+        "win_skills": [
+            "smart",
+            "very smart",
+            "extremely smart",
+            "good teacher",
+            "great teacher",
+            "fantastic teacher"
+        ],
+        "win_trait": [
+            "None"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "childish",
+            "nervous"
+        ],
         "min_cats": 1,
         "max_cats": 1,
         "antagonize_text": null,
         "antagonize_fail_text": null
-},
-{
+    },
+    {
         "patrol_id": "pln_hunt_BIGFOX2",
         "biome": "plains",
         "season": "Any",
-        "tags": ["hunting", "apprentice", "small_bite_injury", "scar", "injury", "shock"],
+        "tags": [
+            "hunting",
+            "apprentice",
+            "small_bite_injury",
+            "scar",
+            "injury",
+            "shock"
+        ],
         "intro_text": "As app1 jumps up onto a rock to survey the plains, they spot the blood red pelt of a truly massive red fox.",
         "decline_text": "Not today, thank you - they'll go back to camp.",
         "chance_of_success": 40,
         "exp": 25,
         "success_text": [
-                "Terrified beyond sense, they freeze - and the massive fox sees them. It paces closer, giving app1 a heartstopping view of its distorted stretched legs and giant gaping mouth, gathering itself, before in one might spring, it - crashes past app1 and into the grass. Bobbing back up with a mouse, it makes eye contact with the shivering apprentice, before loping off.",
-                "app1 crouches to the rock, but it's too late - the fox has seen them. They freeze in terror, already sure they can't out run the horrifically lengthened legs, sure that at any moment they'll be ripped apart and silently begging StarClan to save them. The closer the fox gets, the more gigantic it's revealed to be, and it stares down at app1 on the rock, it's head bigger than their entire body. Only to move on, without a sound.",
-                null,
-                "Slowly, so that the sudden movement doesn't attract attention, app1 lowers themself to the rock. There's something off about the situation here. It's not just a big red fox, it's impossibly big, with legs stretched and distorted until they look more like a deer's than a fox's. Could this be the rare, massive, but mostly harmless maned wolf that the elders told app1 stories of in the nursery?"
+            "Terrified beyond sense, they freeze - and the massive fox sees them. It paces closer, giving app1 a heartstopping view of its distorted stretched legs and giant gaping mouth, gathering itself, before in one might spring, it - crashes past app1 and into the grass. Bobbing back up with a mouse, it makes eye contact with the shivering apprentice, before loping off.",
+            "app1 crouches to the rock, but it's too late - the fox has seen them. They freeze in terror, already sure they can't out run the horrifically lengthened legs, sure that at any moment they'll be ripped apart and silently begging StarClan to save them. The closer the fox gets, the more gigantic it's revealed to be, and it stares down at app1 on the rock, it's head bigger than their entire body. Only to move on, without a sound.",
+            null,
+            "Slowly, so that the sudden movement doesn't attract attention, app1 lowers themself to the rock. There's something off about the situation here. It's not just a big red fox, it's impossibly big, with legs stretched and distorted until they look more like a deer's than a fox's. Could this be the rare, massive, but mostly harmless maned wolf that the elders told app1 stories of in the nursery?"
         ],
         "fail_text": [
-                "Tarror gives app1 strength, and the don't stop running until their back in camp, gasping about the grassland monster they saw.",
-                "Heart filled with daring, app1 slips off the rock and pads towards the monster in the grass, sure that StarClan will reward their bravery. They sneak closer and closer, until a puzzle wuff of air makes them look up. And up. And up. That is no fox. They pelt for home, as behind them, a confused maned wolf watches them go.",
-                null,
-                "Terror freezes app1 as the massive fox sees them, and comes to investigate, its distorted stretched legs carrying it smoothly through the grass. As the massive nose, as big as app1's entire head, wuffles closer, app1 desperately swipes their claws. Their screw their eyes shut at the outraged yelp, and feel themselves being taken up and tossed by those gaping jaws. They tense, waiting for death to descend, and wait, and... waiting?",
-                null,
-                "Heart filled with daring, app1 slips off the rock and pads towards the monster in the grass, sure that StarClan will reward their bravery. A surprised wuff of air seems to come from everywhere and nowhere, as the puzzled maned wolf picks up the apprentice at their feet and tosses them aside so they can get back to hunting."
+            "Tarror gives app1 strength, and the don't stop running until their back in camp, gasping about the grassland monster they saw.",
+            "Heart filled with daring, app1 slips off the rock and pads towards the monster in the grass, sure that StarClan will reward their bravery. They sneak closer and closer, until a puzzle wuff of air makes them look up. And up. And up. That is no fox. They pelt for home, as behind them, a confused maned wolf watches them go.",
+            null,
+            "Terror freezes app1 as the massive fox sees them, and comes to investigate, its distorted stretched legs carrying it smoothly through the grass. As the massive nose, as big as app1's entire head, wuffles closer, app1 desperately swipes their claws. Their screw their eyes shut at the outraged yelp, and feel themselves being taken up and tossed by those gaping jaws. They tense, waiting for death to descend, and wait, and... waiting?",
+            null,
+            "Heart filled with daring, app1 slips off the rock and pads towards the monster in the grass, sure that StarClan will reward their bravery. A surprised wuff of air seems to come from everywhere and nowhere, as the puzzled maned wolf picks up the apprentice at their feet and tosses them aside so they can get back to hunting."
         ],
-        "win_skills": ["None"],
-        "win_trait": ["patient", "responsible", "thoughtful", "wise", "calm", "careful", "strange"],
-        "fail_skills": ["None"],
-        "fail_trait": ["adventurous", "bold", "confident", "daring", "playful", "ambitious", "fierce", "shameless"],
+        "win_skills": [
+            "None"
+        ],
+        "win_trait": [
+            "patient",
+            "responsible",
+            "thoughtful",
+            "wise",
+            "calm",
+            "careful",
+            "strange"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "adventurous",
+            "bold",
+            "confident",
+            "daring",
+            "playful",
+            "ambitious",
+            "fierce",
+            "shameless"
+        ],
         "min_cats": 1,
         "max_cats": 1,
         "antagonize_text": null,
         "antagonize_fail_text": null,
         "history_text": [
-                "r_c carries a scar from irritating a maned wolf as an apprentice."
+            "r_c carries a scar from irritating a maned wolf as an apprentice."
         ]
-},
-{
+    },
+    {
         "patrol_id": "pln_hunt_BIGFOX3",
         "biome": "plains",
         "season": "Any",
-        "tags": ["hunting", "warrior", "p_l_to_r_c", "rel_patrol", "platonic", "dislike"],
+        "tags": [
+            "hunting",
+            "warrior",
+            "p_l_to_r_c",
+            "rel_patrol",
+            "platonic",
+            "dislike"
+        ],
         "intro_text": "This is just one of the weirdest things they've ever seen, r_c comments to p_l, as the patrol stares at c_n's uninvited guest to their hunting grounds. Are they going to do anything about that... thing?",
         "decline_text": "Well, they don't really have time to linger - they'll try another hunting place.",
         "chance_of_success": 50,
         "exp": 25,
         "success_text": [
-                "After a good long session of confusion, the patrol manages to work out that the towering creature they're tracking is almost certainly a maned wolf, a nearly mythical creature. They're all a little uncomfortable, watching an upsized red fox with the legs of a deer amble around their territory, but it's also a little thrilling to follow such an unusual and rarely seen creature.",
-                "The rumours are true - it seems to mostly be hunting for tiny mouse prey, not large things, despite it's massive size. This must be a maned wolf, and just being able to name the odd thing makes it feel so much less threatening. The cats remind each other of the tales sometimes shared in the nursery, of the tallest predator on the plains being one of the shyest.",
-                "s_c is able to recalled some of the stories that get told about the maned wolf, of how it stole its legs from a deer for speed and power, but in doing so also accidentally took the deer's flightiness. Ever since then it has been the tallest and shyest creature on the grasslands.",
-                "Boldly, s_c jumps down to go check the potential threat out, and unwilling to leave their Clanmate in danger, the rest of the patrol follows. s_c refuses to let themselves be intimidated by the huge foxish thing, and bounds up to it, knowing courage can overcome things raw strength cannot. The weird creature skitters away from the incoming patrol, trotting off in a tangle of too long legs."
+            "After a good long session of confusion, the patrol manages to work out that the towering creature they're tracking is almost certainly a maned wolf, a nearly mythical creature. They're all a little uncomfortable, watching an upsized red fox with the legs of a deer amble around their territory, but it's also a little thrilling to follow such an unusual and rarely seen creature.",
+            "The rumours are true - it seems to mostly be hunting for tiny mouse prey, not large things, despite it's massive size. This must be a maned wolf, and just being able to name the odd thing makes it feel so much less threatening. The cats remind each other of the tales sometimes shared in the nursery, of the tallest predator on the plains being one of the shyest.",
+            "s_c is able to recalled some of the stories that get told about the maned wolf, of how it stole its legs from a deer for speed and power, but in doing so also accidentally took the deer's flightiness. Ever since then it has been the tallest and shyest creature on the grasslands.",
+            "Boldly, s_c jumps down to go check the potential threat out, and unwilling to leave their Clanmate in danger, the rest of the patrol follows. s_c refuses to let themselves be intimidated by the huge foxish thing, and bounds up to it, knowing courage can overcome things raw strength cannot. The weird creature skitters away from the incoming patrol, trotting off in a tangle of too long legs."
         ],
         "fail_text": [
-                "The patrol tries, they do, but they can't get a good look as the distorted red foxish creature, and eventually have to return to camp to give a rather unsatisfatory report about it. The cats stalk off to do their own things, feeling like they should've been able to do better.",
-                "s_c's stressed nerves can't handle this weird monster, and they beg to go back homeinstead of confronting it."
+            "The patrol tries, they do, but they can't get a good look as the distorted red foxish creature, and eventually have to return to camp to give a rather unsatisfatory report about it. The cats stalk off to do their own things, feeling like they should've been able to do better.",
+            "s_c's stressed nerves can't handle this weird monster, and they beg to go back homeinstead of confronting it."
         ],
-        "win_skills": ["smart", "very smart", "extremely smart", "good teacher", "great teacher", "fantastic teacher"],
-        "win_trait": ["adventurous", "bold", "confident", "daring", "playful", "ambitious", "fierce", "shameless"],
-        "fail_skills": ["None"],
-        "fail_trait": ["childish", "nervous"],
+        "win_skills": [
+            "smart",
+            "very smart",
+            "extremely smart",
+            "good teacher",
+            "great teacher",
+            "fantastic teacher"
+        ],
+        "win_trait": [
+            "adventurous",
+            "bold",
+            "confident",
+            "daring",
+            "playful",
+            "ambitious",
+            "fierce",
+            "shameless"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "childish",
+            "nervous"
+        ],
         "min_cats": 2,
         "max_cats": 6,
         "antagonize_text": null,
         "antagonize_fail_text": null
-},
-{
+    },
+    {
         "patrol_id": "pln_hunt_BIGFOX4",
         "biome": "plains",
         "season": "Any",
-        "tags": ["hunting", "small_prey", "warrior", "p_l_to_r_c", "rel_patrol", "dislike", "big_bite_injury", "scar", "injury", "shock"],
+        "tags": [
+            "hunting",
+            "small_prey",
+            "warrior",
+            "p_l_to_r_c",
+            "rel_patrol",
+            "dislike",
+            "big_bite_injury",
+            "scar",
+            "injury",
+            "shock"
+        ],
         "intro_text": "This is just one of the weirdest things they've ever seen, r_c comments to p_l, as the patrol stares at c_n's uninvited guest to their hunting grounds. Are they going to do anything about that... thing?",
         "decline_text": "Well, they don't really have time to linger - they'll try another hunting place.",
         "chance_of_success": 30,
         "exp": 30,
         "success_text": [
-                "Looking out over their full six cat patrol, p_l decides it's worth it. The cats fall into battle, decending onto the maned wolf and battering it, using teamwork to pull at its long legs and fox tail, as the wolf turns in skipping circles, yelping. It flees before them, leaving the triumphant cats with a single mouse for all that effort. Great.",
-                "With a sigh, p_l recognises that having a maned wolf poaching from c_n's hunting grounds will become a problem pretty quickly. Their six cat patrol might be the best way to solve the problem before it begins. All the cats, tense and ready, wait to ambush the wolf as it hunts, and manage to drive it out of the territory before it manages to catch more than a mouse. The stolen mouse is returned to c_n's fresh-kill pile, where it belongs.",
-                "While they'd hardly expected to need their skills on a hunting patrol, s_c is able to set up an excellent battle plan. It's only halfway through ambushing the beast that the patrol realises its a maned wolf, which makes their job inifinitely easier, as they drive away the timid predator from c_n territory with enough time left over to bring a mouse or two back for the fresh-kill pile before sundown."
+            "Looking out over their full six cat patrol, p_l decides it's worth it. The cats fall into battle, decending onto the maned wolf and battering it, using teamwork to pull at its long legs and fox tail, as the wolf turns in skipping circles, yelping. It flees before them, leaving the triumphant cats with a single mouse for all that effort. Great.",
+            "With a sigh, p_l recognises that having a maned wolf poaching from c_n's hunting grounds will become a problem pretty quickly. Their six cat patrol might be the best way to solve the problem before it begins. All the cats, tense and ready, wait to ambush the wolf as it hunts, and manage to drive it out of the territory before it manages to catch more than a mouse. The stolen mouse is returned to c_n's fresh-kill pile, where it belongs.",
+            "While they'd hardly expected to need their skills on a hunting patrol, s_c is able to set up an excellent battle plan. It's only halfway through ambushing the beast that the patrol realises its a maned wolf, which makes their job inifinitely easier, as they drive away the timid predator from c_n territory with enough time left over to bring a mouse or two back for the fresh-kill pile before sundown."
         ],
         "fail_text": [
-                "Looking out over their full six cat patrol, p_l decides it's worth it. The cats fall into battle, decending onto the maned wolf and battering it, using teamwork to pull at its long legs and fox tail, as the wolf turns in skipping circles, yelping. It flees before them, leaving the triumphant cats with... a fruit? All that effort for a sodding useless fruit?!",
-                "With a full patrol, it's possible to take on something the size of a maned wolf, especially when it has the bravery of a deer fawn - but not when s_c attacks with so little forethought, not when the rest of the patrol has to come save their tail. They retreat, as the inceased maned wolf snarls and the rest of the patrol tries not to do the same at s_c.",
-                null,
-                "Looking out over their full six cat patrol, p_l decides it's worth it. The cats fall into battle, decending onto the maned wolf and battering it, but a kick from a flailing long leg sends cats flying, and the wolf manages to whirl to sink its teeth into r_c.",
-                null,
-                "With a full patrol, it's possible to take on something the size of a maned wolf, especially when it has the bravery of a deer fawn - but not when s_c attacks with so little forethought, not when the rest of the patrol has to come save their tail. s_c gets grabbed by those dangerous jaws, and while the patrol is able to mob the wolf until it lets them go, its a serious wound."
+            "Looking out over their full six cat patrol, p_l decides it's worth it. The cats fall into battle, decending onto the maned wolf and battering it, using teamwork to pull at its long legs and fox tail, as the wolf turns in skipping circles, yelping. It flees before them, leaving the triumphant cats with... a fruit? All that effort for a sodding useless fruit?!",
+            "With a full patrol, it's possible to take on something the size of a maned wolf, especially when it has the bravery of a deer fawn - but not when s_c attacks with so little forethought, not when the rest of the patrol has to come save their tail. They retreat, as the inceased maned wolf snarls and the rest of the patrol tries not to do the same at s_c.",
+            null,
+            "Looking out over their full six cat patrol, p_l decides it's worth it. The cats fall into battle, decending onto the maned wolf and battering it, but a kick from a flailing long leg sends cats flying, and the wolf manages to whirl to sink its teeth into r_c.",
+            null,
+            "With a full patrol, it's possible to take on something the size of a maned wolf, especially when it has the bravery of a deer fawn - but not when s_c attacks with so little forethought, not when the rest of the patrol has to come save their tail. s_c gets grabbed by those dangerous jaws, and while the patrol is able to mob the wolf until it lets them go, its a serious wound."
         ],
-        "win_skills": ["smart", "very smart", "extremely smart", "good fighter", "great fighter", "excellent fighter"],
-        "win_trait": ["None"],
-        "fail_skills": ["None"],
-        "fail_trait": ["adventurous", "bold", "confident", "daring", "playful", "ambitious", "fierce", "shameless"],
+        "win_skills": [
+            "smart",
+            "very smart",
+            "extremely smart",
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "None"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "adventurous",
+            "bold",
+            "confident",
+            "daring",
+            "playful",
+            "ambitious",
+            "fierce",
+            "shameless"
+        ],
         "min_cats": 6,
         "max_cats": 6,
         "antagonize_text": null,
         "antagonize_fail_text": null,
         "history_text": [
-                "r_c was scarred by a maned wolf, fighting over food."
+            "r_c was scarred by a maned wolf, fighting over food."
         ]
-}
+    }
 ]

--- a/resources/dicts/patrols/hunting/hunting_wetlands.json
+++ b/resources/dicts/patrols/hunting/hunting_wetlands.json
@@ -5,7 +5,7 @@
         "season": "Any",
         "tags": [
             "hunting",
-			"small_prey"
+            "small_prey"
         ],
         "intro_text": "Your patrol comes across a lizard.",
         "success_text": [
@@ -32,7 +32,7 @@
         "season": "Any",
         "tags": [
             "hunting",
-			"medium_prey"
+            "medium_prey"
         ],
         "intro_text": "The patrol approaches a Twoleg nest perched on the edge of a swamp, with smoke rising from it's corner.",
         "decline_text": "The patrol decides to hunt elsewhere.",
@@ -79,10 +79,11 @@
         "season": "Any",
         "tags": [
             "hunting",
-			"medium_prey0",
-			"medium_prey1",
-			"large_prey2",
-			"large_prey3"
+            "medium_prey0",
+            "medium_prey1",
+            "large_prey2",
+            "large_prey3",
+            "no_fail_prey"
         ],
         "intro_text": "The patrol looks around for something to disguise their scent while hunting.",
         "decline_text": "On second thought, maybe not.",
@@ -120,10 +121,11 @@
         "season": "Any",
         "tags": [
             "hunting",
-			"medium_prey0",
-			"medium_prey1",
-			"large_prey2",
-			"large_prey3"
+            "medium_prey0",
+            "medium_prey1",
+            "large_prey2",
+            "large_prey3",
+            "no_fail_prey"
         ],
         "intro_text": "r_c looks around for something to disguise their scent while hunting.",
         "decline_text": "On second thought, maybe not.",
@@ -164,10 +166,11 @@
             "apprentice",
             "injury",
             "scar",
-			"medium_prey0",
-			"medium_prey1",
-			"large_prey2",
-			"large_prey3"
+            "medium_prey0",
+            "medium_prey1",
+            "large_prey2",
+            "large_prey3",
+            "no_fail_prey"
         ],
         "intro_text": "r_c's mentor assesses them by sending them on a solo hunt.",
         "decline_text": "r_c asks their mentor to do the assessment some other time.",
@@ -226,10 +229,11 @@
         "season": "Any",
         "tags": [
             "hunting",
-			"medium_prey0",
-			"medium_prey1",
-			"large_prey2",
-			"large_prey3"
+            "medium_prey0",
+            "medium_prey1",
+            "large_prey2",
+            "large_prey3",
+            "no_fail_prey"
         ],
         "intro_text": "r_c heads out into the swamps alone, wanting to sink their teeth into some prey and have some time to themselves.",
         "decline_text": "r_c turns back to camp, deciding that a group hunt would be more effective.",
@@ -285,10 +289,11 @@
         "tags": [
             "hunting",
             "deputy",
-			"medium_prey0",
-			"medium_prey1",
-			"large_prey2",
-			"large_prey3"
+            "medium_prey0",
+            "medium_prey1",
+            "large_prey2",
+            "large_prey3",
+            "no_fail_prey"
         ],
         "intro_text": "r_c heads out into the swamps alone, wanting to sink their teeth into some prey and have some time to themselves.",
         "decline_text": "r_c turns back to camp, deciding that a group hunt would be more effective.",
@@ -344,10 +349,11 @@
         "tags": [
             "hunting",
             "leader",
-			"medium_prey0",
-			"medium_prey1",
-			"large_prey2",
-			"large_prey3"
+            "medium_prey0",
+            "medium_prey1",
+            "large_prey2",
+            "large_prey3",
+            "no_fail_prey"
         ],
         "intro_text": "r_c heads out into the swamps alone, wanting to sink their teeth into some prey and have some time to themselves.",
         "decline_text": "r_c turns back to camp, deciding that a group hunt would be more effective.",
@@ -528,7 +534,7 @@
             "hunting",
             "multi_gone",
             "medium_prey0",
-			"medium_prey1"
+            "medium_prey1"
         ],
         "intro_text": "Your patrol encounters a clearing of dry grassy ground where a lot of Twolegs linger.",
         "decline_text": "Your patrol decides to hunt elsewhere.",
@@ -652,8 +658,8 @@
             "hunting",
             "gone",
             "medium_prey0",
-			"medium_prey2",
-			"large_prey3"
+            "medium_prey2",
+            "large_prey3"
         ],
         "intro_text": "r_c decides to hunt out near the Twoleg dens.",
         "decline_text": "On second thought, they decide to reline their nest today instead.",
@@ -718,7 +724,7 @@
             "gone",
             "apprentice",
             "medium_prey0",
-			"large_prey3"
+            "large_prey3"
         ],
         "intro_text": "app1 decides to hunt out near the Twoleg dens.",
         "decline_text": "On second thought, they decide to reline their nest today instead.",
@@ -782,7 +788,7 @@
             "small_prey",
             "romantic",
             "platonic",
-			"medium_prey0"
+            "medium_prey0"
         ],
         "intro_text": "Boldly, eyes daring p_l to say no, r_c suggests hunting by the Twoleg dens.",
         "decline_text": "On second thought, they decide to reline their nests today instead.",
@@ -849,7 +855,7 @@
             "apprentice",
             "romantic",
             "platonic",
-			"medium_prey0"
+            "medium_prey0"
         ],
         "intro_text": "Boldly, eyes daring app1 to say no, app2 suggests hunting by the Twoleg dens. Where apprentices are definitely not allowed.",
         "decline_text": "On second thought, they decide to reline their nests today instead.",
@@ -1356,7 +1362,7 @@
             "romantic",
             "two_apprentices",
             "apprentice",
-			"small_prey"
+            "small_prey"
         ],
         "intro_text": "Something skitters across the leaf litter, catching the patrols eyes. A little salamander!",
         "decline_text": "Startled by the salamander, the patrol watches it scurry away.",
@@ -1401,9 +1407,10 @@
             "patrol_to_p_l",
             "patrol_to_r_c",
             "small_prey0",
-			"medium_prey1",
-			"medium_prey2",
-			"large_prey3"
+            "medium_prey1",
+            "medium_prey2",
+            "large_prey3",
+            "no_fail_prey"
         ],
         "intro_text": "It starts snowing soon after the patrol sets out, trying to bring back something nice for the fresh-kill pile.",
         "decline_text": "They decide to turn back and wait until the snow dies down.",
@@ -1453,9 +1460,9 @@
         "season": "leaf-bare",
         "tags": [
             "hunting",
-			"medium_prey0",
-			"medium_prey1",
-			"large_prey2"
+            "medium_prey0",
+            "medium_prey1",
+            "large_prey2"
         ],
         "intro_text": "It starts snowing soon after the patrol sets out, trying to bring back something nice for the fresh-kill pile.",
         "decline_text": "They decide to turn back and wait until the snow dies down.",
@@ -1560,10 +1567,10 @@
             "clan_to_patrol",
             "respect",
             "rel_patrol",
-			"medium_prey0",
-			"medium_prey1",
-			"large_prey2",
-			"large_prey3"
+            "medium_prey0",
+            "medium_prey1",
+            "large_prey2",
+            "large_prey3"
         ],
         "intro_text": "Your patrol catches the scent of a red fox. Tracking it, they find the animal feeding on a gigantic dead eel it's fished from the swamp, although whether the eel was dead before the fox found it is up for debate.",
         "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
@@ -1629,10 +1636,10 @@
             "clan_to_patrol",
             "respect",
             "rel_patrol",
-			"medium_prey0",
-			"medium_prey1",
-			"large_prey2",
-			"large_prey3"
+            "medium_prey0",
+            "medium_prey1",
+            "large_prey2",
+            "large_prey3"
         ],
         "intro_text": "Your patrol catches the scent of a red fox. Tracking it, they find the animal feeding on a gigantic dead eel it's fished from the swamp, although whether the eel was dead before the fox found it is up for debate.",
         "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
@@ -1696,10 +1703,10 @@
             "bite-wound",
             "clan_to_patrol",
             "respect",
-			"medium_prey0",
-			"medium_prey1",
-			"large_prey2",
-			"large_prey3"
+            "medium_prey0",
+            "medium_prey1",
+            "large_prey2",
+            "large_prey3"
         ],
         "intro_text": "r_c catches the scent of a red fox. Tracking it, they find the animal feeding on a gigantic dead eel it's fished from the swamp, although whether the eel was dead before the fox found it is up for debate.",
         "decline_text": "r_c decides not to quarrel with the fox and to find prey elsewhere.",
@@ -1751,818 +1758,1088 @@
             "r_c fell in a solo battle with a fox."
         ]
     },
-{
-    "patrol_id": "wtlnd_hunt_redfox_scavenge1",
-    "biome": "wetland",
-    "season": "Any",
-    "tags": ["hunting", "medium_prey", "fighting", "scar", "big_bite_injury", "clan_to_patrol", "respect", "rel_patrol"],
-    "intro_text": "Your patrol catches the scent of a red fox. Tracking it, they find the animal feeding on the body of a stork. Odd prey, but not out of the question for a red fox.",
-    "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
-    "chance_of_success": 50,
-    "exp": 20,
-    "success_text": [
-        "Your cats are smaller but they outnumber the fox, if only by a little, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full of food and unwilling to lose blood over it, is driven off from the kill.",
-        null,
-        "s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until it gives up and runs.",
-        "The patrol launches into battle, but with so few cats it's exhausting trying to keep the fox and its snapping jaws on the defensive. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. It's only one bite, but the fox has had enough and flees."
-    ],
-    "fail_text": [
-        "Your patrol fails to drive away the fox, which keeps possession of the food. However there were no injuries.",
-        null,
-        null,
-        "The patrol launches into battle, but r_c is caught with a nasty bite, and the cats give up on challenging for the food in favor of quickly helping r_c back to the medicine cat den.",
-        null,
-        "s_c means well, but they're overconfident in their attack and the fox manages to sink their teeth into them. The patrol is forced to retreat, forming a defensive ring around the hurt s_c."
-    ],
-    "win_skills": ["good fighter", "great fighter", "excellent fighter"],
-    "win_trait": ["adventurous", "altruistic", "ambitious", "confident", "daring", "fierce", "responsible", "righteous"],
-    "fail_skills": ["None"],
-    "fail_trait": ["troublesome", "vengeful", "bloodthirsty", "bold"],
-    "min_cats": 2,
-    "max_cats": 3,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c carries a scar from a fox fight.",
-        null
-    ]
-},
-{
-    "patrol_id": "wtlnd_hunt_redfox_scavenge2",
-    "biome": "wetland",
-    "season": "Any",
-    "tags":["hunting", "medium_prey", "fighting", "scar", "big_bite_injury", "clan_to_patrol", "respect", "rel_patrol"],
-    "intro_text": "Your patrol catches the scent of a red fox. Tracking it, they find the animal feeding on the body of a stork. Odd prey, but not out of the question for a red fox.",
-    "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
-    "chance_of_success": 80,
-    "exp": 20,
-    "success_text": [
-        "Your cats are smaller but heavily outnumber the fox, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full and unwilling to lose blood over it, is driven off from the kill.",
-        null,
-        "s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until s_c lands a crucial blow, snapping a tendon in one of the fox's hindlegs. The fox runs, but there's no way it'll live long with such a crippling injury.",
-        "The patrol launches into battle, keeping the fox on the defensive with teamwork. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. Holding on grimly, s_c's daring move gives the rest of the patrol the opportunity needed to bring the fox down for good."
-    ],
-    "fail_text":[
-        "Your patrol fails to drive away the fox, which keeps possession of the food. However with so many cats to protect each other, there were no injuries.",
-        null,
-        null,
-        "The patrol launches into battle, but r_c is caught with a nasty bite, and the cats give up on challenging for the food in favor of quickly helping r_c back to the medicine cat den.",
-        null,
-        "s_c means well, but they're overconfident in their attack and the fox manages to sink their teeth into them. The patrol is forced to retreat, forming a defensive ring around the hurt s_c."
-    ],
-    "win_skills": ["good fighter", "great fighter", "excellent fighter"],
-    "win_trait": ["adventurous", "altruistic", "ambitious", "confident", "daring", "fierce", "responsible", "righteous"],
-    "fail_skills": ["None"],
-    "fail_trait": ["troublesome", "vengeful", "bloodthirsty", "bold"],
-    "min_cats": 4,
-    "max_cats": 6,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c carries a scar from a fox fight."
-    ]
-},
-{
-    "patrol_id": "wtlnd_hunt_redfox_scavenge3",
-    "biome": "wetland",
-    "season": "Any",
-    "tags": ["hunting", "medium_prey", "fighting", "scar", "big_bite_injury", "clan_to_patrol", "respect"],
-    "intro_text": "r_c catches the scent of a red fox. Tracking it, they find the animal feeding on the body of a stork. Odd prey, but not out of the question for a red fox.",
-    "decline_text": "r_c decides not to quarrel with the fox and to find prey elsewhere.",
-    "chance_of_success": 30,
-    "exp": 30,
-    "success_text": [
-        "r_c is smaller, alone, and half its weight, but the fox has a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle. The fox, already stuffed full and unwilling to lose blood over it, leaves the kill with a grumble.",
-        null,
-        "s_c uses every trick in their talented fighting skillset to attack the fox with no one to watch their flank, until the perfect opportunity opens up and they pounce onto the fox's back, digging in their claws. It's a wild ride through the wetlands until the fox bucks them off, but it wins them the stork carcass.",
-        "In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. But then they're stuck, unwilling to let go and risk being bitten. They're dragged through the forest, over rocks and through bushes, until the fox finally collapses and the battered s_c goes back to proudly claim the stork."
-    ],
-    "fail_text": [
-        "Your patrol fails to drive away the fox, which keeps possession of the food. However there were no injuries.",
-        null,
-        "Fiercely, r_c throws themselves at the fox, determined to win the stork prize. But the fox values it just as dearly, and manages to get a good grip on r_c, shaking them to pieces and killing them.",
-        "r_c launches into battle, but is caught with a nasty bite, and retreats to limp back home. The fox doesn't follow, happy enough to eat the stork instead of the foolish cat.",
-        null,
-        "s_c is overconfident in their attack and the fox manages to sink their teeth into them. They retreat, bleeding and in pain, and the fox settles back down to its meal."
-    ],
-    "win_skills": ["great fighter", "excellent fighter"],
-    "win_trait": ["adventurous", "altruistic", "ambitious", "confident", "daring", "fierce", "responsible", "righteous"],
-    "fail_skills": ["None"],
-    "fail_trait": ["troublesome", "vengeful", "bloodthirsty", "bold"],
-    "min_cats": 1,
-    "max_cats": 1,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c carries a scar from a solo fox fight.",
-        "r_c fell in a solo battle with a fox.",
-        "died fighting a fox"
-    ]
-},
-{
-    "patrol_id": "wtlnd_hunt_foxgray_scavenge1",
-    "biome": "wetland",
-    "season": "Any",
-    "tags": ["hunting", "medium_prey", "fighting", "scar", "injury", "bite-wound", "clan_to_patrol", "respect", "rel_patrol"],
-    "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? Tracking it, they find a stocky gray fox feeding on an unidentifiable but deliciously stinky small mound of carrion fished up from the swamp.",
-    "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
-    "chance_of_success": 70,
-    "exp": 20,
-    "success_text": [
-        "While a gray fox is bigger and far stockier than the cats, the delicious stench of whatever it is makes the cats' eyes go wide and silly, and they leap to claim possession of it. Outnumbered and already full of stinky nonsense, the gray fox leaves, scrambling up a tree as the cats give in to instinct and roll around in the glorious smell.",
-        "A gray fox is bigger than them, yes... but only just, and that carcass smells divine. The cats creep up on the fox, using the thick swamp brush for cover, and wait until the fox has its head buried in the carcass to attack. The ambush sends the competing predator fleeing, and leaves the cats to claim the heavenly stinky food.",
-        "s_c shows their strength, leading the fight against the gray fox. By working together and keeping it distracted, the cats harry and harass the fox until it gives up and runs.",
-        "The patrol launches into battle, but with so few cats it's exhausting trying to keep the fox and its snapping jaws on the defensive. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. It's only one bite, but the fox has had enough and flees."
-    ],
-    "fail_text": [
-        "Your patrol fails to drive away the fox, which keeps possession of the food. However there were no injuries.",
-        "s_c makes a stupid mistake, too intent on winning the fight to respect their enemy's teeth, and it's only being yanked back by the tail that saves them from injury. The patrol gives up, and settles down to wait a safe distance away until the fox leaves of its own accord.",
-        null,
-        null,
-        null,
-        "s_c means well, but they're overconfident in their attack and the fox manages to sink their teeth into them. The patrol is forced to retreat, forming a defensive ring around the hurt s_c."
-    ],
-    "win_skills": ["good fighter", "great fighter", "excellent fighter"],
-    "win_trait": ["adventurous", "altruistic", "ambitious", "confident", "daring", "fierce", "responsible", "righteous"],
-    "fail_skills": ["None"],
-    "fail_trait": ["troublesome", "vengeful", "bloodthirsty", "bold"],
-    "min_cats": 2,
-    "max_cats": 3,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c carries a scar from a gray fox fight.",
-        null
-    ]
-},
-{
-    "patrol_id": "wtlnd_hunt_foxgray_scavenge2",
-    "biome": "wetland",
-    "season": "Any",
-    "tags": ["hunting", "medium_prey", "fighting", "clan_to_patrol", "respect", "rel_patrol"],
-    "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? Tracking it, they find a stocky gray fox feeding on an unidentifiable but deliciously stinky small mound of carrion fished up from the swamp.",
-    "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
-    "chance_of_success": 90,
-    "exp": 20,
-    "success_text": [
-        "While a gray fox is bigger and far stockier than the cats, the delicious stench of whatever it is makes the cats' eyes go wide and silly, and they leap to claim possession of it. Heavily outnumbered and already full of stinky nonsense, the gray fox leaves, scrambling up a tree as the cats give in to instinct and roll around in the glorious smell.",
-        "A gray fox is bigger than them, yes... but only just, and that carcass smells divine. The cats creep up on the fox, using the thick swamp brush for cover, and wait until the fox has its head buried in the carcass to attack. The ambush sends the competing predator fleeing, and leaves the cats to claim the heavenly stinky food.",
-        "s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until s_c lands a crucial blow, snapping a tendon in one of the fox's hindlegs. The fox runs, but there's no way it'll live long with such a crippling injury.",
-        "The patrol launches into battle, keeping the fox on the defensive with teamwork. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. Holding on grimly, s_c's daring move gives the rest of the patrol the opportunity needed to bring the fox down for good."
-    ],
-    "fail_text": [
-        "Your patrol fails to drive away the fox, which keeps possession of the food. However with so many cats to protect each other, there were no injuries.",
-        "s_c makes a stupid mistake, too intent on winning the fight to respect their enemy's teeth, and it's only being yanked back by the tail that saves them from injury. The patrol gives up, and settles down to wait a safe distance away until the fox leaves of its own accord."
-    ],
-    "win_skills": ["good fighter", "great fighter", "excellent fighter"],
-    "win_trait": ["adventurous", "altruistic", "ambitious", "confident", "daring", "fierce", "responsible", "righteous"],
-    "fail_skills": ["None"],
-    "fail_trait": ["troublesome", "vengeful", "bloodthirsty", "bold"],
-    "min_cats": 4,
-    "max_cats": 6,
-    "antagonize_text": null,
-    "antagonize_fail_text": null
-},
-{
-    "patrol_id": "wtlnd_hunt_foxgray_scavenge3",
-    "biome": "wetland",
-    "season": "Any",
-    "tags": ["hunting", "medium_prey", "fighting", "scar", "injury", "bite-wound", "clan_to_patrol", "respect"],
-    "intro_text": "r_c catches the scent of a fox - but is it red, or gray? Tracking it, they find a stocky gray fox feeding on an unidentifiable but deliciously stinky small mound of carrion fished up from the swamp.",
-    "decline_text": "r_c decides not to quarrel with the fox and to find prey elsewhere.",
-    "chance_of_success": 50,
-    "exp": 30,
-    "success_text": [
-        "While a gray fox is bigger and far stockier than r_c, the delicious stench of whatever it is makes their eyes go wide and silly, and they leap to claim some of it for themselves and c_n. It's only a little lump, but the fox is apparently not too keen to face a fight over it, and gives up with a prefunctory snarl.",
-        "A gray fox is bigger than them, yes... but only just, and that carcass smells divine. r_c creeps up on the fox, using the thick swamp brush for cover, and waits until the fox has its head buried in the carcass to attack. The ambush sends the competing predator fleeing, and leaves r_c to claim the heavenly stinky food.",
-        "s_c uses every trick in their talented fighting skillset to attack the fox with no one to watch their flank, until the perfect opportunity opens up and they pounce onto the fox's back, digging in their claws. It's enough to convince the gray to back off, and s_c claims a seat at the carcass.",
-        "In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. But then they're stuck, unwilling to let go and risk being bitten. They're dragged through the swamp, muck casing their pelt, until the fox finally throws them off and the battered s_c goes back to proudly claim the carcass."
-    ],
-    "fail_text": [
-        "Your patrol fails to drive away the gray fox, which keeps possession of the food. However there were no injuries.",
-        "s_c makes a stupid mistake, too intent on winning the fight to respect their enemy's teeth, and it's tripping over their own feet that saves them. They give up, and settle down to wait a safe distance away until the fox leaves of its own accord.",
-        null,
-        "r_c launches into battle, but is caught with a nasty bite, and retreats to limp back home. The gray fox doesn't follow, happy enough to eat the carcass instead of the foolish cat.",
-        null,
-        "s_c is overconfident in their attack and the fox manages to sink their teeth into them. They retreat, bleeding and in pain, and the gray fox settles back down to its meal."
-    ],
-    "win_skills": ["great fighter", "excellent fighter"],
-    "win_trait": ["adventurous", "altruistic", "ambitious", "confident", "daring", "fierce", "responsible", "righteous"],
-    "fail_skills": ["None"],
-    "fail_trait": ["troublesome", "vengeful", "bloodthirsty", "bold"],
-    "min_cats": 1,
-    "max_cats": 1,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c carries a scar from a solo fight with a gray fox.",
-        null
-    ]
-},
-{
-        "patrol_id": "wtlnd_hunt_redvixen1",
+    {
+        "patrol_id": "wtlnd_hunt_redfox_scavenge1",
         "biome": "wetland",
-        "season": "newleaf",
-        "tags": ["fighting", "death", "scar", "big_bite_injury", "respect", "trust",  "clan_to_r_c", "patrol_to_r_c", "clan_to_patrol"],
-        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
-        "decline_text": "Your patrol decides not to pursue the fox.",
-        "chance_of_success": 30,
-        "exp": 30,
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "medium_prey",
+            "fighting",
+            "scar",
+            "big_bite_injury",
+            "clan_to_patrol",
+            "respect",
+            "rel_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a red fox. Tracking it, they find the animal feeding on the body of a stork. Odd prey, but not out of the question for a red fox.",
+        "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 50,
+        "exp": 20,
         "success_text": [
-        "The red vixen smells of milk, and hopefully by driving her out of the territory, her litter this Newleaf won't be a threat to the Clan. If they don't starve, c_n will hunt them down - they do not share territory with foxes.",
-        "Your patrol drives away the red fox, seeks out her den, and kills her young cubs. It's brutal, but these fluffy baby foxes would one day have grown to be kit-killers and thieves.",
-        "s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the red fox nor her cubs pose a threat to the Clan. It truly proves s_c's place as one of c_n's most talented and skillful fighters.",
-        "The patrol overcomes the red vixen and drives her off thanks to a brilliant battle move by s_c at a critical moment. Their bravery ensures the patrol's success, and the cats arrive back at camp singing their praises to make sure the Clan knows it."
+            "Your cats are smaller but they outnumber the fox, if only by a little, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full of food and unwilling to lose blood over it, is driven off from the kill.",
+            null,
+            "s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until it gives up and runs.",
+            "The patrol launches into battle, but with so few cats it's exhausting trying to keep the fox and its snapping jaws on the defensive. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. It's only one bite, but the fox has had enough and flees."
         ],
         "fail_text": [
-        "The mother red fox is vicious and determined, and the small patrol is beaten back. But these swampy woodlands are c_n's and they haven't given up. They may have lost this battle, but c_n will win this war.",
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the rest of the patrol have to rescue them from the red vixen.",
-        "Never threaten a mother's young - the red vixen kills r_c in the skirmish.",
-        "The mother red fox's snapping jaws leave r_c dripping blood into the mud, forcing the patrol to back off.",
-        null,
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the red vixen manages to sink her teeth into them. The patrol rallies around s_c, but they have to give up on the fight.",
-        "As their hunt descends into a full on battle with the red vixen, p_l takes a blow meant for one of their Clanmates, losing a life."
+            "Your patrol fails to drive away the fox, which keeps possession of the food. However there were no injuries.",
+            null,
+            null,
+            "The patrol launches into battle, but r_c is caught with a nasty bite, and the cats give up on challenging for the food in favor of quickly helping r_c back to the medicine cat den.",
+            null,
+            "s_c means well, but they're overconfident in their attack and the fox manages to sink their teeth into them. The patrol is forced to retreat, forming a defensive ring around the hurt s_c."
         ],
-        "win_skills": ["excellent fighter"],
-        "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-    "fail_skills": ["good fighter"],
-    "fail_trait": ["None"],
+        "win_skills": [
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "troublesome",
+            "vengeful",
+            "bloodthirsty",
+            "bold"
+        ],
         "min_cats": 2,
         "max_cats": 3,
         "antagonize_text": null,
         "antagonize_fail_text": null,
         "history_text": [
-        "r_c carries a scar from a fight with a red vixen.",
-        "r_c fell in battle with a red fox.",
-        "died while fighting a red vixen"
+            "r_c carries a scar from a fox fight.",
+            null
         ]
-},
-{
-        "patrol_id": "wtlnd_hunt_redvixen2",
+    },
+    {
+        "patrol_id": "wtlnd_hunt_redfox_scavenge2",
         "biome": "wetland",
-        "season": "newleaf",
-        "tags": ["fighting", "scar", "big_bite_injury", "respect", "trust",  "clan_to_r_c", "patrol_to_r_c", "clan_to_patrol"],
-        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
-        "decline_text": "Your patrol decides not to pursue the fox.",
-        "chance_of_success": 60,
-        "exp": 30,
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "medium_prey",
+            "fighting",
+            "scar",
+            "big_bite_injury",
+            "clan_to_patrol",
+            "respect",
+            "rel_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a red fox. Tracking it, they find the animal feeding on the body of a stork. Odd prey, but not out of the question for a red fox.",
+        "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 80,
+        "exp": 20,
         "success_text": [
-        "Led by p_l, and with a heap of cooperation and teamwork, the patrol drives away the red fox, seeks out her den, and kills her young cubs. The swamps will be safe from both the threat the vixen posed this season, and the threat her cubs would've given c_n in the seasons to come.",
-        "With so many cats working together in tight coordination, they manage to accomplish the near-impossible, killing the red mother vixen and ending the threat to the Clan that she and her cubs pose.",
-        "s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the red fox nor her dependent cubs pose a threat to the Clan. It truly proves s_c's place as one of c_n's most talented and skillful fighters.",
-        "The patrol overcomes the red vixen and drives her off thanks to a brilliant battle move by s_c at a critical moment. Their bravery ensures the patrol's success, and the cats arrive back at camp singing their praises to make sure the Clan knows it."
+            "Your cats are smaller but heavily outnumber the fox, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full and unwilling to lose blood over it, is driven off from the kill.",
+            null,
+            "s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until s_c lands a crucial blow, snapping a tendon in one of the fox's hindlegs. The fox runs, but there's no way it'll live long with such a crippling injury.",
+            "The patrol launches into battle, keeping the fox on the defensive with teamwork. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. Holding on grimly, s_c's daring move gives the rest of the patrol the opportunity needed to bring the fox down for good."
         ],
         "fail_text": [
-        "The mother red fox is vicious and determined. Although they lose this battle, through teamwork the cats manage to retreat without injury.",
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the rest of the patrol have to rescue them from the red vixen.",
-        null,
-        "r_c is left wounded as the patrol and the red mother vixen fight to a stalemate. Hopefully they've given the fox mother a reason not to return to this part of the swamp.",
-        null,
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the red vixen manages to sink her teeth into them. The patrol rallies around s_c, but they have to give up on the fight."
+            "Your patrol fails to drive away the fox, which keeps possession of the food. However with so many cats to protect each other, there were no injuries.",
+            null,
+            null,
+            "The patrol launches into battle, but r_c is caught with a nasty bite, and the cats give up on challenging for the food in favor of quickly helping r_c back to the medicine cat den.",
+            null,
+            "s_c means well, but they're overconfident in their attack and the fox manages to sink their teeth into them. The patrol is forced to retreat, forming a defensive ring around the hurt s_c."
         ],
-        "win_skills": ["excellent fighter"],
-        "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-        "fail_skills": ["good fighter"],
-        "fail_trait": ["None"],
+        "win_skills": [
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "troublesome",
+            "vengeful",
+            "bloodthirsty",
+            "bold"
+        ],
         "min_cats": 4,
         "max_cats": 6,
         "antagonize_text": null,
         "antagonize_fail_text": null,
         "history_text": [
-        "r_c carries a scar from a fight with a red vixen."
+            "r_c carries a scar from a fox fight."
         ]
-},
-{
-        "patrol_id": "wtlnd_hunt_redvixen3",
+    },
+    {
+        "patrol_id": "wtlnd_hunt_redfox_scavenge3",
         "biome": "wetland",
-        "season": "newleaf",
-        "tags": ["fighting", "death", "scar", "big_bite_injury", "shock", "injury", "respect", "trust", "clan_to_patrol", "no_body"],
-        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
-        "decline_text": "Your patrol decides not to pursue the fox.",
-        "chance_of_success": 20,
-        "exp": 50,
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "medium_prey",
+            "fighting",
+            "scar",
+            "big_bite_injury",
+            "clan_to_patrol",
+            "respect"
+        ],
+        "intro_text": "r_c catches the scent of a red fox. Tracking it, they find the animal feeding on the body of a stork. Odd prey, but not out of the question for a red fox.",
+        "decline_text": "r_c decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 30,
+        "exp": 30,
         "success_text": [
-        "The red vixen smells of milk, and hopefully by driving her out of the territory, her litter this Newleaf won't be a threat to the Clan. If they don't starve, c_n will hunt them down - they do not share territory with foxes.",
-        null,
-        "s_c displays incredible skill, driving the mother vixen and her brood out of c_n's swamps all by themselves. Now neither the red fox nor her dependent cubs pose a threat to the Clan. They swell with pride, feeling the confidence of knowing that they're truly one of the best fighters c_n has ever produced.",
-        "A brilliant battle move by s_c knocks the red vixen off balance, and s_c manages to drive her out of c_n territory, though it takes every spark of strength in their pelt to do it alone."
+            "r_c is smaller, alone, and half its weight, but the fox has a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle. The fox, already stuffed full and unwilling to lose blood over it, leaves the kill with a grumble.",
+            null,
+            "s_c uses every trick in their talented fighting skillset to attack the fox with no one to watch their flank, until the perfect opportunity opens up and they pounce onto the fox's back, digging in their claws. It's a wild ride through the wetlands until the fox bucks them off, but it wins them the stork carcass.",
+            "In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. But then they're stuck, unwilling to let go and risk being bitten. They're dragged through the forest, over rocks and through bushes, until the fox finally collapses and the battered s_c goes back to proudly claim the stork."
         ],
         "fail_text": [
-        null,
-        null,
-        "Never threaten a mother's young - the red vixen kills r_c in the skirmish, and carries off the body to feed her litter.",
-        "The mother red fox's snapping jaws leave r_c dripping blood into the mud, and barely able to escape further injury.",
-        null,
-        "s_c is determined to win, but the red vixen is determined to live, and that makes all the difference. s_c ends up pinned in a defensible hiding spot, bleeding and terrified, until the vixen judges them no longer a threat and continues on her way."
+            "Your patrol fails to drive away the fox, which keeps possession of the food. However there were no injuries.",
+            null,
+            "Fiercely, r_c throws themselves at the fox, determined to win the stork prize. But the fox values it just as dearly, and manages to get a good grip on r_c, shaking them to pieces and killing them.",
+            "r_c launches into battle, but is caught with a nasty bite, and retreats to limp back home. The fox doesn't follow, happy enough to eat the stork instead of the foolish cat.",
+            null,
+            "s_c is overconfident in their attack and the fox manages to sink their teeth into them. They retreat, bleeding and in pain, and the fox settles back down to its meal."
         ],
-        "win_skills": ["excellent fighter"],
-        "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-        "fail_skills": ["good fighter"],
-        "fail_trait": ["None"],
+        "win_skills": [
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "troublesome",
+            "vengeful",
+            "bloodthirsty",
+            "bold"
+        ],
         "min_cats": 1,
         "max_cats": 1,
         "antagonize_text": null,
         "antagonize_fail_text": null,
         "history_text": [
-        "r_c carries a scar from a solo fight with a red vixen.",
-        "r_c fell in a solo battle with a vixen.",
-        "died while fighting a red vixen"
+            "r_c carries a scar from a solo fox fight.",
+            "r_c fell in a solo battle with a fox.",
+            "died fighting a fox"
         ]
-},
-{
-        "patrol_id": "wtlnd_hunt_redvixen4",
+    },
+    {
+        "patrol_id": "wtlnd_hunt_foxgray_scavenge1",
         "biome": "wetland",
-        "season": "greenleaf",
-        "tags": ["fighting", "death", "scar", "big_bite_injury", "respect", "trust",  "clan_to_r_c", "patrol_to_r_c", "clan_to_patrol"],
-        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
-        "decline_text": "Your patrol decides not to pursue the fox.",
-        "chance_of_success": 30,
-        "exp": 30,
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "medium_prey",
+            "fighting",
+            "scar",
+            "injury",
+            "bite-wound",
+            "clan_to_patrol",
+            "respect",
+            "rel_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? Tracking it, they find a stocky gray fox feeding on an unidentifiable but deliciously stinky small mound of carrion fished up from the swamp.",
+        "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 70,
+        "exp": 20,
         "success_text": [
-        "The red vixen smells of milk and blood. Hopefully by driving her out of the territory, the litter she has been raising this greenleaf won't be a threat to the Clan. If they don't starve, c_n will hunt them down - they do not share with foxes.",
-        "Your patrol drives away the red fox, seeks out her den, and kills her cubs. It's brutal, but these fluffy small foxes would one day have grown to be kit-killers and thieves.",
-        "s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the red fox nor her dependent cubs pose a threat to the Clan. It truly proves s_c's place as one of c_n's most talented and skillful fighters.",
-        "The patrol overcomes the red vixen and drives her off thanks to a brilliant battle move by s_c at a critical moment. Their bravery ensures the patrol's success, and the cats arrive back at camp singing their praises to make sure the Clan knows it."
+            "While a gray fox is bigger and far stockier than the cats, the delicious stench of whatever it is makes the cats' eyes go wide and silly, and they leap to claim possession of it. Outnumbered and already full of stinky nonsense, the gray fox leaves, scrambling up a tree as the cats give in to instinct and roll around in the glorious smell.",
+            "A gray fox is bigger than them, yes... but only just, and that carcass smells divine. The cats creep up on the fox, using the thick swamp brush for cover, and wait until the fox has its head buried in the carcass to attack. The ambush sends the competing predator fleeing, and leaves the cats to claim the heavenly stinky food.",
+            "s_c shows their strength, leading the fight against the gray fox. By working together and keeping it distracted, the cats harry and harass the fox until it gives up and runs.",
+            "The patrol launches into battle, but with so few cats it's exhausting trying to keep the fox and its snapping jaws on the defensive. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. It's only one bite, but the fox has had enough and flees."
         ],
         "fail_text": [
-        "The mother red fox is vicious and determined, and the small patrol is beaten back. But this wetland is c_n's and they haven't given up. They may have lost this battle, but c_n will win this war.",
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the rest of the patrol have to rescue them from the red vixen.",
-        "Never threaten a mother's young - the red vixen kills r_c in the skirmish.",
-        "The mother red fox's snapping jaws leave r_c dripping blood into the mud, forcing the patrol to back off.",
-        null,
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the red vixen manages to sink her teeth into them. The patrol rallies around s_c, but they have to give up on the fight.",
-        "As their hunt descends into a full on battle with the red vixen, p_l takes a blow meant for one of their Clanmates, losing a life."
+            "Your patrol fails to drive away the fox, which keeps possession of the food. However there were no injuries.",
+            "s_c makes a stupid mistake, too intent on winning the fight to respect their enemy's teeth, and it's only being yanked back by the tail that saves them from injury. The patrol gives up, and settles down to wait a safe distance away until the fox leaves of its own accord.",
+            null,
+            null,
+            null,
+            "s_c means well, but they're overconfident in their attack and the fox manages to sink their teeth into them. The patrol is forced to retreat, forming a defensive ring around the hurt s_c."
         ],
-        "win_skills": ["excellent fighter"],
-        "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-        "fail_skills": ["good fighter"],
-        "fail_trait": ["None"],
+        "win_skills": [
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "troublesome",
+            "vengeful",
+            "bloodthirsty",
+            "bold"
+        ],
         "min_cats": 2,
         "max_cats": 3,
         "antagonize_text": null,
         "antagonize_fail_text": null,
         "history_text": [
-        "r_c carries a scar from a fight with a red vixen.",
-        "r_c fell in battle with a red fox.",
-        "died while fighting a red vixen"
-        ]    
-},
-{
-        "patrol_id": "wtlnd_hunt_redvixen5",
+            "r_c carries a scar from a gray fox fight.",
+            null
+        ]
+    },
+    {
+        "patrol_id": "wtlnd_hunt_foxgray_scavenge2",
         "biome": "wetland",
-        "season": "greenleaf",
-        "tags": ["fighting", "scar", "big_bite_injury", "respect", "trust",  "clan_to_r_c", "patrol_to_r_c", "clan_to_patrol"],
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "medium_prey",
+            "fighting",
+            "clan_to_patrol",
+            "respect",
+            "rel_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? Tracking it, they find a stocky gray fox feeding on an unidentifiable but deliciously stinky small mound of carrion fished up from the swamp.",
+        "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 90,
+        "exp": 20,
+        "success_text": [
+            "While a gray fox is bigger and far stockier than the cats, the delicious stench of whatever it is makes the cats' eyes go wide and silly, and they leap to claim possession of it. Heavily outnumbered and already full of stinky nonsense, the gray fox leaves, scrambling up a tree as the cats give in to instinct and roll around in the glorious smell.",
+            "A gray fox is bigger than them, yes... but only just, and that carcass smells divine. The cats creep up on the fox, using the thick swamp brush for cover, and wait until the fox has its head buried in the carcass to attack. The ambush sends the competing predator fleeing, and leaves the cats to claim the heavenly stinky food.",
+            "s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until s_c lands a crucial blow, snapping a tendon in one of the fox's hindlegs. The fox runs, but there's no way it'll live long with such a crippling injury.",
+            "The patrol launches into battle, keeping the fox on the defensive with teamwork. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. Holding on grimly, s_c's daring move gives the rest of the patrol the opportunity needed to bring the fox down for good."
+        ],
+        "fail_text": [
+            "Your patrol fails to drive away the fox, which keeps possession of the food. However with so many cats to protect each other, there were no injuries.",
+            "s_c makes a stupid mistake, too intent on winning the fight to respect their enemy's teeth, and it's only being yanked back by the tail that saves them from injury. The patrol gives up, and settles down to wait a safe distance away until the fox leaves of its own accord."
+        ],
+        "win_skills": [
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "troublesome",
+            "vengeful",
+            "bloodthirsty",
+            "bold"
+        ],
+        "min_cats": 4,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null
+    },
+    {
+        "patrol_id": "wtlnd_hunt_foxgray_scavenge3",
+        "biome": "wetland",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "medium_prey",
+            "fighting",
+            "scar",
+            "injury",
+            "bite-wound",
+            "clan_to_patrol",
+            "respect"
+        ],
+        "intro_text": "r_c catches the scent of a fox - but is it red, or gray? Tracking it, they find a stocky gray fox feeding on an unidentifiable but deliciously stinky small mound of carrion fished up from the swamp.",
+        "decline_text": "r_c decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 50,
+        "exp": 30,
+        "success_text": [
+            "While a gray fox is bigger and far stockier than r_c, the delicious stench of whatever it is makes their eyes go wide and silly, and they leap to claim some of it for themselves and c_n. It's only a little lump, but the fox is apparently not too keen to face a fight over it, and gives up with a prefunctory snarl.",
+            "A gray fox is bigger than them, yes... but only just, and that carcass smells divine. r_c creeps up on the fox, using the thick swamp brush for cover, and waits until the fox has its head buried in the carcass to attack. The ambush sends the competing predator fleeing, and leaves r_c to claim the heavenly stinky food.",
+            "s_c uses every trick in their talented fighting skillset to attack the fox with no one to watch their flank, until the perfect opportunity opens up and they pounce onto the fox's back, digging in their claws. It's enough to convince the gray to back off, and s_c claims a seat at the carcass.",
+            "In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. But then they're stuck, unwilling to let go and risk being bitten. They're dragged through the swamp, muck casing their pelt, until the fox finally throws them off and the battered s_c goes back to proudly claim the carcass."
+        ],
+        "fail_text": [
+            "Your patrol fails to drive away the gray fox, which keeps possession of the food. However there were no injuries.",
+            "s_c makes a stupid mistake, too intent on winning the fight to respect their enemy's teeth, and it's tripping over their own feet that saves them. They give up, and settle down to wait a safe distance away until the fox leaves of its own accord.",
+            null,
+            "r_c launches into battle, but is caught with a nasty bite, and retreats to limp back home. The gray fox doesn't follow, happy enough to eat the carcass instead of the foolish cat.",
+            null,
+            "s_c is overconfident in their attack and the fox manages to sink their teeth into them. They retreat, bleeding and in pain, and the gray fox settles back down to its meal."
+        ],
+        "win_skills": [
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "troublesome",
+            "vengeful",
+            "bloodthirsty",
+            "bold"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a solo fight with a gray fox.",
+            null
+        ]
+    },
+    {
+        "patrol_id": "wtlnd_hunt_redvixen1",
+        "biome": "wetland",
+        "season": "newleaf",
+        "tags": [
+            "fighting",
+            "death",
+            "scar",
+            "big_bite_injury",
+            "respect",
+            "trust",
+            "clan_to_r_c",
+            "patrol_to_r_c",
+            "clan_to_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
+        "decline_text": "Your patrol decides not to pursue the fox.",
+        "chance_of_success": 30,
+        "exp": 30,
+        "success_text": [
+            "The red vixen smells of milk, and hopefully by driving her out of the territory, her litter this Newleaf won't be a threat to the Clan. If they don't starve, c_n will hunt them down - they do not share territory with foxes.",
+            "Your patrol drives away the red fox, seeks out her den, and kills her young cubs. It's brutal, but these fluffy baby foxes would one day have grown to be kit-killers and thieves.",
+            "s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the red fox nor her cubs pose a threat to the Clan. It truly proves s_c's place as one of c_n's most talented and skillful fighters.",
+            "The patrol overcomes the red vixen and drives her off thanks to a brilliant battle move by s_c at a critical moment. Their bravery ensures the patrol's success, and the cats arrive back at camp singing their praises to make sure the Clan knows it."
+        ],
+        "fail_text": [
+            "The mother red fox is vicious and determined, and the small patrol is beaten back. But these swampy woodlands are c_n's and they haven't given up. They may have lost this battle, but c_n will win this war.",
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the rest of the patrol have to rescue them from the red vixen.",
+            "Never threaten a mother's young - the red vixen kills r_c in the skirmish.",
+            "The mother red fox's snapping jaws leave r_c dripping blood into the mud, forcing the patrol to back off.",
+            null,
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the red vixen manages to sink her teeth into them. The patrol rallies around s_c, but they have to give up on the fight.",
+            "As their hunt descends into a full on battle with the red vixen, p_l takes a blow meant for one of their Clanmates, losing a life."
+        ],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 2,
+        "max_cats": 3,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a fight with a red vixen.",
+            "r_c fell in battle with a red fox.",
+            "died while fighting a red vixen"
+        ]
+    },
+    {
+        "patrol_id": "wtlnd_hunt_redvixen2",
+        "biome": "wetland",
+        "season": "newleaf",
+        "tags": [
+            "fighting",
+            "scar",
+            "big_bite_injury",
+            "respect",
+            "trust",
+            "clan_to_r_c",
+            "patrol_to_r_c",
+            "clan_to_patrol"
+        ],
         "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
         "decline_text": "Your patrol decides not to pursue the fox.",
         "chance_of_success": 60,
         "exp": 30,
         "success_text": [
-        "Led by p_l, and with a heap of cooperation and teamwork, the patrol drives away the red fox, seeks out her den, and kills her growing cubs. The swamps will be safe from both the threat the vixen posed this season, and the threat her cubs would've given c_n in the seasons to come.",
-        "With so many cats working together in tight coordination, they manage to accomplish the near-impossible, killing the red mother vixen and ending the threat to the Clan that she and her cubs pose.",
-        "s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the red fox nor her dependent cubs pose a threat to the Clan. It truly proves s_c's place as one of c_n's most talented and skillful fighters.",
-        "The patrol overcomes the red vixen and drives her off thanks to a brilliant battle move by s_c at a critical moment. Their bravery ensures the patrol's success, and the cats arrive back at camp singing their praises to make sure the Clan knows it."
+            "Led by p_l, and with a heap of cooperation and teamwork, the patrol drives away the red fox, seeks out her den, and kills her young cubs. The swamps will be safe from both the threat the vixen posed this season, and the threat her cubs would've given c_n in the seasons to come.",
+            "With so many cats working together in tight coordination, they manage to accomplish the near-impossible, killing the red mother vixen and ending the threat to the Clan that she and her cubs pose.",
+            "s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the red fox nor her dependent cubs pose a threat to the Clan. It truly proves s_c's place as one of c_n's most talented and skillful fighters.",
+            "The patrol overcomes the red vixen and drives her off thanks to a brilliant battle move by s_c at a critical moment. Their bravery ensures the patrol's success, and the cats arrive back at camp singing their praises to make sure the Clan knows it."
         ],
         "fail_text": [
-        "The mother red fox is vicious and determined. Although they lose this battle, through teamwork the cats manage to retreat without injury.",
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the rest of the patrol have to rescue them from the red vixen.",
-        null,
-        "r_c is left wounded as the patrol and the red mother vixen fight to a stalemate. Hopefully they've given the fox mother a reason not to return to this part of the swamp.",
-        null,
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the red vixen manages to sink her teeth into them. The patrol rallies around s_c, but they have to give up on the fight."
+            "The mother red fox is vicious and determined. Although they lose this battle, through teamwork the cats manage to retreat without injury.",
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the rest of the patrol have to rescue them from the red vixen.",
+            null,
+            "r_c is left wounded as the patrol and the red mother vixen fight to a stalemate. Hopefully they've given the fox mother a reason not to return to this part of the swamp.",
+            null,
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the red vixen manages to sink her teeth into them. The patrol rallies around s_c, but they have to give up on the fight."
         ],
-        "win_skills": ["excellent fighter"],
-        "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-        "fail_skills": ["good fighter"],
-        "fail_trait": ["None"],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
         "min_cats": 4,
         "max_cats": 6,
         "antagonize_text": null,
         "antagonize_fail_text": null,
         "history_text": [
-        "r_c carries a scar from a fight with a red vixen."
+            "r_c carries a scar from a fight with a red vixen."
         ]
-},
-{
+    },
+    {
+        "patrol_id": "wtlnd_hunt_redvixen3",
+        "biome": "wetland",
+        "season": "newleaf",
+        "tags": [
+            "fighting",
+            "death",
+            "scar",
+            "big_bite_injury",
+            "shock",
+            "injury",
+            "respect",
+            "trust",
+            "clan_to_patrol",
+            "no_body"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
+        "decline_text": "Your patrol decides not to pursue the fox.",
+        "chance_of_success": 20,
+        "exp": 50,
+        "success_text": [
+            "The red vixen smells of milk, and hopefully by driving her out of the territory, her litter this Newleaf won't be a threat to the Clan. If they don't starve, c_n will hunt them down - they do not share territory with foxes.",
+            null,
+            "s_c displays incredible skill, driving the mother vixen and her brood out of c_n's swamps all by themselves. Now neither the red fox nor her dependent cubs pose a threat to the Clan. They swell with pride, feeling the confidence of knowing that they're truly one of the best fighters c_n has ever produced.",
+            "A brilliant battle move by s_c knocks the red vixen off balance, and s_c manages to drive her out of c_n territory, though it takes every spark of strength in their pelt to do it alone."
+        ],
+        "fail_text": [
+            null,
+            null,
+            "Never threaten a mother's young - the red vixen kills r_c in the skirmish, and carries off the body to feed her litter.",
+            "The mother red fox's snapping jaws leave r_c dripping blood into the mud, and barely able to escape further injury.",
+            null,
+            "s_c is determined to win, but the red vixen is determined to live, and that makes all the difference. s_c ends up pinned in a defensible hiding spot, bleeding and terrified, until the vixen judges them no longer a threat and continues on her way."
+        ],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a solo fight with a red vixen.",
+            "r_c fell in a solo battle with a vixen.",
+            "died while fighting a red vixen"
+        ]
+    },
+    {
+        "patrol_id": "wtlnd_hunt_redvixen4",
+        "biome": "wetland",
+        "season": "greenleaf",
+        "tags": [
+            "fighting",
+            "death",
+            "scar",
+            "big_bite_injury",
+            "respect",
+            "trust",
+            "clan_to_r_c",
+            "patrol_to_r_c",
+            "clan_to_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
+        "decline_text": "Your patrol decides not to pursue the fox.",
+        "chance_of_success": 30,
+        "exp": 30,
+        "success_text": [
+            "The red vixen smells of milk and blood. Hopefully by driving her out of the territory, the litter she has been raising this greenleaf won't be a threat to the Clan. If they don't starve, c_n will hunt them down - they do not share with foxes.",
+            "Your patrol drives away the red fox, seeks out her den, and kills her cubs. It's brutal, but these fluffy small foxes would one day have grown to be kit-killers and thieves.",
+            "s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the red fox nor her dependent cubs pose a threat to the Clan. It truly proves s_c's place as one of c_n's most talented and skillful fighters.",
+            "The patrol overcomes the red vixen and drives her off thanks to a brilliant battle move by s_c at a critical moment. Their bravery ensures the patrol's success, and the cats arrive back at camp singing their praises to make sure the Clan knows it."
+        ],
+        "fail_text": [
+            "The mother red fox is vicious and determined, and the small patrol is beaten back. But this wetland is c_n's and they haven't given up. They may have lost this battle, but c_n will win this war.",
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the rest of the patrol have to rescue them from the red vixen.",
+            "Never threaten a mother's young - the red vixen kills r_c in the skirmish.",
+            "The mother red fox's snapping jaws leave r_c dripping blood into the mud, forcing the patrol to back off.",
+            null,
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the red vixen manages to sink her teeth into them. The patrol rallies around s_c, but they have to give up on the fight.",
+            "As their hunt descends into a full on battle with the red vixen, p_l takes a blow meant for one of their Clanmates, losing a life."
+        ],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 2,
+        "max_cats": 3,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a fight with a red vixen.",
+            "r_c fell in battle with a red fox.",
+            "died while fighting a red vixen"
+        ]
+    },
+    {
+        "patrol_id": "wtlnd_hunt_redvixen5",
+        "biome": "wetland",
+        "season": "greenleaf",
+        "tags": [
+            "fighting",
+            "scar",
+            "big_bite_injury",
+            "respect",
+            "trust",
+            "clan_to_r_c",
+            "patrol_to_r_c",
+            "clan_to_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
+        "decline_text": "Your patrol decides not to pursue the fox.",
+        "chance_of_success": 60,
+        "exp": 30,
+        "success_text": [
+            "Led by p_l, and with a heap of cooperation and teamwork, the patrol drives away the red fox, seeks out her den, and kills her growing cubs. The swamps will be safe from both the threat the vixen posed this season, and the threat her cubs would've given c_n in the seasons to come.",
+            "With so many cats working together in tight coordination, they manage to accomplish the near-impossible, killing the red mother vixen and ending the threat to the Clan that she and her cubs pose.",
+            "s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the red fox nor her dependent cubs pose a threat to the Clan. It truly proves s_c's place as one of c_n's most talented and skillful fighters.",
+            "The patrol overcomes the red vixen and drives her off thanks to a brilliant battle move by s_c at a critical moment. Their bravery ensures the patrol's success, and the cats arrive back at camp singing their praises to make sure the Clan knows it."
+        ],
+        "fail_text": [
+            "The mother red fox is vicious and determined. Although they lose this battle, through teamwork the cats manage to retreat without injury.",
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the rest of the patrol have to rescue them from the red vixen.",
+            null,
+            "r_c is left wounded as the patrol and the red mother vixen fight to a stalemate. Hopefully they've given the fox mother a reason not to return to this part of the swamp.",
+            null,
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the red vixen manages to sink her teeth into them. The patrol rallies around s_c, but they have to give up on the fight."
+        ],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 4,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a fight with a red vixen."
+        ]
+    },
+    {
         "patrol_id": "wtlnd_hunt_redvixen6",
         "biome": "wetland",
         "season": "greenleaf",
-        "tags": ["fighting", "death", "scar", "big_bite_injury", "shock", "injury", "respect", "trust", "clan_to_patrol", "no_body"],
+        "tags": [
+            "fighting",
+            "death",
+            "scar",
+            "big_bite_injury",
+            "shock",
+            "injury",
+            "respect",
+            "trust",
+            "clan_to_patrol",
+            "no_body"
+        ],
         "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
         "decline_text": "Your patrol decides not to pursue the fox.",
         "chance_of_success": 10,
         "exp": 50,
         "success_text": [
-        "The red vixen smells of milk and blood. Hopefully by driving her out of the territory, the litter she has been raising this greenleaf won't be a threat to the Clan.",
-        null,
-        "s_c displays incredible skill, driving the mother vixen and her brood out of c_n's swamps all by themselves. Now neither the red fox nor her dependent cubs pose a threat to the Clan. They swell with pride, feeling the confidence of knowing that they're truly one of the best fighters c_n has ever produced.",
-        "A brilliant battle move by s_c at a critical moment knocks the red vixen off balance, and s_c manages to drive her out of c_n territory, though it takes every spark of strength in their pelt to do it alone."
+            "The red vixen smells of milk and blood. Hopefully by driving her out of the territory, the litter she has been raising this greenleaf won't be a threat to the Clan.",
+            null,
+            "s_c displays incredible skill, driving the mother vixen and her brood out of c_n's swamps all by themselves. Now neither the red fox nor her dependent cubs pose a threat to the Clan. They swell with pride, feeling the confidence of knowing that they're truly one of the best fighters c_n has ever produced.",
+            "A brilliant battle move by s_c at a critical moment knocks the red vixen off balance, and s_c manages to drive her out of c_n territory, though it takes every spark of strength in their pelt to do it alone."
         ],
         "fail_text": [
-        null,
-        null,
-        "Never threaten a mother's young - the red vixen kills r_c in the skirmish, and carries off the body to feed her litter.",
-        "The mother red fox's snapping jaws leave r_c dripping blood into the mud, and barely able to escape further injury.",
-        null,
-        "s_c is determined to win, but the red vixen is determined to live, and that makes all the difference. s_c ends up pinned in a defensible hiding spot, bleeding and terrified, until the vixen judges them no longer a threat and continues on her way."
+            null,
+            null,
+            "Never threaten a mother's young - the red vixen kills r_c in the skirmish, and carries off the body to feed her litter.",
+            "The mother red fox's snapping jaws leave r_c dripping blood into the mud, and barely able to escape further injury.",
+            null,
+            "s_c is determined to win, but the red vixen is determined to live, and that makes all the difference. s_c ends up pinned in a defensible hiding spot, bleeding and terrified, until the vixen judges them no longer a threat and continues on her way."
         ],
-        "win_skills": ["excellent fighter"],
-        "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-        "fail_skills": ["good fighter"],
-        "fail_trait": ["None"],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
         "min_cats": 1,
         "max_cats": 1,
         "antagonize_text": null,
         "antagonize_fail_text": null,
         "history_text": [
-        "r_c carries a scar from a solo fight with a red vixen.",
-        "r_c fell in a solo battle with a vixen.",
-        "died while fighting a red vixen"
+            "r_c carries a scar from a solo fight with a red vixen.",
+            "r_c fell in a solo battle with a vixen.",
+            "died while fighting a red vixen"
         ]
-},
-{
+    },
+    {
         "patrol_id": "wtlnd_hunt_redvixen7",
         "biome": "wetland",
         "season": "leaf-fall",
-        "tags": ["fighting", "death", "scar", "big_bite_injury", "respect", "trust",  "clan_to_r_c", "patrol_to_r_c", "clan_to_patrol"],
+        "tags": [
+            "fighting",
+            "death",
+            "scar",
+            "big_bite_injury",
+            "respect",
+            "trust",
+            "clan_to_r_c",
+            "patrol_to_r_c",
+            "clan_to_patrol"
+        ],
         "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
         "decline_text": "Your patrol decides not to pursue the fox.",
         "chance_of_success": 30,
         "exp": 30,
         "success_text": [
-        "The red vixen smells like the prey she's been poaching to feed her litter. She's stolen from c_n for the last time, and the patrol drives her from their territory, yowling their anger and fury.",
-        "Your patrol drives away the red fox, and seeks out her den, but her Leaf-fall cubs are near full-grown and scatter into the wilderness. Hopefully Leaf-bare takes care of them.",
-        "s_c displays incredible skill, driving the red mother vixen out of the territory almost by themselves. It truly proves s_c's place as one of c_n's most talented and skillful fighters.",
-        "The patrol overcomes the red vixen and drives her off thanks to a brilliant battle move by s_c at a critical moment. Their bravery ensures the patrol's success, and the cats arrive back at camp singing their praises to make sure the Clan knows it."
+            "The red vixen smells like the prey she's been poaching to feed her litter. She's stolen from c_n for the last time, and the patrol drives her from their territory, yowling their anger and fury.",
+            "Your patrol drives away the red fox, and seeks out her den, but her Leaf-fall cubs are near full-grown and scatter into the wilderness. Hopefully Leaf-bare takes care of them.",
+            "s_c displays incredible skill, driving the red mother vixen out of the territory almost by themselves. It truly proves s_c's place as one of c_n's most talented and skillful fighters.",
+            "The patrol overcomes the red vixen and drives her off thanks to a brilliant battle move by s_c at a critical moment. Their bravery ensures the patrol's success, and the cats arrive back at camp singing their praises to make sure the Clan knows it."
         ],
         "fail_text": [
-        "The mother red fox is vicious and determined, and the small patrol is beaten back. But this wetland is c_n's and they haven't given up. They may have lost this battle, but c_n will win this war.",
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the rest of the patrol have to rescue them from the red vixen.",
-        "Never threaten a mother's young - the red vixen kills r_c in the skirmish.",
-        "The mother red fox's snapping jaws leave r_c dripping blood into the mud, forcing the patrol to back off.",
-        null,
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the red vixen manages to sink her teeth into them. The patrol rallies around s_c, but they have to give up on the fight.",
-        "As their hunt descends into a full on battle with the red vixen, p_l takes a blow meant for one of their Clanmates, losing a life."
+            "The mother red fox is vicious and determined, and the small patrol is beaten back. But this wetland is c_n's and they haven't given up. They may have lost this battle, but c_n will win this war.",
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the rest of the patrol have to rescue them from the red vixen.",
+            "Never threaten a mother's young - the red vixen kills r_c in the skirmish.",
+            "The mother red fox's snapping jaws leave r_c dripping blood into the mud, forcing the patrol to back off.",
+            null,
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the red vixen manages to sink her teeth into them. The patrol rallies around s_c, but they have to give up on the fight.",
+            "As their hunt descends into a full on battle with the red vixen, p_l takes a blow meant for one of their Clanmates, losing a life."
         ],
-        "win_skills": ["excellent fighter"],
-        "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-        "fail_skills": ["good fighter"],
-        "fail_trait": ["None"],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
         "min_cats": 2,
         "max_cats": 3,
         "antagonize_text": null,
         "antagonize_fail_text": null,
         "history_text": [
-        "r_c carries a scar from a fight with a red vixen.",
-        "r_c fell in battle with a red fox.",
-        "died while fighting a red vixen"
+            "r_c carries a scar from a fight with a red vixen.",
+            "r_c fell in battle with a red fox.",
+            "died while fighting a red vixen"
         ]
-},
-{
+    },
+    {
         "patrol_id": "wtlnd_hunt_redvixen8",
         "biome": "wetland",
         "season": "leaf-fall",
-        "tags": ["fighting", "scar", "big_bite_injury", "respect", "trust",  "clan_to_r_c", "patrol_to_r_c", "clan_to_patrol"],
+        "tags": [
+            "fighting",
+            "scar",
+            "big_bite_injury",
+            "respect",
+            "trust",
+            "clan_to_r_c",
+            "patrol_to_r_c",
+            "clan_to_patrol"
+        ],
         "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
         "decline_text": "Your patrol decides not to pursue the fox.",
         "chance_of_success": 60,
         "exp": 30,
         "success_text": [
-        "Led by p_l and with a heap of cooperation and teamwork, the patrol drives away the red fox, and seeks out her den. But her cubs are near full-grown with the bounty of Leaf-fall, and scatter from the patrol into the wilderness. Hopefully Leaf-bare takes care of them.",
-        "With so many cats working together in tight coordination, they manage to accomplish the near-impossible, killing the red mother vixen and ending the threat to the Clan that she poses. The patrol drives her near-full grown litter of fox cubs out from the territory. Hopefully the coming Leaf-bare will take care of them.",
-        "s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the red fox nor her cubs pose a threat to c_n.",
-        "The patrol overcomes the red vixen and drives her off thanks to a brilliant battle move by s_c at a critical moment. Their bravery ensures the patrol's success, and the cats arrive back at camp singing their praises to make sure the Clan knows it."
+            "Led by p_l and with a heap of cooperation and teamwork, the patrol drives away the red fox, and seeks out her den. But her cubs are near full-grown with the bounty of Leaf-fall, and scatter from the patrol into the wilderness. Hopefully Leaf-bare takes care of them.",
+            "With so many cats working together in tight coordination, they manage to accomplish the near-impossible, killing the red mother vixen and ending the threat to the Clan that she poses. The patrol drives her near-full grown litter of fox cubs out from the territory. Hopefully the coming Leaf-bare will take care of them.",
+            "s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the red fox nor her cubs pose a threat to c_n.",
+            "The patrol overcomes the red vixen and drives her off thanks to a brilliant battle move by s_c at a critical moment. Their bravery ensures the patrol's success, and the cats arrive back at camp singing their praises to make sure the Clan knows it."
         ],
         "fail_text": [
-        "The mother red fox is vicious and determined. Although they lose this battle, through teamwork the cats manage to retreat without injury.",
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the red vixen manages to sink her teeth into them. The patrol rallies around s_c, but they have to give up the fight.",
-        null,
-        "r_c is left wounded as the patrol and the red mother vixen fight to a stalemate. Hopefully they've given the fox mother a reason not to return to this part of the swamp."
+            "The mother red fox is vicious and determined. Although they lose this battle, through teamwork the cats manage to retreat without injury.",
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the red vixen manages to sink her teeth into them. The patrol rallies around s_c, but they have to give up the fight.",
+            null,
+            "r_c is left wounded as the patrol and the red mother vixen fight to a stalemate. Hopefully they've given the fox mother a reason not to return to this part of the swamp."
         ],
-        "win_skills": ["excellent fighter"],
-        "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-        "fail_skills": ["good fighter"],
-        "fail_trait": ["None"],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
         "min_cats": 4,
         "max_cats": 6,
         "antagonize_text": null,
         "antagonize_fail_text": null,
         "history_text": [
-        "r_c carries a scar from a red fox fight."
+            "r_c carries a scar from a red fox fight."
         ]
-},
-{
+    },
+    {
         "patrol_id": "wtlnd_hunt_redvixen9",
         "biome": "wetland",
         "season": "leaf-fall",
-        "tags": ["fighting", "death", "scar", "big_bite_injury", "shock", "injury", "respect", "trust", "clan_to_patrol", "no_body"],
+        "tags": [
+            "fighting",
+            "death",
+            "scar",
+            "big_bite_injury",
+            "shock",
+            "injury",
+            "respect",
+            "trust",
+            "clan_to_patrol",
+            "no_body"
+        ],
         "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
         "decline_text": "Your patrol decides not to pursue the fox.",
         "chance_of_success": 20,
         "exp": 50,
         "success_text": [
-        "It takes r_c's every scrap of bravery and strength to drive away the red vixen - her near grown litter, fat on the bounty of Leaf-fall, is a challenge for another day. c_n will have to deal with the young foxes now roaming motherless in the swamps, before they start to compete for prey in Leaf-bare.",
-        null,
-        "s_c displays incredible skill, driving the mother vixen and her brood out of c_n's swamps all by themselves. Now neither the red fox nor her cubs pose a threat to the Clan. They swell with pride, feeling the confidence of knowing that they're truly one of the best fighters c_n has ever produced.",
-        "A brilliant battle move by s_c at a critical moment knocks the red vixen off balance, and s_c manages to drive her out of c_n territory, though it takes every spark of strength in their pelt to do it alone."
+            "It takes r_c's every scrap of bravery and strength to drive away the red vixen - her near grown litter, fat on the bounty of Leaf-fall, is a challenge for another day. c_n will have to deal with the young foxes now roaming motherless in the swamps, before they start to compete for prey in Leaf-bare.",
+            null,
+            "s_c displays incredible skill, driving the mother vixen and her brood out of c_n's swamps all by themselves. Now neither the red fox nor her cubs pose a threat to the Clan. They swell with pride, feeling the confidence of knowing that they're truly one of the best fighters c_n has ever produced.",
+            "A brilliant battle move by s_c at a critical moment knocks the red vixen off balance, and s_c manages to drive her out of c_n territory, though it takes every spark of strength in their pelt to do it alone."
         ],
         "fail_text": [
-        null,
-        null,
-        "Never threaten a mother's young - the red vixen kills r_c in the skirmish, and carries off the body to feed her litter.",
-        "The mother red fox's snapping jaws leave r_c dripping blood into the mud, and barely able to escape further injury.",
-        null,
-        "s_c is determined to win, but the red vixen is determined to live, and that makes all the difference. s_c ends up pinned in a defensible hiding spot, bleeding and terrified, until the vixen judges them no longer a threat and continues on her way."
+            null,
+            null,
+            "Never threaten a mother's young - the red vixen kills r_c in the skirmish, and carries off the body to feed her litter.",
+            "The mother red fox's snapping jaws leave r_c dripping blood into the mud, and barely able to escape further injury.",
+            null,
+            "s_c is determined to win, but the red vixen is determined to live, and that makes all the difference. s_c ends up pinned in a defensible hiding spot, bleeding and terrified, until the vixen judges them no longer a threat and continues on her way."
         ],
-        "win_skills": ["excellent fighter"],
-        "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-        "fail_skills": ["good fighter"],
-        "fail_trait": ["None"],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
         "min_cats": 1,
         "max_cats": 1,
         "antagonize_text": null,
         "antagonize_fail_text": null,
         "history_text": [
-        "r_c carries a scar from a solo fight with a red vixen.",
-        "r_c fell in a solo battle with a red vixen.",
-        "died while fighting a red vixen"
+            "r_c carries a scar from a solo fight with a red vixen.",
+            "r_c fell in a solo battle with a red vixen.",
+            "died while fighting a red vixen"
         ]
-},
-{
+    },
+    {
         "patrol_id": "wtlnd_hunt_grayvixen1",
         "biome": "wetland",
         "season": "newleaf",
-        "tags": ["fighting", "minor_injury", "respect", "trust", "rel_patrol", "patrol_to_r_c"],
+        "tags": [
+            "fighting",
+            "minor_injury",
+            "respect",
+            "trust",
+            "rel_patrol",
+            "patrol_to_r_c"
+        ],
         "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
         "decline_text": "Your patrol decides not to pursue the fox.",
         "chance_of_success": 60,
         "exp": 30,
         "success_text": [
-        "The stocky gray vixen they track down smells of milk, and though she's nearly double the weight of any of the patrol and all of it muscle, they meet her eyes squarely, and leap to attack. c_n does not tolerate sharing their territory with foxes, and they work together to drive her off.",
-        "Your patrol drives away the gray fox, seeks out her den, and kills her young cubs. It's brutal, but these fluffy baby foxes would one day have grown to be kit-killers and thieves. Better to deal with them now than when they're the height and nearly double the weight of a cat, though a gray fox will always be easier than a big red one.",
-        "s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the gray fox nor her cubs pose a threat to the Clan. It places s_c as one of c_n's most talented and skillful fighters, a gray fox is a dangerous competitor.",
-        "The patrol overcomes the gray vixen they find and drives her off thanks to a brilliant battle move by s_c. The cats swirl around s_c afterwards, congratulating them on their bravery and skill."
+            "The stocky gray vixen they track down smells of milk, and though she's nearly double the weight of any of the patrol and all of it muscle, they meet her eyes squarely, and leap to attack. c_n does not tolerate sharing their territory with foxes, and they work together to drive her off.",
+            "Your patrol drives away the gray fox, seeks out her den, and kills her young cubs. It's brutal, but these fluffy baby foxes would one day have grown to be kit-killers and thieves. Better to deal with them now than when they're the height and nearly double the weight of a cat, though a gray fox will always be easier than a big red one.",
+            "s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the gray fox nor her cubs pose a threat to the Clan. It places s_c as one of c_n's most talented and skillful fighters, a gray fox is a dangerous competitor.",
+            "The patrol overcomes the gray vixen they find and drives her off thanks to a brilliant battle move by s_c. The cats swirl around s_c afterwards, congratulating them on their bravery and skill."
         ],
         "fail_text": [
-        "The patrol comes across a gray vixen at the end of the scent trail. She spots them too, measures herself up against them, then flees, scrambling up a tree and into the swamp canopy in a move that completely surprises the cats. This round goes to the gray fox.",
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the gray vixen slips past them and flees into the maze of the many wooded semi-submerged islands of the swamp.",
-        null,
-        "The patrol finds a stocky gray vixen wandering their wetland, and drives her out in a scene that mostly involves yowling and screaming and yapping at each other until she gives in. r_c gets a little battered, but everyone is mostly fine.",
-        null,
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is all muscle, barging past s_c and knocking them ass over paws as she flees from the patrol."
+            "The patrol comes across a gray vixen at the end of the scent trail. She spots them too, measures herself up against them, then flees, scrambling up a tree and into the swamp canopy in a move that completely surprises the cats. This round goes to the gray fox.",
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the gray vixen slips past them and flees into the maze of the many wooded semi-submerged islands of the swamp.",
+            null,
+            "The patrol finds a stocky gray vixen wandering their wetland, and drives her out in a scene that mostly involves yowling and screaming and yapping at each other until she gives in. r_c gets a little battered, but everyone is mostly fine.",
+            null,
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is all muscle, barging past s_c and knocking them ass over paws as she flees from the patrol."
         ],
-        "win_skills": ["excellent fighter"],
-        "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-    "fail_skills": ["good fighter"],
-    "fail_trait": ["None"],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
         "min_cats": 2,
         "max_cats": 3,
         "antagonize_text": null,
         "antagonize_fail_text": null,
         "history_text": [
-        "r_c carries a scar from a fight with a gray vixen.",
-        null
+            "r_c carries a scar from a fight with a gray vixen.",
+            null
         ]
-},
-{
+    },
+    {
         "patrol_id": "wtlnd_hunt_grayvixen2",
         "biome": "wetland",
         "season": "newleaf",
-        "tags": ["fighting", "minor_injury", "respect", "trust", "rel_patrol", "patrol_to_r_c"],
+        "tags": [
+            "fighting",
+            "minor_injury",
+            "respect",
+            "trust",
+            "rel_patrol",
+            "patrol_to_r_c"
+        ],
         "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
         "decline_text": "Your patrol decides not to pursue the fox.",
         "chance_of_success": 90,
         "exp": 30,
         "success_text": [
-        "The stocky gray vixen they track down smells of milk, and though she's nearly double the weight of any of the patrol and all of it muscle, they meet her eyes squarely, and leap to attack. c_n does not tolerate sharing their territory with foxes, and they work together to drive her off.",
-        "With so many cats working together in tight coordination, they're able to keep the gray vixen they find pinned and distracted as they wear her down. The fox eventually flees for her den, and the patrol follows to take care of the cubs she's raising.",
-        "s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the gray fox nor her cubs pose a threat to the Clan. It places s_c as one of c_n's most talented and skillful fighters, a gray fox is a dangerous competitor.",
-        "Bravely, s_c charges the gray fox, yowling threats. The vixen spooks and skitters up a tree, growling and barking in a squeaky tone, and s_c follows her up into the branches. As the rest of the patrol backs them up from the ground, s_c screams until the fox is cowering and afraid, then lets her flee."
+            "The stocky gray vixen they track down smells of milk, and though she's nearly double the weight of any of the patrol and all of it muscle, they meet her eyes squarely, and leap to attack. c_n does not tolerate sharing their territory with foxes, and they work together to drive her off.",
+            "With so many cats working together in tight coordination, they're able to keep the gray vixen they find pinned and distracted as they wear her down. The fox eventually flees for her den, and the patrol follows to take care of the cubs she's raising.",
+            "s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the gray fox nor her cubs pose a threat to the Clan. It places s_c as one of c_n's most talented and skillful fighters, a gray fox is a dangerous competitor.",
+            "Bravely, s_c charges the gray fox, yowling threats. The vixen spooks and skitters up a tree, growling and barking in a squeaky tone, and s_c follows her up into the branches. As the rest of the patrol backs them up from the ground, s_c screams until the fox is cowering and afraid, then lets her flee."
         ],
         "fail_text": [
-        "The patrol comes across a gray vixen at the end of the scent trail. She spots them too, measures herself up against them, then flees, scrambling up a tree and into the swamp canopy in a move that completely surprises the cats. This round goes to the gray fox.",
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the gray vixen slips past them and flees into the maze of the many wooded semi-submerged islands of the swamp.",
-        null,
-        "The patrol finds a stocky gray vixen wandering their wetland, and drives her out in a scene that mostly involves yowling and screaming and yapping at each other until she gives in. r_c gets a little battered, but everyone is mostly fine.",
-        null,
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is all muscle, barging past s_c and knocking them ass over paws as she flees from the patrol."
+            "The patrol comes across a gray vixen at the end of the scent trail. She spots them too, measures herself up against them, then flees, scrambling up a tree and into the swamp canopy in a move that completely surprises the cats. This round goes to the gray fox.",
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the gray vixen slips past them and flees into the maze of the many wooded semi-submerged islands of the swamp.",
+            null,
+            "The patrol finds a stocky gray vixen wandering their wetland, and drives her out in a scene that mostly involves yowling and screaming and yapping at each other until she gives in. r_c gets a little battered, but everyone is mostly fine.",
+            null,
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is all muscle, barging past s_c and knocking them ass over paws as she flees from the patrol."
         ],
-        "win_skills": ["excellent fighter"],
-        "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-    "fail_skills": ["good fighter"],
-    "fail_trait": ["None"],
-        "min_cats": 4,
-        "max_cats": 6,
-        "antagonize_text": null,
-        "antagonize_fail_text": null,
-        "history_text": [
-        "r_c carries a scar from a fight with a gray vixen."
-        ]
-},
-{
-        "patrol_id": "wtlnd_hunt_grayvixen3",
-        "biome": "wetland",
-        "season": "newleaf",
-        "tags": ["fighting", "scar", "big_bite_injury", "respect", "trust", "clan_to_patrol"],
-        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
-        "decline_text": "Your patrol decides not to pursue the fox.",
-        "chance_of_success": 50,
-        "exp": 50,
-        "success_text": [
-        "The stocky gray vixen they track down smells of milk, and though she's near double r_c's weight and all of it muscle, they meet her eyes squarely, and leap to attack. c_n does not tolerate sharing their territory with foxes.",
-        null,
-        "s_c displays incredible skill, driving the mother vixen and her brood out of c_n's swamps all by themselves. Now neither the gray fox nor her dependent cubs pose a threat to the Clan. They swell with pride, returning to camp knowing there's one less competitor poaching c_n's prey.",
-        "They're nearly of equal height, with s_c's bold aggression making up for the weight that the gray vixen has on them, and the stand off is resolved when s_c charges the gray fox and she chooses flight over fight."
+        "win_skills": [
+            "excellent fighter"
         ],
-        "fail_text": [
-        "r_c comes across a gray vixen at the end of the scent trail. She spots them too, measures herself up against them, then flees, scrambling up a tree and into the swamp canopy in a move that completely surprises r_c. This round goes to the gray fox.",
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the gray vixen slips past them and flees into the maze of the many wooded semi-submerged islands of the swamp.",
-        null,
-        "r_c nearly managed to pin the gray vixen they find on a wet, barely above water island, but snapping jaws leave r_c dripping blood into the mud. Today this round goes to the gray fox.",
-        null,
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is cunning, sinking her teeth into s_c to distract them as she flees."
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
         ],
-        "win_skills": ["excellent fighter"],
-        "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-    "fail_skills": ["good fighter"],
-    "fail_trait": ["None"],
-        "min_cats": 1,
-        "max_cats": 1,
-        "antagonize_text": null,
-        "antagonize_fail_text": null,
-        "history_text": [
-        "r_c carries a scar from a solo fight with a gray vixen.",
-        null
-        ]
-},
-{
-        "patrol_id": "wtlnd_hunt_grayvixen4",
-        "biome": "wetland",
-        "season": "greenleaf",
-        "tags": ["fighting", "minor_injury", "respect", "trust", "rel_patrol", "patrol_to_r_c"],
-        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
-        "decline_text": "Your patrol decides not to pursue the fox.",
-        "chance_of_success": 60,
-        "exp": 30,
-        "success_text": [
-        "The stocky gray vixen they track down smells of milk, and though she's nearly double the weight of any of the patrol and all of it muscle, they meet her eyes squarely, and leap to attack. c_n does not tolerate sharing their territory with foxes, and they work together to drive her off.",
-        "Your patrol drives away the gray fox, seeks out her den, and kills her young cubs. It's brutal, but these fluffy small foxes would one day have grown to be kit-killers and thieves. Better to deal with them now than when they're the height and nearly double the weight of a cat, though a gray fox will always be easier than a bigger red one.",
-        "s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the gray fox nor her cubs pose a threat to the Clan. It places s_c as one of c_n's most talented and skillful fighters, a gray fox is a dangerous competitor.",
-        "The patrol overcomes the gray vixen they find and drives her off thanks to a brilliant battle move by s_c. The cats swirl around s_c afterwards, congratulating them on their bravery and skill."
+        "fail_skills": [
+            "good fighter"
         ],
-        "fail_text": [
-        "The patrol comes across a gray vixen at the end of the scent trail. She spots them too, measures herself up against them, then flees, scrambling up a tree and into the swamp canopy in a move that completely surprises the cats. This round goes to the gray fox.",
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the gray vixen slips past them and flees into the maze of the many wooded semi-submerged islands of the swamp.",
-        null,
-        "The patrol finds a stocky gray vixen wandering their wetland, and drives her out in a scene that mostly involves yowling and screaming and yapping at each other until she gives in. r_c gets a little battered, but everyone is mostly fine.",
-        null,
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is all muscle, barging past s_c and knocking them ass over paws as she flees from the patrol."
+        "fail_trait": [
+            "None"
         ],
-        "win_skills": ["excellent fighter"],
-        "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-    "fail_skills": ["good fighter"],
-    "fail_trait": ["None"],
-        "min_cats": 2,
-        "max_cats": 3,
-        "antagonize_text": null,
-        "antagonize_fail_text": null,
-        "history_text": [
-        "r_c carries a scar from a fight with a gray vixen.",
-        null
-        ]    
-},
-{
-        "patrol_id": "wtlnd_hunt_grayvixen5",
-        "biome": "wetland",
-        "season": "greenleaf",
-        "tags": ["fighting", "minor_injury", "respect", "trust", "rel_patrol", "patrol_to_r_c"],
-        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
-        "decline_text": "Your patrol decides not to pursue the fox.",
-        "chance_of_success": 90,
-        "exp": 30,
-        "success_text": [
-        "Led by p_l, and with a heap of cooperation and teamwork, the patrol drives away the gray fox, seeks out her den, and kills her growing cubs. The wetland will be safe from both the competition the vixen posed this season, and the threat her cubs would've given c_n in the seasons to come.",
-        "With so many cats working together in tight coordination, they're able to keep the gray vixen they find pinned and distracted as they wear her down. The fox eventually flees for her den, and the patrol follows to take care of the cubs she's raising.",
-        "s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the gray fox nor her cubs pose a threat to the Clan. It places s_c as one of c_n's most talented and skillful fighters, a gray fox is a dangerous competitor.",
-        "Bravely, s_c charges the gray fox, yowling threats. The vixen spooks and skitters up a tree, growling and barking in a squeaky tone, and s_c follows her up into the branches. As the rest of the patrol backs them up from the ground, s_c screams until the fox is cowering and afraid, then lets her flee."
-        ],
-        "fail_text": [
-        "The patrol comes across a gray vixen at the end of the scent trail. She spots them too, measures herself up against them, then flees, scrambling up a tree and into the swamp canopy in a move that completely surprises the cats. This round goes to the gray fox.",
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the gray vixen slips past them and flees into the maze of the many wooded semi-submerged islands of the swamp.",
-        null,
-        "The patrol finds a stocky gray vixen wandering their wetland, and drives her out in a scene that mostly involves yowling and screaming and yapping at each other until she gives in. r_c gets a little battered, but everyone is mostly fine.",
-        null,
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is all muscle, barging past s_c and knocking them ass over paws as she flees from the patrol."
-        ],
-        "win_skills": ["excellent fighter"],
-        "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-    "fail_skills": ["good fighter"],
-    "fail_trait": ["None"],
-        "min_cats": 4,
-        "max_cats": 6,
-        "antagonize_text": null,
-        "antagonize_fail_text": null,
-        "history_text": [
-        "r_c carries a scar from a fight with a gray vixen."
-        ]
-},
-{
-        "patrol_id": "wtlnd_hunt_grayvixen6",
-        "biome": "wetland",
-        "season": "greenleaf",
-        "tags": ["fighting", "scar", "big_bite_injury", "respect", "trust", "clan_to_patrol"],
-        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
-        "decline_text": "Your patrol decides not to pursue the fox.",
-        "chance_of_success": 50,
-        "exp": 50,
-        "success_text": [
-        "r_c finds a gray vixen smelling of milk and blood. Hopefully by driving her out of the territory, the litter she has been raising this greenleaf won't be a threat to the Clan.",
-        null,
-        "s_c displays incredible skill, driving the mother vixen and her brood out of c_n's swamps all by themselves. Now neither the gray fox nor her dependent cubs pose a threat to the Clan. They swell with pride, returning to camp knowing there's one less competitor poaching c_n's prey.",
-        "They're nearly of equal height, with s_c's bold aggression making up for the weight that the gray vixen has on them, and the stand off is resolved when s_c charges the gray fox and she chooses flight over fight."
-        ],
-        "fail_text": [
-        "r_c comes across a gray vixen at the end of the scent trail. She spots them too, measures herself up against them, then flees, scrambling up a tree and into the swamp canopy in a move that completely surprises r_c. This round goes to the gray fox.",
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the gray vixen slips past them and flees into the maze of the many wooded semi-submerged islands of the swamp.",
-        null,
-        "r_c nearly managed to pin the gray vixen they find on a wet, barely above water island, but snapping jaws leave r_c dripping blood into the mud. Today this round goes to the gray fox.",
-        null,
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is cunning, sinking her teeth into s_c to distract them as she flees."
-        ],
-        "win_skills": ["excellent fighter"],
-        "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-    "fail_skills": ["good fighter"],
-    "fail_trait": ["None"],
-        "min_cats": 1,
-        "max_cats": 1,
-        "antagonize_text": null,
-        "antagonize_fail_text": null,
-        "history_text": [
-            "r_c carries a scar from a solo fight with a gray vixen."
-        ]
-},
-{
-        "patrol_id": "wtlnd_hunt_grayvixen7",
-        "biome": "wetland",
-        "season": "leaf-fall",
-        "tags": ["fighting", "minor_injury", "respect", "trust", "rel_patrol", "patrol_to_r_c"],
-        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
-        "decline_text": "Your patrol decides not to pursue the fox.",
-        "chance_of_success": 60,
-        "exp": 30,
-        "success_text": [
-        "The gray vixen smells like the prey she's been poaching to feed her litter. She's stolen from c_n for the last time, and the patrol drives her from their territory, yowling their anger and fury.",
-        "Your patrol drives away the gray fox, and seeks out her den, but her Leaf-fall cubs are near full-grown and scatter into the wilderness. Hopefully Leaf-bare takes care of them, but if c_n spots them, they won't hesitate.",
-        "s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the gray fox nor her scattered cubs pose a threat to the Clan. It places s_c as one of c_n's most talented and skillful fighters, a gray fox is a dangerous competitor.",
-        "The patrol overcomes the gray vixen they find and drives her off thanks to a brilliant battle move by s_c. The cats swirl around s_c afterwards, congratulating them on their bravery and skill."
-        ],
-        "fail_text": [
-        "The patrol comes across a gray vixen at the end of the scent trail. She spots them too, measures herself up against them, then flees, scrambling up a tree and into the swamp canopy in a move that completely surprises the cats. This round goes to the gray fox.",
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the gray vixen slips past them and flees into the maze of the many wooded semi-submerged islands of the swamp.",
-        null,
-        "The patrol finds a stocky gray vixen wandering their wetland, and drives her out in a scene that mostly involves yowling and screaming and yapping at each other until she gives in. r_c gets a little battered, but everyone is mostly fine.",
-        null,
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is all muscle, barging past s_c and knocking them ass over paws as she flees from the patrol."
-        ],
-        "win_skills": ["excellent fighter"],
-        "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-    "fail_skills": ["good fighter"],
-    "fail_trait": ["None"],
-        "min_cats": 2,
-        "max_cats": 3,
-        "antagonize_text": null,
-        "antagonize_fail_text": null,
-        "history_text": [
-        "r_c carries a scar from a fight with a gray vixen.",
-        null
-        ]
-},
-{
-        "patrol_id": "wtlnd_hunt_grayvixen8",
-        "biome": "wetland",
-        "season": "leaf-fall",
-        "tags": ["fighting", "minor_injury", "respect", "trust", "rel_patrol", "patrol_to_r_c"],
-        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
-        "decline_text": "Your patrol decides not to pursue the fox.",
-        "chance_of_success": 90,
-        "exp": 30,
-        "success_text": [
-        "Led by p_l and with a heap of cooperation and teamwork, the patrol drives away the gray fox, and seeks out her den. But her cubs are near full-grown with the bounty of Leaf-fall, and scatter from the patrol into the wilderness. Hopefully Leaf-bare takes care of them.",
-        "With so many cats working together in tight coordination, they're able to keep the gray vixen they find pinned and distracted as they wear her down. The fox eventually flees for her den, and the patrol follows to drive her near-full grown litter of fox cubs out from the territory. Hopefully the coming Leaf-bare will take care of them.",
-        "s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the gray fox nor her scattered cubs pose a threat to the Clan. It places s_c as one of c_n's most talented and skillful fighters, a gray fox is a dangerous competitor.",
-        "Bravely, s_c charges the gray fox, yowling threats. The vixen spooks and skitters up a tree, growling and barking in a squeaky tone, and s_c follows her up into the branches. As the rest of the patrol backs them up from the ground, s_c screams until the fox is cowering and afraid, then lets her flee."
-        ],
-        "fail_text": [
-        "The patrol comes across a gray vixen at the end of the scent trail. She spots them too, measures herself up against them, then flees, scrambling up a tree and into the swamp canopy in a move that completely surprises the cats. This round goes to the gray fox.",
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the gray vixen slips past them and flees into the maze of the many wooded semi-submerged islands of the swamp.",
-        null,
-        "The patrol finds a stocky gray vixen wandering their wetland, and drives her out in a scene that mostly involves yowling and screaming and yapping at each other until she gives in. r_c gets a little battered, but everyone is mostly fine.",
-        null,
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is all muscle, barging past s_c and knocking them ass over paws as she flees from the patrol."
-        ],
-        "win_skills": ["excellent fighter"],
-        "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-    "fail_skills": ["good fighter"],
-    "fail_trait": ["None"],
         "min_cats": 4,
         "max_cats": 6,
         "antagonize_text": null,
@@ -2570,1378 +2847,184 @@
         "history_text": [
             "r_c carries a scar from a fight with a gray vixen."
         ]
-},
-{
-        "patrol_id": "wtlnd_hunt_grayvixen9",
-        "biome": "wetland",
-        "season": "leaf-fall",
-        "tags": ["fighting", "scar", "big_bite_injury", "respect", "trust", "clan_to_patrol"],
-        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
-        "decline_text": "Your patrol decides not to pursue the fox.",
-        "chance_of_success": 50,
-        "exp": 50,
-        "success_text": [
-        "In an exhausting fight, r_c manages to bring down and kill the gray vixen they've tracked. Her near grown litter, fat on the bounty of Leaf-fall, is a challenge for another day. c_n will have to deal with the young foxes now roaming motherless in the swamps, before they start to compete for prey in Leaf-bare.",
-        null,
-        "s_c displays incredible skill, driving the mother vixen and her brood out of c_n's swamps all by themselves. Now neither the gray fox nor her cubs pose a threat to the Clan. They swell with pride, returning to camp knowing there's one less competitor poaching c_n's prey.",
-        "They're nearly of equal height, with s_c's bold aggression making up for the weight that the gray vixen has on them, and the stand off is resolved when s_c charges the gray fox and she chooses flight over fight."
-        ],
-        "fail_text": [
-        "r_c comes across a gray vixen at the end of the scent trail. She spots them too, measures herself up against them, then flees, scrambling up a tree and into the swamp canopy in a move that completely surprises r_c. This round goes to the gray fox.",
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the gray vixen slips past them and flees into the maze of the many wooded semi-submerged islands of the swamp.",
-        null,
-        "r_c nearly managed to pin the gray vixen they find on a wet, barely above water island, but snapping jaws leave r_c dripping blood into the mud. Today this round goes to the gray fox.",
-        null,
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is cunning, sinking her teeth into s_c to distract them as she flees."
-        ],
-        "win_skills": ["excellent fighter"],
-        "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-    "fail_skills": ["good fighter"],
-    "fail_trait": ["None"],
-        "min_cats": 1,
-        "max_cats": 1,
-        "antagonize_text": null,
-        "antagonize_fail_text": null,
-        "history_text": [
-            "r_c carries a scar from a solo fight with a gray vixen."
-        ]
-},
-{
-    "patrol_id": "wtlnd_hunt_redfox_steal1",
-    "biome": "wetland",
-    "season": "Any",
-    "tags": ["hunting", "small_prey", "fighting", "scar", "small_bite_injury", "platonic", "dislike", "respect", "rel_patrol"],
-    "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? And is it worth a fight if they encounter it?",
-    "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
-    "chance_of_success": 50,
-    "exp": 20,
-    "success_text": [
-        "p_l leads the patrol to the end of the scent trail, where a red fox sits plucking the feathers off a plump duck. With careful signals, the cats set up an ambush. There aren't many of them, but the fox doesn't need to know that - with a massive explosion of yowls, the cats sound like a full battle patrol, and the fox leaps up frightened out of its skin as the cats pounce to take possession of the bird.",
-        null,
-        "They're a small patrol, but a skilled one, and when they track down the red fox at the end of the scent trail they have enough skill and muscle to drive it off from the fish it was gnawing on. The cats gather around it, congraduating each other.",
-        "Tracking the fox trail, s_c reminds the rest of the patrol that things don't always need to end in a fight, using the trail to uncover a food cache of dead fish buried under a log. They still don't know what kind of fox left the trail, and they don't need to - these fish will make great additions to the fresh-kill pile back home."
-    ],
-    "fail_text": [
-        "The fox's trail vanishes, almost as though the creature has figured out they're tracking it. Grumbling and arguing, the patrol has to head back home disappointed.",
-        "The patrol tracks down a red fox, and spots that it's holding fresh-kill. However, s_c bursts from cover without warning, trying to intimidate the fox. Which they can say sort of worked, but also causes the fox to run off with the food it carries. The other cats aren't particularly pleased with s_c.",
-        null,
-        "p_l leads the patrol to the end of the scent trail, where a red fox sits plucking the feathers off a plump duck. With careful signals, the cats set up an ambush, but they aren't careful enough, and with a snarl the fox takes a bite at r_c as it flees with its dinner.",
-        null,
-        "The patrol tracks down a red fox, and spots that it's holding fresh-kill. However, s_c bursts from cover without warning, trying to intimidate the fox, and the overconfident attack ends in disaster as the fox bites s_c, leaving the rest of the patrol to rescue their annoying Clanmate as the fox runs off with what could've been their dinner."
-    ],
-    "win_skills": ["good hunter", "great hunter", "fantastic hunter", "good fighter", "great fighter", "excellent fighter"],
-    "win_trait": ["altruistic", "calm", "careful", "faithful", "insecure", "loyal", "nervous", "patient", "responsible", "righteous", "thoughtful", "wise"],
-    "fail_skills": ["None"],
-    "fail_trait": ["adventurous", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "playful", "troublesome", "vengeful"],
-    "min_cats": 2,
-    "max_cats": 3,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c carries a scar from a red fox fight.",
-        null
-    ]
-},
-{
-    "patrol_id": "wtlnd_hunt_redfox_steal2",
-    "biome": "wetland",
-    "season": "Any",
-    "tags": ["hunting", "small_prey", "fighting", "scar", "small_bite_injury", "platonic", "respect", "rel_patrol"],
-    "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? And is it worth a fight if they encounter it?",
-    "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
-    "chance_of_success": 50,
-    "exp": 20,
-    "success_text": [
-        "p_l leads the patrol to the end of the scent trail, where a red fox sits plucking the feathers off a plump duck. With careful signals, the cats set up an ambush. While they'd expected having more cats would make it easier, it also makes the patrol far more of a threat to the red fox, and the creature panicks when they reveal themselves. They win the bird, but r_c nearly gets injured, and it's only p_l shoving them both out of the way that saves both their pelts.",
-        null,
-        "With such a big patrol, and with s_c there, when they track down the red fox at the end of the scent trail they have more than enough skill and muscle to drive it off from the fish it was gnawing on. The cats gather around it, congraduating each other.",
-        "Tracking the fox trail, s_c reminds the rest of the patrol that things don't always need to end in a fight, using the trail to uncover a food cache of dead fish buried under a log. They still don't know what kind of fox left the trail, and they don't need to - these fish will make great additions to the fresh-kill pile back home."
-    ],
-    "fail_text": [
-        "The fox's trail vanishes, almost as though the creature has figured out they're tracking it. Grumbling and arguing, the patrol has to head back home disappointed.",
-        "The patrol tracks down a red fox, and spots that it's holding fresh-kill. However, s_c bursts from cover without warning, trying to intimidate the fox. Which they can say sort of worked, but also causes the fox to run off with the food it carries. The other cats aren't particularly pleased with s_c.",
-        null,
-        "p_l leads the patrol to the end of the scent trail, where a red fox sits plucking the feathers off a plump duck. With careful signals, the cats set up an ambush, but they aren't careful enough, and with a snarl the fox takes a bite at r_c as it flees with its dinner.",
-        null,
-        "The patrol tracks down a red fox, and spots that it's holding fresh-kill. However, s_c bursts from cover without warning, trying to intimidate the fox, and the overconfident attack ends in disaster as the fox bites s_c, leaving the rest of the patrol to rescue their annoying Clanmate as the fox runs off with what could've been their dinner."
-    ],
-    "win_skills": ["good hunter", "great hunter", "fantastic hunter", "good fighter", "great fighter", "excellent fighter"],
-    "win_trait": ["altruistic", "calm", "careful", "faithful", "insecure", "loyal", "nervous", "patient", "responsible", "righteous", "thoughtful", "wise"],
-    "fail_skills": ["None"],
-    "fail_trait": ["adventurous", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "playful", "troublesome", "vengeful"],
-    "min_cats": 4,
-    "max_cats": 6,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c carries a scar from a red fox fight."
-    ]
-},
-{
-    "patrol_id": "wtlnd_hunt_redfox_steal3",
-    "biome": "wetland",
-    "season": "Any",
-    "tags": ["hunting", "medium_prey", "fighting", "scar", "big_bite_injury",  "clan_to_patrol", "respect"],
-    "intro_text": "r_c catches the scent of a fox - but is it red, or gray? And is it worth a fight if they encounter it?",
-    "decline_text": "r_c decides not to quarrel with the fox and to find prey elsewhere.",
-    "chance_of_success": 30,
-    "exp": 20,
-    "success_text": [
-        "Spotting the red fox they've tracked dipping into the shelter of a little scrub covered bit of dry land, r_c hangs back, sneaking around until they spot the fox burying a fish for later. They simply wait for it to finish and leave, then creep in to steal the fox's hard work, bringing the prize back to camp for the fresh-kill pile. Sometimes winning a battle doesn't require fighting.",
-        null,
-        "It requires s_c to use some of their best tricks, but they sneak close to the red fox at the end of the scent trail, eyes on the fish the fox carries. The creature puts down its fresh-kill to start fishing again, and s_c takes the opportunity, grabbing the fish and running. It's a good prize, and they feel proud to present it to the elders when they pad into camp, tired but satisfied.",
-        "It's a situation that calls for careful calm, not implusive action. s_c tracks down a red fox at the end of the scent trail, holding a young duck, and waits carefully. Eventually, as the fox starts to hunt at a different river, it drops its fresh-kill to try win more. s_c carefully snatches it while the fox is distracted, and trots back to camp having successfully outwitted the competing predator."
-    ],
-    "fail_text": [
-        "It embarrasses them, but r_c doesn't even manage to find the fox they track, let alone earn anything useful from the afternoon's attempts.",
-        "s_c hones in on the scent, and as soon as they spot the red fox with a dead fish hanging from its jaws, throwes themselves to the attack. The fox hears them coming, and with insulting nonchalance trots off, unwilling to get into a fight.",
-        null,
-        "Finding a red fox holding a fish that would be much appreciated for c_n's fresh-kill pile, r_c goes to attack it. But the fox is just as keen to keep it as r_c is to win it, and they're injured in the resulting fight.",
-        null,
-        "s_c hones in on the scent, and as soon as they spot the red fox with a dead fish hanging from its jaws, recklessly throwes themselves to the attack. But the fox is as desperate to keep its meal as s_c is to win it from them, and s_c has to retreat bleeding, as the fox trots off with its dinner."
-    ],
-    "win_skills": ["good hunter", "great hunter", "fantastic hunter", "good fighter", "great fighter", "excellent fighter"],
-    "win_trait": ["altruistic", "calm", "careful", "faithful", "insecure", "loyal", "nervous", "patient", "responsible", "righteous", "thoughtful", "wise"],
-    "fail_skills": ["None"],
-    "fail_trait": ["adventurous", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "playful", "troublesome", "vengeful"],
-    "min_cats": 1,
-    "max_cats": 1,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c carries a scar from a solo fight with a red fox."
-    ]
-},
-{
-    "patrol_id": "wtlnd_hunt_foxgray_steal1",
-    "biome": "wetland",
-    "season": "Any",
-    "tags": ["hunting", "small_prey", "fighting", "scar", "small_bite_injury", "platonic", "respect", "rel_patrol"],
-    "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? And is it worth a fight if they encounter it?",
-    "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
-    "chance_of_success": 50,
-    "exp": 20,
-    "success_text": [
-        "Its a gray fox, which as far as the cats are concerned, means free food. They leap after it, and after a short chase the fox drops the mouse it was holding. That's not enough to satisfy the c_n cats, who drive it out of their territory before collecting the mouse and continuing the afternoon's hunt.",
-        "The scent trail leads to where some kind of fox has cached half a fish in a poorly concealed hole. The cats take it as their due, and leave the fox to wander on.",
-        "The trail leads to a gray fox, and s_c makes sure it both hands over the prey it's poached from c_n land and flees for the border, tail between its legs and yelping. The smaller predator can't stand up to a patrol working together.",
-        "The cats slowly follow the trail, with s_c urging caution. There's no reason to rush into things. Sure enough, they find a grey fox. It's digging at a rotten log, unearthing insects. The patrol uses the presence of the other predator as a distraction to bring down a pump bird, one that was too busy watching the fox to guard from them, and the fox is left unscathed to keep bug hunting."
-    ],
-    "fail_text": [
-        "The fox's trail vanishes, almost as though the creature has figured out they're tracking it. Grumbling and arguing, the patrol has to head back home disappointed.",
-        "The patrol tracks down a gray fox trespassing on c_n land, but s_c runs at it without thinking, and instead of intimidating the fox into fleeing for the border it makes the gray fox skitter up a tree and start yelping. It takes all afternoon to wait the fox out and then drive it more gently from c_n's hunting grounds, and no one is happy with s_c.",
-        null,
-        "p_l leads the patrol to the end of the scent trail, where a gray fox sits grooming it's fur in the sunshine. With careful signals, the cats set up an ambush, but the small gray panics beyond anything any cat expected, and as it flees, convinced its life is in danger, it bites at r_c.",
-        null,
-        "The patrol tracks down a gray fox trespassing on c_n land, but s_c runs at it without thinking, and instead of intimidating the fox into fleeing for the border it makes the gray fox skitter up a tree and start yelping. s_c tries to make up for the mistake by following the fox up into the branches, which goes even more poorly and leaves the patrol needing to help them back to the medicine den."
-    ],
-    "win_skills": ["good hunter", "great hunter", "fantastic hunter", "great fighter", "excellent fighter"],
-    "win_trait": ["altruistic", "calm", "careful", "faithful", "insecure", "loyal", "nervous", "patient", "responsible", "righteous", "thoughtful", "wise"],
-    "fail_skills": ["None"],
-    "fail_trait": ["adventurous", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "playful", "troublesome", "vengeful"],
-    "min_cats": 2,
-    "max_cats": 3,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c carries a scar from a gray fox fight.",
-        null
-    ]
-},
-{
-    "patrol_id": "wtlnd_hunt_foxgray_steal2",
-    "biome": "wetland",
-    "season": "Any",
-    "tags": ["hunting", "small_prey", "fighting", "scar", "small_bite_injury", "platonic", "respect", "rel_patrol"],
-    "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? And is it worth a fight if they encounter it?",
-    "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
-    "chance_of_success": 70,
-    "exp": 20,
-    "success_text": [
-        "Its a gray fox, which as far as the cats are concerned, means free food. They leap after it, and after a short chase the fox drops the mouse it was holding. That's not enough to satisfy the c_n cats, who drive it out of their territory before collecting the mouse and continuing the afternoon's hunt.",
-        "The scent trail leads to where some kind of fox has cached a wood rat in a poorly concealed hole. The cats take it as their due, and leave the fox to wander on.",
-        "The trail leads to a gray fox, and s_c makes sure it both hands over the prey it's poached from c_n land and flees for the border, tail between its legs and yelping. The smaller predator can't stand up to a patrol working together.",
-        "The cats slowly follow the trail, with s_c urging caution. There's no reason to rush into things. Sure enough, they find a grey fox. It's digging at a rotten log, unearthing insects. The patrol uses the presence of the other predator as a distraction to bring down a pump bird, one that was too busy watching the fox to guard from them, and the fox is left unscathed to keep bug hunting."
-    ],
-    "fail_text": [
-        "The fox's trail vanishes, almost as though the creature has figured out they're tracking it. Grumbling and arguing, the patrol has to head back home disappointed.",
-        "The patrol tracks down a gray fox trespassing on c_n land, but s_c runs at it without thinking, and instead of intimidating the fox into fleeing for the border it makes the gray fox skitter up a tree and start yelping. It takes all afternoon to wait the fox out and then drive it more gently from c_n's hunting grounds, and no one is happy with s_c.",
-        null,
-        "p_l leads the patrol to the end of the scent trail, where a gray fox sits grooming its fur in the sunshine. With careful signals, the cats set up an ambush, but the small gray panics beyond anything any cat expected, and as it flees, convinced its life is in danger, it bites at r_c.",
-        null,
-        "The patrol tracks down a gray fox trespassing on c_n land, but s_c runs at it without thinking, and instead of intimidating the fox into fleeing for the border it makes the gray fox skitter up a tree and start yelping. s_c tries to make up for the mistake by following the fox up into the branches, which goes even more poorly and leaves the patrol needing to help them back to the medicine den."
-    ],
-    "win_skills": ["good hunter", "great hunter", "fantastic hunter", "great fighter", "excellent fighter"],
-    "win_trait": ["altruistic", "calm", "careful", "faithful", "insecure", "loyal", "nervous", "patient", "responsible", "righteous", "thoughtful", "wise"],
-    "fail_skills": ["None"],
-    "fail_trait": ["adventurous", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "playful", "troublesome", "vengeful"],
-    "min_cats": 4,
-    "max_cats": 6,
-    "antagonize_text": null,
-    "antagonize_fail_text": null
-},
-{
-    "patrol_id": "wtlnd_hunt_foxgray_steal3",
-    "biome": "wetland",
-    "season": "Any",
-    "tags": ["hunting", "medium_prey", "fighting", "scar", "small_bite_injury"],
-    "intro_text": "r_c catches the scent of a fox - but is it red, or gray? And is it worth a fight if they encounter it?",
-    "decline_text": "r_c decides not to quarrel with the fox and to find prey elsewhere.",
-    "chance_of_success": 50,
-    "exp": 15,
-    "success_text": [
-        "Spotting the gray fox they've tracked dipping into the shelter of a little scrub covered bit of dry land, r_c hangs back, sneaking around until they spot the fox caching a bird kill in an old log a storm washed in moons ago. They simply wait for it to finish and leave, then creep in to steal the fox's hard work, bringing the prize back to camp for the fresh-kill pile. Sometimes winning a battle doesn't require fighting.",
-        null,
-        "s_c tracks down a gray fox, and carefully cosiders it as an opponent. Stocky, yes, but they finally decide they can take it, and burst from cover, using surprise to get in a couple vicious swipes to the fox's face while its jaws are still full of prey. Yelping, the gray fox retreats from the cat, unwilling to risk more split blood, and s_c picks up the rat it carried with a proud grin.",
-        "It's a situation that calls for careful calm, not implusive action. s_c tracks down a gray fox at the end of the scent trail, holding a little plump mouse, and waits carefully. Eventually, the fox tries to cache its fresh-kill in a little hole. s_c picks it up once the fox leaves, strolling back to camp having successfully outwitted the competing predator."
-    ],
-    "fail_text": [
-        "It embarrasses them, but r_c doesn't even manage to find the fox they track, let alone earn anything useful from the afternoon's attempts.",
-        "s_c hones in on the scent, and as soon as they spot the gray fox with a dead fish hanging from its jaws, throwes themselves to the attack. The fox hears them coming, and makes a hasty retreat before the fight can start, taking its dinner with it.",
-        null,
-        "Finding a gray fox holding a mouse that would make a nice addition to c_n's fresh-kill pile, r_c goes to attack it. But the fox is just as keen to keep it as r_c is to win it, and they're injured in the resulting fight.",
-        null,
-        "s_c hones in on the scent, and as soon as they spot the gray fox with a dead fish hanging from its jaws, recklessly throwes themselves to the attack. But the fox is a little too desperate to keep itself from harm, and s_c has to retreat bleeding."
-    ],
-    "win_skills": ["good hunter", "great hunter", "fantastic hunter", "good fighter", "great fighter", "excellent fighter"],
-    "win_trait": ["altruistic", "calm", "careful", "faithful", "insecure", "loyal", "nervous", "patient", "responsible", "righteous", "thoughtful", "wise"],
-    "fail_skills": ["None"],
-    "fail_trait": ["adventurous", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "playful", "troublesome", "vengeful"],
-    "min_cats": 1,
-    "max_cats": 1,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c carries a scar from a solo fight with a gray fox."
-    ]
-},
-{
-    "patrol_id": "wtlnd_hunt_swiftfox_newleafscavenge1",
-    "biome": "wetland",
-    "season": "newleaf",
-    "tags": ["hunting", "small_prey", "comfort", "respect", "rel_patrol"],
-    "intro_text": "Your patrol catches the scent of a fox. Tracking it, they find a swift fox feeding on a fish about as big as it is. The cat-sized predator definitely didn't kill this.",
-    "decline_text": "Your patrol decides not to quarrel with the fox. There're plenty of fish in the river for everyone, and it's best to focus on feeding the Clan rather than quarreling.",
-    "chance_of_success": 70,
-    "exp": 20,
-    "success_text": [
-    "As the patrol approaches, the swift fox spots them and backs off from the carcass with a whine. Your cats bring it home, no fuss, no worries.",
-    null,
-    "The patrol takes over the carcass without a fight, the small swift fox giving way without trouble. Still, it's hardly worth the effort, and s_c can think of better things they should be doing.",
-    "Responsibly, s_c keeps the patrol moving once they take the fish from the unfortunate-but-unable-to-complain swift fox. They don't find anything, but with the stolen fish the afternoon hasn't been a completely wasted hunting trip."
-    ],
-    "fail_text": [
-    "The swift fox gives way easily to the bigger canivores, but the fish carcass is rotten, too rotten for the Clan cats to want to touch.",
-    "The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth. s_c calls the rest of the patrol for backup and no one is injured, but by the time they get back to the kill a different predator has absconded with the fish."
-    ],
-    "win_skills": ["smart", "very smart", "extremely smart"],
-    "win_trait": ["altruistic", "patient", "responsible", "thoughtful", "wise", "calm", "careful", "insecure", "nervous", "sneaky"],
-    "fail_skills": ["None"],
-    "fail_trait": ["bold", "childish", "confident", "daring", "playful", "shameless"],
-    "min_cats": 2,
-    "max_cats": 6,
-    "antagonize_text": null,
-    "antagonize_fail_text": null
-},
-{
-    "patrol_id": "wtlnd_hunt_swiftfox_newleafscavenge2",
-    "biome": "wetland",
-    "season": "newleaf",
-    "tags": ["hunting", "medium_prey", "fighting", "scar", "death", "no_body", "all_lives", "small_bite_injury"],
-    "intro_text": "r_c catches the scent of a fox. Tracking it, they find a swift fox feeding on a fish about as big as it is. The cat-sized predator definitely didn't kill this.",
-    "decline_text": "r_c decides not to quarrel with the fox. There're plenty of fish in the river for everyone, and it's best to focus on feeding the Clan rather than quarreling.",
-    "chance_of_success": 70,
-    "exp": 10,
-    "success_text": [
-    "r_c approaches the kill, fur puffed up. The swift fox grumbles, but with a hiss both animals agree to disagree, feeding from opposite ends of the calf without further trouble. r_c is able to find some decent scraps to carry back to camp, though with only them there they can't bring back as much meat as they'd like.",
-    null,
-    "Watching the swift fox at the carcass, s_c notices it stripping meat from the fish and caching it in little holes, and starts to copy it. The bigger predators will return to claim the fish soon, but by the time they do s_c will have hidden away the choicest morsels to fetch later.",
-    "With great care, aware that the kill's original owner must be somewhere about, s_c snatches the first large scrap they find and leaves the swift fox to risk the wrath of the bigger predators."
-    ],
-    "fail_text": [
-    "r_c muscles in as the swft fox gives way to the bigger predator, but the carcass is rotten and worthless.",
-    "The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth. s_c dances out of the way, but when they return, another predator has already snapped up the abandoned fish.",
-    "r_c starts arguing with the fox over the fish. Neither sees the alligator coming.",
-    "Puffed up, r_c approaches the swift fox. But there's only one of them, and the fox is their equal in size and weight. instead of running or giving it, it snarls, and attacks. r_c gives just as good as they get, and both animals end up limping away from the kill.",
-    null,
-    "The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth, sinking them into s_c and giving s_c a bigger concern than scavenging a fish carcass."
-    ],
-    "win_skills": ["good fighter", "great fighter", "excellent fighter"],
-    "win_trait": ["altruistic", "patient", "responsible", "thoughtful", "wise", "calm", "careful", "insecure", "nervous", "sneaky"],
-    "fail_skills": ["None"],
-    "fail_trait": ["bold", "childish", "confident", "daring", "playful", "shameless"],
-    "min_cats": 1,
-    "max_cats": 1,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c carries a scar from fighting with a swift fox.",
-        "While scavenging alone, r_c was killed by a predator they didn't see.",
-        "taken by an alligator"
-    ]
-},
-{
-    "patrol_id": "wtlnd_hunt_swiftfox_greenleafscavenge1",
-    "biome": "wetland",
-    "season": "greenleaf",
-    "tags": ["hunting", "small_prey", "comfort", "respect", "rel_patrol"],
-    "intro_text": "Your patrol catches the scent of a fox. Tracking it, they find a swift fox feeding on a fish about as big as it is. The cat-sized predator definitely didn't kill this.",
-    "decline_text": "Your patrol decides not to quarrel with the fox. There're plenty of fish in the river for everyone, and it's best to focus on feeding the Clan rather than quarreling.",
-    "chance_of_success": 70,
-    "exp": 20,
-    "success_text": [
-    "As the patrol approaches, the swift fox spots them and backs off from the carcass with a whine. Your cats bring it home, no fuss, no worries.",
-    null,
-    "The patrol takes over the carcass without a fight, the small swift fox giving way without trouble. Still, it's hardly worth the effort, and s_c can think of better things they should be doing.",
-    "Responsibly, s_c keeps the patrol moving once they take the fish from the unfortunate-but-unable-to-complain swift fox. They don't find anything, but with the stolen fish the afternoon hasn't been a completely wasted hunting trip."
-    ],
-    "fail_text": [
-    "The swift fox gives way easily to the bigger canivores, but the fish carcass is rotten, too rotten for the Clan cats to want to touch.",
-    "The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth. s_c calls the rest of the patrol for backup and no one is injured, but by the time they get back to the kill a different predator has absconded with the fish."
-    ],
-    "win_skills": ["smart", "very smart", "extremely smart"],
-    "win_trait": ["altruistic", "patient", "responsible", "thoughtful", "wise", "calm", "careful", "insecure", "nervous", "sneaky"],
-    "fail_skills": ["None"],
-    "fail_trait": ["bold", "childish", "confident", "daring", "playful", "shameless"],
-    "min_cats": 2,
-    "max_cats": 6,
-    "antagonize_text": null,
-    "antagonize_fail_text": null
-},
-{
-    "patrol_id": "wtlnd_hunt_swiftfox_greenleafscavenge2",
-    "biome": "wetland",
-    "season": "greenleaf",
-    "tags": ["hunting", "medium_prey", "fighting", "scar", "death", "no_body", "all_lives", "small_bite_injury"],
-    "intro_text": "r_c catches the scent of a fox. Tracking it, they find a swift fox feeding on a fish about as big as it is. The cat-sized predator definitely didn't kill this.",
-    "decline_text": "r_c decides not to quarrel with the fox. There're plenty of fish in the river for everyone, and it's best to focus on feeding the Clan rather than quarreling.",
-    "chance_of_success": 70,
-    "exp": 10,
-    "success_text": [
-    "r_c smaller, alone, and half its weight, but the fox has a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle. The fox, already stuffed full and unwilling to lose blood over it, leaves the kill with a grumble.",
-        null,
-        "s_c uses every trick in their talented fighting skillset to attack the fox with no one to watch their flank, until the perfect opportunity opens up and they pounce onto the fox's back, digging in their claws. It's a wild ride through the swamp until the fox bucks them off, but it wins them the fish carcass.",
-    "In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. But then they're stuck, unwilling to let go and risk being bitten. They're dragged through the swamp, over rocks and through bushes, until the fox finally collapses and the battered s_c goes back to proudly claim the fish."
-    ],
-    "fail_text": [
-"r_c muscles in as the swft fox gives way to the bigger predator, but the carcass is rotten and worthless.",
-    "The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth. s_c dances out of the way, but when they return, another predator has already snapped up the abandoned fish.",
-    "r_c starts arguing with the fox over the fish. Neither sees the alligator coming.",
-    "Puffed up, r_c approaches the swift fox. But there's only one of them, and the fox is their equal in size and weight. instead of running or giving it, it snarls, and attacks. r_c gives just as good as they get, and both animals end up limping away from the kill.",
-    null,
-    "The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth, sinking them into s_c and giving s_c a bigger concern than scavenging a fish carcass."
-    ],
-    "win_skills": ["good fighter", "great fighter", "excellent fighter"],
-    "win_trait": ["altruistic", "patient", "responsible", "thoughtful", "wise", "calm", "careful", "insecure", "nervous", "sneaky"],
-    "fail_skills": ["None"],
-    "fail_trait": ["bold", "childish", "confident", "daring", "playful", "shameless"],
-    "min_cats": 1,
-    "max_cats": 1,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c carries a scar from fighting with a swift fox.",
-        "While scavenging alone, r_c was killed by a predator they didn't see.",
-        "taken by an alligator"
-    ]
-},
-{
-    "patrol_id": "wtlnd_hunt_swiftfox_leaf-fallscavenge1",
-    "biome": "wetland",
-    "season": "leaf-fall",
-    "tags": ["hunting", "small_prey", "comfort", "respect", "rel_patrol"],
-    "intro_text": "Your patrol catches the scent of a fox. Tracking it, they find a swift fox feeding on a fish about as big as it is. The cat-sized predator definitely didn't kill this.",
-    "decline_text": "Your patrol decides not to quarrel with the fox. There're plenty of fish in the river for everyone, and it's best to focus on feeding the Clan rather than quarreling.",
-    "chance_of_success": 70,
-    "exp": 20,
-    "success_text": [
-    "As the patrol approaches, the swift fox spots them and backs off from the carcass with a whine. Your cats bring it home, no fuss, no worries.",
-    null,
-    "The patrol takes over the carcass without a fight, the small swift fox giving way without trouble. Still, it's hardly worth the effort, and s_c can think of better things they should be doing.",
-    "Responsibly, s_c keeps the patrol moving once they take the fish from the unfortunate-but-unable-to-complain swift fox. They don't find anything, but with the stolen fish the afternoon hasn't been a completely wasted hunting trip."
-    ],
-    "fail_text": [
-    "The swift fox gives way easily to the bigger canivores, but the fish carcass is rotten, too rotten for the Clan cats to want to touch.",
-    "The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth. s_c calls the rest of the patrol for backup and no one is injured, but by the time they get back to the kill a different predator has absconded with the fish."
-    ],
-    "win_skills": ["smart", "very smart", "extremely smart"],
-    "win_trait": ["altruistic", "patient", "responsible", "thoughtful", "wise", "calm", "careful", "insecure", "nervous", "sneaky"],
-    "fail_skills": ["None"],
-    "fail_trait": ["bold", "childish", "confident", "daring", "playful", "shameless"],
-    "min_cats": 2,
-    "max_cats": 6,
-    "antagonize_text": null,
-    "antagonize_fail_text": null
-},
-{
-    "patrol_id": "wtlnd_hunt_swiftfox_leaf-fallscavenge2",
-    "biome": "wetland",
-    "season": "leaf-fall",
-    "tags": ["hunting", "medium_prey", "fighting", "scar", "death", "no_body", "all_lives", "small_bite_injury"],
-    "intro_text": "r_c catches the scent of a fox. Tracking it, they find a swift fox feeding on a fish about as big as it is. The cat-sized predator definitely didn't kill this.",
-    "decline_text": "r_c decides not to quarrel with the fox. There're plenty of fish in the river for everyone, and it's best to focus on feeding the Clan rather than quarreling.",
-    "chance_of_success": 70,
-    "exp": 10,
-    "success_text": [
-    "r_c smaller, alone, and half its weight, but the fox has a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle. The fox, already on the look out for other predators and unwilling to lose blood over it, leaves the kill with a grumble.",
-        null,
-        "s_c uses every trick in their talented fighting skillset to attack the fox with no one to watch their flank, until the perfect opportunity opens up and they pounce onto the fox's back, digging in their claws. It's a wild ride through the swamp until the fox bucks them off, but it wins them the fish carcass.",
-    "In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. But then they're stuck, unwilling to let go and risk being bitten. They're dragged through the swamp, over rocks and through bushes, until the fox finally collapses and the battered s_c goes back to proudly claim the fish."
-    ],
-    "fail_text": [
-"r_c muscles in as the swft fox gives way to the bigger predator, but the carcass is rotten and worthless.",
-    "The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth. s_c dances out of the way, but when they return, another predator has already snapped up the abandoned fish.",
-    "r_c starts arguing with the fox over the fish. Neither sees the alligator coming.",
-    "Puffed up, r_c approaches the swift fox. But there's only one of them, and the fox is their equal in size and weight. instead of running or giving it, it snarls, and attacks. r_c gives just as good as they get, and both animals end up limping away from the kill.",
-    null,
-    "The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth, sinking them into s_c and giving s_c a bigger concern than scavenging a fish carcass."
-    ],
-    "win_skills": ["good fighter", "great fighter", "excellent fighter"],
-    "win_trait": ["altruistic", "patient", "responsible", "thoughtful", "wise", "calm", "careful", "insecure", "nervous", "sneaky"],
-    "fail_skills": ["None"],
-    "fail_trait": ["bold", "childish", "confident", "daring", "playful", "shameless"],
-    "min_cats": 1,
-    "max_cats": 1,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c carries a scar from fighting with a swift fox.",
-        "While scavenging alone, r_c was killed by a predator they didn't see.",
-        "taken by an alligator"
-    ]
-},
-{
-    "patrol_id": "wtlnd_hunt_swiftfox_leaf-barescavenge1",
-    "biome": "wetland",
-    "season": "leaf-bare",
-    "tags": ["hunting", "small_prey", "comfort", "respect", "rel_patrol"],
-    "intro_text": "Your patrol catches the scent of a fox. Tracking it, they find a swift fox feeding on a fish about as big as it is. The cat-sized predator definitely didn't kill this.",
-    "decline_text": "Your patrol decides not to quarrel with the fox. There're plenty of fish in the river for everyone, and it's best to focus on feeding the Clan rather than quarreling.",
-    "chance_of_success": 60,
-    "exp": 20,
-    "success_text": [
-    "As the patrol approaches, the swift fox spots them and backs off from the carcass with a whine. Your cats bring it home, no fuss, no worries.",
-    null,
-    "The patrol takes over the carcass without a fight, the small swift fox giving way without trouble. Still, it's hardly worth the effort, and s_c can think of better things they should be doing.",
-    "Responsibly, s_c keeps the patrol moving once they take the fish from the unfortunate-but-unable-to-complain swift fox. They don't find anything, but with the stolen fish the afternoon hasn't been a completely wasted hunting trip."
-    ],
-    "fail_text": [
-    "The swift fox gives way easily to the bigger canivores, but the fish carcass is rotten, too rotten for the Clan cats to want to touch.",
-    "The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth. s_c calls the rest of the patrol for backup and no one is injured, but by the time they get back to the kill a different predator has absconded with the fish."
-    ],
-    "win_skills": ["smart", "very smart", "extremely smart"],
-    "win_trait": ["altruistic", "patient", "responsible", "thoughtful", "wise", "calm", "careful", "insecure", "nervous", "sneaky"],
-    "fail_skills": ["None"],
-    "fail_trait": ["bold", "childish", "confident", "daring", "playful", "shameless"],
-    "min_cats": 2,
-    "max_cats": 6,
-    "antagonize_text": null,
-    "antagonize_fail_text": null
-},
-{
-    "patrol_id": "wtlnd_hunt_swiftfox_leaf-barescavenge2",
-    "biome": "wetland",
-    "season": "leaf-bare",
-    "tags": ["hunting", "medium_prey", "fighting", "scar", "death", "no_body", "all_lives", "small_bite_injury"],
-    "intro_text": "r_c catches the scent of a fox. Tracking it, they find a swift fox feeding on a fish about as big as it is. Roughly equal in size to r_c, the swift fox definitely didn't bring down this feast themselves.",
-    "decline_text": "r_c decides not to quarrel with the fox. There're plenty of fish in the river for everyone, and it's best to focus on feeding the Clan rather than quarreling.",
-    "chance_of_success": 50,
-    "exp": 10,
-    "success_text": [
-    "r_c smaller, alone, and half its weight, but the fox has a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle. The fox, already on the look out for other predators and unwilling to lose blood over it, leaves the kill with a grumble.",
-        null,
-        "s_c uses every trick in their talented fighting skillset to attack the fox with no one to watch their flank, until the perfect opportunity opens up and they pounce onto the fox's back, digging in their claws. It's a wild ride through the swamp until the fox bucks them off, but it wins them the fish carcass.",
-    "In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. But then they're stuck, unwilling to let go and risk being bitten. They're dragged through the swamp, over rocks and through bushes, until the fox finally collapses and the battered s_c goes back to proudly claim the fish."
-    ],
-    "fail_text": [
-"r_c muscles in as the swft fox gives way to the bigger predator, but the carcass is rotten and worthless.",
-    "The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth. s_c dances out of the way, but when they return, another predator has already snapped up the abandoned fish.",
-    "r_c starts arguing with the fox over the fish. Neither sees the alligator coming.",
-    "Puffed up, r_c approaches the swift fox. But there's only one of them, and the fox is their equal in size and weight. instead of running or giving it, it snarls, and attacks. r_c gives just as good as they get, and both animals end up limping away from the kill.",
-    null,
-    "The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth, sinking them into s_c and giving s_c a bigger concern than scavenging a fish carcass."
-    ],
-    "win_skills": ["good fighter", "great fighter", "excellent fighter"],
-    "win_trait": ["altruistic", "patient", "responsible", "thoughtful", "wise", "calm", "careful", "insecure", "nervous", "sneaky"],
-    "fail_skills": ["None"],
-    "fail_trait": ["bold", "childish", "confident", "daring", "playful", "shameless"],
-    "min_cats": 1,
-    "max_cats": 1,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c carries a scar from fighting with a swift fox.",
-        "While scavenging alone, r_c was killed by a predator they didn't see.",
-        "taken by an alligator"
-    ]
-},
-{
-    "patrol_id": "wtlnd_hunt_kitfox_scavenge1",
-    "biome": "wetland",
-    "season": "leaf-bare",
-    "tags": ["hunting", "small_prey", "comfort", "respect", "rel_patrol"],
-    "intro_text": "Your patrol catches the scent of a fox. Tracking it, they find a kit fox fishing on a branch overlooking the shallows.",
-    "decline_text": "Your patrol decides not to quarrel with the fox. There're plenty of fish in the river for everyone, and it's best to focus on feeding the Clan rather than quarreling.",
-    "chance_of_success": 70,
-    "exp": 10,
-    "success_text": [
-    "The cats freeze, and carefully creep back into cover. A kit fox is small enough to inevitably startle and run from them, but if they play this right... they wait until the tiny fox drops down onto a salamandar before they pop out of the bushes. Not only to they scare off a potential competitor, they also get the added reward of a little snack.",
-    "It's a truely ridiculous power disparity, with even a single member of the patrol outweighing the little fox. The cats drive it out of c_n's swamps no trouble, but it's hardly worth the little fishy morsel they win for their efforts.",
-    "A simple display of just how badly the kit fox is outmatched convinces it to run, and s_c carefully seeks out the little food cache the kit fox was workign on, taking the minnows for the camp's fresh-kill pile.",
-    "It's frustrating that it only wins them a single minnow, but hte patrol drives out the kit fox, and s_c reminds them that's what matters - that now the fox won't keep poaching from c_n's hunting grounds in the future."
-    ],
-    "fail_text": [
-    "The cats freeze, and carefully creep back into cover. A kit fox is small enough to inevitably startle and run from them, but if they play this right... but not, the kit fox has spotted them, and flees from the cats. At least that's one less competitior in c_n's hunting grounds?"
-    ],
-    "win_skills": ["smart", "very smart", "extremely smart"],
-    "win_trait": ["altruistic", "patient", "responsible", "thoughtful", "wise", "calm", "careful", "insecure", "nervous", "sneaky"],
-    "fail_skills": ["None"],
-    "fail_trait": ["bold", "childish", "confident", "daring", "playful", "shameless"],
-    "min_cats": 2,
-    "max_cats": 6,
-    "antagonize_text": null,
-    "antagonize_fail_text": null
-},
-{
-    "patrol_id": "wtlnd_hunt_kitfox_scavenge2",
-    "biome": "wetland",
-    "season": "leaf-bare",
-    "tags": ["hunting", "medium_prey"],
-    "intro_text": "r_c catches the scent of a fox. Tracking it, they find a kit fox fishing on a branch overlooking the shallows.",
-    "decline_text": "r_c decides not to quarrel with the fox. There're plenty of fish in the river for everyone, and it's best to focus on feeding the Clan rather than quarreling.",
-    "chance_of_success": 70,
-    "exp": 10,
-    "success_text": [
-        "r_c freezes, and carefully creeps back into cover. A kit fox is small enough to inevitably startle and run from them, but if they play this right... they wait until the tiny fox drops down onto a salamandar before they pop out of the bushes. Not only to they scare off a potential competitor, they also get the added reward of a little snack.",
-        "r_c throws their weight around as the bigger predator, stealing the kit fox's lunch and driving it away from the river.",
-        "s_c uses every trick in their talented fighting skillset to attack the fox with no one to watch their flank, until the perfect opportunity opens up and they pounce onto the fox's back, digging in their claws. It's a wild ride through the swamp until the fox bucks them off, but it wins them the fish carcass.",
-        "In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. But then they're stuck, unwilling to let go and risk being bitten. They're dragged through the swamp, over rocks and through bushes, until the fox finally collapses and the battered s_c goes back to proudly claim the fish."
-    ],
-    "fail_text": [
-    "r_c freezes, and carefully creeps back into cover. A kit fox is small enough to inevitably startle and run from them, but if they play this right... but not, the kit fox has spotted them, and flees from the cat. At least that's one less competitior in c_n's hunting grounds?"
-    ],
-    "win_skills": ["good fighter", "great fighter", "excellent fighter"],
-    "win_trait": ["altruistic", "patient", "responsible", "thoughtful", "wise", "calm", "careful", "insecure", "nervous", "sneaky"],
-    "fail_skills": ["None"],
-    "fail_trait": ["bold", "childish", "confident", "daring", "playful", "shameless"],
-    "min_cats": 1,
-    "max_cats": 1,
-    "antagonize_text": null,
-    "antagonize_fail_text": null
-},
-
-{
-    "patrol_id": "wtlnd_hunt_redfox_scavenge1",
-    "biome": "wetland",
-    "season": "Any",
-    "tags": ["hunting", "medium_prey", "fighting", "scar", "big_bite_injury", "clan_to_patrol", "respect", "rel_patrol"],
-    "intro_text": "Your patrol catches the scent of a red fox. Tracking it, they find the animal feeding on the body of a stork. Odd prey, but not out of the question for a red fox.",
-    "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
-    "chance_of_success": 50,
-    "exp": 20,
-    "success_text": [
-        "Your cats are smaller but they outnumber the fox, if only by a little, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full of food and unwilling to lose blood over it, is driven off from the kill.",
-        null,
-        "s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until it gives up and runs.",
-        "The patrol launches into battle, but with so few cats it's exhausting trying to keep the fox and its snapping jaws on the defensive. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. It's only one bite, but the fox has had enough and flees."
-    ],
-    "fail_text": [
-        "Your patrol fails to drive away the fox, which keeps possession of the food. However there were no injuries.",
-        null,
-        null,
-        "The patrol launches into battle, but r_c is caught with a nasty bite, and the cats give up on challenging for the food in favor of quickly helping r_c back to the medicine cat den.",
-        null,
-        "s_c means well, but they're overconfident in their attack and the fox manages to sink their teeth into them. The patrol is forced to retreat, forming a defensive ring around the hurt s_c."
-    ],
-    "win_skills": ["good fighter", "great fighter", "excellent fighter"],
-    "win_trait": ["adventurous", "altruistic", "ambitious", "confident", "daring", "fierce", "responsible", "righteous"],
-    "fail_skills": ["None"],
-    "fail_trait": ["troublesome", "vengeful", "bloodthirsty", "bold"],
-    "min_cats": 2,
-    "max_cats": 3,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c carries a scar from a fox fight.",
-        null
-    ]
-},
-{
-    "patrol_id": "wtlnd_hunt_redfox_scavenge2",
-    "biome": "wetland",
-    "season": "Any",
-    "tags":["hunting", "medium_prey", "fighting", "scar", "big_bite_injury", "clan_to_patrol", "respect", "rel_patrol"],
-    "intro_text": "Your patrol catches the scent of a red fox. Tracking it, they find the animal feeding on the body of a stork. Odd prey, but not out of the question for a red fox.",
-    "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
-    "chance_of_success": 80,
-    "exp": 20,
-    "success_text": [
-        "Your cats are smaller but heavily outnumber the fox, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full and unwilling to lose blood over it, is driven off from the kill.",
-        null,
-        "s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until s_c lands a crucial blow, snapping a tendon in one of the fox's hindlegs. The fox runs, but there's no way it'll live long with such a crippling injury.",
-        "The patrol launches into battle, keeping the fox on the defensive with teamwork. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. Holding on grimly, s_c's daring move gives the rest of the patrol the opportunity needed to bring the fox down for good."
-    ],
-    "fail_text":[
-        "Your patrol fails to drive away the fox, which keeps possession of the food. However with so many cats to protect each other, there were no injuries.",
-        null,
-        null,
-        "The patrol launches into battle, but r_c is caught with a nasty bite, and the cats give up on challenging for the food in favor of quickly helping r_c back to the medicine cat den.",
-        null,
-        "s_c means well, but they're overconfident in their attack and the fox manages to sink their teeth into them. The patrol is forced to retreat, forming a defensive ring around the hurt s_c."
-    ],
-    "win_skills": ["good fighter", "great fighter", "excellent fighter"],
-    "win_trait": ["adventurous", "altruistic", "ambitious", "confident", "daring", "fierce", "responsible", "righteous"],
-    "fail_skills": ["None"],
-    "fail_trait": ["troublesome", "vengeful", "bloodthirsty", "bold"],
-    "min_cats": 4,
-    "max_cats": 6,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c carries a scar from a fox fight."
-    ]
-},
-{
-    "patrol_id": "wtlnd_hunt_redfox_scavenge3",
-    "biome": "wetland",
-    "season": "Any",
-    "tags": ["hunting", "medium_prey", "fighting", "scar", "big_bite_injury", "clan_to_patrol", "respect"],
-    "intro_text": "r_c catches the scent of a red fox. Tracking it, they find the animal feeding on the body of a stork. Odd prey, but not out of the question for a red fox.",
-    "decline_text": "r_c decides not to quarrel with the fox and to find prey elsewhere.",
-    "chance_of_success": 30,
-    "exp": 30,
-    "success_text": [
-        "r_c is smaller, alone, and half its weight, but the fox has a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle. The fox, already stuffed full and unwilling to lose blood over it, leaves the kill with a grumble.",
-        null,
-        "s_c uses every trick in their talented fighting skillset to attack the fox with no one to watch their flank, until the perfect opportunity opens up and they pounce onto the fox's back, digging in their claws. It's a wild ride through the wetlands until the fox bucks them off, but it wins them the stork carcass.",
-        "In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. But then they're stuck, unwilling to let go and risk being bitten. They're dragged through the forest, over rocks and through bushes, until the fox finally collapses and the battered s_c goes back to proudly claim the stork."
-    ],
-    "fail_text": [
-        "Your patrol fails to drive away the fox, which keeps possession of the food. However there were no injuries.",
-        null,
-        "Fiercely, r_c throws themselves at the fox, determined to win the stork prize. But the fox values it just as dearly, and manages to get a good grip on r_c, shaking them to pieces and killing them.",
-        "r_c launches into battle, but is caught with a nasty bite, and retreats to limp back home. The fox doesn't follow, happy enough to eat the stork instead of the foolish cat.",
-        null,
-        "s_c is overconfident in their attack and the fox manages to sink their teeth into them. They retreat, bleeding and in pain, and the fox settles back down to its meal."
-    ],
-    "win_skills": ["great fighter", "excellent fighter"],
-    "win_trait": ["adventurous", "altruistic", "ambitious", "confident", "daring", "fierce", "responsible", "righteous"],
-    "fail_skills": ["None"],
-    "fail_trait": ["troublesome", "vengeful", "bloodthirsty", "bold"],
-    "min_cats": 1,
-    "max_cats": 1,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c carries a scar from a solo fox fight.",
-        "r_c fell in a solo battle with a fox.",
-        "died fighting a fox"
-    ]
-},
-{
-    "patrol_id": "wtlnd_hunt_foxgray_scavenge1",
-    "biome": "wetland",
-    "season": "Any",
-    "tags": ["hunting", "medium_prey", "fighting", "scar", "injury", "bite-wound", "clan_to_patrol", "respect", "rel_patrol"],
-    "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? Tracking it, they find a stocky gray fox feeding on an unidentifiable but deliciously stinky small mound of carrion fished up from the swamp.",
-    "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
-    "chance_of_success": 70,
-    "exp": 20,
-    "success_text": [
-        "While a gray fox is bigger and far stockier than the cats, the delicious stench of whatever it is makes the cats' eyes go wide and silly, and they leap to claim possession of it. Outnumbered and already full of stinky nonsense, the gray fox leaves, scrambling up a tree as the cats give in to instinct and roll around in the glorious smell.",
-        "A gray fox is bigger than them, yes... but only just, and that carcass smells divine. The cats creep up on the fox, using the thick swamp brush for cover, and wait until the fox has its head buried in the carcass to attack. The ambush sends the competing predator fleeing, and leaves the cats to claim the heavenly stinky food.",
-        "s_c shows their strength, leading the fight against the gray fox. By working together and keeping it distracted, the cats harry and harass the fox until it gives up and runs.",
-        "The patrol launches into battle, but with so few cats it's exhausting trying to keep the fox and its snapping jaws on the defensive. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. It's only one bite, but the fox has had enough and flees."
-    ],
-    "fail_text": [
-        "Your patrol fails to drive away the fox, which keeps possession of the food. However there were no injuries.",
-        "s_c makes a stupid mistake, too intent on winning the fight to respect their enemy's teeth, and it's only being yanked back by the tail that saves them from injury. The patrol gives up, and settles down to wait a safe distance away until the fox leaves of its own accord.",
-        null,
-        null,
-        null,
-        "s_c means well, but they're overconfident in their attack and the fox manages to sink their teeth into them. The patrol is forced to retreat, forming a defensive ring around the hurt s_c."
-    ],
-    "win_skills": ["good fighter", "great fighter", "excellent fighter"],
-    "win_trait": ["adventurous", "altruistic", "ambitious", "confident", "daring", "fierce", "responsible", "righteous"],
-    "fail_skills": ["None"],
-    "fail_trait": ["troublesome", "vengeful", "bloodthirsty", "bold"],
-    "min_cats": 2,
-    "max_cats": 3,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c carries a scar from a gray fox fight.",
-        null
-    ]
-},
-{
-    "patrol_id": "wtlnd_hunt_foxgray_scavenge2",
-    "biome": "wetland",
-    "season": "Any",
-    "tags": ["hunting", "medium_prey", "fighting", "clan_to_patrol", "respect", "rel_patrol"],
-    "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? Tracking it, they find a stocky gray fox feeding on an unidentifiable but deliciously stinky small mound of carrion fished up from the swamp.",
-    "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
-    "chance_of_success": 90,
-    "exp": 20,
-    "success_text": [
-        "While a gray fox is bigger and far stockier than the cats, the delicious stench of whatever it is makes the cats' eyes go wide and silly, and they leap to claim possession of it. Heavily outnumbered and already full of stinky nonsense, the gray fox leaves, scrambling up a tree as the cats give in to instinct and roll around in the glorious smell.",
-        "A gray fox is bigger than them, yes... but only just, and that carcass smells divine. The cats creep up on the fox, using the thick swamp brush for cover, and wait until the fox has its head buried in the carcass to attack. The ambush sends the competing predator fleeing, and leaves the cats to claim the heavenly stinky food.",
-        "s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until s_c lands a crucial blow, snapping a tendon in one of the fox's hindlegs. The fox runs, but there's no way it'll live long with such a crippling injury.",
-        "The patrol launches into battle, keeping the fox on the defensive with teamwork. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. Holding on grimly, s_c's daring move gives the rest of the patrol the opportunity needed to bring the fox down for good."
-    ],
-    "fail_text": [
-        "Your patrol fails to drive away the fox, which keeps possession of the food. However with so many cats to protect each other, there were no injuries.",
-        "s_c makes a stupid mistake, too intent on winning the fight to respect their enemy's teeth, and it's only being yanked back by the tail that saves them from injury. The patrol gives up, and settles down to wait a safe distance away until the fox leaves of its own accord."
-    ],
-    "win_skills": ["good fighter", "great fighter", "excellent fighter"],
-    "win_trait": ["adventurous", "altruistic", "ambitious", "confident", "daring", "fierce", "responsible", "righteous"],
-    "fail_skills": ["None"],
-    "fail_trait": ["troublesome", "vengeful", "bloodthirsty", "bold"],
-    "min_cats": 4,
-    "max_cats": 6,
-    "antagonize_text": null,
-    "antagonize_fail_text": null
-},
-{
-    "patrol_id": "wtlnd_hunt_foxgray_scavenge3",
-    "biome": "wetland",
-    "season": "Any",
-    "tags": ["hunting", "medium_prey", "fighting", "scar", "injury", "bite-wound", "clan_to_patrol", "respect"],
-    "intro_text": "r_c catches the scent of a fox - but is it red, or gray? Tracking it, they find a stocky gray fox feeding on an unidentifiable but deliciously stinky small mound of carrion fished up from the swamp.",
-    "decline_text": "r_c decides not to quarrel with the fox and to find prey elsewhere.",
-    "chance_of_success": 50,
-    "exp": 30,
-    "success_text": [
-        "While a gray fox is bigger and far stockier than r_c, the delicious stench of whatever it is makes their eyes go wide and silly, and they leap to claim some of it for themselves and c_n. It's only a little lump, but the fox is apparently not too keen to face a fight over it, and gives up with a prefunctory snarl.",
-        "A gray fox is bigger than them, yes... but only just, and that carcass smells divine. r_c creeps up on the fox, using the thick swamp brush for cover, and waits until the fox has its head buried in the carcass to attack. The ambush sends the competing predator fleeing, and leaves r_c to claim the heavenly stinky food.",
-        "s_c uses every trick in their talented fighting skillset to attack the fox with no one to watch their flank, until the perfect opportunity opens up and they pounce onto the fox's back, digging in their claws. It's enough to convince the gray to back off, and s_c claims a seat at the carcass.",
-        "In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. But then they're stuck, unwilling to let go and risk being bitten. They're dragged through the swamp, muck casing their pelt, until the fox finally throws them off and the battered s_c goes back to proudly claim the carcass."
-    ],
-    "fail_text": [
-        "Your patrol fails to drive away the gray fox, which keeps possession of the food. However there were no injuries.",
-        "s_c makes a stupid mistake, too intent on winning the fight to respect their enemy's teeth, and it's tripping over their own feet that saves them. They give up, and settle down to wait a safe distance away until the fox leaves of its own accord.",
-        null,
-        "r_c launches into battle, but is caught with a nasty bite, and retreats to limp back home. The gray fox doesn't follow, happy enough to eat the carcass instead of the foolish cat.",
-        null,
-        "s_c is overconfident in their attack and the fox manages to sink their teeth into them. They retreat, bleeding and in pain, and the gray fox settles back down to its meal."
-    ],
-    "win_skills": ["great fighter", "excellent fighter"],
-    "win_trait": ["adventurous", "altruistic", "ambitious", "confident", "daring", "fierce", "responsible", "righteous"],
-    "fail_skills": ["None"],
-    "fail_trait": ["troublesome", "vengeful", "bloodthirsty", "bold"],
-    "min_cats": 1,
-    "max_cats": 1,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c carries a scar from a solo fight with a gray fox.",
-        null
-    ]
-},
-{
-        "patrol_id": "wtlnd_hunt_redvixen1",
-        "biome": "wetland",
-        "season": "newleaf",
-        "tags": ["fighting", "death", "scar", "big_bite_injury", "respect", "trust",  "clan_to_r_c", "patrol_to_r_c", "clan_to_patrol"],
-        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
-        "decline_text": "Your patrol decides not to pursue the fox.",
-        "chance_of_success": 30,
-        "exp": 30,
-        "success_text": [
-        "The red vixen smells of milk, and hopefully by driving her out of the territory, her litter this Newleaf won't be a threat to the Clan. If they don't starve, c_n will hunt them down - they do not share territory with foxes.",
-        "Your patrol drives away the red fox, seeks out her den, and kills her young cubs. It's brutal, but these fluffy baby foxes would one day have grown to be kit-killers and thieves.",
-        "s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the red fox nor her cubs pose a threat to the Clan. It truly proves s_c's place as one of c_n's most talented and skillful fighters.",
-        "The patrol overcomes the red vixen and drives her off thanks to a brilliant battle move by s_c at a critical moment. Their bravery ensures the patrol's success, and the cats arrive back at camp singing their praises to make sure the Clan knows it."
-        ],
-        "fail_text": [
-        "The mother red fox is vicious and determined, and the small patrol is beaten back. But these swampy woodlands are c_n's and they haven't given up. They may have lost this battle, but c_n will win this war.",
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the rest of the patrol have to rescue them from the red vixen.",
-        "Never threaten a mother's young - the red vixen kills r_c in the skirmish.",
-        "The mother red fox's snapping jaws leave r_c dripping blood into the mud, forcing the patrol to back off.",
-        null,
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the red vixen manages to sink her teeth into them. The patrol rallies around s_c, but they have to give up on the fight.",
-        "As their hunt descends into a full on battle with the red vixen, p_l takes a blow meant for one of their Clanmates, losing a life."
-        ],
-        "win_skills": ["excellent fighter"],
-        "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-    "fail_skills": ["good fighter"],
-    "fail_trait": ["None"],
-        "min_cats": 2,
-        "max_cats": 3,
-        "antagonize_text": null,
-        "antagonize_fail_text": null,
-        "history_text": [
-        "r_c carries a scar from a fight with a red vixen.",
-        "r_c fell in battle with a red fox.",
-        "died while fighting a red vixen"
-        ]
-},
-{
-        "patrol_id": "wtlnd_hunt_redvixen2",
-        "biome": "wetland",
-        "season": "newleaf",
-        "tags": ["fighting", "scar", "big_bite_injury", "respect", "trust",  "clan_to_r_c", "patrol_to_r_c", "clan_to_patrol"],
-        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
-        "decline_text": "Your patrol decides not to pursue the fox.",
-        "chance_of_success": 60,
-        "exp": 30,
-        "success_text": [
-        "Led by p_l, and with a heap of cooperation and teamwork, the patrol drives away the red fox, seeks out her den, and kills her young cubs. The swamps will be safe from both the threat the vixen posed this season, and the threat her cubs would've given c_n in the seasons to come.",
-        "With so many cats working together in tight coordination, they manage to accomplish the near-impossible, killing the red mother vixen and ending the threat to the Clan that she and her cubs pose.",
-        "s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the red fox nor her dependent cubs pose a threat to the Clan. It truly proves s_c's place as one of c_n's most talented and skillful fighters.",
-        "The patrol overcomes the red vixen and drives her off thanks to a brilliant battle move by s_c at a critical moment. Their bravery ensures the patrol's success, and the cats arrive back at camp singing their praises to make sure the Clan knows it."
-        ],
-        "fail_text": [
-        "The mother red fox is vicious and determined. Although they lose this battle, through teamwork the cats manage to retreat without injury.",
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the rest of the patrol have to rescue them from the red vixen.",
-        null,
-        "r_c is left wounded as the patrol and the red mother vixen fight to a stalemate. Hopefully they've given the fox mother a reason not to return to this part of the swamp.",
-        null,
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the red vixen manages to sink her teeth into them. The patrol rallies around s_c, but they have to give up on the fight."
-        ],
-        "win_skills": ["excellent fighter"],
-        "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-        "fail_skills": ["good fighter"],
-        "fail_trait": ["None"],
-        "min_cats": 4,
-        "max_cats": 6,
-        "antagonize_text": null,
-        "antagonize_fail_text": null,
-        "history_text": [
-        "r_c carries a scar from a fight with a red vixen."
-        ]
-},
-{
-        "patrol_id": "wtlnd_hunt_redvixen3",
-        "biome": "wetland",
-        "season": "newleaf",
-        "tags": ["fighting", "death", "scar", "big_bite_injury", "shock", "injury", "respect", "trust", "clan_to_patrol", "no_body"],
-        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
-        "decline_text": "Your patrol decides not to pursue the fox.",
-        "chance_of_success": 20,
-        "exp": 50,
-        "success_text": [
-        "The red vixen smells of milk, and hopefully by driving her out of the territory, her litter this Newleaf won't be a threat to the Clan. If they don't starve, c_n will hunt them down - they do not share territory with foxes.",
-        null,
-        "s_c displays incredible skill, driving the mother vixen and her brood out of c_n's swamps all by themselves. Now neither the red fox nor her dependent cubs pose a threat to the Clan. They swell with pride, feeling the confidence of knowing that they're truly one of the best fighters c_n has ever produced.",
-        "A brilliant battle move by s_c knocks the red vixen off balance, and s_c manages to drive her out of c_n territory, though it takes every spark of strength in their pelt to do it alone."
-        ],
-        "fail_text": [
-        null,
-        null,
-        "Never threaten a mother's young - the red vixen kills r_c in the skirmish, and carries off the body to feed her litter.",
-        "The mother red fox's snapping jaws leave r_c dripping blood into the mud, and barely able to escape further injury.",
-        null,
-        "s_c is determined to win, but the red vixen is determined to live, and that makes all the difference. s_c ends up pinned in a defensible hiding spot, bleeding and terrified, until the vixen judges them no longer a threat and continues on her way."
-        ],
-        "win_skills": ["excellent fighter"],
-        "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-        "fail_skills": ["good fighter"],
-        "fail_trait": ["None"],
-        "min_cats": 1,
-        "max_cats": 1,
-        "antagonize_text": null,
-        "antagonize_fail_text": null,
-        "history_text": [
-        "r_c carries a scar from a solo fight with a red vixen.",
-        "r_c fell in a solo battle with a vixen.",
-        "died while fighting a red vixen"
-        ]
-},
-{
-        "patrol_id": "wtlnd_hunt_redvixen4",
-        "biome": "wetland",
-        "season": "greenleaf",
-        "tags": ["fighting", "death", "scar", "big_bite_injury", "respect", "trust",  "clan_to_r_c", "patrol_to_r_c", "clan_to_patrol"],
-        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
-        "decline_text": "Your patrol decides not to pursue the fox.",
-        "chance_of_success": 30,
-        "exp": 30,
-        "success_text": [
-        "The red vixen smells of milk and blood. Hopefully by driving her out of the territory, the litter she has been raising this greenleaf won't be a threat to the Clan. If they don't starve, c_n will hunt them down - they do not share with foxes.",
-        "Your patrol drives away the red fox, seeks out her den, and kills her cubs. It's brutal, but these fluffy small foxes would one day have grown to be kit-killers and thieves.",
-        "s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the red fox nor her dependent cubs pose a threat to the Clan. It truly proves s_c's place as one of c_n's most talented and skillful fighters.",
-        "The patrol overcomes the red vixen and drives her off thanks to a brilliant battle move by s_c at a critical moment. Their bravery ensures the patrol's success, and the cats arrive back at camp singing their praises to make sure the Clan knows it."
-        ],
-        "fail_text": [
-        "The mother red fox is vicious and determined, and the small patrol is beaten back. But this wetland is c_n's and they haven't given up. They may have lost this battle, but c_n will win this war.",
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the rest of the patrol have to rescue them from the red vixen.",
-        "Never threaten a mother's young - the red vixen kills r_c in the skirmish.",
-        "The mother red fox's snapping jaws leave r_c dripping blood into the mud, forcing the patrol to back off.",
-        null,
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the red vixen manages to sink her teeth into them. The patrol rallies around s_c, but they have to give up on the fight.",
-        "As their hunt descends into a full on battle with the red vixen, p_l takes a blow meant for one of their Clanmates, losing a life."
-        ],
-        "win_skills": ["excellent fighter"],
-        "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-        "fail_skills": ["good fighter"],
-        "fail_trait": ["None"],
-        "min_cats": 2,
-        "max_cats": 3,
-        "antagonize_text": null,
-        "antagonize_fail_text": null,
-        "history_text": [
-        "r_c carries a scar from a fight with a red vixen.",
-        "r_c fell in battle with a red fox.",
-        "died while fighting a red vixen"
-        ]    
-},
-{
-        "patrol_id": "wtlnd_hunt_redvixen5",
-        "biome": "wetland",
-        "season": "greenleaf",
-        "tags": ["fighting", "scar", "big_bite_injury", "respect", "trust",  "clan_to_r_c", "patrol_to_r_c", "clan_to_patrol"],
-        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
-        "decline_text": "Your patrol decides not to pursue the fox.",
-        "chance_of_success": 60,
-        "exp": 30,
-        "success_text": [
-        "Led by p_l, and with a heap of cooperation and teamwork, the patrol drives away the red fox, seeks out her den, and kills her growing cubs. The swamps will be safe from both the threat the vixen posed this season, and the threat her cubs would've given c_n in the seasons to come.",
-        "With so many cats working together in tight coordination, they manage to accomplish the near-impossible, killing the red mother vixen and ending the threat to the Clan that she and her cubs pose.",
-        "s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the red fox nor her dependent cubs pose a threat to the Clan. It truly proves s_c's place as one of c_n's most talented and skillful fighters.",
-        "The patrol overcomes the red vixen and drives her off thanks to a brilliant battle move by s_c at a critical moment. Their bravery ensures the patrol's success, and the cats arrive back at camp singing their praises to make sure the Clan knows it."
-        ],
-        "fail_text": [
-        "The mother red fox is vicious and determined. Although they lose this battle, through teamwork the cats manage to retreat without injury.",
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the rest of the patrol have to rescue them from the red vixen.",
-        null,
-        "r_c is left wounded as the patrol and the red mother vixen fight to a stalemate. Hopefully they've given the fox mother a reason not to return to this part of the swamp.",
-        null,
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the red vixen manages to sink her teeth into them. The patrol rallies around s_c, but they have to give up on the fight."
-        ],
-        "win_skills": ["excellent fighter"],
-        "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-        "fail_skills": ["good fighter"],
-        "fail_trait": ["None"],
-        "min_cats": 4,
-        "max_cats": 6,
-        "antagonize_text": null,
-        "antagonize_fail_text": null,
-        "history_text": [
-        "r_c carries a scar from a fight with a red vixen."
-        ]
-},
-{
-        "patrol_id": "wtlnd_hunt_redvixen6",
-        "biome": "wetland",
-        "season": "greenleaf",
-        "tags": ["fighting", "death", "scar", "big_bite_injury", "shock", "injury", "respect", "trust", "clan_to_patrol", "no_body"],
-        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
-        "decline_text": "Your patrol decides not to pursue the fox.",
-        "chance_of_success": 10,
-        "exp": 50,
-        "success_text": [
-        "The red vixen smells of milk and blood. Hopefully by driving her out of the territory, the litter she has been raising this greenleaf won't be a threat to the Clan.",
-        null,
-        "s_c displays incredible skill, driving the mother vixen and her brood out of c_n's swamps all by themselves. Now neither the red fox nor her dependent cubs pose a threat to the Clan. They swell with pride, feeling the confidence of knowing that they're truly one of the best fighters c_n has ever produced.",
-        "A brilliant battle move by s_c at a critical moment knocks the red vixen off balance, and s_c manages to drive her out of c_n territory, though it takes every spark of strength in their pelt to do it alone."
-        ],
-        "fail_text": [
-        null,
-        null,
-        "Never threaten a mother's young - the red vixen kills r_c in the skirmish, and carries off the body to feed her litter.",
-        "The mother red fox's snapping jaws leave r_c dripping blood into the mud, and barely able to escape further injury.",
-        null,
-        "s_c is determined to win, but the red vixen is determined to live, and that makes all the difference. s_c ends up pinned in a defensible hiding spot, bleeding and terrified, until the vixen judges them no longer a threat and continues on her way."
-        ],
-        "win_skills": ["excellent fighter"],
-        "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-        "fail_skills": ["good fighter"],
-        "fail_trait": ["None"],
-        "min_cats": 1,
-        "max_cats": 1,
-        "antagonize_text": null,
-        "antagonize_fail_text": null,
-        "history_text": [
-        "r_c carries a scar from a solo fight with a red vixen.",
-        "r_c fell in a solo battle with a vixen.",
-        "died while fighting a red vixen"
-        ]
-},
-{
-        "patrol_id": "wtlnd_hunt_redvixen7",
-        "biome": "wetland",
-        "season": "leaf-fall",
-        "tags": ["fighting", "death", "scar", "big_bite_injury", "respect", "trust",  "clan_to_r_c", "patrol_to_r_c", "clan_to_patrol"],
-        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
-        "decline_text": "Your patrol decides not to pursue the fox.",
-        "chance_of_success": 30,
-        "exp": 30,
-        "success_text": [
-        "The red vixen smells like the prey she's been poaching to feed her litter. She's stolen from c_n for the last time, and the patrol drives her from their territory, yowling their anger and fury.",
-        "Your patrol drives away the red fox, and seeks out her den, but her Leaf-fall cubs are near full-grown and scatter into the wilderness. Hopefully Leaf-bare takes care of them.",
-        "s_c displays incredible skill, driving the red mother vixen out of the territory almost by themselves. It truly proves s_c's place as one of c_n's most talented and skillful fighters.",
-        "The patrol overcomes the red vixen and drives her off thanks to a brilliant battle move by s_c at a critical moment. Their bravery ensures the patrol's success, and the cats arrive back at camp singing their praises to make sure the Clan knows it."
-        ],
-        "fail_text": [
-        "The mother red fox is vicious and determined, and the small patrol is beaten back. But this wetland is c_n's and they haven't given up. They may have lost this battle, but c_n will win this war.",
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the rest of the patrol have to rescue them from the red vixen.",
-        "Never threaten a mother's young - the red vixen kills r_c in the skirmish.",
-        "The mother red fox's snapping jaws leave r_c dripping blood into the mud, forcing the patrol to back off.",
-        null,
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the red vixen manages to sink her teeth into them. The patrol rallies around s_c, but they have to give up on the fight.",
-        "As their hunt descends into a full on battle with the red vixen, p_l takes a blow meant for one of their Clanmates, losing a life."
-        ],
-        "win_skills": ["excellent fighter"],
-        "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-        "fail_skills": ["good fighter"],
-        "fail_trait": ["None"],
-        "min_cats": 2,
-        "max_cats": 3,
-        "antagonize_text": null,
-        "antagonize_fail_text": null,
-        "history_text": [
-        "r_c carries a scar from a fight with a red vixen.",
-        "r_c fell in battle with a red fox.",
-        "died while fighting a red vixen"
-        ]
-},
-{
-        "patrol_id": "wtlnd_hunt_redvixen8",
-        "biome": "wetland",
-        "season": "leaf-fall",
-        "tags": ["fighting", "scar", "big_bite_injury", "respect", "trust",  "clan_to_r_c", "patrol_to_r_c", "clan_to_patrol"],
-        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
-        "decline_text": "Your patrol decides not to pursue the fox.",
-        "chance_of_success": 60,
-        "exp": 30,
-        "success_text": [
-        "Led by p_l and with a heap of cooperation and teamwork, the patrol drives away the red fox, and seeks out her den. But her cubs are near full-grown with the bounty of Leaf-fall, and scatter from the patrol into the wilderness. Hopefully Leaf-bare takes care of them.",
-        "With so many cats working together in tight coordination, they manage to accomplish the near-impossible, killing the red mother vixen and ending the threat to the Clan that she poses. The patrol drives her near-full grown litter of fox cubs out from the territory. Hopefully the coming Leaf-bare will take care of them.",
-        "s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the red fox nor her cubs pose a threat to c_n.",
-        "The patrol overcomes the red vixen and drives her off thanks to a brilliant battle move by s_c at a critical moment. Their bravery ensures the patrol's success, and the cats arrive back at camp singing their praises to make sure the Clan knows it."
-        ],
-        "fail_text": [
-        "The mother red fox is vicious and determined. Although they lose this battle, through teamwork the cats manage to retreat without injury.",
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the red vixen manages to sink her teeth into them. The patrol rallies around s_c, but they have to give up the fight.",
-        null,
-        "r_c is left wounded as the patrol and the red mother vixen fight to a stalemate. Hopefully they've given the fox mother a reason not to return to this part of the swamp."
-        ],
-        "win_skills": ["excellent fighter"],
-        "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-        "fail_skills": ["good fighter"],
-        "fail_trait": ["None"],
-        "min_cats": 4,
-        "max_cats": 6,
-        "antagonize_text": null,
-        "antagonize_fail_text": null,
-        "history_text": [
-        "r_c carries a scar from a red fox fight."
-        ]
-},
-{
-        "patrol_id": "wtlnd_hunt_redvixen9",
-        "biome": "wetland",
-        "season": "leaf-fall",
-        "tags": ["fighting", "death", "scar", "big_bite_injury", "shock", "injury", "respect", "trust", "clan_to_patrol", "no_body"],
-        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
-        "decline_text": "Your patrol decides not to pursue the fox.",
-        "chance_of_success": 20,
-        "exp": 50,
-        "success_text": [
-        "It takes r_c's every scrap of bravery and strength to drive away the red vixen - her near grown litter, fat on the bounty of Leaf-fall, is a challenge for another day. c_n will have to deal with the young foxes now roaming motherless in the swamps, before they start to compete for prey in Leaf-bare.",
-        null,
-        "s_c displays incredible skill, driving the mother vixen and her brood out of c_n's swamps all by themselves. Now neither the red fox nor her cubs pose a threat to the Clan. They swell with pride, feeling the confidence of knowing that they're truly one of the best fighters c_n has ever produced.",
-        "A brilliant battle move by s_c at a critical moment knocks the red vixen off balance, and s_c manages to drive her out of c_n territory, though it takes every spark of strength in their pelt to do it alone."
-        ],
-        "fail_text": [
-        null,
-        null,
-        "Never threaten a mother's young - the red vixen kills r_c in the skirmish, and carries off the body to feed her litter.",
-        "The mother red fox's snapping jaws leave r_c dripping blood into the mud, and barely able to escape further injury.",
-        null,
-        "s_c is determined to win, but the red vixen is determined to live, and that makes all the difference. s_c ends up pinned in a defensible hiding spot, bleeding and terrified, until the vixen judges them no longer a threat and continues on her way."
-        ],
-        "win_skills": ["excellent fighter"],
-        "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-        "fail_skills": ["good fighter"],
-        "fail_trait": ["None"],
-        "min_cats": 1,
-        "max_cats": 1,
-        "antagonize_text": null,
-        "antagonize_fail_text": null,
-        "history_text": [
-        "r_c carries a scar from a solo fight with a red vixen.",
-        "r_c fell in a solo battle with a red vixen.",
-        "died while fighting a red vixen"
-        ]
-},
-{
-        "patrol_id": "wtlnd_hunt_grayvixen1",
-        "biome": "wetland",
-        "season": "newleaf",
-        "tags": ["fighting", "minor_injury", "respect", "trust", "rel_patrol", "patrol_to_r_c"],
-        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
-        "decline_text": "Your patrol decides not to pursue the fox.",
-        "chance_of_success": 60,
-        "exp": 30,
-        "success_text": [
-        "The stocky gray vixen they track down smells of milk, and though she's nearly double the weight of any of the patrol and all of it muscle, they meet her eyes squarely, and leap to attack. c_n does not tolerate sharing their territory with foxes, and they work together to drive her off.",
-        "Your patrol drives away the gray fox, seeks out her den, and kills her young cubs. It's brutal, but these fluffy baby foxes would one day have grown to be kit-killers and thieves. Better to deal with them now than when they're the height and nearly double the weight of a cat, though a gray fox will always be easier than a big red one.",
-        "s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the gray fox nor her cubs pose a threat to the Clan. It places s_c as one of c_n's most talented and skillful fighters, a gray fox is a dangerous competitor.",
-        "The patrol overcomes the gray vixen they find and drives her off thanks to a brilliant battle move by s_c. The cats swirl around s_c afterwards, congratulating them on their bravery and skill."
-        ],
-        "fail_text": [
-        "The patrol comes across a gray vixen at the end of the scent trail. She spots them too, measures herself up against them, then flees, scrambling up a tree and into the swamp canopy in a move that completely surprises the cats. This round goes to the gray fox.",
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the gray vixen slips past them and flees into the maze of the many wooded semi-submerged islands of the swamp.",
-        null,
-        "The patrol finds a stocky gray vixen wandering their wetland, and drives her out in a scene that mostly involves yowling and screaming and yapping at each other until she gives in. r_c gets a little battered, but everyone is mostly fine.",
-        null,
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is all muscle, barging past s_c and knocking them ass over paws as she flees from the patrol."
-        ],
-        "win_skills": ["excellent fighter"],
-        "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-    "fail_skills": ["good fighter"],
-    "fail_trait": ["None"],
-        "min_cats": 2,
-        "max_cats": 3,
-        "antagonize_text": null,
-        "antagonize_fail_text": null,
-        "history_text": [
-        "r_c carries a scar from a fight with a gray vixen.",
-        null
-        ]
-},
-{
-        "patrol_id": "wtlnd_hunt_grayvixen2",
-        "biome": "wetland",
-        "season": "newleaf",
-        "tags": ["fighting", "minor_injury", "respect", "trust", "rel_patrol", "patrol_to_r_c"],
-        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
-        "decline_text": "Your patrol decides not to pursue the fox.",
-        "chance_of_success": 90,
-        "exp": 30,
-        "success_text": [
-        "The stocky gray vixen they track down smells of milk, and though she's nearly double the weight of any of the patrol and all of it muscle, they meet her eyes squarely, and leap to attack. c_n does not tolerate sharing their territory with foxes, and they work together to drive her off.",
-        "With so many cats working together in tight coordination, they're able to keep the gray vixen they find pinned and distracted as they wear her down. The fox eventually flees for her den, and the patrol follows to take care of the cubs she's raising.",
-        "s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the gray fox nor her cubs pose a threat to the Clan. It places s_c as one of c_n's most talented and skillful fighters, a gray fox is a dangerous competitor.",
-        "Bravely, s_c charges the gray fox, yowling threats. The vixen spooks and skitters up a tree, growling and barking in a squeaky tone, and s_c follows her up into the branches. As the rest of the patrol backs them up from the ground, s_c screams until the fox is cowering and afraid, then lets her flee."
-        ],
-        "fail_text": [
-        "The patrol comes across a gray vixen at the end of the scent trail. She spots them too, measures herself up against them, then flees, scrambling up a tree and into the swamp canopy in a move that completely surprises the cats. This round goes to the gray fox.",
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the gray vixen slips past them and flees into the maze of the many wooded semi-submerged islands of the swamp.",
-        null,
-        "The patrol finds a stocky gray vixen wandering their wetland, and drives her out in a scene that mostly involves yowling and screaming and yapping at each other until she gives in. r_c gets a little battered, but everyone is mostly fine.",
-        null,
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is all muscle, barging past s_c and knocking them ass over paws as she flees from the patrol."
-        ],
-        "win_skills": ["excellent fighter"],
-        "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-    "fail_skills": ["good fighter"],
-    "fail_trait": ["None"],
-        "min_cats": 4,
-        "max_cats": 6,
-        "antagonize_text": null,
-        "antagonize_fail_text": null,
-        "history_text": [
-        "r_c carries a scar from a fight with a gray vixen."
-        ]
-},
-{
+    },
+    {
         "patrol_id": "wtlnd_hunt_grayvixen3",
         "biome": "wetland",
         "season": "newleaf",
-        "tags": ["fighting", "scar", "big_bite_injury", "respect", "trust", "clan_to_patrol"],
+        "tags": [
+            "fighting",
+            "scar",
+            "big_bite_injury",
+            "respect",
+            "trust",
+            "clan_to_patrol"
+        ],
         "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
         "decline_text": "Your patrol decides not to pursue the fox.",
         "chance_of_success": 50,
         "exp": 50,
         "success_text": [
-        "The stocky gray vixen they track down smells of milk, and though she's near double r_c's weight and all of it muscle, they meet her eyes squarely, and leap to attack. c_n does not tolerate sharing their territory with foxes.",
-        null,
-        "s_c displays incredible skill, driving the mother vixen and her brood out of c_n's swamps all by themselves. Now neither the gray fox nor her dependent cubs pose a threat to the Clan. They swell with pride, returning to camp knowing there's one less competitor poaching c_n's prey.",
-        "They're nearly of equal height, with s_c's bold aggression making up for the weight that the gray vixen has on them, and the stand off is resolved when s_c charges the gray fox and she chooses flight over fight."
+            "The stocky gray vixen they track down smells of milk, and though she's near double r_c's weight and all of it muscle, they meet her eyes squarely, and leap to attack. c_n does not tolerate sharing their territory with foxes.",
+            null,
+            "s_c displays incredible skill, driving the mother vixen and her brood out of c_n's swamps all by themselves. Now neither the gray fox nor her dependent cubs pose a threat to the Clan. They swell with pride, returning to camp knowing there's one less competitor poaching c_n's prey.",
+            "They're nearly of equal height, with s_c's bold aggression making up for the weight that the gray vixen has on them, and the stand off is resolved when s_c charges the gray fox and she chooses flight over fight."
         ],
         "fail_text": [
-        "r_c comes across a gray vixen at the end of the scent trail. She spots them too, measures herself up against them, then flees, scrambling up a tree and into the swamp canopy in a move that completely surprises r_c. This round goes to the gray fox.",
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the gray vixen slips past them and flees into the maze of the many wooded semi-submerged islands of the swamp.",
-        null,
-        "r_c nearly managed to pin the gray vixen they find on a wet, barely above water island, but snapping jaws leave r_c dripping blood into the mud. Today this round goes to the gray fox.",
-        null,
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is cunning, sinking her teeth into s_c to distract them as she flees."
+            "r_c comes across a gray vixen at the end of the scent trail. She spots them too, measures herself up against them, then flees, scrambling up a tree and into the swamp canopy in a move that completely surprises r_c. This round goes to the gray fox.",
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the gray vixen slips past them and flees into the maze of the many wooded semi-submerged islands of the swamp.",
+            null,
+            "r_c nearly managed to pin the gray vixen they find on a wet, barely above water island, but snapping jaws leave r_c dripping blood into the mud. Today this round goes to the gray fox.",
+            null,
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is cunning, sinking her teeth into s_c to distract them as she flees."
         ],
-        "win_skills": ["excellent fighter"],
-        "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-    "fail_skills": ["good fighter"],
-    "fail_trait": ["None"],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
         "min_cats": 1,
         "max_cats": 1,
         "antagonize_text": null,
         "antagonize_fail_text": null,
         "history_text": [
-        "r_c carries a scar from a solo fight with a gray vixen.",
-        null
+            "r_c carries a scar from a solo fight with a gray vixen.",
+            null
         ]
-},
-{
+    },
+    {
         "patrol_id": "wtlnd_hunt_grayvixen4",
         "biome": "wetland",
         "season": "greenleaf",
-        "tags": ["fighting", "minor_injury", "respect", "trust", "rel_patrol", "patrol_to_r_c"],
+        "tags": [
+            "fighting",
+            "minor_injury",
+            "respect",
+            "trust",
+            "rel_patrol",
+            "patrol_to_r_c"
+        ],
         "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
         "decline_text": "Your patrol decides not to pursue the fox.",
         "chance_of_success": 60,
         "exp": 30,
         "success_text": [
-        "The stocky gray vixen they track down smells of milk, and though she's nearly double the weight of any of the patrol and all of it muscle, they meet her eyes squarely, and leap to attack. c_n does not tolerate sharing their territory with foxes, and they work together to drive her off.",
-        "Your patrol drives away the gray fox, seeks out her den, and kills her young cubs. It's brutal, but these fluffy small foxes would one day have grown to be kit-killers and thieves. Better to deal with them now than when they're the height and nearly double the weight of a cat, though a gray fox will always be easier than a bigger red one.",
-        "s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the gray fox nor her cubs pose a threat to the Clan. It places s_c as one of c_n's most talented and skillful fighters, a gray fox is a dangerous competitor.",
-        "The patrol overcomes the gray vixen they find and drives her off thanks to a brilliant battle move by s_c. The cats swirl around s_c afterwards, congratulating them on their bravery and skill."
+            "The stocky gray vixen they track down smells of milk, and though she's nearly double the weight of any of the patrol and all of it muscle, they meet her eyes squarely, and leap to attack. c_n does not tolerate sharing their territory with foxes, and they work together to drive her off.",
+            "Your patrol drives away the gray fox, seeks out her den, and kills her young cubs. It's brutal, but these fluffy small foxes would one day have grown to be kit-killers and thieves. Better to deal with them now than when they're the height and nearly double the weight of a cat, though a gray fox will always be easier than a bigger red one.",
+            "s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the gray fox nor her cubs pose a threat to the Clan. It places s_c as one of c_n's most talented and skillful fighters, a gray fox is a dangerous competitor.",
+            "The patrol overcomes the gray vixen they find and drives her off thanks to a brilliant battle move by s_c. The cats swirl around s_c afterwards, congratulating them on their bravery and skill."
         ],
         "fail_text": [
-        "The patrol comes across a gray vixen at the end of the scent trail. She spots them too, measures herself up against them, then flees, scrambling up a tree and into the swamp canopy in a move that completely surprises the cats. This round goes to the gray fox.",
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the gray vixen slips past them and flees into the maze of the many wooded semi-submerged islands of the swamp.",
-        null,
-        "The patrol finds a stocky gray vixen wandering their wetland, and drives her out in a scene that mostly involves yowling and screaming and yapping at each other until she gives in. r_c gets a little battered, but everyone is mostly fine.",
-        null,
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is all muscle, barging past s_c and knocking them ass over paws as she flees from the patrol."
+            "The patrol comes across a gray vixen at the end of the scent trail. She spots them too, measures herself up against them, then flees, scrambling up a tree and into the swamp canopy in a move that completely surprises the cats. This round goes to the gray fox.",
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the gray vixen slips past them and flees into the maze of the many wooded semi-submerged islands of the swamp.",
+            null,
+            "The patrol finds a stocky gray vixen wandering their wetland, and drives her out in a scene that mostly involves yowling and screaming and yapping at each other until she gives in. r_c gets a little battered, but everyone is mostly fine.",
+            null,
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is all muscle, barging past s_c and knocking them ass over paws as she flees from the patrol."
         ],
-        "win_skills": ["excellent fighter"],
-        "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-    "fail_skills": ["good fighter"],
-    "fail_trait": ["None"],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
         "min_cats": 2,
         "max_cats": 3,
         "antagonize_text": null,
         "antagonize_fail_text": null,
         "history_text": [
-        "r_c carries a scar from a fight with a gray vixen.",
-        null
-        ]    
-},
-{
+            "r_c carries a scar from a fight with a gray vixen.",
+            null
+        ]
+    },
+    {
         "patrol_id": "wtlnd_hunt_grayvixen5",
         "biome": "wetland",
         "season": "greenleaf",
-        "tags": ["fighting", "minor_injury", "respect", "trust", "rel_patrol", "patrol_to_r_c"],
+        "tags": [
+            "fighting",
+            "minor_injury",
+            "respect",
+            "trust",
+            "rel_patrol",
+            "patrol_to_r_c"
+        ],
         "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
         "decline_text": "Your patrol decides not to pursue the fox.",
         "chance_of_success": 90,
         "exp": 30,
         "success_text": [
-        "Led by p_l, and with a heap of cooperation and teamwork, the patrol drives away the gray fox, seeks out her den, and kills her growing cubs. The wetland will be safe from both the competition the vixen posed this season, and the threat her cubs would've given c_n in the seasons to come.",
-        "With so many cats working together in tight coordination, they're able to keep the gray vixen they find pinned and distracted as they wear her down. The fox eventually flees for her den, and the patrol follows to take care of the cubs she's raising.",
-        "s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the gray fox nor her cubs pose a threat to the Clan. It places s_c as one of c_n's most talented and skillful fighters, a gray fox is a dangerous competitor.",
-        "Bravely, s_c charges the gray fox, yowling threats. The vixen spooks and skitters up a tree, growling and barking in a squeaky tone, and s_c follows her up into the branches. As the rest of the patrol backs them up from the ground, s_c screams until the fox is cowering and afraid, then lets her flee."
+            "Led by p_l, and with a heap of cooperation and teamwork, the patrol drives away the gray fox, seeks out her den, and kills her growing cubs. The wetland will be safe from both the competition the vixen posed this season, and the threat her cubs would've given c_n in the seasons to come.",
+            "With so many cats working together in tight coordination, they're able to keep the gray vixen they find pinned and distracted as they wear her down. The fox eventually flees for her den, and the patrol follows to take care of the cubs she's raising.",
+            "s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the gray fox nor her cubs pose a threat to the Clan. It places s_c as one of c_n's most talented and skillful fighters, a gray fox is a dangerous competitor.",
+            "Bravely, s_c charges the gray fox, yowling threats. The vixen spooks and skitters up a tree, growling and barking in a squeaky tone, and s_c follows her up into the branches. As the rest of the patrol backs them up from the ground, s_c screams until the fox is cowering and afraid, then lets her flee."
         ],
         "fail_text": [
-        "The patrol comes across a gray vixen at the end of the scent trail. She spots them too, measures herself up against them, then flees, scrambling up a tree and into the swamp canopy in a move that completely surprises the cats. This round goes to the gray fox.",
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the gray vixen slips past them and flees into the maze of the many wooded semi-submerged islands of the swamp.",
-        null,
-        "The patrol finds a stocky gray vixen wandering their wetland, and drives her out in a scene that mostly involves yowling and screaming and yapping at each other until she gives in. r_c gets a little battered, but everyone is mostly fine.",
-        null,
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is all muscle, barging past s_c and knocking them ass over paws as she flees from the patrol."
+            "The patrol comes across a gray vixen at the end of the scent trail. She spots them too, measures herself up against them, then flees, scrambling up a tree and into the swamp canopy in a move that completely surprises the cats. This round goes to the gray fox.",
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the gray vixen slips past them and flees into the maze of the many wooded semi-submerged islands of the swamp.",
+            null,
+            "The patrol finds a stocky gray vixen wandering their wetland, and drives her out in a scene that mostly involves yowling and screaming and yapping at each other until she gives in. r_c gets a little battered, but everyone is mostly fine.",
+            null,
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is all muscle, barging past s_c and knocking them ass over paws as she flees from the patrol."
         ],
-        "win_skills": ["excellent fighter"],
-        "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-    "fail_skills": ["good fighter"],
-    "fail_trait": ["None"],
-        "min_cats": 4,
-        "max_cats": 6,
-        "antagonize_text": null,
-        "antagonize_fail_text": null,
-        "history_text": [
-        "r_c carries a scar from a fight with a gray vixen."
-        ]
-},
-{
-        "patrol_id": "wtlnd_hunt_grayvixen6",
-        "biome": "wetland",
-        "season": "greenleaf",
-        "tags": ["fighting", "scar", "big_bite_injury", "respect", "trust", "clan_to_patrol"],
-        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
-        "decline_text": "Your patrol decides not to pursue the fox.",
-        "chance_of_success": 50,
-        "exp": 50,
-        "success_text": [
-        "r_c finds a gray vixen smelling of milk and blood. Hopefully by driving her out of the territory, the litter she has been raising this greenleaf won't be a threat to the Clan.",
-        null,
-        "s_c displays incredible skill, driving the mother vixen and her brood out of c_n's swamps all by themselves. Now neither the gray fox nor her dependent cubs pose a threat to the Clan. They swell with pride, returning to camp knowing there's one less competitor poaching c_n's prey.",
-        "They're nearly of equal height, with s_c's bold aggression making up for the weight that the gray vixen has on them, and the stand off is resolved when s_c charges the gray fox and she chooses flight over fight."
+        "win_skills": [
+            "excellent fighter"
         ],
-        "fail_text": [
-        "r_c comes across a gray vixen at the end of the scent trail. She spots them too, measures herself up against them, then flees, scrambling up a tree and into the swamp canopy in a move that completely surprises r_c. This round goes to the gray fox.",
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the gray vixen slips past them and flees into the maze of the many wooded semi-submerged islands of the swamp.",
-        null,
-        "r_c nearly managed to pin the gray vixen they find on a wet, barely above water island, but snapping jaws leave r_c dripping blood into the mud. Today this round goes to the gray fox.",
-        null,
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is cunning, sinking her teeth into s_c to distract them as she flees."
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
         ],
-        "win_skills": ["excellent fighter"],
-        "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-    "fail_skills": ["good fighter"],
-    "fail_trait": ["None"],
-        "min_cats": 1,
-        "max_cats": 1,
-        "antagonize_text": null,
-        "antagonize_fail_text": null,
-        "history_text": [
-            "r_c carries a scar from a solo fight with a gray vixen."
-        ]
-},
-{
-        "patrol_id": "wtlnd_hunt_grayvixen7",
-        "biome": "wetland",
-        "season": "leaf-fall",
-        "tags": ["fighting", "minor_injury", "respect", "trust", "rel_patrol", "patrol_to_r_c"],
-        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
-        "decline_text": "Your patrol decides not to pursue the fox.",
-        "chance_of_success": 60,
-        "exp": 30,
-        "success_text": [
-        "The gray vixen smells like the prey she's been poaching to feed her litter. She's stolen from c_n for the last time, and the patrol drives her from their territory, yowling their anger and fury.",
-        "Your patrol drives away the gray fox, and seeks out her den, but her Leaf-fall cubs are near full-grown and scatter into the wilderness. Hopefully Leaf-bare takes care of them, but if c_n spots them, they won't hesitate.",
-        "s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the gray fox nor her scattered cubs pose a threat to the Clan. It places s_c as one of c_n's most talented and skillful fighters, a gray fox is a dangerous competitor.",
-        "The patrol overcomes the gray vixen they find and drives her off thanks to a brilliant battle move by s_c. The cats swirl around s_c afterwards, congratulating them on their bravery and skill."
+        "fail_skills": [
+            "good fighter"
         ],
-        "fail_text": [
-        "The patrol comes across a gray vixen at the end of the scent trail. She spots them too, measures herself up against them, then flees, scrambling up a tree and into the swamp canopy in a move that completely surprises the cats. This round goes to the gray fox.",
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the gray vixen slips past them and flees into the maze of the many wooded semi-submerged islands of the swamp.",
-        null,
-        "The patrol finds a stocky gray vixen wandering their wetland, and drives her out in a scene that mostly involves yowling and screaming and yapping at each other until she gives in. r_c gets a little battered, but everyone is mostly fine.",
-        null,
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is all muscle, barging past s_c and knocking them ass over paws as she flees from the patrol."
+        "fail_trait": [
+            "None"
         ],
-        "win_skills": ["excellent fighter"],
-        "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-    "fail_skills": ["good fighter"],
-    "fail_trait": ["None"],
-        "min_cats": 2,
-        "max_cats": 3,
-        "antagonize_text": null,
-        "antagonize_fail_text": null,
-        "history_text": [
-        "r_c carries a scar from a fight with a gray vixen.",
-        null
-        ]
-},
-{
-        "patrol_id": "wtlnd_hunt_grayvixen8",
-        "biome": "wetland",
-        "season": "leaf-fall",
-        "tags": ["fighting", "minor_injury", "respect", "trust", "rel_patrol", "patrol_to_r_c"],
-        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
-        "decline_text": "Your patrol decides not to pursue the fox.",
-        "chance_of_success": 90,
-        "exp": 30,
-        "success_text": [
-        "Led by p_l and with a heap of cooperation and teamwork, the patrol drives away the gray fox, and seeks out her den. But her cubs are near full-grown with the bounty of Leaf-fall, and scatter from the patrol into the wilderness. Hopefully Leaf-bare takes care of them.",
-        "With so many cats working together in tight coordination, they're able to keep the gray vixen they find pinned and distracted as they wear her down. The fox eventually flees for her den, and the patrol follows to drive her near-full grown litter of fox cubs out from the territory. Hopefully the coming Leaf-bare will take care of them.",
-        "s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the gray fox nor her scattered cubs pose a threat to the Clan. It places s_c as one of c_n's most talented and skillful fighters, a gray fox is a dangerous competitor.",
-        "Bravely, s_c charges the gray fox, yowling threats. The vixen spooks and skitters up a tree, growling and barking in a squeaky tone, and s_c follows her up into the branches. As the rest of the patrol backs them up from the ground, s_c screams until the fox is cowering and afraid, then lets her flee."
-        ],
-        "fail_text": [
-        "The patrol comes across a gray vixen at the end of the scent trail. She spots them too, measures herself up against them, then flees, scrambling up a tree and into the swamp canopy in a move that completely surprises the cats. This round goes to the gray fox.",
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the gray vixen slips past them and flees into the maze of the many wooded semi-submerged islands of the swamp.",
-        null,
-        "The patrol finds a stocky gray vixen wandering their wetland, and drives her out in a scene that mostly involves yowling and screaming and yapping at each other until she gives in. r_c gets a little battered, but everyone is mostly fine.",
-        null,
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is all muscle, barging past s_c and knocking them ass over paws as she flees from the patrol."
-        ],
-        "win_skills": ["excellent fighter"],
-        "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-    "fail_skills": ["good fighter"],
-    "fail_trait": ["None"],
         "min_cats": 4,
         "max_cats": 6,
         "antagonize_text": null,
@@ -3949,34 +3032,60 @@
         "history_text": [
             "r_c carries a scar from a fight with a gray vixen."
         ]
-},
-{
-        "patrol_id": "wtlnd_hunt_grayvixen9",
+    },
+    {
+        "patrol_id": "wtlnd_hunt_grayvixen6",
         "biome": "wetland",
-        "season": "leaf-fall",
-        "tags": ["fighting", "scar", "big_bite_injury", "respect", "trust", "clan_to_patrol"],
+        "season": "greenleaf",
+        "tags": [
+            "fighting",
+            "scar",
+            "big_bite_injury",
+            "respect",
+            "trust",
+            "clan_to_patrol"
+        ],
         "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
         "decline_text": "Your patrol decides not to pursue the fox.",
         "chance_of_success": 50,
         "exp": 50,
         "success_text": [
-        "In an exhausting fight, r_c manages to bring down and kill the gray vixen they've tracked. Her near grown litter, fat on the bounty of Leaf-fall, is a challenge for another day. c_n will have to deal with the young foxes now roaming motherless in the swamps, before they start to compete for prey in Leaf-bare.",
-        null,
-        "s_c displays incredible skill, driving the mother vixen and her brood out of c_n's swamps all by themselves. Now neither the gray fox nor her cubs pose a threat to the Clan. They swell with pride, returning to camp knowing there's one less competitor poaching c_n's prey.",
-        "They're nearly of equal height, with s_c's bold aggression making up for the weight that the gray vixen has on them, and the stand off is resolved when s_c charges the gray fox and she chooses flight over fight."
+            "r_c finds a gray vixen smelling of milk and blood. Hopefully by driving her out of the territory, the litter she has been raising this greenleaf won't be a threat to the Clan.",
+            null,
+            "s_c displays incredible skill, driving the mother vixen and her brood out of c_n's swamps all by themselves. Now neither the gray fox nor her dependent cubs pose a threat to the Clan. They swell with pride, returning to camp knowing there's one less competitor poaching c_n's prey.",
+            "They're nearly of equal height, with s_c's bold aggression making up for the weight that the gray vixen has on them, and the stand off is resolved when s_c charges the gray fox and she chooses flight over fight."
         ],
         "fail_text": [
-        "r_c comes across a gray vixen at the end of the scent trail. She spots them too, measures herself up against them, then flees, scrambling up a tree and into the swamp canopy in a move that completely surprises r_c. This round goes to the gray fox.",
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the gray vixen slips past them and flees into the maze of the many wooded semi-submerged islands of the swamp.",
-        null,
-        "r_c nearly managed to pin the gray vixen they find on a wet, barely above water island, but snapping jaws leave r_c dripping blood into the mud. Today this round goes to the gray fox.",
-        null,
-        "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is cunning, sinking her teeth into s_c to distract them as she flees."
+            "r_c comes across a gray vixen at the end of the scent trail. She spots them too, measures herself up against them, then flees, scrambling up a tree and into the swamp canopy in a move that completely surprises r_c. This round goes to the gray fox.",
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the gray vixen slips past them and flees into the maze of the many wooded semi-submerged islands of the swamp.",
+            null,
+            "r_c nearly managed to pin the gray vixen they find on a wet, barely above water island, but snapping jaws leave r_c dripping blood into the mud. Today this round goes to the gray fox.",
+            null,
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is cunning, sinking her teeth into s_c to distract them as she flees."
         ],
-        "win_skills": ["excellent fighter"],
-        "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-    "fail_skills": ["good fighter"],
-    "fail_trait": ["None"],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
         "min_cats": 1,
         "max_cats": 1,
         "antagonize_text": null,
@@ -3984,529 +3093,3868 @@
         "history_text": [
             "r_c carries a scar from a solo fight with a gray vixen."
         ]
-},
-{
-    "patrol_id": "wtlnd_hunt_redfox_steal1",
-    "biome": "wetland",
-    "season": "Any",
-    "tags": ["hunting", "small_prey", "fighting", "scar", "small_bite_injury", "platonic", "dislike", "respect", "rel_patrol"],
-    "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? And is it worth a fight if they encounter it?",
-    "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
-    "chance_of_success": 50,
-    "exp": 20,
-    "success_text": [
-        "p_l leads the patrol to the end of the scent trail, where a red fox sits plucking the feathers off a plump duck. With careful signals, the cats set up an ambush. There aren't many of them, but the fox doesn't need to know that - with a massive explosion of yowls, the cats sound like a full battle patrol, and the fox leaps up frightened out of its skin as the cats pounce to take possession of the bird.",
-        null,
-        "They're a small patrol, but a skilled one, and when they track down the red fox at the end of the scent trail they have enough skill and muscle to drive it off from the fish it was gnawing on. The cats gather around it, congraduating each other.",
-        "Tracking the fox trail, s_c reminds the rest of the patrol that things don't always need to end in a fight, using the trail to uncover a food cache of dead fish buried under a log. They still don't know what kind of fox left the trail, and they don't need to - these fish will make great additions to the fresh-kill pile back home."
-    ],
-    "fail_text": [
-        "The fox's trail vanishes, almost as though the creature has figured out they're tracking it. Grumbling and arguing, the patrol has to head back home disappointed.",
-        "The patrol tracks down a red fox, and spots that it's holding fresh-kill. However, s_c bursts from cover without warning, trying to intimidate the fox. Which they can say sort of worked, but also causes the fox to run off with the food it carries. The other cats aren't particularly pleased with s_c.",
-        null,
-        "p_l leads the patrol to the end of the scent trail, where a red fox sits plucking the feathers off a plump duck. With careful signals, the cats set up an ambush, but they aren't careful enough, and with a snarl the fox takes a bite at r_c as it flees with its dinner.",
-        null,
-        "The patrol tracks down a red fox, and spots that it's holding fresh-kill. However, s_c bursts from cover without warning, trying to intimidate the fox, and the overconfident attack ends in disaster as the fox bites s_c, leaving the rest of the patrol to rescue their annoying Clanmate as the fox runs off with what could've been their dinner."
-    ],
-    "win_skills": ["good hunter", "great hunter", "fantastic hunter", "good fighter", "great fighter", "excellent fighter"],
-    "win_trait": ["altruistic", "calm", "careful", "faithful", "insecure", "loyal", "nervous", "patient", "responsible", "righteous", "thoughtful", "wise"],
-    "fail_skills": ["None"],
-    "fail_trait": ["adventurous", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "playful", "troublesome", "vengeful"],
-    "min_cats": 2,
-    "max_cats": 3,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c carries a scar from a red fox fight.",
-        null
-    ]
-},
-{
-    "patrol_id": "wtlnd_hunt_redfox_steal2",
-    "biome": "wetland",
-    "season": "Any",
-    "tags": ["hunting", "small_prey", "fighting", "scar", "small_bite_injury", "platonic", "respect", "rel_patrol"],
-    "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? And is it worth a fight if they encounter it?",
-    "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
-    "chance_of_success": 50,
-    "exp": 20,
-    "success_text": [
-        "p_l leads the patrol to the end of the scent trail, where a red fox sits plucking the feathers off a plump duck. With careful signals, the cats set up an ambush. While they'd expected having more cats would make it easier, it also makes the patrol far more of a threat to the red fox, and the creature panicks when they reveal themselves. They win the bird, but r_c nearly gets injured, and it's only p_l shoving them both out of the way that saves both their pelts.",
-        null,
-        "With such a big patrol, and with s_c there, when they track down the red fox at the end of the scent trail they have more than enough skill and muscle to drive it off from the fish it was gnawing on. The cats gather around it, congraduating each other.",
-        "Tracking the fox trail, s_c reminds the rest of the patrol that things don't always need to end in a fight, using the trail to uncover a food cache of dead fish buried under a log. They still don't know what kind of fox left the trail, and they don't need to - these fish will make great additions to the fresh-kill pile back home."
-    ],
-    "fail_text": [
-        "The fox's trail vanishes, almost as though the creature has figured out they're tracking it. Grumbling and arguing, the patrol has to head back home disappointed.",
-        "The patrol tracks down a red fox, and spots that it's holding fresh-kill. However, s_c bursts from cover without warning, trying to intimidate the fox. Which they can say sort of worked, but also causes the fox to run off with the food it carries. The other cats aren't particularly pleased with s_c.",
-        null,
-        "p_l leads the patrol to the end of the scent trail, where a red fox sits plucking the feathers off a plump duck. With careful signals, the cats set up an ambush, but they aren't careful enough, and with a snarl the fox takes a bite at r_c as it flees with its dinner.",
-        null,
-        "The patrol tracks down a red fox, and spots that it's holding fresh-kill. However, s_c bursts from cover without warning, trying to intimidate the fox, and the overconfident attack ends in disaster as the fox bites s_c, leaving the rest of the patrol to rescue their annoying Clanmate as the fox runs off with what could've been their dinner."
-    ],
-    "win_skills": ["good hunter", "great hunter", "fantastic hunter", "good fighter", "great fighter", "excellent fighter"],
-    "win_trait": ["altruistic", "calm", "careful", "faithful", "insecure", "loyal", "nervous", "patient", "responsible", "righteous", "thoughtful", "wise"],
-    "fail_skills": ["None"],
-    "fail_trait": ["adventurous", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "playful", "troublesome", "vengeful"],
-    "min_cats": 4,
-    "max_cats": 6,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c carries a scar from a red fox fight."
-    ]
-},
-{
-    "patrol_id": "wtlnd_hunt_redfox_steal3",
-    "biome": "wetland",
-    "season": "Any",
-    "tags": ["hunting", "medium_prey", "fighting", "death", "scar", "big_bite_injury",  "clan_to_patrol", "respect"],
-    "intro_text": "r_c catches the scent of a fox - but is it red, or gray? And is it worth a fight if they encounter it?",
-    "decline_text": "r_c decides not to quarrel with the fox and to find prey elsewhere.",
-    "chance_of_success": 30,
-    "exp": 20,
-    "success_text": [
-        "Spotting the red fox they've tracked dipping into the shelter of a little scrub covered bit of dry land, r_c hangs back, sneaking around until they spot the fox burying a fish for later. They simply wait for it to finish and leave, then creep in to steal the fox's hard work, bringing the prize back to camp for the fresh-kill pile. Sometimes winning a battle doesn't require fighting.",
-        null,
-        "It requires s_c to use some of their best tricks, but they sneak close to the red fox at the end of the scent trail, eyes on the fish the fox carries. The creature puts down its fresh-kill to start fishing again, and s_c takes the opportunity, grabbing the fish and running. It's a good prize, and they feel proud to present it to the elders when they pad into camp, tired but satisfied.",
-        "It's a situation that calls for careful calm, not implusive action. s_c tracks down a red fox at the end of the scent trail, holding a young duck, and waits carefully. Eventually, as the fox starts to hunt at a different river, it drops its fresh-kill to try win more. s_c carefully snatches it while the fox is distracted, and trots back to camp having successfully outwitted the competing predator."
-    ],
-    "fail_text": [
-        "It embarrasses them, but r_c doesn't even manage to find the fox they track, let alone earn anything useful from the afternoon's attempts.",
-        "s_c hones in on the scent, and as soon as they spot the red fox with a dead fish hanging from its jaws, throwes themselves to the attack. The fox hears them coming, and with insulting nonchalance trots off, unwilling to get into a fight.",
-        null,
-        "Finding a red fox holding a fish that would be much appreciated for c_n's fresh-kill pile, r_c goes to attack it. But the fox is just as keen to keep it as r_c is to win it, and they're injured in the resulting fight.",
-        null,
-        "s_c hones in on the scent, and as soon as they spot the red fox with a dead fish hanging from its jaws, recklessly throwes themselves to the attack. But the fox is as desperate to keep its meal as s_c is to win it from them, and s_c has to retreat bleeding, as the fox trots off with its dinner."
-    ],
-    "win_skills": ["good hunter", "great hunter", "fantastic hunter", "good fighter", "great fighter", "excellent fighter"],
-    "win_trait": ["altruistic", "calm", "careful", "faithful", "insecure", "loyal", "nervous", "patient", "responsible", "righteous", "thoughtful", "wise"],
-    "fail_skills": ["None"],
-    "fail_trait": ["adventurous", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "playful", "troublesome", "vengeful"],
-    "min_cats": 1,
-    "max_cats": 1,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c carries a scar from a solo fight with a red fox."
-    ]
-},
-{
-    "patrol_id": "wtlnd_hunt_foxgray_steal1",
-    "biome": "wetland",
-    "season": "Any",
-    "tags": ["hunting", "small_prey", "fighting", "scar", "small_bite_injury", "platonic", "respect", "rel_patrol"],
-    "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? And is it worth a fight if they encounter it?",
-    "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
-    "chance_of_success": 50,
-    "exp": 20,
-    "success_text": [
-        "Its a gray fox, which as far as the cats are concerned, means free food. They leap after it, and after a short chase the fox drops the mouse it was holding. That's not enough to satisfy the c_n cats, who drive it out of their territory before collecting the mouse and continuing the afternoon's hunt.",
-        "The scent trail leads to where some kind of fox has cached half a fish in a poorly concealed hole. The cats take it as their due, and leave the fox to wander on.",
-        "The trail leads to a gray fox, and s_c makes sure it both hands over the prey it's poached from c_n land and flees for the border, tail between its legs and yelping. The smaller predator can't stand up to a patrol working together.",
-        "The cats slowly follow the trail, with s_c urging caution. There's no reason to rush into things. Sure enough, they find a grey fox. It's digging at a rotten log, unearthing insects. The patrol uses the presence of the other predator as a distraction to bring down a pump bird, one that was too busy watching the fox to guard from them, and the fox is left unscathed to keep bug hunting."
-    ],
-    "fail_text": [
-        "The fox's trail vanishes, almost as though the creature has figured out they're tracking it. Grumbling and arguing, the patrol has to head back home disappointed.",
-        "The patrol tracks down a gray fox trespassing on c_n land, but s_c runs at it without thinking, and instead of intimidating the fox into fleeing for the border it makes the gray fox skitter up a tree and start yelping. It takes all afternoon to wait the fox out and then drive it more gently from c_n's hunting grounds, and no one is happy with s_c.",
-        null,
-        "p_l leads the patrol to the end of the scent trail, where a gray fox sits grooming it's fur in the sunshine. With careful signals, the cats set up an ambush, but the small gray panics beyond anything any cat expected, and as it flees, convinced its life is in danger, it bites at r_c.",
-        null,
-        "The patrol tracks down a gray fox trespassing on c_n land, but s_c runs at it without thinking, and instead of intimidating the fox into fleeing for the border it makes the gray fox skitter up a tree and start yelping. s_c tries to make up for the mistake by following the fox up into the branches, which goes even more poorly and leaves the patrol needing to help them back to the medicine den."
-    ],
-    "win_skills": ["good hunter", "great hunter", "fantastic hunter", "great fighter", "excellent fighter"],
-    "win_trait": ["altruistic", "calm", "careful", "faithful", "insecure", "loyal", "nervous", "patient", "responsible", "righteous", "thoughtful", "wise"],
-    "fail_skills": ["None"],
-    "fail_trait": ["adventurous", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "playful", "troublesome", "vengeful"],
-    "min_cats": 2,
-    "max_cats": 3,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c carries a scar from a gray fox fight.",
-        null
-    ]
-},
-{
-    "patrol_id": "wtlnd_hunt_foxgray_steal2",
-    "biome": "wetland",
-    "season": "Any",
-    "tags": ["hunting", "small_prey", "fighting", "scar", "small_bite_injury", "platonic", "respect", "rel_patrol"],
-    "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? And is it worth a fight if they encounter it?",
-    "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
-    "chance_of_success": 70,
-    "exp": 20,
-    "success_text": [
-        "Its a gray fox, which as far as the cats are concerned, means free food. They leap after it, and after a short chase the fox drops the mouse it was holding. That's not enough to satisfy the c_n cats, who drive it out of their territory before collecting the mouse and continuing the afternoon's hunt.",
-        "The scent trail leads to where some kind of fox has cached a wood rat in a poorly concealed hole. The cats take it as their due, and leave the fox to wander on.",
-        "The trail leads to a gray fox, and s_c makes sure it both hands over the prey it's poached from c_n land and flees for the border, tail between its legs and yelping. The smaller predator can't stand up to a patrol working together.",
-        "The cats slowly follow the trail, with s_c urging caution. There's no reason to rush into things. Sure enough, they find a grey fox. It's digging at a rotten log, unearthing insects. The patrol uses the presence of the other predator as a distraction to bring down a pump bird, one that was too busy watching the fox to guard from them, and the fox is left unscathed to keep bug hunting."
-    ],
-    "fail_text": [
-        "The fox's trail vanishes, almost as though the creature has figured out they're tracking it. Grumbling and arguing, the patrol has to head back home disappointed.",
-        "The patrol tracks down a gray fox trespassing on c_n land, but s_c runs at it without thinking, and instead of intimidating the fox into fleeing for the border it makes the gray fox skitter up a tree and start yelping. It takes all afternoon to wait the fox out and then drive it more gently from c_n's hunting grounds, and no one is happy with s_c.",
-        null,
-        "p_l leads the patrol to the end of the scent trail, where a gray fox sits grooming its fur in the sunshine. With careful signals, the cats set up an ambush, but the small gray panics beyond anything any cat expected, and as it flees, convinced its life is in danger, it bites at r_c.",
-        null,
-        "The patrol tracks down a gray fox trespassing on c_n land, but s_c runs at it without thinking, and instead of intimidating the fox into fleeing for the border it makes the gray fox skitter up a tree and start yelping. s_c tries to make up for the mistake by following the fox up into the branches, which goes even more poorly and leaves the patrol needing to help them back to the medicine den."
-    ],
-    "win_skills": ["good hunter", "great hunter", "fantastic hunter", "great fighter", "excellent fighter"],
-    "win_trait": ["altruistic", "calm", "careful", "faithful", "insecure", "loyal", "nervous", "patient", "responsible", "righteous", "thoughtful", "wise"],
-    "fail_skills": ["None"],
-    "fail_trait": ["adventurous", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "playful", "troublesome", "vengeful"],
-    "min_cats": 4,
-    "max_cats": 6,
-    "antagonize_text": null,
-    "antagonize_fail_text": null
-},
-{
-    "patrol_id": "wtlnd_hunt_foxgray_steal3",
-    "biome": "wetland",
-    "season": "Any",
-    "tags": ["hunting", "medium_prey", "fighting", "scar", "small_bite_injury"],
-    "intro_text": "r_c catches the scent of a fox - but is it red, or gray? And is it worth a fight if they encounter it?",
-    "decline_text": "r_c decides not to quarrel with the fox and to find prey elsewhere.",
-    "chance_of_success": 50,
-    "exp": 15,
-    "success_text": [
-        "Spotting the gray fox they've tracked dipping into the shelter of a little scrub covered bit of dry land, r_c hangs back, sneaking around until they spot the fox caching a bird kill in an old log a storm washed in moons ago. They simply wait for it to finish and leave, then creep in to steal the fox's hard work, bringing the prize back to camp for the fresh-kill pile. Sometimes winning a battle doesn't require fighting.",
-        null,
-        "s_c tracks down a gray fox, and carefully cosiders it as an opponent. Stocky, yes, but they finally decide they can take it, and burst from cover, using surprise to get in a couple vicious swipes to the fox's face while its jaws are still full of prey. Yelping, the gray fox retreats from the cat, unwilling to risk more split blood, and s_c picks up the rat it carried with a proud grin.",
-        "It's a situation that calls for careful calm, not implusive action. s_c tracks down a gray fox at the end of the scent trail, holding a little plump mouse, and waits carefully. Eventually, the fox tries to cache its fresh-kill in a little hole. s_c picks it up once the fox leaves, strolling back to camp having successfully outwitted the competing predator."
-    ],
-    "fail_text": [
-        "It embarrasses them, but r_c doesn't even manage to find the fox they track, let alone earn anything useful from the afternoon's attempts.",
-        "s_c hones in on the scent, and as soon as they spot the gray fox with a dead fish hanging from its jaws, throwes themselves to the attack. The fox hears them coming, and makes a hasty retreat before the fight can start, taking its dinner with it.",
-        null,
-        "Finding a gray fox holding a mouse that would make a nice addition to c_n's fresh-kill pile, r_c goes to attack it. But the fox is just as keen to keep it as r_c is to win it, and they're injured in the resulting fight.",
-        null,
-        "s_c hones in on the scent, and as soon as they spot the gray fox with a dead fish hanging from its jaws, recklessly throwes themselves to the attack. But the fox is a little too desperate to keep itself from harm, and s_c has to retreat bleeding."
-    ],
-    "win_skills": ["good hunter", "great hunter", "fantastic hunter", "good fighter", "great fighter", "excellent fighter"],
-    "win_trait": ["altruistic", "calm", "careful", "faithful", "insecure", "loyal", "nervous", "patient", "responsible", "righteous", "thoughtful", "wise"],
-    "fail_skills": ["None"],
-    "fail_trait": ["adventurous", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "playful", "troublesome", "vengeful"],
-    "min_cats": 1,
-    "max_cats": 1,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c carries a scar from a solo fight with a gray fox."
-    ]
-},
-{
-    "patrol_id": "wtlnd_hunt_swiftfox_newleafscavenge1",
-    "biome": "wetland",
-    "season": "newleaf",
-    "tags": ["hunting", "small_prey", "comfort", "respect", "rel_patrol"],
-    "intro_text": "Your patrol catches the scent of a fox. Tracking it, they find a swift fox feeding on a fish about as big as it is. The cat-sized predator definitely didn't kill this.",
-    "decline_text": "Your patrol decides not to quarrel with the fox. There're plenty of fish in the river for everyone, and it's best to focus on feeding the Clan rather than quarreling.",
-    "chance_of_success": 70,
-    "exp": 20,
-    "success_text": [
-    "As the patrol approaches, the swift fox spots them and backs off from the carcass with a whine. Your cats bring it home, no fuss, no worries.",
-    null,
-    "The patrol takes over the carcass without a fight, the small swift fox giving way without trouble. Still, it's hardly worth the effort, and s_c can think of better things they should be doing.",
-    "Responsibly, s_c keeps the patrol moving once they take the fish from the unfortunate-but-unable-to-complain swift fox. They don't find anything, but with the stolen fish the afternoon hasn't been a completely wasted hunting trip."
-    ],
-    "fail_text": [
-    "The swift fox gives way easily to the bigger canivores, but the fish carcass is rotten, too rotten for the Clan cats to want to touch.",
-    "The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth. s_c calls the rest of the patrol for backup and no one is injured, but by the time they get back to the kill a different predator has absconded with the fish."
-    ],
-    "win_skills": ["smart", "very smart", "extremely smart"],
-    "win_trait": ["altruistic", "patient", "responsible", "thoughtful", "wise", "calm", "careful", "insecure", "nervous", "sneaky"],
-    "fail_skills": ["None"],
-    "fail_trait": ["bold", "childish", "confident", "daring", "playful", "shameless"],
-    "min_cats": 2,
-    "max_cats": 6,
-    "antagonize_text": null,
-    "antagonize_fail_text": null
-},
-{
-    "patrol_id": "wtlnd_hunt_swiftfox_newleafscavenge2",
-    "biome": "wetland",
-    "season": "newleaf",
-    "tags": ["hunting", "medium_prey", "fighting", "scar", "death", "no_body", "all_lives", "small_bite_injury"],
-    "intro_text": "r_c catches the scent of a fox. Tracking it, they find a swift fox feeding on a fish about as big as it is. The cat-sized predator definitely didn't kill this.",
-    "decline_text": "r_c decides not to quarrel with the fox. There're plenty of fish in the river for everyone, and it's best to focus on feeding the Clan rather than quarreling.",
-    "chance_of_success": 70,
-    "exp": 10,
-    "success_text": [
-    "r_c approaches the kill, fur puffed up. The swift fox grumbles, but with a hiss both animals agree to disagree, feeding from opposite ends of the calf without further trouble. r_c is able to find some decent scraps to carry back to camp, though with only them there they can't bring back as much meat as they'd like.",
-    null,
-    "Watching the swift fox at the carcass, s_c notices it stripping meat from the fish and caching it in little holes, and starts to copy it. The bigger predators will return to claim the fish soon, but by the time they do s_c will have hidden away the choicest morsels to fetch later.",
-    "With great care, aware that the kill's original owner must be somewhere about, s_c snatches the first large scrap they find and leaves the swift fox to risk the wrath of the bigger predators."
-    ],
-    "fail_text": [
-    "r_c muscles in as the swft fox gives way to the bigger predator, but the carcass is rotten and worthless.",
-    "The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth. s_c dances out of the way, but when they return, another predator has already snapped up the abandoned fish.",
-    "r_c starts arguing with the fox over the fish. Neither sees the alligator coming.",
-    "Puffed up, r_c approaches the swift fox. But there's only one of them, and the fox is their equal in size and weight. instead of running or giving it, it snarls, and attacks. r_c gives just as good as they get, and both animals end up limping away from the kill.",
-    null,
-    "The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth, sinking them into s_c and giving s_c a bigger concern than scavenging a fish carcass."
-    ],
-    "win_skills": ["good fighter", "great fighter", "excellent fighter"],
-    "win_trait": ["altruistic", "patient", "responsible", "thoughtful", "wise", "calm", "careful", "insecure", "nervous", "sneaky"],
-    "fail_skills": ["None"],
-    "fail_trait": ["bold", "childish", "confident", "daring", "playful", "shameless"],
-    "min_cats": 1,
-    "max_cats": 1,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c carries a scar from fighting with a swift fox.",
-        "While scavenging alone, r_c was killed by a predator they didn't see.",
-        "taken by an alligator"
-    ]
-},
-{
-    "patrol_id": "wtlnd_hunt_swiftfox_greenleafscavenge1",
-    "biome": "wetland",
-    "season": "greenleaf",
-    "tags": ["hunting", "small_prey", "comfort", "respect", "rel_patrol"],
-    "intro_text": "Your patrol catches the scent of a fox. Tracking it, they find a swift fox feeding on a fish about as big as it is. The cat-sized predator definitely didn't kill this.",
-    "decline_text": "Your patrol decides not to quarrel with the fox. There're plenty of fish in the river for everyone, and it's best to focus on feeding the Clan rather than quarreling.",
-    "chance_of_success": 70,
-    "exp": 20,
-    "success_text": [
-    "As the patrol approaches, the swift fox spots them and backs off from the carcass with a whine. Your cats bring it home, no fuss, no worries.",
-    null,
-    "The patrol takes over the carcass without a fight, the small swift fox giving way without trouble. Still, it's hardly worth the effort, and s_c can think of better things they should be doing.",
-    "Responsibly, s_c keeps the patrol moving once they take the fish from the unfortunate-but-unable-to-complain swift fox. They don't find anything, but with the stolen fish the afternoon hasn't been a completely wasted hunting trip."
-    ],
-    "fail_text": [
-    "The swift fox gives way easily to the bigger canivores, but the fish carcass is rotten, too rotten for the Clan cats to want to touch.",
-    "The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth. s_c calls the rest of the patrol for backup and no one is injured, but by the time they get back to the kill a different predator has absconded with the fish."
-    ],
-    "win_skills": ["smart", "very smart", "extremely smart"],
-    "win_trait": ["altruistic", "patient", "responsible", "thoughtful", "wise", "calm", "careful", "insecure", "nervous", "sneaky"],
-    "fail_skills": ["None"],
-    "fail_trait": ["bold", "childish", "confident", "daring", "playful", "shameless"],
-    "min_cats": 2,
-    "max_cats": 6,
-    "antagonize_text": null,
-    "antagonize_fail_text": null
-},
-{
-    "patrol_id": "wtlnd_hunt_swiftfox_greenleafscavenge2",
-    "biome": "wetland",
-    "season": "greenleaf",
-    "tags": ["hunting", "medium_prey", "fighting", "scar", "death", "no_body", "all_lives", "small_bite_injury"],
-    "intro_text": "r_c catches the scent of a fox. Tracking it, they find a swift fox feeding on a fish about as big as it is. The cat-sized predator definitely didn't kill this.",
-    "decline_text": "r_c decides not to quarrel with the fox. There're plenty of fish in the river for everyone, and it's best to focus on feeding the Clan rather than quarreling.",
-    "chance_of_success": 70,
-    "exp": 10,
-    "success_text": [
-    "r_c smaller, alone, and half its weight, but the fox has a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle. The fox, already stuffed full and unwilling to lose blood over it, leaves the kill with a grumble.",
-        null,
-        "s_c uses every trick in their talented fighting skillset to attack the fox with no one to watch their flank, until the perfect opportunity opens up and they pounce onto the fox's back, digging in their claws. It's a wild ride through the swamp until the fox bucks them off, but it wins them the fish carcass.",
-    "In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. But then they're stuck, unwilling to let go and risk being bitten. They're dragged through the swamp, over rocks and through bushes, until the fox finally collapses and the battered s_c goes back to proudly claim the fish."
-    ],
-    "fail_text": [
-    "r_c muscles in as the swft fox gives way to the bigger predator, but the carcass is rotten and worthless.",
-    "The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth. s_c dances out of the way, but when they return, another predator has already snapped up the abandoned fish.",
-    "r_c starts arguing with the fox over the fish. Neither sees the alligator coming.",
-    "Puffed up, r_c approaches the swift fox. But there's only one of them, and the fox is their equal in size and weight. instead of running or giving it, it snarls, and attacks. r_c gives just as good as they get, and both animals end up limping away from the kill.",
-    null,
-    "The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth, sinking them into s_c and giving s_c a bigger concern than scavenging a fish carcass."
-    ],
-    "win_skills": ["good fighter", "great fighter", "excellent fighter"],
-    "win_trait": ["altruistic", "patient", "responsible", "thoughtful", "wise", "calm", "careful", "insecure", "nervous", "sneaky"],
-    "fail_skills": ["None"],
-    "fail_trait": ["bold", "childish", "confident", "daring", "playful", "shameless"],
-    "min_cats": 1,
-    "max_cats": 1,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c carries a scar from fighting with a swift fox.",
-        "While scavenging alone, r_c was killed by a predator they didn't see.",
-        "taken by an alligator"
-    ]
-},
-{
-    "patrol_id": "wtlnd_hunt_swiftfox_leaf-fallscavenge1",
-    "biome": "wetland",
-    "season": "leaf-fall",
-    "tags": ["hunting", "small_prey", "comfort", "respect", "rel_patrol"],
-    "intro_text": "Your patrol catches the scent of a fox. Tracking it, they find a swift fox feeding on a fish about as big as it is. The cat-sized predator definitely didn't kill this.",
-    "decline_text": "Your patrol decides not to quarrel with the fox. There're plenty of fish in the river for everyone, and it's best to focus on feeding the Clan rather than quarreling.",
-    "chance_of_success": 70,
-    "exp": 20,
-    "success_text": [
-    "As the patrol approaches, the swift fox spots them and backs off from the carcass with a whine. Your cats bring it home, no fuss, no worries.",
-    null,
-    "The patrol takes over the carcass without a fight, the small swift fox giving way without trouble. Still, it's hardly worth the effort, and s_c can think of better things they should be doing.",
-    "Responsibly, s_c keeps the patrol moving once they take the fish from the unfortunate-but-unable-to-complain swift fox. They don't find anything, but with the stolen fish the afternoon hasn't been a completely wasted hunting trip."
-    ],
-    "fail_text": [
-    "The swift fox gives way easily to the bigger canivores, but the fish carcass is rotten, too rotten for the Clan cats to want to touch.",
-    "The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth. s_c calls the rest of the patrol for backup and no one is injured, but by the time they get back to the kill a different predator has absconded with the fish."
-    ],
-    "win_skills": ["smart", "very smart", "extremely smart"],
-    "win_trait": ["altruistic", "patient", "responsible", "thoughtful", "wise", "calm", "careful", "insecure", "nervous", "sneaky"],
-    "fail_skills": ["None"],
-    "fail_trait": ["bold", "childish", "confident", "daring", "playful", "shameless"],
-    "min_cats": 2,
-    "max_cats": 6,
-    "antagonize_text": null,
-    "antagonize_fail_text": null
-},
-{
-    "patrol_id": "wtlnd_hunt_swiftfox_leaf-fallscavenge2",
-    "biome": "wetland",
-    "season": "leaf-fall",
-    "tags": ["hunting", "medium_prey", "fighting", "scar", "death", "no_body", "all_lives", "small_bite_injury"],
-    "intro_text": "r_c catches the scent of a fox. Tracking it, they find a swift fox feeding on a fish about as big as it is. The cat-sized predator definitely didn't kill this.",
-    "decline_text": "r_c decides not to quarrel with the fox. There're plenty of fish in the river for everyone, and it's best to focus on feeding the Clan rather than quarreling.",
-    "chance_of_success": 70,
-    "exp": 10,
-    "success_text": [
-    "r_c smaller, alone, and half its weight, but the fox has a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle. The fox, already on the look out for other predators and unwilling to lose blood over it, leaves the kill with a grumble.",
-        null,
-        "s_c uses every trick in their talented fighting skillset to attack the fox with no one to watch their flank, until the perfect opportunity opens up and they pounce onto the fox's back, digging in their claws. It's a wild ride through the swamp until the fox bucks them off, but it wins them the fish carcass.",
-    "In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. But then they're stuck, unwilling to let go and risk being bitten. They're dragged through the swamp, over rocks and through bushes, until the fox finally collapses and the battered s_c goes back to proudly claim the fish."
-    ],
-    "fail_text": [
-"r_c muscles in as the swft fox gives way to the bigger predator, but the carcass is rotten and worthless.",
-    "The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth. s_c dances out of the way, but when they return, another predator has already snapped up the abandoned fish.",
-    "r_c starts arguing with the fox over the fish. Neither sees the alligator coming.",
-    "Puffed up, r_c approaches the swift fox. But there's only one of them, and the fox is their equal in size and weight. instead of running or giving it, it snarls, and attacks. r_c gives just as good as they get, and both animals end up limping away from the kill.",
-    null,
-    "The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth, sinking them into s_c and giving s_c a bigger concern than scavenging a fish carcass."
-    ],
-    "win_skills": ["good fighter", "great fighter", "excellent fighter"],
-    "win_trait": ["altruistic", "patient", "responsible", "thoughtful", "wise", "calm", "careful", "insecure", "nervous", "sneaky"],
-    "fail_skills": ["None"],
-    "fail_trait": ["bold", "childish", "confident", "daring", "playful", "shameless"],
-    "min_cats": 1,
-    "max_cats": 1,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c carries a scar from fighting with a swift fox.",
-        "While scavenging alone, r_c was killed by a predator they didn't see.",
-        "taken by an alligator"
-    ]
-},
-{
-    "patrol_id": "wtlnd_hunt_swiftfox_leaf-barescavenge1",
-    "biome": "wetland",
-    "season": "leaf-bare",
-    "tags": ["hunting", "small_prey", "comfort", "respect", "rel_patrol"],
-    "intro_text": "Your patrol catches the scent of a fox. Tracking it, they find a swift fox feeding on a fish about as big as it is. The cat-sized predator definitely didn't kill this.",
-    "decline_text": "Your patrol decides not to quarrel with the fox. There're plenty of fish in the river for everyone, and it's best to focus on feeding the Clan rather than quarreling.",
-    "chance_of_success": 60,
-    "exp": 20,
-    "success_text": [
-    "As the patrol approaches, the swift fox spots them and backs off from the carcass with a whine. Your cats bring it home, no fuss, no worries.",
-    null,
-    "The patrol takes over the carcass without a fight, the small swift fox giving way without trouble. Still, it's hardly worth the effort, and s_c can think of better things they should be doing.",
-    "Responsibly, s_c keeps the patrol moving once they take the fish from the unfortunate-but-unable-to-complain swift fox. They don't find anything, but with the stolen fish the afternoon hasn't been a completely wasted hunting trip."
-    ],
-    "fail_text": [
-    "The swift fox gives way easily to the bigger canivores, but the fish carcass is rotten, too rotten for the Clan cats to want to touch.",
-    "The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth. s_c calls the rest of the patrol for backup and no one is injured, but by the time they get back to the kill a different predator has absconded with the fish."
-    ],
-    "win_skills": ["smart", "very smart", "extremely smart"],
-    "win_trait": ["altruistic", "patient", "responsible", "thoughtful", "wise", "calm", "careful", "insecure", "nervous", "sneaky"],
-    "fail_skills": ["None"],
-    "fail_trait": ["bold", "childish", "confident", "daring", "playful", "shameless"],
-    "min_cats": 2,
-    "max_cats": 6,
-    "antagonize_text": null,
-    "antagonize_fail_text": null
-},
-{
-    "patrol_id": "wtlnd_hunt_swiftfox_leaf-barescavenge2",
-    "biome": "wetland",
-    "season": "leaf-bare",
-    "tags": ["hunting", "medium_prey", "fighting", "scar", "death", "no_body", "all_lives", "small_bite_injury"],
-    "intro_text": "r_c catches the scent of a fox. Tracking it, they find a swift fox feeding on a fish about as big as it is. Roughly equal in size to r_c, the swift fox definitely didn't bring down this feast themselves.",
-    "decline_text": "r_c decides not to quarrel with the fox. There're plenty of fish in the river for everyone, and it's best to focus on feeding the Clan rather than quarreling.",
-    "chance_of_success": 50,
-    "exp": 10,
-    "success_text": [
-    "r_c smaller, alone, and half its weight, but the fox has a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle. The fox, already on the look out for other predators and unwilling to lose blood over it, leaves the kill with a grumble.",
-        null,
-        "s_c uses every trick in their talented fighting skillset to attack the fox with no one to watch their flank, until the perfect opportunity opens up and they pounce onto the fox's back, digging in their claws. It's a wild ride through the swamp until the fox bucks them off, but it wins them the fish carcass.",
-    "In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. But then they're stuck, unwilling to let go and risk being bitten. They're dragged through the swamp, over rocks and through bushes, until the fox finally collapses and the battered s_c goes back to proudly claim the fish."
-    ],
-    "fail_text": [
-"r_c muscles in as the swft fox gives way to the bigger predator, but the carcass is rotten and worthless.",
-    "The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth. s_c dances out of the way, but when they return, another predator has already snapped up the abandoned fish.",
-    "r_c starts arguing with the fox over the fish. Neither sees the alligator coming.",
-    "Puffed up, r_c approaches the swift fox. But there's only one of them, and the fox is their equal in size and weight. instead of running or giving it, it snarls, and attacks. r_c gives just as good as they get, and both animals end up limping away from the kill.",
-    null,
-    "The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth, sinking them into s_c and giving s_c a bigger concern than scavenging a fish carcass."
-    ],
-    "win_skills": ["good fighter", "great fighter", "excellent fighter"],
-    "win_trait": ["altruistic", "patient", "responsible", "thoughtful", "wise", "calm", "careful", "insecure", "nervous", "sneaky"],
-    "fail_skills": ["None"],
-    "fail_trait": ["bold", "childish", "confident", "daring", "playful", "shameless"],
-    "min_cats": 1,
-    "max_cats": 1,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c carries a scar from fighting with a swift fox.",
-        "While scavenging alone, r_c was killed by a predator they didn't see.",
-        "taken by an alligator"
-    ]
-},
-{
-    "patrol_id": "wtlnd_hunt_kitfox_scavenge1",
-    "biome": "wetland",
-    "season": "leaf-bare",
-    "tags": ["hunting", "small_prey", "comfort", "respect", "rel_patrol"],
-    "intro_text": "Your patrol catches the scent of a fox. Tracking it, they find a kit fox fishing on a branch overlooking the shallows.",
-    "decline_text": "Your patrol decides not to quarrel with the fox. There're plenty of fish in the river for everyone, and it's best to focus on feeding the Clan rather than quarreling.",
-    "chance_of_success": 70,
-    "exp": 10,
-    "success_text": [
-    "The cats freeze, and carefully creep back into cover. A kit fox is small enough to inevitably startle and run from them, but if they play this right... they wait until the tiny fox drops down onto a salamandar before they pop out of the bushes. Not only to they scare off a potential competitor, they also get the added reward of a little snack.",
-    "It's a truely ridiculous power disparity, with even a single member of the patrol outweighing the little fox. The cats drive it out of c_n's swamps no trouble, but it's hardly worth the little fishy morsel they win for their efforts.",
-    "A simple display of just how badly the kit fox is outmatched convinces it to run, and s_c carefully seeks out the little food cache the kit fox was workign on, taking the minnows for the camp's fresh-kill pile.",
-    "It's frustrating that it only wins them a single minnow, but hte patrol drives out the kit fox, and s_c reminds them that's what matters - that now the fox won't keep poaching from c_n's hunting grounds in the future."
-    ],
-    "fail_text": [
-    "The cats freeze, and carefully creep back into cover. A kit fox is small enough to inevitably startle and run from them, but if they play this right... but not, the kit fox has spotted them, and flees from the cats. At least that's one less competitior in c_n's hunting grounds?"
-    ],
-    "win_skills": ["smart", "very smart", "extremely smart"],
-    "win_trait": ["altruistic", "patient", "responsible", "thoughtful", "wise", "calm", "careful", "insecure", "nervous", "sneaky"],
-    "fail_skills": ["None"],
-    "fail_trait": ["bold", "childish", "confident", "daring", "playful", "shameless"],
-    "min_cats": 2,
-    "max_cats": 6,
-    "antagonize_text": null,
-    "antagonize_fail_text": null
-},
-{
-    "patrol_id": "wtlnd_hunt_kitfox_scavenge2",
-    "biome": "wetland",
-    "season": "leaf-bare",
-    "tags": ["hunting", "medium_prey"],
-    "intro_text": "r_c catches the scent of a fox. Tracking it, they find a kit fox fishing on a branch overlooking the shallows.",
-    "decline_text": "r_c decides not to quarrel with the fox. There're plenty of fish in the river for everyone, and it's best to focus on feeding the Clan rather than quarreling.",
-    "chance_of_success": 70,
-    "exp": 10,
-    "success_text": [
-        "r_c freezes, and carefully creeps back into cover. A kit fox is small enough to inevitably startle and run from them, but if they play this right... they wait until the tiny fox drops down onto a salamandar before they pop out of the bushes. Not only to they scare off a potential competitor, they also get the added reward of a little snack.",
-        "r_c throws their weight around as the bigger predator, stealing the kit fox's lunch and driving it away from the river.",
-        "s_c uses every trick in their talented fighting skillset to attack the fox with no one to watch their flank, until the perfect opportunity opens up and they pounce onto the fox's back, digging in their claws. It's a wild ride through the swamp until the fox bucks them off, but it wins them the fish carcass.",
-        "In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. But then they're stuck, unwilling to let go and risk being bitten. They're dragged through the swamp, over rocks and through bushes, until the fox finally collapses and the battered s_c goes back to proudly claim the fish."
-    ],
-    "fail_text": [
-    "r_c freezes, and carefully creeps back into cover. A kit fox is small enough to inevitably startle and run from them, but if they play this right... but not, the kit fox has spotted them, and flees from the cat. At least that's one less competitior in c_n's hunting grounds?"
-    ],
-    "win_skills": ["good fighter", "great fighter", "excellent fighter"],
-    "win_trait": ["altruistic", "patient", "responsible", "thoughtful", "wise", "calm", "careful", "insecure", "nervous", "sneaky"],
-    "fail_skills": ["None"],
-    "fail_trait": ["bold", "childish", "confident", "daring", "playful", "shameless"],
-    "min_cats": 1,
-    "max_cats": 1,
-    "antagonize_text": null,
-    "antagonize_fail_text": null
-}
-
+    },
+    {
+        "patrol_id": "wtlnd_hunt_grayvixen7",
+        "biome": "wetland",
+        "season": "leaf-fall",
+        "tags": [
+            "fighting",
+            "minor_injury",
+            "respect",
+            "trust",
+            "rel_patrol",
+            "patrol_to_r_c"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
+        "decline_text": "Your patrol decides not to pursue the fox.",
+        "chance_of_success": 60,
+        "exp": 30,
+        "success_text": [
+            "The gray vixen smells like the prey she's been poaching to feed her litter. She's stolen from c_n for the last time, and the patrol drives her from their territory, yowling their anger and fury.",
+            "Your patrol drives away the gray fox, and seeks out her den, but her Leaf-fall cubs are near full-grown and scatter into the wilderness. Hopefully Leaf-bare takes care of them, but if c_n spots them, they won't hesitate.",
+            "s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the gray fox nor her scattered cubs pose a threat to the Clan. It places s_c as one of c_n's most talented and skillful fighters, a gray fox is a dangerous competitor.",
+            "The patrol overcomes the gray vixen they find and drives her off thanks to a brilliant battle move by s_c. The cats swirl around s_c afterwards, congratulating them on their bravery and skill."
+        ],
+        "fail_text": [
+            "The patrol comes across a gray vixen at the end of the scent trail. She spots them too, measures herself up against them, then flees, scrambling up a tree and into the swamp canopy in a move that completely surprises the cats. This round goes to the gray fox.",
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the gray vixen slips past them and flees into the maze of the many wooded semi-submerged islands of the swamp.",
+            null,
+            "The patrol finds a stocky gray vixen wandering their wetland, and drives her out in a scene that mostly involves yowling and screaming and yapping at each other until she gives in. r_c gets a little battered, but everyone is mostly fine.",
+            null,
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is all muscle, barging past s_c and knocking them ass over paws as she flees from the patrol."
+        ],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 2,
+        "max_cats": 3,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a fight with a gray vixen.",
+            null
+        ]
+    },
+    {
+        "patrol_id": "wtlnd_hunt_grayvixen8",
+        "biome": "wetland",
+        "season": "leaf-fall",
+        "tags": [
+            "fighting",
+            "minor_injury",
+            "respect",
+            "trust",
+            "rel_patrol",
+            "patrol_to_r_c"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
+        "decline_text": "Your patrol decides not to pursue the fox.",
+        "chance_of_success": 90,
+        "exp": 30,
+        "success_text": [
+            "Led by p_l and with a heap of cooperation and teamwork, the patrol drives away the gray fox, and seeks out her den. But her cubs are near full-grown with the bounty of Leaf-fall, and scatter from the patrol into the wilderness. Hopefully Leaf-bare takes care of them.",
+            "With so many cats working together in tight coordination, they're able to keep the gray vixen they find pinned and distracted as they wear her down. The fox eventually flees for her den, and the patrol follows to drive her near-full grown litter of fox cubs out from the territory. Hopefully the coming Leaf-bare will take care of them.",
+            "s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the gray fox nor her scattered cubs pose a threat to the Clan. It places s_c as one of c_n's most talented and skillful fighters, a gray fox is a dangerous competitor.",
+            "Bravely, s_c charges the gray fox, yowling threats. The vixen spooks and skitters up a tree, growling and barking in a squeaky tone, and s_c follows her up into the branches. As the rest of the patrol backs them up from the ground, s_c screams until the fox is cowering and afraid, then lets her flee."
+        ],
+        "fail_text": [
+            "The patrol comes across a gray vixen at the end of the scent trail. She spots them too, measures herself up against them, then flees, scrambling up a tree and into the swamp canopy in a move that completely surprises the cats. This round goes to the gray fox.",
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the gray vixen slips past them and flees into the maze of the many wooded semi-submerged islands of the swamp.",
+            null,
+            "The patrol finds a stocky gray vixen wandering their wetland, and drives her out in a scene that mostly involves yowling and screaming and yapping at each other until she gives in. r_c gets a little battered, but everyone is mostly fine.",
+            null,
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is all muscle, barging past s_c and knocking them ass over paws as she flees from the patrol."
+        ],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 4,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a fight with a gray vixen."
+        ]
+    },
+    {
+        "patrol_id": "wtlnd_hunt_grayvixen9",
+        "biome": "wetland",
+        "season": "leaf-fall",
+        "tags": [
+            "fighting",
+            "scar",
+            "big_bite_injury",
+            "respect",
+            "trust",
+            "clan_to_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
+        "decline_text": "Your patrol decides not to pursue the fox.",
+        "chance_of_success": 50,
+        "exp": 50,
+        "success_text": [
+            "In an exhausting fight, r_c manages to bring down and kill the gray vixen they've tracked. Her near grown litter, fat on the bounty of Leaf-fall, is a challenge for another day. c_n will have to deal with the young foxes now roaming motherless in the swamps, before they start to compete for prey in Leaf-bare.",
+            null,
+            "s_c displays incredible skill, driving the mother vixen and her brood out of c_n's swamps all by themselves. Now neither the gray fox nor her cubs pose a threat to the Clan. They swell with pride, returning to camp knowing there's one less competitor poaching c_n's prey.",
+            "They're nearly of equal height, with s_c's bold aggression making up for the weight that the gray vixen has on them, and the stand off is resolved when s_c charges the gray fox and she chooses flight over fight."
+        ],
+        "fail_text": [
+            "r_c comes across a gray vixen at the end of the scent trail. She spots them too, measures herself up against them, then flees, scrambling up a tree and into the swamp canopy in a move that completely surprises r_c. This round goes to the gray fox.",
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the gray vixen slips past them and flees into the maze of the many wooded semi-submerged islands of the swamp.",
+            null,
+            "r_c nearly managed to pin the gray vixen they find on a wet, barely above water island, but snapping jaws leave r_c dripping blood into the mud. Today this round goes to the gray fox.",
+            null,
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is cunning, sinking her teeth into s_c to distract them as she flees."
+        ],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a solo fight with a gray vixen."
+        ]
+    },
+    {
+        "patrol_id": "wtlnd_hunt_redfox_steal1",
+        "biome": "wetland",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "small_prey",
+            "fighting",
+            "scar",
+            "small_bite_injury",
+            "platonic",
+            "dislike",
+            "respect",
+            "rel_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? And is it worth a fight if they encounter it?",
+        "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 50,
+        "exp": 20,
+        "success_text": [
+            "p_l leads the patrol to the end of the scent trail, where a red fox sits plucking the feathers off a plump duck. With careful signals, the cats set up an ambush. There aren't many of them, but the fox doesn't need to know that - with a massive explosion of yowls, the cats sound like a full battle patrol, and the fox leaps up frightened out of its skin as the cats pounce to take possession of the bird.",
+            null,
+            "They're a small patrol, but a skilled one, and when they track down the red fox at the end of the scent trail they have enough skill and muscle to drive it off from the fish it was gnawing on. The cats gather around it, congraduating each other.",
+            "Tracking the fox trail, s_c reminds the rest of the patrol that things don't always need to end in a fight, using the trail to uncover a food cache of dead fish buried under a log. They still don't know what kind of fox left the trail, and they don't need to - these fish will make great additions to the fresh-kill pile back home."
+        ],
+        "fail_text": [
+            "The fox's trail vanishes, almost as though the creature has figured out they're tracking it. Grumbling and arguing, the patrol has to head back home disappointed.",
+            "The patrol tracks down a red fox, and spots that it's holding fresh-kill. However, s_c bursts from cover without warning, trying to intimidate the fox. Which they can say sort of worked, but also causes the fox to run off with the food it carries. The other cats aren't particularly pleased with s_c.",
+            null,
+            "p_l leads the patrol to the end of the scent trail, where a red fox sits plucking the feathers off a plump duck. With careful signals, the cats set up an ambush, but they aren't careful enough, and with a snarl the fox takes a bite at r_c as it flees with its dinner.",
+            null,
+            "The patrol tracks down a red fox, and spots that it's holding fresh-kill. However, s_c bursts from cover without warning, trying to intimidate the fox, and the overconfident attack ends in disaster as the fox bites s_c, leaving the rest of the patrol to rescue their annoying Clanmate as the fox runs off with what could've been their dinner."
+        ],
+        "win_skills": [
+            "good hunter",
+            "great hunter",
+            "fantastic hunter",
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "altruistic",
+            "calm",
+            "careful",
+            "faithful",
+            "insecure",
+            "loyal",
+            "nervous",
+            "patient",
+            "responsible",
+            "righteous",
+            "thoughtful",
+            "wise"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "adventurous",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "playful",
+            "troublesome",
+            "vengeful"
+        ],
+        "min_cats": 2,
+        "max_cats": 3,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a red fox fight.",
+            null
+        ]
+    },
+    {
+        "patrol_id": "wtlnd_hunt_redfox_steal2",
+        "biome": "wetland",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "small_prey",
+            "fighting",
+            "scar",
+            "small_bite_injury",
+            "platonic",
+            "respect",
+            "rel_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? And is it worth a fight if they encounter it?",
+        "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 50,
+        "exp": 20,
+        "success_text": [
+            "p_l leads the patrol to the end of the scent trail, where a red fox sits plucking the feathers off a plump duck. With careful signals, the cats set up an ambush. While they'd expected having more cats would make it easier, it also makes the patrol far more of a threat to the red fox, and the creature panicks when they reveal themselves. They win the bird, but r_c nearly gets injured, and it's only p_l shoving them both out of the way that saves both their pelts.",
+            null,
+            "With such a big patrol, and with s_c there, when they track down the red fox at the end of the scent trail they have more than enough skill and muscle to drive it off from the fish it was gnawing on. The cats gather around it, congraduating each other.",
+            "Tracking the fox trail, s_c reminds the rest of the patrol that things don't always need to end in a fight, using the trail to uncover a food cache of dead fish buried under a log. They still don't know what kind of fox left the trail, and they don't need to - these fish will make great additions to the fresh-kill pile back home."
+        ],
+        "fail_text": [
+            "The fox's trail vanishes, almost as though the creature has figured out they're tracking it. Grumbling and arguing, the patrol has to head back home disappointed.",
+            "The patrol tracks down a red fox, and spots that it's holding fresh-kill. However, s_c bursts from cover without warning, trying to intimidate the fox. Which they can say sort of worked, but also causes the fox to run off with the food it carries. The other cats aren't particularly pleased with s_c.",
+            null,
+            "p_l leads the patrol to the end of the scent trail, where a red fox sits plucking the feathers off a plump duck. With careful signals, the cats set up an ambush, but they aren't careful enough, and with a snarl the fox takes a bite at r_c as it flees with its dinner.",
+            null,
+            "The patrol tracks down a red fox, and spots that it's holding fresh-kill. However, s_c bursts from cover without warning, trying to intimidate the fox, and the overconfident attack ends in disaster as the fox bites s_c, leaving the rest of the patrol to rescue their annoying Clanmate as the fox runs off with what could've been their dinner."
+        ],
+        "win_skills": [
+            "good hunter",
+            "great hunter",
+            "fantastic hunter",
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "altruistic",
+            "calm",
+            "careful",
+            "faithful",
+            "insecure",
+            "loyal",
+            "nervous",
+            "patient",
+            "responsible",
+            "righteous",
+            "thoughtful",
+            "wise"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "adventurous",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "playful",
+            "troublesome",
+            "vengeful"
+        ],
+        "min_cats": 4,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a red fox fight."
+        ]
+    },
+    {
+        "patrol_id": "wtlnd_hunt_redfox_steal3",
+        "biome": "wetland",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "medium_prey",
+            "fighting",
+            "scar",
+            "big_bite_injury",
+            "clan_to_patrol",
+            "respect"
+        ],
+        "intro_text": "r_c catches the scent of a fox - but is it red, or gray? And is it worth a fight if they encounter it?",
+        "decline_text": "r_c decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 30,
+        "exp": 20,
+        "success_text": [
+            "Spotting the red fox they've tracked dipping into the shelter of a little scrub covered bit of dry land, r_c hangs back, sneaking around until they spot the fox burying a fish for later. They simply wait for it to finish and leave, then creep in to steal the fox's hard work, bringing the prize back to camp for the fresh-kill pile. Sometimes winning a battle doesn't require fighting.",
+            null,
+            "It requires s_c to use some of their best tricks, but they sneak close to the red fox at the end of the scent trail, eyes on the fish the fox carries. The creature puts down its fresh-kill to start fishing again, and s_c takes the opportunity, grabbing the fish and running. It's a good prize, and they feel proud to present it to the elders when they pad into camp, tired but satisfied.",
+            "It's a situation that calls for careful calm, not implusive action. s_c tracks down a red fox at the end of the scent trail, holding a young duck, and waits carefully. Eventually, as the fox starts to hunt at a different river, it drops its fresh-kill to try win more. s_c carefully snatches it while the fox is distracted, and trots back to camp having successfully outwitted the competing predator."
+        ],
+        "fail_text": [
+            "It embarrasses them, but r_c doesn't even manage to find the fox they track, let alone earn anything useful from the afternoon's attempts.",
+            "s_c hones in on the scent, and as soon as they spot the red fox with a dead fish hanging from its jaws, throwes themselves to the attack. The fox hears them coming, and with insulting nonchalance trots off, unwilling to get into a fight.",
+            null,
+            "Finding a red fox holding a fish that would be much appreciated for c_n's fresh-kill pile, r_c goes to attack it. But the fox is just as keen to keep it as r_c is to win it, and they're injured in the resulting fight.",
+            null,
+            "s_c hones in on the scent, and as soon as they spot the red fox with a dead fish hanging from its jaws, recklessly throwes themselves to the attack. But the fox is as desperate to keep its meal as s_c is to win it from them, and s_c has to retreat bleeding, as the fox trots off with its dinner."
+        ],
+        "win_skills": [
+            "good hunter",
+            "great hunter",
+            "fantastic hunter",
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "altruistic",
+            "calm",
+            "careful",
+            "faithful",
+            "insecure",
+            "loyal",
+            "nervous",
+            "patient",
+            "responsible",
+            "righteous",
+            "thoughtful",
+            "wise"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "adventurous",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "playful",
+            "troublesome",
+            "vengeful"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a solo fight with a red fox."
+        ]
+    },
+    {
+        "patrol_id": "wtlnd_hunt_foxgray_steal1",
+        "biome": "wetland",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "small_prey",
+            "fighting",
+            "scar",
+            "small_bite_injury",
+            "platonic",
+            "respect",
+            "rel_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? And is it worth a fight if they encounter it?",
+        "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 50,
+        "exp": 20,
+        "success_text": [
+            "Its a gray fox, which as far as the cats are concerned, means free food. They leap after it, and after a short chase the fox drops the mouse it was holding. That's not enough to satisfy the c_n cats, who drive it out of their territory before collecting the mouse and continuing the afternoon's hunt.",
+            "The scent trail leads to where some kind of fox has cached half a fish in a poorly concealed hole. The cats take it as their due, and leave the fox to wander on.",
+            "The trail leads to a gray fox, and s_c makes sure it both hands over the prey it's poached from c_n land and flees for the border, tail between its legs and yelping. The smaller predator can't stand up to a patrol working together.",
+            "The cats slowly follow the trail, with s_c urging caution. There's no reason to rush into things. Sure enough, they find a grey fox. It's digging at a rotten log, unearthing insects. The patrol uses the presence of the other predator as a distraction to bring down a pump bird, one that was too busy watching the fox to guard from them, and the fox is left unscathed to keep bug hunting."
+        ],
+        "fail_text": [
+            "The fox's trail vanishes, almost as though the creature has figured out they're tracking it. Grumbling and arguing, the patrol has to head back home disappointed.",
+            "The patrol tracks down a gray fox trespassing on c_n land, but s_c runs at it without thinking, and instead of intimidating the fox into fleeing for the border it makes the gray fox skitter up a tree and start yelping. It takes all afternoon to wait the fox out and then drive it more gently from c_n's hunting grounds, and no one is happy with s_c.",
+            null,
+            "p_l leads the patrol to the end of the scent trail, where a gray fox sits grooming it's fur in the sunshine. With careful signals, the cats set up an ambush, but the small gray panics beyond anything any cat expected, and as it flees, convinced its life is in danger, it bites at r_c.",
+            null,
+            "The patrol tracks down a gray fox trespassing on c_n land, but s_c runs at it without thinking, and instead of intimidating the fox into fleeing for the border it makes the gray fox skitter up a tree and start yelping. s_c tries to make up for the mistake by following the fox up into the branches, which goes even more poorly and leaves the patrol needing to help them back to the medicine den."
+        ],
+        "win_skills": [
+            "good hunter",
+            "great hunter",
+            "fantastic hunter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "altruistic",
+            "calm",
+            "careful",
+            "faithful",
+            "insecure",
+            "loyal",
+            "nervous",
+            "patient",
+            "responsible",
+            "righteous",
+            "thoughtful",
+            "wise"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "adventurous",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "playful",
+            "troublesome",
+            "vengeful"
+        ],
+        "min_cats": 2,
+        "max_cats": 3,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a gray fox fight.",
+            null
+        ]
+    },
+    {
+        "patrol_id": "wtlnd_hunt_foxgray_steal2",
+        "biome": "wetland",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "small_prey",
+            "fighting",
+            "scar",
+            "small_bite_injury",
+            "platonic",
+            "respect",
+            "rel_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? And is it worth a fight if they encounter it?",
+        "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 70,
+        "exp": 20,
+        "success_text": [
+            "Its a gray fox, which as far as the cats are concerned, means free food. They leap after it, and after a short chase the fox drops the mouse it was holding. That's not enough to satisfy the c_n cats, who drive it out of their territory before collecting the mouse and continuing the afternoon's hunt.",
+            "The scent trail leads to where some kind of fox has cached a wood rat in a poorly concealed hole. The cats take it as their due, and leave the fox to wander on.",
+            "The trail leads to a gray fox, and s_c makes sure it both hands over the prey it's poached from c_n land and flees for the border, tail between its legs and yelping. The smaller predator can't stand up to a patrol working together.",
+            "The cats slowly follow the trail, with s_c urging caution. There's no reason to rush into things. Sure enough, they find a grey fox. It's digging at a rotten log, unearthing insects. The patrol uses the presence of the other predator as a distraction to bring down a pump bird, one that was too busy watching the fox to guard from them, and the fox is left unscathed to keep bug hunting."
+        ],
+        "fail_text": [
+            "The fox's trail vanishes, almost as though the creature has figured out they're tracking it. Grumbling and arguing, the patrol has to head back home disappointed.",
+            "The patrol tracks down a gray fox trespassing on c_n land, but s_c runs at it without thinking, and instead of intimidating the fox into fleeing for the border it makes the gray fox skitter up a tree and start yelping. It takes all afternoon to wait the fox out and then drive it more gently from c_n's hunting grounds, and no one is happy with s_c.",
+            null,
+            "p_l leads the patrol to the end of the scent trail, where a gray fox sits grooming its fur in the sunshine. With careful signals, the cats set up an ambush, but the small gray panics beyond anything any cat expected, and as it flees, convinced its life is in danger, it bites at r_c.",
+            null,
+            "The patrol tracks down a gray fox trespassing on c_n land, but s_c runs at it without thinking, and instead of intimidating the fox into fleeing for the border it makes the gray fox skitter up a tree and start yelping. s_c tries to make up for the mistake by following the fox up into the branches, which goes even more poorly and leaves the patrol needing to help them back to the medicine den."
+        ],
+        "win_skills": [
+            "good hunter",
+            "great hunter",
+            "fantastic hunter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "altruistic",
+            "calm",
+            "careful",
+            "faithful",
+            "insecure",
+            "loyal",
+            "nervous",
+            "patient",
+            "responsible",
+            "righteous",
+            "thoughtful",
+            "wise"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "adventurous",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "playful",
+            "troublesome",
+            "vengeful"
+        ],
+        "min_cats": 4,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null
+    },
+    {
+        "patrol_id": "wtlnd_hunt_foxgray_steal3",
+        "biome": "wetland",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "medium_prey",
+            "fighting",
+            "scar",
+            "small_bite_injury"
+        ],
+        "intro_text": "r_c catches the scent of a fox - but is it red, or gray? And is it worth a fight if they encounter it?",
+        "decline_text": "r_c decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 50,
+        "exp": 15,
+        "success_text": [
+            "Spotting the gray fox they've tracked dipping into the shelter of a little scrub covered bit of dry land, r_c hangs back, sneaking around until they spot the fox caching a bird kill in an old log a storm washed in moons ago. They simply wait for it to finish and leave, then creep in to steal the fox's hard work, bringing the prize back to camp for the fresh-kill pile. Sometimes winning a battle doesn't require fighting.",
+            null,
+            "s_c tracks down a gray fox, and carefully cosiders it as an opponent. Stocky, yes, but they finally decide they can take it, and burst from cover, using surprise to get in a couple vicious swipes to the fox's face while its jaws are still full of prey. Yelping, the gray fox retreats from the cat, unwilling to risk more split blood, and s_c picks up the rat it carried with a proud grin.",
+            "It's a situation that calls for careful calm, not implusive action. s_c tracks down a gray fox at the end of the scent trail, holding a little plump mouse, and waits carefully. Eventually, the fox tries to cache its fresh-kill in a little hole. s_c picks it up once the fox leaves, strolling back to camp having successfully outwitted the competing predator."
+        ],
+        "fail_text": [
+            "It embarrasses them, but r_c doesn't even manage to find the fox they track, let alone earn anything useful from the afternoon's attempts.",
+            "s_c hones in on the scent, and as soon as they spot the gray fox with a dead fish hanging from its jaws, throwes themselves to the attack. The fox hears them coming, and makes a hasty retreat before the fight can start, taking its dinner with it.",
+            null,
+            "Finding a gray fox holding a mouse that would make a nice addition to c_n's fresh-kill pile, r_c goes to attack it. But the fox is just as keen to keep it as r_c is to win it, and they're injured in the resulting fight.",
+            null,
+            "s_c hones in on the scent, and as soon as they spot the gray fox with a dead fish hanging from its jaws, recklessly throwes themselves to the attack. But the fox is a little too desperate to keep itself from harm, and s_c has to retreat bleeding."
+        ],
+        "win_skills": [
+            "good hunter",
+            "great hunter",
+            "fantastic hunter",
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "altruistic",
+            "calm",
+            "careful",
+            "faithful",
+            "insecure",
+            "loyal",
+            "nervous",
+            "patient",
+            "responsible",
+            "righteous",
+            "thoughtful",
+            "wise"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "adventurous",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "playful",
+            "troublesome",
+            "vengeful"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a solo fight with a gray fox."
+        ]
+    },
+    {
+        "patrol_id": "wtlnd_hunt_swiftfox_newleafscavenge1",
+        "biome": "wetland",
+        "season": "newleaf",
+        "tags": [
+            "hunting",
+            "small_prey",
+            "comfort",
+            "respect",
+            "rel_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox. Tracking it, they find a swift fox feeding on a fish about as big as it is. The cat-sized predator definitely didn't kill this.",
+        "decline_text": "Your patrol decides not to quarrel with the fox. There're plenty of fish in the river for everyone, and it's best to focus on feeding the Clan rather than quarreling.",
+        "chance_of_success": 70,
+        "exp": 20,
+        "success_text": [
+            "As the patrol approaches, the swift fox spots them and backs off from the carcass with a whine. Your cats bring it home, no fuss, no worries.",
+            null,
+            "The patrol takes over the carcass without a fight, the small swift fox giving way without trouble. Still, it's hardly worth the effort, and s_c can think of better things they should be doing.",
+            "Responsibly, s_c keeps the patrol moving once they take the fish from the unfortunate-but-unable-to-complain swift fox. They don't find anything, but with the stolen fish the afternoon hasn't been a completely wasted hunting trip."
+        ],
+        "fail_text": [
+            "The swift fox gives way easily to the bigger canivores, but the fish carcass is rotten, too rotten for the Clan cats to want to touch.",
+            "The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth. s_c calls the rest of the patrol for backup and no one is injured, but by the time they get back to the kill a different predator has absconded with the fish."
+        ],
+        "win_skills": [
+            "smart",
+            "very smart",
+            "extremely smart"
+        ],
+        "win_trait": [
+            "altruistic",
+            "patient",
+            "responsible",
+            "thoughtful",
+            "wise",
+            "calm",
+            "careful",
+            "insecure",
+            "nervous",
+            "sneaky"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "bold",
+            "childish",
+            "confident",
+            "daring",
+            "playful",
+            "shameless"
+        ],
+        "min_cats": 2,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null
+    },
+    {
+        "patrol_id": "wtlnd_hunt_swiftfox_newleafscavenge2",
+        "biome": "wetland",
+        "season": "newleaf",
+        "tags": [
+            "hunting",
+            "medium_prey",
+            "fighting",
+            "scar",
+            "death",
+            "no_body",
+            "all_lives",
+            "small_bite_injury"
+        ],
+        "intro_text": "r_c catches the scent of a fox. Tracking it, they find a swift fox feeding on a fish about as big as it is. The cat-sized predator definitely didn't kill this.",
+        "decline_text": "r_c decides not to quarrel with the fox. There're plenty of fish in the river for everyone, and it's best to focus on feeding the Clan rather than quarreling.",
+        "chance_of_success": 70,
+        "exp": 10,
+        "success_text": [
+            "r_c approaches the kill, fur puffed up. The swift fox grumbles, but with a hiss both animals agree to disagree, feeding from opposite ends of the calf without further trouble. r_c is able to find some decent scraps to carry back to camp, though with only them there they can't bring back as much meat as they'd like.",
+            null,
+            "Watching the swift fox at the carcass, s_c notices it stripping meat from the fish and caching it in little holes, and starts to copy it. The bigger predators will return to claim the fish soon, but by the time they do s_c will have hidden away the choicest morsels to fetch later.",
+            "With great care, aware that the kill's original owner must be somewhere about, s_c snatches the first large scrap they find and leaves the swift fox to risk the wrath of the bigger predators."
+        ],
+        "fail_text": [
+            "r_c muscles in as the swft fox gives way to the bigger predator, but the carcass is rotten and worthless.",
+            "The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth. s_c dances out of the way, but when they return, another predator has already snapped up the abandoned fish.",
+            "r_c starts arguing with the fox over the fish. Neither sees the alligator coming.",
+            "Puffed up, r_c approaches the swift fox. But there's only one of them, and the fox is their equal in size and weight. instead of running or giving it, it snarls, and attacks. r_c gives just as good as they get, and both animals end up limping away from the kill.",
+            null,
+            "The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth, sinking them into s_c and giving s_c a bigger concern than scavenging a fish carcass."
+        ],
+        "win_skills": [
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "altruistic",
+            "patient",
+            "responsible",
+            "thoughtful",
+            "wise",
+            "calm",
+            "careful",
+            "insecure",
+            "nervous",
+            "sneaky"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "bold",
+            "childish",
+            "confident",
+            "daring",
+            "playful",
+            "shameless"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from fighting with a swift fox.",
+            "While scavenging alone, r_c was killed by a predator they didn't see.",
+            "taken by an alligator"
+        ]
+    },
+    {
+        "patrol_id": "wtlnd_hunt_swiftfox_greenleafscavenge1",
+        "biome": "wetland",
+        "season": "greenleaf",
+        "tags": [
+            "hunting",
+            "small_prey",
+            "comfort",
+            "respect",
+            "rel_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox. Tracking it, they find a swift fox feeding on a fish about as big as it is. The cat-sized predator definitely didn't kill this.",
+        "decline_text": "Your patrol decides not to quarrel with the fox. There're plenty of fish in the river for everyone, and it's best to focus on feeding the Clan rather than quarreling.",
+        "chance_of_success": 70,
+        "exp": 20,
+        "success_text": [
+            "As the patrol approaches, the swift fox spots them and backs off from the carcass with a whine. Your cats bring it home, no fuss, no worries.",
+            null,
+            "The patrol takes over the carcass without a fight, the small swift fox giving way without trouble. Still, it's hardly worth the effort, and s_c can think of better things they should be doing.",
+            "Responsibly, s_c keeps the patrol moving once they take the fish from the unfortunate-but-unable-to-complain swift fox. They don't find anything, but with the stolen fish the afternoon hasn't been a completely wasted hunting trip."
+        ],
+        "fail_text": [
+            "The swift fox gives way easily to the bigger canivores, but the fish carcass is rotten, too rotten for the Clan cats to want to touch.",
+            "The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth. s_c calls the rest of the patrol for backup and no one is injured, but by the time they get back to the kill a different predator has absconded with the fish."
+        ],
+        "win_skills": [
+            "smart",
+            "very smart",
+            "extremely smart"
+        ],
+        "win_trait": [
+            "altruistic",
+            "patient",
+            "responsible",
+            "thoughtful",
+            "wise",
+            "calm",
+            "careful",
+            "insecure",
+            "nervous",
+            "sneaky"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "bold",
+            "childish",
+            "confident",
+            "daring",
+            "playful",
+            "shameless"
+        ],
+        "min_cats": 2,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null
+    },
+    {
+        "patrol_id": "wtlnd_hunt_swiftfox_greenleafscavenge2",
+        "biome": "wetland",
+        "season": "greenleaf",
+        "tags": [
+            "hunting",
+            "medium_prey",
+            "fighting",
+            "scar",
+            "death",
+            "no_body",
+            "all_lives",
+            "small_bite_injury"
+        ],
+        "intro_text": "r_c catches the scent of a fox. Tracking it, they find a swift fox feeding on a fish about as big as it is. The cat-sized predator definitely didn't kill this.",
+        "decline_text": "r_c decides not to quarrel with the fox. There're plenty of fish in the river for everyone, and it's best to focus on feeding the Clan rather than quarreling.",
+        "chance_of_success": 70,
+        "exp": 10,
+        "success_text": [
+            "r_c smaller, alone, and half its weight, but the fox has a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle. The fox, already stuffed full and unwilling to lose blood over it, leaves the kill with a grumble.",
+            null,
+            "s_c uses every trick in their talented fighting skillset to attack the fox with no one to watch their flank, until the perfect opportunity opens up and they pounce onto the fox's back, digging in their claws. It's a wild ride through the swamp until the fox bucks them off, but it wins them the fish carcass.",
+            "In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. But then they're stuck, unwilling to let go and risk being bitten. They're dragged through the swamp, over rocks and through bushes, until the fox finally collapses and the battered s_c goes back to proudly claim the fish."
+        ],
+        "fail_text": [
+            "r_c muscles in as the swft fox gives way to the bigger predator, but the carcass is rotten and worthless.",
+            "The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth. s_c dances out of the way, but when they return, another predator has already snapped up the abandoned fish.",
+            "r_c starts arguing with the fox over the fish. Neither sees the alligator coming.",
+            "Puffed up, r_c approaches the swift fox. But there's only one of them, and the fox is their equal in size and weight. instead of running or giving it, it snarls, and attacks. r_c gives just as good as they get, and both animals end up limping away from the kill.",
+            null,
+            "The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth, sinking them into s_c and giving s_c a bigger concern than scavenging a fish carcass."
+        ],
+        "win_skills": [
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "altruistic",
+            "patient",
+            "responsible",
+            "thoughtful",
+            "wise",
+            "calm",
+            "careful",
+            "insecure",
+            "nervous",
+            "sneaky"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "bold",
+            "childish",
+            "confident",
+            "daring",
+            "playful",
+            "shameless"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from fighting with a swift fox.",
+            "While scavenging alone, r_c was killed by a predator they didn't see.",
+            "taken by an alligator"
+        ]
+    },
+    {
+        "patrol_id": "wtlnd_hunt_swiftfox_leaf-fallscavenge1",
+        "biome": "wetland",
+        "season": "leaf-fall",
+        "tags": [
+            "hunting",
+            "small_prey",
+            "comfort",
+            "respect",
+            "rel_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox. Tracking it, they find a swift fox feeding on a fish about as big as it is. The cat-sized predator definitely didn't kill this.",
+        "decline_text": "Your patrol decides not to quarrel with the fox. There're plenty of fish in the river for everyone, and it's best to focus on feeding the Clan rather than quarreling.",
+        "chance_of_success": 70,
+        "exp": 20,
+        "success_text": [
+            "As the patrol approaches, the swift fox spots them and backs off from the carcass with a whine. Your cats bring it home, no fuss, no worries.",
+            null,
+            "The patrol takes over the carcass without a fight, the small swift fox giving way without trouble. Still, it's hardly worth the effort, and s_c can think of better things they should be doing.",
+            "Responsibly, s_c keeps the patrol moving once they take the fish from the unfortunate-but-unable-to-complain swift fox. They don't find anything, but with the stolen fish the afternoon hasn't been a completely wasted hunting trip."
+        ],
+        "fail_text": [
+            "The swift fox gives way easily to the bigger canivores, but the fish carcass is rotten, too rotten for the Clan cats to want to touch.",
+            "The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth. s_c calls the rest of the patrol for backup and no one is injured, but by the time they get back to the kill a different predator has absconded with the fish."
+        ],
+        "win_skills": [
+            "smart",
+            "very smart",
+            "extremely smart"
+        ],
+        "win_trait": [
+            "altruistic",
+            "patient",
+            "responsible",
+            "thoughtful",
+            "wise",
+            "calm",
+            "careful",
+            "insecure",
+            "nervous",
+            "sneaky"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "bold",
+            "childish",
+            "confident",
+            "daring",
+            "playful",
+            "shameless"
+        ],
+        "min_cats": 2,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null
+    },
+    {
+        "patrol_id": "wtlnd_hunt_swiftfox_leaf-fallscavenge2",
+        "biome": "wetland",
+        "season": "leaf-fall",
+        "tags": [
+            "hunting",
+            "medium_prey",
+            "fighting",
+            "scar",
+            "death",
+            "no_body",
+            "all_lives",
+            "small_bite_injury"
+        ],
+        "intro_text": "r_c catches the scent of a fox. Tracking it, they find a swift fox feeding on a fish about as big as it is. The cat-sized predator definitely didn't kill this.",
+        "decline_text": "r_c decides not to quarrel with the fox. There're plenty of fish in the river for everyone, and it's best to focus on feeding the Clan rather than quarreling.",
+        "chance_of_success": 70,
+        "exp": 10,
+        "success_text": [
+            "r_c smaller, alone, and half its weight, but the fox has a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle. The fox, already on the look out for other predators and unwilling to lose blood over it, leaves the kill with a grumble.",
+            null,
+            "s_c uses every trick in their talented fighting skillset to attack the fox with no one to watch their flank, until the perfect opportunity opens up and they pounce onto the fox's back, digging in their claws. It's a wild ride through the swamp until the fox bucks them off, but it wins them the fish carcass.",
+            "In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. But then they're stuck, unwilling to let go and risk being bitten. They're dragged through the swamp, over rocks and through bushes, until the fox finally collapses and the battered s_c goes back to proudly claim the fish."
+        ],
+        "fail_text": [
+            "r_c muscles in as the swft fox gives way to the bigger predator, but the carcass is rotten and worthless.",
+            "The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth. s_c dances out of the way, but when they return, another predator has already snapped up the abandoned fish.",
+            "r_c starts arguing with the fox over the fish. Neither sees the alligator coming.",
+            "Puffed up, r_c approaches the swift fox. But there's only one of them, and the fox is their equal in size and weight. instead of running or giving it, it snarls, and attacks. r_c gives just as good as they get, and both animals end up limping away from the kill.",
+            null,
+            "The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth, sinking them into s_c and giving s_c a bigger concern than scavenging a fish carcass."
+        ],
+        "win_skills": [
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "altruistic",
+            "patient",
+            "responsible",
+            "thoughtful",
+            "wise",
+            "calm",
+            "careful",
+            "insecure",
+            "nervous",
+            "sneaky"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "bold",
+            "childish",
+            "confident",
+            "daring",
+            "playful",
+            "shameless"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from fighting with a swift fox.",
+            "While scavenging alone, r_c was killed by a predator they didn't see.",
+            "taken by an alligator"
+        ]
+    },
+    {
+        "patrol_id": "wtlnd_hunt_swiftfox_leaf-barescavenge1",
+        "biome": "wetland",
+        "season": "leaf-bare",
+        "tags": [
+            "hunting",
+            "small_prey",
+            "comfort",
+            "respect",
+            "rel_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox. Tracking it, they find a swift fox feeding on a fish about as big as it is. The cat-sized predator definitely didn't kill this.",
+        "decline_text": "Your patrol decides not to quarrel with the fox. There're plenty of fish in the river for everyone, and it's best to focus on feeding the Clan rather than quarreling.",
+        "chance_of_success": 60,
+        "exp": 20,
+        "success_text": [
+            "As the patrol approaches, the swift fox spots them and backs off from the carcass with a whine. Your cats bring it home, no fuss, no worries.",
+            null,
+            "The patrol takes over the carcass without a fight, the small swift fox giving way without trouble. Still, it's hardly worth the effort, and s_c can think of better things they should be doing.",
+            "Responsibly, s_c keeps the patrol moving once they take the fish from the unfortunate-but-unable-to-complain swift fox. They don't find anything, but with the stolen fish the afternoon hasn't been a completely wasted hunting trip."
+        ],
+        "fail_text": [
+            "The swift fox gives way easily to the bigger canivores, but the fish carcass is rotten, too rotten for the Clan cats to want to touch.",
+            "The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth. s_c calls the rest of the patrol for backup and no one is injured, but by the time they get back to the kill a different predator has absconded with the fish."
+        ],
+        "win_skills": [
+            "smart",
+            "very smart",
+            "extremely smart"
+        ],
+        "win_trait": [
+            "altruistic",
+            "patient",
+            "responsible",
+            "thoughtful",
+            "wise",
+            "calm",
+            "careful",
+            "insecure",
+            "nervous",
+            "sneaky"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "bold",
+            "childish",
+            "confident",
+            "daring",
+            "playful",
+            "shameless"
+        ],
+        "min_cats": 2,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null
+    },
+    {
+        "patrol_id": "wtlnd_hunt_swiftfox_leaf-barescavenge2",
+        "biome": "wetland",
+        "season": "leaf-bare",
+        "tags": [
+            "hunting",
+            "medium_prey",
+            "fighting",
+            "scar",
+            "death",
+            "no_body",
+            "all_lives",
+            "small_bite_injury"
+        ],
+        "intro_text": "r_c catches the scent of a fox. Tracking it, they find a swift fox feeding on a fish about as big as it is. Roughly equal in size to r_c, the swift fox definitely didn't bring down this feast themselves.",
+        "decline_text": "r_c decides not to quarrel with the fox. There're plenty of fish in the river for everyone, and it's best to focus on feeding the Clan rather than quarreling.",
+        "chance_of_success": 50,
+        "exp": 10,
+        "success_text": [
+            "r_c smaller, alone, and half its weight, but the fox has a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle. The fox, already on the look out for other predators and unwilling to lose blood over it, leaves the kill with a grumble.",
+            null,
+            "s_c uses every trick in their talented fighting skillset to attack the fox with no one to watch their flank, until the perfect opportunity opens up and they pounce onto the fox's back, digging in their claws. It's a wild ride through the swamp until the fox bucks them off, but it wins them the fish carcass.",
+            "In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. But then they're stuck, unwilling to let go and risk being bitten. They're dragged through the swamp, over rocks and through bushes, until the fox finally collapses and the battered s_c goes back to proudly claim the fish."
+        ],
+        "fail_text": [
+            "r_c muscles in as the swft fox gives way to the bigger predator, but the carcass is rotten and worthless.",
+            "The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth. s_c dances out of the way, but when they return, another predator has already snapped up the abandoned fish.",
+            "r_c starts arguing with the fox over the fish. Neither sees the alligator coming.",
+            "Puffed up, r_c approaches the swift fox. But there's only one of them, and the fox is their equal in size and weight. instead of running or giving it, it snarls, and attacks. r_c gives just as good as they get, and both animals end up limping away from the kill.",
+            null,
+            "The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth, sinking them into s_c and giving s_c a bigger concern than scavenging a fish carcass."
+        ],
+        "win_skills": [
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "altruistic",
+            "patient",
+            "responsible",
+            "thoughtful",
+            "wise",
+            "calm",
+            "careful",
+            "insecure",
+            "nervous",
+            "sneaky"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "bold",
+            "childish",
+            "confident",
+            "daring",
+            "playful",
+            "shameless"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from fighting with a swift fox.",
+            "While scavenging alone, r_c was killed by a predator they didn't see.",
+            "taken by an alligator"
+        ]
+    },
+    {
+        "patrol_id": "wtlnd_hunt_kitfox_scavenge1",
+        "biome": "wetland",
+        "season": "leaf-bare",
+        "tags": [
+            "hunting",
+            "small_prey",
+            "comfort",
+            "respect",
+            "rel_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox. Tracking it, they find a kit fox fishing on a branch overlooking the shallows.",
+        "decline_text": "Your patrol decides not to quarrel with the fox. There're plenty of fish in the river for everyone, and it's best to focus on feeding the Clan rather than quarreling.",
+        "chance_of_success": 70,
+        "exp": 10,
+        "success_text": [
+            "The cats freeze, and carefully creep back into cover. A kit fox is small enough to inevitably startle and run from them, but if they play this right... they wait until the tiny fox drops down onto a salamandar before they pop out of the bushes. Not only to they scare off a potential competitor, they also get the added reward of a little snack.",
+            "It's a truely ridiculous power disparity, with even a single member of the patrol outweighing the little fox. The cats drive it out of c_n's swamps no trouble, but it's hardly worth the little fishy morsel they win for their efforts.",
+            "A simple display of just how badly the kit fox is outmatched convinces it to run, and s_c carefully seeks out the little food cache the kit fox was workign on, taking the minnows for the camp's fresh-kill pile.",
+            "It's frustrating that it only wins them a single minnow, but hte patrol drives out the kit fox, and s_c reminds them that's what matters - that now the fox won't keep poaching from c_n's hunting grounds in the future."
+        ],
+        "fail_text": [
+            "The cats freeze, and carefully creep back into cover. A kit fox is small enough to inevitably startle and run from them, but if they play this right... but not, the kit fox has spotted them, and flees from the cats. At least that's one less competitior in c_n's hunting grounds?"
+        ],
+        "win_skills": [
+            "smart",
+            "very smart",
+            "extremely smart"
+        ],
+        "win_trait": [
+            "altruistic",
+            "patient",
+            "responsible",
+            "thoughtful",
+            "wise",
+            "calm",
+            "careful",
+            "insecure",
+            "nervous",
+            "sneaky"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "bold",
+            "childish",
+            "confident",
+            "daring",
+            "playful",
+            "shameless"
+        ],
+        "min_cats": 2,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null
+    },
+    {
+        "patrol_id": "wtlnd_hunt_kitfox_scavenge2",
+        "biome": "wetland",
+        "season": "leaf-bare",
+        "tags": [
+            "hunting",
+            "medium_prey"
+        ],
+        "intro_text": "r_c catches the scent of a fox. Tracking it, they find a kit fox fishing on a branch overlooking the shallows.",
+        "decline_text": "r_c decides not to quarrel with the fox. There're plenty of fish in the river for everyone, and it's best to focus on feeding the Clan rather than quarreling.",
+        "chance_of_success": 70,
+        "exp": 10,
+        "success_text": [
+            "r_c freezes, and carefully creeps back into cover. A kit fox is small enough to inevitably startle and run from them, but if they play this right... they wait until the tiny fox drops down onto a salamandar before they pop out of the bushes. Not only to they scare off a potential competitor, they also get the added reward of a little snack.",
+            "r_c throws their weight around as the bigger predator, stealing the kit fox's lunch and driving it away from the river.",
+            "s_c uses every trick in their talented fighting skillset to attack the fox with no one to watch their flank, until the perfect opportunity opens up and they pounce onto the fox's back, digging in their claws. It's a wild ride through the swamp until the fox bucks them off, but it wins them the fish carcass.",
+            "In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. But then they're stuck, unwilling to let go and risk being bitten. They're dragged through the swamp, over rocks and through bushes, until the fox finally collapses and the battered s_c goes back to proudly claim the fish."
+        ],
+        "fail_text": [
+            "r_c freezes, and carefully creeps back into cover. A kit fox is small enough to inevitably startle and run from them, but if they play this right... but not, the kit fox has spotted them, and flees from the cat. At least that's one less competitior in c_n's hunting grounds?"
+        ],
+        "win_skills": [
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "altruistic",
+            "patient",
+            "responsible",
+            "thoughtful",
+            "wise",
+            "calm",
+            "careful",
+            "insecure",
+            "nervous",
+            "sneaky"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "bold",
+            "childish",
+            "confident",
+            "daring",
+            "playful",
+            "shameless"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null
+    },
+    {
+        "patrol_id": "wtlnd_hunt_redfox_scavenge1",
+        "biome": "wetland",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "medium_prey",
+            "fighting",
+            "scar",
+            "big_bite_injury",
+            "clan_to_patrol",
+            "respect",
+            "rel_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a red fox. Tracking it, they find the animal feeding on the body of a stork. Odd prey, but not out of the question for a red fox.",
+        "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 50,
+        "exp": 20,
+        "success_text": [
+            "Your cats are smaller but they outnumber the fox, if only by a little, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full of food and unwilling to lose blood over it, is driven off from the kill.",
+            null,
+            "s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until it gives up and runs.",
+            "The patrol launches into battle, but with so few cats it's exhausting trying to keep the fox and its snapping jaws on the defensive. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. It's only one bite, but the fox has had enough and flees."
+        ],
+        "fail_text": [
+            "Your patrol fails to drive away the fox, which keeps possession of the food. However there were no injuries.",
+            null,
+            null,
+            "The patrol launches into battle, but r_c is caught with a nasty bite, and the cats give up on challenging for the food in favor of quickly helping r_c back to the medicine cat den.",
+            null,
+            "s_c means well, but they're overconfident in their attack and the fox manages to sink their teeth into them. The patrol is forced to retreat, forming a defensive ring around the hurt s_c."
+        ],
+        "win_skills": [
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "troublesome",
+            "vengeful",
+            "bloodthirsty",
+            "bold"
+        ],
+        "min_cats": 2,
+        "max_cats": 3,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a fox fight.",
+            null
+        ]
+    },
+    {
+        "patrol_id": "wtlnd_hunt_redfox_scavenge2",
+        "biome": "wetland",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "medium_prey",
+            "fighting",
+            "scar",
+            "big_bite_injury",
+            "clan_to_patrol",
+            "respect",
+            "rel_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a red fox. Tracking it, they find the animal feeding on the body of a stork. Odd prey, but not out of the question for a red fox.",
+        "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 80,
+        "exp": 20,
+        "success_text": [
+            "Your cats are smaller but heavily outnumber the fox, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full and unwilling to lose blood over it, is driven off from the kill.",
+            null,
+            "s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until s_c lands a crucial blow, snapping a tendon in one of the fox's hindlegs. The fox runs, but there's no way it'll live long with such a crippling injury.",
+            "The patrol launches into battle, keeping the fox on the defensive with teamwork. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. Holding on grimly, s_c's daring move gives the rest of the patrol the opportunity needed to bring the fox down for good."
+        ],
+        "fail_text": [
+            "Your patrol fails to drive away the fox, which keeps possession of the food. However with so many cats to protect each other, there were no injuries.",
+            null,
+            null,
+            "The patrol launches into battle, but r_c is caught with a nasty bite, and the cats give up on challenging for the food in favor of quickly helping r_c back to the medicine cat den.",
+            null,
+            "s_c means well, but they're overconfident in their attack and the fox manages to sink their teeth into them. The patrol is forced to retreat, forming a defensive ring around the hurt s_c."
+        ],
+        "win_skills": [
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "troublesome",
+            "vengeful",
+            "bloodthirsty",
+            "bold"
+        ],
+        "min_cats": 4,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a fox fight."
+        ]
+    },
+    {
+        "patrol_id": "wtlnd_hunt_redfox_scavenge3",
+        "biome": "wetland",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "medium_prey",
+            "fighting",
+            "scar",
+            "big_bite_injury",
+            "clan_to_patrol",
+            "respect"
+        ],
+        "intro_text": "r_c catches the scent of a red fox. Tracking it, they find the animal feeding on the body of a stork. Odd prey, but not out of the question for a red fox.",
+        "decline_text": "r_c decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 30,
+        "exp": 30,
+        "success_text": [
+            "r_c is smaller, alone, and half its weight, but the fox has a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle. The fox, already stuffed full and unwilling to lose blood over it, leaves the kill with a grumble.",
+            null,
+            "s_c uses every trick in their talented fighting skillset to attack the fox with no one to watch their flank, until the perfect opportunity opens up and they pounce onto the fox's back, digging in their claws. It's a wild ride through the wetlands until the fox bucks them off, but it wins them the stork carcass.",
+            "In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. But then they're stuck, unwilling to let go and risk being bitten. They're dragged through the forest, over rocks and through bushes, until the fox finally collapses and the battered s_c goes back to proudly claim the stork."
+        ],
+        "fail_text": [
+            "Your patrol fails to drive away the fox, which keeps possession of the food. However there were no injuries.",
+            null,
+            "Fiercely, r_c throws themselves at the fox, determined to win the stork prize. But the fox values it just as dearly, and manages to get a good grip on r_c, shaking them to pieces and killing them.",
+            "r_c launches into battle, but is caught with a nasty bite, and retreats to limp back home. The fox doesn't follow, happy enough to eat the stork instead of the foolish cat.",
+            null,
+            "s_c is overconfident in their attack and the fox manages to sink their teeth into them. They retreat, bleeding and in pain, and the fox settles back down to its meal."
+        ],
+        "win_skills": [
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "troublesome",
+            "vengeful",
+            "bloodthirsty",
+            "bold"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a solo fox fight.",
+            "r_c fell in a solo battle with a fox.",
+            "died fighting a fox"
+        ]
+    },
+    {
+        "patrol_id": "wtlnd_hunt_foxgray_scavenge1",
+        "biome": "wetland",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "medium_prey",
+            "fighting",
+            "scar",
+            "injury",
+            "bite-wound",
+            "clan_to_patrol",
+            "respect",
+            "rel_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? Tracking it, they find a stocky gray fox feeding on an unidentifiable but deliciously stinky small mound of carrion fished up from the swamp.",
+        "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 70,
+        "exp": 20,
+        "success_text": [
+            "While a gray fox is bigger and far stockier than the cats, the delicious stench of whatever it is makes the cats' eyes go wide and silly, and they leap to claim possession of it. Outnumbered and already full of stinky nonsense, the gray fox leaves, scrambling up a tree as the cats give in to instinct and roll around in the glorious smell.",
+            "A gray fox is bigger than them, yes... but only just, and that carcass smells divine. The cats creep up on the fox, using the thick swamp brush for cover, and wait until the fox has its head buried in the carcass to attack. The ambush sends the competing predator fleeing, and leaves the cats to claim the heavenly stinky food.",
+            "s_c shows their strength, leading the fight against the gray fox. By working together and keeping it distracted, the cats harry and harass the fox until it gives up and runs.",
+            "The patrol launches into battle, but with so few cats it's exhausting trying to keep the fox and its snapping jaws on the defensive. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. It's only one bite, but the fox has had enough and flees."
+        ],
+        "fail_text": [
+            "Your patrol fails to drive away the fox, which keeps possession of the food. However there were no injuries.",
+            "s_c makes a stupid mistake, too intent on winning the fight to respect their enemy's teeth, and it's only being yanked back by the tail that saves them from injury. The patrol gives up, and settles down to wait a safe distance away until the fox leaves of its own accord.",
+            null,
+            null,
+            null,
+            "s_c means well, but they're overconfident in their attack and the fox manages to sink their teeth into them. The patrol is forced to retreat, forming a defensive ring around the hurt s_c."
+        ],
+        "win_skills": [
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "troublesome",
+            "vengeful",
+            "bloodthirsty",
+            "bold"
+        ],
+        "min_cats": 2,
+        "max_cats": 3,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a gray fox fight.",
+            null
+        ]
+    },
+    {
+        "patrol_id": "wtlnd_hunt_foxgray_scavenge2",
+        "biome": "wetland",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "medium_prey",
+            "fighting",
+            "clan_to_patrol",
+            "respect",
+            "rel_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? Tracking it, they find a stocky gray fox feeding on an unidentifiable but deliciously stinky small mound of carrion fished up from the swamp.",
+        "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 90,
+        "exp": 20,
+        "success_text": [
+            "While a gray fox is bigger and far stockier than the cats, the delicious stench of whatever it is makes the cats' eyes go wide and silly, and they leap to claim possession of it. Heavily outnumbered and already full of stinky nonsense, the gray fox leaves, scrambling up a tree as the cats give in to instinct and roll around in the glorious smell.",
+            "A gray fox is bigger than them, yes... but only just, and that carcass smells divine. The cats creep up on the fox, using the thick swamp brush for cover, and wait until the fox has its head buried in the carcass to attack. The ambush sends the competing predator fleeing, and leaves the cats to claim the heavenly stinky food.",
+            "s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until s_c lands a crucial blow, snapping a tendon in one of the fox's hindlegs. The fox runs, but there's no way it'll live long with such a crippling injury.",
+            "The patrol launches into battle, keeping the fox on the defensive with teamwork. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. Holding on grimly, s_c's daring move gives the rest of the patrol the opportunity needed to bring the fox down for good."
+        ],
+        "fail_text": [
+            "Your patrol fails to drive away the fox, which keeps possession of the food. However with so many cats to protect each other, there were no injuries.",
+            "s_c makes a stupid mistake, too intent on winning the fight to respect their enemy's teeth, and it's only being yanked back by the tail that saves them from injury. The patrol gives up, and settles down to wait a safe distance away until the fox leaves of its own accord."
+        ],
+        "win_skills": [
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "troublesome",
+            "vengeful",
+            "bloodthirsty",
+            "bold"
+        ],
+        "min_cats": 4,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null
+    },
+    {
+        "patrol_id": "wtlnd_hunt_foxgray_scavenge3",
+        "biome": "wetland",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "medium_prey",
+            "fighting",
+            "scar",
+            "injury",
+            "bite-wound",
+            "clan_to_patrol",
+            "respect"
+        ],
+        "intro_text": "r_c catches the scent of a fox - but is it red, or gray? Tracking it, they find a stocky gray fox feeding on an unidentifiable but deliciously stinky small mound of carrion fished up from the swamp.",
+        "decline_text": "r_c decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 50,
+        "exp": 30,
+        "success_text": [
+            "While a gray fox is bigger and far stockier than r_c, the delicious stench of whatever it is makes their eyes go wide and silly, and they leap to claim some of it for themselves and c_n. It's only a little lump, but the fox is apparently not too keen to face a fight over it, and gives up with a prefunctory snarl.",
+            "A gray fox is bigger than them, yes... but only just, and that carcass smells divine. r_c creeps up on the fox, using the thick swamp brush for cover, and waits until the fox has its head buried in the carcass to attack. The ambush sends the competing predator fleeing, and leaves r_c to claim the heavenly stinky food.",
+            "s_c uses every trick in their talented fighting skillset to attack the fox with no one to watch their flank, until the perfect opportunity opens up and they pounce onto the fox's back, digging in their claws. It's enough to convince the gray to back off, and s_c claims a seat at the carcass.",
+            "In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. But then they're stuck, unwilling to let go and risk being bitten. They're dragged through the swamp, muck casing their pelt, until the fox finally throws them off and the battered s_c goes back to proudly claim the carcass."
+        ],
+        "fail_text": [
+            "Your patrol fails to drive away the gray fox, which keeps possession of the food. However there were no injuries.",
+            "s_c makes a stupid mistake, too intent on winning the fight to respect their enemy's teeth, and it's tripping over their own feet that saves them. They give up, and settle down to wait a safe distance away until the fox leaves of its own accord.",
+            null,
+            "r_c launches into battle, but is caught with a nasty bite, and retreats to limp back home. The gray fox doesn't follow, happy enough to eat the carcass instead of the foolish cat.",
+            null,
+            "s_c is overconfident in their attack and the fox manages to sink their teeth into them. They retreat, bleeding and in pain, and the gray fox settles back down to its meal."
+        ],
+        "win_skills": [
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "troublesome",
+            "vengeful",
+            "bloodthirsty",
+            "bold"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a solo fight with a gray fox.",
+            null
+        ]
+    },
+    {
+        "patrol_id": "wtlnd_hunt_redvixen1",
+        "biome": "wetland",
+        "season": "newleaf",
+        "tags": [
+            "fighting",
+            "death",
+            "scar",
+            "big_bite_injury",
+            "respect",
+            "trust",
+            "clan_to_r_c",
+            "patrol_to_r_c",
+            "clan_to_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
+        "decline_text": "Your patrol decides not to pursue the fox.",
+        "chance_of_success": 30,
+        "exp": 30,
+        "success_text": [
+            "The red vixen smells of milk, and hopefully by driving her out of the territory, her litter this Newleaf won't be a threat to the Clan. If they don't starve, c_n will hunt them down - they do not share territory with foxes.",
+            "Your patrol drives away the red fox, seeks out her den, and kills her young cubs. It's brutal, but these fluffy baby foxes would one day have grown to be kit-killers and thieves.",
+            "s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the red fox nor her cubs pose a threat to the Clan. It truly proves s_c's place as one of c_n's most talented and skillful fighters.",
+            "The patrol overcomes the red vixen and drives her off thanks to a brilliant battle move by s_c at a critical moment. Their bravery ensures the patrol's success, and the cats arrive back at camp singing their praises to make sure the Clan knows it."
+        ],
+        "fail_text": [
+            "The mother red fox is vicious and determined, and the small patrol is beaten back. But these swampy woodlands are c_n's and they haven't given up. They may have lost this battle, but c_n will win this war.",
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the rest of the patrol have to rescue them from the red vixen.",
+            "Never threaten a mother's young - the red vixen kills r_c in the skirmish.",
+            "The mother red fox's snapping jaws leave r_c dripping blood into the mud, forcing the patrol to back off.",
+            null,
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the red vixen manages to sink her teeth into them. The patrol rallies around s_c, but they have to give up on the fight.",
+            "As their hunt descends into a full on battle with the red vixen, p_l takes a blow meant for one of their Clanmates, losing a life."
+        ],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 2,
+        "max_cats": 3,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a fight with a red vixen.",
+            "r_c fell in battle with a red fox.",
+            "died while fighting a red vixen"
+        ]
+    },
+    {
+        "patrol_id": "wtlnd_hunt_redvixen2",
+        "biome": "wetland",
+        "season": "newleaf",
+        "tags": [
+            "fighting",
+            "scar",
+            "big_bite_injury",
+            "respect",
+            "trust",
+            "clan_to_r_c",
+            "patrol_to_r_c",
+            "clan_to_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
+        "decline_text": "Your patrol decides not to pursue the fox.",
+        "chance_of_success": 60,
+        "exp": 30,
+        "success_text": [
+            "Led by p_l, and with a heap of cooperation and teamwork, the patrol drives away the red fox, seeks out her den, and kills her young cubs. The swamps will be safe from both the threat the vixen posed this season, and the threat her cubs would've given c_n in the seasons to come.",
+            "With so many cats working together in tight coordination, they manage to accomplish the near-impossible, killing the red mother vixen and ending the threat to the Clan that she and her cubs pose.",
+            "s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the red fox nor her dependent cubs pose a threat to the Clan. It truly proves s_c's place as one of c_n's most talented and skillful fighters.",
+            "The patrol overcomes the red vixen and drives her off thanks to a brilliant battle move by s_c at a critical moment. Their bravery ensures the patrol's success, and the cats arrive back at camp singing their praises to make sure the Clan knows it."
+        ],
+        "fail_text": [
+            "The mother red fox is vicious and determined. Although they lose this battle, through teamwork the cats manage to retreat without injury.",
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the rest of the patrol have to rescue them from the red vixen.",
+            null,
+            "r_c is left wounded as the patrol and the red mother vixen fight to a stalemate. Hopefully they've given the fox mother a reason not to return to this part of the swamp.",
+            null,
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the red vixen manages to sink her teeth into them. The patrol rallies around s_c, but they have to give up on the fight."
+        ],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 4,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a fight with a red vixen."
+        ]
+    },
+    {
+        "patrol_id": "wtlnd_hunt_redvixen3",
+        "biome": "wetland",
+        "season": "newleaf",
+        "tags": [
+            "fighting",
+            "death",
+            "scar",
+            "big_bite_injury",
+            "shock",
+            "injury",
+            "respect",
+            "trust",
+            "clan_to_patrol",
+            "no_body"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
+        "decline_text": "Your patrol decides not to pursue the fox.",
+        "chance_of_success": 20,
+        "exp": 50,
+        "success_text": [
+            "The red vixen smells of milk, and hopefully by driving her out of the territory, her litter this Newleaf won't be a threat to the Clan. If they don't starve, c_n will hunt them down - they do not share territory with foxes.",
+            null,
+            "s_c displays incredible skill, driving the mother vixen and her brood out of c_n's swamps all by themselves. Now neither the red fox nor her dependent cubs pose a threat to the Clan. They swell with pride, feeling the confidence of knowing that they're truly one of the best fighters c_n has ever produced.",
+            "A brilliant battle move by s_c knocks the red vixen off balance, and s_c manages to drive her out of c_n territory, though it takes every spark of strength in their pelt to do it alone."
+        ],
+        "fail_text": [
+            null,
+            null,
+            "Never threaten a mother's young - the red vixen kills r_c in the skirmish, and carries off the body to feed her litter.",
+            "The mother red fox's snapping jaws leave r_c dripping blood into the mud, and barely able to escape further injury.",
+            null,
+            "s_c is determined to win, but the red vixen is determined to live, and that makes all the difference. s_c ends up pinned in a defensible hiding spot, bleeding and terrified, until the vixen judges them no longer a threat and continues on her way."
+        ],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a solo fight with a red vixen.",
+            "r_c fell in a solo battle with a vixen.",
+            "died while fighting a red vixen"
+        ]
+    },
+    {
+        "patrol_id": "wtlnd_hunt_redvixen4",
+        "biome": "wetland",
+        "season": "greenleaf",
+        "tags": [
+            "fighting",
+            "death",
+            "scar",
+            "big_bite_injury",
+            "respect",
+            "trust",
+            "clan_to_r_c",
+            "patrol_to_r_c",
+            "clan_to_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
+        "decline_text": "Your patrol decides not to pursue the fox.",
+        "chance_of_success": 30,
+        "exp": 30,
+        "success_text": [
+            "The red vixen smells of milk and blood. Hopefully by driving her out of the territory, the litter she has been raising this greenleaf won't be a threat to the Clan. If they don't starve, c_n will hunt them down - they do not share with foxes.",
+            "Your patrol drives away the red fox, seeks out her den, and kills her cubs. It's brutal, but these fluffy small foxes would one day have grown to be kit-killers and thieves.",
+            "s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the red fox nor her dependent cubs pose a threat to the Clan. It truly proves s_c's place as one of c_n's most talented and skillful fighters.",
+            "The patrol overcomes the red vixen and drives her off thanks to a brilliant battle move by s_c at a critical moment. Their bravery ensures the patrol's success, and the cats arrive back at camp singing their praises to make sure the Clan knows it."
+        ],
+        "fail_text": [
+            "The mother red fox is vicious and determined, and the small patrol is beaten back. But this wetland is c_n's and they haven't given up. They may have lost this battle, but c_n will win this war.",
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the rest of the patrol have to rescue them from the red vixen.",
+            "Never threaten a mother's young - the red vixen kills r_c in the skirmish.",
+            "The mother red fox's snapping jaws leave r_c dripping blood into the mud, forcing the patrol to back off.",
+            null,
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the red vixen manages to sink her teeth into them. The patrol rallies around s_c, but they have to give up on the fight.",
+            "As their hunt descends into a full on battle with the red vixen, p_l takes a blow meant for one of their Clanmates, losing a life."
+        ],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 2,
+        "max_cats": 3,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a fight with a red vixen.",
+            "r_c fell in battle with a red fox.",
+            "died while fighting a red vixen"
+        ]
+    },
+    {
+        "patrol_id": "wtlnd_hunt_redvixen5",
+        "biome": "wetland",
+        "season": "greenleaf",
+        "tags": [
+            "fighting",
+            "scar",
+            "big_bite_injury",
+            "respect",
+            "trust",
+            "clan_to_r_c",
+            "patrol_to_r_c",
+            "clan_to_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
+        "decline_text": "Your patrol decides not to pursue the fox.",
+        "chance_of_success": 60,
+        "exp": 30,
+        "success_text": [
+            "Led by p_l, and with a heap of cooperation and teamwork, the patrol drives away the red fox, seeks out her den, and kills her growing cubs. The swamps will be safe from both the threat the vixen posed this season, and the threat her cubs would've given c_n in the seasons to come.",
+            "With so many cats working together in tight coordination, they manage to accomplish the near-impossible, killing the red mother vixen and ending the threat to the Clan that she and her cubs pose.",
+            "s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the red fox nor her dependent cubs pose a threat to the Clan. It truly proves s_c's place as one of c_n's most talented and skillful fighters.",
+            "The patrol overcomes the red vixen and drives her off thanks to a brilliant battle move by s_c at a critical moment. Their bravery ensures the patrol's success, and the cats arrive back at camp singing their praises to make sure the Clan knows it."
+        ],
+        "fail_text": [
+            "The mother red fox is vicious and determined. Although they lose this battle, through teamwork the cats manage to retreat without injury.",
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the rest of the patrol have to rescue them from the red vixen.",
+            null,
+            "r_c is left wounded as the patrol and the red mother vixen fight to a stalemate. Hopefully they've given the fox mother a reason not to return to this part of the swamp.",
+            null,
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the red vixen manages to sink her teeth into them. The patrol rallies around s_c, but they have to give up on the fight."
+        ],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 4,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a fight with a red vixen."
+        ]
+    },
+    {
+        "patrol_id": "wtlnd_hunt_redvixen6",
+        "biome": "wetland",
+        "season": "greenleaf",
+        "tags": [
+            "fighting",
+            "death",
+            "scar",
+            "big_bite_injury",
+            "shock",
+            "injury",
+            "respect",
+            "trust",
+            "clan_to_patrol",
+            "no_body"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
+        "decline_text": "Your patrol decides not to pursue the fox.",
+        "chance_of_success": 10,
+        "exp": 50,
+        "success_text": [
+            "The red vixen smells of milk and blood. Hopefully by driving her out of the territory, the litter she has been raising this greenleaf won't be a threat to the Clan.",
+            null,
+            "s_c displays incredible skill, driving the mother vixen and her brood out of c_n's swamps all by themselves. Now neither the red fox nor her dependent cubs pose a threat to the Clan. They swell with pride, feeling the confidence of knowing that they're truly one of the best fighters c_n has ever produced.",
+            "A brilliant battle move by s_c at a critical moment knocks the red vixen off balance, and s_c manages to drive her out of c_n territory, though it takes every spark of strength in their pelt to do it alone."
+        ],
+        "fail_text": [
+            null,
+            null,
+            "Never threaten a mother's young - the red vixen kills r_c in the skirmish, and carries off the body to feed her litter.",
+            "The mother red fox's snapping jaws leave r_c dripping blood into the mud, and barely able to escape further injury.",
+            null,
+            "s_c is determined to win, but the red vixen is determined to live, and that makes all the difference. s_c ends up pinned in a defensible hiding spot, bleeding and terrified, until the vixen judges them no longer a threat and continues on her way."
+        ],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a solo fight with a red vixen.",
+            "r_c fell in a solo battle with a vixen.",
+            "died while fighting a red vixen"
+        ]
+    },
+    {
+        "patrol_id": "wtlnd_hunt_redvixen7",
+        "biome": "wetland",
+        "season": "leaf-fall",
+        "tags": [
+            "fighting",
+            "death",
+            "scar",
+            "big_bite_injury",
+            "respect",
+            "trust",
+            "clan_to_r_c",
+            "patrol_to_r_c",
+            "clan_to_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
+        "decline_text": "Your patrol decides not to pursue the fox.",
+        "chance_of_success": 30,
+        "exp": 30,
+        "success_text": [
+            "The red vixen smells like the prey she's been poaching to feed her litter. She's stolen from c_n for the last time, and the patrol drives her from their territory, yowling their anger and fury.",
+            "Your patrol drives away the red fox, and seeks out her den, but her Leaf-fall cubs are near full-grown and scatter into the wilderness. Hopefully Leaf-bare takes care of them.",
+            "s_c displays incredible skill, driving the red mother vixen out of the territory almost by themselves. It truly proves s_c's place as one of c_n's most talented and skillful fighters.",
+            "The patrol overcomes the red vixen and drives her off thanks to a brilliant battle move by s_c at a critical moment. Their bravery ensures the patrol's success, and the cats arrive back at camp singing their praises to make sure the Clan knows it."
+        ],
+        "fail_text": [
+            "The mother red fox is vicious and determined, and the small patrol is beaten back. But this wetland is c_n's and they haven't given up. They may have lost this battle, but c_n will win this war.",
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the rest of the patrol have to rescue them from the red vixen.",
+            "Never threaten a mother's young - the red vixen kills r_c in the skirmish.",
+            "The mother red fox's snapping jaws leave r_c dripping blood into the mud, forcing the patrol to back off.",
+            null,
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the red vixen manages to sink her teeth into them. The patrol rallies around s_c, but they have to give up on the fight.",
+            "As their hunt descends into a full on battle with the red vixen, p_l takes a blow meant for one of their Clanmates, losing a life."
+        ],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 2,
+        "max_cats": 3,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a fight with a red vixen.",
+            "r_c fell in battle with a red fox.",
+            "died while fighting a red vixen"
+        ]
+    },
+    {
+        "patrol_id": "wtlnd_hunt_redvixen8",
+        "biome": "wetland",
+        "season": "leaf-fall",
+        "tags": [
+            "fighting",
+            "scar",
+            "big_bite_injury",
+            "respect",
+            "trust",
+            "clan_to_r_c",
+            "patrol_to_r_c",
+            "clan_to_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
+        "decline_text": "Your patrol decides not to pursue the fox.",
+        "chance_of_success": 60,
+        "exp": 30,
+        "success_text": [
+            "Led by p_l and with a heap of cooperation and teamwork, the patrol drives away the red fox, and seeks out her den. But her cubs are near full-grown with the bounty of Leaf-fall, and scatter from the patrol into the wilderness. Hopefully Leaf-bare takes care of them.",
+            "With so many cats working together in tight coordination, they manage to accomplish the near-impossible, killing the red mother vixen and ending the threat to the Clan that she poses. The patrol drives her near-full grown litter of fox cubs out from the territory. Hopefully the coming Leaf-bare will take care of them.",
+            "s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the red fox nor her cubs pose a threat to c_n.",
+            "The patrol overcomes the red vixen and drives her off thanks to a brilliant battle move by s_c at a critical moment. Their bravery ensures the patrol's success, and the cats arrive back at camp singing their praises to make sure the Clan knows it."
+        ],
+        "fail_text": [
+            "The mother red fox is vicious and determined. Although they lose this battle, through teamwork the cats manage to retreat without injury.",
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the red vixen manages to sink her teeth into them. The patrol rallies around s_c, but they have to give up the fight.",
+            null,
+            "r_c is left wounded as the patrol and the red mother vixen fight to a stalemate. Hopefully they've given the fox mother a reason not to return to this part of the swamp."
+        ],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 4,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a red fox fight."
+        ]
+    },
+    {
+        "patrol_id": "wtlnd_hunt_redvixen9",
+        "biome": "wetland",
+        "season": "leaf-fall",
+        "tags": [
+            "fighting",
+            "death",
+            "scar",
+            "big_bite_injury",
+            "shock",
+            "injury",
+            "respect",
+            "trust",
+            "clan_to_patrol",
+            "no_body"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
+        "decline_text": "Your patrol decides not to pursue the fox.",
+        "chance_of_success": 20,
+        "exp": 50,
+        "success_text": [
+            "It takes r_c's every scrap of bravery and strength to drive away the red vixen - her near grown litter, fat on the bounty of Leaf-fall, is a challenge for another day. c_n will have to deal with the young foxes now roaming motherless in the swamps, before they start to compete for prey in Leaf-bare.",
+            null,
+            "s_c displays incredible skill, driving the mother vixen and her brood out of c_n's swamps all by themselves. Now neither the red fox nor her cubs pose a threat to the Clan. They swell with pride, feeling the confidence of knowing that they're truly one of the best fighters c_n has ever produced.",
+            "A brilliant battle move by s_c at a critical moment knocks the red vixen off balance, and s_c manages to drive her out of c_n territory, though it takes every spark of strength in their pelt to do it alone."
+        ],
+        "fail_text": [
+            null,
+            null,
+            "Never threaten a mother's young - the red vixen kills r_c in the skirmish, and carries off the body to feed her litter.",
+            "The mother red fox's snapping jaws leave r_c dripping blood into the mud, and barely able to escape further injury.",
+            null,
+            "s_c is determined to win, but the red vixen is determined to live, and that makes all the difference. s_c ends up pinned in a defensible hiding spot, bleeding and terrified, until the vixen judges them no longer a threat and continues on her way."
+        ],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a solo fight with a red vixen.",
+            "r_c fell in a solo battle with a red vixen.",
+            "died while fighting a red vixen"
+        ]
+    },
+    {
+        "patrol_id": "wtlnd_hunt_grayvixen1",
+        "biome": "wetland",
+        "season": "newleaf",
+        "tags": [
+            "fighting",
+            "minor_injury",
+            "respect",
+            "trust",
+            "rel_patrol",
+            "patrol_to_r_c"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
+        "decline_text": "Your patrol decides not to pursue the fox.",
+        "chance_of_success": 60,
+        "exp": 30,
+        "success_text": [
+            "The stocky gray vixen they track down smells of milk, and though she's nearly double the weight of any of the patrol and all of it muscle, they meet her eyes squarely, and leap to attack. c_n does not tolerate sharing their territory with foxes, and they work together to drive her off.",
+            "Your patrol drives away the gray fox, seeks out her den, and kills her young cubs. It's brutal, but these fluffy baby foxes would one day have grown to be kit-killers and thieves. Better to deal with them now than when they're the height and nearly double the weight of a cat, though a gray fox will always be easier than a big red one.",
+            "s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the gray fox nor her cubs pose a threat to the Clan. It places s_c as one of c_n's most talented and skillful fighters, a gray fox is a dangerous competitor.",
+            "The patrol overcomes the gray vixen they find and drives her off thanks to a brilliant battle move by s_c. The cats swirl around s_c afterwards, congratulating them on their bravery and skill."
+        ],
+        "fail_text": [
+            "The patrol comes across a gray vixen at the end of the scent trail. She spots them too, measures herself up against them, then flees, scrambling up a tree and into the swamp canopy in a move that completely surprises the cats. This round goes to the gray fox.",
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the gray vixen slips past them and flees into the maze of the many wooded semi-submerged islands of the swamp.",
+            null,
+            "The patrol finds a stocky gray vixen wandering their wetland, and drives her out in a scene that mostly involves yowling and screaming and yapping at each other until she gives in. r_c gets a little battered, but everyone is mostly fine.",
+            null,
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is all muscle, barging past s_c and knocking them ass over paws as she flees from the patrol."
+        ],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 2,
+        "max_cats": 3,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a fight with a gray vixen.",
+            null
+        ]
+    },
+    {
+        "patrol_id": "wtlnd_hunt_grayvixen2",
+        "biome": "wetland",
+        "season": "newleaf",
+        "tags": [
+            "fighting",
+            "minor_injury",
+            "respect",
+            "trust",
+            "rel_patrol",
+            "patrol_to_r_c"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
+        "decline_text": "Your patrol decides not to pursue the fox.",
+        "chance_of_success": 90,
+        "exp": 30,
+        "success_text": [
+            "The stocky gray vixen they track down smells of milk, and though she's nearly double the weight of any of the patrol and all of it muscle, they meet her eyes squarely, and leap to attack. c_n does not tolerate sharing their territory with foxes, and they work together to drive her off.",
+            "With so many cats working together in tight coordination, they're able to keep the gray vixen they find pinned and distracted as they wear her down. The fox eventually flees for her den, and the patrol follows to take care of the cubs she's raising.",
+            "s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the gray fox nor her cubs pose a threat to the Clan. It places s_c as one of c_n's most talented and skillful fighters, a gray fox is a dangerous competitor.",
+            "Bravely, s_c charges the gray fox, yowling threats. The vixen spooks and skitters up a tree, growling and barking in a squeaky tone, and s_c follows her up into the branches. As the rest of the patrol backs them up from the ground, s_c screams until the fox is cowering and afraid, then lets her flee."
+        ],
+        "fail_text": [
+            "The patrol comes across a gray vixen at the end of the scent trail. She spots them too, measures herself up against them, then flees, scrambling up a tree and into the swamp canopy in a move that completely surprises the cats. This round goes to the gray fox.",
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the gray vixen slips past them and flees into the maze of the many wooded semi-submerged islands of the swamp.",
+            null,
+            "The patrol finds a stocky gray vixen wandering their wetland, and drives her out in a scene that mostly involves yowling and screaming and yapping at each other until she gives in. r_c gets a little battered, but everyone is mostly fine.",
+            null,
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is all muscle, barging past s_c and knocking them ass over paws as she flees from the patrol."
+        ],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 4,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a fight with a gray vixen."
+        ]
+    },
+    {
+        "patrol_id": "wtlnd_hunt_grayvixen3",
+        "biome": "wetland",
+        "season": "newleaf",
+        "tags": [
+            "fighting",
+            "scar",
+            "big_bite_injury",
+            "respect",
+            "trust",
+            "clan_to_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
+        "decline_text": "Your patrol decides not to pursue the fox.",
+        "chance_of_success": 50,
+        "exp": 50,
+        "success_text": [
+            "The stocky gray vixen they track down smells of milk, and though she's near double r_c's weight and all of it muscle, they meet her eyes squarely, and leap to attack. c_n does not tolerate sharing their territory with foxes.",
+            null,
+            "s_c displays incredible skill, driving the mother vixen and her brood out of c_n's swamps all by themselves. Now neither the gray fox nor her dependent cubs pose a threat to the Clan. They swell with pride, returning to camp knowing there's one less competitor poaching c_n's prey.",
+            "They're nearly of equal height, with s_c's bold aggression making up for the weight that the gray vixen has on them, and the stand off is resolved when s_c charges the gray fox and she chooses flight over fight."
+        ],
+        "fail_text": [
+            "r_c comes across a gray vixen at the end of the scent trail. She spots them too, measures herself up against them, then flees, scrambling up a tree and into the swamp canopy in a move that completely surprises r_c. This round goes to the gray fox.",
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the gray vixen slips past them and flees into the maze of the many wooded semi-submerged islands of the swamp.",
+            null,
+            "r_c nearly managed to pin the gray vixen they find on a wet, barely above water island, but snapping jaws leave r_c dripping blood into the mud. Today this round goes to the gray fox.",
+            null,
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is cunning, sinking her teeth into s_c to distract them as she flees."
+        ],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a solo fight with a gray vixen.",
+            null
+        ]
+    },
+    {
+        "patrol_id": "wtlnd_hunt_grayvixen4",
+        "biome": "wetland",
+        "season": "greenleaf",
+        "tags": [
+            "fighting",
+            "minor_injury",
+            "respect",
+            "trust",
+            "rel_patrol",
+            "patrol_to_r_c"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
+        "decline_text": "Your patrol decides not to pursue the fox.",
+        "chance_of_success": 60,
+        "exp": 30,
+        "success_text": [
+            "The stocky gray vixen they track down smells of milk, and though she's nearly double the weight of any of the patrol and all of it muscle, they meet her eyes squarely, and leap to attack. c_n does not tolerate sharing their territory with foxes, and they work together to drive her off.",
+            "Your patrol drives away the gray fox, seeks out her den, and kills her young cubs. It's brutal, but these fluffy small foxes would one day have grown to be kit-killers and thieves. Better to deal with them now than when they're the height and nearly double the weight of a cat, though a gray fox will always be easier than a bigger red one.",
+            "s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the gray fox nor her cubs pose a threat to the Clan. It places s_c as one of c_n's most talented and skillful fighters, a gray fox is a dangerous competitor.",
+            "The patrol overcomes the gray vixen they find and drives her off thanks to a brilliant battle move by s_c. The cats swirl around s_c afterwards, congratulating them on their bravery and skill."
+        ],
+        "fail_text": [
+            "The patrol comes across a gray vixen at the end of the scent trail. She spots them too, measures herself up against them, then flees, scrambling up a tree and into the swamp canopy in a move that completely surprises the cats. This round goes to the gray fox.",
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the gray vixen slips past them and flees into the maze of the many wooded semi-submerged islands of the swamp.",
+            null,
+            "The patrol finds a stocky gray vixen wandering their wetland, and drives her out in a scene that mostly involves yowling and screaming and yapping at each other until she gives in. r_c gets a little battered, but everyone is mostly fine.",
+            null,
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is all muscle, barging past s_c and knocking them ass over paws as she flees from the patrol."
+        ],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 2,
+        "max_cats": 3,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a fight with a gray vixen.",
+            null
+        ]
+    },
+    {
+        "patrol_id": "wtlnd_hunt_grayvixen5",
+        "biome": "wetland",
+        "season": "greenleaf",
+        "tags": [
+            "fighting",
+            "minor_injury",
+            "respect",
+            "trust",
+            "rel_patrol",
+            "patrol_to_r_c"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
+        "decline_text": "Your patrol decides not to pursue the fox.",
+        "chance_of_success": 90,
+        "exp": 30,
+        "success_text": [
+            "Led by p_l, and with a heap of cooperation and teamwork, the patrol drives away the gray fox, seeks out her den, and kills her growing cubs. The wetland will be safe from both the competition the vixen posed this season, and the threat her cubs would've given c_n in the seasons to come.",
+            "With so many cats working together in tight coordination, they're able to keep the gray vixen they find pinned and distracted as they wear her down. The fox eventually flees for her den, and the patrol follows to take care of the cubs she's raising.",
+            "s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the gray fox nor her cubs pose a threat to the Clan. It places s_c as one of c_n's most talented and skillful fighters, a gray fox is a dangerous competitor.",
+            "Bravely, s_c charges the gray fox, yowling threats. The vixen spooks and skitters up a tree, growling and barking in a squeaky tone, and s_c follows her up into the branches. As the rest of the patrol backs them up from the ground, s_c screams until the fox is cowering and afraid, then lets her flee."
+        ],
+        "fail_text": [
+            "The patrol comes across a gray vixen at the end of the scent trail. She spots them too, measures herself up against them, then flees, scrambling up a tree and into the swamp canopy in a move that completely surprises the cats. This round goes to the gray fox.",
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the gray vixen slips past them and flees into the maze of the many wooded semi-submerged islands of the swamp.",
+            null,
+            "The patrol finds a stocky gray vixen wandering their wetland, and drives her out in a scene that mostly involves yowling and screaming and yapping at each other until she gives in. r_c gets a little battered, but everyone is mostly fine.",
+            null,
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is all muscle, barging past s_c and knocking them ass over paws as she flees from the patrol."
+        ],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 4,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a fight with a gray vixen."
+        ]
+    },
+    {
+        "patrol_id": "wtlnd_hunt_grayvixen6",
+        "biome": "wetland",
+        "season": "greenleaf",
+        "tags": [
+            "fighting",
+            "scar",
+            "big_bite_injury",
+            "respect",
+            "trust",
+            "clan_to_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
+        "decline_text": "Your patrol decides not to pursue the fox.",
+        "chance_of_success": 50,
+        "exp": 50,
+        "success_text": [
+            "r_c finds a gray vixen smelling of milk and blood. Hopefully by driving her out of the territory, the litter she has been raising this greenleaf won't be a threat to the Clan.",
+            null,
+            "s_c displays incredible skill, driving the mother vixen and her brood out of c_n's swamps all by themselves. Now neither the gray fox nor her dependent cubs pose a threat to the Clan. They swell with pride, returning to camp knowing there's one less competitor poaching c_n's prey.",
+            "They're nearly of equal height, with s_c's bold aggression making up for the weight that the gray vixen has on them, and the stand off is resolved when s_c charges the gray fox and she chooses flight over fight."
+        ],
+        "fail_text": [
+            "r_c comes across a gray vixen at the end of the scent trail. She spots them too, measures herself up against them, then flees, scrambling up a tree and into the swamp canopy in a move that completely surprises r_c. This round goes to the gray fox.",
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the gray vixen slips past them and flees into the maze of the many wooded semi-submerged islands of the swamp.",
+            null,
+            "r_c nearly managed to pin the gray vixen they find on a wet, barely above water island, but snapping jaws leave r_c dripping blood into the mud. Today this round goes to the gray fox.",
+            null,
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is cunning, sinking her teeth into s_c to distract them as she flees."
+        ],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a solo fight with a gray vixen."
+        ]
+    },
+    {
+        "patrol_id": "wtlnd_hunt_grayvixen7",
+        "biome": "wetland",
+        "season": "leaf-fall",
+        "tags": [
+            "fighting",
+            "minor_injury",
+            "respect",
+            "trust",
+            "rel_patrol",
+            "patrol_to_r_c"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
+        "decline_text": "Your patrol decides not to pursue the fox.",
+        "chance_of_success": 60,
+        "exp": 30,
+        "success_text": [
+            "The gray vixen smells like the prey she's been poaching to feed her litter. She's stolen from c_n for the last time, and the patrol drives her from their territory, yowling their anger and fury.",
+            "Your patrol drives away the gray fox, and seeks out her den, but her Leaf-fall cubs are near full-grown and scatter into the wilderness. Hopefully Leaf-bare takes care of them, but if c_n spots them, they won't hesitate.",
+            "s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the gray fox nor her scattered cubs pose a threat to the Clan. It places s_c as one of c_n's most talented and skillful fighters, a gray fox is a dangerous competitor.",
+            "The patrol overcomes the gray vixen they find and drives her off thanks to a brilliant battle move by s_c. The cats swirl around s_c afterwards, congratulating them on their bravery and skill."
+        ],
+        "fail_text": [
+            "The patrol comes across a gray vixen at the end of the scent trail. She spots them too, measures herself up against them, then flees, scrambling up a tree and into the swamp canopy in a move that completely surprises the cats. This round goes to the gray fox.",
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the gray vixen slips past them and flees into the maze of the many wooded semi-submerged islands of the swamp.",
+            null,
+            "The patrol finds a stocky gray vixen wandering their wetland, and drives her out in a scene that mostly involves yowling and screaming and yapping at each other until she gives in. r_c gets a little battered, but everyone is mostly fine.",
+            null,
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is all muscle, barging past s_c and knocking them ass over paws as she flees from the patrol."
+        ],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 2,
+        "max_cats": 3,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a fight with a gray vixen.",
+            null
+        ]
+    },
+    {
+        "patrol_id": "wtlnd_hunt_grayvixen8",
+        "biome": "wetland",
+        "season": "leaf-fall",
+        "tags": [
+            "fighting",
+            "minor_injury",
+            "respect",
+            "trust",
+            "rel_patrol",
+            "patrol_to_r_c"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
+        "decline_text": "Your patrol decides not to pursue the fox.",
+        "chance_of_success": 90,
+        "exp": 30,
+        "success_text": [
+            "Led by p_l and with a heap of cooperation and teamwork, the patrol drives away the gray fox, and seeks out her den. But her cubs are near full-grown with the bounty of Leaf-fall, and scatter from the patrol into the wilderness. Hopefully Leaf-bare takes care of them.",
+            "With so many cats working together in tight coordination, they're able to keep the gray vixen they find pinned and distracted as they wear her down. The fox eventually flees for her den, and the patrol follows to drive her near-full grown litter of fox cubs out from the territory. Hopefully the coming Leaf-bare will take care of them.",
+            "s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the gray fox nor her scattered cubs pose a threat to the Clan. It places s_c as one of c_n's most talented and skillful fighters, a gray fox is a dangerous competitor.",
+            "Bravely, s_c charges the gray fox, yowling threats. The vixen spooks and skitters up a tree, growling and barking in a squeaky tone, and s_c follows her up into the branches. As the rest of the patrol backs them up from the ground, s_c screams until the fox is cowering and afraid, then lets her flee."
+        ],
+        "fail_text": [
+            "The patrol comes across a gray vixen at the end of the scent trail. She spots them too, measures herself up against them, then flees, scrambling up a tree and into the swamp canopy in a move that completely surprises the cats. This round goes to the gray fox.",
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the gray vixen slips past them and flees into the maze of the many wooded semi-submerged islands of the swamp.",
+            null,
+            "The patrol finds a stocky gray vixen wandering their wetland, and drives her out in a scene that mostly involves yowling and screaming and yapping at each other until she gives in. r_c gets a little battered, but everyone is mostly fine.",
+            null,
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is all muscle, barging past s_c and knocking them ass over paws as she flees from the patrol."
+        ],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 4,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a fight with a gray vixen."
+        ]
+    },
+    {
+        "patrol_id": "wtlnd_hunt_grayvixen9",
+        "biome": "wetland",
+        "season": "leaf-fall",
+        "tags": [
+            "fighting",
+            "scar",
+            "big_bite_injury",
+            "respect",
+            "trust",
+            "clan_to_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray?",
+        "decline_text": "Your patrol decides not to pursue the fox.",
+        "chance_of_success": 50,
+        "exp": 50,
+        "success_text": [
+            "In an exhausting fight, r_c manages to bring down and kill the gray vixen they've tracked. Her near grown litter, fat on the bounty of Leaf-fall, is a challenge for another day. c_n will have to deal with the young foxes now roaming motherless in the swamps, before they start to compete for prey in Leaf-bare.",
+            null,
+            "s_c displays incredible skill, driving the mother vixen and her brood out of c_n's swamps all by themselves. Now neither the gray fox nor her cubs pose a threat to the Clan. They swell with pride, returning to camp knowing there's one less competitor poaching c_n's prey.",
+            "They're nearly of equal height, with s_c's bold aggression making up for the weight that the gray vixen has on them, and the stand off is resolved when s_c charges the gray fox and she chooses flight over fight."
+        ],
+        "fail_text": [
+            "r_c comes across a gray vixen at the end of the scent trail. She spots them too, measures herself up against them, then flees, scrambling up a tree and into the swamp canopy in a move that completely surprises r_c. This round goes to the gray fox.",
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and in a moment that embarrasses them deeply the gray vixen slips past them and flees into the maze of the many wooded semi-submerged islands of the swamp.",
+            null,
+            "r_c nearly managed to pin the gray vixen they find on a wet, barely above water island, but snapping jaws leave r_c dripping blood into the mud. Today this round goes to the gray fox.",
+            null,
+            "s_c is determined to win, but their confidence is misplaced. They're a good fighter, but not a great one, and the stocky gray vixen is cunning, sinking her teeth into s_c to distract them as she flees."
+        ],
+        "win_skills": [
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "adventurous",
+            "altruistic",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "responsible",
+            "righteous",
+            "troublesome",
+            "vengeful"
+        ],
+        "fail_skills": [
+            "good fighter"
+        ],
+        "fail_trait": [
+            "None"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a solo fight with a gray vixen."
+        ]
+    },
+    {
+        "patrol_id": "wtlnd_hunt_redfox_steal1",
+        "biome": "wetland",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "small_prey",
+            "fighting",
+            "scar",
+            "small_bite_injury",
+            "platonic",
+            "dislike",
+            "respect",
+            "rel_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? And is it worth a fight if they encounter it?",
+        "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 50,
+        "exp": 20,
+        "success_text": [
+            "p_l leads the patrol to the end of the scent trail, where a red fox sits plucking the feathers off a plump duck. With careful signals, the cats set up an ambush. There aren't many of them, but the fox doesn't need to know that - with a massive explosion of yowls, the cats sound like a full battle patrol, and the fox leaps up frightened out of its skin as the cats pounce to take possession of the bird.",
+            null,
+            "They're a small patrol, but a skilled one, and when they track down the red fox at the end of the scent trail they have enough skill and muscle to drive it off from the fish it was gnawing on. The cats gather around it, congraduating each other.",
+            "Tracking the fox trail, s_c reminds the rest of the patrol that things don't always need to end in a fight, using the trail to uncover a food cache of dead fish buried under a log. They still don't know what kind of fox left the trail, and they don't need to - these fish will make great additions to the fresh-kill pile back home."
+        ],
+        "fail_text": [
+            "The fox's trail vanishes, almost as though the creature has figured out they're tracking it. Grumbling and arguing, the patrol has to head back home disappointed.",
+            "The patrol tracks down a red fox, and spots that it's holding fresh-kill. However, s_c bursts from cover without warning, trying to intimidate the fox. Which they can say sort of worked, but also causes the fox to run off with the food it carries. The other cats aren't particularly pleased with s_c.",
+            null,
+            "p_l leads the patrol to the end of the scent trail, where a red fox sits plucking the feathers off a plump duck. With careful signals, the cats set up an ambush, but they aren't careful enough, and with a snarl the fox takes a bite at r_c as it flees with its dinner.",
+            null,
+            "The patrol tracks down a red fox, and spots that it's holding fresh-kill. However, s_c bursts from cover without warning, trying to intimidate the fox, and the overconfident attack ends in disaster as the fox bites s_c, leaving the rest of the patrol to rescue their annoying Clanmate as the fox runs off with what could've been their dinner."
+        ],
+        "win_skills": [
+            "good hunter",
+            "great hunter",
+            "fantastic hunter",
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "altruistic",
+            "calm",
+            "careful",
+            "faithful",
+            "insecure",
+            "loyal",
+            "nervous",
+            "patient",
+            "responsible",
+            "righteous",
+            "thoughtful",
+            "wise"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "adventurous",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "playful",
+            "troublesome",
+            "vengeful"
+        ],
+        "min_cats": 2,
+        "max_cats": 3,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a red fox fight.",
+            null
+        ]
+    },
+    {
+        "patrol_id": "wtlnd_hunt_redfox_steal2",
+        "biome": "wetland",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "small_prey",
+            "fighting",
+            "scar",
+            "small_bite_injury",
+            "platonic",
+            "respect",
+            "rel_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? And is it worth a fight if they encounter it?",
+        "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 50,
+        "exp": 20,
+        "success_text": [
+            "p_l leads the patrol to the end of the scent trail, where a red fox sits plucking the feathers off a plump duck. With careful signals, the cats set up an ambush. While they'd expected having more cats would make it easier, it also makes the patrol far more of a threat to the red fox, and the creature panicks when they reveal themselves. They win the bird, but r_c nearly gets injured, and it's only p_l shoving them both out of the way that saves both their pelts.",
+            null,
+            "With such a big patrol, and with s_c there, when they track down the red fox at the end of the scent trail they have more than enough skill and muscle to drive it off from the fish it was gnawing on. The cats gather around it, congraduating each other.",
+            "Tracking the fox trail, s_c reminds the rest of the patrol that things don't always need to end in a fight, using the trail to uncover a food cache of dead fish buried under a log. They still don't know what kind of fox left the trail, and they don't need to - these fish will make great additions to the fresh-kill pile back home."
+        ],
+        "fail_text": [
+            "The fox's trail vanishes, almost as though the creature has figured out they're tracking it. Grumbling and arguing, the patrol has to head back home disappointed.",
+            "The patrol tracks down a red fox, and spots that it's holding fresh-kill. However, s_c bursts from cover without warning, trying to intimidate the fox. Which they can say sort of worked, but also causes the fox to run off with the food it carries. The other cats aren't particularly pleased with s_c.",
+            null,
+            "p_l leads the patrol to the end of the scent trail, where a red fox sits plucking the feathers off a plump duck. With careful signals, the cats set up an ambush, but they aren't careful enough, and with a snarl the fox takes a bite at r_c as it flees with its dinner.",
+            null,
+            "The patrol tracks down a red fox, and spots that it's holding fresh-kill. However, s_c bursts from cover without warning, trying to intimidate the fox, and the overconfident attack ends in disaster as the fox bites s_c, leaving the rest of the patrol to rescue their annoying Clanmate as the fox runs off with what could've been their dinner."
+        ],
+        "win_skills": [
+            "good hunter",
+            "great hunter",
+            "fantastic hunter",
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "altruistic",
+            "calm",
+            "careful",
+            "faithful",
+            "insecure",
+            "loyal",
+            "nervous",
+            "patient",
+            "responsible",
+            "righteous",
+            "thoughtful",
+            "wise"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "adventurous",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "playful",
+            "troublesome",
+            "vengeful"
+        ],
+        "min_cats": 4,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a red fox fight."
+        ]
+    },
+    {
+        "patrol_id": "wtlnd_hunt_redfox_steal3",
+        "biome": "wetland",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "medium_prey",
+            "fighting",
+            "death",
+            "scar",
+            "big_bite_injury",
+            "clan_to_patrol",
+            "respect"
+        ],
+        "intro_text": "r_c catches the scent of a fox - but is it red, or gray? And is it worth a fight if they encounter it?",
+        "decline_text": "r_c decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 30,
+        "exp": 20,
+        "success_text": [
+            "Spotting the red fox they've tracked dipping into the shelter of a little scrub covered bit of dry land, r_c hangs back, sneaking around until they spot the fox burying a fish for later. They simply wait for it to finish and leave, then creep in to steal the fox's hard work, bringing the prize back to camp for the fresh-kill pile. Sometimes winning a battle doesn't require fighting.",
+            null,
+            "It requires s_c to use some of their best tricks, but they sneak close to the red fox at the end of the scent trail, eyes on the fish the fox carries. The creature puts down its fresh-kill to start fishing again, and s_c takes the opportunity, grabbing the fish and running. It's a good prize, and they feel proud to present it to the elders when they pad into camp, tired but satisfied.",
+            "It's a situation that calls for careful calm, not implusive action. s_c tracks down a red fox at the end of the scent trail, holding a young duck, and waits carefully. Eventually, as the fox starts to hunt at a different river, it drops its fresh-kill to try win more. s_c carefully snatches it while the fox is distracted, and trots back to camp having successfully outwitted the competing predator."
+        ],
+        "fail_text": [
+            "It embarrasses them, but r_c doesn't even manage to find the fox they track, let alone earn anything useful from the afternoon's attempts.",
+            "s_c hones in on the scent, and as soon as they spot the red fox with a dead fish hanging from its jaws, throwes themselves to the attack. The fox hears them coming, and with insulting nonchalance trots off, unwilling to get into a fight.",
+            null,
+            "Finding a red fox holding a fish that would be much appreciated for c_n's fresh-kill pile, r_c goes to attack it. But the fox is just as keen to keep it as r_c is to win it, and they're injured in the resulting fight.",
+            null,
+            "s_c hones in on the scent, and as soon as they spot the red fox with a dead fish hanging from its jaws, recklessly throwes themselves to the attack. But the fox is as desperate to keep its meal as s_c is to win it from them, and s_c has to retreat bleeding, as the fox trots off with its dinner."
+        ],
+        "win_skills": [
+            "good hunter",
+            "great hunter",
+            "fantastic hunter",
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "altruistic",
+            "calm",
+            "careful",
+            "faithful",
+            "insecure",
+            "loyal",
+            "nervous",
+            "patient",
+            "responsible",
+            "righteous",
+            "thoughtful",
+            "wise"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "adventurous",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "playful",
+            "troublesome",
+            "vengeful"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a solo fight with a red fox."
+        ]
+    },
+    {
+        "patrol_id": "wtlnd_hunt_foxgray_steal1",
+        "biome": "wetland",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "small_prey",
+            "fighting",
+            "scar",
+            "small_bite_injury",
+            "platonic",
+            "respect",
+            "rel_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? And is it worth a fight if they encounter it?",
+        "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 50,
+        "exp": 20,
+        "success_text": [
+            "Its a gray fox, which as far as the cats are concerned, means free food. They leap after it, and after a short chase the fox drops the mouse it was holding. That's not enough to satisfy the c_n cats, who drive it out of their territory before collecting the mouse and continuing the afternoon's hunt.",
+            "The scent trail leads to where some kind of fox has cached half a fish in a poorly concealed hole. The cats take it as their due, and leave the fox to wander on.",
+            "The trail leads to a gray fox, and s_c makes sure it both hands over the prey it's poached from c_n land and flees for the border, tail between its legs and yelping. The smaller predator can't stand up to a patrol working together.",
+            "The cats slowly follow the trail, with s_c urging caution. There's no reason to rush into things. Sure enough, they find a grey fox. It's digging at a rotten log, unearthing insects. The patrol uses the presence of the other predator as a distraction to bring down a pump bird, one that was too busy watching the fox to guard from them, and the fox is left unscathed to keep bug hunting."
+        ],
+        "fail_text": [
+            "The fox's trail vanishes, almost as though the creature has figured out they're tracking it. Grumbling and arguing, the patrol has to head back home disappointed.",
+            "The patrol tracks down a gray fox trespassing on c_n land, but s_c runs at it without thinking, and instead of intimidating the fox into fleeing for the border it makes the gray fox skitter up a tree and start yelping. It takes all afternoon to wait the fox out and then drive it more gently from c_n's hunting grounds, and no one is happy with s_c.",
+            null,
+            "p_l leads the patrol to the end of the scent trail, where a gray fox sits grooming it's fur in the sunshine. With careful signals, the cats set up an ambush, but the small gray panics beyond anything any cat expected, and as it flees, convinced its life is in danger, it bites at r_c.",
+            null,
+            "The patrol tracks down a gray fox trespassing on c_n land, but s_c runs at it without thinking, and instead of intimidating the fox into fleeing for the border it makes the gray fox skitter up a tree and start yelping. s_c tries to make up for the mistake by following the fox up into the branches, which goes even more poorly and leaves the patrol needing to help them back to the medicine den."
+        ],
+        "win_skills": [
+            "good hunter",
+            "great hunter",
+            "fantastic hunter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "altruistic",
+            "calm",
+            "careful",
+            "faithful",
+            "insecure",
+            "loyal",
+            "nervous",
+            "patient",
+            "responsible",
+            "righteous",
+            "thoughtful",
+            "wise"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "adventurous",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "playful",
+            "troublesome",
+            "vengeful"
+        ],
+        "min_cats": 2,
+        "max_cats": 3,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a gray fox fight.",
+            null
+        ]
+    },
+    {
+        "patrol_id": "wtlnd_hunt_foxgray_steal2",
+        "biome": "wetland",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "small_prey",
+            "fighting",
+            "scar",
+            "small_bite_injury",
+            "platonic",
+            "respect",
+            "rel_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox - but is it red, or gray? And is it worth a fight if they encounter it?",
+        "decline_text": "Your patrol decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 70,
+        "exp": 20,
+        "success_text": [
+            "Its a gray fox, which as far as the cats are concerned, means free food. They leap after it, and after a short chase the fox drops the mouse it was holding. That's not enough to satisfy the c_n cats, who drive it out of their territory before collecting the mouse and continuing the afternoon's hunt.",
+            "The scent trail leads to where some kind of fox has cached a wood rat in a poorly concealed hole. The cats take it as their due, and leave the fox to wander on.",
+            "The trail leads to a gray fox, and s_c makes sure it both hands over the prey it's poached from c_n land and flees for the border, tail between its legs and yelping. The smaller predator can't stand up to a patrol working together.",
+            "The cats slowly follow the trail, with s_c urging caution. There's no reason to rush into things. Sure enough, they find a grey fox. It's digging at a rotten log, unearthing insects. The patrol uses the presence of the other predator as a distraction to bring down a pump bird, one that was too busy watching the fox to guard from them, and the fox is left unscathed to keep bug hunting."
+        ],
+        "fail_text": [
+            "The fox's trail vanishes, almost as though the creature has figured out they're tracking it. Grumbling and arguing, the patrol has to head back home disappointed.",
+            "The patrol tracks down a gray fox trespassing on c_n land, but s_c runs at it without thinking, and instead of intimidating the fox into fleeing for the border it makes the gray fox skitter up a tree and start yelping. It takes all afternoon to wait the fox out and then drive it more gently from c_n's hunting grounds, and no one is happy with s_c.",
+            null,
+            "p_l leads the patrol to the end of the scent trail, where a gray fox sits grooming its fur in the sunshine. With careful signals, the cats set up an ambush, but the small gray panics beyond anything any cat expected, and as it flees, convinced its life is in danger, it bites at r_c.",
+            null,
+            "The patrol tracks down a gray fox trespassing on c_n land, but s_c runs at it without thinking, and instead of intimidating the fox into fleeing for the border it makes the gray fox skitter up a tree and start yelping. s_c tries to make up for the mistake by following the fox up into the branches, which goes even more poorly and leaves the patrol needing to help them back to the medicine den."
+        ],
+        "win_skills": [
+            "good hunter",
+            "great hunter",
+            "fantastic hunter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "altruistic",
+            "calm",
+            "careful",
+            "faithful",
+            "insecure",
+            "loyal",
+            "nervous",
+            "patient",
+            "responsible",
+            "righteous",
+            "thoughtful",
+            "wise"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "adventurous",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "playful",
+            "troublesome",
+            "vengeful"
+        ],
+        "min_cats": 4,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null
+    },
+    {
+        "patrol_id": "wtlnd_hunt_foxgray_steal3",
+        "biome": "wetland",
+        "season": "Any",
+        "tags": [
+            "hunting",
+            "medium_prey",
+            "fighting",
+            "scar",
+            "small_bite_injury"
+        ],
+        "intro_text": "r_c catches the scent of a fox - but is it red, or gray? And is it worth a fight if they encounter it?",
+        "decline_text": "r_c decides not to quarrel with the fox and to find prey elsewhere.",
+        "chance_of_success": 50,
+        "exp": 15,
+        "success_text": [
+            "Spotting the gray fox they've tracked dipping into the shelter of a little scrub covered bit of dry land, r_c hangs back, sneaking around until they spot the fox caching a bird kill in an old log a storm washed in moons ago. They simply wait for it to finish and leave, then creep in to steal the fox's hard work, bringing the prize back to camp for the fresh-kill pile. Sometimes winning a battle doesn't require fighting.",
+            null,
+            "s_c tracks down a gray fox, and carefully cosiders it as an opponent. Stocky, yes, but they finally decide they can take it, and burst from cover, using surprise to get in a couple vicious swipes to the fox's face while its jaws are still full of prey. Yelping, the gray fox retreats from the cat, unwilling to risk more split blood, and s_c picks up the rat it carried with a proud grin.",
+            "It's a situation that calls for careful calm, not implusive action. s_c tracks down a gray fox at the end of the scent trail, holding a little plump mouse, and waits carefully. Eventually, the fox tries to cache its fresh-kill in a little hole. s_c picks it up once the fox leaves, strolling back to camp having successfully outwitted the competing predator."
+        ],
+        "fail_text": [
+            "It embarrasses them, but r_c doesn't even manage to find the fox they track, let alone earn anything useful from the afternoon's attempts.",
+            "s_c hones in on the scent, and as soon as they spot the gray fox with a dead fish hanging from its jaws, throwes themselves to the attack. The fox hears them coming, and makes a hasty retreat before the fight can start, taking its dinner with it.",
+            null,
+            "Finding a gray fox holding a mouse that would make a nice addition to c_n's fresh-kill pile, r_c goes to attack it. But the fox is just as keen to keep it as r_c is to win it, and they're injured in the resulting fight.",
+            null,
+            "s_c hones in on the scent, and as soon as they spot the gray fox with a dead fish hanging from its jaws, recklessly throwes themselves to the attack. But the fox is a little too desperate to keep itself from harm, and s_c has to retreat bleeding."
+        ],
+        "win_skills": [
+            "good hunter",
+            "great hunter",
+            "fantastic hunter",
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "altruistic",
+            "calm",
+            "careful",
+            "faithful",
+            "insecure",
+            "loyal",
+            "nervous",
+            "patient",
+            "responsible",
+            "righteous",
+            "thoughtful",
+            "wise"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "adventurous",
+            "ambitious",
+            "bloodthirsty",
+            "bold",
+            "confident",
+            "daring",
+            "fierce",
+            "playful",
+            "troublesome",
+            "vengeful"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from a solo fight with a gray fox."
+        ]
+    },
+    {
+        "patrol_id": "wtlnd_hunt_swiftfox_newleafscavenge1",
+        "biome": "wetland",
+        "season": "newleaf",
+        "tags": [
+            "hunting",
+            "small_prey",
+            "comfort",
+            "respect",
+            "rel_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox. Tracking it, they find a swift fox feeding on a fish about as big as it is. The cat-sized predator definitely didn't kill this.",
+        "decline_text": "Your patrol decides not to quarrel with the fox. There're plenty of fish in the river for everyone, and it's best to focus on feeding the Clan rather than quarreling.",
+        "chance_of_success": 70,
+        "exp": 20,
+        "success_text": [
+            "As the patrol approaches, the swift fox spots them and backs off from the carcass with a whine. Your cats bring it home, no fuss, no worries.",
+            null,
+            "The patrol takes over the carcass without a fight, the small swift fox giving way without trouble. Still, it's hardly worth the effort, and s_c can think of better things they should be doing.",
+            "Responsibly, s_c keeps the patrol moving once they take the fish from the unfortunate-but-unable-to-complain swift fox. They don't find anything, but with the stolen fish the afternoon hasn't been a completely wasted hunting trip."
+        ],
+        "fail_text": [
+            "The swift fox gives way easily to the bigger canivores, but the fish carcass is rotten, too rotten for the Clan cats to want to touch.",
+            "The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth. s_c calls the rest of the patrol for backup and no one is injured, but by the time they get back to the kill a different predator has absconded with the fish."
+        ],
+        "win_skills": [
+            "smart",
+            "very smart",
+            "extremely smart"
+        ],
+        "win_trait": [
+            "altruistic",
+            "patient",
+            "responsible",
+            "thoughtful",
+            "wise",
+            "calm",
+            "careful",
+            "insecure",
+            "nervous",
+            "sneaky"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "bold",
+            "childish",
+            "confident",
+            "daring",
+            "playful",
+            "shameless"
+        ],
+        "min_cats": 2,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null
+    },
+    {
+        "patrol_id": "wtlnd_hunt_swiftfox_newleafscavenge2",
+        "biome": "wetland",
+        "season": "newleaf",
+        "tags": [
+            "hunting",
+            "medium_prey",
+            "fighting",
+            "scar",
+            "death",
+            "no_body",
+            "all_lives",
+            "small_bite_injury"
+        ],
+        "intro_text": "r_c catches the scent of a fox. Tracking it, they find a swift fox feeding on a fish about as big as it is. The cat-sized predator definitely didn't kill this.",
+        "decline_text": "r_c decides not to quarrel with the fox. There're plenty of fish in the river for everyone, and it's best to focus on feeding the Clan rather than quarreling.",
+        "chance_of_success": 70,
+        "exp": 10,
+        "success_text": [
+            "r_c approaches the kill, fur puffed up. The swift fox grumbles, but with a hiss both animals agree to disagree, feeding from opposite ends of the calf without further trouble. r_c is able to find some decent scraps to carry back to camp, though with only them there they can't bring back as much meat as they'd like.",
+            null,
+            "Watching the swift fox at the carcass, s_c notices it stripping meat from the fish and caching it in little holes, and starts to copy it. The bigger predators will return to claim the fish soon, but by the time they do s_c will have hidden away the choicest morsels to fetch later.",
+            "With great care, aware that the kill's original owner must be somewhere about, s_c snatches the first large scrap they find and leaves the swift fox to risk the wrath of the bigger predators."
+        ],
+        "fail_text": [
+            "r_c muscles in as the swft fox gives way to the bigger predator, but the carcass is rotten and worthless.",
+            "The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth. s_c dances out of the way, but when they return, another predator has already snapped up the abandoned fish.",
+            "r_c starts arguing with the fox over the fish. Neither sees the alligator coming.",
+            "Puffed up, r_c approaches the swift fox. But there's only one of them, and the fox is their equal in size and weight. instead of running or giving it, it snarls, and attacks. r_c gives just as good as they get, and both animals end up limping away from the kill.",
+            null,
+            "The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth, sinking them into s_c and giving s_c a bigger concern than scavenging a fish carcass."
+        ],
+        "win_skills": [
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "altruistic",
+            "patient",
+            "responsible",
+            "thoughtful",
+            "wise",
+            "calm",
+            "careful",
+            "insecure",
+            "nervous",
+            "sneaky"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "bold",
+            "childish",
+            "confident",
+            "daring",
+            "playful",
+            "shameless"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from fighting with a swift fox.",
+            "While scavenging alone, r_c was killed by a predator they didn't see.",
+            "taken by an alligator"
+        ]
+    },
+    {
+        "patrol_id": "wtlnd_hunt_swiftfox_greenleafscavenge1",
+        "biome": "wetland",
+        "season": "greenleaf",
+        "tags": [
+            "hunting",
+            "small_prey",
+            "comfort",
+            "respect",
+            "rel_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox. Tracking it, they find a swift fox feeding on a fish about as big as it is. The cat-sized predator definitely didn't kill this.",
+        "decline_text": "Your patrol decides not to quarrel with the fox. There're plenty of fish in the river for everyone, and it's best to focus on feeding the Clan rather than quarreling.",
+        "chance_of_success": 70,
+        "exp": 20,
+        "success_text": [
+            "As the patrol approaches, the swift fox spots them and backs off from the carcass with a whine. Your cats bring it home, no fuss, no worries.",
+            null,
+            "The patrol takes over the carcass without a fight, the small swift fox giving way without trouble. Still, it's hardly worth the effort, and s_c can think of better things they should be doing.",
+            "Responsibly, s_c keeps the patrol moving once they take the fish from the unfortunate-but-unable-to-complain swift fox. They don't find anything, but with the stolen fish the afternoon hasn't been a completely wasted hunting trip."
+        ],
+        "fail_text": [
+            "The swift fox gives way easily to the bigger canivores, but the fish carcass is rotten, too rotten for the Clan cats to want to touch.",
+            "The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth. s_c calls the rest of the patrol for backup and no one is injured, but by the time they get back to the kill a different predator has absconded with the fish."
+        ],
+        "win_skills": [
+            "smart",
+            "very smart",
+            "extremely smart"
+        ],
+        "win_trait": [
+            "altruistic",
+            "patient",
+            "responsible",
+            "thoughtful",
+            "wise",
+            "calm",
+            "careful",
+            "insecure",
+            "nervous",
+            "sneaky"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "bold",
+            "childish",
+            "confident",
+            "daring",
+            "playful",
+            "shameless"
+        ],
+        "min_cats": 2,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null
+    },
+    {
+        "patrol_id": "wtlnd_hunt_swiftfox_greenleafscavenge2",
+        "biome": "wetland",
+        "season": "greenleaf",
+        "tags": [
+            "hunting",
+            "medium_prey",
+            "fighting",
+            "scar",
+            "death",
+            "no_body",
+            "all_lives",
+            "small_bite_injury"
+        ],
+        "intro_text": "r_c catches the scent of a fox. Tracking it, they find a swift fox feeding on a fish about as big as it is. The cat-sized predator definitely didn't kill this.",
+        "decline_text": "r_c decides not to quarrel with the fox. There're plenty of fish in the river for everyone, and it's best to focus on feeding the Clan rather than quarreling.",
+        "chance_of_success": 70,
+        "exp": 10,
+        "success_text": [
+            "r_c smaller, alone, and half its weight, but the fox has a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle. The fox, already stuffed full and unwilling to lose blood over it, leaves the kill with a grumble.",
+            null,
+            "s_c uses every trick in their talented fighting skillset to attack the fox with no one to watch their flank, until the perfect opportunity opens up and they pounce onto the fox's back, digging in their claws. It's a wild ride through the swamp until the fox bucks them off, but it wins them the fish carcass.",
+            "In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. But then they're stuck, unwilling to let go and risk being bitten. They're dragged through the swamp, over rocks and through bushes, until the fox finally collapses and the battered s_c goes back to proudly claim the fish."
+        ],
+        "fail_text": [
+            "r_c muscles in as the swft fox gives way to the bigger predator, but the carcass is rotten and worthless.",
+            "The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth. s_c dances out of the way, but when they return, another predator has already snapped up the abandoned fish.",
+            "r_c starts arguing with the fox over the fish. Neither sees the alligator coming.",
+            "Puffed up, r_c approaches the swift fox. But there's only one of them, and the fox is their equal in size and weight. instead of running or giving it, it snarls, and attacks. r_c gives just as good as they get, and both animals end up limping away from the kill.",
+            null,
+            "The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth, sinking them into s_c and giving s_c a bigger concern than scavenging a fish carcass."
+        ],
+        "win_skills": [
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "altruistic",
+            "patient",
+            "responsible",
+            "thoughtful",
+            "wise",
+            "calm",
+            "careful",
+            "insecure",
+            "nervous",
+            "sneaky"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "bold",
+            "childish",
+            "confident",
+            "daring",
+            "playful",
+            "shameless"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from fighting with a swift fox.",
+            "While scavenging alone, r_c was killed by a predator they didn't see.",
+            "taken by an alligator"
+        ]
+    },
+    {
+        "patrol_id": "wtlnd_hunt_swiftfox_leaf-fallscavenge1",
+        "biome": "wetland",
+        "season": "leaf-fall",
+        "tags": [
+            "hunting",
+            "small_prey",
+            "comfort",
+            "respect",
+            "rel_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox. Tracking it, they find a swift fox feeding on a fish about as big as it is. The cat-sized predator definitely didn't kill this.",
+        "decline_text": "Your patrol decides not to quarrel with the fox. There're plenty of fish in the river for everyone, and it's best to focus on feeding the Clan rather than quarreling.",
+        "chance_of_success": 70,
+        "exp": 20,
+        "success_text": [
+            "As the patrol approaches, the swift fox spots them and backs off from the carcass with a whine. Your cats bring it home, no fuss, no worries.",
+            null,
+            "The patrol takes over the carcass without a fight, the small swift fox giving way without trouble. Still, it's hardly worth the effort, and s_c can think of better things they should be doing.",
+            "Responsibly, s_c keeps the patrol moving once they take the fish from the unfortunate-but-unable-to-complain swift fox. They don't find anything, but with the stolen fish the afternoon hasn't been a completely wasted hunting trip."
+        ],
+        "fail_text": [
+            "The swift fox gives way easily to the bigger canivores, but the fish carcass is rotten, too rotten for the Clan cats to want to touch.",
+            "The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth. s_c calls the rest of the patrol for backup and no one is injured, but by the time they get back to the kill a different predator has absconded with the fish."
+        ],
+        "win_skills": [
+            "smart",
+            "very smart",
+            "extremely smart"
+        ],
+        "win_trait": [
+            "altruistic",
+            "patient",
+            "responsible",
+            "thoughtful",
+            "wise",
+            "calm",
+            "careful",
+            "insecure",
+            "nervous",
+            "sneaky"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "bold",
+            "childish",
+            "confident",
+            "daring",
+            "playful",
+            "shameless"
+        ],
+        "min_cats": 2,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null
+    },
+    {
+        "patrol_id": "wtlnd_hunt_swiftfox_leaf-fallscavenge2",
+        "biome": "wetland",
+        "season": "leaf-fall",
+        "tags": [
+            "hunting",
+            "medium_prey",
+            "fighting",
+            "scar",
+            "death",
+            "no_body",
+            "all_lives",
+            "small_bite_injury"
+        ],
+        "intro_text": "r_c catches the scent of a fox. Tracking it, they find a swift fox feeding on a fish about as big as it is. The cat-sized predator definitely didn't kill this.",
+        "decline_text": "r_c decides not to quarrel with the fox. There're plenty of fish in the river for everyone, and it's best to focus on feeding the Clan rather than quarreling.",
+        "chance_of_success": 70,
+        "exp": 10,
+        "success_text": [
+            "r_c smaller, alone, and half its weight, but the fox has a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle. The fox, already on the look out for other predators and unwilling to lose blood over it, leaves the kill with a grumble.",
+            null,
+            "s_c uses every trick in their talented fighting skillset to attack the fox with no one to watch their flank, until the perfect opportunity opens up and they pounce onto the fox's back, digging in their claws. It's a wild ride through the swamp until the fox bucks them off, but it wins them the fish carcass.",
+            "In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. But then they're stuck, unwilling to let go and risk being bitten. They're dragged through the swamp, over rocks and through bushes, until the fox finally collapses and the battered s_c goes back to proudly claim the fish."
+        ],
+        "fail_text": [
+            "r_c muscles in as the swft fox gives way to the bigger predator, but the carcass is rotten and worthless.",
+            "The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth. s_c dances out of the way, but when they return, another predator has already snapped up the abandoned fish.",
+            "r_c starts arguing with the fox over the fish. Neither sees the alligator coming.",
+            "Puffed up, r_c approaches the swift fox. But there's only one of them, and the fox is their equal in size and weight. instead of running or giving it, it snarls, and attacks. r_c gives just as good as they get, and both animals end up limping away from the kill.",
+            null,
+            "The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth, sinking them into s_c and giving s_c a bigger concern than scavenging a fish carcass."
+        ],
+        "win_skills": [
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "altruistic",
+            "patient",
+            "responsible",
+            "thoughtful",
+            "wise",
+            "calm",
+            "careful",
+            "insecure",
+            "nervous",
+            "sneaky"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "bold",
+            "childish",
+            "confident",
+            "daring",
+            "playful",
+            "shameless"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from fighting with a swift fox.",
+            "While scavenging alone, r_c was killed by a predator they didn't see.",
+            "taken by an alligator"
+        ]
+    },
+    {
+        "patrol_id": "wtlnd_hunt_swiftfox_leaf-barescavenge1",
+        "biome": "wetland",
+        "season": "leaf-bare",
+        "tags": [
+            "hunting",
+            "small_prey",
+            "comfort",
+            "respect",
+            "rel_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox. Tracking it, they find a swift fox feeding on a fish about as big as it is. The cat-sized predator definitely didn't kill this.",
+        "decline_text": "Your patrol decides not to quarrel with the fox. There're plenty of fish in the river for everyone, and it's best to focus on feeding the Clan rather than quarreling.",
+        "chance_of_success": 60,
+        "exp": 20,
+        "success_text": [
+            "As the patrol approaches, the swift fox spots them and backs off from the carcass with a whine. Your cats bring it home, no fuss, no worries.",
+            null,
+            "The patrol takes over the carcass without a fight, the small swift fox giving way without trouble. Still, it's hardly worth the effort, and s_c can think of better things they should be doing.",
+            "Responsibly, s_c keeps the patrol moving once they take the fish from the unfortunate-but-unable-to-complain swift fox. They don't find anything, but with the stolen fish the afternoon hasn't been a completely wasted hunting trip."
+        ],
+        "fail_text": [
+            "The swift fox gives way easily to the bigger canivores, but the fish carcass is rotten, too rotten for the Clan cats to want to touch.",
+            "The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth. s_c calls the rest of the patrol for backup and no one is injured, but by the time they get back to the kill a different predator has absconded with the fish."
+        ],
+        "win_skills": [
+            "smart",
+            "very smart",
+            "extremely smart"
+        ],
+        "win_trait": [
+            "altruistic",
+            "patient",
+            "responsible",
+            "thoughtful",
+            "wise",
+            "calm",
+            "careful",
+            "insecure",
+            "nervous",
+            "sneaky"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "bold",
+            "childish",
+            "confident",
+            "daring",
+            "playful",
+            "shameless"
+        ],
+        "min_cats": 2,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null
+    },
+    {
+        "patrol_id": "wtlnd_hunt_swiftfox_leaf-barescavenge2",
+        "biome": "wetland",
+        "season": "leaf-bare",
+        "tags": [
+            "hunting",
+            "medium_prey",
+            "fighting",
+            "scar",
+            "death",
+            "no_body",
+            "all_lives",
+            "small_bite_injury"
+        ],
+        "intro_text": "r_c catches the scent of a fox. Tracking it, they find a swift fox feeding on a fish about as big as it is. Roughly equal in size to r_c, the swift fox definitely didn't bring down this feast themselves.",
+        "decline_text": "r_c decides not to quarrel with the fox. There're plenty of fish in the river for everyone, and it's best to focus on feeding the Clan rather than quarreling.",
+        "chance_of_success": 50,
+        "exp": 10,
+        "success_text": [
+            "r_c smaller, alone, and half its weight, but the fox has a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle. The fox, already on the look out for other predators and unwilling to lose blood over it, leaves the kill with a grumble.",
+            null,
+            "s_c uses every trick in their talented fighting skillset to attack the fox with no one to watch their flank, until the perfect opportunity opens up and they pounce onto the fox's back, digging in their claws. It's a wild ride through the swamp until the fox bucks them off, but it wins them the fish carcass.",
+            "In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. But then they're stuck, unwilling to let go and risk being bitten. They're dragged through the swamp, over rocks and through bushes, until the fox finally collapses and the battered s_c goes back to proudly claim the fish."
+        ],
+        "fail_text": [
+            "r_c muscles in as the swft fox gives way to the bigger predator, but the carcass is rotten and worthless.",
+            "The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth. s_c dances out of the way, but when they return, another predator has already snapped up the abandoned fish.",
+            "r_c starts arguing with the fox over the fish. Neither sees the alligator coming.",
+            "Puffed up, r_c approaches the swift fox. But there's only one of them, and the fox is their equal in size and weight. instead of running or giving it, it snarls, and attacks. r_c gives just as good as they get, and both animals end up limping away from the kill.",
+            null,
+            "The swift fox gives up the kill, but s_c pursues it anyway, until the fox turns and threatens with snapping teeth, sinking them into s_c and giving s_c a bigger concern than scavenging a fish carcass."
+        ],
+        "win_skills": [
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "altruistic",
+            "patient",
+            "responsible",
+            "thoughtful",
+            "wise",
+            "calm",
+            "careful",
+            "insecure",
+            "nervous",
+            "sneaky"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "bold",
+            "childish",
+            "confident",
+            "daring",
+            "playful",
+            "shameless"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from fighting with a swift fox.",
+            "While scavenging alone, r_c was killed by a predator they didn't see.",
+            "taken by an alligator"
+        ]
+    },
+    {
+        "patrol_id": "wtlnd_hunt_kitfox_scavenge1",
+        "biome": "wetland",
+        "season": "leaf-bare",
+        "tags": [
+            "hunting",
+            "small_prey",
+            "comfort",
+            "respect",
+            "rel_patrol"
+        ],
+        "intro_text": "Your patrol catches the scent of a fox. Tracking it, they find a kit fox fishing on a branch overlooking the shallows.",
+        "decline_text": "Your patrol decides not to quarrel with the fox. There're plenty of fish in the river for everyone, and it's best to focus on feeding the Clan rather than quarreling.",
+        "chance_of_success": 70,
+        "exp": 10,
+        "success_text": [
+            "The cats freeze, and carefully creep back into cover. A kit fox is small enough to inevitably startle and run from them, but if they play this right... they wait until the tiny fox drops down onto a salamandar before they pop out of the bushes. Not only to they scare off a potential competitor, they also get the added reward of a little snack.",
+            "It's a truely ridiculous power disparity, with even a single member of the patrol outweighing the little fox. The cats drive it out of c_n's swamps no trouble, but it's hardly worth the little fishy morsel they win for their efforts.",
+            "A simple display of just how badly the kit fox is outmatched convinces it to run, and s_c carefully seeks out the little food cache the kit fox was workign on, taking the minnows for the camp's fresh-kill pile.",
+            "It's frustrating that it only wins them a single minnow, but hte patrol drives out the kit fox, and s_c reminds them that's what matters - that now the fox won't keep poaching from c_n's hunting grounds in the future."
+        ],
+        "fail_text": [
+            "The cats freeze, and carefully creep back into cover. A kit fox is small enough to inevitably startle and run from them, but if they play this right... but not, the kit fox has spotted them, and flees from the cats. At least that's one less competitior in c_n's hunting grounds?"
+        ],
+        "win_skills": [
+            "smart",
+            "very smart",
+            "extremely smart"
+        ],
+        "win_trait": [
+            "altruistic",
+            "patient",
+            "responsible",
+            "thoughtful",
+            "wise",
+            "calm",
+            "careful",
+            "insecure",
+            "nervous",
+            "sneaky"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "bold",
+            "childish",
+            "confident",
+            "daring",
+            "playful",
+            "shameless"
+        ],
+        "min_cats": 2,
+        "max_cats": 6,
+        "antagonize_text": null,
+        "antagonize_fail_text": null
+    },
+    {
+        "patrol_id": "wtlnd_hunt_kitfox_scavenge2",
+        "biome": "wetland",
+        "season": "leaf-bare",
+        "tags": [
+            "hunting",
+            "medium_prey"
+        ],
+        "intro_text": "r_c catches the scent of a fox. Tracking it, they find a kit fox fishing on a branch overlooking the shallows.",
+        "decline_text": "r_c decides not to quarrel with the fox. There're plenty of fish in the river for everyone, and it's best to focus on feeding the Clan rather than quarreling.",
+        "chance_of_success": 70,
+        "exp": 10,
+        "success_text": [
+            "r_c freezes, and carefully creeps back into cover. A kit fox is small enough to inevitably startle and run from them, but if they play this right... they wait until the tiny fox drops down onto a salamandar before they pop out of the bushes. Not only to they scare off a potential competitor, they also get the added reward of a little snack.",
+            "r_c throws their weight around as the bigger predator, stealing the kit fox's lunch and driving it away from the river.",
+            "s_c uses every trick in their talented fighting skillset to attack the fox with no one to watch their flank, until the perfect opportunity opens up and they pounce onto the fox's back, digging in their claws. It's a wild ride through the swamp until the fox bucks them off, but it wins them the fish carcass.",
+            "In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. But then they're stuck, unwilling to let go and risk being bitten. They're dragged through the swamp, over rocks and through bushes, until the fox finally collapses and the battered s_c goes back to proudly claim the fish."
+        ],
+        "fail_text": [
+            "r_c freezes, and carefully creeps back into cover. A kit fox is small enough to inevitably startle and run from them, but if they play this right... but not, the kit fox has spotted them, and flees from the cat. At least that's one less competitior in c_n's hunting grounds?"
+        ],
+        "win_skills": [
+            "good fighter",
+            "great fighter",
+            "excellent fighter"
+        ],
+        "win_trait": [
+            "altruistic",
+            "patient",
+            "responsible",
+            "thoughtful",
+            "wise",
+            "calm",
+            "careful",
+            "insecure",
+            "nervous",
+            "sneaky"
+        ],
+        "fail_skills": [
+            "None"
+        ],
+        "fail_trait": [
+            "bold",
+            "childish",
+            "confident",
+            "daring",
+            "playful",
+            "shameless"
+        ],
+        "min_cats": 1,
+        "max_cats": 1,
+        "antagonize_text": null,
+        "antagonize_fail_text": null
+    }
 ]

--- a/resources/game_config.json
+++ b/resources/game_config.json
@@ -2,8 +2,46 @@
 	"freshkill":{
 		"auto_warrior_prey": [1,2],
 		"auto_apprentice_prey": [0,2],
+		"condition_increase": 0.5,
+		"prey_requirement":{
+			"leader": 3,
+			"deputy": 3,
+			"medicine cat": 2,
+			"medicine cat apprentice": 1.5,
+			"mediator apprentice": 1.5,
+			"mediator": 2,
+			"warrior": 3,
+			"apprentice": 1.5,
+			"elder": 1.5,
+			"queen": 4,
+			"kitten": 0.5
+		},
+		"feeding_order":[
+			"kitten",
+			"queen",
+			"elder",
+			"medicine cat",
+			"medicine cat apprentice",
+			"apprentice",
+			"mediator apprentice",
+			"warrior",
+			"mediator",
+			"deputy",
+			"leader"
+		],
+		"hunter_bonus": {"fantastic_hunter": 3, "great_hunter": 2, "good_hunter": 1},
+		"hunter_exp_bonus": {
+			"very_low": 1,
+			"low": 2,
+			"average": 3,
+			"high": 4,
+			"master": 5,
+			"max": 7
+		},
 		"comment": [
-			"The auto parameters are for the prey each moon, each healthy warrior/apprentice will catch an amount of between these two values of prey."
+			"The auto parameters are for the prey each moon, each healthy warrior/apprentice will catch an amount of between these two values of prey.",
+			"hunter_bonus is the factor which is be used to multiply on a hunting patrol.",
+			"hunter_exp_bonus is the additional prey which will be added on a hunting patrol."
 		]
 	}
 }

--- a/resources/game_config.json
+++ b/resources/game_config.json
@@ -1,0 +1,9 @@
+{
+	"freshkill":{
+		"auto_warrior_prey": [1,2],
+		"auto_apprentice_prey": [0,2],
+		"comment": [
+			"The auto parameters are for the prey each moon, each healthy warrior/apprentice will catch an amount of between these two values of prey."
+		]
+	}
+}

--- a/resources/game_config.json
+++ b/resources/game_config.json
@@ -1,5 +1,6 @@
 {
 	"freshkill":{
+		"start_amount": 60,
 		"auto_warrior_prey": [1,2],
 		"auto_apprentice_prey": [0,2],
 		"condition_increase": 0.5,
@@ -39,6 +40,7 @@
 			"max": 7
 		},
 		"comment": [
+			"start_amount defines the amount of prey when a new freshkill-pile is made",
 			"The auto parameters are for the prey each moon, each healthy warrior/apprentice will catch an amount of between these two values of prey.",
 			"hunter_bonus is the factor which is be used to multiply on a hunting patrol.",
 			"hunter_exp_bonus is the additional prey which will be added on a hunting patrol."

--- a/scripts/clan_resources/freshkill.py
+++ b/scripts/clan_resources/freshkill.py
@@ -4,46 +4,6 @@ from scripts.game_structure.game_essentials import *
 from copy import deepcopy
 import random
 
-PREY_REQUIREMENT = {
-    "leader": 3,
-    "deputy": 3,
-    "medicine cat": 2,
-    "medicine cat apprentice": 1.5,
-    "mediator apprentice": 1.5,
-    "mediator": 2,
-    "warrior": 3,
-    "apprentice": 1.5,
-    "elder": 1.5,
-    "queen": 4,
-    "kitten": 0.5,
-}
-
-CONDITION_INCREASE = 0.5
-
-FEEDING_ORDER = [
-    "kitten",
-    "queen",
-    "elder",
-    "medicine cat",
-    "medicine cat apprentice",
-    "apprentice",
-    "mediator apprentice",
-    "warrior",
-    "mediator",
-    "deputy",
-    "leader"
-]
-
-HUNTER_BONUS = {"fantastic_hunter": 3, "great_hunter": 2, "good_hunter": 1}
-HUNTER_EXP_BONUS = {
-    "very_low": 1,
-    "low": 2,
-    "average": 3,
-    "high": 4,
-    "master": 5,
-    "max": 7
-}
-
 class Nutrition():
     """All the information about nutrition from one cat."""
 
@@ -308,3 +268,19 @@ class Freshkill_Pile():
         nutrition.percentage = 100
 
         self.nutrition_info[cat.ID] = nutrition
+
+
+
+# ---------------------------------------------------------------------------- #
+#                                LOAD RESOURCES                                #
+# ---------------------------------------------------------------------------- #
+
+GAME_CONFIG = None
+with open(f"resources/game_config.json", 'r') as read_file:
+    GAME_CONFIG = ujson.loads(read_file.read())
+
+PREY_REQUIREMENT = GAME_CONFIG["freshkill"]["prey_requirement"]
+CONDITION_INCREASE = GAME_CONFIG["freshkill"]["condition_increase"]
+FEEDING_ORDER = GAME_CONFIG["freshkill"]["feeding_order"]
+HUNTER_BONUS = GAME_CONFIG["freshkill"]["hunter_bonus"]
+HUNTER_EXP_BONUS = GAME_CONFIG["freshkill"]["hunter_exp_bonus"]

--- a/scripts/clan_resources/freshkill.py
+++ b/scripts/clan_resources/freshkill.py
@@ -72,7 +72,6 @@ class Freshkill_Pile():
         for key in order:
             amount = self.take_from_pile(key, amount)
         
-
     def time_skip(self, living_cats):
         """Handle the time skip for the freshkill pile, including feeding the cats."""
         previous_amount = 0
@@ -83,7 +82,6 @@ class Freshkill_Pile():
         self.total_amount = sum(self.pile.values())
 
         self.feed_cats(living_cats)
-        # print(f"REMAINING AMOUNT: {self.total_amount} (needed: {self.amount_food_needed()})")
 
     def feed_cats(self, living_cats):
         """Handles to feed all living cats. This happens before the aging up."""
@@ -136,8 +134,19 @@ class Freshkill_Pile():
     #                               helper functions                               #
     # ---------------------------------------------------------------------------- #
 
-    def handle_not_enough_food(self, group, status_):
-        """Handle the situation where there is not enough food for this group."""
+    def handle_not_enough_food(self, group: list, status_ : str):
+        """Handle the situation where there is not enough food for this group.
+
+            Parameters
+            ----------
+            group : list
+                the list of cats which should be fed
+            status_ : str
+                the status of each cat of the group
+
+            Returns
+            -------
+        """
         tactic = None # TODO: handle with a setting
         if tactic == "younger_first":
             sorted_group = sorted(group, key=lambda x: x.moons)
@@ -162,8 +171,19 @@ class Freshkill_Pile():
         else:
             self.feed_group(group, status_)
 
-    def feed_group(self, group, status_):
-        """Handle the feeding of a specific group of cats, the order is already set."""
+    def feed_group(self, group: list, status_: str):
+        """Handle the feeding of a specific group of cats, the order is already set.
+
+            Parameters
+            ----------
+            group : list
+                the list of cats which should be fed
+            status_ : str
+                the status of each cat of the group
+
+            Returns
+            -------
+        """
         # ration_prey < healthy warrior will only eat half of the food they need
         ration_prey = False # TODO: handled with a setting
 
@@ -176,14 +196,16 @@ class Freshkill_Pile():
             else:
                 if ration_prey and status_ == "warrior":
                     feeding_amount = feeding_amount/2
+            lot_more_prey = self.amount_food_needed() < self.total_amount * 1.5
+            if lot_more_prey and self.nutrition_info[cat.ID].percentage < 100:
+                feeding_amount += 1
             self.feed_cat(cat, feeding_amount, needed_amount)
 
     def tactic_less_nutrition(self, group, status_):
         """With this tactic, the cats with the lowest nutrition will be feed first."""
         group_ids = [cat.id for cat in group]
         sorted_nutrition = sorted(self.nutrition_info.items(), key=lambda x: x[1].percentage)
-        # ration_prey < warrior will only eat half of the food they need
-        ration_prey = True # TODO: handled with a setting
+        ration_prey = False # TODO: handled with a setting
 
         for k, v in sorted_nutrition:
             if k not in group_ids:

--- a/scripts/clan_resources/freshkill.py
+++ b/scripts/clan_resources/freshkill.py
@@ -49,12 +49,12 @@ class Freshkill_Pile():
             self.total_amount = total
         else:
             self.pile = {
-                "expires_in_4": GAME_CONFIG["freshkill"]["hunter_exp_bonus"],
+                "expires_in_4": GAME_CONFIG["freshkill"]["start_amount"],
                 "expires_in_3": 0,
                 "expires_in_2": 0,
                 "expires_in_1": 0,
             }
-            self.total_amount = GAME_CONFIG["freshkill"]["hunter_exp_bonus"]
+            self.total_amount = GAME_CONFIG["freshkill"]["start_amount"]
         self.nutrition_info = {}
 
     def add_freshkill(self, amount):

--- a/scripts/clan_resources/freshkill.py
+++ b/scripts/clan_resources/freshkill.py
@@ -49,12 +49,12 @@ class Freshkill_Pile():
             self.total_amount = total
         else:
             self.pile = {
-                "expires_in_4": 0,
+                "expires_in_4": GAME_CONFIG["freshkill"]["hunter_exp_bonus"],
                 "expires_in_3": 0,
                 "expires_in_2": 0,
                 "expires_in_1": 0,
             }
-            self.total_amount = 0
+            self.total_amount = GAME_CONFIG["freshkill"]["hunter_exp_bonus"]
         self.nutrition_info = {}
 
     def add_freshkill(self, amount):

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -58,9 +58,10 @@ class Events():
             relevant_cats = [cat for cat in Cat.all_cats.copy().values() if cat.is_alive() and not cat.exiled and not cat.outside]
             game.clan.freshkill_pile.time_skip(relevant_cats)
             # handle freshkill pile events, after feeding
-            # self.freshkill_events.handle_amount_freshkill_pile(game.clan.freshkill_pile, relevant_cats)
-            # if not game.clan.freshkill_pile.clan_has_enough_food():
-            #     game.cur_events_list.insert(0, Single_Event(f"{game.clan.name}Clan has not enough food for the next moon!"))    
+            self.get_moon_freshkill()
+            self.freshkill_events.handle_amount_freshkill_pile(game.clan.freshkill_pile, relevant_cats)
+            if not game.clan.freshkill_pile.clan_has_enough_food():
+                game.cur_events_list.insert(0, Single_Event(f"{game.clan.name}Clan has not enough food for the next moon!"))    
 
         for cat in Cat.all_cats.copy().values():
             if not cat.outside or cat.dead:
@@ -228,6 +229,24 @@ class Events():
                 cat.status_change("mediator")
                 game.ranks_changed_timeskip = True
 
+    def get_moon_freshkill(self):
+        """Adding auto freshkill for the current moon."""
+        healthy_hunter = list(filter(
+            lambda c: c.status in ['warrior', 'apprentice', 'leader', 'deputy'] and not c.dead and not c.outside and not c.exiled and not c.not_working()
+            , Cat.all_cats.values()
+        ))
+
+        prey_amount = 0
+        for cat in healthy_hunter:
+            lower_value = GAME_CONFIG["freshkill"]["auto_warrior_prey"][0]
+            upper_value = GAME_CONFIG["freshkill"]["auto_warrior_prey"][1]
+            if cat.status == "apprentice":
+                lower_value = GAME_CONFIG["freshkill"]["auto_apprentice_prey"][0]
+                upper_value = GAME_CONFIG["freshkill"]["auto_apprentice_prey"][1]
+
+            prey_amount += randint(lower_value, upper_value)
+        print(f"ADDING {prey_amount} to pile. warrior_amount = {len(healthy_hunter)}")
+        game.clan.freshkill_pile.add_freshkill(prey_amount)
 
     def herb_gather(self):
         if game.clan.game_mode == 'classic':
@@ -505,10 +524,10 @@ class Events():
         self.mediator_events(cat)
 
         # handle nutrition amount (CARE: the cats has to be fed before - should be handled in "one_moon" function)
-        #if game.clan.game_mode in ['expanded', 'cruel season'] and game.clan.freshkill_pile:
-        #    self.freshkill_events.handle_nutrient(cat, game.clan.freshkill_pile.nutrition_info)
-        #    if cat.dead:
-        #        return
+        if game.clan.game_mode in ['expanded', 'cruel season'] and game.clan.freshkill_pile:
+            self.freshkill_events.handle_nutrient(cat, game.clan.freshkill_pile.nutrition_info)
+            if cat.dead:
+                return
 
         # prevent injured or sick cats from unrealistic clan events
         if cat.is_ill() or cat.is_injured():
@@ -2119,3 +2138,11 @@ class Events():
 
 
 events_class = Events()
+
+# ---------------------------------------------------------------------------- #
+#                                LOAD RESOURCES                                #
+# ---------------------------------------------------------------------------- #
+
+GAME_CONFIG = None
+with open(f"resources/game_config.json", 'r') as read_file:
+    GAME_CONFIG = ujson.loads(read_file.read())

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -62,6 +62,8 @@ class Events():
             self.freshkill_events.handle_amount_freshkill_pile(game.clan.freshkill_pile, relevant_cats)
             if not game.clan.freshkill_pile.clan_has_enough_food():
                 game.cur_events_list.insert(0, Single_Event(f"{game.clan.name}Clan has not enough food for the next moon!"))    
+            needed_amount = game.clan.freshkill_pile.amount_food_needed()
+            print(f"current freshkill amount: {game.clan.freshkill_pile.total_amount}, needed {needed_amount}")
 
         for cat in Cat.all_cats.copy().values():
             if not cat.outside or cat.dead:
@@ -523,10 +525,10 @@ class Events():
         self.mediator_events(cat)
 
         # handle nutrition amount (CARE: the cats has to be fed before - should be handled in "one_moon" function)
-        if game.clan.game_mode in ['expanded', 'cruel season'] and game.clan.freshkill_pile:
-            self.freshkill_events.handle_nutrient(cat, game.clan.freshkill_pile.nutrition_info)
-            if cat.dead:
-                return
+        #if game.clan.game_mode in ['expanded', 'cruel season'] and game.clan.freshkill_pile:
+        #    self.freshkill_events.handle_nutrient(cat, game.clan.freshkill_pile.nutrition_info)
+        #    if cat.dead:
+        #        return
 
         # prevent injured or sick cats from unrealistic clan events
         if cat.is_ill() or cat.is_injured():

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -245,7 +245,6 @@ class Events():
                 upper_value = GAME_CONFIG["freshkill"]["auto_apprentice_prey"][1]
 
             prey_amount += randint(lower_value, upper_value)
-        print(f"ADDING {prey_amount} to pile. warrior_amount = {len(healthy_hunter)}")
         game.clan.freshkill_pile.add_freshkill(prey_amount)
 
     def herb_gather(self):

--- a/scripts/events_module/freshkill_pile_events.py
+++ b/scripts/events_module/freshkill_pile_events.py
@@ -190,9 +190,7 @@ class Freshkill_Events():
             reduce_amount = int(freshkill_pile.total_amount / 4)
         elif "reduce_eighth" in chosen_event.tags:
             reduce_amount = int(freshkill_pile.total_amount /8)
-        print(f"pile before: {freshkill_pile.total_amount}, reduce: {reduce_amount}")
         freshkill_pile.remove_freshkill(reduce_amount, take_random=True)
-        print(f"pile after: {freshkill_pile.total_amount}, reduce: {reduce_amount}")
 
         types = ["misc"]
         if chosen_event.injury:

--- a/scripts/patrol.py
+++ b/scripts/patrol.py
@@ -898,7 +898,7 @@ class Patrol():
             if len(relevant_patrol_tags) == 0:
                 amount = int(PREY_REQUIREMENT["warrior"] * len(self.patrol_cats) / 2)
                 game.clan.freshkill_pile.add_freshkill(amount)
-                self.results_text.append(f"The patrol still manages some amount of prey.")
+                self.results_text.append(f"The patrol still manages to catch some amount of prey.")
             return
 
         prey_amount_per_cat = 0

--- a/scripts/patrol.py
+++ b/scripts/patrol.py
@@ -484,7 +484,6 @@ class Patrol():
             self.handle_relationships()
             if game.clan.game_mode != 'classic' and not antagonize:
                 self.handle_herbs(n)
-                self.handle_prey(n)
             self.final_success = self.patrol_event.success_text[n]
             if antagonize:
                 self.antagonize = self.patrol_event.antagonize_text
@@ -565,6 +564,10 @@ class Patrol():
             self.final_fail = self.patrol_event.fail_text[n]
             if antagonize:
                 self.antagonize_fail = self.patrol_event.antagonize_fail_text
+
+        if not antagonize:
+            self.handle_prey(n) 
+
 
     def results(self):
         text = "<br>".join(self.results_text)
@@ -889,12 +892,23 @@ class Patrol():
             "huge_prey" : PREY_REQUIREMENT["warrior"]*4
         }
 
+        if not self.success:
+            cancel_tags = ["no_fail_prey", "poison_clan", "death", "multi_deaths", "gone"]
+            relevant_patrol_tags = [tag for tag in patrol.patrol_event.tags if tag in cancel_tags]
+            if len(relevant_patrol_tags) == 0:
+                amount = int(PREY_REQUIREMENT["warrior"] * len(self.patrol_cats) / 2)
+                game.clan.freshkill_pile.add_freshkill(amount)
+                self.results_text.append(f"The patrol still manages some amount of prey.")
+            return
+
         prey_amount_per_cat = 0
         total_amount = 0
 
         # check what kind of prey type this succeeded patrol event has
+        prey_size = None
         for prey_type, amount in prey_types.items():
             current_tag = prey_type + str(outcome_nr)
+            prey_size = prey_type.split('_')[0]
             if current_tag in patrol.patrol_event.tags or prey_type in patrol.patrol_event.tags:
                 prey_amount_per_cat = amount
                 break
@@ -914,8 +928,8 @@ class Patrol():
             total_amount = total_amount * (HUNTER_BONUS["good_hunter"] / 10)
 
         game.clan.freshkill_pile.add_freshkill(total_amount)
-        '''if total_amount > 0:
-            self.results_text.append(f"Patrol managed to catch a total amount of {total_amount} prey.")'''
+        if total_amount > 0:
+            self.results_text.append(f"Each cat catches a {prey_size} amount of prey.")
 
     def handle_clan_relations(self, difference):
         """
@@ -1636,10 +1650,13 @@ class PatrolEvent():
         "no_change_fail_rep" is for when rep should not change when a new_cat patrol fails
 
         - PREY TAGS -
-        If there is no tag, there will be no prey 
+        If there is no tag, there will be no prey if the hunt is successful
         There are 4 tag types "small_prey", "medium_prey", "large_prey" and "huge_prey". 
         If you want to differentiate between the success texts how much prey each success will get, you have to use the tag and then add the index of the sentence you want the prey to
         E.g. 3 successful outcome texts -> "small_prey0", "medium_prey1", "medium_prey2"
+
+        There will be auto prey for failed hunts to stop the auto, following tags do not allow auto prey:
+        > "no_fail_prey", "death", "multi_deaths", "poison_clan", "gone"
 
         We want a mix of medium_prey and large_prey under normal conditions.
 

--- a/scripts/patrol.py
+++ b/scripts/patrol.py
@@ -893,7 +893,7 @@ class Patrol():
         }
 
         if not self.success:
-            cancel_tags = ["no_fail_prey", "poison_clan", "death", "multi_deaths", "gone"]
+            cancel_tags = ["no_fail_prey", "poison_clan", "death", "disaster", "multi_deaths", "no_body", "cruel_season", "gone", "multi_gone", "disaster_gone"]
             relevant_patrol_tags = [tag for tag in patrol.patrol_event.tags if tag in cancel_tags]
             if len(relevant_patrol_tags) == 0:
                 amount = int(PREY_REQUIREMENT["warrior"] * len(self.patrol_cats) / 2)
@@ -1656,7 +1656,9 @@ class PatrolEvent():
         E.g. 3 successful outcome texts -> "small_prey0", "medium_prey1", "medium_prey2"
 
         There will be auto prey for failed hunts to stop the auto, following tags do not allow auto prey:
-        > "no_fail_prey", "death", "multi_deaths", "poison_clan", "gone"
+        > "no_fail_prey"
+        + all disaster tags ("death", "disaster", "multi_deaths", "no_body", "cruel_season", "gone", "multi_gone", "disaster_gone")
+        + "poison_clan"
 
         We want a mix of medium_prey and large_prey under normal conditions.
 

--- a/scripts/patrol.py
+++ b/scripts/patrol.py
@@ -892,7 +892,7 @@ class Patrol():
             "huge_prey" : PREY_REQUIREMENT["warrior"]*4
         }
 
-        if not self.success:
+        if not self.success and "hunting" in patrol.patrol_event.tags:
             cancel_tags = ["no_fail_prey", "poison_clan", "death", "disaster", "multi_deaths", "no_body", "cruel_season", "gone", "multi_gone", "disaster_gone"]
             relevant_patrol_tags = [tag for tag in patrol.patrol_event.tags if tag in cancel_tags]
             if len(relevant_patrol_tags) == 0:

--- a/scripts/screens/cat_screens.py
+++ b/scripts/screens/cat_screens.py
@@ -907,7 +907,7 @@ class ProfileScreen(Screens):
         output += "\n"
 
         # NUTRITION INFO (if the game is in the correct mode)
-        '''if game.clan.game_mode in ["expanded", "cruel season"] and the_cat.is_alive():
+        if game.clan.game_mode in ["expanded", "cruel season"] and the_cat.is_alive():
             nutr = None
             if the_cat.ID in game.clan.freshkill_pile.nutrition_info:
                 nutr = game.clan.freshkill_pile.nutrition_info[the_cat.ID]
@@ -916,7 +916,7 @@ class ProfileScreen(Screens):
                 output += f"nutrition status: {round(nutr.percentage, 1)}%\n"
             else:
                 output += "\n"
-                output += f"nutrition status: 100%\n"'''
+                output += f"nutrition status: 100%\n"
 
         if the_cat.is_disabled():
             for condition in the_cat.permanent_condition:


### PR DESCRIPTION
Some addition to the prey system to lower the difficulty:
* failed hunting patrols still gain some amount of prey (only if it is not mentioned)
* moonly prey additions
* warriors eat 1 prey more if their nutrition is low and there is enough food

currently working system:
* adding/removing prey
* nutritions rise and lower (and is shown in the cat screen)
* some prey events (if too much prey) - needing some rewriting

**!!No cat will die of the low nutrition amount!!**

To consider: some nutritions of cats are very high while others are on 0% (if no one hunts)--> this is because of the current feeding tactic. To choose the tactic, frontend is needed.

**Missing parts to completing the feature:**
* UI + art
* rewriting too much prey events