### PR TITLE
Bugfix: Patrol Related

### DIFF
--- a/resources/dicts/patrols/other_clan.json
+++ b/resources/dicts/patrols/other_clan.json
@@ -65,7 +65,7 @@
     "patrol_id": "gen_bord_otherclan3",
     "biome": "Any",
     "season": "Any",
-    "tags": ["border", "other_clan", "hunting", "scar", "battle_injury", "small_prey"],
+    "tags": ["otherclan_nochangesuccess","border", "other_clan", "hunting", "scar", "battle_injury", "small_prey"],
     "intro_text": "r_c spies a fat rabbit on the other side of the o_c_n border. A tempting opportunity to be sure, but it may not be wise to hunt on a different Clan's territory.",
     "decline_text": "Your patrol decides that one rabbit isn't worth making an enemy.",
     "chance_of_success": 60,

--- a/scripts/patrol.py
+++ b/scripts/patrol.py
@@ -727,6 +727,11 @@ class Patrol():
                     if fail_text[2]:
                         outcome = 2
 
+            # if /still/ no outcome is picked then double check that an outcome 0 is available,
+            # if it isn't, then injure the cat instead
+            if not outcome and not fail_text[0]:
+                outcome = 3
+
             if outcome == 2:
                 self.handle_deaths(self.patrol_random_cat)
             elif outcome == 4:


### PR DESCRIPTION
- If no outcome 0 is available, then the injury outcome will be used.  This fixes some occurrences of 'This should not appear' patrol events.
- Fixed an incorrect other_clan relation change for patrol gen_bord_otherclan3