### PR TITLE
Two Crashfixes

### DIFF
--- a/resources/dicts/events/ceremonies/ceremony-master.json
+++ b/resources/dicts/events/ceremonies/ceremony-master.json
@@ -980,8 +980,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "Knowing the Clan is in desperate need of a medicine cat, and wanting to do something to stand out and do something more important, m_c announces mid-meeting that they want to be the new medicine cat apprentice.",
-    "Worried they may not be good as a hunter or fighter, but still wanting to make their Clan proud somehow, m_c decides to become a medicine cat, and is trained by StarClan."
+    "Knowing the Clan is in desperate need of a medicine cat, and wanting to do something to stand out and do something more important, m_c announces mid-meeting that they want to be the new medicine cat apprentice."
   ],
   "med_app_17": [
     [
@@ -2407,6 +2406,6 @@
       "general_backstory",
       "all_traits"
     ],
-    "Time as taken it's toll, and m_c noticed themselves slowing down. They have worked timelessly for many moons, but is it time for them to retire. "
+    "Time as taken it's toll, and m_c has noticed themselves slowing down. They have worked timelessly for many moons, but is it time for them to retire. "
   ]
 }

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -929,7 +929,7 @@ class Events():
             except KeyError:
                 random_honor = "hard work"
 
-        print(possible_ceremonies)
+        # print(possible_ceremonies)
         ceremony_tags, ceremony_text = self.CEREMONY_TXT[choice(list(possible_ceremonies))]
 
         # This is a bit strange, but it works. If there is only one parent involved, but more than one living

--- a/scripts/events_module/new_cat_events.py
+++ b/scripts/events_module/new_cat_events.py
@@ -94,7 +94,7 @@ class NewCatEvents:
             involved_cats.append(new_cat.ID)
 
         # give injuries to other cat if tagged as such
-        if "injured" in new_cat_event.tags and game.clan.mode != "classic":
+        if "injured" in new_cat_event.tags and game.clan.game_mode != "classic":
             major_injuries = []
             if "major_injury" in new_cat_event.tags:
                 for injury in INJURIES:


### PR DESCRIPTION
- Fixed crash when a certain med cap apprentice ceremony is rolled. 
- Fixed crash when an injured cat joins your clan on moonskip. 
- Typo