### PR TITLE
Bugfixes/Tweaks

### DIFF
--- a/.idea/clan_gen_working.iml
+++ b/.idea/clan_gen_working.iml
@@ -4,7 +4,7 @@
     <content url="file://$MODULE_DIR$">
       <excludeFolder url="file://$MODULE_DIR$/venv" />
     </content>
-    <orderEntry type="jdk" jdkName="Python 3.10 (clangen)" jdkType="Python SDK" />
+    <orderEntry type="jdk" jdkName="Python 3.11 (clangen)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
   <component name="PyDocumentationSettings">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.10 (clangen)" project-jdk-type="Python SDK" />
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.11 (clangen)" project-jdk-type="Python SDK" />
 </project>

--- a/main.py
+++ b/main.py
@@ -125,7 +125,7 @@ while True:
 
         if event.type == pygame.QUIT:
             # Dont display if on the start screen
-            if game.switches['cur_screen'] in ['start screen']:
+            if game.switches['cur_screen'] in ['start screen', 'switch clan screen', 'settings screen', 'info screen']:
                 game.rpc.close()
                 pygame.display.quit()
                 pygame.quit()

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -365,12 +365,12 @@ class Events():
             insert = "medicine cat"
         else:
             insert = "medicine cats"
-        herbs = game.clan.herbs
+        #herbs = game.clan.herbs
 
         herbs_lost = []
-        for herb in herbs:
-            if herbs[herb] > 25:
-                herbs.update({herb: 25})
+        for herb in game.clan.herbs:
+            if game.clan.herbs[herb] > 25:
+                game.clan.herbs[herb] = 25
                 herbs_lost.append(herb)
 
         if herbs_lost:
@@ -385,26 +385,32 @@ class Events():
             text = f"The herb stores have too {insert2}. The excess is given back to the earth."
             game.herb_events_list.append(text)
 
-        if sum(herbs.values()) >= 50:
+        if sum(game.clan.herbs.values()) >= 50:
             chance = 2
         else:
             chance = 5
 
-        if len(herbs.keys()) >= 10 and not int(random.random() * chance):
-            index = random.randrange(1, int(len(herbs.keys()) / 2))
-            count = 0
-            bad_herb = None
-            for herb in herbs:
-                count += 1
-                if count == index:
-                    bad_herb = herb
-                    break
-            herb_amount = random.randrange(1, int(herbs[bad_herb] + 2))
+        if len(game.clan.herbs.keys()) >= 10 and not int(random.random() * chance):
+            bad_herb = random.choice(list(game.clan.herbs.keys()))
+
+            # Failsafe, since I have no idea why we are getting 0-herb entries.
+            while game.clan.herbs[bad_herb] <= 0:
+                print(f"Warning: {bad_herb} was chosen to destroy, although you currently have "
+                      f"{game.clan.herbs[bad_herb]}. Removing {bad_herb} from herb dict, finding a new herb...")
+                game.clan.herbs.pop(bad_herb)
+                if game.clan.herbs:
+                    bad_herb = random.choice(list(game.clan.herbs.keys()))
+                else:
+                    print("No herbs to destroy")
+                    return
+                print(f"New herb found: {bad_herb}")
+
+            herb_amount = random.randrange(1, game.clan.herbs[bad_herb] + 1)
             # deplete the herb
-            herbs[bad_herb] -= herb_amount
+            game.clan.herbs[bad_herb] -= herb_amount
             insert2 = 'some of'
-            if herbs[bad_herb] <= 0:
-                herbs.pop(bad_herb)
+            if game.clan.herbs[bad_herb] <= 0:
+                game.clan.herbs.pop(bad_herb)
                 insert2 = "all of"
 
             event = f"As the herb stores are inspected by the {insert}, it's noticed that {insert2} the {bad_herb.replace('_', ' ')}" \
@@ -414,7 +420,7 @@ class Events():
 
         elif allies and not int(random.random() * 5):
             chosen_ally = random.choice(allies)
-            if len(herbs.keys()) == 0:
+            if game.clan.herbs == {}:
                 # If you have no herbs, you can't give any to a clan. Special events for that.
                 possible_events = [
                     f"The {chosen_ally.name}Clan medicine cat comes asking if your Clan has any herbs to spare. "
@@ -425,18 +431,12 @@ class Events():
                 ]
                 chosen_ally.relations -= 2
             else:
-                index = random.randrange(1, int(len(herbs.keys())) + 1)
-                count = 0
-                herb_given = None
-                for herb in herbs:
-                    count += 1
-                    if count == index:
-                        herb_given = herb
-                        break
-                if herbs[herb_given] > 2:
-                    herb_amount = random.randrange(1, int(herbs[herb_given] - 1))
+                herb_given = random.choice(list(game.clan.herbs.keys()))
+
+                if game.clan.herbs[herb_given] > 2:
+                    herb_amount = random.randrange(1, int(game.clan.herbs[herb_given] - 1))
                     # deplete the herb
