### PR TITLE
chore: Switch to pygame 2.13 release

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-pygame==2.1.3.dev8; platform_system != "Darwin"
-pygame==2.1.2; platform_system == "Darwin"
+pygame==2.1.3
 ujson==5.7.0
 pygame_gui==0.6.8


### PR DESCRIPTION
Was using prerelease for Python 3.11 support but now pygame 2.13 has been released so we can use the actual release.