### PR TITLE
Bugfix: Variety of Patrol Related Bugs

### DIFF
--- a/resources/dicts/patrols/beach/med/any.json
+++ b/resources/dicts/patrols/beach/med/any.json
@@ -298,7 +298,7 @@
     "antagonize_fail_text": null
 },
 {
-"patrol_id": "gen_med_gatheringmoss1",
+"patrol_id": "bch_med_gatheringmoss1",
 "biome": "beach",
 "season": "Any",
 "tags": ["med_cat", "moss", "herb"],
@@ -315,7 +315,7 @@
 "min_cats": 1,
 "max_cats": 1,
 "win_skills": null,
-"win_trait": ["None"],
+"win_trait": null,
 "antagonize_text": null,
 "antagonize_fail_text": null
 },

--- a/resources/dicts/patrols/forest/hunting/greenleaf.json
+++ b/resources/dicts/patrols/forest/hunting/greenleaf.json
@@ -5,7 +5,6 @@
     "season": "greenleaf",
     "tags": [
         "hunting",
-        "small_prey",
         "heat_illness",
         "medium_prey0",
         "huge_prey1"

--- a/resources/dicts/patrols/forest/med/any.json
+++ b/resources/dicts/patrols/forest/med/any.json
@@ -294,7 +294,7 @@
     "antagonize_fail_text": null
 },
     {
-    "patrol_id": "gen_med_gatheringmoss1",
+    "patrol_id": "fst_med_gatheringmoss1",
     "biome": "forest",
     "season": "Any",
     "tags": ["med_cat", "moss", "herb"],
@@ -311,7 +311,7 @@
     "min_cats": 1,
     "max_cats": 1,
     "win_skills": null,
-    "win_trait": ["None"],
+    "win_trait": null,
     "antagonize_text": null,
     "antagonize_fail_text": null
     },

--- a/resources/dicts/patrols/mountainous/med/any.json
+++ b/resources/dicts/patrols/mountainous/med/any.json
@@ -499,7 +499,7 @@
     "antagonize_fail_text": null
 },
 {
-    "patrol_id": "gen_med_gatheringmoss1",
+    "patrol_id": "mtn_med_gatheringmoss1",
     "biome": "mountainous",
     "season": "Any",
     "tags": ["med_cat", "moss", "herb"],
@@ -519,7 +519,7 @@
     "antagonize_fail_text": null
 },
 {
-    "patrol_id": "gen_med_gatheringmoss2",
+    "patrol_id": "mtn_med_gatheringmoss2",
     "biome": "mountainous",
     "season": "Any",
     "tags": ["med_cat", "apprentice", "herb", "moss", "big_change", "platonic", "dislike"],
@@ -539,7 +539,7 @@
     "antagonize_fail_text": null
     },
     {
-    "patrol_id": "gen_med_gatheringmoss3",
+    "patrol_id": "mtn_med_gatheringmoss3",
     "biome": "mountainous",
     "season": "Any",
     "tags": ["med_cat", "warrior", "herb", "moss", "big_change", "platonic", "dislike"],
@@ -559,7 +559,7 @@
     "antagonize_fail_text": null
 },
 {
-    "patrol_id": "gen_med_gatheringmoss4",
+    "patrol_id": "mtn_med_gatheringmoss4",
     "biome": "mountainous",
     "season": "Any",
     "tags": ["med_cat", "warrior", "herb", "moss", "big_change", "platonic"],

--- a/resources/dicts/patrols/mountainous/med/greenleaf.json
+++ b/resources/dicts/patrols/mountainous/med/greenleaf.json
@@ -1192,7 +1192,7 @@
     "chance_of_success": 70,
     "exp": 10,
     "success_text": [
-            "The shade of the oak tree makes the ground beneath it cool, and bodes well for harvesting its leaves. The warriors flex their talents, and p_l encourages them as they show off their climbing skils, breaking off twigs to send the leaves down to p_l, the warriors eye a nearby elder tree and dare oneanother to race to the top.",
+            "The shade of the oak tree makes the ground beneath it cool, and bodes well for harvesting its leaves. The warriors flex their talents, and p_l encourages them as they show off their climbing skils, breaking off twigs to send the leaves down to p_l, the warriors eye a nearby elder tree and dare one another to race to the top.",
             "As a basic infection-preventing herb, oak leaves are useful for nearly all of the various scrapes, cuts, and injuries p_l sees in the medicine den, and they're always happy to bring a good crop of them back to the herb stores. Elder leaves work well alongside them, being great for easing the pains of a sprain and to p_l's excitement they come across a young elder tree. Their Clanmates are, as expected, a huge help carrying everything back home.",
             "s_c spots an oak tree that's valiantly trying to sprout leaves from a half-fallen branch, one of the casualties of last leaf-bare, and heads to harvest from that, taking the safe option of plucking leaves from the ground. There are also elder leaves lying about, so the patrol takes the opportunity to gather a decent collection. It's less entertaining for the warriors helping them, but the cats still make a nice easy afternoon of it."
     ],

--- a/resources/dicts/patrols/new_cat.json
+++ b/resources/dicts/patrols/new_cat.json
@@ -505,7 +505,7 @@
     ],
     "win_skills": ["good speaker", "great speaker", "excellent speaker"],
     "win_trait": null,
