### PR TITLE
Content: Patrols with relationship constraints 

### DIFF
--- a/scripts/patrol.py
+++ b/scripts/patrol.py
@@ -142,66 +142,9 @@ class Patrol():
         # ---------------------------------------------------------------------------- #
         biome = biome.lower()
         season = current_season.lower()
-        resource_dir = "resources/dicts/patrols/"
         biome_dir = f"{biome}/"
-        h = "hunting/"
-        t = "training/"
-        b = "border/"
-        m = "med/"
         leaf = f"{season}"
-
-        # HUNTING #
-        HUNTING_SZN = None
-        with open(f"{resource_dir}{biome_dir}{h}{leaf}.json", 'r', encoding='ascii') as read_file:
-            HUNTING_SZN = ujson.loads(read_file.read())
-        HUNTING = None
-        with open(f"{resource_dir}{biome_dir}{h}any.json", 'r', encoding='ascii') as read_file:
-            HUNTING = ujson.loads(read_file.read())
-        # BORDER #
-        BORDER_SZN = None
-        with open(f"{resource_dir}{biome_dir}{b}{leaf}.json", 'r', encoding='ascii') as read_file:
-            BORDER_SZN = ujson.loads(read_file.read())
-        BORDER = None
-        with open(f"{resource_dir}{biome_dir}{b}any.json", 'r', encoding='ascii') as read_file:
-            BORDER = ujson.loads(read_file.read())
-        # TRAINING #
-        TRAINING_SZN = None
-        with open(f"{resource_dir}{biome_dir}{t}{leaf}.json", 'r', encoding='ascii') as read_file:
-            TRAINING_SZN = ujson.loads(read_file.read())
-        TRAINING = None
-        with open(f"{resource_dir}{biome_dir}{t}any.json", 'r', encoding='ascii') as read_file:
-            TRAINING = ujson.loads(read_file.read())
-        # MED #
-        MEDCAT_SZN = None
-        with open(f"{resource_dir}{biome_dir}{m}{leaf}.json", 'r', encoding='ascii') as read_file:
-            MEDCAT_SZN = ujson.loads(read_file.read())
-        MEDCAT = None
-        with open(f"{resource_dir}{biome_dir}{m}any.json", 'r', encoding='ascii') as read_file:
-            MEDCAT = ujson.loads(read_file.read())
-        # NEW CAT #
-        NEW_CAT = None
-        with open(f"{resource_dir}new_cat.json", 'r', encoding='ascii') as read_file:
-            NEW_CAT = ujson.loads(read_file.read())
-        NEW_CAT_HOSTILE = None
-        with open(f"{resource_dir}new_cat_hostile.json", 'r', encoding='ascii') as read_file:
-            NEW_CAT_HOSTILE = ujson.loads(read_file.read())
-        NEW_CAT_WELCOMING = None
-        with open(f"{resource_dir}new_cat_welcoming.json", 'r', encoding='ascii') as read_file:
-            NEW_CAT_WELCOMING = ujson.loads(read_file.read())
-        # OTHER CLAN #
-        OTHER_CLAN = None
-        with open(f"{resource_dir}other_clan.json", 'r', encoding='ascii') as read_file:
-            OTHER_CLAN = ujson.loads(read_file.read())
-        OTHER_CLAN_ALLIES = None
-        with open(f"{resource_dir}other_clan_allies.json", 'r', encoding='ascii') as read_file:
-            OTHER_CLAN_ALLIES = ujson.loads(read_file.read())
-        OTHER_CLAN_HOSTILE = None
-        with open(f"{resource_dir}other_clan_hostile.json", 'r', encoding='ascii') as read_file:
-            OTHER_CLAN_HOSTILE = ujson.loads(read_file.read())
-
-        DISASTER = None
-        with open(f"{resource_dir}disaster.json", 'r', encoding='ascii') as read_file:
-            DISASTER = ujson.loads(read_file.read())
+        self.update_resources(biome_dir, leaf)
 
         possible_patrols = []
         final_patrols = []
@@ -251,37 +194,37 @@ class Patrol():
             welcoming_rep = True
             chance = welcoming_chance
 
-        possible_patrols.extend(self.generate_patrol_events(HUNTING))
-        possible_patrols.extend(self.generate_patrol_events(HUNTING_SZN))
-        possible_patrols.extend(self.generate_patrol_events(BORDER))
-        possible_patrols.extend(self.generate_patrol_events(BORDER_SZN))
-        possible_patrols.extend(self.generate_patrol_events(TRAINING))
-        possible_patrols.extend(self.generate_patrol_events(TRAINING_SZN))
-        possible_patrols.extend(self.generate_patrol_events(MEDCAT))
-        possible_patrols.extend(self.generate_patrol_events(MEDCAT_SZN))
+        possible_patrols.extend(self.generate_patrol_events(self.HUNTING))
+        possible_patrols.extend(self.generate_patrol_events(self.HUNTING_SZN))
+        possible_patrols.extend(self.generate_patrol_events(self.BORDER))
+        possible_patrols.extend(self.generate_patrol_events(self.BORDER_SZN))
+        possible_patrols.extend(self.generate_patrol_events(self.TRAINING))
+        possible_patrols.extend(self.generate_patrol_events(self.TRAINING_SZN))
+        possible_patrols.extend(self.generate_patrol_events(self.MEDCAT))
+        possible_patrols.extend(self.generate_patrol_events(self.MEDCAT_SZN))
 
         if game_setting_disaster:
             dis_chance = int(random.getrandbits(3)) # disaster patrol chance
             if dis_chance == 1:
-                possible_patrols.extend(self.generate_patrol_events(DISASTER))
+                possible_patrols.extend(self.generate_patrol_events(self.DISASTER))
 
         # new cat patrols
         if chance == 1:
             if welcoming_rep:
-                possible_patrols.extend(self.generate_patrol_events(NEW_CAT_WELCOMING))
+                possible_patrols.extend(self.generate_patrol_events(self.NEW_CAT_WELCOMING))
             elif neutral_rep:
-                possible_patrols.extend(self.generate_patrol_events(NEW_CAT))
+                possible_patrols.extend(self.generate_patrol_events(self.NEW_CAT))
             elif hostile_rep:
-                possible_patrols.extend(self.generate_patrol_events(NEW_CAT_HOSTILE))
+                possible_patrols.extend(self.generate_patrol_events(self.NEW_CAT_HOSTILE))
 
         # other clan patrols
         if other_clan_chance == 1:
             if clan_neutral:
-                possible_patrols.extend(self.generate_patrol_events(OTHER_CLAN))
+                possible_patrols.extend(self.generate_patrol_events(self.OTHER_CLAN))
             elif clan_allies:
-                possible_patrols.extend(self.generate_patrol_events(OTHER_CLAN_ALLIES))
+                possible_patrols.extend(self.generate_patrol_events(self.OTHER_CLAN_ALLIES))
             elif clan_hostile:
-                possible_patrols.extend(self.generate_patrol_events(OTHER_CLAN_HOSTILE))
+                possible_patrols.extend(self.generate_patrol_events(self.OTHER_CLAN_HOSTILE))
 
         # makes sure that it grabs patrols in the correct biomes, season, with the correct number of cats
         for patrol in possible_patrols:
@@ -1467,6 +1410,59 @@ class Patrol():
 
         return created_cats
 
