### PR TITLE
Other: Tweaks

### DIFF
--- a/resources/dicts/events/ceremonies/ceremony-master.json
+++ b/resources/dicts/events/ceremonies/ceremony-master.json
@@ -14,6 +14,7 @@
     [
       "apprentice",
       "yes_mentor",
+      "yes_leader_mentor",
       "general_parents",
       "general_leader",
       "general_backstory",
@@ -25,6 +26,7 @@
     [
       "apprentice",
       "yes_mentor",
+      "yes_leader_mentor",
       "general_parents",
       "general_leader",
       "general_backstory",
@@ -36,6 +38,7 @@
     [
       "apprentice",
       "yes_mentor",
+      "yes_leader_mentor",
       "general_parents",
       "general_leader",
       "general_backstory",
@@ -49,6 +52,7 @@
     [
       "apprentice",
       "yes_mentor",
+      "yes_leader_mentor",
       "general_parents",
       "general_leader",
       "general_backstory",
@@ -66,6 +70,7 @@
     [
       "apprentice",
       "yes_mentor",
+      "yes_leader_mentor",
       "general_parents",
       "general_leader",
       "general_backstory",
@@ -78,6 +83,7 @@
     [
       "apprentice",
       "yes_mentor",
+      "yes_leader_mentor",
       "general_parents",
       "general_leader",
       "general_backstory",
@@ -96,6 +102,7 @@
     [
       "apprentice",
       "yes_mentor",
+      "yes_leader_mentor",
       "general_parents",
       "general_leader",
       "general_backstory",
@@ -109,6 +116,7 @@
     [
       "apprentice",
       "yes_mentor",
+      "yes_leader_mentor",
       "general_parents",
       "general_leader",
       "general_backstory",
@@ -127,6 +135,7 @@
     [
       "apprentice",
       "yes_mentor",
+      "yes_leader_mentor",
       "general_parents",
       "general_leader",
       "general_backstory",
@@ -142,6 +151,7 @@
     [
       "apprentice",
       "yes_mentor",
+      "yes_leader_mentor",
       "general_parents",
       "general_leader",
       "general_backstory",
@@ -159,6 +169,7 @@
     [
       "apprentice",
       "yes_mentor",
+      "yes_leader_mentor",
       "general_parents",
       "general_leader",
       "general_backstory",
@@ -177,6 +188,7 @@
     [
       "apprentice",
       "yes_mentor",
+      "yes_leader_mentor",
       "general_parents",
       "general_leader",
       "general_backstory",
@@ -191,6 +203,7 @@
     [
       "apprentice",
       "yes_mentor",
+      "yes_leader_mentor",
       "general_parents",
       "general_leader",
       "general_backstory",
@@ -264,6 +277,7 @@
     [
       "apprentice",
       "yes_mentor",
+      "yes_leader_mentor",
       "general_parents",
       "general_leader",
       "abandoned",
@@ -275,6 +289,7 @@
     [
       "apprentice",
       "yes_mentor",
+      "yes_leader_mentor",
       "general_parents",
       "general_leader",
       "general_backstory",
@@ -297,6 +312,7 @@
     [
       "apprentice",
       "yes_mentor",
+      "yes_leader_mentor",
       "general_parents",
       "general_leader",
       "general_backstory",
@@ -312,6 +328,7 @@
     [
       "apprentice",
       "yes_mentor",
+      "yes_leader_mentor",
       "general_parents",
       "general_leader",
       "general_backstory",
@@ -338,6 +355,7 @@
     [
       "apprentice",
       "yes_mentor",
+      "yes_leader_mentor",
       "general_parents",
       "general_leader",
       "general_backstory",
@@ -362,6 +380,7 @@
     [
       "apprentice",
       "yes_mentor",
+      "yes_leader_mentor",
       "general_parents",
       "general_leader",
       "general_backstory",
@@ -384,6 +403,7 @@
     [
       "apprentice",
       "yes_mentor",
+      "yes_leader_mentor",
       "general_parents",
       "general_leader",
       "general_backstory",
@@ -403,6 +423,7 @@
     [
       "apprentice",
       "yes_mentor",
+      "yes_leader_mentor",
       "general_parents",
       "general_leader",
       "general_backstory",
@@ -425,6 +446,7 @@
     [
       "apprentice",
       "yes_mentor",
+      "yes_leader_mentor",
       "general_parents",
       "general_leader",
       "general_backstory",
@@ -446,6 +468,7 @@
     [
       "apprentice",
       "yes_mentor",
+      "yes_leader_mentor",
       "general_parents",
       "general_leader",
       "general_backstory",
@@ -463,6 +486,7 @@
     [
       "apprentice",
       "yes_mentor",
+      "yes_leader_mentor",
       "general_parents",
       "general_leader",
       "general_backstory",
@@ -477,12 +501,13 @@
       "strict",
       "wise"
     ],
-    "m_c touches noses with their mentor, (mentor), looking bored and unimpressed. But on the inside, they're bouncing with euphoria around as if they were still a kit!"
+    "m_c touches noses with their mentor, (mentor), looking bored and unimpressed. But on the inside, they're bouncing around with euphoria as if they were still a kit!"
   ],
   "app_39": [
     [
       "apprentice",
       "yes_mentor",
+      "yes_leader_mentor",
       "general_parents",
       "general_leader",
       "general_backstory",
@@ -496,6 +521,7 @@
     [
       "apprentice",
       "yes_mentor",
+      "yes_leader_mentor",
       "general_parents",
       "general_leader",
       "general_backstory",
@@ -510,6 +536,7 @@
     [
       "apprentice",
       "yes_mentor",
+      "yes_leader_mentor",
       "general_parents",
       "general_leader",
       "general_backstory",
@@ -524,6 +551,7 @@
     [
       "apprentice",
       "yes_mentor",
+      "yes_leader_mentor",
       "general_parents",
       "general_leader",
       "general_backstory",
@@ -580,6 +608,7 @@
     [
       "apprentice",
       "yes_mentor",
+      "yes_leader_mentor",
       "alive1_parents",
       "general_leader",
       "general_backstory",
@@ -591,6 +620,7 @@
     [
       "apprentice",
       "yes_mentor",
+      "yes_leader_mentor",
       "alive1_parents",
       "general_leader",
       "general_backstory",
@@ -602,6 +632,7 @@
     [
       "apprentice",
       "yes_mentor",
+      "yes_leader_mentor",
       "dead1_parents",
       "general_leader",
       "general_backstory",
@@ -613,6 +644,7 @@
     [
       "apprentice",
       "yes_mentor",
+      "yes_leader_mentor",
       "dead1_parents",
       "general_leader",
       "clanborn",
@@ -624,6 +656,7 @@
     [
       "apprentice",
       "yes_mentor",
+      "yes_leader_mentor",
       "dead1_parents",
       "general_leader",
       "clanborn",
@@ -635,6 +668,7 @@
     [
       "apprentice",
       "yes_mentor",
+      "yes_leader_mentor",
       "dead1_parents",
       "general_leader",
       "general_backstory",
@@ -646,6 +680,7 @@
     [
       "apprentice",
       "yes_mentor",
+      "yes_leader_mentor",
       "dead1_parents",
       "general_leader",
       "general_backstory",
@@ -657,6 +692,7 @@
     [
       "apprentice",
       "yes_mentor",
+      "yes_leader_mentor",
       "dead1_parents",
       "general_leader",
       "general_backstory",
@@ -667,7 +703,7 @@
   "app_55": [
     [
       "apprentice",
-      "yes_mentor",
+      "general_mentor",
       "alive2_parents",
       "general_leader",
       "general_backstory",
@@ -679,6 +715,7 @@
     [
       "apprentice",
       "yes_mentor",
+      "yes_leader_mentor",
       "dead2_parents",
       "general_leader",
       "general_backstory",
@@ -690,6 +727,7 @@
     [
       "apprentice",
       "yes_mentor",
+      "yes_leader_mentor",
       "dead2_parents",
       "general_leader",
       "clanborn",
@@ -701,6 +739,7 @@
     [
       "apprentice",
       "yes_mentor",
+      "yes_leader_mentor",
       "dead2_parents",
       "general_leader",
       "clanborn",
@@ -712,6 +751,7 @@
     [
       "apprentice",
       "yes_mentor",
+      "yes_leader_mentor",
       "dead2_parents",
       "general_leader",
       "general_backstory",
@@ -723,6 +763,7 @@
     [
       "apprentice",
       "yes_mentor",
+      "yes_leader_mentor",
       "dead2_parents",
       "general_leader",
       "general_backstory",
@@ -734,12 +775,24 @@
     [
       "apprentice",
       "yes_mentor",
+      "yes_leader_mentor",
       "dead2_parents",
       "general_leader",
       "general_backstory",
       "all_traits"
     ],
     "As m_c touches noses with their new mentor, (mentor), they make a silent promise to dead_par1 and dead_par2 to make them proud, and to take care of the Clan in their parent's absence."
+  ],
+  "app_62": [
+    [
+      "apprentice",
+      "yes_leader_mentor",
+      "general_parents",
+      "yes_leader",
+      "general_backstory",
+      "all_traits"
+    ],
+    "(mentor) calls a meeting. They have been watching (prefix)kit for a while now, and have decided to mentor them personally. m_c's eyes shine with pride. "
   ],
   "med_app_0": [
     [
@@ -1130,7 +1183,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "(previous_mentor) still remembers when (prefix)paw was just a kit, batting around in the medicine den, and asking endless questions about everything under the sun. Even now, they ask why their new name, m_c, was chosen with shining eyes and twitching whiskers."
+    "(previous_mentor) still remembers when (prefix)paw was just a kit, batting around in the medicine den, and asking endless questions about everything under the sun. (previous_mentor) chuckles with fondness as m_c asks why their new name was chosen with shining eyes and twitching whiskers."
   ],
   "med_8": [
     [
@@ -1724,7 +1777,7 @@
       "general_backstory",
       "bloodthirsty"
     ],
-    "Although (prefix)paw's paw's eagerness to fight has left l_n a little worried before, they know that the Clan can count on (prefix)paw's bravery and sharp claws when they need them the most. In honor of their r_h, (prefix)paw is given the name m_c."
+    "Although (prefix)paw's eagerness to fight has left l_n a little worried before, they know that the Clan can count on (prefix)paw's bravery and sharp claws when they need them the most. In honor of their r_h, (prefix)paw is given the name m_c."
   ],
   "warrior_12": [
     [
@@ -2246,6 +2299,17 @@
     ],
     "(prefix)paw tries to keep their head high as they step forward, and are given the name m_c in honor of their r_h. It doesn't seem fair. dead_par1 and dead_par2 should be here with them! They promised they would! m_c looks to the stars, and their anger and frustration vanishes. It feels as though the stars are brighter, and they know that, even if they cannot be there in body, their parents are there in spirit."
   ],
+  "warrior_59": [
+    [
+      "warrior",
+      "alive_leader_mentor",
+      "general_parents",
+      "yes_leader",
+      "general_backstory",
+      "all_traits"
+    ],
+    "(previous_mentor) gathers the clan for a meeting. They have spent many moons training (prefix)paw, and it's time for them to be granted their warrior name. (previous_mentor) gives them the name m_c and honors their r_h."
+  ],
   "mediator_0": [
     [
       "mediator",
@@ -2321,7 +2385,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "m_c's has been resist to retiring, but the aches and pains of old age have worn them down. They approach l_n, and are honored for their tireless service. "
+    "m_c's been resist to retiring, but the aches and pains of old age have worn them down. They approach l_n, and are honored for their tireless service. "
   ],
   "elder_4": [
     [

--- a/resources/game_config.json
+++ b/resources/game_config.json
@@ -55,11 +55,20 @@
 		"base_permanent_condition": 90,
 		"base_male_tortie": 13,
 		"base_female_tortie": 4,
-		"base_heterochromia": 120
+		"base_heterochromia": 120,
+		"direct_inheritance": 15
 	},
 	"fading": {
 		"age_to_fade": 302,
 		"opacity_at_fade": 20,
 		"visual_fading_speed": 5
+	},
+	"roles": {
+		"mediator_app_chance": 50,
+		"base_medicine_app_chance": 41,
+		"become_mediator_chances": {
+			"warrior": 5000,
+			"elder": 400
+		}
 	}
 }

--- a/scripts/cat/appearance_utility.py
+++ b/scripts/cat/appearance_utility.py
@@ -184,10 +184,10 @@ def pelt_inheritance(cat, parents: tuple):
     par_white = []
     for p in parents:
         if p:
-            #Gather pelt color.
+            # Gather pelt color.
             par_peltcolours.add(p.pelt.colour)
 
-            #Gather pelt length
+             # Gather pelt length
             par_peltlength.add(p.pelt.length)
 
             # Gather pelt name
@@ -196,10 +196,10 @@ def pelt_inheritance(cat, parents: tuple):
             else:
                 par_peltnames.add(p.pelt.name)
 
-            #Gather exact pelts, for direct inheritance.
+            # Gather exact pelts, for direct inheritance.
             par_pelts.append(p.pelt)
 
-            #Gather if they have white in their pelt.
+            # Gather if they have white in their pelt.
             par_white.append(p.pelt.white)
         else:
             # If order for white patches to work correctly, we also want to randomly generate a "pelt_white"
@@ -212,14 +212,14 @@ def pelt_inheritance(cat, parents: tuple):
             par_peltlength.add(None)
             par_peltnames.add(None)
 
-    #If this list is empty, something went wrong.
+    # If this list is empty, something went wrong.
     if not par_peltcolours:
         print("Error - no parents: pelt randomized")
         randomize_pelt(cat)
         return
 
     # There is a 1/10 chance for kits to have the exact same pelt as one of their parents
-    if not randint(0, 10):  # 1/15 chance
+    if not randint(0, game.config["cat_generation"]["direct_inheritance"]):  # 1/10 chance
         selected = choice(par_pelts)
         cat.pelt = choose_pelt(selected.colour, selected.white, selected.name,
                                selected.length)
@@ -571,7 +571,7 @@ def white_patches_inheritance(cat, parents: tuple):
         return
 
     # Direct inheritance. Will only work if at least one parent has white patches, otherwise continue on.
-    if par_whitepatches and not randint(0, 10):
+    if par_whitepatches and not randint(0, game.config["cat_generation"]["direct_inheritance"]):
         cat.white_patches = choice(list(par_whitepatches))
         return
 

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -235,11 +235,9 @@ class Events():
         if game.settings['become_mediator']:
             # Note: These chances are large since it triggers every moon.
             # Checking every moon has the effect giving older cats more chances to become a mediator
-            mediator_chance = {
-                "warrior": 5000,
-                "elder": 400
-            }
-            if cat.status in mediator_chance and not int(random.random() * mediator_chance[cat.status]):
+
+            if cat.status in game.config["roles"]["become_mediator_chances"] and \
+                    not int(random.random() * game.config["roles"]["become_mediator_chances"][cat.status]):
                 game.cur_events_list.append(
                     Single_Event(f"{cat.name} had chosen to use their skills and experience to help "
                                  f"solve the Clan's disagreements. A meeting is called, and they "
@@ -726,24 +724,23 @@ class Events():
                     has_med_app = any(cat.status == "medicine cat apprentice" for cat in med_cat_list)
 
                     # assign chance to become med app depending on current med cat and traits
+                    chance = game.config["roles"]["base_medicine_app_chance"]
                     if has_elder_med is True and has_med is False:
-                        chance = int(random.random() * 3)  # 3 is not part of the range
+                        chance = int(chance/13.67)
                     elif has_med is False:
-                        chance = int(random.random() * 8)
-                    elif has_elder_med is False and has_med is True:
-                        chance = int(random.random() * 91)
+                        chance = int(chance/5.125)
+                    elif not has_elder_med and has_med:
+                        chance = int(chance * 2.22)
                     elif has_elder_med and has_med:
                         if very_old_med:
-                            chance = int(random.random() * 20)
+                            chance = int(chance/2.05)
                         else:
-                            chance = 0
-                    else:
-                        chance = int(random.random() * 41)
+                            chance = int(chance/1.7)
 
-                    if chance in range(1, 10):
-                        if cat.trait in ['polite', 'quiet', 'sweet', 'daydreamer']:
-                            chance = 1
-                    if has_med_app is False and chance == 1:
+                    if cat.trait in ['altruistic', 'compassionate', 'empathetic', 'wise', 'faithful']:
+                        chance = int(chance/1.3)
+
+                    if has_med_app is False and not int(random.random() * chance):
                         self.ceremony(cat, 'medicine cat apprentice')
                         self.ceremony_accessory = True
                         self.gain_accessories(cat)
@@ -753,7 +750,7 @@ class Events():
                                                               and not x.outside, Cat.all_cats_list))
 
                         # Only become a mediator if there is already one in the clan.
-                        if mediator_list and not int(random.random() * 50):
+                        if mediator_list and not int(random.random() * game.config["roles"]["mediator_app_chance"]):
                             self.ceremony(cat, 'mediator apprentice')
                             self.ceremony_accessory = True
                             self.gain_accessories(cat)
@@ -819,9 +816,11 @@ class Events():
             # Gather ones for mentor. -----------------------------------------------------
             tags = []
 
-            dead_mentor = None
             if cat.mentor:
-                tags.append("yes_mentor")
+                if Cat.fetch_cat(cat.mentor).status == "leader":
+                    tags.append("yes_leader_mentor")
+                else:
+                    tags.append("yes_mentor")
                 mentor = Cat.fetch_cat(cat.mentor)
             else:
                 tags.append("no_mentor")
@@ -833,9 +832,13 @@ class Events():
                     dead_mentor = Cat.fetch_cat(c)
                     break
 
+            # Living Former mentors who are also the leader do not count.
             for c in reversed(cat.former_mentor):
                 if Cat.fetch_cat(c) and not Cat.fetch_cat(c).dead and not Cat.fetch_cat(c).outside:
-                    tags.append("alive_mentor")
+                    if Cat.fetch_cat(c).status == "leader":
+                        tags.append("alive_leader_mentor")
+                    else:
+                        tags.append("alive_mentor")
                     previous_alive_mentor = Cat.fetch_cat(c)
                     break
 
@@ -926,7 +929,7 @@ class Events():
             except KeyError:
                 random_honor = "hard work"
 
-        # print(possible_ceremonies)
+        print(possible_ceremonies)
         ceremony_tags, ceremony_text = self.CEREMONY_TXT[choice(list(possible_ceremonies))]
 
         # This is a bit strange, but it works. If there is only one parent involved, but more than one living
@@ -943,26 +946,25 @@ class Events():
         for tag in ceremony_tags:
             if tag == "yes_leader":
                 involved_cats.append(game.clan.leader.ID)
-            elif tag == "yes_mentor":
+            elif tag in ["yes_mentor", "yes_leader_mentor"]:
                 involved_cats.append(cat.mentor)
             elif tag == "dead_mentor":
                 involved_cats.append(dead_mentor.ID)
-            elif tag == "alive_mentor":
+            elif tag in ["alive_mentor", "alive_leader_mentor"]:
                 involved_cats.append(previous_alive_mentor.ID)
             elif tag == "alive2_parents" and len(living_parents) >= 2:
                 for c in living_parents[:2]:
-                    if c.ID not in involved_cats:
-                        involved_cats.append(c.ID)
+                    involved_cats.append(c.ID)
             elif tag == "alive1_parents" and involved_living_parent:
-                if involved_living_parent.ID not in involved_cats:
-                    involved_cats.append(involved_living_parent.ID)
+                involved_cats.append(involved_living_parent.ID)
             elif tag == "dead2_parents" and len(dead_parents) >= 2:
                 for c in dead_parents[:2]:
-                    if c.ID not in involved_cats:
-                        involved_cats.append(c.ID)
+                    involved_cats.append(c.ID)
             elif tag == "dead1_parent" and involved_dead_parent:
-                if involved_dead_parent.ID not in involved_cats:
-                    involved_cats.append(involved_dead_parent.ID)
+                involved_cats.append(involved_dead_parent.ID)
+
+        # remove duplicates
+        involved_cats = list(set(involved_cats))
 
         game.cur_events_list.append(Single_Event(f'{ceremony_text}', "ceremony", involved_cats))
         # game.ceremony_events_list.append(f'{str(cat.name)}{ceremony_text}')


### PR DESCRIPTION
- added the "yes_leader_mentor"  and "alive_leader_mentor" tag to ceremonies for mentors who are also leader. Added one warrior and one apprentice ceremony specific to this tag, and added tags to appropriate existing ceremonies. 
- Fixed trait-specific boost to med app chances - it was previously based on kit traits, but now cats get their apprentice trait before the check. 
- Moved some chances to game_config. 
- Typos