-                    herbs[herb_given] -= herb_amount
+                    game.clan.herbs[herb_given] -= herb_amount
 
                     possible_events = [
                         f"The {chosen_ally.name}Clan medicine cat comes asking if your Clan has any {herb_given.replace('_', ' ')} to spare. "
@@ -471,19 +471,18 @@ class Events():
             game.herb_events_list.append(event)
             game.cur_events_list.append(Single_Event(event, "health"))
 
-        elif not int(random.random() * 10) and 'moss' in herbs:
-            herb_amount = random.randrange(1, herbs['moss'] + 1)
-            herbs['moss'] -= herb_amount
-            if herbs['moss'] <= 0:
-                herbs.pop('moss')
+        elif not int(random.random() * 10) and 'moss' in game.clan.herbs:
+            herb_amount = random.randrange(1, game.clan.herbs['moss'] + 1)
+            game.clan.herbs['moss'] -= herb_amount
+            if game.clan.herbs['moss'] <= 0:
+                game.clan.herbs.pop('moss')
             event = "The medicine den nests have been refreshed with new moss from the herb stores."
             game.herb_events_list.append(event)
             game.cur_events_list.append(Single_Event(event, "health"))
 
         elif not int(random.random() * 80) and sum(game.clan.herbs.values()) > 0 and len(meds) > 0:
-
             possible_events = []
-            if self.at_war is True:
+            if self.at_war and self.enemy_clan:
                 possible_events.append(f"{self.enemy_clan} breaks into the camp and ravages the herb stores, "
                                        f"taking some for themselves and destroying the rest.")
             possible_events.extend([

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -433,6 +433,18 @@ class Events():
             else:
                 herb_given = random.choice(list(game.clan.herbs.keys()))
 
+                # Failsafe, since I have no idea why we are getting 0-herb entries.
+                while game.clan.herbs[herb_given] <= 0:
+                    print(f"Warning: {herb_given} was chosen to give to another clan, although you currently have "
+                          f"{game.clan.herbs[herb_given]}. Removing {herb_given} from herb dict, finding a new herb...")
+                    game.clan.herbs.pop(herb_given)
+                    if game.clan.herbs:
+                        herb_given = random.choice(list(game.clan.herbs.keys()))
+                    else:
+                        print("No herbs to destroy")
+                        return
+                    print(f"New herb found: {herb_given}")
+
                 if game.clan.herbs[herb_given] > 2:
                     herb_amount = random.randrange(1, int(game.clan.herbs[herb_given] - 1))
                     # deplete the herb

--- a/scripts/events_module/condition_events.py
+++ b/scripts/events_module/condition_events.py
@@ -791,8 +791,7 @@ class Condition_Events():
         clan_herbs.update(game.clan.herbs.keys())
         needed_herbs.update(source[condition]["herbs"])
         herb_set = clan_herbs.intersection(needed_herbs)
-        usable_herbs = []
-        usable_herbs.extend(herb_set)
+        usable_herbs = list(herb_set)
 
         if not source[condition]["herbs"]:
             return
@@ -813,12 +812,22 @@ class Condition_Events():
 
             effect = random.choice(possible_effects)
 
-            # deplete the herb
             herb_used = usable_herbs[0]
-            if game.clan.herbs[herb_used] == 1:
-                amount_used = 1
-            else:
-                amount_used = random.randrange(1, game.clan.herbs[herb_used])
+            # Failsafe, since I have no idea why we are getting 0-herb entries.
+            while game.clan.herbs[herb_used] <= 0:
+                print(f"Warning: {herb_used} was chosen to use, although you currently have "
+                      f"{game.clan.herbs[herb_used]}. Removing {herb_used} from herb dict, finding a new herb...")
+                game.clan.herbs.pop(herb_used)
+                usable_herbs.pop(0)
+                if usable_herbs:
+                    herb_used = usable_herbs[0]
+                else:
+                    print("No herbs to use for this injury")
+                    return
+                print(f"New herb found: {herb_used}")
+
+            # deplete the herb
+            amount_used = 1
             game.clan.herbs[herb_used] -= amount_used
             if game.clan.herbs[herb_used] <= 0:
                 game.clan.herbs.pop(herb_used)


### PR DESCRIPTION
- Treating a cat will now only use one herb. 
- I have no idea what is causing the bug where entries in the herb dictionary aren't being deleted after they reach 0.  I went through herb destruction and removed re-named herb dictionary which may be causing issues (it shouldn't be, but you never know). Added fail-save checks in herb destruction and usage to prevent using a herb that you don't have. These checks will also remove it from the herb dict. 
- Save check message will no longer show up when exiting from the settings screen or switch clan screen. 