+    def update_resources(self, biome_dir, leaf):
+        resource_dir = "resources/dicts/patrols/"
+        # HUNTING #
+        self.HUNTING_SZN = None
+        with open(f"{resource_dir}{biome_dir}hunting/{leaf}.json", 'r', encoding='ascii') as read_file:
+            self.HUNTING_SZN = ujson.loads(read_file.read())
+        self.HUNTING = None
+        with open(f"{resource_dir}{biome_dir}hunting/any.json", 'r', encoding='ascii') as read_file:
+            self.HUNTING = ujson.loads(read_file.read())
+        # BORDER #
+        self.BORDER_SZN = None
+        with open(f"{resource_dir}{biome_dir}border/{leaf}.json", 'r', encoding='ascii') as read_file:
+            self.BORDER_SZN = ujson.loads(read_file.read())
+        self.BORDER = None
+        with open(f"{resource_dir}{biome_dir}border/any.json", 'r', encoding='ascii') as read_file:
+            self.BORDER = ujson.loads(read_file.read())
+        # TRAINING #
+        self.TRAINING_SZN = None
+        with open(f"{resource_dir}{biome_dir}training/{leaf}.json", 'r', encoding='ascii') as read_file:
+            self.TRAINING_SZN = ujson.loads(read_file.read())
+        self.TRAINING = None
+        with open(f"{resource_dir}{biome_dir}training/any.json", 'r', encoding='ascii') as read_file:
+            self.TRAINING = ujson.loads(read_file.read())
+        # MED #
+        self.MEDCAT_SZN = None
+        with open(f"{resource_dir}{biome_dir}med/{leaf}.json", 'r', encoding='ascii') as read_file:
+            self.MEDCAT_SZN = ujson.loads(read_file.read())
+        self.MEDCAT = None
+        with open(f"{resource_dir}{biome_dir}med/any.json", 'r', encoding='ascii') as read_file:
+            self.MEDCAT = ujson.loads(read_file.read())
+        # NEW CAT #
+        self.NEW_CAT = None
+        with open(f"{resource_dir}new_cat.json", 'r', encoding='ascii') as read_file:
+            self.NEW_CAT = ujson.loads(read_file.read())
+        self.NEW_CAT_HOSTILE = None
+        with open(f"{resource_dir}new_cat_hostile.json", 'r', encoding='ascii') as read_file:
+            self.NEW_CAT_HOSTILE = ujson.loads(read_file.read())
+        self.NEW_CAT_WELCOMING = None
+        with open(f"{resource_dir}new_cat_welcoming.json", 'r', encoding='ascii') as read_file:
+            self.NEW_CAT_WELCOMING = ujson.loads(read_file.read())
+        # OTHER CLAN #
+        self.OTHER_CLAN = None
+        with open(f"{resource_dir}other_clan.json", 'r', encoding='ascii') as read_file:
+            self.OTHER_CLAN = ujson.loads(read_file.read())
+        self.OTHER_CLAN_ALLIES = None
+        with open(f"{resource_dir}other_clan_allies.json", 'r', encoding='ascii') as read_file:
+            self.OTHER_CLAN_ALLIES = ujson.loads(read_file.read())
+        self.OTHER_CLAN_HOSTILE = None
+        with open(f"{resource_dir}other_clan_hostile.json", 'r', encoding='ascii') as read_file:
+            self.OTHER_CLAN_HOSTILE = ujson.loads(read_file.read())
+        self.DISASTER = None
+        with open(f"{resource_dir}disaster.json", 'r', encoding='ascii') as read_file:
+            self.DISASTER = ujson.loads(read_file.read())
 
 
 # ---------------------------------------------------------------------------- #

--- a/scripts/patrol.py
+++ b/scripts/patrol.py
@@ -50,7 +50,17 @@ class Patrol():
         self.other_clan = None
         self.experience_levels = []
 
-    def add_patrol_cats(self, patrol_cats):
+    def add_patrol_cats(self, patrol_cats: list) -> None:
+        """Add the list of cats to the patrol class and handles to set all needed values.
+
+            Parameters
+            ----------
+            patrol_cats : list
+                list of cats which are on the patrol
+
+            Returns
+            ----------
+        """
         self.patrol_cats.clear()
         self.patrol_names.clear()
         self.possible_patrol_leaders.clear()

--- a/scripts/patrol.py
+++ b/scripts/patrol.py
@@ -476,7 +476,7 @@ class Patrol():
                 fulfilled = True
                 for inter_cat in self.patrol_cats:
                     rel_above_threshold = []
