### PR TITLE
Pyinstaller Version File

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,8 @@ jobs:
         run: python -m pip install --upgrade Pillow
       - name: Install PyInstaller
         run: python -m pip install --upgrade PyInstaller
+      - name: Write Version File
+        run: echo ${{ GITHUB_SHA }} > commit.txt
       - name: Run PyInstaller
         #run: python -m PyInstaller -i resources/images/icon.png --name clangen --windowed --onedir --clean --add-data sprites:sprites --add-data resources:resources --add-data README.md:. main.py
         run: python -m PyInstaller Clangen.spec
@@ -56,6 +58,8 @@ jobs:
         run: python -m pip install --upgrade Pillow
       - name: Install PyInstaller
         run: python -m pip install --upgrade PyInstaller
+      - name: Write Version File
+        run: echo ${{ GITHUB_SHA }} > commit.txt
       - name: Run PyInstaller
         run: python -m PyInstaller Clangen.spec
       - name: Create archive (.tar.xz)
@@ -89,6 +93,8 @@ jobs:
         run: python -m pip install --upgrade Pillow
       - name: Install PyInstaller
         run: python -m pip install --upgrade PyInstaller
+      - name: Write Version File
+        run: echo ${{ GITHUB_SHA }} > commit.txt
       - name: Run PyInstaller
         #run: python -m PyInstaller -i resources/images/icon.png --name clangen --windowed --noupx --onedir --clean --add-data "sprites;sprites" --add-data "resources;resources" --add-data "README.md;." main.py
         run: python -m PyInstaller Clangen.spec
@@ -124,6 +130,8 @@ jobs:
         run: python -m pip install --upgrade Pillow
       - name: Install PyInstaller
         run: python -m pip install --upgrade PyInstaller
+      - name: Write Version File
+        run: echo ${{ GITHUB_SHA }} > commit.txt
       # Example of an upx install, also requires adding "--upx-dir upx-4.0.0-win64" to the pyinst run
       #- name: Setup UPX 
       #  run: |
@@ -164,6 +172,8 @@ jobs:
         run: python -m pip install --upgrade Pillow
       - name: Install PyInstaller
         run: python -m pip install --upgrade PyInstaller
+      - name: Write Version File
+        run: echo ${{ GITHUB_SHA }} > commit.txt
       # Example of an upx install, also requires adding "--upx-dir upx-4.0.0-win64" to the pyinst run
       #- name: Setup UPX 
       #  run: |
@@ -206,6 +216,8 @@ jobs:
         run: python -m pip install --upgrade Pillow
       - name: Install PyInstaller
         run: python -m pip install --upgrade PyInstaller
+      - name: Write Version File
+        run: echo ${{ GITHUB_SHA }} > commit.txt
       - name: Run PyInstaller
         #run: python -m PyInstaller -i resources/images/icon.png --name clangen --windowed --onedir --clean --add-data sprites:sprites --add-data resources:resources --add-data README.md:. main.py
         run: python -m PyInstaller Clangen.spec

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install PyInstaller
         run: python -m pip install --upgrade PyInstaller
       - name: Write Version File
-        run: echo ${{ GITHUB_SHA }} > commit.txt
+        run: echo ${{ github.sha }} > commit.txt
       - name: Run PyInstaller
         #run: python -m PyInstaller -i resources/images/icon.png --name clangen --windowed --onedir --clean --add-data sprites:sprites --add-data resources:resources --add-data README.md:. main.py
         run: python -m PyInstaller Clangen.spec
@@ -59,7 +59,7 @@ jobs:
       - name: Install PyInstaller
         run: python -m pip install --upgrade PyInstaller
       - name: Write Version File
-        run: echo ${{ GITHUB_SHA }} > commit.txt
+        run: echo ${{ github.sha }} > commit.txt
       - name: Run PyInstaller
         run: python -m PyInstaller Clangen.spec
       - name: Create archive (.tar.xz)
@@ -94,7 +94,7 @@ jobs:
       - name: Install PyInstaller
         run: python -m pip install --upgrade PyInstaller
       - name: Write Version File
-        run: echo ${{ GITHUB_SHA }} > commit.txt
+        run: echo ${{ github.sha }} > commit.txt
       - name: Run PyInstaller
         #run: python -m PyInstaller -i resources/images/icon.png --name clangen --windowed --noupx --onedir --clean --add-data "sprites;sprites" --add-data "resources;resources" --add-data "README.md;." main.py
         run: python -m PyInstaller Clangen.spec
@@ -131,7 +131,7 @@ jobs:
       - name: Install PyInstaller
         run: python -m pip install --upgrade PyInstaller
       - name: Write Version File
-        run: echo ${{ GITHUB_SHA }} > commit.txt
+        run: echo ${{ github.sha }} > commit.txt
       # Example of an upx install, also requires adding "--upx-dir upx-4.0.0-win64" to the pyinst run
       #- name: Setup UPX 
       #  run: |
@@ -173,7 +173,7 @@ jobs:
       - name: Install PyInstaller
         run: python -m pip install --upgrade PyInstaller
       - name: Write Version File
-        run: echo ${{ GITHUB_SHA }} > commit.txt
+        run: echo ${{ github.sha }} > commit.txt
       # Example of an upx install, also requires adding "--upx-dir upx-4.0.0-win64" to the pyinst run
       #- name: Setup UPX 
       #  run: |
@@ -217,7 +217,7 @@ jobs:
       - name: Install PyInstaller
         run: python -m pip install --upgrade PyInstaller
       - name: Write Version File
-        run: echo ${{ GITHUB_SHA }} > commit.txt
+        run: echo ${{ github.sha }} > commit.txt
       - name: Run PyInstaller
         #run: python -m PyInstaller -i resources/images/icon.png --name clangen --windowed --onedir --clean --add-data sprites:sprites --add-data resources:resources --add-data README.md:. main.py
         run: python -m PyInstaller Clangen.spec

--- a/Clangen.spec
+++ b/Clangen.spec
@@ -7,7 +7,7 @@ a = Analysis(
     ['main.py'],
     pathex=[],
     binaries=[],
-    datas=[],
+    datas=[('commit.txt', '.')],
     hiddenimports=[],
     hookspath=[],
     hooksconfig={},
@@ -23,7 +23,6 @@ pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
 a.datas += Tree('./resources', prefix='resources')
 a.datas += Tree('./sprites', prefix='sprites')
 
-a.datas += [('commit.txt', '.')]
 
 exe = EXE(
     pyz,

--- a/Clangen.spec
+++ b/Clangen.spec
@@ -23,6 +23,8 @@ pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
 a.datas += Tree('./resources', prefix='resources')
 a.datas += Tree('./sprites', prefix='sprites')
 
+a.datas += ('commit.txt', '.')
+
 exe = EXE(
     pyz,
     a.scripts,

--- a/Clangen.spec
+++ b/Clangen.spec
@@ -23,7 +23,7 @@ pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
 a.datas += Tree('./resources', prefix='resources')
 a.datas += Tree('./sprites', prefix='sprites')
 
-a.datas += ('commit.txt', '.')
+a.datas += [('commit.txt', '.')]
 
 exe = EXE(
     pyz,


### PR DESCRIPTION
Adds a commit.txt file to pyinstaller builds containing the commit hash from the push that triggered it, eg: `42b3eed45eca0e738ed7bfe94cad3ab658017e9e`. This can be used to help debugging, as we can see the state of the code  as it is on the player's end