-    "fail_skills": ["None"],
+    "fail_skills": null,
     "fail_trait": null,
     "min_cats": 1,
     "max_cats": 6,

--- a/resources/dicts/patrols/new_cat_welcoming.json
+++ b/resources/dicts/patrols/new_cat_welcoming.json
@@ -151,7 +151,7 @@
     "success_text": [
             "Before p_l can move to check the bush, a loner emerges. The cat explains that they would like to join the Clan and after a short conversation with p_l, the loner joins the patrol on the journey back to camp.",
             "p_l pads towards the bush to check on the noise when a rabbit suddenly bursts out! None of the cats are quick enough to catch it, but at least the noise was nothing dangerous.",
-            "s_c takes the lead in checking the noise, and it's a good thing they did, because the moment they step closer to the bush a rogue comes springing out! s_c is quick to bat them away, hissing and spitting, before promptly chasing the rogue out of the territory. It was hardly a fight, really. ",
+            null,
             "s_c takes the lead in checking the noise and finds that the bush is hiding a loner and their litter! The kits are freshly born, new to the world, and s_c is quick to sit and talk quietly with the new parent. After some coaxing, s_c convinces them to come stay with the Clan for a while, maybe even to join permanently."
     ],
     "fail_text": [
@@ -372,7 +372,7 @@
     ],
     "win_skills": ["good speaker", "great speaker", "excellent speaker"],
     "win_trait": null,
-    "fail_skills": ["None"],
+    "fail_skills": null,
     "fail_trait": null,
     "min_cats": 1,
     "max_cats": 6,

