### PR TITLE
Bugfixes: Ceremonies and Typos

### DIFF
--- a/resources/dicts/events/ceremonies/ceremony-master.json
+++ b/resources/dicts/events/ceremonies/ceremony-master.json
@@ -1237,7 +1237,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "(prefix)paw still can't believe that their mentor is gone. They don't feel ready to heal the Clan, and so politely decline being given a name yet. However, as they visit StarClan that half moon, (deadmentor) appears to them in a dream. They assure (prefix)paw that they'll be alright without them, and that they are ready for their full name. Resting their muzzle on (prefix)paw's head, (mentor) names them m_c."
+    "(prefix)paw still can't believe that their mentor is gone. They don't feel ready to heal the Clan, and so politely decline being given a name yet. However, as they visit StarClan that half moon, (deadmentor) appears to them in a dream. They assure (prefix)paw that they'll be alright without them, and that they are ready for their full name. Resting their muzzle on (prefix)paw's head, (deadmentor) names them m_c."
   ],
   "med_3": [
     [
@@ -1308,7 +1308,7 @@
   "med_9": [
     [
       "medicine cat",
-      "no_previous_mentor",
+      "no_valid_previous_mentor",
       "general_parents",
       "general_leader",
       "general_backstory",
@@ -1319,7 +1319,7 @@
   "med_10": [
     [
       "medicine cat",
-      "no_previous_mentor",
+      "no_valid_previous_mentor",
       "general_parents",
       "general_leader",
       "general_backstory",
@@ -1743,7 +1743,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "(prefix)paw almost sobs as they spot dead_par1 and dead_par2 step out of the crowd towards them to congratulate them on completing their training. dead_par2 rests their muzzle on (prefix)paw's head, naming them m_c, and welcoming them as a full medicine cat."
+    "(prefix)paw almost sobs as they spot dead_par1 and dead_par2 step out of the starry crowd to congratulate them on completing their training. dead_par2 rests their muzzle on (prefix)paw's head, naming them m_c, and welcoming them as a full medicine cat."
   ],
   "med_50": [
     [

--- a/resources/dicts/events/ceremonies/ceremony-master.json
+++ b/resources/dicts/events/ceremonies/ceremony-master.json
@@ -1308,7 +1308,7 @@
   "med_9": [
     [
       "medicine cat",
-      "no_mentor",
+      "no_previous_mentor",
       "general_parents",
       "general_leader",
       "general_backstory",
@@ -1319,7 +1319,7 @@
   "med_10": [
     [
       "medicine cat",
-      "no_mentor",
+      "no_previous_mentor",
       "general_parents",
       "general_leader",
       "general_backstory",

--- a/resources/dicts/patrols/beach/hunting/any.json
+++ b/resources/dicts/patrols/beach/hunting/any.json
@@ -2108,7 +2108,7 @@
         "success_text": [
             "p_l leads the patrol to the end of the scent trail, where a red fox sits plucking the feathers off a plump seagull. With careful signals, the cats set up an ambush. There aren't many of them, but the fox doesn't need to know that - with a massive explosion of yowls, the cats sound like a full battle patrol, and the fox leaps up frightened out of its skin as the cats pounce to take possession of the bird.",
             null,
-            "They're a small patrol, but a skilled one, and when they track down the red fox at the end of the scent trail they have enough skill and muscle to drive it off from the fish it was gnawing on. The cats gather around it, congraduating each other.",
+            "They're a small patrol, but a skilled one, and when they track down the red fox at the end of the scent trail they have enough skill and muscle to drive it off from the fish it was gnawing on. The cats gather around it, congratulating each other.",
             "Tracking the fox trail, s_c reminds the rest of the patrol that things don't always need to end in a fight, using the trail to uncover a food cache of dead fish buried in a dune. They still don't know what kind of fox left the trail, and they don't need to - these fish will make great additions to the fresh-kill pile back home."
         ],
         "fail_text": [
@@ -2186,7 +2186,7 @@
         "success_text": [
             "p_l leads the patrol to the end of the scent trail, where a red fox sits plucking the feathers off a plump seagull. With careful signals, the cats set up an ambush. While they'd expected having more cats would make it easier, it also makes the patrol far more of a threat to the red fox, and the creature panicks when they reveal themselves. They win the bird, but r_c nearly gets injured, and it's only p_l shoving them both out of the way that saves both their pelts.",
             null,
-            "With such a big patrol, and with s_c there, when they track down the red fox at the end of the scent trail they have more than enough skill and muscle to drive it off from the fish it was gnawing on. The cats gather around it, congraduating each other.",
+            "With such a big patrol, and with s_c there, when they track down the red fox at the end of the scent trail they have more than enough skill and muscle to drive it off from the fish it was gnawing on. The cats gather around it, congratulating each other.",
             "Tracking the fox trail, s_c reminds the rest of the patrol that things don't always need to end in a fight, using the trail to uncover a food cache of dead fish buried in a dune. They still don't know what kind of fox left the trail, and they don't need to - these fish will make great additions to the fresh-kill pile back home."
         ],
         "fail_text": [
@@ -2340,7 +2340,7 @@
             "It's a gray fox, which as far as the cats are concerned, means free food. They leap after it, and after a short chase the fox drops the mouse it was holding. That's not enough to satisfy the c_n cats, who drive it out of their territory before collecting the mouse and continuing the afternoon's hunt.",
             "The scent trail leads to where some kind of fox has cached half a fish in a poorly concealed hole. The cats take it as their due, and leave the fox to wander on.",
             "The trail leads to a gray fox, and s_c makes sure it both hands over the prey it's poached from c_n land and flees for the border, tail between its legs and yelping. The smaller predator can't stand up to a patrol working together.",
-            "The cats slowly follow the trail, with s_c urging caution. There's no reason to rush into things. Sure enough, they find a grey fox. It's digging at a rotten log, unearthing insects. The patrol uses the presence of the other predator as a distraction to bring down a pump bird, one that was too busy watching the fox to guard from them, and the fox is left unscathed to keep bug hunting."
+            "The cats slowly follow the trail, with s_c urging caution. There's no reason to rush into things. Sure enough, they find a grey fox. It's digging at a rotten log, unearthing insects. The patrol uses the presence of the other predator as a distraction to bring down a plump bird, one that was too busy watching the fox to guard from them, and the fox is left unscathed to keep bug hunting."
         ],
         "fail_text": [
             "The fox's trail vanishes, almost as though the creature has figured out they're tracking it. Grumbling and arguing, the patrol has to head back home disappointed.",
@@ -2417,7 +2417,7 @@
             "It's a gray fox, which as far as the cats are concerned, means free food. They leap after it, and after a short chase the fox drops the mouse it was holding. That's not enough to satisfy the c_n cats, who drive it out of their territory before collecting the mouse and continuing the afternoon's hunt.",
             "The scent trail leads to where some kind of fox has cached a wood rat in a poorly concealed hole. The cats take it as their due, and leave the fox to wander on.",
             "The trail leads to a gray fox, and s_c makes sure it both hands over the prey it's poached from c_n land and flees for the border, tail between its legs and yelping. The smaller predator can't stand up to a patrol working together.",
-            "The cats slowly follow the trail, with s_c urging caution. There's no reason to rush into things. Sure enough, they find a grey fox. It's digging at a rotten log, unearthing insects. The patrol uses the presence of the other predator as a distraction to bring down a pump bird, one that was too busy watching the fox to guard from them, and the fox is left unscathed to keep bug hunting."
+            "The cats slowly follow the trail, with s_c urging caution. There's no reason to rush into things. Sure enough, they find a grey fox. It's digging at a rotten log, unearthing insects. The patrol uses the presence of the other predator as a distraction to bring down a plump bird, one that was too busy watching the fox to guard from them, and the fox is left unscathed to keep bug hunting."
         ],
         "fail_text": [
             "The fox's trail vanishes, almost as though the creature has figured out they're tracking it. Grumbling and arguing, the patrol has to head back home disappointed.",

--- a/resources/dicts/patrols/count_patrols.py
+++ b/resources/dicts/patrols/count_patrols.py
@@ -1,5 +1,6 @@
 import ujson
 import collections
+import os
 
 """ This script exists to count and catalogue all patrols.   """
 
@@ -12,6 +13,14 @@ def get_patrol_details(path):
 
     with open(path, "r") as read_file:
         patrols = ujson.loads(read_file.read())
+
+    if not patrols:
+        return
+
+    if type(patrols[0]) != dict:
+        print(path, "is not in the correct patrol format. It may not be a patrol .json.")
+        return
+
 
     for p_ in patrols:
         ALL_PATROLS.append(p_["patrol_id"])
@@ -42,9 +51,17 @@ def get_patrol_details(path):
             DETAILS["MIN_" + str(p_["min_cats"])] = {p_["patrol_id"]}
 
 
-paths = ["disaster.json", "new_cat.json", "other_clan.json"]
+root_dir = "../patrols"
+file_set = set()
 
-for pa in paths:
+for dir_, _, files in os.walk(root_dir):
+    for file_name in files:
+        rel_dir = os.path.relpath(dir_, root_dir)
+        rel_file = os.path.join(rel_dir, file_name)
+        if os.path.splitext(rel_file)[-1].lower() == ".json":
+            file_set.add(rel_file)
+
+for pa in file_set:
     get_patrol_details(pa)
 
 # Now that we have everything gathered, lets do some checks.

--- a/resources/dicts/patrols/wetlands/hunting/hunting_wetlands.json
+++ b/resources/dicts/patrols/wetlands/hunting/hunting_wetlands.json
@@ -3301,7 +3301,7 @@
         "success_text": [
             "p_l leads the patrol to the end of the scent trail, where a red fox sits plucking the feathers off a plump duck. With careful signals, the cats set up an ambush. There aren't many of them, but the fox doesn't need to know that - with a massive explosion of yowls, the cats sound like a full battle patrol, and the fox leaps up frightened out of its skin as the cats pounce to take possession of the bird.",
             null,
-            "They're a small patrol, but a skilled one, and when they track down the red fox at the end of the scent trail they have enough skill and muscle to drive it off from the fish it was gnawing on. The cats gather around it, congraduating each other.",
+            "They're a small patrol, but a skilled one, and when they track down the red fox at the end of the scent trail they have enough skill and muscle to drive it off from the fish it was gnawing on. The cats gather around it, congratulating each other.",
             "Tracking the fox trail, s_c reminds the rest of the patrol that things don't always need to end in a fight, using the trail to uncover a food cache of dead fish buried under a log. They still don't know what kind of fox left the trail, and they don't need to - these fish will make great additions to the fresh-kill pile back home."
         ],
         "fail_text": [
@@ -3379,7 +3379,7 @@
         "success_text": [
             "p_l leads the patrol to the end of the scent trail, where a red fox sits plucking the feathers off a plump duck. With careful signals, the cats set up an ambush. While they'd expected having more cats would make it easier, it also makes the patrol far more of a threat to the red fox, and the creature panicks when they reveal themselves. They win the bird, but r_c nearly gets injured, and it's only p_l shoving them both out of the way that saves both their pelts.",
             null,
-            "With such a big patrol, and with s_c there, when they track down the red fox at the end of the scent trail they have more than enough skill and muscle to drive it off from the fish it was gnawing on. The cats gather around it, congraduating each other.",
+            "With such a big patrol, and with s_c there, when they track down the red fox at the end of the scent trail they have more than enough skill and muscle to drive it off from the fish it was gnawing on. The cats gather around it, congratulating each other.",
             "Tracking the fox trail, s_c reminds the rest of the patrol that things don't always need to end in a fight, using the trail to uncover a food cache of dead fish buried under a log. They still don't know what kind of fox left the trail, and they don't need to - these fish will make great additions to the fresh-kill pile back home."
         ],
         "fail_text": [
@@ -3533,7 +3533,7 @@
             "Its a gray fox, which as far as the cats are concerned, means free food. They leap after it, and after a short chase the fox drops the mouse it was holding. That's not enough to satisfy the c_n cats, who drive it out of their territory before collecting the mouse and continuing the afternoon's hunt.",
             "The scent trail leads to where some kind of fox has cached half a fish in a poorly concealed hole. The cats take it as their due, and leave the fox to wander on.",
             "The trail leads to a gray fox, and s_c makes sure it both hands over the prey it's poached from c_n land and flees for the border, tail between its legs and yelping. The smaller predator can't stand up to a patrol working together.",
-            "The cats slowly follow the trail, with s_c urging caution. There's no reason to rush into things. Sure enough, they find a grey fox. It's digging at a rotten log, unearthing insects. The patrol uses the presence of the other predator as a distraction to bring down a pump bird, one that was too busy watching the fox to guard from them, and the fox is left unscathed to keep bug hunting."
+            "The cats slowly follow the trail, with s_c urging caution. There's no reason to rush into things. Sure enough, they find a grey fox. It's digging at a rotten log, unearthing insects. The patrol uses the presence of the other predator as a distraction to bring down a plump bird, one that was too busy watching the fox to guard from them, and the fox is left unscathed to keep bug hunting."
         ],
         "fail_text": [
             "The fox's trail vanishes, almost as though the creature has figured out they're tracking it. Grumbling and arguing, the patrol has to head back home disappointed.",
@@ -3610,7 +3610,7 @@
             "Its a gray fox, which as far as the cats are concerned, means free food. They leap after it, and after a short chase the fox drops the mouse it was holding. That's not enough to satisfy the c_n cats, who drive it out of their territory before collecting the mouse and continuing the afternoon's hunt.",
             "The scent trail leads to where some kind of fox has cached a wood rat in a poorly concealed hole. The cats take it as their due, and leave the fox to wander on.",
             "The trail leads to a gray fox, and s_c makes sure it both hands over the prey it's poached from c_n land and flees for the border, tail between its legs and yelping. The smaller predator can't stand up to a patrol working together.",
-            "The cats slowly follow the trail, with s_c urging caution. There's no reason to rush into things. Sure enough, they find a grey fox. It's digging at a rotten log, unearthing insects. The patrol uses the presence of the other predator as a distraction to bring down a pump bird, one that was too busy watching the fox to guard from them, and the fox is left unscathed to keep bug hunting."
+            "The cats slowly follow the trail, with s_c urging caution. There's no reason to rush into things. Sure enough, they find a grey fox. It's digging at a rotten log, unearthing insects. The patrol uses the presence of the other predator as a distraction to bring down a plump bird, one that was too busy watching the fox to guard from them, and the fox is left unscathed to keep bug hunting."
         ],
         "fail_text": [
             "The fox's trail vanishes, almost as though the creature has figured out they're tracking it. Grumbling and arguing, the patrol has to head back home disappointed.",
@@ -5900,7 +5900,7 @@
         "success_text": [
             "p_l leads the patrol to the end of the scent trail, where a red fox sits plucking the feathers off a plump duck. With careful signals, the cats set up an ambush. There aren't many of them, but the fox doesn't need to know that - with a massive explosion of yowls, the cats sound like a full battle patrol, and the fox leaps up frightened out of its skin as the cats pounce to take possession of the bird.",
             null,
-            "They're a small patrol, but a skilled one, and when they track down the red fox at the end of the scent trail they have enough skill and muscle to drive it off from the fish it was gnawing on. The cats gather around it, congraduating each other.",
+            "They're a small patrol, but a skilled one, and when they track down the red fox at the end of the scent trail they have enough skill and muscle to drive it off from the fish it was gnawing on. The cats gather around it, congratulating each other.",
             "Tracking the fox trail, s_c reminds the rest of the patrol that things don't always need to end in a fight, using the trail to uncover a food cache of dead fish buried under a log. They still don't know what kind of fox left the trail, and they don't need to - these fish will make great additions to the fresh-kill pile back home."
         ],
         "fail_text": [
@@ -5978,7 +5978,7 @@
         "success_text": [
             "p_l leads the patrol to the end of the scent trail, where a red fox sits plucking the feathers off a plump duck. With careful signals, the cats set up an ambush. While they'd expected having more cats would make it easier, it also makes the patrol far more of a threat to the red fox, and the creature panicks when they reveal themselves. They win the bird, but r_c nearly gets injured, and it's only p_l shoving them both out of the way that saves both their pelts.",
             null,
-            "With such a big patrol, and with s_c there, when they track down the red fox at the end of the scent trail they have more than enough skill and muscle to drive it off from the fish it was gnawing on. The cats gather around it, congraduating each other.",
+            "With such a big patrol, and with s_c there, when they track down the red fox at the end of the scent trail they have more than enough skill and muscle to drive it off from the fish it was gnawing on. The cats gather around it, congratulating each other.",
             "Tracking the fox trail, s_c reminds the rest of the patrol that things don't always need to end in a fight, using the trail to uncover a food cache of dead fish buried under a log. They still don't know what kind of fox left the trail, and they don't need to - these fish will make great additions to the fresh-kill pile back home."
         ],
         "fail_text": [
@@ -6133,7 +6133,7 @@
             "Its a gray fox, which as far as the cats are concerned, means free food. They leap after it, and after a short chase the fox drops the mouse it was holding. That's not enough to satisfy the c_n cats, who drive it out of their territory before collecting the mouse and continuing the afternoon's hunt.",
             "The scent trail leads to where some kind of fox has cached half a fish in a poorly concealed hole. The cats take it as their due, and leave the fox to wander on.",
             "The trail leads to a gray fox, and s_c makes sure it both hands over the prey it's poached from c_n land and flees for the border, tail between its legs and yelping. The smaller predator can't stand up to a patrol working together.",
-            "The cats slowly follow the trail, with s_c urging caution. There's no reason to rush into things. Sure enough, they find a grey fox. It's digging at a rotten log, unearthing insects. The patrol uses the presence of the other predator as a distraction to bring down a pump bird, one that was too busy watching the fox to guard from them, and the fox is left unscathed to keep bug hunting."
+            "The cats slowly follow the trail, with s_c urging caution. There's no reason to rush into things. Sure enough, they find a grey fox. It's digging at a rotten log, unearthing insects. The patrol uses the presence of the other predator as a distraction to bring down a plump bird, one that was too busy watching the fox to guard from them, and the fox is left unscathed to keep bug hunting."
         ],
         "fail_text": [
             "The fox's trail vanishes, almost as though the creature has figured out they're tracking it. Grumbling and arguing, the patrol has to head back home disappointed.",
@@ -6210,7 +6210,7 @@
             "Its a gray fox, which as far as the cats are concerned, means free food. They leap after it, and after a short chase the fox drops the mouse it was holding. That's not enough to satisfy the c_n cats, who drive it out of their territory before collecting the mouse and continuing the afternoon's hunt.",
             "The scent trail leads to where some kind of fox has cached a wood rat in a poorly concealed hole. The cats take it as their due, and leave the fox to wander on.",
             "The trail leads to a gray fox, and s_c makes sure it both hands over the prey it's poached from c_n land and flees for the border, tail between its legs and yelping. The smaller predator can't stand up to a patrol working together.",
-            "The cats slowly follow the trail, with s_c urging caution. There's no reason to rush into things. Sure enough, they find a grey fox. It's digging at a rotten log, unearthing insects. The patrol uses the presence of the other predator as a distraction to bring down a pump bird, one that was too busy watching the fox to guard from them, and the fox is left unscathed to keep bug hunting."
+            "The cats slowly follow the trail, with s_c urging caution. There's no reason to rush into things. Sure enough, they find a grey fox. It's digging at a rotten log, unearthing insects. The patrol uses the presence of the other predator as a distraction to bring down a plump bird, one that was too busy watching the fox to guard from them, and the fox is left unscathed to keep bug hunting."
         ],
         "fail_text": [
             "The fox's trail vanishes, almost as though the creature has figured out they're tracking it. Grumbling and arguing, the patrol has to head back home disappointed.",

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -870,22 +870,25 @@ class Events():
             else:
                 tags.append("no_mentor")
 
-            # Dead mentor
-            for c in reversed(cat.former_mentor):
-                if Cat.fetch_cat(c) and Cat.fetch_cat(c).dead:
-                    tags.append("dead_mentor")
-                    dead_mentor = Cat.fetch_cat(c)
-                    break
+            if cat.former_mentor:
+                # Dead mentor
+                for c in reversed(cat.former_mentor):
+                    if Cat.fetch_cat(c) and Cat.fetch_cat(c).dead:
+                        tags.append("dead_mentor")
+                        dead_mentor = Cat.fetch_cat(c)
+                        break
 
-            # Living Former mentors who are also the leader do not count.
-            for c in reversed(cat.former_mentor):
-                if Cat.fetch_cat(c) and not Cat.fetch_cat(c).dead and not Cat.fetch_cat(c).outside:
-                    if Cat.fetch_cat(c).status == "leader":
-                        tags.append("alive_leader_mentor")
-                    else:
-                        tags.append("alive_mentor")
-                    previous_alive_mentor = Cat.fetch_cat(c)
-                    break
+                # Living Former mentors.
+                for c in reversed(cat.former_mentor):
+                    if Cat.fetch_cat(c) and not Cat.fetch_cat(c).dead and not Cat.fetch_cat(c).outside:
+                        if Cat.fetch_cat(c).status == "leader":
+                            tags.append("alive_leader_mentor")
+                        else:
+                            tags.append("alive_mentor")
+                        previous_alive_mentor = Cat.fetch_cat(c)
+                        break
+            else:
+                tags.append("no_previous_mentor")
 
             # Now we add the mentor stuff:
             temp = possible_ceremonies.intersection(self.ceremony_id_by_tag["general_mentor"])

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -854,6 +854,12 @@ class Events():
         previous_alive_mentor = None
         dead_parents = []
         living_parents = []
+        mentor_type = {
+            "medicine cat": ["medicine cat"],
+            "warrior": ["warrior", "deputy", "leader", "elder"],
+            "mediator": ["mediator"]
+        }
+
         try:
             # Get all the ceremonies for the role ----------------------------------------
             possible_ceremonies.update(self.ceremony_id_by_tag[promoted_to])
@@ -861,6 +867,7 @@ class Events():
             # Gather ones for mentor. -----------------------------------------------------
             tags = []
 
+            # CURRENT MENTOR TAG CHECK
             if cat.mentor:
                 if Cat.fetch_cat(cat.mentor).status == "leader":
                     tags.append("yes_leader_mentor")
@@ -870,25 +877,34 @@ class Events():
             else:
                 tags.append("no_mentor")
 
-            if cat.former_mentor:
-                # Dead mentor
-                for c in reversed(cat.former_mentor):
-                    if Cat.fetch_cat(c) and Cat.fetch_cat(c).dead:
-                        tags.append("dead_mentor")
-                        dead_mentor = Cat.fetch_cat(c)
-                        break
+            for c in reversed(cat.former_mentor):
+                if Cat.fetch_cat(c) and Cat.fetch_cat(c).dead:
+                    tags.append("dead_mentor")
+                    dead_mentor = Cat.fetch_cat(c)
+                    break
 
-                # Living Former mentors.
-                for c in reversed(cat.former_mentor):
-                    if Cat.fetch_cat(c) and not Cat.fetch_cat(c).dead and not Cat.fetch_cat(c).outside:
-                        if Cat.fetch_cat(c).status == "leader":
-                            tags.append("alive_leader_mentor")
-                        else:
-                            tags.append("alive_mentor")
-                        previous_alive_mentor = Cat.fetch_cat(c)
-                        break
+            # Unlike dead mentors, living mentors must be VALID - they must have the correct status for the role the cat
+            # is being promoted too.
+            valid_living_former_mentors = []
+            for c in cat.former_mentor:
+                if not(Cat.fetch_cat(c).dead or Cat.fetch_cat(c).outside):
+                    if promoted_to in mentor_type:
+                        if Cat.fetch_cat(c).status in mentor_type[promoted_to]:
+                            valid_living_former_mentors.append(c)
+                    else:
+                        valid_living_former_mentors.append(c)
+
+            # ALL FORMER MENTOR TAG CHECKS
+            if valid_living_former_mentors:
+                #  Living Former mentors. Grab the latest living valid mentor.
+                previous_alive_mentor = Cat.fetch_cat(valid_living_former_mentors[-1])
+                if previous_alive_mentor.status == "leader":
+                    tags.append("alive_leader_mentor")
+                else:
+                    tags.append("alive_mentor")
             else:
-                tags.append("no_previous_mentor")
+                # This tag means the cat has no living, valid mentors.
+                tags.append("no_valid_previous_mentor")
 
             # Now we add the mentor stuff:
             temp = possible_ceremonies.intersection(self.ceremony_id_by_tag["general_mentor"])


### PR DESCRIPTION
- When determining if a cat has a living mentor for the purpose of a ceremony, only cats with valid statuses will be consisted. This will prevent an edge-case when a previous warrior mentor would give a medicine cat their name. 
- Added a tag "no_valid_previous_mentor", to be used when none of a cats previous mentors are alive or have the correct status. 
- Typos
- Edited a dead parent ceremony to make it more clear the parents are dead. 
- Updated count_patrols.py to grab all patrol jsons without having to list them. 