### PR TITLE
Bugfix: Ceremonies, Ext

### DIFF
--- a/resources/dicts/events/ceremonies/ceremony_text.json
+++ b/resources/dicts/events/ceremonies/ceremony_text.json
@@ -207,7 +207,7 @@
             "abandoned": [
                 "m_c is so, so very excited to finally have a mentor, solidifying them as part of the Clan. They're grateful to be here, really... but (mentor) can't replace the parent who gave them to this Clan, the parent who should've been here chanting their name."
             ],
-            "inquisitive": [
+            "adventurous": [
                 "m_c excitedly touches noses with their new mentor, (mentor), looking quite eager to start training.",
                 "m_c can't seem to sit still as they bounce up to touch noses with (mentor), swearing they'll be the best warrior the Clan has ever seen.",
                 "Almost immediately after m_c touches noses with (mentor), they start asking about when they're going to go out and explore the territory.",
@@ -215,14 +215,42 @@
                 "As m_c touches noses with (mentor), they hope that they won't be boring and let them do something cool. Anything but gathering moss or tick duty!",
                 "(prefix)kit sits in front of the Clan with pride, their tiny heart beating so fast they think it might explode! They very excitedly touch noses with (mentor), happy to start their apprenticeship!"
             ],
-            "sweet": [
+            "altruistic": [
                 "Surprising (mentor), the first thing that m_c asks to do once the meeting ends is gather moss so everyone has fresh bedding.",
                 "m_c touches noses with (mentor) and hopes that they'll get to hunt first, so they can make sure the Clan is fed.",
                 "Eager to learn the best ways to help their Clan thrive, m_c excitedly touches noses with (mentor).",
                 "m_c purrs so hard that they're shaking as they touch noses with (mentor).",
                 "m_c silently swears to StarClan to do their best for the Clan as they touch noses with (mentor)."
             ],
-            "attention-seeker":[
+            "compassionate": [
+                "Surprising (mentor), the first thing that m_c asks to do once the meeting ends is gather moss so everyone has fresh bedding.",
+                "m_c touches noses with (mentor) and hopes that they'll get to hunt first, so they can make sure the Clan is fed.",
+                "Eager to learn the best ways to help their Clan thrive, m_c excitedly touches noses with (mentor).",
+                "m_c purrs so hard that they're shaking as they touch noses with (mentor).",
+                "m_c silently swears to StarClan to do their best for the Clan as they touch noses with (mentor)."
+            ],
+            "empathetic":[
+                "Surprising (mentor), the first thing that m_c asks to do once the meeting ends is gather moss so everyone has fresh bedding.",
+                "m_c touches noses with (mentor) and hopes that they'll get to hunt first, so they can make sure the Clan is fed.",
+                "Eager to learn the best ways to help their Clan thrive, m_c excitedly touches noses with (mentor).",
+                "m_c purrs so hard that they're shaking as they touch noses with (mentor).",
+                "m_c silently swears to StarClan to do their best for the Clan as they touch noses with (mentor)."
+            ],
+            "loving":[
+                "Surprising (mentor), the first thing that m_c asks to do once the meeting ends is gather moss so everyone has fresh bedding.",
+                "m_c touches noses with (mentor) and hopes that they'll get to hunt first, so they can make sure the Clan is fed.",
+                "Eager to learn the best ways to help their Clan thrive, m_c excitedly touches noses with (mentor).",
+                "m_c purrs so hard that they're shaking as they touch noses with (mentor).",
+                "m_c silently swears to StarClan to do their best for the Clan as they touch noses with (mentor)."
+            ],
+            "faithful":[
+                "Surprising (mentor), the first thing that m_c asks to do once the meeting ends is gather moss so everyone has fresh bedding.",
+                "m_c touches noses with (mentor) and hopes that they'll get to hunt first, so they can make sure the Clan is fed.",
+                "Eager to learn the best ways to help their Clan thrive, m_c excitedly touches noses with (mentor).",
+                "m_c purrs so hard that they're shaking as they touch noses with (mentor).",
+                "m_c silently swears to StarClan to do their best for the Clan as they touch noses with (mentor)."
+            ],
+            "ambitious":[
                 "m_c excitedly touches noses with their new mentor, (mentor), looking quite eager to start training.",
                 "m_c strides up to their new mentor, looking very proud and excited that they were apprenticed to (mentor).",
                 "Almost immediately after m_c touches noses with (mentor), they start asking about when they're going to go out and explore the territory.",
@@ -233,13 +261,13 @@
                 "m_c touches noses with their mentor, (mentor), looking bored and unimpressed. But on the inside, they're bouncing with euphoria around as if they were still a kit!",
                 "m_c has been pestering everyone for moons on when they finally get to be an apprentice, and everyone is relieved that they're finally free of the young cat's nagging... Until they start asking about when they're going to be a warrior as soon as the meeting ends."
             ],
-            "bossy":[
+            "bloodthirsty":[
                 "m_c excitedly touches noses with their new mentor, (mentor), looking quite eager to start training.",
                 "As m_c touches noses with (mentor), they hope they'll get to do something that will really impress the Clan on their first day. Maybe they could catch a big, fat, rabbit? Or chase off a fox! That'll show the Clan they're the best apprentice anyone's ever seen!",
                 "m_c sits excitedly beside (mentor) as the meeting ends, and hopes they'll be do something exciting, like battle training, first. Their claws are itching to tear at something.",
                 "As m_c touches noses with (mentor), they hope that they won't be boring and let them do something cool. Anything but gathering moss or tick duty!"
             ],
-            "bouncy":[
+            "bold":[
                 "m_c excitedly touches noses with their new mentor, (mentor), looking quite eager to start training.",
                 "In their eagerness, m_c accidentally shoves their nose into (mentor)'s so hard that (mentor) flinches back in surprise. m_c sheepishly apologizes, and the two have a good laugh about it.",
                 "m_c can't seem to sit still as they bounce up to touch noses with (mentor), swearing they'll be the best warrior the Clan has ever seen.",
@@ -265,14 +293,26 @@
                 "(prefix)kit sits in front of the Clan with pride, their tiny heart beating so fast they think it might explode! They very excitedly touch noses with (mentor), happy to start their apprenticeship!",
                 "m_c can't believe their apprenticeship is finally here! Nearly tripping over their own paws, they scurry up to (mentor), excitedly touching noses with them."
             ],
-            "charming":[
+            "calm":[
+                "m_c remains calm as they touch noses with (mentor), but their twitching tail gives away how excited they truly are.",
+                "m_c sits up straighter as they're called forward to be made an apprentice. While they try to look calm and collected, they still tremble a bit as they touch noses with (mentor).",
+                "Eager to learn the best ways to help their Clan thrive, m_c excitedly touches noses with (mentor).",
+                "m_c touches noses with their mentor, (mentor), looking bored and unimpressed. But on the inside, they're bouncing with euphoria around as if they were still a kit!"
+            ],
+            "careful":[
+                "m_c carefully touches noses with their new mentor, (mentor), looking quite intimidated and nervous.",
+                "m_c sits up straighter as they're called forward to be made an apprentice. While they try to look calm and collected, they still tremble a bit as they touch noses with (mentor).",
+                "Surprising (mentor), the first thing that m_c asks to do once the meeting ends is gather moss so everyone has fresh bedding.",
+                "m_c touches noses with their mentor, (mentor), looking bored and unimpressed. But on the inside, they're bouncing with euphoria around as if they were still a kit!"
+            ],
+            "charismatic":[
                 "In their eagerness, m_c accidentally shoves their nose into (mentor)'s so hard that (mentor) flinches back in surprise. m_c sheepishly apologizes, and the two have a good laugh about it.",
                 "Surprising (mentor), the first thing that m_c asks to do once the meeting ends is gather moss so everyone has fresh bedding.",
                 "m_c touches noses with (mentor) and hopes that they'll get to hunt first, so they can make sure the Clan is fed.",
                 "Eager to learn the best ways to help their Clan thrive, m_c excitedly touches noses with (mentor).",
                 "m_c purrs so hard that they're shaking as they touch noses with (mentor)."
             ],
-            "impulsive":[
+            "childish":[
                 "In their eagerness, m_c accidentally shoves their nose into (mentor)'s so hard that (mentor) flinches back in surprise. m_c sheepishly apologizes, and the two have a good laugh about it.",
                 "m_c can't seem to sit still as they bounce up to touch noses with (mentor), swearing they'll be the best warrior the Clan has ever seen.",
                 "m_c fidgets impatiently beside (mentor) as they wait for the meeting to end. They're finally an apprentice! They want to hurry up, get out there, and go, go, go!",
@@ -280,14 +320,14 @@
                 "m_c purrs so hard that they're shaking as they touch noses with (mentor).",
                 "m_c can't believe their apprenticeship is finally here! Nearly tripping over their own paws, they scurry up to (mentor), excitedly touching noses with them."
             ],
-            "quiet":[
+            "cold":[
                 "m_c touches noses with (mentor), wondering if this is truly the right path for them or not.",
                 "m_c remains calm as they touch noses with (mentor), but their twitching tail gives away how excited they truly are.",
                 "m_c sits up straighter as they're called forward to be made an apprentice. While they try to look calm and collected, they still tremble a bit as they touch noses with (mentor).",
                 "As m_c touches noses with (mentor), they hope that they won't be boring and let them do something cool. Anything but gathering moss or tick duty!",
                 "m_c touches noses with their mentor, (mentor), looking bored and unimpressed. But on the inside, they're bouncing with euphoria around as if they were still a kit!"
             ],
-            "noisy":[
+            "confident":[
                 "m_c excitedly touches noses with their new mentor, (mentor), looking quite eager to start training.",
                 "m_c strides up to their new mentor, looking very proud and excited that they were apprenticed to (mentor).",
                 "m_c can't seem to sit still as they bounce up to touch noses with (mentor), swearing they'll be the best warrior the Clan has ever seen.",
@@ -296,11 +336,33 @@
                 "m_c silently swears to StarClan to do their best for the Clan as they touch noses with (mentor).",
                 "As their mentor is about to be chosen, m_c interrupts and announces they want their mentor to be (mentor). They stride forward with confidence to touch noses with (mentor) when it's allowed."
             ],
+            "fierce":[
+                "m_c excitedly touches noses with their new mentor, (mentor), looking quite eager to start training.",
+                "In their eagerness, m_c accidentally shoves their nose into (mentor)'s so hard that (mentor) flinches back in surprise. m_c sheepishly apologizes, and the two have a good laugh about it.",
+                "As m_c touches noses with (mentor), they hope they'll get to do something that will really impress the Clan on their first day. Maybe they could catch a big, fat, rabbit? Or chase off a fox! That'll show the Clan they're the best apprentice anyone's ever seen!",
+                "m_c sits excitedly beside (mentor) as the meeting ends, and hopes they'll be do something exciting, like battle training, first. Their claws are itching to tear at something.",
+                "As m_c touches noses with (mentor), they hope that they won't be boring and let them do something cool. Anything but gathering moss or tick duty!",
+                "m_c silently swears to StarClan to do their best for the Clan as they touch noses with (mentor).",
+                "(prefix)kit sits in front of the Clan with pride, their tiny heart beating so fast they think it might explode! They very excitedly touch noses with (mentor), happy to start their apprenticeship!"
+            ],
             "insecure":[
                 "m_c carefully touches noses with their new mentor, (mentor), looking quite intimidated and nervous.",
                 "(mentor) sees how nervous m_c is and whispers a quiet encouragement to them as they touch noses, promising to be a good mentor to them.",
                 "m_c touches noses with (mentor), wondering if this is truly the right path for them or not.",
                 "Newly apprenticed m_c can't help but squeak when their mentor's name is announced, and they run with their tail tucked between their legs in embarrassment to touch noses with (mentor)."
+            ],
+            "lonesome":[
+                "m_c touches noses with (mentor), wondering if this is truly the right path for them or not.",
+                "As m_c touches noses with (mentor), they hope that they won't be boring and let them do something cool. Anything but gathering moss or tick duty!",
+                "m_c touches noses with their mentor, (mentor), looking bored and unimpressed. But on the inside, they're bouncing with euphoria around as if they were still a kit!"
+            ],
+            "loyal":[
+                "m_c can't seem to sit still as they bounce up to touch noses with (mentor), swearing they'll be the best warrior the Clan has ever seen.",
+                "Surprising (mentor), the first thing that m_c asks to do once the meeting ends is gather moss so everyone has fresh bedding.",
+                "m_c touches noses with (mentor) and hopes that they'll get to hunt first, so they can make sure the Clan is fed.",
+                "Eager to learn the best ways to help their Clan thrive, m_c excitedly touches noses with (mentor).",
+                "As m_c touches noses with (mentor), they hope they'll get to do something that will really impress the Clan on their first day. Maybe they could catch a big, fat, rabbit? Or chase off a fox! That'll show the Clan they're the best apprentice anyone's ever seen!",
+                "m_c silently swears to StarClan to do their best for the Clan as they touch noses with (mentor)."
             ],
             "nervous":[
                 "m_c carefully touches noses with their new mentor, (mentor), looking quite intimidated and nervous.",
@@ -308,17 +370,58 @@
                 "Surprising (mentor), the first thing that m_c asks to do once the meeting ends is gather moss so everyone has fresh bedding.",
                 "Newly apprenticed m_c can't help but squeak when their mentor's name is announced, and they run with their tail tucked between their legs in embarrassment to touch noses with (mentor)."
             ],
-            "polite":[
+            "patient":[
                 "m_c sits up straighter as they're called forward to be made an apprentice. While they try to look calm and collected, they still tremble a bit as they touch noses with (mentor).",
                 "Surprising (mentor), the first thing that m_c asks to do once the meeting ends is gather moss so everyone has fresh bedding.",
                 "m_c touches noses with (mentor) and hopes that they'll get to hunt first, so they can make sure the Clan is fed.",
                 "m_c touches noses with their mentor, (mentor), looking bored and unimpressed. But on the inside, they're bouncing with euphoria around as if they were still a kit!"
             ],
-            "bullying":[
+            "playful":[
+                "In their eagerness, m_c accidentally shoves their nose into (mentor)'s so hard that (mentor) flinches back in surprise. m_c sheepishly apologizes, and the two have a good laugh about it.",
+                "m_c fidgets impatiently beside (mentor) as they wait for the meeting to end. They're finally an apprentice! They want to hurry up, get out there, and go, go, go!",
+                "m_c purrs so hard that they're shaking as they touch noses with (mentor).",
+                "(prefix)kit sits in front of the Clan with pride, their tiny heart beating so fast they think it might explode! They very excitedly touch noses with (mentor), happy to start their apprenticeship!",
+                "m_c can't believe their apprenticeship is finally here! Nearly tripping over their own paws, they scurry up to (mentor), excitedly touching noses with them."
+            ],
+            "responsible":[
+                "Surprising (mentor), the first thing that m_c asks to do once the meeting ends is gather moss so everyone has fresh bedding.",
+                "m_c touches noses with (mentor) and hopes that they'll get to hunt first, so they can make sure the Clan is fed.",
+                "Eager to learn the best ways to help their Clan thrive, m_c excitedly touches noses with (mentor).",
+                "m_c touches noses with their mentor, (mentor), looking bored and unimpressed. But on the inside, they're bouncing with euphoria around as if they were still a kit!"
+            ],
+            "righteous":[
+                "m_c can't seem to sit still as they bounce up to touch noses with (mentor), swearing they'll be the best warrior the Clan has ever seen.",
+                "Surprising (mentor), the first thing that m_c asks to do once the meeting ends is gather moss so everyone has fresh bedding.",
+                "m_c touches noses with (mentor) and hopes that they'll get to hunt first, so they can make sure the Clan is fed.",
+                "Eager to learn the best ways to help their Clan thrive, m_c excitedly touches noses with (mentor).",
+                "As m_c touches noses with (mentor), they hope they'll get to do something that will really impress the Clan on their first day. Maybe they could catch a big, fat, rabbit? Or chase off a fox! That'll show the Clan they're the best apprentice anyone's ever seen!",
+                "m_c silently swears to StarClan to do their best for the Clan as they touch noses with (mentor)."
+            ],
+            "shameless":[
                 "Almost immediately after m_c touches noses with (mentor), they start asking about when they're going to go out and explore the territory.",
                 "m_c fidgets impatiently beside (mentor) as they wait for the meeting to end. They're finally an apprentice! They want to hurry up, get out there, and go, go, go!",
                 "As m_c touches noses with (mentor), they hope that they won't be boring and let them do something cool. Anything but gathering moss or tick duty!",
                 "m_c has been pestering everyone for moons on when they finally get to be an apprentice, and everyone is relieved that they're finally free of the young cat's nagging... Until they start asking about when they're going to be a warrior as soon as the meeting ends."
+            ],
+            "sneaky":[
+                "m_c remains calm as they touch noses with (mentor), but their twitching tail gives away how excited they truly are.",
+                "m_c sits up straighter as they're called forward to be made an apprentice. While they try to look calm and collected, they still tremble a bit as they touch noses with (mentor).",
+                "m_c touches noses with (mentor) and hopes that they'll get to hunt first, so they can make sure the Clan is fed.",
+                "As m_c touches noses with (mentor), they hope that they won't be boring and let them do something cool. Anything but gathering moss or tick duty!",
+                "m_c touches noses with their mentor, (mentor), looking bored and unimpressed. But on the inside, they're bouncing with euphoria around as if they were still a kit!"
+            ],
+            "strange":[
+                "In their eagerness, m_c accidentally shoves their nose into (mentor)'s so hard that (mentor) flinches back in surprise. m_c sheepishly apologizes, and the two have a good laugh about it.",
+                "m_c touches noses with (mentor), wondering if this is truly the right path for them or not.",
+                "m_c fidgets impatiently beside (mentor) as they wait for the meeting to end. They're finally an apprentice! They want to hurry up, get out there, and go, go, go!",
+                "Surprising (mentor), the first thing that m_c asks to do once the meeting ends is gather moss so everyone has fresh bedding."
+            ],
+            "strict":[
+                "m_c remains calm as they touch noses with (mentor), but their twitching tail gives away how excited they truly are.",
+                "m_c sits up straighter as they're called forward to be made an apprentice. While they try to look calm and collected, they still tremble a bit as they touch noses with (mentor).",
+                "Surprising (mentor), the first thing that m_c asks to do once the meeting ends is gather moss so everyone has fresh bedding.",
+                "m_c touches noses with (mentor) and hopes that they'll get to hunt first, so they can make sure the Clan is fed.",
+                "m_c touches noses with their mentor, (mentor), looking bored and unimpressed. But on the inside, they're bouncing with euphoria around as if they were still a kit!"
             ],
             "troublesome":[
                 "In their eagerness, m_c accidentally shoves their nose into (mentor)'s so hard that (mentor) flinches back in surprise. m_c sheepishly apologizes, and the two have a good laugh about it.",
@@ -329,7 +432,13 @@
                 "As m_c touches noses with (mentor), they hope that they won't be boring and let them do something cool. Anything but gathering moss or tick duty!",
                 "m_c has been pestering everyone for moons on when they finally get to be an apprentice, and everyone is relieved that they're finally free of the young cat's nagging... Until they start asking about when they're going to be a warrior as soon as the meeting ends."
             ],
-            "daydreamer":[
+            "vengeful":[
+                "m_c sits up straighter as they're called forward to be made an apprentice. While they try to look calm and collected, they still tremble a bit as they touch noses with (mentor).",
+                "As m_c touches noses with (mentor), they hope they'll get to do something that will really impress the Clan on their first day. Maybe they could catch a big, fat, rabbit? Or chase off a fox! That'll show the Clan they're the best apprentice anyone's ever seen!",
+                "m_c sits excitedly beside (mentor) as the meeting ends, and hopes they'll be do something exciting, like battle training, first. Their claws are itching to tear at something.",
+                "As m_c touches noses with (mentor), they hope that they won't be boring and let them do something cool. Anything but gathering moss or tick duty!"
+            ],
+            "wise":[
                 "m_c remains calm as they touch noses with (mentor), but their twitching tail gives away how excited they truly are.",
                 "m_c sits up straighter as they're called forward to be made an apprentice. While they try to look calm and collected, they still tremble a bit as they touch noses with (mentor).",
                 "Surprising (mentor), the first thing that m_c asks to do once the meeting ends is gather moss so everyone has fresh bedding.",
@@ -337,7 +446,8 @@
                 "Eager to learn the best ways to help their Clan thrive, m_c excitedly touches noses with (mentor).",
                 "m_c silently swears to StarClan to do their best for the Clan as they touch noses with (mentor).",
                 "m_c touches noses with their mentor, (mentor), looking bored and unimpressed. But on the inside, they're bouncing with euphoria around as if they were still a kit!"
-            ]
+            ],
+            "thoughtful" : []
         },
         "no_leader":{
             "general": [
@@ -591,7 +701,8 @@
                 "Eager to learn the best ways to help their Clan thrive, m_c excitedly touches noses with (mentor).",
                 "m_c silently swears to StarClan to do their best for the Clan as they touch noses with (mentor).",
                 "m_c touches noses with their mentor, (mentor), looking bored and unimpressed. But on the inside, they're bouncing with euphoria around as if they were still a kit!"
-            ]
+            ],
+            "thoughtful" : []
         },
         "parent1":{
             "alive":[
@@ -656,22 +767,40 @@
                 "Knowing the Clan is in desperate need of a medicine cat, and wanting to do something to stand out and do something more important, m_c announces mid-meeting that they want to be the new medicine cat apprentice.",
                 "Worried they may not be good as a hunter or fighter, but still wanting to make their Clan proud somehow, m_c decides to become a medicine cat, and is trained by StarClan."
             ],
-            "inquisitive": [],
-            "sweet": [],
-            "attention-seeker":[],
-            "bossy":[],
-            "bouncy":[],
+            "abandoned": [],
+            "adventurous": [],
+            "altruistic": [],
+            "compassionate": [],
+            "empathetic":[],
+            "loving":[],
+            "faithful":[],
+            "ambitious":[],
+            "bloodthirsty":[],
+            "bold":[],
             "daring":[],
-            "charming":[],
-            "impulsive":[],
-            "quiet":[],
-            "noisy":[],
+            "calm":[],
+            "careful":[],
+            "charismatic":[],
+            "childish":[],
+            "cold":[],
+            "confident":[],
+            "fierce":[],
             "insecure":[],
+            "lonesome":[],
+            "loyal":[],
             "nervous":[],
-            "polite":[],
-            "bullying":[],
+            "patient":[],
+            "playful":[],
+            "responsible":[],
+            "righteous":[],
+            "shameless":[],
+            "sneaky":[],
+            "strange":[],
+            "strict":[],
             "troublesome":[],
-            "daydreamer":[]
+            "vengeful":[],
+            "wise":[],
+            "thoughtful" : []
         },
         "no_leader":{
             "general":[
@@ -695,7 +824,41 @@
                 "The thought alone of fighting and hurting another cat makes m_c shiver. Knowing the Clan needs a medicine cat, they seize the chance to do good for the Clan without harming others, they take on the role of medicine cat apprentice.",
                 "Knowing the Clan is in desperate need of a medicine cat, and wanting to do something to stand out and do something more important, m_c announces mid-meeting that they want to be the new medicine cat apprentice.",
                 "Worried they may not be good as a hunter or fighter, but still wanting to make their Clan proud somehow, m_c decides to become a medicine cat, and is trained by StarClan."
-            ]
+            ],
+            "abandoned": [],
+            "adventurous": [],
+            "altruistic": [],
+            "compassionate": [],
+            "empathetic":[],
+            "loving":[],
+            "faithful":[],
+            "ambitious":[],
+            "bloodthirsty":[],
+            "bold":[],
+            "daring":[],
+            "calm":[],
+            "careful":[],
+            "charismatic":[],
+            "childish":[],
+            "cold":[],
+            "confident":[],
+            "fierce":[],
+            "insecure":[],
+            "lonesome":[],
+            "loyal":[],
+            "nervous":[],
+            "patient":[],
+            "playful":[],
+            "responsible":[],
+            "righteous":[],
+            "shameless":[],
+            "sneaky":[],
+            "strange":[],
+            "strict":[],
+            "troublesome":[],
+            "vengeful":[],
+            "wise":[],
+            "thoughtful" : []
         },
         "parent1":{
             "alive":[],

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -876,9 +876,6 @@ class Cat():
         else:
             self.update_skill()
 
-        self.create_interaction()
-        self.thoughts()
-
     def thoughts(self):
         """ Generates a thought for the cat, which displays on their profile. """
         all_cats = self.all_cats

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -521,6 +521,10 @@ class Events():
             self.handle_fading(cat)  # Deal with fading.
             return
 
+        # all actions, which do not trigger an event display and
+        # are connected to cats are located in there
+        cat.one_moon()
+
         #Handle Mediator Events
         self.mediator_events(cat)
 
@@ -554,9 +558,10 @@ class Events():
             self.gain_scars(cat)
         self.relation_events.handle_having_kits(cat, clan=game.clan)
 
-        # all actions, which do not trigger an event display and
-        # are connected to cats are located in there
-        cat.one_moon()
+        cat.create_interaction()
+        cat.thoughts()
+
+
 
     def check_clan_relations(self):
         # ---------------------------------------------------------------------------- #
@@ -682,7 +687,7 @@ class Events():
                 # cat.status_change('elder')
 
             # apprentice a kitten to either med or warrior
-            if cat.moons == cat_class.age_moons[cat.age][1]:
+            if cat.moons == cat_class.age_moons[cat.age][0]:
                 if cat.status == 'kitten':
 
                     med_cat_list = list(filter(lambda x: x.status in ["medicine cat", "medicine cat apprentice"]
@@ -764,9 +769,12 @@ class Events():
         #                      promote cats and add to event list                      #
         # ---------------------------------------------------------------------------- #
         ceremony = []
+        print(f"Promoting {cat.name} to {promoted_to}")
         cat.status_change(promoted_to)
         involved_cats = [cat.ID]  # Clearly, the cat the ceremony is about is involved.
         game.ranks_changed_timeskip = True
+
+
 
         if game.clan.leader:
             leader_dead = game.clan.leader.dead
@@ -834,8 +842,10 @@ class Events():
                 parent_status = "dead"
             elif not parent1.dead and not parent2.dead:
                 parent_status = "alive"
-            
+
+
         ceremony += CEREMONY_TXT[promoted_to][leader_txt][trait]
+        print(CEREMONY_TXT[promoted_to][leader_txt][trait])
         ceremony += CEREMONY_TXT[promoted_to][leader_txt][general_txt]
         if mentor_txt != None:
             ceremony += CEREMONY_TXT[promoted_to][leader_txt][mentor_txt]
@@ -856,10 +866,13 @@ class Events():
         if dead_mentor:
             mentor_name = str(dead_mentor.name)
         else:
-            try:
+            if cat.mentor:
                 mentor_name = str(Cat.fetch_cat(cat.mentor).name)
-            except:
+            elif cat.former_mentor:
                 mentor_name = str(Cat.fetch_cat(cat.former_mentor[-1]).name)
+            else:
+                mentor_name = "mentor_placeholder"
+
         # getting the random honor if it's needed
         random_honor = None
         if promoted_to == 'warrior':
@@ -2044,50 +2057,70 @@ class Events():
                     involved_cats = [random_cat]
                     text = ''
 
-                    if game.clan.deputy and game.clan.leader:
-                        if game.clan.deputy.dead and not (game.clan.leader.dead or game.clan.leader.exiled):
-                            text = f"{game.clan.leader.name} chooses {Cat.all_cats[random_cat].name} to take over " \
-                                   f"as deputy. They know that {game.clan.deputy.name} would approve."
-                            involved_cats.extend([game.clan.leader.ID, game.clan.deputy.ID])
-                        if not game.clan.deputy.dead and not game.clan.deputy.outside:
-                            text = f"{Cat.all_cats[random_cat].name} has been chosen as the new deputy. " \
-                                   f"The retired deputy nods their approval."
-                            # No other cat are involved here.
-                        if game.clan.deputy.outside:
-                            text = f"{Cat.all_cats[random_cat].name} has been chosen as the new deputy. " \
-                                   f"The Clan hopes that {game.clan.deputy.name} would approve."
-                            involved_cats.append(game.clan.deputy.ID)
-                    elif not game.clan.leader or game.clan.leader.dead or game.clan.leader.exiled:
-                        if game.clan.leader:
-                            text = f"Since losing {game.clan.leader.name} the Clan has been directionless. " \
-                                   f"They all turn to {Cat.all_cats[random_cat].name} with hope for the future."
-                            involved_cats.append(game.clan.leader.ID)
+                    # Gather deputy and leader status
+                    if game.clan.leader:
+                        if game.clan.leader.dead or game.clan.leader.outside:
+                            leader_status = "not_here"
                         else:
-                            text = f"Without a leader, the Clan has been directionless. " \
-                                   f"They all turn to {Cat.all_cats[random_cat].name} with hope for the future."
-                            # No additional involved cats.
+                            leader_status = "here"
                     else:
+                        leader_status = "not_here"
+
+                    if game.clan.deputy:
+                        if game.clan.deputy.dead or game.clan.deputy.outside:
+                            deputy_status = "not_here"
+                        else:
+                            deputy_status = "here"
+                    else:
+                        deputy_status = "not_here"
+
+                    if leader_status == "here" and deputy_status == "not_here":
+
                         if Cat.all_cats[random_cat].trait == 'bloodthirsty':
                             text = f"{Cat.all_cats[random_cat].name} has been chosen as the new deputy. " \
                                    f"They look at the Clan leader with an odd glint in their eyes."
                             # No additional involved cats
-
                         else:
-                            possible_events = [
-                                f"{Cat.all_cats[random_cat].name} has been chosen as the new deputy. "
-                                f"The Clan yowls their name in approval.",
-                                f"{Cat.all_cats[random_cat].name} has been chosen as the new deputy. "
-                                f"Some of the older Clan members question the wisdom in this choice.",
-                                f"{Cat.all_cats[random_cat].name} has been chosen as the new deputy. "
-                                f"They hold their head up high and promise to do their best for the Clan.",
-                                f"{game.clan.leader.name} has been thinking deeply all day who they would "
-                                f"respect and trust enough to stand at their side and at sunhigh makes the "
-                                f"announcement that {Cat.all_cats[random_cat].name} will be the Clan's new deputy.",
-                                f"{Cat.all_cats[random_cat].name} has been chosen as the new deputy. They pray to "
-                                f"StarClan that they are the right choice for the Clan.",
-                            ]
-                            # No additional involved cats
-                            text = choice(possible_events)
+                            if game.clan.deputy:
+                                previous_deputy_mention = choice([f"They know that {game.clan.deputy.name} would approve.",
+                                                                  f"They hope that {game.clan.deputy.name} would approve.",
+                                                                  f"They don't know that {game.clan.deputy.name} would approve,"
+                                                                  f"but life must go on. "])
+                                involved_cats.append(game.clan.deputy.ID)
+
+                            else:
+                                previous_deputy_mention = ""
+
+                            text = f"{game.clan.leader.name} chooses {Cat.all_cats[random_cat].name} to take over " \
+                                   f"as deputy. " + previous_deputy_mention
+
+                            involved_cats.append(game.clan.leader.ID)
+                    elif leader_status == "not_here" and deputy_status == "here":
+                        text = f"The clan is without a leader, but a new deputy must still be named.  " \
+                               f"{Cat.all_cats[random_cat].name} is chosen as the new deputy. " \
+                               f"The retired deputy nods their approval."
+                    elif leader_status == "not_here" and deputy_status == "not_here":
+                        text = f"Without a leader or deputy, the Clan has been directionless. " \
+                               f"They all turn to {Cat.all_cats[random_cat].name} with hope for the future."
+                    elif leader_status == "here" and deputy_status == "here":
+                        possible_events = [
+                            f"{Cat.all_cats[random_cat].name} has been chosen as the new deputy. "
+                            f"The Clan yowls their name in approval.",
+                            f"{Cat.all_cats[random_cat].name} has been chosen as the new deputy. "
+                            f"Some of the older Clan members question the wisdom in this choice.",
+                            f"{Cat.all_cats[random_cat].name} has been chosen as the new deputy. "
+                            f"They hold their head up high and promise to do their best for the Clan.",
+                            f"{game.clan.leader.name} has been thinking deeply all day who they would "
+                            f"respect and trust enough to stand at their side and at sunhigh makes the "
+                            f"announcement that {Cat.all_cats[random_cat].name} will be the Clan's new deputy.",
+                            f"{Cat.all_cats[random_cat].name} has been chosen as the new deputy. They pray to "
+                            f"StarClan that they are the right choice for the Clan.",
+                        ]
+                        # No additional involved cats
+                        text = choice(possible_events)
+                    else:
+                        # This should never happen. Failsave.
+                        text = f"{Cat.all_cats[random_cat].name} becomes deputy. "
 
                     game.clan.deputy = Cat.all_cats[random_cat]
                     game.ranks_changed_timeskip = True

--- a/scripts/patrol.py
+++ b/scripts/patrol.py
@@ -609,7 +609,7 @@ class Patrol():
             if antagonize:
                 self.antagonize_fail = self.patrol_event.antagonize_fail_text
 
-        if not antagonize:
+        if not antagonize and game.clan.game_mode != "classic":
             self.handle_prey(outcome)
 
 

--- a/scripts/screens/cat_screens.py
+++ b/scripts/screens/cat_screens.py
@@ -2376,6 +2376,8 @@ class RoleScreen(Screens):
                 game.switches["cat"] = self.previous_cat
                 self.update_selected_cat()
             elif event.ui_element == self.promote_leader:
+                if self.the_cat == game.clan.deputy:
+                    game.clan.deputy = None
                 game.clan.new_leader(self.the_cat)
                 if game.sort_type == "rank":
                     Cat.sort_cats()
@@ -2647,7 +2649,7 @@ class RoleScreen(Screens):
             else:
                 self.promote_leader.disable()
 
-            if deputy_invalid:
+            if deputy_invalid and self.the_cat.age != "elder":
                 self.promote_deputy.enable()
             else:
                 self.promote_deputy.disable()


### PR DESCRIPTION
- Ceremonies are now based on their after-promotion trait, rather than before, 
- Fix mentor name crash. 
- Fix classic patrol crash was associated with freshkill. 
- You can no longer make senior mediators deputy. 