### PR TITLE
Bugfixes/Tweaks

### DIFF
--- a/scripts/events_module/relation_events.py
+++ b/scripts/events_module/relation_events.py
@@ -170,7 +170,6 @@ class Relation_Events():
         else:
             chance = 100
 
-        print(str(cat.name), chance)
         # This is the first chance. Other checks will then be made that can "cancel" this roll.
         if not int(random.random() * chance):
             print(f"primary kit roll triggered for {cat.name}")

--- a/scripts/events_module/relation_events.py
+++ b/scripts/events_module/relation_events.py
@@ -671,7 +671,7 @@ class Relation_Events():
                 cat.mate = None
 
         # If the "no unknown fathers setting in on, we should only allow cats that have mates to have kits.
-        if unknown_parent_setting and not cat.mate:
+        if not unknown_parent_setting and not cat.mate:
             return False
 
         # if function reaches this point, having kits is possible

--- a/scripts/events_module/relation_events.py
+++ b/scripts/events_module/relation_events.py
@@ -166,10 +166,11 @@ class Relation_Events():
 
         # Roll to see if the cat will have kits.
         if cat.mate:
-            chance = 60
+            chance = 50
         else:
             chance = 100
 
+        print(str(cat.name), chance)
         # This is the first chance. Other checks will then be made that can "cancel" this roll.
         if not int(random.random() * chance):
             print(f"primary kit roll triggered for {cat.name}")

--- a/scripts/utility.py
+++ b/scripts/utility.py
@@ -493,7 +493,7 @@ def update_sprite(cat):
 
     try:
         if cat.pelt.name not in ['Tortie', 'Calico']:
-            if cat.pelt.length == 'long' and cat.age not in ['kitten', 'adolescent', 'elder']:
+            if cat.age == 'elder' or (cat.pelt.length == 'long' and cat.age not in ['kitten', 'adolescent']):
                 new_sprite.blit(
                     sprites.sprites[cat.pelt.sprites[1] + 'extra' + cat.pelt.colour + str(cat.age_sprites[cat.age])],
                     (0, 0))
@@ -501,7 +501,7 @@ def update_sprite(cat):
                 new_sprite.blit(sprites.sprites[cat.pelt.sprites[1] + cat.pelt.colour + str(cat.age_sprites[cat.age])],
                                 (0, 0))
         else:
-            if cat.pelt.length == 'long' and cat.age not in ['kitten', 'adolescent', 'elder']:
+            if cat.age == 'elder' or (cat.pelt.length == 'long' and cat.age not in ['kitten', 'adolescent']):
                 new_sprite.blit(
                     sprites.sprites[cat.tortiebase + 'extra' + cat.tortiecolour + str(cat.age_sprites[cat.age])],
                     (0, 0))
@@ -528,7 +528,7 @@ def update_sprite(cat):
 
         # draw white patches
         if cat.white_patches is not None:
-            if cat.pelt.length == 'long' and cat.age not in ['kitten', 'adolescent', 'elder']:
+            if cat.age == 'elder' or (cat.pelt.length == 'long' and cat.age not in ['kitten', 'adolescent']):
                 new_sprite.blit(
                     sprites.sprites['whiteextra' + cat.white_patches +
                                     str(cat.age_sprites[cat.age])], (0, 0))
@@ -537,7 +537,7 @@ def update_sprite(cat):
                     sprites.sprites['white' + cat.white_patches +
                                     str(cat.age_sprites[cat.age])], (0, 0))
         # draw eyes & scars1
-        if cat.pelt.length == 'long' and cat.age not in ['kitten', 'adolescent', 'elder']:
+        if cat.age == 'elder' or (cat.pelt.length == 'long' and cat.age not in ['kitten', 'adolescent']):
             new_sprite.blit(
                 sprites.sprites['eyesextra' + cat.eye_colour +
                                 str(cat.age_sprites[cat.age])], (0, 0))
@@ -579,7 +579,7 @@ def update_sprite(cat):
 
         # draw line art
         if game.settings['shaders'] and not cat.dead:
-            if cat.pelt.length == 'long' and cat.age not in ['kitten', 'adolescent', 'elder']:
+            if cat.age == 'elder' or (cat.pelt.length == 'long' and cat.age not in ['kitten', 'adolescent']):
                 new_sprite.blit(
                     sprites.sprites['shaders' +
                                     str(cat.age_sprites[cat.age] + 9)],
@@ -600,7 +600,7 @@ def update_sprite(cat):
                     (0, 0))
 
         if not cat.dead:
-            if cat.pelt.length == 'long' and cat.age not in ['kitten', 'adolescent', 'elder']:
+            if cat.age == 'elder' or (cat.pelt.length == 'long' and cat.age not in ['kitten', 'adolescent']):
                 new_sprite.blit(
                     sprites.sprites['lines' +
                                     str(cat.age_sprites[cat.age] + 9)],
@@ -610,7 +610,7 @@ def update_sprite(cat):
                     sprites.sprites['lines' + str(cat.age_sprites[cat.age])],
                     (0, 0))
         elif cat.df:
-            if cat.pelt.length == 'long' and cat.age not in ['kitten', 'adolescent', 'elder']:
+            if cat.age == 'elder' or (cat.pelt.length == 'long' and cat.age not in ['kitten', 'adolescent']):
                 new_sprite.blit(
                     sprites.sprites['lineartdf' +
                                     str(cat.age_sprites[cat.age] + 9)],
@@ -620,7 +620,7 @@ def update_sprite(cat):
                     sprites.sprites['lineartdf' +
                                     str(cat.age_sprites[cat.age])], (0, 0))
         elif cat.dead:
-            if cat.pelt.length == 'long' and cat.age not in ['kitten', 'adolescent', 'elder']:
+            if cat.age == 'elder' or (cat.pelt.length == 'long' and cat.age not in ['kitten', 'adolescent']):
                 new_sprite.blit(
                     sprites.sprites['lineartdead' +
                                     str(cat.age_sprites[cat.age] + 9)],
@@ -631,7 +631,7 @@ def update_sprite(cat):
                                     str(cat.age_sprites[cat.age])], (0, 0))
         # draw skin and scars2
         blendmode = pygame.BLEND_RGBA_MIN
-        if cat.pelt.length == 'long' and cat.age not in ['kitten', 'adolescent', 'elder']:
+        if cat.age == 'elder' or (cat.pelt.length == 'long' and cat.age not in ['kitten', 'adolescent']):
             new_sprite.blit(
                 sprites.sprites['skinextra' + cat.skin +
                                 str(cat.age_sprites[cat.age])], (0, 0))
@@ -650,7 +650,7 @@ def update_sprite(cat):
                                                     str(cat.age_sprites[cat.age])], (0, 0), special_flags=blendmode)
 
         # draw accessories        