--- a/resources/dicts/patrols/other_clan.json
+++ b/resources/dicts/patrols/other_clan.json
@@ -166,7 +166,7 @@
     "exp": 20,
     "success_text": [
     "They pad over to the border and hesitate only momentarily before crossing. They quickly gather some of the berries, making sure to leave plenty for o_c_n's medicine cat if they need some, too.",
-    "They pad to the border and pause for a heartbeat to scent the air. o_c_n's scent is very strong, but there's something else... o_c_n's medicine cat appears at that moment. They're walking towards the raspberriesies when they spot p_l and wave their tail in greeting. They invite p_l to gather some, as there's plenty. p_l gratefully accepts.",
+    "They pad to the border and pause for a heartbeat to scent the air. o_c_n's scent is very strong, but there's something else... o_c_n's medicine cat appears at that moment. They're walking towards the raspberries when they spot p_l and wave their tail in greeting. They invite p_l to gather some, as there's plenty. p_l gratefully accepts.",
     "p_l is about to step over the border when a hiss stops them in their tracks. A o_c_n warrior bounds into view, bristling. They quickly explain that they're the medicine cat and the warrior code allows them to cross the border and assure that they won't take many of the berries. The warrior looks torn, but agrees to this."
     ],
     "fail_text": [

--- a/resources/dicts/patrols/other_clan_hostile.json
+++ b/resources/dicts/patrols/other_clan_hostile.json
@@ -119,7 +119,7 @@
     "exp": 20,
     "success_text": [
         "They pad over to the border and hesitate only momentarily before crossing. They quickly gather some of the berries, making sure to leave plenty for o_c_n's medicine cat if they need some, too.",
-        "They pad to the border and pause for a heartbeat to scent the air. o_c_n's scent is very strong, but there's something else... o_c_n's medicine cat appears at that moment. They're walking towards the raspberriesies when they spot p_l and curl their lip. They snarl that they're not willing to share with an enemy Clan. p_l takes the hint and leaves.",
+        "They pad to the border and pause for a heartbeat to scent the air. o_c_n's scent is very strong, but there's something else... o_c_n's medicine cat appears at that moment. They're walking towards the raspberries when they spot p_l and curl their lip. They snarl that they're not willing to share with an enemy Clan. p_l takes the hint and leaves.",
         "p_l is about to step over the border when a hiss stops them in their tracks. A o_c_n warrior bounds into view, bristling with rage. They quickly explain that they're the medicine cat and the warrior code allows them to cross the border and assure that they only need a few berries for some sick Clanmates. The warrior looks torn, but agrees to this."
     ],
     "fail_text": [

--- a/resources/dicts/patrols/plains/med/any.json
+++ b/resources/dicts/patrols/plains/med/any.json
@@ -273,7 +273,7 @@
     "antagonize_fail_text": null
 },
 {
-    "patrol_id": "gen_med_gatheringmoss1",
+    "patrol_id": "pln_med_gatheringmoss1",
     "biome": "plains",
     "season": "Any",
     "tags": ["med_cat", "moss", "herb"],
@@ -290,7 +290,7 @@
     "min_cats": 1,
     "max_cats": 1,
     "win_skills": null,
-    "win_trait": ["None"],
+    "win_trait": null,
     "antagonize_text": null,
     "antagonize_fail_text": null
     },

--- a/resources/dicts/thoughts/alive/mediator_to_other.json
+++ b/resources/dicts/thoughts/alive/mediator_to_other.json
@@ -49,6 +49,6 @@
         "Is mediating a long time friendship between two Clanmates",
         "Is feeling frustrated after a failed negotiation",
         "Is feeling exhausted from resolving petty arguments",
-        "Wants to solve a dispute with another clan"
+        "Wants to solve a dispute with another Clan"
     ]
 }

--- a/scripts/patrol.py
+++ b/scripts/patrol.py
@@ -700,7 +700,7 @@ class Patrol():
             # first we check for a fail stat outcome
             if self.patrol_fail_stat_cat:
                 # safe, just failed
-                if unscathed:
+                if unscathed and len(fail_text) >= 2:
                     if fail_text[1]:
                         outcome = 1
                 # injured
@@ -757,6 +757,8 @@ class Patrol():
 
         if not antagonize and game.clan.game_mode != "classic":
             self.handle_prey(outcome)
+
+        print('Patrol Succeeded?', self.success, ', Outcome Index:', outcome)
 
     def results(self):
         text = "<br>".join(self.results_text)

--- a/scripts/patrol.py
+++ b/scripts/patrol.py
@@ -1496,7 +1496,6 @@ class Patrol():
             if not outcome_nr:
                 current_tag = prey_type + '0'
             prey_size = prey_type.split('_')[0]
-            print(current_tag)
             if current_tag in patrol.patrol_event.tags or prey_type in patrol.patrol_event.tags:
                 prey_amount_per_cat = amount
                 break
@@ -1517,9 +1516,7 @@ class Patrol():
 
         if game.clan.game_mode != "classic":
             game.clan.freshkill_pile.add_freshkill(total_amount)
-            print('added freshkill')
             if total_amount > 0:
-                print('test results')
                 self.results_text.append(f"Each cat catches a {prey_size} amount of prey.")
 
     def handle_clan_relations(self, difference, antagonize):

--- a/scripts/patrol.py
+++ b/scripts/patrol.py
@@ -571,7 +571,9 @@ class Patrol():
         elif game.clan.game_mode == "cruel season":
             gm_modifier = 3
 
-        # initially setting stat_cats
+        # resetting stat cats and then finding new stat cats
+        self.patrol_fail_stat_cat = None
+        self.patrol_win_stat_cat = None
         if self.patrol_event.win_skills:
             for cat in self.patrol_cats:
                 if "app_stat" in self.patrol_event.tags and cat.status not in ['apprentice', "medicine cat apprentice"]:

--- a/scripts/patrol.py
+++ b/scripts/patrol.py
@@ -628,20 +628,19 @@ class Patrol():
         if c < success_chance:
             self.success = True
             self.patrol_fail_stat_cat = None
-            # this adds the stat cat (if there is one)
+
+            # default is outcome 0
+            outcome = 0
             if self.patrol_win_stat_cat:
                 if self.patrol_win_stat_cat.trait in self.patrol_event.win_trait:
                     outcome = 3
                 elif self.patrol_win_stat_cat.skill in self.patrol_event.win_skills:
                     outcome = 2
             else:
-                if rare and len(success_text) >= 2 and success_text[1] is not None:
-                    outcome = 1
-                else:
-                    if success_text[0] is not None:
-                        outcome = 0
-                    else:
+                if rare and len(success_text) >= 2:
+                    if success_text[1]:
                         outcome = 1
+
             # this is specifically for new cat events that can come with kits
             litter_choice = False
             if self.patrol_event.tags is not None:
@@ -1467,7 +1466,7 @@ class Patrol():
             self.results_text.append(f"{insert.capitalize()} gathered during this patrol.")
 
     def handle_prey(self, outcome_nr):
-        """Handle the amount of prey which was caught and add it to the freshkill pile of the clan."""
+        """Handle the amount of prey which was caught and add it to the fresh-kill pile of the clan."""
         prey_types = {
             "small_prey": PREY_REQUIREMENT["warrior"],
             "medium_prey": PREY_REQUIREMENT["warrior"] * 2,
@@ -1492,7 +1491,10 @@ class Patrol():
         prey_size = None
         for prey_type, amount in prey_types.items():
             current_tag = prey_type + str(outcome_nr)
+            if not outcome_nr:
+                current_tag = prey_type + '0'
             prey_size = prey_type.split('_')[0]
+            print(current_tag)
             if current_tag in patrol.patrol_event.tags or prey_type in patrol.patrol_event.tags:
                 prey_amount_per_cat = amount
                 break
@@ -1513,7 +1515,9 @@ class Patrol():
 
         if game.clan.game_mode != "classic":
             game.clan.freshkill_pile.add_freshkill(total_amount)
+            print('added freshkill')
             if total_amount > 0:
+                print('test results')
                 self.results_text.append(f"Each cat catches a {prey_size} amount of prey.")
 
     def handle_clan_relations(self, difference, antagonize):

--- a/scripts/screens/patrol_screens.py
+++ b/scripts/screens/patrol_screens.py
@@ -392,6 +392,8 @@ class PatrolScreen(Screens):
         always set size to patrol_size
         """
         vowels = ['A', 'E', 'I', 'O', 'U']
+        if not text:
+            text = 'This should not appear, report as a bug please!'
         if size == 1:
             text = text.replace('Your patrol',
                                 str(patrol.patrol_leader_name))


### PR DESCRIPTION
- Fixed stat cats carrying over to new patrols, thus causing a cat who isn't in the patrol to appear in the patrol text anyways
- Fixed hunting patrols not showing results if the success outcome was 0
- Fixed a variety of patrol related crashes
- Added a print message to help bugfix patrols in the future.  Print message looks something like: 'Patrol Succeeded? True, Outcome: 3'  Beta Testers, please include this print in your patrol related bug reports just like you do the patrol ID prints.