-                    patrol_cats_ids = [cat.id for cat in self.patrol_cats]
+                    patrol_cats_ids = [cat.ID for cat in self.patrol_cats]
                     relevant_relationships = list(
                         filter(lambda rel: rel.cat_to.ID in patrol_cats_ids and rel.cat_to.ID != inter_cat.ID,
                             list(inter_cat.relationships.values())

--- a/scripts/patrol.py
+++ b/scripts/patrol.py
@@ -395,11 +395,9 @@ class Patrol():
             # check if all are siblings
             if "siblings" in patrol.relationship_constraint:
                 test_cat = self.patrol_cats[0]
-                testing_cats = copy.deepcopy(self.patrol_cats)
-                if test_cat in testing_cats:
-                    testing_cats.remove(test_cat)
+                testing_cats = [cat for cat in self.patrol_cats if cat.ID != test_cat.ID]
                 
-                siblings = [test_cat.is_sibling(inter_cat) for inter_cat in testing_cats]
+                siblings = [inter_cat for inter_cat in testing_cats if test_cat.is_sibling(inter_cat)]
                 if len(siblings)+1 != len(self.patrol_cats):
                     continue
 

--- a/scripts/patrol.py
+++ b/scripts/patrol.py
@@ -1558,135 +1558,161 @@ class PatrolEvent():
 
     training patrols - "training",
 
-        border patrols - "border", "other_clan", "reputation",
+    border patrols - "border", "other_clan", "reputation",
 
-            med patrols - "med_cat", "herb", "random_herbs", "many_herbs#"
+    med patrols - "med_cat", "herb", "random_herbs", "many_herbs#"
             
-            new cat tags - ("kittypet" in the patrol ID will make the cat a kittypet no matter what)                                                              
-            "new_cat", "new_cat_med", "new_cat_queen", "new_cat_female", "new_cat_tom", "new_cat_neutered",
-            "new_cat_elder", "new_cat_majorinjury", "new_cat_kit", "new_cat_kits", "new_cat_newborn",
-            "new_cat_apprentice", "new_cat_adult",
+    new cat tags - ("kittypet" in the patrol ID will make the cat a kittypet no matter what)                                                              
+    "new_cat", "new_cat_med", "new_cat_queen", "new_cat_female", "new_cat_tom", "new_cat_neutered",
+    "new_cat_elder", "new_cat_majorinjury", "new_cat_kit", "new_cat_kits", "new_cat_newborn",
+    "new_cat_apprentice", "new_cat_adult",
 
-            un-used for now - "npc", "gone_cat"
+    un-used for now - "npc", "gone_cat"
             
-            death and gone tags -
-            "death", "disaster", "multi_deaths", "no_body", "cruel_season", "gone", "multi_gone", "disaster_gone",
+    death and gone tags -
+    "death", "disaster", "multi_deaths", "no_body", "cruel_season", "gone", "multi_gone", "disaster_gone",
 
-            relationship tags - 
-            "romantic", "platonic", "comfort", "respect", "trust", "dislike", "pos_dislike", "jealous", "pos_jealous", "distrust", "disrespect",
-            "apprentice", "two_apprentices", "three_apprentices", "warrior", "no_app", "med_only", "no_leader",
-            "no_deputy", "leader", "deputy",
+    relationship tags - 
+    "romantic", "platonic", "comfort", "respect", "trust", "dislike", "pos_dislike", "jealous", "pos_jealous", "distrust", "disrespect",
+    "apprentice", "two_apprentices", "three_apprentices", "warrior", "no_app", "med_only", "no_leader",
+    "no_deputy", "leader", "deputy",
 
-            "clan_to_p_l", "clan_to_r_c", "patrol_to_p_l", "patrol_to_r_c",
-            "rel_two_apps", "p_l_to_r_c", "s_c_to_r_c", "clan_to_patrol", "rel_patrol",
-            "sacrificial", "pos_fail", "no_change_fail", "no_change_success", "big_change",
-            "all_lives", "some_lives"
+    "clan_to_p_l", "clan_to_r_c", "patrol_to_p_l", "patrol_to_r_c",
+    "rel_two_apps", "p_l_to_r_c", "s_c_to_r_c", "clan_to_patrol", "rel_patrol",
+    "sacrificial", "pos_fail", "no_change_fail", "no_change_success", "big_change",
+    "all_lives", "some_lives"
+
+    relationship constraint - 
+    "siblings", "mates", "parent_child", "parent_children", "parents_children"
+    "romantic_NUMBER", "platonic_NUMBER", "dislike_NUMBER", "comfortable_NUMBER", "jealousy_NUMBER", "trust_NUMBER"
 
 """
 
-        # ! Patrol Notes
+# ! Patrol Notes
 """
-        -- success/fail outcomes -- 
-        Success[0] is the most common
-        Success[1] is slightly rarer
-        Success[2] is if win skill is applicable
-        Success[3] is if win trait is applicable
+-- success/fail outcomes -- 
+    Success[0] is the most common
+    Success[1] is slightly rarer
+    Success[2] is if win skill is applicable
+    Success[3] is if win trait is applicable
 
-        Fail text[0] is unscathed fail 1
-        Fail text[1] is unscathed 2, fail skill or fail traits
-        Fail text[2] is death
-        Fail text[3] is scar/injury
-        Fail text[4] is death for s_c
-        fail text[5] is scar/injury for s_c
-        fail text[6] is alt leader death
+    Fail text[0] is unscathed fail 1
+    Fail text[1] is unscathed 2, fail skill or fail traits
+    Fail text[2] is death
+    Fail text[3] is scar/injury
+    Fail text[4] is death for s_c
+    fail text[5] is scar/injury for s_c
+    fail text[6] is alt leader death
 
-        History text[0] is scar text
-        History text[1] is death text for normal cats
-        History text[2] is death text for leaders
+    History text[0] is scar text
+    History text[1] is death text for normal cats
+    History text[2] is death text for leaders
         
-        -- PATROL ABBREVIATIONS --
-        Clan name - c_n
-        Other clan name - o_c_n
-        Random cat - r_c
-        Patrol leader - p_l
-        Stat Cat - s_c (this is the cat with relevant skills/traits for the situation)
-        Apprentice 1 - app1
-        Apprentice 2 - app2
-        Apprentice 3 - app3 
-        Apprentice 4 - app4 
-        Apprentice 5 - app5 
-        Apprentice 6 - app6 
-        Random cat 2 - r_c2
-        Random cat 3 - r_c3
-        Random cat 4 - r_c4
-        Random cat 5 - r_c5
+-- PATROL ABBREVIATIONS --
+    Clan name - c_n
+    Other clan name - o_c_n
+    Random cat - r_c
+    Patrol leader - p_l
+    Stat Cat - s_c (this is the cat with relevant skills/traits for the situation)
+    Apprentice 1 - app1
+    Apprentice 2 - app2
+    Apprentice 3 - app3 
+    Apprentice 4 - app4 
+    Apprentice 5 - app5 
+    Apprentice 6 - app6 
+    Random cat 2 - r_c2
+    Random cat 3 - r_c3
+    Random cat 4 - r_c4
+    Random cat 5 - r_c5
 
-        -- PATROL ID GUIDELINES --
+-- PATROL ID GUIDELINES --
+    ID format: biome_type_descriptor 
         
-        ID format: biome_type_descriptor 
+    biomes:
+    Forest - fst
+    Plains - pln
+    Mountainous - mtn
+    Beach - bch
+    Wetlands - wtlnd
+    Desert - dst
+    If no specific biome - gen
+    If it needs multiple biomes, but not all biomes, then create dupe patrols in relevant biomes with appropriate 
+    patrol IDs
         
-        biomes:
-        Forest - fst
-        Plains - pln
-        Mountainous - mtn
-        Beach - bch
-        Wetlands - wtlnd
-        Desert - dst
-        If no specific biome - gen
-        If it needs multiple biomes, but not all biomes, then create dupe patrols in relevant biomes with appropriate 
-        patrol IDs
+    types:
+    Hunting - hunt
+    Border - bord
+    Training - train
+    Med Cat - med
+    If no specific type, pick one bc they gotta be categorized somewhere.  Make dupes in each type if you feel like 
+    they all apply or some apply.
+
+    descriptors:
+    Descriptors should be one word and a number, starting at 1 and incrementing up (i.e. mtn_hunt_mouse1 then 
+    mtn_hunt_mouse2 for another patrol involving a mouse. If you then make a new patrol that is not mouse 
+    related, choose a different descriptor word and start over again at 1) try to keep descriptor words unique from 
+    other descriptors being used to make identification and sorting easier. 
+
+-- RELATIONSHIP CONSTRAINT:
+    This is an optional constraint, if you use this, all cats in the patrol has to have these relation.
+    If there are multiple 'tags', all 'tags' will be be used for the filtering.
+
+    general:
+    "sibling", "mates"
+    "parent_child" -> one parent and one child
+    "parent_children" -> one parent and one/more children
+    "parents_children" -> one/two parent and one/more children
+
+    'thresholds':
+    for a 'threshold' tag, you only have to add the value type and then a number.
+    !ALL! relationship values of each cat to each other has to have these values or higher
+    "romantic_NUMBER",
+    "platonic_NUMBER",
+    "dislike_NUMBER",
+    "comfortable_NUMBER",
+    "jealousy_NUMBER",
+    "trust_NUMBER"
+
+    NUMBER has to be replaced with a number -> e.g. "romantic_10"
+
+
+-- TAG INFO: --
+    You can ONLY have one of these:
+    "death" (r_c dies), "disaster" (all die), "multi_deaths" (2-4 cats die)
+    If you have more than one, it takes the first one in this order.
+    same for: "gone" (r_c leaves the clan), "disaster_gone" (all leave the clan), "multi_gone" (2-4 cats leave the clan)
+
+    #!FOR INJURIES, SEE CONDITIONS LIST FOR TAGGING
+    Tag all injury patrols that should give a scar with "scar" to ensure that classic mode will still scar the cat.
+    If you'd like a patrol to have an injury from one of the injury pools, tag with the pool name
+    -- Possible Pools --
+        "battle_injury": ["claw-wound", "bite-wound", "mangled leg", "mangled tail", "torn pelt"],
+        "minor_injury": ["sprain", "sore", "bruises", "scrapes"],
+        "blunt_force_injury": ["broken bone", "paralyzed", "head damage", "broken jaw"],
+        "hot_injury": ["heat exhaustion", "heat stroke", "dehydrated"],
+        "cold_injury": ["shivering", "frostbite"],
+        "big_bite_injury": ["bite-wound", "broken bone", "torn pelt", "mangled leg", "mangled tail"],
+        "small_bite_injury": ["bite-wound", "torn ear", "torn pelt", "scrapes"]
+        "beak_bite": ["beak bite", "torn ear", "scrapes"]
+    If you want to specify a certain condition, tag both with "injury" and the condition
+    If you want to injure all the cats in the patrol, tag with "injure_all"
+    This will work with any condition whether they are an illness, injury, or perm condition
+    If you want to ensure that a cat cannot die from the condition, tag with "non_lethal"
+    Keep in mind that minor injuries are already non lethal by default and permanent conditions will not be affected by this tag.
+    These tags will stack! So you could tag a patrol as "blunt_force_injury", "injury", "water in their lungs" to give all the 
+    conditions from blunt_force_injury AND water in their lungs as possible conditions for that patrol. 
+    Keep in mind that the "non_lethal" tag will apply to ALL the conditions for that patrol.
+    Right now, nonlethal shock is auto applied to all cats present when another cat dies. This may change in the future.
         
-        types:
-        Hunting - hunt
-        Border - bord
-        Training - train
-        Med Cat - med
-        If no specific type, pick one bc they gotta be categorized somewhere.  Make dupes in each type if you feel like 
-        they all apply or some apply.
 
-        descriptors:
-        Descriptors should be one word and a number, starting at 1 and incrementing up (i.e. mtn_hunt_mouse1 then 
-        mtn_hunt_mouse2 for another patrol involving a mouse. If you then make a new patrol that is not mouse 
-        related, choose a different descriptor word and start over again at 1) try to keep descriptor words unique from 
-        other descriptors being used to make identification and sorting easier. 
-
-        TAG INFO:
-        You can ONLY have one of these:
-        "death" (r_c dies), "disaster" (all die), "multi_deaths" (2-4 cats die)
-        If you have more than one, it takes the first one in this order.
-        same for: "gone" (r_c leaves the clan), "disaster_gone" (all leave the clan), "multi_gone" (2-4 cats leave the clan)
-
-        #!FOR INJURIES, SEE CONDITIONS LIST FOR TAGGING
-        Tag all injury patrols that should give a scar with "scar" to ensure that classic mode will still scar the cat.
-        If you'd like a patrol to have an injury from one of the injury pools, tag with the pool name
-        -- Possible Pools --
-            "battle_injury": ["claw-wound", "bite-wound", "mangled leg", "mangled tail", "torn pelt"],
-            "minor_injury": ["sprain", "sore", "bruises", "scrapes"],
-            "blunt_force_injury": ["broken bone", "paralyzed", "head damage", "broken jaw"],
-            "hot_injury": ["heat exhaustion", "heat stroke", "dehydrated"],
-            "cold_injury": ["shivering", "frostbite"],
-            "big_bite_injury": ["bite-wound", "broken bone", "torn pelt", "mangled leg", "mangled tail"],
-            "small_bite_injury": ["bite-wound", "torn ear", "torn pelt", "scrapes"]
-            "beak_bite": ["beak bite", "torn ear", "scrapes"]
-        If you want to specify a certain condition, tag both with "injury" and the condition
-        If you want to injure all the cats in the patrol, tag with "injure_all"
-        This will work with any condition whether they are an illness, injury, or perm condition
-        If you want to ensure that a cat cannot die from the condition, tag with "non_lethal"
-        Keep in mind that minor injuries are already non lethal by default and permanent conditions will not be affected by this tag.
-        These tags will stack! So you could tag a patrol as "blunt_force_injury", "injury", "water in their lungs" to give all the 
-        conditions from blunt_force_injury AND water in their lungs as possible conditions for that patrol. 
-        Keep in mind that the "non_lethal" tag will apply to ALL the conditions for that patrol.
-        Right now, nonlethal shock is auto applied to all cats present when another cat dies. This may change in the future.
-        
-
-        HERB TAGGING:
+    - HERB TAGGING: -
         herbs are given on successes only
         "random_herbs" <give a random assortment of herbs
         
         "herbs" < use to mark that this patrol gives a specific herb, use in conjunction with a herb tag. 
         
         Herb tags:
-         reference herbs.json, you can use any herb name listed there
+        reference herbs.json, you can use any herb name listed there
         
         "many_herbs#" < to cause the patrol to give a large number of herbs automatically. Numbering starts at 0. 
         Replace the # with the outcome number (i.e. if you want success[2] - which is the skill success - to give lots of herbs, then 
@@ -1696,7 +1722,7 @@ class PatrolEvent():
         outcomes. Numbering starts at 0. Replace the # with the outcome number (i.e. if you want success[2] - which is the skill 
         success - to give no herbs, then use "no_herbs2")
 
-        - TO SPECIFY -
+    - TO SPECIFY -
         "one_apprentice" is for patrols with one apprentice in them. It works with the "apprentice" tag. 
         "two_apprentices" is for patrols with two apprentices in them. It works with the "apprentice" tag. 
         "three_apprentices" is for patrols with two apprentices in them. It works with the "apprentice" tag. 
@@ -1710,7 +1736,7 @@ class PatrolEvent():
         "warrior" is used to specify that the patrol should only trigger with at least 1 warrior in it. 
         "no_app" is for when no apps should be on the patrol
 
-        - RELATIONSHIP TAGS -
+    - RELATIONSHIP TAGS -
         I think all of these can be used together. the tag for which relationships are increased should ALSO be used
         # whole clan gains relationship towards p_l - "clan_to_p_l"
         # whole clan gains relationship towards s_c - "clan_to_r_c" (triggers to be s_c if s_c is present)
@@ -1753,7 +1779,7 @@ class PatrolEvent():
 
         "no_change_fail_rep" is for when rep should not change when a new_cat patrol fails
 
-        - PREY TAGS -
+    - PREY TAGS -
         If there is no tag, there will be no prey if the hunt is successful
         There are 4 tag types "small_prey", "medium_prey", "large_prey" and "huge_prey". 
         If you want to differentiate between the success texts how much prey each success will get, you have to use the tag and then add the index of the sentence you want the prey to
@@ -1767,7 +1793,7 @@ class PatrolEvent():
         We want a mix of medium_prey and large_prey under normal conditions.
 
 
-        -- WHEN WRIING --   
+-- WHEN WRIING --   
         Event text should be kept to 350 characters at the maximum to keep it easily readable and concise.
         History text needs to be written in past tense.
         o_c_n and c_n should use "a" not "an" in front of them

--- a/scripts/patrol.py
+++ b/scripts/patrol.py
@@ -9,6 +9,7 @@ from scripts.cat.names import *
 from scripts.cat.cats import *
 from scripts.cat.pelts import *
 from scripts.clan_resources.freshkill import PREY_REQUIREMENT, HUNTER_EXP_BONUS, HUNTER_BONUS
+from scripts.clan import Clan
 
 # ---------------------------------------------------------------------------- #
 #                              PATROL CLASS START                              #
@@ -50,13 +51,16 @@ class Patrol():
         self.other_clan = None
         self.experience_levels = []
 
-    def add_patrol_cats(self, patrol_cats: list) -> None:
+    def add_patrol_cats(self, patrol_cats: list, clan: Clan) -> None:
         """Add the list of cats to the patrol class and handles to set all needed values.
 
             Parameters
             ----------
             patrol_cats : list
                 list of cats which are on the patrol
+            
+            clan: Clan
+                the clan class of the game, this parameter is needed to make tests possible
 
             Returns
             ----------
@@ -89,8 +93,8 @@ class Patrol():
             med_index = self.patrol_statuses.index("medicine cat")
             self.patrol_leader = self.patrol_cats[med_index]
         # sets leader as patrol leader
-        elif game.clan.leader in self.patrol_cats:
-            self.patrol_leader = game.clan.leader
+        elif clan.leader and clan.leader in self.patrol_cats:
+            self.patrol_leader = clan.leader
         else:
             if self.possible_patrol_leaders:
                 self.patrol_leader = choice(self.possible_patrol_leaders)
@@ -143,7 +147,10 @@ class Patrol():
                 self.app5_name = str(self.patrol_apprentices[4].name)
                 self.app6_name = str(self.patrol_apprentices[5].name)
 
-        self.other_clan = choice(game.clan.all_clans)
+        if clan.all_clans and len(clan.all_clans) > 0:
+            self.other_clan = choice(clan.all_clans)
+        else: 
+            self.other_clan = None
 
     def get_possible_patrols(self, current_season, biome, all_clans, patrol_type,
                              game_setting_disaster=game.settings['disasters']):
@@ -388,10 +395,11 @@ class Patrol():
             # check if all are siblings
             if "siblings" in patrol.relationship_constraint:
                 test_cat = self.patrol_cats[0]
-                testing_cats = copy(self.patrol_cats)
-                testing_cats.remove(test_cat)
+                testing_cats = copy.deepcopy(self.patrol_cats)
+                if test_cat in testing_cats:
+                    testing_cats.remove(test_cat)
                 
-                siblings = [test_cat.is_silbing(inter_cat) for inter_cat in testing_cats]
+                siblings = [test_cat.is_sibling(inter_cat) for inter_cat in testing_cats]
                 if len(siblings)+1 != len(self.patrol_cats):
                     continue
 

--- a/scripts/patrol.py
+++ b/scripts/patrol.py
@@ -374,7 +374,54 @@ class Patrol():
                 filtered_patrols.append(patrol)
                 continue
             
-            # filtering
+            # filtering - relationship status
+            # check if all are siblings
+            if "siblings" in patrol.relationship_constraint:
+                test_cat = self.patrol_cats[0]
+                testing_cats = copy(self.patrol_cats)
+                testing_cats.remove(test_cat)
+                
+                siblings_amount = [test_cat.is_silbing(inter_cat) for inter_cat in testing_cats]
+                if len(siblings_amount)+1 != len(self.patrol_cats):
+                    continue
+
+            # check if the cats are mates
+            if "mate" in patrol.relationship_constraint:
+                # it should be exactly two cats for a "mate" patrol
+                if len(self.patrol_cats) != 2:
+                    continue
+                else:
+                    cat1 = self.patrol_cats[0]
+                    cat2 = self.patrol_cats[1]
+                    # if one of the cat has no mate, not add this patrol
+                    if not cat1.mate or not cat2.mate:
+                        continue
+                    elif cat1.mate != cat2.ID or cat2.mate != cat1.ID:
+                        continue
+            
+            # check if the cats are in a parent/child relationship
+            if "parent/child" in patrol.relationship_constraint:
+                # it should be exactly two cats for a "parent/child" patrol
+                if len(self.patrol_cats) != 2:
+                    continue
+                # when there are two cats in the patrol, p_l and r_c are different cats per default
+                if not self.patrol_leader.is_parent(self.patrol_random_cat):
+                    continue
+
+            # check if the cats are in a child/parent relationship
+            if "child/parent" in patrol.relationship_constraint:
+                # it should be exactly two cats for a "child/parent" patrol
+                if len(self.patrol_cats) != 2:
+                    continue
+                # when there are two cats in the patrol, p_l and r_c are different cats per default
+                if not self.patrol_random_cat.is_parent(self.patrol_leader):
+                    continue
+
+
+            # filtering - relationship values
+            value_types = [""]
+
+            filtered_patrols.append(patrol)
 
         return filtered_patrols
 
@@ -1583,7 +1630,7 @@ class PatrolEvent():
     "all_lives", "some_lives"
 
     relationship constraint - 
-    "siblings", "mates", "parent_child", "parent_children", "parents_children"
+    "siblings", "mates", "parent/child", "child/parent",
     "romantic_NUMBER", "platonic_NUMBER", "dislike_NUMBER", "comfortable_NUMBER", "jealousy_NUMBER", "trust_NUMBER"
 
 """
@@ -1659,9 +1706,8 @@ class PatrolEvent():
 
     general:
     "sibling", "mates"
-    "parent_child" -> one parent and one child
-    "parent_children" -> one parent and one/more children
-    "parents_children" -> one/two parent and one/more children
+    "parent/child" -> patrol leader is parent, random cat is child
+    "child/parent" -> patrol leader is child, random cat is parent
 
     'thresholds':
     for a 'threshold' tag, you only have to add the value type and then a number.

--- a/scripts/patrol.py
+++ b/scripts/patrol.py
@@ -402,7 +402,7 @@ class Patrol():
                     continue
 
             # check if the cats are mates
-            if "mate" in patrol.relationship_constraint:
+            if "mates" in patrol.relationship_constraint:
                 # it should be exactly two cats for a "mate" patrol
                 if len(self.patrol_cats) != 2:
                     continue
@@ -1652,8 +1652,8 @@ class PatrolEvent():
                  decline_text="",
                  chance_of_success=0,
                  exp=0,
-                 success_text=[],
-                 fail_text=[],
+                 success_text=None,
+                 fail_text=None,
                  win_skills=None,
                  win_trait=None,
                  fail_skills=None,
@@ -1662,15 +1662,13 @@ class PatrolEvent():
                  max_cats=6,
                  antagonize_text="",
                  antagonize_fail_text="",
-                 history_text=[],
-                 relationship_constraint=[]):
+                 history_text=None,
+                 relationship_constraint=None):
         self.patrol_id = patrol_id
         self.biome = biome or "Any"
         self.season = season or "Any"
         self.tags = tags
         self.intro_text = intro_text
