### PR TITLE
lowered the kit roll number to make more likely to roll kits

### DIFF
--- a/scripts/events_module/relation_events.py
+++ b/scripts/events_module/relation_events.py
@@ -167,8 +167,7 @@ class Relation_Events():
 
         # Roll to see if the cat will have kits.
         living_cats = len(list(filter(lambda r: not r.dead, Cat.all_cats.values())))
-        chance = 120
-
+        chance = 60
         # This is the first chance. Other checks will then be made that can "cancel" this roll.
         if not int(random.random() * chance):
             print(f"primary kit roll triggered for {cat.name}")


### PR DESCRIPTION
As far as I understand it, lowering the number makes it more likely for this event to happen, it worked when I tested it but could be RNG messing with me.