### PR TITLE
Other: Logging

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 import sys
 import os
-import traceback
 directory = os.path.dirname(__file__)
 if directory:
     os.chdir(directory)
@@ -45,7 +44,7 @@ if clan_list:
         load_cats()
         clan_class.load_clan()
     except Exception as e:
-        print("ERROR: \n",traceback.format_exc())
+        logging.exception("File failed to load")
         if not game.switches['error_message']:
             game.switches[
                 'error_message'] = 'There was an error loading the cats file!'

--- a/main.py
+++ b/main.py
@@ -7,8 +7,15 @@ if directory:
 
 # Setup logging
 import logging 
+formatter = logging.Formatter("%(name)s - %(levelname)s - %(message)s")
+# Logging for file
 file_handler = logging.FileHandler("clangen.log")
+file_handler.setFormatter(formatter)
+# Only log errors to file
+file_handler.setLevel(logging.ERROR)
+# Logging for console 
 stream_handler = logging.StreamHandler()
+stream_handler.setFormatter(formatter)
 logging.root.addHandler(file_handler)
 logging.root.addHandler(stream_handler)
 

--- a/main.py
+++ b/main.py
@@ -6,6 +6,20 @@ directory = os.path.dirname(__file__)
 if directory:
     os.chdir(directory)
 
+# Setup logging
+import logging 
+file_handler = logging.FileHandler("clangen.log")
+stream_handler = logging.StreamHandler()
+logging.root.addHandler(file_handler)
+logging.root.addHandler(stream_handler)
+
+def log_crash(type, value, tb):
+    # Log exception on crash
+    logging.critical("Uncaught exception", exc_info=(type, value, tb))
+
+sys.excepthook = log_crash
+
+# Load game
 from scripts.game_structure.load_cat import *
 from scripts.cat.sprites import sprites
 from scripts.clan import clan_class

--- a/scripts/utility.py
+++ b/scripts/utility.py
@@ -4,7 +4,8 @@ try:
     import ujson
 except ImportError:
     import json as ujson
-import traceback
+import logging
+logger = logging.getLogger(__name__)
 from scripts.game_structure import image_cache
 
 from scripts.cat.sprites import *
@@ -646,7 +647,7 @@ def update_sprite(cat):
                     sprites.sprites['collars' + cat.accessory +
                                     str(cat.age_sprites[cat.age])], (0, 0))
     except (TypeError, KeyError):
-        print(f"ERROR: Failed to load cat ID #{cat}'s sprite:\n", traceback.format_exc())
+        logger.exception("Failed to load sprite")
 
         # Placeholder image
         new_sprite.blit(


### PR DESCRIPTION
When the game crashes, the traceback will be logged to `clangen.log` in the same folder as the executable. The traceback will also print in console.

Also logs:
* Save file failing to load
* Cat's sprite failing to load properly

Not sure this way of setting up logging is "best practices" but I think it can be revisited if needed.