-        self.success_text = success_text
-        self.fail_text = fail_text
         self.decline_text = decline_text
         self.chance_of_success = chance_of_success  # out of 100
         self.exp = exp
@@ -1682,9 +1680,29 @@ class PatrolEvent():
         self.max_cats = max_cats
         self.antagonize_text = antagonize_text
         self.antagonize_fail_text = antagonize_fail_text
-        self.history_text = history_text
-        self.relationship_constraint = relationship_constraint
 
+        # if someone needs a empty list, don't make it as a default parameter
+        # otherwise all instances of this class will use the same list
+
+        if success_text:
+            self.success_text = success_text
+        else:
+            self.success_text = []
+
+        if fail_text:
+            self.fail_text = fail_text
+        else: 
+            self.fail_text = []
+
+        if history_text:
+            self.history_text = history_text
+        else:
+            history_text = []
+
+        if relationship_constraint:
+            self.relationship_constraint = relationship_constraint
+        else:
+            self.relationship_constraint = []
 
 # ---------------------------------------------------------------------------- #
 #                              GENERAL INFORMATION                             #

--- a/scripts/screens/patrol_screens.py
+++ b/scripts/screens/patrol_screens.py
@@ -552,7 +552,7 @@ class PatrolScreen(Screens):
                                                                    ), manager=MANAGER)
 
         # Add selected cats to the patrol.
