### PR TITLE
Bugfixes: Medicine Cat Apprentice Patrols, Lasting Grief

### DIFF
--- a/.idea/clan_gen_working.iml
+++ b/.idea/clan_gen_working.iml
@@ -4,7 +4,7 @@
     <content url="file://$MODULE_DIR$">
       <excludeFolder url="file://$MODULE_DIR$/venv" />
     </content>
-    <orderEntry type="jdk" jdkName="Python 3.10 (clangen)" jdkType="Python SDK" />
+    <orderEntry type="jdk" jdkName="Python 3.11 (clangen)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
   <component name="PyDocumentationSettings">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.10 (clangen)" project-jdk-type="Python SDK" />
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.11 (clangen)" project-jdk-type="Python SDK" />
 </project>

--- a/main.py
+++ b/main.py
@@ -87,7 +87,7 @@ else:
         VERSION_NUMBER = subprocess.check_output(['git', 'rev-parse', 'HEAD']).decode('ascii').strip()
     except:
         print("Failed to get git commit hash, using hardcoded version number instead.")
-        print("Hey testers! We reccomend you use git to clone the repository, as it makes things easier for everyone.")
+        print("Hey testers! We recommend you use git to clone the repository, as it makes things easier for everyone.")
         print("There are instructions at https://discord.com/channels/1003759225522110524/1054942461178421289/1078170877117616169")
 print("Running on commit " + VERSION_NUMBER)
 

--- a/resources/dicts/conditions/illnesses.json
+++ b/resources/dicts/conditions/illnesses.json
@@ -538,7 +538,7 @@
         "risks": [
             {
                 "name": "lasting grief",
-                "chance": 50
+                "chance": 100
             },
             {
                 "name": "constant nightmares",

--- a/scripts/cat/names.py
+++ b/scripts/cat/names.py
@@ -130,7 +130,7 @@ class Name():
         ],
         'GHOST': [
             'Black', 'Black', 'Shade', 'Shaded', 'Crow', 'Raven', 'Ebony', 'Dark',
-            'Night', 'Shadow', 'Scorch', 'Midnight', 'Bleak', 'Storm', 'Violet', 'Pepper', 'Bat'
+            'Night', 'Shadow', 'Scorch', 'Midnight', 'Bleak', 'Storm', 'Violet', 'Pepper', 'Bat', 'Fade'
         ],
         'PALEGINGER': [
             'Pale', 'Ginger', 'Sand', 'Sandy', 'Yellow', 'Sun', 'Sunny', 'Light', 'Lion', 'Bright',
@@ -243,7 +243,7 @@ class Name():
         "Potato", "Pouncival", "President", "Prickle", "Princess", "Private Eye", "Pudding", "Pumpernickel", "Punk", "Purdy",
         "Purry", "Pisces", "Pushee", "Quagmire", "Quake", "Queen", "Queenie", "Queeny", "Queso", "Queso Ruby", "Quest",
         "Quickie", "Quimby", "Quinn", "Quino", "Quinzee", "Quesadilla", "Radar", "Ramble", "Randy", "Rapunzel",
-        "Rarity", "Rat", "Ray", "Reese", "Reeses Puff", "Ren", "Rio", "Riot", "River", "Riya", "Rocket", "Rodeo",
+        "Raptor", "Rarity", "Rat", "Ray", "Reese", "Reeses Puff", "Ren", "Rio", "Riot", "River", "Riya", "Rocket", "Rodeo",
         "Rolo", "Roman", "Roomba", "Rooster", "Rory", "Rose", "Roselie", "Ruby", "Rudolph", "Rufus", "Rue", "Ruffnut", "Rum", "Rumpleteazer", "Rum Tum Tugger", "Russel",
         "Sadie", "Sagwa", "Sailor", "Saki", "Salmon", "Salt", "Sam", "Samantha", "Sandwich", "Sandy", "Sarge", "Sassy", "Sashimi", "Sausage", "Schmidt",
         "Scotch", "Scrooge", "Seamus", "Sekhmet", "Sega", "Seri", "Shamash", "Shampoo", "Shamwow", "Shay", "Sherman",

--- a/scripts/patrol.py
+++ b/scripts/patrol.py
@@ -311,7 +311,8 @@ class Patrol():
             if "apprentice" in patrol.tags:
                 if "apprentice" not in self.patrol_statuses and "medicine cat apprentice" not in self.patrol_statuses:
                     continue
-                # If there is only a medicine cat apprentice in the patrol without a medicine cat, remove all
+                # If there is only a medicine cat apprentice in the patrol without a full medicine cat and
+                # the number of cats is greater than one, remove all
                 # the patrols that assume as apprentice is present, resulting in treating the med apprentice like a
                 # full medicine cat for the patrol.
                 # This is not ideal, since it also means patrols with warrior apprentices may not work correctly
@@ -319,7 +320,8 @@ class Patrol():
                 # apprentice will only show up if there is also a full medicine cat in the patrol.
                 # TODO: Write patrols for med cat apprentices + warriors.
                 if "medicine cat apprentice" in self.patrol_statuses and "medicine cat" not in self.patrol_statuses:
-                    continue
+                    if len(self.patrol_cats) > 1:
+                        continue
 
             # makes sure that the deputy is present if the deputy tag is
             if "deputy" in patrol.tags:

--- a/scripts/patrol.py
+++ b/scripts/patrol.py
@@ -109,6 +109,11 @@ class Patrol():
         if "medicine cat" in self.patrol_statuses:
             med_index = self.patrol_statuses.index("medicine cat")
             self.patrol_leader = self.patrol_cats[med_index]
+        # If there is no medicine cat, but there is a medicine cat apprentice, set them as the patrol leader.
+        # This prevents warrior from being treated as medicine cats in medicine cat patrols.
+        elif "medicine cat apprentice" in self.patrol_statuses:
+            med_index = self.patrol_statuses.index("medicine cat apprentice")
+            self.patrol_leader = self.patrol_cats[med_index]
         # sets leader as patrol leader
         elif clan.leader and clan.leader in self.patrol_cats:
             self.patrol_leader = clan.leader
@@ -305,6 +310,15 @@ class Patrol():
             # makes sure that an apprentice is present if the apprentice tag is
             if "apprentice" in patrol.tags:
                 if "apprentice" not in self.patrol_statuses and "medicine cat apprentice" not in self.patrol_statuses:
+                    continue
+                # If there is only a medicine cat apprentice in the patrol without a medicine cat, remove all
+                # the patrols that assume as apprentice is present, resulting in treating the med apprentice like a
+                # full medicine cat for the patrol.
+                # This is not ideal, since it also means patrols with warrior apprentices may not work correctly
+                # This also means patrols the are written for both a medicine cat apprentice and a warrior
+                # apprentice will only show up if there is also a full medicine cat in the patrol.
+                # TODO: Write patrols for med cat apprentices + warriors.
+                if "medicine cat apprentice" in self.patrol_statuses and "medicine cat" not in self.patrol_statuses:
                     continue
 
             # makes sure that the deputy is present if the deputy tag is


### PR DESCRIPTION
- Chance to develop lasting grief has been reduced. 
- When medicine cat apprentices are sent on patrol (with other cats) and a full medicine cat is not on the patrol, the medicine cat apprentice is now treated as a full medicine cat.  This will prevent a warrior from being treated as a medicine cat on a patrol with a medicine cat apprentice.  In the future, we plan to write new patrols for med cat app + warrior patrols. 
- Typos