### PR TITLE
Bugfixes/Tweaks

### DIFF
--- a/resources/dicts/events/ceremonies/ceremony-master.json
+++ b/resources/dicts/events/ceremonies/ceremony-master.json
@@ -1042,7 +1042,7 @@
       "compassionate",
       "empathetic"
     ],
-    "(prefix)kit has taken to following (mentor) around during their daily duties, fascinated by the life of a mediator. m_c is more than happy to train as a mediator. "
+    "m_c has taken to following (mentor) around during their daily duties, fascinated by the life of a mediator. (mentor) is happy to train them. "
   ],
   "med_0": [
     [
@@ -2319,7 +2319,7 @@
       "general_parents",
       "yes_leader",
       "general_backstory",
-      "all_trait"
+      "all_traits"
     ],
     "m_c's has been resist to retiring, but the aches and pains of old age have worn them down. They approach l_n, and are honored for their tireless service. "
   ],
@@ -2330,8 +2330,19 @@
       "general_parents",
       "general_leader",
       "general_backstory",
-      "all_trait"
+      "all_traits"
     ],
     "m_c has been looking forward to their moons of rest as an elder. They happily retire, quickly settling into the elder's den. "
+  ],
+  "elder_5": [
+    [
+      "elder",
+      "general_mentor",
+      "general_parents",
+      "general_leader",
+      "general_backstory",
+      "all_traits"
+    ],
+    "Time as taken it's toll, and m_c noticed themselves slowing down. They have worked timelessly for many moons, but is it time for them to retire. "
   ]
 }

--- a/resources/dicts/events/ceremonies/ceremony-master.json
+++ b/resources/dicts/events/ceremonies/ceremony-master.json
@@ -2308,7 +2308,7 @@
       "general_backstory",
       "all_trait"
     ],
-    "m_c's has been resist to retiring, but the aches and pains of old age have worn them down. They approach l_n, and honored for their tireless service. "
+    "m_c's has been resist to retiring, but the aches and pains of old age have worn them down. They approach l_n, and are honored for their tireless service. "
   ],
   "elder_4": [
     [

--- a/resources/dicts/events/ceremonies/ceremony-master.json
+++ b/resources/dicts/events/ceremonies/ceremony-master.json
@@ -1029,7 +1029,20 @@
       "compassionate",
       "empathetic"
     ],
-    "Impressed by their r_h, (mentor) chooses m_c as the clan's new mediator apprentice."
+    "Impressed by their eagerness, (mentor) chooses m_c as the clan's new mediator apprentice."
+  ],
+  "mediator_app_5": [
+    [
+      "mediator apprentice",
+      "no_mentor",
+      "general_parents",
+      "general_leader",
+      "general_backstory",
+      "thoughtful",
+      "compassionate",
+      "empathetic"
+    ],
+    "(prefix)kit has taken to following (mentor) around during their daily duties, fascinated by the life of a mediator. m_c is more than happy to train as a mediator. "
   ],
   "med_0": [
     [
@@ -1502,7 +1515,7 @@
       "general_backstory",
       "troublesome"
     ],
-    "This is a serious time for (prefex)paw, their medicine cat naming ceremony! Naturally, they're cracking jokes and being irreverent right up until the moment they get their name of m_c, and quiet down long enough to think of something funny to add."
+    "This is a serious time for (prefix)paw, their medicine cat naming ceremony! Naturally, they're cracking jokes and being irreverent right up until the moment they get their name of m_c, and quiet down long enough to think of something funny to add."
   ],
   "med_43": [
     [

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -748,7 +748,7 @@ class Events():
                                                               and not x.outside, Cat.all_cats_list))
 
                         # Only become a mediator if there is already one in the clan.
-                        if mediator_list and not int(random.random() * 80):
+                        if mediator_list and not int(random.random() * 50):
                             self.ceremony(cat, 'mediator apprentice')
                             self.ceremony_accessory = True
                             self.gain_accessories(cat)

--- a/scripts/events_module/condition_events.py
+++ b/scripts/events_module/condition_events.py
@@ -640,7 +640,8 @@ class Condition_Events():
         }
 
         if not triggered and not cat.dead and not cat.retired and cat.status not in \
-                ['leader', 'medicine cat', 'kitten', 'medicine cat apprentice'] and game.settings['retirement'] is False:
+                ['leader', 'medicine cat', 'kitten', 'medicine cat apprentice', 'mediator', 'mediator apprentice'] \
+                and game.settings['retirement'] is False:
             for condition in cat.permanent_condition:
                 if cat.permanent_condition[condition]['severity'] == 'major':
                     chance = int(retire_chances.get(cat.age))

--- a/scripts/utility.py
+++ b/scripts/utility.py
@@ -414,13 +414,13 @@ def ceremony_text_adjust(Cat, text, cat, dead_mentor=None, mentor=None, previous
         adjust_text = adjust_text.replace("p2", str(random_living_parent.name))
 
     # Dead Parents
-    if "p1" in adjust_text and "p2" in adjust_text and len(dead_parents) >= 2:
-        adjust_text = adjust_text.replace("p1", str(dead_parents[0].name))
-        adjust_text = adjust_text.replace("p2", str(dead_parents[1].name))
-    elif "p1" in adjust_text and random_dead_parent:
-        adjust_text = adjust_text.replace("p1", str(random_dead_parent.name))
-    elif "p2" in adjust_text and random_living_parent:
-        adjust_text = adjust_text.replace("p2", str(random_dead_parent.name))
+    if "dead_par1" in adjust_text and "dead_par2" in adjust_text and len(dead_parents) >= 2:
+        adjust_text = adjust_text.replace("dead_par1", str(dead_parents[0].name))
+        adjust_text = adjust_text.replace("dead_par2", str(dead_parents[1].name))
+    elif "dead_par1" in adjust_text and random_dead_parent:
+        adjust_text = adjust_text.replace("dead_par1", str(random_dead_parent.name))
+    elif "dead_par2" in adjust_text and random_living_parent:
+        adjust_text = adjust_text.replace("dead_par2", str(random_dead_parent.name))
 
     if random_honor:
         adjust_text = adjust_text.replace("r_h", random_honor)


### PR DESCRIPTION
- Mediators and mediator apprentices can no longer retire due to permanent conditions. 
- Dead parent names are now properly replaced in ceremonies. 
- Ceremony Typos
- New elder and mediator apprentice ceremony. 
- Fixes typo that prevented previous new elder ceremonies from showing up. 
- Slightly increase the chance for an apprentice to become a mediator apprentice.  