-        if cat.pelt.length == 'long' and cat.age not in ['kitten', 'adolescent', 'elder']:
+        if cat.age == 'elder' or (cat.pelt.length == 'long' and cat.age not in ['kitten', 'adolescent']):
             if cat.accessory in plant_accessories:
                 new_sprite.blit(
                     sprites.sprites['acc_herbsextra' + cat.accessory +

--- a/scripts/utility.py
+++ b/scripts/utility.py
@@ -493,9 +493,7 @@ def update_sprite(cat):
 
     try:
         if cat.pelt.name not in ['Tortie', 'Calico']:
-            if cat.pelt.length == 'long' and cat.status not in ['kitten', 'apprentice',
-                                                                'medicine cat apprentice', "mediator apprentice"] \
-                    or cat.age == 'elder':
+            if cat.pelt.length == 'long' and cat.age not in ['kitten', 'adolescent', 'elder']:
                 new_sprite.blit(
                     sprites.sprites[cat.pelt.sprites[1] + 'extra' + cat.pelt.colour + str(cat.age_sprites[cat.age])],
                     (0, 0))
@@ -503,9 +501,7 @@ def update_sprite(cat):
                 new_sprite.blit(sprites.sprites[cat.pelt.sprites[1] + cat.pelt.colour + str(cat.age_sprites[cat.age])],
                                 (0, 0))
         else:
-            if cat.pelt.length == 'long' and cat.status not in ['kitten', 'apprentice',
-                                                                'medicine cat apprentice', "mediator apprentice"] \
-                    or cat.age == 'elder':
+            if cat.pelt.length == 'long' and cat.age not in ['kitten', 'adolescent', 'elder']:
                 new_sprite.blit(
                     sprites.sprites[cat.tortiebase + 'extra' + cat.tortiecolour + str(cat.age_sprites[cat.age])],
                     (0, 0))
@@ -532,9 +528,7 @@ def update_sprite(cat):
 
         # draw white patches
         if cat.white_patches is not None:
-            if cat.pelt.length == 'long' and cat.status not in ['kitten', 'apprentice', 'medicine cat apprentice',
-                                                                "mediator apprentice"] \
-                    or cat.age == 'elder':
+            if cat.pelt.length == 'long' and cat.age not in ['kitten', 'adolescent', 'elder']:
                 new_sprite.blit(
                     sprites.sprites['whiteextra' + cat.white_patches +
                                     str(cat.age_sprites[cat.age])], (0, 0))
@@ -543,9 +537,7 @@ def update_sprite(cat):
                     sprites.sprites['white' + cat.white_patches +
                                     str(cat.age_sprites[cat.age])], (0, 0))
         # draw eyes & scars1
-        if cat.pelt.length == 'long' and cat.status not in [
-            'kitten', 'apprentice', 'medicine cat apprentice', "mediator apprentice"
-        ] or cat.age == 'elder':
+        if cat.pelt.length == 'long' and cat.age not in ['kitten', 'adolescent', 'elder']:
             new_sprite.blit(
                 sprites.sprites['eyesextra' + cat.eye_colour +
                                 str(cat.age_sprites[cat.age])], (0, 0))
@@ -587,9 +579,7 @@ def update_sprite(cat):
 
         # draw line art
         if game.settings['shaders'] and not cat.dead:
-            if cat.pelt.length == 'long' and cat.status not in [
-                'kitten', 'apprentice', 'medicine cat apprentice', "mediator apprentice"
-            ] or cat.age == 'elder':
+            if cat.pelt.length == 'long' and cat.age not in ['kitten', 'adolescent', 'elder']:
                 new_sprite.blit(
                     sprites.sprites['shaders' +
                                     str(cat.age_sprites[cat.age] + 9)],
@@ -610,9 +600,7 @@ def update_sprite(cat):
                     (0, 0))
 
         if not cat.dead:
-            if cat.pelt.length == 'long' and cat.status not in [
-                'kitten', 'apprentice', 'medicine cat apprentice', "mediator apprentice"
-            ] or cat.age == 'elder':
+            if cat.pelt.length == 'long' and cat.age not in ['kitten', 'adolescent', 'elder']:
                 new_sprite.blit(
                     sprites.sprites['lines' +
                                     str(cat.age_sprites[cat.age] + 9)],
@@ -622,9 +610,7 @@ def update_sprite(cat):
                     sprites.sprites['lines' + str(cat.age_sprites[cat.age])],
                     (0, 0))
         elif cat.df:
-            if cat.pelt.length == 'long' and cat.status not in [
-                'kitten', 'apprentice', 'medicine cat apprentice', "mediator apprentice"
-            ] or cat.age == 'elder':
+            if cat.pelt.length == 'long' and cat.age not in ['kitten', 'adolescent', 'elder']:
                 new_sprite.blit(
                     sprites.sprites['lineartdf' +
                                     str(cat.age_sprites[cat.age] + 9)],
@@ -634,9 +620,7 @@ def update_sprite(cat):
                     sprites.sprites['lineartdf' +
                                     str(cat.age_sprites[cat.age])], (0, 0))
         elif cat.dead:
-            if cat.pelt.length == 'long' and cat.status not in [
-                'kitten', 'apprentice', 'medicine cat apprentice', "mediator apprentice"
-            ] or cat.age == 'elder':
+            if cat.pelt.length == 'long' and cat.age not in ['kitten', 'adolescent', 'elder']:
                 new_sprite.blit(
                     sprites.sprites['lineartdead' +
                                     str(cat.age_sprites[cat.age] + 9)],
@@ -647,9 +631,7 @@ def update_sprite(cat):
                                     str(cat.age_sprites[cat.age])], (0, 0))
         # draw skin and scars2
         blendmode = pygame.BLEND_RGBA_MIN
-        if cat.pelt.length == 'long' and cat.status not in [
-            'kitten', 'apprentice', 'medicine cat apprentice', "mediator apprentice"
-        ] or cat.age == 'elder':
+        if cat.pelt.length == 'long' and cat.age not in ['kitten', 'adolescent', 'elder']:
             new_sprite.blit(
                 sprites.sprites['skinextra' + cat.skin +
                                 str(cat.age_sprites[cat.age])], (0, 0))
@@ -668,9 +650,7 @@ def update_sprite(cat):
                                                     str(cat.age_sprites[cat.age])], (0, 0), special_flags=blendmode)
 
         # draw accessories        
-        if cat.pelt.length == 'long' and cat.status not in [
-            'kitten', 'apprentice', 'medicine cat apprentice', "mediator apprentice"
-        ] or cat.age == 'elder':
+        if cat.pelt.length == 'long' and cat.age not in ['kitten', 'adolescent', 'elder']:
             if cat.accessory in plant_accessories:
                 new_sprite.blit(
                     sprites.sprites['acc_herbsextra' + cat.accessory +


### PR DESCRIPTION
 - Slightly increase mated kit-chance. 
 - Prevent unmated cat from rolling the primary kit roll if unmated kits are turned off. 
 - De-coupled sprite from rank. This should fix the issue of long-haired lost cats having the kit sprite if their age and rank do not match.  
 - Moved some "already pregnant" checks for clarity. 