### PR TITLE
Run Discord RPC in a seperate thread

### DIFF
--- a/main.py
+++ b/main.py
@@ -117,7 +117,7 @@ else:
     version_number.set_position((800 - version_number.get_relative_rect()[2] - 8, 700 - version_number.get_relative_rect()[3]))
 
 
-game.rpc = _DiscordRPC("1076277970060185701")
+game.rpc = _DiscordRPC("1076277970060185701", daemon=True)
 game.rpc.start()
 game.rpc.start_rpc.set()
 while True:
@@ -144,6 +144,7 @@ while True:
                 game.rpc.update_rpc.set()
                 pygame.display.quit()
                 pygame.quit()
+                game.rpc.finished.wait(1)
                 sys.exit()
             else:
                 SaveCheck(game.switches['cur_screen'], False, None)

--- a/main.py
+++ b/main.py
@@ -118,6 +118,8 @@ else:
 
 
 game.rpc = _DiscordRPC("1076277970060185701")
+game.rpc.start()
+game.rpc.start_rpc.set()
 while True:
     time_delta = clock.tick(30) / 1000.0
     if game.switches['cur_screen'] not in ['start screen']:
@@ -138,7 +140,8 @@ while True:
             # Dont display if on the start screen or there is no clan.
             if (game.switches['cur_screen'] in ['start screen', 'switch clan screen', 'settings screen', 'info screen', 'make clan screen']
                 or not game.clan):
-                game.rpc.close()
+                game.rpc.close_rpc.set()
+                game.rpc.update_rpc.set()
                 pygame.display.quit()
                 pygame.quit()
                 sys.exit()

--- a/main.py
+++ b/main.py
@@ -144,7 +144,8 @@ while True:
                 game.rpc.update_rpc.set()
                 pygame.display.quit()
                 pygame.quit()
-                game.rpc.finished.wait(1)
+                if game.rpc.is_alive():
+                    game.rpc.join(1)
                 sys.exit()
             else:
                 SaveCheck(game.switches['cur_screen'], False, None)

--- a/scripts/clan.py
+++ b/scripts/clan.py
@@ -371,7 +371,8 @@ class Clan():
         game.rpc.update_rpc.set()
         pygame.display.quit()
         pygame.quit()
-        game.rpc.finished.wait(1)
+        if game.rpc.is_alive():
+            game.rpc.join(1)
         exit()
 
     def save_clan(self):

--- a/scripts/clan.py
+++ b/scripts/clan.py
@@ -371,6 +371,7 @@ class Clan():
         game.rpc.update_rpc.set()
         pygame.display.quit()
         pygame.quit()
+        game.rpc.finished.wait(1)
         exit()
 
     def save_clan(self):

--- a/scripts/clan.py
+++ b/scripts/clan.py
@@ -367,8 +367,8 @@ class Clan():
     def switch_clans(self, clan):
         game.save_clanlist(clan)
         game.cur_events_list.clear()
-
-        game.rpc.close()
+        game.rpc.close_rpc.set()
+        game.rpc.update_rpc.set()
         pygame.display.quit()
         pygame.quit()
         exit()

--- a/scripts/game_structure/discord_rpc.py
+++ b/scripts/game_structure/discord_rpc.py
@@ -37,17 +37,13 @@ class _DiscordRPC(threading.Thread):
         self.start_rpc = threading.Event()
         self.update_rpc = threading.Event()
         self.close_rpc = threading.Event()
-        self.finished = threading.Event()
             
     def run(self):
-        print("It begins....")
         self.start_rpc.wait()
-        print("pre connect!!")
         self.get_rpc()
         self.connect()
         while not self.close_rpc.is_set():
             self.update_rpc.wait()
-            print("Update!!")
             self.update()
         self.close()
 
@@ -128,5 +124,4 @@ class _DiscordRPC(threading.Thread):
         if self._connected:
             self._rpc.close()
             self._connected = False
-        self.finished.set()
             

--- a/scripts/game_structure/discord_rpc.py
+++ b/scripts/game_structure/discord_rpc.py
@@ -25,8 +25,8 @@ status_dict = {
     }
 
 class _DiscordRPC(threading.Thread):
-    def __init__(self, client_id: str):
-        super().__init__()
+    def __init__(self, client_id: str, daemon: bool):
+        super().__init__(daemon=daemon)
         self._rpc = None
         self._client_id = client_id
         self._connected = False
@@ -37,7 +37,8 @@ class _DiscordRPC(threading.Thread):
         self.start_rpc = threading.Event()
         self.update_rpc = threading.Event()
         self.close_rpc = threading.Event()
-
+        self.finished = threading.Event()
+            
     def run(self):
         print("It begins....")
         self.start_rpc.wait()
@@ -127,4 +128,5 @@ class _DiscordRPC(threading.Thread):
         if self._connected:
             self._rpc.close()
             self._connected = False
+        self.finished.set()
             

