### PR TITLE
Fixed a bug where success would worsen relationships between clans

### DIFF
--- a/resources/dicts/patrols/other_clan_allies.json
+++ b/resources/dicts/patrols/other_clan_allies.json
@@ -65,7 +65,7 @@
     "patrol_id": "gen_bord_otherclan3",
     "biome": "Any",
     "season": "Any",
-    "tags": ["border", "other_clan", "hunting", "small_prey"],
+    "tags": ["otherclan_nochangesuccess","border", "other_clan", "hunting", "small_prey"],
     "intro_text": "r_c spies a fat rabbit on the other side of the o_c_n border. A tempting opportunity to be sure, but it may not be wise to hunt on their ally's territory.",
     "decline_text": "It's not worth ruining c_n's relationship with their ally.",
     "chance_of_success": 60,

--- a/resources/dicts/patrols/other_clan_hostile.json
+++ b/resources/dicts/patrols/other_clan_hostile.json
@@ -75,7 +75,7 @@
     "patrol_id": "gen_bord_otherclan3",
     "biome": "Any",
     "season": "Any",
-    "tags": ["border", "other_clan", "hunting", "scar", "battle_injury", "death", "small_prey"],
+    "tags": ["otherclan_nochangesuccess", "border", "other_clan", "hunting", "scar", "battle_injury", "death", "small_prey"],
     "intro_text": "r_c spies a fat rabbit on the other side of the o_c_n border. A tempting opportunity to be sure, but it may not be wise to hunt on an enemy's territory.",
     "decline_text": "Your patrol decides that one rabbit isn't worth the potential fight.",
     "chance_of_success": 60,


### PR DESCRIPTION
Added "otherclan_nochangesuccess" to all rabbit patrols with other clans.