### PR TITLE
Bugfixing

### DIFF
--- a/resources/dicts/events/ceremonies/ceremony-master.json
+++ b/resources/dicts/events/ceremonies/ceremony-master.json
@@ -2516,6 +2516,6 @@
       "general_backstory",
       "all_traits"
     ],
-    "Time has taken it's toll, and m_c has noticed themselves slowing down. They have worked timelessly for many moons, but is it time for them to retire. "
+    "Time has taken its toll, and m_c has noticed themselves slowing down. They have worked timelessly for many moons, but is it time for them to retire. "
   ]
 }

--- a/resources/dicts/events/injury/general/general.json
+++ b/resources/dicts/events/injury/general/general.json
@@ -5,7 +5,9 @@
             "Newleaf",
             "Greenleaf",
             "Leaf-fall",
-            "Leaf-bare"
+            "Leaf-bare",
+            "scar",
+            "SNAKE"
         ],
         "event_text": "m_c was bitten by a snake and miraculously survived!",
         "history_text": [
@@ -351,7 +353,9 @@
             "neg_trust",
             "neg_comfort",
             "dislike",
-            "neg_platonic"
+            "neg_platonic",
+            "scar",
+            "ONE"
         ],
         "event_text": "m_c was hurt by r_c to make an example out of them.",
         "history_text": [
@@ -529,7 +533,9 @@
             "neg_trust",
             "neg_comfort",
             "dislike",
-            "neg_platonic"
+            "neg_platonic",
+            "scar",
+            "CATBITE"
         ],
         "event_text": "m_c was hurt by r_c to make an example out of them.",
         "history_text": [

--- a/resources/dicts/patrols/beach/border/leaf-bare.json
+++ b/resources/dicts/patrols/beach/border/leaf-bare.json
@@ -3,7 +3,7 @@
     "patrol_id": "bch_bord_flashflood7",
     "biome": "beach",
     "season": "leaf-bare",
-    "tags": ["border", "death", "large_prey", "no_body"],
+    "tags": ["border", "death", "large_prey", "no_body", "no_fail_prey"],
     "intro_text": "As r_c crosses a beach, shivering with the cold, there's a creaking, rushing sound, like a wave - but out of sync with the ocean.",
     "decline_text": "r_c decides to head back early.",
     "chance_of_success": 60,

--- a/resources/dicts/patrols/beach/hunting/any.json
+++ b/resources/dicts/patrols/beach/hunting/any.json
@@ -556,7 +556,7 @@
             "thoughtful",
             "wise"
         ],
-        "min_cats": 1,
+        "min_cats": 2,
         "max_cats": 3,
         "antagonize_text": null,
         "antagonize_fail_text": null,

--- a/resources/dicts/patrols/beach/hunting/any.json
+++ b/resources/dicts/patrols/beach/hunting/any.json
@@ -1338,7 +1338,7 @@
             "r_c professionally flips the octopus out of its refuge and dispatches it with a quick bite. One for the fresh-kill pile!",
             "This rockpool proves to be a good fishing ground, and as well as the octopus, the patrol pulls crabs and limpets out from where the tides have left them.",
             "The octopus sees the cats and vanishes into a crevice, but s_c is able to lever it out with a thin strip of driftwood.",
-            "s_c pounces on the octopus enthusiastically. It thwacks it's tentacles around their head, trying to avoid their snapping muzzle, but s_c takes it in stride, prancing out of the rockpool to cheers and hilarity from the patrol, letting their friends guide them and their semi-captured prey blindly back to camp as everyone murrps with laughter."
+            "s_c pounces on the octopus enthusiastically. It thwacks its tentacles around their head, trying to avoid their snapping muzzle, but s_c takes it in stride, prancing out of the rockpool to cheers and hilarity from the patrol, letting their friends guide them and their semi-captured prey blindly back to camp as everyone murrps with laughter."
         ],
         "fail_text": [
             "The octopus spots the patrol and vanishes into an impossibly small crevice. The cats check it carefully, but there doesn't seem to be a way to get it out.",

--- a/resources/dicts/patrols/forest/hunting/any.json
+++ b/resources/dicts/patrols/forest/hunting/any.json
@@ -1148,7 +1148,7 @@
         "thoughtful",
         "wise"
     ],
