### PR TITLE
Bugfix

### DIFF
--- a/resources/dicts/events/ceremonies/ceremony_traits.json
+++ b/resources/dicts/events/ceremonies/ceremony_traits.json
@@ -266,7 +266,7 @@
         "adaptability",
         "pragmatism",
         "realism",
-        "observance",
+        "observance"
     ],
     "patient": [
         "patience",

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -1561,7 +1561,7 @@ class Events():
                                 previous_deputy_mention = choice(
                                     [f"They know that {game.clan.deputy.name} would approve.",
                                      f"They hope that {game.clan.deputy.name} would approve.",
-                                     f"They don't know that {game.clan.deputy.name} would approve,"
+                                     f"They don't know if {game.clan.deputy.name} would approve, "
                                      f"but life must go on. "])
                                 involved_cats.append(game.clan.deputy.ID)
 

--- a/scripts/events_module/generate_events.py
+++ b/scripts/events_module/generate_events.py
@@ -34,6 +34,9 @@ class GenerateEvents:
 
     def generate_events(self, events_dict):
         event_list = []
+        if not events_dict:
+            print("no possible events")
+            return
         for event in events_dict:
             event_text = event["event_text"] if "event_text" in event else None
             if not event_text:
@@ -137,6 +140,9 @@ class GenerateEvents:
 
             # some events are classic only
             if game.clan.game_mode in ["expanded", "cruel season"] and "classic" in event.tags:
+                continue
+
+            if "other_cat" in event.tags and not other_cat:
                 continue
 
             # make complete leader death less likely until the leader is over 150 moons

--- a/scripts/screens/cat_screens.py
+++ b/scripts/screens/cat_screens.py
@@ -158,7 +158,8 @@ def backstory_text(cat):
         'orphaned2': 'orphaned'
     }
 
-    bs_display = backstory_map.get(bs_display)
+    if bs_display in backstory_map:
+        bs_display = backstory_map[bs_display]
 
     if bs_display == "disgraced":
         if cat.status == 'medicine cat':


### PR DESCRIPTION
- warrior ceremonies will no longer crash the game. 
- typos. 
- Bandaid fix to NoneType events crash. 
- Unknown backstory text should not longer crash the game. 
- "Other_cat" events should no longer crash the game if there is only one cat in the clan. 