### PR TITLE
Bugfixes/Unmated Kit Chance

### DIFF
--- a/resources/dicts/events/ceremonies/ceremony-master.json
+++ b/resources/dicts/events/ceremonies/ceremony-master.json
@@ -2064,7 +2064,7 @@
       "general_backstory",
       "faithful"
     ],
-    "As l_n names (prefix)paw m_c, they swear that they see some starry cats yowling their support amongst their other Clanmates."
+    "As l_n gives (prefix)paw the name m_c, they swear that they see some starry cats yowling their support amongst their other Clanmates."
   ],
   "warrior_28": [
     [

--- a/resources/dicts/events/ceremonies/ceremony-master.json
+++ b/resources/dicts/events/ceremonies/ceremony-master.json
@@ -825,7 +825,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "Interested in herbs even in their kithood, m_c is eager to be apprenticed to be apprenticed to (mentor)."
+    "Interested in herbs even in their kithood, m_c is eager to be apprenticed to (mentor)."
   ],
   "med_app_3": [
     [
@@ -1046,7 +1046,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "m_c feel sick at the mere thought of fighting. They decide to train as a mediator, and (mentor) is named as their mentor. "
+    "m_c feels sick at the mere thought of fighting. They decide to train as a mediator, and (mentor) is named as their mentor. "
   ],
   "mediator_app_2": [
     [
@@ -2494,7 +2494,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "m_c's been resist to retiring, but the aches and pains of old age have worn them down. They approach l_n, and are honored for their tireless service. "
+    "m_c's been resistant to retiring, but the aches and pains of old age have worn them down. They approach l_n, and are honored for their tireless service. "
   ],
   "elder_4": [
     [

--- a/resources/dicts/patrols/beach/med/leaf-fall.json
+++ b/resources/dicts/patrols/beach/med/leaf-fall.json
@@ -526,8 +526,8 @@
     "exp": 10,
     "success_text": [
             "Elder leaves being used to soothe sprains and elder leaves having to be gathered in a way that risks sprains is truly one of StarClan's little ironies, p_l reflects. They share the little joke with the patrol, and the cats murrp with amusement, but it also reminds everyone to be careful as they strip leaves from the tree.",
-            "Ignoring the leaves piled up at the tree's base, which lack any herbal potency, p_l instead gets a good crop, choosing leaves as close to green as possible for maximum usefulness, which p_l finds tends to fade the more red the leaf-fall elder leaves get. The wrriors are less selective, but the sheer quantity p_l is able to bring back to camp with their help more than makes up for it.",
-            "s_c has managed to discover, with time and experience, that elder leaf picking is actually better handled by chewing off several low hanging thin branches and carting those back to camp instead. With so many assistants they can bring a truely massive haul home, where the rest of the patrol helps them strip the leaves and carefully store them."
+            "Ignoring the leaves piled up at the tree's base, which lack any herbal potency, p_l instead gets a good crop, choosing leaves as close to green as possible for maximum usefulness, which p_l finds tends to fade the more red the leaf-fall elder leaves get. The warriors are less selective, but the sheer quantity p_l is able to bring back to camp with their help more than makes up for it.",
+            "s_c has managed to discover, with time and experience, that elder leaf picking is actually better handled by chewing off several low hanging thin branches and carting those back to camp instead. With so many assistants they can bring a truly massive haul home, where the rest of the patrol helps them strip the leaves and carefully store them."
     ],
     "fail_text": [
             "Unfortunately, the elder tree p_l has picked out seems to have a bug infestation of some kind, and p_l doesn't want to use these tattered, diseased-looking leaves.",

--- a/resources/dicts/patrols/beach/training/newleaf.json
+++ b/resources/dicts/patrols/beach/training/newleaf.json
@@ -10,7 +10,7 @@
     "exp": 20,
     "success_text": [
             "As the cats watch, the silence is broken, as one of the massive boulders rears up and snorts. The apprentices jolt with fear, app1's fur standing on end while app2 looks seconds away from fleeing, but p_l flicks their tail encouragingly. These are nosy-seals, they explain, as the beach full of 'boulders' suddenly seems far more intimidating.",
-            "app1 and app2's jaws drop, disbelieving, as p_l explains these are animals, not a rockslide. They stare as a nosy-seal wakes from his slumber and bellows a challenge to his neighbour, flinching as the monolithic animals crash towards each other. Each drips enough blood to fill the veins of an enitre cat, crashing and careening off each other.",
+            "app1 and app2's jaws drop, disbelieving, as p_l explains these are animals, not a rockslide. They stare as a nosy-seal wakes from his slumber and bellows a challenge to his neighbour, flinching as the monolithic animals crash towards each other. Each drips enough blood to fill the veins of an entire cat, crashing and careening off each other.",
             "As the 'rocks' wake and reveal themselves to be the most massive animals app1 and app2 have ever seen, s_c reassures them - they may never have seen these frightening seals before, but c_n has. s_c spends the morning quizzing the apprentices until each is able to identify a male nosy-seal with his trunk vs the comparatively smaller females.",
             "As the sun hits them and the massive boulders wake with grumbling snorts, app1 and app2 both look about to run. s_c quickly calms them, explaining that these massive yearly visitors to c_n are nosy-seals, and that if the cat's don't bother them, they won't bother the cats."
     ],

--- a/resources/dicts/patrols/forest/med/leaf-fall.json
+++ b/resources/dicts/patrols/forest/med/leaf-fall.json
@@ -580,8 +580,8 @@
     "exp": 10,
     "success_text": [
             "Elder leaves being used to soothe sprains and elder leaves having to be gathered in a way that risks sprains is truly one of StarClan's little ironies, p_l reflects. They share the little joke with the patrol, and the cats murrp with amusement, but it also reminds everyone to be careful as they strip leaves from the tree.",
-            "Ignoring the leaves piled up at the tree's base, which lack any herbal potency, p_l instead gets a good crop, choosing leaves as close to green as possible for maximum usefulness, which p_l finds tends to fade the more red the leaf-fall elder leaves get. The wrriors are less selective, but the sheer quantity p_l is able to bring back to camp with their help more than makes up for it.",
-            "s_c has managed to discover, with time and experience, that elder leaf picking is actually better handled by chewing off several low hanging thin branches and carting those back to camp instead. With so many assistants they can bring a truely massive haul home, where the rest of the patrol helps them strip the leaves and carefully store them."
+            "Ignoring the leaves piled up at the tree's base, which lack any herbal potency, p_l instead gets a good crop, choosing leaves as close to green as possible for maximum usefulness, which p_l finds tends to fade the more red the leaf-fall elder leaves get. The warriors are less selective, but the sheer quantity p_l is able to bring back to camp with their help more than makes up for it.",
+            "s_c has managed to discover, with time and experience, that elder leaf picking is actually better handled by chewing off several low hanging thin branches and carting those back to camp instead. With so many assistants they can bring a truly massive haul home, where the rest of the patrol helps them strip the leaves and carefully store them."
     ],
     "fail_text": [
             "Unfortunately, the elder tree p_l has picked out seems to have a bug infestation of some kind, and p_l doesn't want to use these tattered, diseased-looking leaves.",

--- a/resources/dicts/patrols/mountainous/med/leaf-fall.json
+++ b/resources/dicts/patrols/mountainous/med/leaf-fall.json
@@ -549,8 +549,8 @@
     "exp": 10,
     "success_text": [
             "Elder leaves being used to soothe sprains and elder leaves having to be gathered in a way that risks sprains is truly one of StarClan's little ironies, p_l reflects. They share the little joke with the patrol, and the cats <i>murrp</i> with amusement, but it also reminds everyone to be careful as they strip leaves from the tree.",
-            "Ignoring the leaves piled up at the tree's base, which lack any herbal potency, p_l instead gets a good crop, choosing leaves as close to green as possible for maximum usefulness, which p_l finds tends to fade the more red the leaf-fall elder leaves get. The wrriors are less selective, but the sheer quantity p_l is able to bring back to camp with their help more than makes up for it.",
-            "s_c has managed to discover, with time and experience, that elder leaf picking is actually better handled by chewing off several low hanging thin branches and carting those back to camp instead. With so many assistants they can bring a truely massive haul home, where the rest of the patrol helps them strip the leaves and carefully store them."
+            "Ignoring the leaves piled up at the tree's base, which lack any herbal potency, p_l instead gets a good crop, choosing leaves as close to green as possible for maximum usefulness, which p_l finds tends to fade the more red the leaf-fall elder leaves get. The warriors are less selective, but the sheer quantity p_l is able to bring back to camp with their help more than makes up for it.",
+            "s_c has managed to discover, with time and experience, that elder leaf picking is actually better handled by chewing off several low hanging thin branches and carting those back to camp instead. With so many assistants they can bring a truly massive haul home, where the rest of the patrol helps them strip the leaves and carefully store them."
     ],
     "fail_text": [
             "Unfortunately, the elder tree p_l has picked out seems to have a bug infestation of some kind, and p_l doesn't want to use these tattered, diseased-looking leaves.",

--- a/resources/dicts/patrols/other_clan.json
+++ b/resources/dicts/patrols/other_clan.json
@@ -41,7 +41,7 @@
     "success_text": [
     "When the two patrols get closer to each other the patrol leaders share a quick nod of acknowledgement. The patrols refocus on their tasks without stopping for a conversation, but a feeling of mutual respect has been fostered.",
     "p_l approaches the other Clan patrol, striking up a conversation about the weather. After talking for a short time, the two patrols part ways. p_l remarks on the o_c_n cats' kindness to the leader once the patrol has returned to camp.",
-    "Once the patrols cross paths, s_c is quick to break the awkward atmosphere with a friendly greeting and easy conversation. s_c remembers some of the news that o_c_n shared at a recent Gathering and brings it up, impressing the other patrol with their polite interest.",
+    "Once the patrols cross paths, s_c is quick to break the awkward atmosphere with a friendly greeting and easy conversation. They remember some of the news that o_c_n shared at a recent Gathering and bring it up, impressing the other patrol with their polite interest.",
     "Once the patrols cross paths, s_c is quick to break the awkward atmosphere with a friendly greeting. The patrols pause to converse for a little while, s_c bringing up a story that, while slightly embarrassing for s_c, is entertaining and lighthearted. The patrols part in good spirits."
     ],
     "fail_text": [
@@ -133,7 +133,7 @@
     "success_text": [
     "When the two patrols get closer to each other the patrol leader from o_c_n gives p_l a respectful nod, which they return. The patrols refocus on their tasks without stopping for a conversation, but a feeling of mutual respect has been fostered.",
     "The other patrol greets p_l respectfully, remarking on the weather and enquiring politely about the youngest members of the Clan. p_l smiles, impressed with them.",
-    "Once the patrols cross paths, s_c is quick to break the awkward atmosphere with a friendly greeting and easy conversation. s_c remembers some of the news that o_c_n shared at a recent Gathering and brings it up, impressing the other patrol with their polite interest.",
+    "Once the patrols cross paths, s_c is quick to break the awkward atmosphere with a friendly greeting and easy conversation. They remember some of the news that o_c_n shared at a recent Gathering and bring it up, impressing the other patrol with their polite interest.",
     "Once the patrols cross paths, s_c is quick to break the awkward atmosphere with a friendly greeting. The patrols pause to converse for a little while, s_c bringing up a story that, while slightly embarrassing for s_c, is entertaining and lighthearted. The patrols part in good spirits."
     ],
     "fail_text": [

--- a/resources/dicts/patrols/plains/med/leaf-fall.json
+++ b/resources/dicts/patrols/plains/med/leaf-fall.json
@@ -549,8 +549,8 @@
     "exp": 10,
     "success_text": [
             "Elder leaves being used to soothe sprains and elder leaves having to be gathered in a way that risks sprains is truly one of StarClan's little ironies, p_l reflects. They share the little joke with the patrol, and the cats murrp with amusement, but it also reminds everyone to be careful as they strip leaves from the tree.",
-            "Ignoring the leaves piled up at the tree's base, which lack any herbal potency, p_l instead gets a good crop, choosing leaves as close to green as possible for maximum usefulness, which p_l finds tends to fade the more red the leaf-fall elder leaves get. The wrriors are less selective, but the sheer quantity p_l is able to bring back to camp with their help more than makes up for it.",
-            "s_c has managed to discover, with time and experience, that elder leaf picking is actually better handled by chewing off several low hanging thin branches and carting those back to camp instead. With so many assistants they can bring a truely massive haul home, where the rest of the patrol helps them strip the leaves and carefully store them."
+            "Ignoring the leaves piled up at the tree's base, which lack any herbal potency, p_l instead gets a good crop, choosing leaves as close to green as possible for maximum usefulness, which p_l finds tends to fade the more red the leaf-fall elder leaves get. The warriors are less selective, but the sheer quantity p_l is able to bring back to camp with their help more than makes up for it.",
+            "s_c has managed to discover, with time and experience, that elder leaf picking is actually better handled by chewing off several low hanging thin branches and carting those back to camp instead. With so many assistants they can bring a truly massive haul home, where the rest of the patrol helps them strip the leaves and carefully store them."
     ],
     "fail_text": [
             "Unfortunately, the elder tree p_l has picked out seems to have a bug infestation of some kind, and p_l doesn't want to use these tattered, diseased-looking leaves.",

--- a/resources/game_config.json
+++ b/resources/game_config.json
@@ -68,7 +68,7 @@
 	},
 	"pregnancy": {
 		"primary_chance_mated": 50,
-		"primary_chance_unmated": 100,
+		"primary_chance_unmated": 110,
 		"random_affair_chance": 70
 	},
 	"cat_generation": {

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -740,6 +740,7 @@ class Cat():
 
         elif self.status == 'mediator':
             self.update_mentor()
+            self.update_skill()
 
         elif self.status == 'mediator apprentice':
             self.update_mentor()
@@ -1063,6 +1064,7 @@ class Cat():
         # also adds a chance for cat to take a skill similar to their mentor"""
 
         if self.skill == '???':
+            print(str(self.name))
             if len(self.mentor_influence) < 1:
                 self.mentor_influence = ['None']
             # assign skill to new medicine cat
@@ -1132,7 +1134,7 @@ class Cat():
 
                     all_skills = []
                     for x in possible_groups:
-                        all_skills = all_skills + self.skill_groups[x]
+                        all_skills.extend(self.skill_groups[x])
                     self.skill = choice(all_skills)
                     self.mentor_influence.insert(1, 'None')
 

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -1064,7 +1064,6 @@ class Cat():
         # also adds a chance for cat to take a skill similar to their mentor"""
 
         if self.skill == '???':
-            print(str(self.name))
             if len(self.mentor_influence) < 1:
                 self.mentor_influence = ['None']
             # assign skill to new medicine cat

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -1431,13 +1431,11 @@ class Events():
             self.death_events.handle_deaths(cat, other_cat, self.at_war, self.enemy_clan, alive_kits)
             triggered_death = True
             return triggered_death
-            return triggered_death
 
         # chance to die of old age
         if cat.moons > int(random.random() * game.config["death_related"]["old_age_death_chance"]) + game.config["death_related"]["old_age_death_start"] and not triggered_death:  # cat.moons > 150 <--> 200
             self.death_events.handle_deaths(cat, other_cat, self.at_war, self.enemy_clan, alive_kits)
             triggered_death = True
-            return triggered_death
             return triggered_death
 
         # classic death chance
@@ -1451,7 +1449,6 @@ class Events():
             if not random.getrandbits(9):  # 1/512
                 triggered_death = True
                 self.handle_disasters()
-                return triggered_death
                 return triggered_death
 
         # final death chance and then, if not triggered, head to injuries

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -1404,8 +1404,6 @@ class Events():
         # ---------------------------------------------------------------------------- #
         #                           decide if cat dies                                 #
         # ---------------------------------------------------------------------------- #
-        # if triggered_death is True then the cat will die
-        triggered_death = False
         # choose other cat
         possible_other_cats = list(filter(
             lambda c: not c.dead and not c.exiled and not c.outside and (c.ID != cat.ID), Cat.all_cats.values()
@@ -1426,36 +1424,32 @@ class Events():
         alive_kits = get_alive_kits(Cat)
 
         # chance to kill leader: 1/100
+        # chance to kill leader: 1/100
         if not int(
-                random.random() * game.config["death_related"]["leader_death_chance"]) and cat.status == 'leader' and not triggered_death and not cat.not_working():
+                random.random() * 100) and cat.status == 'leader' and not cat.not_working():
             self.death_events.handle_deaths(cat, other_cat, self.at_war, self.enemy_clan, alive_kits)
-            triggered_death = True
-            return triggered_death
+            return True
 
         # chance to die of old age
-        if cat.moons > int(random.random() * game.config["death_related"]["old_age_death_chance"]) + game.config["death_related"]["old_age_death_start"] and not triggered_death:  # cat.moons > 150 <--> 200
+        if cat.moons > int(random.random() * 51) + 150:  # cat.moons > 150 <--> 200
             self.death_events.handle_deaths(cat, other_cat, self.at_war, self.enemy_clan, alive_kits)
-            triggered_death = True
-            return triggered_death
+            return True
 
         # classic death chance
         if game.clan.game_mode == "classic" and not int(random.random() * 500):  # 1/500
             self.death_events.handle_deaths(cat, other_cat, self.at_war, self.enemy_clan, alive_kits)
-            triggered_death = True
-            return triggered_death
+            return True
 
         # disaster death chance
         if game.settings.get('disasters'):
             if not random.getrandbits(9):  # 1/512
-                triggered_death = True
                 self.handle_disasters()
-                return triggered_death
+                return True
 
-        # final death chance and then, if not triggered, head to injuries
-        if not int (random.random() *game.config["death_related"][f"{game.clan.game_mode}_death_chance"]) and not cat.not_working():  # 1/400
+        # extra death chance and injuries in expanded & cruel season
+        if game.clan.game_mode != 'classic' and not int(random.random() * 500) and not cat.not_working():  # 1/400
             self.death_events.handle_deaths(cat, other_cat, self.at_war, self.enemy_clan, alive_kits)
-            triggered_death = True
-            return triggered_death
+            return True
         else:
             triggered_death = self.condition_events.handle_injuries(cat, other_cat, alive_kits, self.at_war,
                                                                     self.enemy_clan, game.clan.current_season)

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -541,7 +541,9 @@ class Events():
             name = random.choice(names.loner_names)
         elif status in ['loner', 'rogue']:
             name = random.choice(names.loner_names + names.normal_prefixes)
-        new_cat = Cat(prefix=name, suffix = None, status=status, gender=random.choice(['female', 'male']))
+        else:
+            name = random.choice(names.loner_names)
+        new_cat = Cat(prefix=name, suffix=None, status=status, gender=random.choice(['female', 'male']))
         if status == 'kittypet':
             new_cat.accessory = random.choice(collars)
         new_cat.outside = True
@@ -1428,33 +1430,37 @@ class Events():
                 random.random() * 100) and cat.status == 'leader' and not triggered_death and not cat.not_working():
             self.death_events.handle_deaths(cat, other_cat, self.at_war, self.enemy_clan, alive_kits)
             triggered_death = True
+            return triggered_death
 
         # chance to die of old age
         if cat.moons > int(random.random() * 51) + 150 and not triggered_death:  # cat.moons > 150 <--> 200
             self.death_events.handle_deaths(cat, other_cat, self.at_war, self.enemy_clan, alive_kits)
             triggered_death = True
+            return triggered_death
 
         # classic death chance
         if game.clan.game_mode == "classic" and not int(random.random() * 500):  # 1/500
             self.death_events.handle_deaths(cat, other_cat, self.at_war, self.enemy_clan, alive_kits)
             triggered_death = True
+            return triggered_death
 
         # disaster death chance
-        if game.settings.get('disasters') and not triggered_death:
+        if game.settings.get('disasters'):
             if not random.getrandbits(9):  # 1/512
                 triggered_death = True
                 self.handle_disasters()
+                return triggered_death
 
         # extra death chance and injuries in expanded & cruel season
         if game.clan.game_mode != 'classic' and not int(random.random() * 500) and not cat.not_working():  # 1/400
             self.death_events.handle_deaths(cat, other_cat, self.at_war, self.enemy_clan, alive_kits)
             triggered_death = True
+            return triggered_death
         else:
             triggered_death = self.condition_events.handle_injuries(cat, other_cat, alive_kits, self.at_war,
                                                                     self.enemy_clan, game.clan.current_season)
             return triggered_death
 
-        return triggered_death
 
     def handle_disasters(self):
         """Handles events when the setting of disasters is turned on.

--- a/scripts/events_module/condition_events.py
+++ b/scripts/events_module/condition_events.py
@@ -667,7 +667,7 @@ class Condition_Events():
                         game.ranks_changed_timeskip = True
                         event_list.append(event)
 
-                if cat.permanent_condition[condition]['severity'] == 'severe':
+                elif cat.permanent_condition[condition]['severity'] == 'severe':
                     event_types.append('ceremony')
                     if game.clan.leader is not None:
                         if not game.clan.leader.dead and not game.clan.leader.exiled \

--- a/scripts/events_module/relation_events.py
+++ b/scripts/events_module/relation_events.py
@@ -122,6 +122,7 @@ class Relation_Events():
                                                > other_mate_relationship.romantic_love)
                     else:
                         cat_to_mate.relationships[cat_to.ID] = Relationship(cat_to_mate, cat_to, True)
+                        other_mate_relationship = cat_to.relationships[cat_to.mate]
 
                 if ((love_over_30 and not normal_chance) or (bigger_than_current and not bigger_love_chance)):
                     self.had_one_event = True
@@ -221,7 +222,7 @@ class Relation_Events():
             living_cats = len(list(filter(lambda r: not r.dead, Cat.all_cats.values())))
 
             if not affair:
-                if second_parent is not None:
+                if second_parent:
                     chance = 10
                     if second_parent_relation.romantic_love >= 35:
                         chance += 20
@@ -237,8 +238,7 @@ class Relation_Events():
                     elif second_parent_relation.comfortable >= 85:
                         chance += 40
                 else:
-                    chance = int(int(living_cats) / 20 + 5)
-
+                    chance = int(200/living_cats) + 2
                 old_male = False
                 if cat.gender == 'male' and cat.age == 'elder':
                     old_male = True
@@ -248,12 +248,13 @@ class Relation_Events():
                 if old_male:
                     chance = int(chance / 2)
             else:
-                # Affairs almost never cancel - it makes setting affairs number easier.
-                chance = 1000
+                # Affairs never cancel - it makes setting affairs number easier.
+                chance = 0
 
             # print("Kit cancel chance", chance)
-            if not int(random.random() * chance):
+            if int(random.random() * chance) == 1:
                 # Cancel having kits.
+                print("kits canceled")
                 return
 
             # If you've reached here - congrats, kits!

--- a/scripts/screens/organizational_screens.py
+++ b/scripts/screens/organizational_screens.py
@@ -194,8 +194,8 @@ class SwitchClanScreen(Screens):
                 pygame_gui.elements.UIButton(scale(pygame.Rect((600, y_pos), (400, 78))), clan + "Clan",
                                              object_id="#saved_clan", manager=MANAGER))
             self.delete_buttons[-1].append(
-                pygame_gui.elements.UIButton(scale(pygame.Rect((940, y_pos + 17), (44, 44))), "",
-                                            object_id="#exit_window_button", manager=MANAGER, starting_height=2))
+                UIImageButton(scale(pygame.Rect((940, y_pos + 17), (44, 44))), "",
+                              object_id="#exit_window_button", manager=MANAGER, starting_height=2))
 
             y_pos += 82
             i += 1
@@ -206,7 +206,6 @@ class SwitchClanScreen(Screens):
                 i = 0
                 y_pos = 378
 
-        
         self.next_page_button = UIImageButton(scale(pygame.Rect((912, 1080), (68, 68))), "", object_id="#arrow_right_button"
                                               , manager=MANAGER)
         self.previous_page_button = UIImageButton(scale(pygame.Rect((620, 1080), (68, 68))), "",
@@ -241,15 +240,12 @@ class SwitchClanScreen(Screens):
         for page in self.delete_buttons:
             for button in page:
                 button.hide()
-        
 
         for button in self.clan_buttons[self.page]:
             button.show()
         
         for button in self.delete_buttons[self.page]:
             button.show()
-
-
 
     def on_use(self):
         screen.blit(self.screen, (580 / 1600 * screen_x, 300 / 1400 * screen_y))
@@ -1037,7 +1033,7 @@ class StatsScreen(Screens):
         medcat_num = 0
         other_num = 0
         for cat in Cat.all_cats.values():
-            if not cat.dead and not cat.outside:
+            if not cat.dead and not (cat.outside or cat.exiled):
                 living_num += 1
                 if cat.status == 'warrior':
                     warriors_num += 1


### PR DESCRIPTION
- Fixed the fit cancel chance to properly increase with population for unmated cats. It also also no longer linear. 
- Slightly decreased primary kit roll chance for unmated cats. 
- Mediator apprentices will now properly gain their skill when aging up. 
- The delete button on the switch clan screen will now scale in full-screen. 
- Fixed senior cats sometimes dying twice in one moon. 
- Typos and some awkward wording. 