### PR TITLE
Bugfix: Remove entry from game.switches when deleting clan

### DIFF
--- a/scripts/game_structure/windows.py
+++ b/scripts/game_structure/windows.py
@@ -173,6 +173,9 @@ class DeleteCheck(UIWindow):
                     data.remove(self.clan_name)
                 else:
                     print("error")
+
+                # Remove from the list in memory
+                game.switches['clan_list'].remove(self.clan_name)
                 
                 if data[-1].endswith("\n"):
                     data[-1] = data[-1][:-1] #remove the last \n

--- a/scripts/game_structure/windows.py
+++ b/scripts/game_structure/windows.py
@@ -179,7 +179,6 @@ class DeleteCheck(UIWindow):
 
                 # Remove from the list in memory
                 game.switches['clan_list'] = data
-                print(game.switches['clan_list'])
 
                 #write the file
                 with open("saves/clanlist.txt", "w") as clanfile:

--- a/scripts/game_structure/windows.py
+++ b/scripts/game_structure/windows.py
@@ -173,13 +173,14 @@ class DeleteCheck(UIWindow):
                     data.remove(self.clan_name)
                 else:
                     print("error")
-
-                # Remove from the list in memory
-                game.switches['clan_list'].remove(self.clan_name)
                 
                 if data[-1].endswith("\n"):
                     data[-1] = data[-1][:-1] #remove the last \n
-                
+
+                # Remove from the list in memory
+                game.switches['clan_list'] = data
+                print(game.switches['clan_list'])
+
                 #write the file
                 with open("saves/clanlist.txt", "w") as clanfile:
                     clanfile.writelines(data)


### PR DESCRIPTION
- The deleted clan was not being deleted from the game.switches['clan_list'] list when deleting the clan. This was causing a crash when you tried delete a clan twice. 