--- a/scripts/game_structure/windows.py
+++ b/scripts/game_structure/windows.py
@@ -105,7 +105,8 @@ class SaveCheck(UIWindow):
                     game.rpc.update_rpc.set()
                     pygame.display.quit()
                     pygame.quit()
-                    game.rpc.finished.wait(1)
+                    if game.rpc.is_alive():
+                        game.rpc.join(1)
                     exit()
             elif event.ui_element == self.save_button:
                 if game.clan is not None:

--- a/scripts/game_structure/windows.py
+++ b/scripts/game_structure/windows.py
@@ -105,6 +105,7 @@ class SaveCheck(UIWindow):
                     game.rpc.update_rpc.set()
                     pygame.display.quit()
                     pygame.quit()
+                    game.rpc.finished.wait(1)
                     exit()
             elif event.ui_element == self.save_button:
                 if game.clan is not None:

--- a/scripts/game_structure/windows.py
+++ b/scripts/game_structure/windows.py
@@ -101,7 +101,8 @@ class SaveCheck(UIWindow):
                     self.kill()
                 else:
                     game.is_close_menu_open = False
-                    game.rpc.close()
+                    game.rpc.close_rpc.set()
+                    game.rpc.update_rpc.set()
                     pygame.display.quit()
                     pygame.quit()
                     exit()

--- a/scripts/screens/base_screens.py
+++ b/scripts/screens/base_screens.py
@@ -94,9 +94,7 @@ class Screens():
 
         game.switches['cur_screen'] = new_screen
         game.switch_screens = True
-
-        game.rpc.update()
-
+        game.rpc.update_rpc.set()
         
 
     def __init__(self, name=None):

--- a/scripts/screens/organizational_screens.py
+++ b/scripts/screens/organizational_screens.py
@@ -40,6 +40,7 @@ class StartScreen(Screens):
                 game.rpc.update_rpc.set()
                 pygame.display.quit()
                 pygame.quit()
+                game.rpc.finished.wait(1)
                 exit()
 
     def on_use(self):
@@ -348,6 +349,7 @@ class SettingsScreen(Screens):
                 game.rpc.update_rpc.set()
                 pygame.display.quit()
                 pygame.quit()
+                game.rpc.finished.wait(1)
                 exit()
             elif event.ui_element == self.save_settings_button:
                 self.save_settings()

--- a/scripts/screens/organizational_screens.py
+++ b/scripts/screens/organizational_screens.py
@@ -40,7 +40,8 @@ class StartScreen(Screens):
                 game.rpc.update_rpc.set()
                 pygame.display.quit()
                 pygame.quit()
-                game.rpc.finished.wait(1)
+                if game.rpc.is_alive():
+                    game.rpc.join(1)
                 exit()
 
     def on_use(self):
@@ -349,7 +350,8 @@ class SettingsScreen(Screens):
                 game.rpc.update_rpc.set()
                 pygame.display.quit()
                 pygame.quit()
-                game.rpc.finished.wait(1)
+                if game.rpc.is_alive():
+                    game.rpc.join(1)
                 exit()
             elif event.ui_element == self.save_settings_button:
                 self.save_settings()
@@ -474,7 +476,8 @@ class SettingsScreen(Screens):
             self.update_save_button()
             self.refresh_checkboxes()
             if game.settings['discord']:
-                game.rpc = _DiscordRPC("1076277970060185701")
+                game.rpc = _DiscordRPC("1076277970060185701",
+                                       daemon=True)
             else:
                 game.rpc.close()
 

--- a/scripts/screens/organizational_screens.py
+++ b/scripts/screens/organizational_screens.py
@@ -478,6 +478,8 @@ class SettingsScreen(Screens):
             if game.settings['discord']:
                 game.rpc = _DiscordRPC("1076277970060185701",
                                        daemon=True)
+                game.rpc.start()
+                game.rpc.start_rpc.set()
             else:
                 game.rpc.close()
 

--- a/scripts/screens/organizational_screens.py
+++ b/scripts/screens/organizational_screens.py
@@ -36,7 +36,8 @@ class StartScreen(Screens):
             elif event.ui_element == self.settings_button:
                 self.change_screen('settings screen')
             elif event.ui_element == self.quit:
-                game.rpc.close()
+                game.rpc.close_rpc.set()
+                game.rpc.update_rpc.set()
                 pygame.display.quit()
                 pygame.quit()
                 exit()
@@ -343,7 +344,8 @@ class SettingsScreen(Screens):
             if event.ui_element == self.fullscreen_toggle:
                 game.switch_setting('fullscreen')
                 game.save_settings()
-                game.rpc.close()
+                game.rpc.close_rpc.set()
+                game.rpc.update_rpc.set()
                 pygame.display.quit()
                 pygame.quit()
                 exit()


### PR DESCRIPTION
Avoids the blocking socket operations freezing up the entire game.

The thread is daemonic so it'll just die if the main thread ends, it's only given one second to close properly on exit.