### PR TITLE
Tweaks: Deputy Choice, Wording

### DIFF
--- a/scripts/events.py
+++ b/scripts/events.py
@@ -106,7 +106,8 @@ class Events():
                             text = f'Rumors reach your Clan that the exiled {str(cat.name)} has died recently.'
                         else:
                             cat.outside = False
-                            text = f"Will they reach StarClan, even so far away? {str(cat.name)} isn't sure, but as they drift away, they hope to see familiar starry fur on the other side."
+                            text = f"Will they reach StarClan, even so far away? {str(cat.name)} isn't sure, " \
+                                   f"but as they drift away, they hope to see familiar starry fur on the other side."
                         game.cur_events_list.append(Single_Event(text, "birth_death", cat.ID))
 
                 if cat.exiled and cat.status == 'leader' and not cat.dead and random.randint(
@@ -431,8 +432,8 @@ class Events():
                     chosen_ally.relations += 5
                 else:
                     possible_events = [
-                        f"The {chosen_ally.name}Clan medicine cat comes asking if your Clan has any {str(herb_given).replace('_', ' ')} to spare, "
-                        f"your Clan only has enough for themselves however and they refuse to share.",
+                        f"The {chosen_ally.name}Clan medicine cat comes asking if your Clan has any {str(herb_given).replace('_', ' ')} to spare. "
+                        f"However, your Clan only has enough for themselves and they refuse to share.",
                         f"The medicine cat apprentice from {chosen_ally.name}Clan comes asking for herbs. They refuse to "
                         f"say why their Clan needs them and your Clan decides not to share their precious few {str(herb_given).replace('_', ' ')}."
                     ]
@@ -1676,30 +1677,21 @@ class Events():
     def check_and_promote_deputy(self):
         """Checks if a new deputy needs to be appointed, and appointed them if needed. """
         if (not game.clan.deputy
-            or game.clan.deputy.dead
-            or game.clan.deputy.outside
-            or game.clan.deputy.retired):
-            if game.settings.get('deputy') is True:
-                random_count = 0
-                while random_count < 30:
-                    random_cat = str(random.choice(list(Cat.all_cats.keys())))
+                or game.clan.deputy.dead
+                or game.clan.deputy.outside
+                or game.clan.deputy.retired):
+            if game.settings.get('deputy'):
 
-                    if Cat.all_cats[random_cat].dead or Cat.all_cats[random_cat].outside:
-                        random_count += 1
-                        continue
-                    if Cat.all_cats[random_cat].status != 'warrior':
-                        random_count += 1
-                        continue
-                    if (len(Cat.all_cats[random_cat].former_apprentices) == 0
-                        and len(Cat.all_cats[random_cat].apprentice) == 0):
-                        random_count += 1
-                        continue
+                # This determines all the cats who are eligible to be deputy.
+                possible_deputies = list(filter(lambda x: not x.dead and not x.outside and x.status == "warrior" and
+                                                          (x.apprentice or x.former_apprentices), Cat.all_cats_list))
 
-                    Cat.all_cats[random_cat].status_change('deputy')
-                    involved_cats = [random_cat]
-                    text = ''
+                # If there are possible deputies, choose from that list.
+                if possible_deputies:
+                    random_cat = random.choice(possible_deputies)
+                    involved_cats = [random_cat.ID]
 
-                    # Gather deputy and leader status
+                    # Gather deputy and leader status, for determination of the text.
                     if game.clan.leader:
                         if game.clan.leader.dead or game.clan.leader.outside:
                             leader_status = "not_here"
@@ -1718,8 +1710,8 @@ class Events():
 
                     if leader_status == "here" and deputy_status == "not_here":
 
-                        if Cat.all_cats[random_cat].trait == 'bloodthirsty':
-                            text = f"{Cat.all_cats[random_cat].name} has been chosen as the new deputy. " \
+                        if random_cat.trait == 'bloodthirsty':
+                            text = f"{random_cat.name} has been chosen as the new deputy. " \
                                    f"They look at the Clan leader with an odd glint in their eyes."
                             # No additional involved cats
                         else:
@@ -1727,57 +1719,67 @@ class Events():
                                 previous_deputy_mention = random.choice(
                                     [f"They know that {game.clan.deputy.name} would approve.",
                                      f"They hope that {game.clan.deputy.name} would approve.",
-                                     f"They don't know if {game.clan.deputy.name} would approve, " \
+                                     f"They don't know if {game.clan.deputy.name} would approve, "
                                      f"but life must go on. "])
                                 involved_cats.append(game.clan.deputy.ID)
 
                             else:
                                 previous_deputy_mention = ""
 
