### PR TITLE
Bugfixes

### DIFF
--- a/resources/dicts/events/ceremonies/ceremony-master.json
+++ b/resources/dicts/events/ceremonies/ceremony-master.json
@@ -607,7 +607,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "m_c hopes that p1 is watching in pride from StarClan as they are apprenticed to (mentor)."
+    "m_c hopes that dead_par1 is watching in pride from StarClan as they are apprenticed to (mentor)."
   ],
   "app_50": [
     [
@@ -618,7 +618,7 @@
       "clanborn",
       "all_traits"
     ],
-    "m_c wishes that they could be happier about being made an apprentice as they touch noses with (mentor), but all they can think about is how much they wish that p1 was still there to chant their name with the rest of the Clan."
+    "m_c wishes that they could be happier about being made an apprentice as they touch noses with (mentor), but all they can think about is how much they wish that dead_par1 was still there to chant their name with the rest of the Clan."
   ],
   "app_51": [
     [
@@ -629,7 +629,7 @@
       "clanborn",
       "all_traits"
     ],
-    "m_c tries to keep up a brave face as they're apprenticed to (mentor), but they keep stealing glances at the crowd, as if trying to find p1 despite knowing they're no longer with them."
+    "m_c tries to keep up a brave face as they're apprenticed to (mentor), but they keep stealing glances at the crowd, as if trying to find dead_par1 despite knowing they're no longer with them."
   ],
   "app_52": [
     [
@@ -640,7 +640,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "m_c sits beside their new mentor, (mentor) as the meeting comes to a close. Their claws dig into the ground as they glare up at the sky, wondering why p1 couldn't be there with them at such an important moment."
+    "m_c sits beside their new mentor, (mentor) as the meeting comes to a close. Their claws dig into the ground as they glare up at the sky, wondering why dead_par1 couldn't be there with them at such an important moment."
   ],
   "app_53": [
     [
@@ -651,7 +651,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "m_c smiles up at the stars as they sit beside (mentor). The stars seem to shine brighter, and m_c knows it's a sign that p1 is still watching over them."
+    "m_c smiles up at the stars as they sit beside (mentor). The stars seem to shine brighter, and m_c knows it's a sign that dead_par1 is still watching over them."
   ],
   "app_54": [
     [
@@ -662,7 +662,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "As m_c touches noses with their new mentor, (mentor), they make a silent promise to p1 to make them proud, and to take care of the Clan in their parent's absence."
+    "As m_c touches noses with their new mentor, (mentor), they make a silent promise to dead_par1 to make them proud, and to take care of the Clan in their parent's absence."
   ],
   "app_55": [
     [
@@ -684,7 +684,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "m_c hopes that p1 and p2 are watching in pride from StarClan as they are apprenticed to (mentor)."
+    "m_c hopes that dead_par1 and dead_par2 are watching in pride from StarClan as they are apprenticed to (mentor)."
   ],
   "app_57": [
     [
@@ -695,7 +695,7 @@
       "clanborn",
       "all_traits"
     ],
-    "m_c wishes that they could be happier about being made an apprentice as they touch noses with (mentor), but all they can think about is how much they wish that p1 and p2 were still there to chant their name with the rest of the Clan."
+    "m_c wishes that they could be happier about being made an apprentice as they touch noses with (mentor), but all they can think about is how much they wish that dead_par1 and dead_par2 were still there to chant their name with the rest of the Clan."
   ],
   "app_58": [
     [
@@ -706,7 +706,7 @@
       "clanborn",
       "all_traits"
     ],
-    "m_c tries to keep up a brave face as they're apprenticed to (mentor), but they keep stealing glances at the crowd, as if trying to find p1 and p2 despite knowing they're no longer with them."
+    "m_c tries to keep up a brave face as they're apprenticed to (mentor), but they keep stealing glances at the crowd, as if trying to find dead_par1 and dead_par2 despite knowing they're no longer with them."
   ],
   "app_59": [
     [
@@ -717,7 +717,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "m_c sits beside their new mentor, (mentor) as the meeting comes to a close. Their claws dig into the ground as they glare up at the sky, wondering why p1 and p2 couldn't be there with them at such an important moment."
+    "m_c sits beside their new mentor, (mentor) as the meeting comes to a close. Their claws dig into the ground as they glare up at the sky, wondering why dead_par1 and dead_par2 couldn't be there with them at such an important moment."
   ],
   "app_60": [
     [
@@ -728,7 +728,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "m_c smiles up at the stars as they sit beside (mentor). The stars seem to shine brighter, and m_c knows it's a sign that p1 and p2 are still watching over them."
+    "m_c smiles up at the stars as they sit beside (mentor). The stars seem to shine brighter, and m_c knows it's a sign that dead_par1 and dead_par2 are still watching over them."
   ],
   "app_61": [
     [
@@ -739,7 +739,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "As m_c touches noses with their new mentor, (mentor), they make a silent promise to p1 and p2 to make them proud, and to take care of the Clan in their parent's absence."
+    "As m_c touches noses with their new mentor, (mentor), they make a silent promise to dead_par1 and dead_par2 to make them proud, and to take care of the Clan in their parent's absence."
   ],
   "med_app_0": [
     [
@@ -928,7 +928,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "m_c decides to become a medicine cat apprentice in hopes that they will be able to see p1 in StarClan."
+    "m_c decides to become a medicine cat apprentice in hopes that they will be able to see dead_par1 in StarClan."
   ],
   "med_app_17": [
     [
@@ -939,7 +939,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "As the new medicine cat apprentice, m_c dreams of StarClan for the first time. They are greeted by many StarClan cats, one of which they recognize as p1, who is watching in pride as the rest of StarClan's ranks accept the new medicine cat apprentice."
+    "As the new medicine cat apprentice, m_c dreams of StarClan for the first time. They are greeted by many StarClan cats, one of which they recognize as dead_par1, who is watching in pride as the rest of StarClan's ranks accept the new medicine cat apprentice."
   ],
   "med_app_18": [
     [
@@ -950,7 +950,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "m_c decides to become a medicine cat apprentice in hopes that they will be able to see p1 and p2 in StarClan"
+    "m_c decides to become a medicine cat apprentice in hopes that they will be able to see dead_par1 and dead_par2 in StarClan"
   ],
   "med_app_19": [
     [
@@ -961,7 +961,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "As the new medicine cat apprentice, m_c dreams of StarClan for the first time. They are greeted by many StarClan cats, two of which they recognize as p1 and p2, who are watching in pride as the rest of StarClan's ranks accept the new medicine cat apprentice."
+    "As the new medicine cat apprentice, m_c dreams of StarClan for the first time. They are greeted by many StarClan cats, two of which they recognize as dead_par1 and dead_par2, who are watching in pride as the rest of StarClan's ranks accept the new medicine cat apprentice."
   ],
   "mediator_app_0": [
     [
@@ -1500,7 +1500,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "(prefix)paw almost sobs as they spot p1 step out of the crowd towards them to congratulate them on completing their training. p1 rests their muzzle on (prefix)paw's head, naming them m_c, and welcoming them as a full medicine cat."
+    "(prefix)paw almost sobs as they spot dead_par1 step out of the crowd towards them to congratulate them on completing their training. dead_par1 rests their muzzle on (prefix)paw's head, naming them m_c, and welcoming them as a full medicine cat."
   ],
   "med_46": [
     [
@@ -1511,7 +1511,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "As a StarClan cat steps forward to give, (prefix)paw their new name of m_c, they spot p1 watching them proudly from among the StarClan cats."
+    "As a StarClan cat steps forward to give, (prefix)paw their new name of m_c, they spot dead_par1 watching them proudly from among the StarClan cats."
   ],
   "med_47": [
     [
@@ -1522,7 +1522,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "(prefix)paw almost sobs as they spot p1 and p2 step out of the crowd towards them to congratulate them on completing their training. p1 rests their muzzle on (prefix)paw's head, naming them m_c, and welcoming them as a full medicine cat."
+    "(prefix)paw almost sobs as they spot dead_par1 and dead_par2 step out of the crowd towards them to congratulate them on completing their training. dead_par1 rests their muzzle on (prefix)paw's head, naming them m_c, and welcoming them as a full medicine cat."
   ],
   "med_48": [
     [
@@ -1533,7 +1533,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "(prefix)paw almost sobs as they spot p1 and p2 step out of the crowd towards them to congratulate them on completing their training. p2 rests their muzzle on (prefix)paw's head, naming them m_c, and welcoming them as a full medicine cat."
+    "(prefix)paw almost sobs as they spot dead_par1 and dead_par2 step out of the crowd towards them to congratulate them on completing their training. dead_par2 rests their muzzle on (prefix)paw's head, naming them m_c, and welcoming them as a full medicine cat."
   ],
   "med_50": [
     [
@@ -1544,7 +1544,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "As a StarClan cat steps forward to give, (prefix)paw their new name of m_c, they spot p1 and p2 watching them proudly with the other StarClan cats."
+    "As a StarClan cat steps forward to give, (prefix)paw their new name of m_c, they spot dead_par1 and dead_par2 watching them proudly with the other StarClan cats."
   ],
   "warrior_0": [
     [
@@ -2185,7 +2185,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "Are p1 and p2 watching from StarClan? (prefix)paw wonders this as they step in front of the Clan. They hope so. They truly do. As they are given the name m_c in honor of their r_h, m_c hopes that their parents are there, cheering with their Clanmates in the stars for their kit."
+    "Are dead_par1 and dead_par2 watching from StarClan? (prefix)paw wonders this as they step in front of the Clan. They hope so. They truly do. As they are given the name m_c in honor of their r_h, m_c hopes that their parents are there, cheering with their Clanmates in the stars for their kit."
   ],
   "warrior_58": [
     [
@@ -2196,7 +2196,7 @@
       "clanborn",
       "all_traits"
     ],
-    "(prefix)paw tries to keep their head high as they step forward, and are given the name m_c in honor of their r_h. It doesn't seem fair. p1 and p2 should be here with them! They promised they would! m_c looks to the stars, and their anger and frustration vanishes. It feels as though the stars are brighter, and they know that, even if they cannot be there in body, their parents are there in spirit."
+    "(prefix)paw tries to keep their head high as they step forward, and are given the name m_c in honor of their r_h. It doesn't seem fair. dead_par1 and dead_par2 should be here with them! They promised they would! m_c looks to the stars, and their anger and frustration vanishes. It feels as though the stars are brighter, and they know that, even if they cannot be there in body, their parents are there in spirit."
   ],
   "mediator_0": [
     [

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -882,8 +882,13 @@ class Cat():
         other_cat = random.choice(list(all_cats.keys()))
 
         # get other cat
+        i = 0
         while other_cat == self.ID and len(all_cats) > 1:
             other_cat = random.choice(list(all_cats.keys()))
+            i += 1
+            if i > 100:
+                other_cat = None
+                break
         other_cat = all_cats.get(other_cat)
 
         # get possible thoughts

--- a/scripts/cat/thoughts.py
+++ b/scripts/cat/thoughts.py
@@ -80,6 +80,7 @@ def get_alive_thoughts(cat, other_cat):
         first_key = "dead"
     else:
         first_key = "alive"
+
     thoughts += get_family_thoughts(cat, other_cat)
     thoughts += GENERAL_TO_OTHER[first_key]["all"]
 

--- a/scripts/clan.py
+++ b/scripts/clan.py
@@ -629,8 +629,6 @@ class Clan():
             else:
                 game.mediated = clan_data["mediated"]
 
-            print(game.mediated)
-
 
         self.load_pregnancy(game.clan)
         self.load_herbs(game.clan)

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -553,6 +553,8 @@ class Events():
             self.perform_ceremonies(cat)
             self.coming_out(cat)
             self.relation_events.handle_having_kits(cat, clan=game.clan)
+            cat.create_interaction()
+            cat.thoughts()
             return
 
         # check for death/reveal/risks/retire caused by permanent conditions

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -798,6 +798,8 @@ class Events():
         dead_mentor = None
         mentor = None
         previous_alive_mentor = None
+        dead_parents = []
+        living_parents = []
         try:
             # Get all the ceremonies for the role ----------------------------------------
             possible_ceremonies.update(self.ceremony_id_by_tag[promoted_to])
@@ -834,8 +836,6 @@ class Events():
             possible_ceremonies = temp
 
             # Gather for parents ---------------------------------------------------------
-            dead_parents = []
-            living_parents = []
             for p in [cat.parent1, cat.parent2]:
                 if Cat.fetch_cat(p):
                     if Cat.fetch_cat(p).dead:
@@ -844,14 +844,15 @@ class Events():
                         living_parents.append(Cat.fetch_cat(p))
 
             tags = []
-            if len(dead_parents) == 1:
+            if len(dead_parents) >= 1:
                 tags.append("dead1_parents")
-            elif len(dead_parents) == 2:
+            if len(dead_parents) >= 2:
                 tags.append("dead1_parents")
+                tags.append("dead2_parents")
 
-            if len(living_parents) == 1:
+            if len(living_parents) >= 1:
                 tags.append("alive1_parents")
-            elif len(dead_parents) == 2:
+            if len(living_parents) >= 2:
                 tags.append("alive2_parents")
 
             temp = possible_ceremonies.intersection(self.ceremony_id_by_tag["general_parents"])
@@ -916,7 +917,8 @@ class Events():
 
         ceremony_text = ceremony_text_adjust(Cat, ceremony_text, cat, dead_mentor=dead_mentor,
                                              random_honor=random_honor,
-                                             mentor=mentor, previous_alive_mentor=previous_alive_mentor)
+                                             mentor=mentor, previous_alive_mentor=previous_alive_mentor,
+                                             living_parents=living_parents, dead_parents=dead_parents)
         game.cur_events_list.append(Single_Event(f'{ceremony_text}', "ceremony", involved_cats))
         # game.ceremony_events_list.append(f'{str(cat.name)}{ceremony_text}')
     def gain_accessories(self, cat):

--- a/scripts/events_module/relation_events.py
+++ b/scripts/events_module/relation_events.py
@@ -973,4 +973,4 @@ class Relation_Events():
         six_kits = [6] * six_kit_possibility[cat.age]
         amount = choice(one_kit + two_kits + three_kits + four_kits + five_kits + six_kits)
 
-        return amount
+        return 100

--- a/scripts/screens/clan_creation_screens.py
+++ b/scripts/screens/clan_creation_screens.py
@@ -834,7 +834,7 @@ class MakeClanScreen(Screens):
                          game.switches['camp_site'], convert_camp[self.selected_camp_tab],
                          self.game_mode, self.members)
         game.clan.create_clan()
-        game.mediated = False
+        game.mediated.clear()
         game.cur_events_list.clear()
         game.herb_events_list.clear()
         Cat.sort_cats()

--- a/scripts/utility.py
+++ b/scripts/utility.py
@@ -356,7 +356,8 @@ def event_text_adjust(Cat,
     return adjust_text
 
 
-def ceremony_text_adjust(Cat, text, cat, dead_mentor=None, mentor=None, previous_alive_mentor=None, random_honor=None):
+def ceremony_text_adjust(Cat, text, cat, dead_mentor=None, mentor=None, previous_alive_mentor=None, random_honor=None,
+                         living_parents=(), dead_parents=()):
     name = str(cat.name)
     prefix = str(cat.name.prefix)
     clanname = str(game.clan.name + "Clan")
@@ -381,10 +382,15 @@ def ceremony_text_adjust(Cat, text, cat, dead_mentor=None, mentor=None, previous
     else:
         leader_name = "leader_placeholder"
 
-    parent_names = []
-    for c in [cat.parent1, cat.parent2]:
+    living_parent_names = []
+    for c in living_parents:
         if c:
-            parent_names.append(str(Cat.fetch_cat(c).name))
+            living_parent_names.append(str(c.name))
+
+    dead_parent_names = []
+    for c in dead_parents:
+        if c:
+            dead_parent_names.append(str(c.name))
 
     random_honor = random_honor
 
@@ -398,13 +404,23 @@ def ceremony_text_adjust(Cat, text, cat, dead_mentor=None, mentor=None, previous
     adjust_text = adjust_text.replace("(deadmentor)", dead_mentor_name)
     adjust_text = adjust_text.replace("(previous_mentor)", previous_alive_mentor_name)
 
-    if "p1" in adjust_text and "p2" in adjust_text and len(parent_names) >= 2:
-        adjust_text = adjust_text.replace("p1", parent_names[0])
-        adjust_text = adjust_text.replace("p2", parent_names[1])
-    elif "p1" in adjust_text and len(parent_names) >= 1:
-        adjust_text = adjust_text.replace("p1", choice(parent_names))
-    elif "p2" in adjust_text and len(parent_names) >= 1:
-        adjust_text = adjust_text.replace("p2", choice(parent_names))
+    # Living Parents
+    if len(living_parent_names) >= 2:
+        adjust_text = adjust_text.replace("p1", living_parent_names[0])
+        adjust_text = adjust_text.replace("p2", living_parent_names[1])
+    elif "p1" in adjust_text and len(living_parent_names) >= 1:
+        adjust_text = adjust_text.replace("p1", choice(living_parent_names))
+    elif "p2" in adjust_text and len(living_parent_names) >= 1:
+        adjust_text = adjust_text.replace("p2", choice(living_parent_names))
+
+    # Dead Parents
+    if len(dead_parent_names) >= 2:
+        adjust_text = adjust_text.replace("dead_par1", dead_parent_names[0])
+        adjust_text = adjust_text.replace("dead_par2", dead_parent_names[1])
+    elif "dead_par1" in adjust_text and len(dead_parent_names) >= 1:
+        adjust_text = adjust_text.replace("dead_par1", choice(dead_parent_names))
+    elif "dead_par2" in adjust_text and len(dead_parent_names) >= 1:
+        adjust_text = adjust_text.replace("dead_par2", choice(dead_parent_names))
 
     if random_honor:
         adjust_text = adjust_text.replace("r_h", random_honor)


### PR DESCRIPTION
 - Dead parents should no longer show up in ceremonies in the place of alive parents, and visa versa. 
 - Trying to mediate directly after starting a new clan should no longer crash the game. 
 - Added some protection from infinite loop in thoughts generation. 
 - Injured cats will now change their thought and generate interactions. 