### PR TITLE
Fix crash when SaveCheck opens without a clan

### DIFF
--- a/main.py
+++ b/main.py
@@ -124,8 +124,9 @@ while True:
         game.all_screens[game.current_screen].handle_event(event)
 
         if event.type == pygame.QUIT:
-            # Dont display if on the start screen
-            if game.switches['cur_screen'] in ['start screen', 'switch clan screen', 'settings screen', 'info screen']:
+            # Dont display if on the start screen or there is no clan.
+            if (game.switches['cur_screen'] in ['start screen', 'switch clan screen', 'settings screen', 'info screen']
+                or not game.clan):
                 #game.rpc.close()
                 pygame.display.quit()
                 pygame.quit()

--- a/scripts/game_structure/windows.py
+++ b/scripts/game_structure/windows.py
@@ -22,7 +22,10 @@ class SaveCheck(UIWindow):
                          window_display_title='Save Check',
                          object_id='#save_check_window',
                          resizable=False)
-        self.clan_name = str(game.clan.name + 'Clan')
+
+        self.clan_name = "UndefinedClan"
+        if game.clan:
+            self.clan_name = f"{game.clan.name}Clan"
         self.last_screen = last_screen
         self.isMainMenu = isMainMenu
         self.mm_btn = mm_btn


### PR DESCRIPTION
 - Don't open ``SaveCheck`` without a clan.
 - Check if clan exists in ``SaveCheck.__init__()``.