-    "min_cats": 1,
+    "min_cats": 2,
     "max_cats": 3,
     "antagonize_text": null,
     "antagonize_fail_text": null

--- a/resources/dicts/patrols/general/medcat.json
+++ b/resources/dicts/patrols/general/medcat.json
@@ -3,7 +3,7 @@
     "patrol_id": "gen_med_sunny1",
     "biome": "Any",
     "season": "Any",
-    "tags": ["med_only", "platonic", "comfort", "respect", "trust", "med_cat"],
+    "tags": ["med_only", "random_herbs", "platonic", "comfort", "respect", "trust", "med_cat"],
     "intro_text": "The patrol finds a nice spot to sun themselves.",
     "decline_text": "They decide to stay focused instead.",
     "chance_of_success": 80,

--- a/resources/dicts/patrols/new_cat_welcoming.json
+++ b/resources/dicts/patrols/new_cat_welcoming.json
@@ -143,7 +143,7 @@
     "patrol_id": "fst_bord_noise1",
     "biome": "forest",
     "season": "Any",
-    "tags": ["border", "new_cat", "battle_injury", "scar", "BRIDGE", "reputation", "new_cat_newborn", "new_cat_queen"],
+    "tags": ["border", "new_cat", "battle_injury", "scar", "BRIDGE", "reputation","new_cat_kits", "new_cat_newborn", "new_cat_queen"],
     "intro_text": "As the patrol is checking the border lines, they hear an odd sound coming from a nearby bush.",
     "decline_text": "It's probably nothing. The patrol leaves the noise alone and continues on their way.",
     "chance_of_success": 60,

--- a/resources/dicts/patrols/wetlands/hunting/hunting_wetlands.json
+++ b/resources/dicts/patrols/wetlands/hunting/hunting_wetlands.json
@@ -457,7 +457,7 @@
             "thoughtful",
             "wise"
         ],
-        "min_cats": 1,
+        "min_cats": 2,
         "max_cats": 3,
         "antagonize_text": null,
         "antagonize_fail_text": null,

--- a/resources/game_config.json
+++ b/resources/game_config.json
@@ -88,5 +88,19 @@
 		"kittypet_chance": 30,
 		"rogue_chance": 30,
 		"loner_chance": 30
+	},
+	"patrol_generation": {
+		"classic_difficulty_modifier": 1,
+		"expanded_difficulty_modifier": 2,
+		"cruel season_difficulty_modifier": 3,
+		"win_stat_cat_modifier": 30,
+		"better_stat_modifier": 5,
+		"best_stat_modifier": 10,
+		"fail_stat_cat_modifier": -30,
+		"chance_of_romance_patrol": 16,
+		"comment": [
+			"the Cruel Season difficulty modifier needs to have a space rather than an underscore,",
+			"due to how it's written in the save files. So don't try to 'fix' it."
+		]
 	}
 }

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -574,7 +574,8 @@ class Cat():
                     ))
 
                 # grief the cat
-                cat.get_ill("grief stricken", event_triggered=True, severity=severity)
+                if game.clan.game_mode != 'classic':
+                    cat.get_ill("grief stricken", event_triggered=True, severity=severity)
 
             # negative reactions, no grief
             else:

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -314,7 +314,7 @@ class Events():
                     herbs_found = random.sample(HERBS, k=amount[0])
                     herb_display = []
                     for herb in herbs_found:
-                        # TODO: need to add bee sting as an injury so that these two herbs are relevant.
+                        # TODO: need to add bee sting events so that this herb is relevant.
                         if herb in ['blackberry']:
                             continue
                         if game.clan.current_season in ['Newleaf', 'Greenleaf']:

--- a/scripts/events_module/condition_events.py
+++ b/scripts/events_module/condition_events.py
@@ -103,7 +103,6 @@ class Condition_Events():
         else:
             random_number = int(random.random() * 200)
 
-
         if cat.dead:
             triggered = True
             return triggered

