### PR TITLE
Bugfix/Tweaks: Kit Chance, Cheating same-sex pairs

### DIFF
--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -583,7 +583,7 @@ class Cat():
 
             if text:
                 # adjust and append text to grief string list
-                print(text)
+                # print(text)
                 text = ' '.join(text)
                 text = event_text_adjust(Cat, text, self, cat)
                 Cat.grief_strings[cat.ID] = (text, (self.ID, cat.ID))

--- a/scripts/events_module/generate_events.py
+++ b/scripts/events_module/generate_events.py
@@ -138,7 +138,7 @@ class GenerateEvents:
             possible_events.extend(events["general"][body_status])
             possible_events.extend(events[trait][body_status])
 
-        print(possible_events)
+        # print(possible_events)
 
         return possible_events
 

--- a/scripts/events_module/relation_events.py
+++ b/scripts/events_module/relation_events.py
@@ -879,7 +879,7 @@ class Relation_Events():
                             return highest_romantic_relation.cat_to, is_affair
 
         # If the love affair chance did not trigger, this code will be reached.
-        chance_random_affair = 120
+        chance_random_affair = 75
         if not int(random.random() * chance_random_affair):
             possible_affair_partners = list(filter(lambda x: x.is_potential_mate(cat, for_love_interest=True) and
                                                              (samesex or cat.gender != x.gender) and


### PR DESCRIPTION
- Tweaked the base kit chances - it now depends on if the cat has a mate or not.
- Lowered the chance of kit canceling
- Allowed same-sex couples to cheat even if same-sex kittens are off. 
- Lowered affair chances down to more reasonable levels. 