### PR TITLE
Rollback pygame to 2.1.2 on MacOS

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-pygame==2.1.3
+pygame==2.1.3; platform_system != "Darwin"
+pygame==2.1.2; platform_system == "Darwin"
 ujson==5.7.0
 pygame_gui==0.6.8


### PR DESCRIPTION
Seems like font & freetype are broken on MacOS <12 with pygame 2.1.3

```
ImportError: dlopen(/Users/user/clanenv/lib/python3.10/site-packages/pygame/_freetype.cpython-310-darwin.so, 2): Library not loaded: @loader_path/libfreetype.6.dylib
  Referenced from: /Users/user/clanenv/lib/python3.10/site-packages/pygame/.dylibs/libfreetype.6.dylib
  Reason: image not found
```