--- a/scripts/patrol.py
+++ b/scripts/patrol.py
@@ -1534,7 +1534,7 @@ class Patrol():
             other_clan = patrol.other_clan
             if "otherclan_nochangefail" in self.patrol_event.tags and not self.success:
                 difference = 0
-            elif "otherclan_nochangesuccess" in self.patrol_event.tags and self.success:
+            elif "otherclan_nochangesuccess" in self.patrol_event.tags and self.success and not antagonize:
                 difference = 0
             elif "otherclan_antag_nochangefail" in self.patrol_event.tags and antagonize and not self.success:
                 difference = 0

--- a/scripts/patrol.py
+++ b/scripts/patrol.py
@@ -586,28 +586,22 @@ class Patrol():
         success_text = self.patrol_event.success_text
         fail_text = self.patrol_event.fail_text
 
-        gm_modifier = 1
-        if game.clan.game_mode == "classic":
-            gm_modifier = 1
-        elif game.clan.game_mode == "expanded":
-            gm_modifier = 2
-        elif game.clan.game_mode == "cruel season":
-            gm_modifier = 3
+        gm_modifier = game.config["patrol_generation"][f"{game.clan.game_mode}_difficulty_modifier"]
 
         # if patrol contains cats with autowin skill, chance of success is high. otherwise it will calculate the
-        # chance by adding the patrolevent's chance of success plus the patrol's total exp
+        # chance by adding the patrol event's chance of success plus the patrol's total exp
         success_chance = self.patrol_event.chance_of_success + int(
             self.patrol_total_experience / (2 * gm_modifier))
 
         if self.patrol_win_stat_cat:
-            success_chance = success_chance + 30
+            success_chance = success_chance + game.config["patrol_generation"]["win_stat_cat_modifier"]
             if ("great" or "very") in self.patrol_win_stat_cat.skill:
-                success_chance = success_chance + 5
+                success_chance = success_chance + game.config["patrol_generation"]["better_stat_modifier"]
             elif ("fantastic" or "excellent" or "extremely") in self.patrol_win_stat_cat.skill:
-                success_chance = success_chance + 10
+                success_chance = success_chance + game.config["patrol_generation"]["best_stat_modifier"]
 
         if self.patrol_fail_stat_cat:
-            success_chance = success_chance - 30
+            success_chance = success_chance + game.config["patrol_generation"]["fail_stat_cat_modifier"]
 
         c = randint(0, 100)
         outcome = int(random.getrandbits(4))

--- a/scripts/patrol.py
+++ b/scripts/patrol.py
@@ -733,11 +733,11 @@ class Patrol():
                     outcome = 3
 
             if outcome == 2:
-                self.handle_deaths(self.patrol_random_cat)
+                self.handle_deaths_and_gone(self.patrol_random_cat)
             elif outcome == 4:
-                self.handle_deaths(self.patrol_fail_stat_cat)
+                self.handle_deaths_and_gone(self.patrol_fail_stat_cat)
             elif outcome == 6:
-                self.handle_deaths(self.patrol_leader)
+                self.handle_deaths_and_gone(self.patrol_leader)
             elif outcome == 3 or outcome == 5:
                 if game.clan.game_mode == 'classic':
                     self.handle_scars(outcome)
@@ -1176,7 +1176,7 @@ class Patrol():
             final_exp = gained_exp / lvl_modifier
             cat.experience = cat.experience + final_exp
 
-    def handle_deaths(self, cat):
+    def handle_deaths_and_gone(self, cat):
         if "no_body" in self.patrol_event.tags:
             body = False
         else:
@@ -1285,13 +1285,9 @@ class Patrol():
 
         # cats disappearing on patrol is also handled under this def for simplicity's sake
         elif "gone" in self.patrol_event.tags:
-            if len(self.patrol_event.fail_text) > 4 and self.final_fail == self.patrol_event.fail_text[4]:
-                self.results_text.append(f"{self.patrol_fail_stat_cat.name} died.")
-                self.patrol_fail_stat_cat.die(body)
-            else:
-                self.results_text.append(f"{self.patrol_random_cat.name} has been lost.")
-                self.patrol_random_cat.gone()
-                self.patrol_random_cat.grief(body=False)
+            self.results_text.append(f"{cat.name} has been lost.")
+            cat.gone()
+            cat.grief(body=False)
 
         elif "disaster_gone" in self.patrol_event.tags:
             for cat in self.patrol_cats:

