### PR TITLE
Tweaks: Mediator Tweaks

### DIFF
--- a/scripts/clan.py
+++ b/scripts/clan.py
@@ -624,7 +624,12 @@ class Clan():
 
         #Mediated flag
         if "mediated" in clan_data:
-            game.mediated = clan_data["mediated"]
+            if type(clan_data["mediated"]) != list:
+                game.mediated = []
+            else:
+                game.mediated = clan_data["mediated"]
+
+            print(game.mediated)
 
 
         self.load_pregnancy(game.clan)

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -39,7 +39,7 @@ class Events():
     def one_moon(self):
         game.cur_events_list = []
         game.herb_events_list = []
-        game.mediated = False
+        game.mediated = []
         game.switches['saved_clan'] = False
         self.new_cat_invited = False
 

--- a/scripts/game_structure/game_essentials.py
+++ b/scripts/game_structure/game_essentials.py
@@ -25,7 +25,7 @@ class Game():
     #relation_scroll_ct = 0
 
     ranks_changed_timeskip = False  # Flag for when a cat's status changes occurs during a timeskip.
-    mediated = False  # Flag for when you have mediated this moon
+    mediated = []  # Keep track of which couples have been mediated this moon.
 
     cur_events_list = []
     ceremony_events_list = []


### PR DESCRIPTION
- The mediate limit has been reworked. Each mediator may mediate once per moon, rather than a global "one mediate per moon" limit. However, a single pair of cats can only be mediated once per moon. 
- Moved mediate errors to text box above mediator. 