-        patrol.add_patrol_cats(self.current_patrol)
+        patrol.add_patrol_cats(self.current_patrol, game.clan)
         possible_events = patrol.get_possible_patrols(
             str(game.clan.current_season).casefold(),
             str(game.clan.biome).casefold(),

--- a/tests/test_filter_patrol.py
+++ b/tests/test_filter_patrol.py
@@ -28,15 +28,48 @@ class TestRelationshipConstraintPatrols(unittest.TestCase):
 
         test_clan = Clan(name="test")
 
-        patrol_all_events = Patrol()
-        patrol_all_events.add_patrol_cats([cat1, cat2], test_clan)
+        # then
+        patrol = Patrol()
+        cat_list = [cat1, cat2]
+        patrol.add_patrol_cats(cat_list, test_clan)
+        filtered = patrol.filter_relationship(possible_patrols)
+        self.assertEqual(len(filtered), len(possible_patrols))
 
-        patrol_not_all_events = Patrol()
-        patrol_not_all_events.add_patrol_cats([cat1, cat2, parent], test_clan)
+        patrol = Patrol()
+        cat_list = [cat1, cat2, parent]
+        patrol.add_patrol_cats(cat_list, test_clan)
+        filtered = patrol.filter_relationship(possible_patrols)
+        self.assertNotEqual(len(filtered), len(possible_patrols))
 
-        all_filtered = patrol_all_events.filter_relationship(possible_patrols)
-        not_all_filtered = patrol_not_all_events.filter_relationship(possible_patrols)
+    def test_mates_patrol(self):
+        # given
+        mate1 = Cat()
+        mate2 = Cat()
+        cat1 = Cat()
+
+        mate1.mate = mate2.ID
+        mate2.mate =mate1.ID
+
+        # when
+        con_patrol_event = PatrolEvent(patrol_id="test1")
+        con_patrol_event.relationship_constraint.append("mates")
+        no_con_patrol_event = PatrolEvent(patrol_id="test2")
+        possible_patrols = [con_patrol_event, no_con_patrol_event]
+
+        test_clan = Clan(name="test")
 
         # then
+        patrol_all_events = Patrol()
+        patrol_all_events.add_patrol_cats([mate1, mate2], test_clan)
+        all_filtered = patrol_all_events.filter_relationship(possible_patrols)
         self.assertEqual(len(all_filtered), len(possible_patrols))
+
+        patrol_not_all_events = Patrol()
+        patrol_not_all_events.add_patrol_cats([mate1, cat1], test_clan)
+        not_all_filtered = patrol_not_all_events.filter_relationship(possible_patrols)
         self.assertNotEqual(len(not_all_filtered), len(possible_patrols))
+
+        patrol_not_all_events2 = Patrol()
+        patrol_not_all_events2.add_patrol_cats([mate1, mate2, cat1], test_clan)
+        not_all_filtered2 = patrol_not_all_events2.filter_relationship(possible_patrols)
+        self.assertNotEqual(len(not_all_filtered2), len(possible_patrols))

--- a/tests/test_filter_patrol.py
+++ b/tests/test_filter_patrol.py
@@ -468,3 +468,49 @@ class TestRelationshipConstraintPatrols(unittest.TestCase):
         patrol.add_patrol_cats([cat1, cat2, cat3], test_clan)
         filtered = patrol.filter_relationship(possible_patrols)
         self.assertNotEqual(len(filtered), len(possible_patrols))
+
+    def test_multiple_constraint_patrol(self):
+        # given
+        cat1 = Cat()
+        cat2 = Cat()
+
+        relationship1 = Relationship(cat1,cat2)
+        relationship2 = Relationship(cat2,cat1)
+
+        relationship1.romantic_love = 20
+        relationship2.romantic_love = 20
+        relationship1.platonic_like = 20
+        relationship2.platonic_like = 20
+
+        relationship1.opposite_relationship = relationship2
+        relationship2.opposite_relationship = relationship1
+        cat1.relationships[cat2.ID] = relationship1
+        cat2.relationships[cat1.ID] = relationship2
+
+        test_clan = Clan(name="test")
+
+        # when - correct
+        con_patrol_event = PatrolEvent(patrol_id="test1")
+        con_patrol_event.relationship_constraint.append("romantic_10")
+        con_patrol_event2 = PatrolEvent(patrol_id="test2")
+        con_patrol_event2.relationship_constraint.append("platonic_10")
+        possible_patrols = [con_patrol_event, con_patrol_event2]
+
+        # then
+        patrol = Patrol()
+        patrol.add_patrol_cats([cat1, cat2], test_clan)
+        filtered = patrol.filter_relationship(possible_patrols)
+        self.assertEqual(len(filtered), len(possible_patrols))
+
+        # when - to high
+        con_patrol_event = PatrolEvent(patrol_id="test1")
+        con_patrol_event.relationship_constraint.append("romantic_10")
+        con_patrol_event2 = PatrolEvent(patrol_id="test2")
+        con_patrol_event2.relationship_constraint.append("platonic_30")
+        possible_patrols = [con_patrol_event, con_patrol_event2]
+
+        # then
+        patrol = Patrol()
+        patrol.add_patrol_cats([cat1, cat2], test_clan)
+        filtered = patrol.filter_relationship(possible_patrols)
+        self.assertNotEqual(len(filtered), len(possible_patrols))

--- a/tests/test_filter_patrol.py
+++ b/tests/test_filter_patrol.py
@@ -1,0 +1,39 @@
+import unittest
+
+try:
+    import ujson
+except ImportError:
+    import json as ujson
+
+from scripts.cat.cats import Cat
+from scripts.cat_relations.relationship import Relationship
+from scripts.patrol import PatrolEvent, Patrol
+
+class TestRelationshipConstraintPatrols(unittest.TestCase):
+
+    def test_sibling_patrol(self):
+        # given
+        parent = Cat()
+        cat1 = Cat(parent1=parent.ID)
+        cat2 = Cat(parent1=parent.ID)
+        cat1.siblings = [cat2.ID]
+        cat2.siblings = [cat1.ID]
+
+        # when
+        con_patrol_event = PatrolEvent(patrol_id="test1")
+        con_patrol_event.relationship_constraint.append("siblings")
+        no_con_patrol_event = PatrolEvent(patrol_id="test2")
+        possible_patrols = [con_patrol_event, no_con_patrol_event]
+
+        patrol_all_events = Patrol()
+        patrol_all_events.add_patrol_cats([cat1, cat2])
+
+        patrol_not_all_events = Patrol()
+        patrol_not_all_events.add_patrol_cats([cat1,cat2,parent])
+
+        all_filtered = patrol_all_events.filter_relationship(possible_patrols)
+        not_all_filtered = patrol_not_all_events.filter_relationship(possible_patrols)
+
+        # then
+        self.assertEqual(len(all_filtered), len(possible_patrols))
+        self.assertNotEqual(len(not_all_filtered), len(possible_patrols))

--- a/tests/test_filter_patrol.py
+++ b/tests/test_filter_patrol.py
@@ -30,14 +30,12 @@ class TestRelationshipConstraintPatrols(unittest.TestCase):
 
         # then
         patrol = Patrol()
-        cat_list = [cat1, cat2]
-        patrol.add_patrol_cats(cat_list, test_clan)
+        patrol.add_patrol_cats([cat1, cat2], test_clan)
         filtered = patrol.filter_relationship(possible_patrols)
         self.assertEqual(len(filtered), len(possible_patrols))
 
         patrol = Patrol()
-        cat_list = [cat1, cat2, parent]
-        patrol.add_patrol_cats(cat_list, test_clan)
+        patrol.add_patrol_cats([cat1, cat2, parent], test_clan)
         filtered = patrol.filter_relationship(possible_patrols)
         self.assertNotEqual(len(filtered), len(possible_patrols))
 
@@ -73,3 +71,400 @@ class TestRelationshipConstraintPatrols(unittest.TestCase):
         patrol_not_all_events2.add_patrol_cats([mate1, mate2, cat1], test_clan)
         not_all_filtered2 = patrol_not_all_events2.filter_relationship(possible_patrols)
         self.assertNotEqual(len(not_all_filtered2), len(possible_patrols))
+
+    def test_parent_child_patrol(self):
+        # given
+        parent = Cat()
+        cat1 = Cat(parent1=parent.ID)
+        cat2 = Cat(parent1=parent.ID)
+        cat1.siblings = [cat2.ID]
+        cat2.siblings = [cat1.ID]
+
+        # when
+        con_patrol_event = PatrolEvent(patrol_id="test1")
+        con_patrol_event.relationship_constraint.append("parent/child")
+        no_con_patrol_event = PatrolEvent(patrol_id="test2")
+        possible_patrols = [con_patrol_event, no_con_patrol_event]
+
+        test_clan = Clan(name="test")
+
+        # then
+        patrol = Patrol()
+        patrol.add_patrol_cats([parent, cat1], test_clan)
+        patrol.patrol_leader = parent
+        patrol.patrol_random_cat = cat1
+        filtered = patrol.filter_relationship(possible_patrols)
+        self.assertEqual(len(filtered), len(possible_patrols))
+
+        patrol = Patrol()
+        patrol.add_patrol_cats([parent, cat1], test_clan)
+        patrol.patrol_leader = cat1
+        patrol.patrol_random_cat = parent
+        filtered = patrol.filter_relationship(possible_patrols)
+        self.assertNotEqual(len(filtered), len(possible_patrols))
+
+        patrol = Patrol()
+        cat_list = [cat1, cat2, parent]
+        patrol.add_patrol_cats(cat_list, test_clan)
+        patrol.patrol_leader = parent
+        patrol.patrol_random_cat = cat2
+        filtered = patrol.filter_relationship(possible_patrols)
+        self.assertNotEqual(len(filtered), len(possible_patrols))
+
+    def test_child_parent_patrol(self):
+        # given
+        parent = Cat()
+        cat1 = Cat(parent1=parent.ID)
+        cat2 = Cat(parent1=parent.ID)
+        cat1.siblings = [cat2.ID]
+        cat2.siblings = [cat1.ID]
+
+        # when
+        con_patrol_event = PatrolEvent(patrol_id="test1")
+        con_patrol_event.relationship_constraint.append("child/parent")
+        no_con_patrol_event = PatrolEvent(patrol_id="test2")
+        possible_patrols = [con_patrol_event, no_con_patrol_event]
+
+        test_clan = Clan(name="test")
+
+        # then
+        patrol = Patrol()
+        patrol.add_patrol_cats([parent, cat1], test_clan)
+        patrol.patrol_leader = cat1
+        patrol.patrol_random_cat = parent
+        filtered = patrol.filter_relationship(possible_patrols)
+        self.assertEqual(len(filtered), len(possible_patrols))
+
+        patrol = Patrol()
+        patrol.add_patrol_cats([parent, cat1], test_clan)
+        patrol.patrol_leader = parent
+        patrol.patrol_random_cat = cat1
+        filtered = patrol.filter_relationship(possible_patrols)
+        self.assertNotEqual(len(filtered), len(possible_patrols))
+
+        patrol = Patrol()
+        cat_list = [cat1, cat2, parent]
+        patrol.add_patrol_cats(cat_list, test_clan)
+        patrol.patrol_leader = parent
+        patrol.patrol_random_cat = cat2
+        filtered = patrol.filter_relationship(possible_patrols)
+        self.assertNotEqual(len(filtered), len(possible_patrols))
+
+    def test_romantic_constraint_patrol(self):
+        # given
+        cat1 = Cat()
+        cat2 = Cat()
+
+        relationship1 = Relationship(cat1,cat2)
+        relationship2 = Relationship(cat2,cat1)
+
+        relationship1.romantic_love = 20
+        relationship2.romantic_love = 20
+
+        relationship1.opposite_relationship = relationship2
+        relationship2.opposite_relationship = relationship1
+        cat1.relationships[cat2.ID] = relationship1
+        cat2.relationships[cat1.ID] = relationship2
+
+        test_clan = Clan(name="test")
+
+        # when - correct
+        con_patrol_event = PatrolEvent(patrol_id="test1")
+        con_patrol_event.relationship_constraint.append("romantic_10")
+        no_con_patrol_event = PatrolEvent(patrol_id="test2")
+        possible_patrols = [con_patrol_event, no_con_patrol_event]
+
+        # then
+        patrol = Patrol()
+        patrol.add_patrol_cats([cat1, cat2], test_clan)
+        filtered = patrol.filter_relationship(possible_patrols)
+        self.assertEqual(len(filtered), len(possible_patrols))
+
+        # when - to high
+        con_patrol_event = PatrolEvent(patrol_id="test3")
+        con_patrol_event.relationship_constraint.append("romantic_30")
+        possible_patrols = [con_patrol_event, no_con_patrol_event]
+
+        # then
+        patrol = Patrol()
+        patrol.add_patrol_cats([cat1, cat2], test_clan)
+        filtered = patrol.filter_relationship(possible_patrols)
+        self.assertNotEqual(len(filtered), len(possible_patrols))
+
+    def test_platonic_constraint_patrol(self):
+        # given
+        cat1 = Cat()
+        cat2 = Cat()
+
+        relationship1 = Relationship(cat1,cat2)
+        relationship2 = Relationship(cat2,cat1)
+
+        relationship1.platonic_like = 20
+        relationship2.platonic_like = 20
+
+        relationship1.opposite_relationship = relationship2
+        relationship2.opposite_relationship = relationship1
+        cat1.relationships[cat2.ID] = relationship1
+        cat2.relationships[cat1.ID] = relationship2
+
+        test_clan = Clan(name="test")
+
+        # when - correct
+        con_patrol_event = PatrolEvent(patrol_id="test1")
+        con_patrol_event.relationship_constraint.append("platonic_10")
+        no_con_patrol_event = PatrolEvent(patrol_id="test2")
+        possible_patrols = [con_patrol_event, no_con_patrol_event]
+
+        # then
+        patrol = Patrol()
+        patrol.add_patrol_cats([cat1, cat2], test_clan)
+        filtered = patrol.filter_relationship(possible_patrols)
+        self.assertEqual(len(filtered), len(possible_patrols))
+
+        # when - to high
+        con_patrol_event = PatrolEvent(patrol_id="test3")
+        con_patrol_event.relationship_constraint.append("platonic_30")
+        possible_patrols = [con_patrol_event, no_con_patrol_event]
+
+        # then
+        patrol = Patrol()
+        patrol.add_patrol_cats([cat1, cat2], test_clan)
+        filtered = patrol.filter_relationship(possible_patrols)
+        self.assertNotEqual(len(filtered), len(possible_patrols))
+
+    def test_dislike_constraint_patrol(self):
+        # given
+        cat1 = Cat()
+        cat2 = Cat()
+
+        relationship1 = Relationship(cat1,cat2)
+        relationship2 = Relationship(cat2,cat1)
+
+        relationship1.dislike = 20
+        relationship2.dislike = 20
+
+        relationship1.opposite_relationship = relationship2
+        relationship2.opposite_relationship = relationship1
+        cat1.relationships[cat2.ID] = relationship1
+        cat2.relationships[cat1.ID] = relationship2
+
+        test_clan = Clan(name="test")
+
+        # when - correct
+        con_patrol_event = PatrolEvent(patrol_id="test1")
+        con_patrol_event.relationship_constraint.append("dislike_10")
+        no_con_patrol_event = PatrolEvent(patrol_id="test2")
+        possible_patrols = [con_patrol_event, no_con_patrol_event]
+
+        # then
+        patrol = Patrol()
+        patrol.add_patrol_cats([cat1, cat2], test_clan)
+        filtered = patrol.filter_relationship(possible_patrols)
+        self.assertEqual(len(filtered), len(possible_patrols))
+
+        # when - to high
+        con_patrol_event = PatrolEvent(patrol_id="test3")
+        con_patrol_event.relationship_constraint.append("dislike_30")
+        possible_patrols = [con_patrol_event, no_con_patrol_event]
+
+        # then
+        patrol = Patrol()
+        patrol.add_patrol_cats([cat1, cat2], test_clan)
+        filtered = patrol.filter_relationship(possible_patrols)
+        self.assertNotEqual(len(filtered), len(possible_patrols))
+
+    def test_comfortable_constraint_patrol(self):
+        # given
+        cat1 = Cat()
+        cat2 = Cat()
+
+        relationship1 = Relationship(cat1,cat2)
+        relationship2 = Relationship(cat2,cat1)
+
+        relationship1.comfortable = 20
+        relationship2.comfortable = 20
+
+        relationship1.opposite_relationship = relationship2
+        relationship2.opposite_relationship = relationship1
+        cat1.relationships[cat2.ID] = relationship1
+        cat2.relationships[cat1.ID] = relationship2
+
+        test_clan = Clan(name="test")
+
+        # when - correct
+        con_patrol_event = PatrolEvent(patrol_id="test1")
+        con_patrol_event.relationship_constraint.append("comfortable_10")
+        no_con_patrol_event = PatrolEvent(patrol_id="test2")
+        possible_patrols = [con_patrol_event, no_con_patrol_event]
+
+        # then
+        patrol = Patrol()
+        patrol.add_patrol_cats([cat1, cat2], test_clan)
+        filtered = patrol.filter_relationship(possible_patrols)
+        self.assertEqual(len(filtered), len(possible_patrols))
+
+        # when - to high
+        con_patrol_event = PatrolEvent(patrol_id="test3")
+        con_patrol_event.relationship_constraint.append("comfortable_30")
+        possible_patrols = [con_patrol_event, no_con_patrol_event]
+
+        # then
+        patrol = Patrol()
+        patrol.add_patrol_cats([cat1, cat2], test_clan)
+        filtered = patrol.filter_relationship(possible_patrols)
+        self.assertNotEqual(len(filtered), len(possible_patrols))
+
+    def test_jealousy_patrol(self):
+        # given
+        cat1 = Cat()
+        cat2 = Cat()
+
+        relationship1 = Relationship(cat1,cat2)
+        relationship2 = Relationship(cat2,cat1)
+
+        relationship1.jealousy = 20
+        relationship2.jealousy = 20
+
+        relationship1.opposite_relationship = relationship2
+        relationship2.opposite_relationship = relationship1
+        cat1.relationships[cat2.ID] = relationship1
+        cat2.relationships[cat1.ID] = relationship2
+
+        test_clan = Clan(name="test")
+
+        # when - correct
+        con_patrol_event = PatrolEvent(patrol_id="test1")
+        con_patrol_event.relationship_constraint.append("jealousy_10")
+        no_con_patrol_event = PatrolEvent(patrol_id="test2")
+        possible_patrols = [con_patrol_event, no_con_patrol_event]
+
+        # then
+        patrol = Patrol()
+        patrol.add_patrol_cats([cat1, cat2], test_clan)
+        filtered = patrol.filter_relationship(possible_patrols)
+        self.assertEqual(len(filtered), len(possible_patrols))
+
+        # when - to high
+        con_patrol_event = PatrolEvent(patrol_id="test3")
+        con_patrol_event.relationship_constraint.append("jealousy_30")
+        possible_patrols = [con_patrol_event, no_con_patrol_event]
+
+        # then
+        patrol = Patrol()
+        patrol.add_patrol_cats([cat1, cat2], test_clan)
+        filtered = patrol.filter_relationship(possible_patrols)
+        self.assertNotEqual(len(filtered), len(possible_patrols))
+
+    def test_trust_patrol(self):
+        # given
+        cat1 = Cat()
+        cat2 = Cat()
+
+        relationship1 = Relationship(cat1,cat2)
+        relationship2 = Relationship(cat2,cat1)
+
+        relationship1.trust = 20
+        relationship2.trust = 20
+
+        relationship1.opposite_relationship = relationship2
+        relationship2.opposite_relationship = relationship1
+        cat1.relationships[cat2.ID] = relationship1
+        cat2.relationships[cat1.ID] = relationship2
+
+        test_clan = Clan(name="test")
+
+        # when - correct
+        con_patrol_event = PatrolEvent(patrol_id="test1")
+        con_patrol_event.relationship_constraint.append("trust_10")
+        no_con_patrol_event = PatrolEvent(patrol_id="test2")
+        possible_patrols = [con_patrol_event, no_con_patrol_event]
+
+        # then
+        patrol = Patrol()
+        patrol.add_patrol_cats([cat1, cat2], test_clan)
+        filtered = patrol.filter_relationship(possible_patrols)
+        self.assertEqual(len(filtered), len(possible_patrols))
+
+        # when - to high
+        con_patrol_event = PatrolEvent(patrol_id="test3")
+        con_patrol_event.relationship_constraint.append("trust_30")
+        possible_patrols = [con_patrol_event, no_con_patrol_event]
+
+        # then
+        patrol = Patrol()
+        patrol.add_patrol_cats([cat1, cat2], test_clan)
+        filtered = patrol.filter_relationship(possible_patrols)
+        self.assertNotEqual(len(filtered), len(possible_patrols))
+
+    def test_multiple_romantic_patrol(self):
+        # given
+        cat1 = Cat()
+        cat2 = Cat()
+        cat3 = Cat()
+
+        relationship1_2 = Relationship(cat1,cat2)
+        relationship1_3 = Relationship(cat1,cat3)
+        relationship2_1 = Relationship(cat2,cat1)
+        relationship2_3 = Relationship(cat2,cat3)
+        relationship3_1 = Relationship(cat3,cat1)
+        relationship3_2 = Relationship(cat3,cat2)
+
+        relationship1_2.romantic_love = 20
+        relationship1_3.romantic_love = 20
+        relationship2_1.romantic_love = 20
+        relationship2_3.romantic_love = 20
+        relationship3_1.romantic_love = 20
+        relationship3_2.romantic_love = 20
+
+        relationship1_2.opposite_relationship = relationship2_1
+        relationship1_3.opposite_relationship = relationship3_1
+        relationship2_1.opposite_relationship = relationship1_2
+        relationship2_3.opposite_relationship = relationship3_2
+        relationship3_1.opposite_relationship = relationship3_1
+        relationship3_2.opposite_relationship = relationship2_3
+
+        cat1.relationships[cat2.ID] = relationship1_2
+        cat1.relationships[cat3.ID] = relationship1_3
+        cat2.relationships[cat1.ID] = relationship2_1
+        cat2.relationships[cat3.ID] = relationship2_3
+        cat3.relationships[cat1.ID] = relationship3_1
+        cat3.relationships[cat2.ID] = relationship3_2
+
+        test_clan = Clan(name="test")
+
+        # when - all is correct
+        con_patrol_event = PatrolEvent(patrol_id="test1")
+        con_patrol_event.relationship_constraint.append("romantic_10")
+        no_con_patrol_event = PatrolEvent(patrol_id="test2")
+        possible_patrols = [con_patrol_event, no_con_patrol_event]
+
+        # then
+        patrol = Patrol()
+        patrol.add_patrol_cats([cat1, cat2, cat3], test_clan)
+        filtered = patrol.filter_relationship(possible_patrols)
+        self.assertEqual(len(filtered), len(possible_patrols))
+
+        # when - to high limit
+        con_patrol_event = PatrolEvent(patrol_id="test3")
+        con_patrol_event.relationship_constraint.append("romantic_30")
+        possible_patrols = [con_patrol_event, no_con_patrol_event]
+
+        # then
+        patrol = Patrol()
+        patrol.add_patrol_cats([cat1, cat2, cat3], test_clan)
+        filtered = patrol.filter_relationship(possible_patrols)
+        self.assertNotEqual(len(filtered), len(possible_patrols))
+
+
+        # when - different relationship values
+        cat3.relationships[cat2.ID].romantic_love = 5
+        con_patrol_event = PatrolEvent(patrol_id="test1")
+        con_patrol_event.relationship_constraint.append("romantic_10")
+        no_con_patrol_event = PatrolEvent(patrol_id="test2")
+        possible_patrols = [con_patrol_event, no_con_patrol_event]
+
+        # then
+        patrol = Patrol()
+        patrol.add_patrol_cats([cat1, cat2, cat3], test_clan)
+        filtered = patrol.filter_relationship(possible_patrols)
+        self.assertNotEqual(len(filtered), len(possible_patrols))

--- a/tests/test_filter_patrol.py
+++ b/tests/test_filter_patrol.py
@@ -8,6 +8,7 @@ except ImportError:
 from scripts.cat.cats import Cat
 from scripts.cat_relations.relationship import Relationship
 from scripts.patrol import PatrolEvent, Patrol
+from scripts.clan import Clan
 
 class TestRelationshipConstraintPatrols(unittest.TestCase):
 
@@ -25,11 +26,13 @@ class TestRelationshipConstraintPatrols(unittest.TestCase):
         no_con_patrol_event = PatrolEvent(patrol_id="test2")
         possible_patrols = [con_patrol_event, no_con_patrol_event]
 
+        test_clan = Clan(name="test")
+
         patrol_all_events = Patrol()
-        patrol_all_events.add_patrol_cats([cat1, cat2])
+        patrol_all_events.add_patrol_cats([cat1, cat2], test_clan)
 
         patrol_not_all_events = Patrol()
-        patrol_not_all_events.add_patrol_cats([cat1,cat2,parent])
+        patrol_not_all_events.add_patrol_cats([cat1, cat2, parent], test_clan)
 
         all_filtered = patrol_all_events.filter_relationship(possible_patrols)
         not_all_filtered = patrol_not_all_events.filter_relationship(possible_patrols)


### PR DESCRIPTION
It is now possible to add a "key" to a patrol_event --> **relationship_constraint**

**_RELATIONSHIP CONSTRAINT:_**
    This is an optional constraint, if you use this, all cats in the patrol has to have these relations. If there are multiple 'tags', all 'tags' will be used for the filtering.

**general:**
    "sibling", "mates"
    "parent/child" -> patrol leader is parent, random cat is child
    "child/parent" -> patrol leader is child, random cat is parent

**'thresholds':**
    for a 'threshold' tag, you only have to add the value type and then a number.
    !ALL! relationship values of each cat to each other has to have these values or higher
    "romantic_NUMBER",
    "platonic_NUMBER",
    "dislike_NUMBER",
    "comfortable_NUMBER",
    "jealousy_NUMBER",
    "trust_NUMBER"

NUMBER has to be replaced with a number -> e.g. "romantic_10"

It is also described in the instruction to writing patrols (google docs) + in the description of the patrol.py file.