--- a/scripts/screens/clan_screens.py
+++ b/scripts/screens/clan_screens.py
@@ -1564,7 +1564,8 @@ class MedDenScreen(Screens):
                                 self.minor_cats.remove(cat)
                             break
                         else:
-                            self.minor_cats.append(cat)
+                            if cat not in self.minor_cats:
+                                self.minor_cats.append(cat)
                 if cat.illnesses:
                     for illness in cat.illnesses:
                         if cat.illnesses[illness]["severity"] != 'minor' and illness != 'grief stricken':
@@ -1583,9 +1584,8 @@ class MedDenScreen(Screens):
                                 self.minor_cats.remove(cat)
                             break
                         else:
-                            if cat not in (self.in_den_cats and self.out_den_cats):
-                                if cat not in self.in_den_cats and cat not in self.out_den_cats:
-                                    self.minor_cats.append(cat)
+                            if cat not in (self.in_den_cats and self.out_den_cats and self.minor_cats):
+                                self.minor_cats.append(cat)
             self.tab_list = self.in_den_cats
             self.current_page = 1
             self.update_sick_cats()

--- a/scripts/screens/patrol_screens.py
+++ b/scripts/screens/patrol_screens.py
@@ -217,22 +217,22 @@ class PatrolScreen(Screens):
             self.elements['add_six'].enable()
             self.elements["random"].enable()
 
+            # making sure meds don't get the option for other patrols
+            med = False
+            for cat in self.current_patrol:
+                if cat.status in ['medicine cat', 'medicine cat apprentice']:
+                    med = True
+                    self.patrol_type = 'med'
+            if med is False and self.current_patrol:
+                self.elements['herb'].disable()
+                if self.patrol_type == 'med':
+                    self.patrol_type = 'general'
+
             if game.clan.game_mode != 'classic':
                 self.elements['paw'].enable()
                 self.elements['mouse'].enable()
                 self.elements['claws'].enable()
                 self.elements['herb'].enable()
-
-                # making sure meds don't get the option for other patrols
-                med = False
-                for cat in self.current_patrol:
-                    if cat.status in ['medicine cat', 'medicine cat apprentice']:
-                        med = True
-                        self.patrol_type = 'med'
-                if med is False and self.current_patrol:
-                    self.elements['herb'].disable()
-                    if self.patrol_type == 'med':
-                        self.patrol_type = 'general'
 
                 self.elements['info'].kill()  # clearing the text before displaying new text
 

--- a/scripts/screens/patrol_screens.py
+++ b/scripts/screens/patrol_screens.py
@@ -682,7 +682,7 @@ class PatrolScreen(Screens):
             return
 
         print("attempted romance between:", patrol.patrol_leader.name, patrol.patrol_random_cat.name)
-        chance_of_romance_patrol = 16
+        chance_of_romance_patrol = game.config["patrol_generation"]["chance_of_romance_patrol"]
 
         if get_personality_compatibility(patrol.patrol_leader, patrol.patrol_random_cat) is True or patrol.patrol_random_cat.mate == patrol.patrol_leader.ID:
             chance_of_romance_patrol -= 10
@@ -695,6 +695,8 @@ class PatrolScreen(Screens):
                 chance_of_romance_patrol -= 1
             elif val in ["dislike", "jealousy"] and value_check >= 20:
                 chance_of_romance_patrol += 2
+        if chance_of_romance_patrol <= 0:
+            chance_of_romance_patrol = 1
         print("final romance chance:", chance_of_romance_patrol)
         if not int(random.random() * chance_of_romance_patrol):
             patrol.patrol_event = self.romantic_event_choice


### PR DESCRIPTION
- Moved patrol chances into game.config
- Cats on Classic Mode will no longer become permanently grief stricken
- Med cats on Classic Mode can no longer go on any type of patrol
- s_c fail outcomes that result in a lost cat will no longer lose the wrong cat
- Cats with multiple minor injuries will no longer appear twice in the med den
- Fixed a myriad of patrol tagging issues
