### PR TITLE
Bugfix: Classic Patrols

### DIFF
--- a/scripts/patrol.py
+++ b/scripts/patrol.py
@@ -292,7 +292,7 @@ class Patrol():
                 continue
 
             # correct button check
-            if 'general' not in patrol.tags and patrol_type != 'general':
+            if game.clan.game_mode != 'classic' and 'general' not in patrol.tags and patrol_type != 'general':
                 if 'hunting' not in patrol.tags and patrol_type == 'hunting':
                     continue
                 elif 'border' not in patrol.tags and patrol_type == 'border':


### PR DESCRIPTION
Non-general patrols are now possible on classic mode. This should stop the "no possible patrol" messages appearing for that mode.  