-                            text = f"{game.clan.leader.name} chooses {Cat.all_cats[random_cat].name} to take over " \
+                            text = f"{game.clan.leader.name} chooses {random_cat.name} to take over " \
                                    f"as deputy. " + previous_deputy_mention
 
                             involved_cats.append(game.clan.leader.ID)
                     elif leader_status == "not_here" and deputy_status == "here":
                         text = f"The clan is without a leader, but a new deputy must still be named.  " \
-                               f"{Cat.all_cats[random_cat].name} is chosen as the new deputy. " \
+                               f"{random_cat.name} is chosen as the new deputy. " \
                                f"The retired deputy nods their approval."
                     elif leader_status == "not_here" and deputy_status == "not_here":
                         text = f"Without a leader or deputy, the Clan has been directionless. " \
-                               f"They all turn to {Cat.all_cats[random_cat].name} with hope for the future."
+                               f"They all turn to {random_cat.name} with hope for the future."
                     elif leader_status == "here" and deputy_status == "here":
                         possible_events = [
-                            f"{Cat.all_cats[random_cat].name} has been chosen as the new deputy. "
+                            f"{random_cat.name} has been chosen as the new deputy. "
                             f"The Clan yowls their name in approval.",
-                            f"{Cat.all_cats[random_cat].name} has been chosen as the new deputy. "
+                            f"{random_cat.name} has been chosen as the new deputy. "
                             f"Some of the older Clan members question the wisdom in this choice.",
-                            f"{Cat.all_cats[random_cat].name} has been chosen as the new deputy. "
+                            f"{random_cat.name} has been chosen as the new deputy. "
                             f"They hold their head up high and promise to do their best for the Clan.",
                             f"{game.clan.leader.name} has been thinking deeply all day who they would "
                             f"respect and trust enough to stand at their side, and at sunhigh makes the "
-                            f"announcement that {Cat.all_cats[random_cat].name} will be the Clan's new deputy.",
-                            f"{Cat.all_cats[random_cat].name} has been chosen as the new deputy. They pray to "
+                            f"announcement that {random_cat.name} will be the Clan's new deputy.",
+                            f"{random_cat.name} has been chosen as the new deputy. They pray to "
                             f"StarClan that they are the right choice for the Clan.",
-                            f"{Cat.all_cats[random_cat].name} has been chosen as the new deputy. Although"
+                            f"{random_cat.name} has been chosen as the new deputy. Although"
                             f"they are nervous, they put on a brave front and look forward to serving"
                             f"the clan.",
                         ]
                         # No additional involved cats
                         text = random.choice(possible_events)
                     else:
-                        # This should never happen. Failsave.
-                        text = f"{Cat.all_cats[random_cat].name} becomes deputy. "
+                        # This should never happen. Failsafe.
+                        text = f"{random_cat.name} becomes deputy. "
+                else:
+                    # If there are no possible deputies, choose someone else, with special text.
+                    all_warriors = list(filter(lambda x: not x.dead and not x.outside and x.status == "warrior",
+                                               Cat.all_cats_list))
+                    if all_warriors:
+                        random_cat = random.choice(all_warriors)
+                        involved_cats = [random_cat.ID]
+                        text = f"No cat in is truly fit to be deputy, but the position can't remain vacant. " \
+                               f"{random_cat.name} is appointed as the new deputy. "
 
-                    game.clan.deputy = Cat.all_cats[random_cat]
-                    game.ranks_changed_timeskip = True
+                    else:
+                        # Is there are no warriors at all, no one is named deputy.
+                        game.cur_events_list.append(Single_Event("There are no cats fit to become deputy. ",
+                                                                 "ceremony"))
+                        return
 
-                    game.cur_events_list.append(Single_Event(text, "ceremony", involved_cats))
-                    break
+                game.clan.deputy = random_cat
+                game.ranks_changed_timeskip = True
 
-                if random_count >= 30:
-                    text = 'The Clan decides that no cat is fit to be deputy.'
-                    game.cur_events_list.append(Single_Event(text, "ceremony"))
-                    # game.ceremony_events_list.append(text)
+                game.cur_events_list.append(Single_Event(text, "ceremony", involved_cats))
+
             else:
                 game.cur_events_list.insert(0, Single_Event(f"{game.clan.name}Clan has no deputy!"))
 


### PR DESCRIPTION
- Fixed some awkward wording in an herb event. 
- Updated the deputy chance so that it no longer uses a "shotgun" approach.  If there is a possible deputy, they will be appointed. 
- If there are no warriors that have trained apprentices in the clan, a random warrior will be selected to be deputy. A special event text will be displayed for this situation. 
- Although not implemented, this method will allow weighting of deputy choices. 