### PR TITLE
fix: commented out unneeded prints

### DIFF
--- a/scripts/clan_resources/freshkill.py
+++ b/scripts/clan_resources/freshkill.py
@@ -117,8 +117,8 @@ class Freshkill_Pile():
         for key, value in self.pile.items():
             self.pile[key] = previous_amount
             previous_amount = value
-            if key == "expires_in_1":
-                print(f" -- FRESHKILL: {value} expired prey is removed")
+            #if key == "expires_in_1":
+                #print(f" -- FRESHKILL: {value} expired prey is removed")
         self.total_amount = sum(self.pile.values())
 
         self.feed_cats(living_cats)

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -68,8 +68,8 @@ class Events():
 
         if game.clan.game_mode in ['expanded', 'cruel season'] and game.clan.freshkill_pile:
             needed_amount = game.clan.freshkill_pile.amount_food_needed()
-            print(f" -- FRESHKILL: prey amount before feeding {game.clan.freshkill_pile.total_amount}")
-            print(f" -- FRESHKILL: clan needs {needed_amount} prey")
+            #print(f" -- FRESHKILL: prey amount before feeding {game.clan.freshkill_pile.total_amount}")
+            #print(f" -- FRESHKILL: clan needs {needed_amount} prey")
             # feed the cats and update the nutrient status
             relevant_cats = list(
                 filter(lambda _cat: _cat.is_alive() and not _cat.exiled and not _cat.outside, Cat.all_cats.values())
@@ -84,7 +84,7 @@ class Events():
             if not game.clan.freshkill_pile.clan_has_enough_food() and FRESHKILL_EVENT_ACTIVE:
                 game.cur_events_list.insert(0, Single_Event(
                     f"{game.clan.name}Clan doesn't have enough prey for next moon!"))
-            print(f" -- FRESHKILL: prey amount after feeding {game.clan.freshkill_pile.total_amount}")
+            #print(f" -- FRESHKILL: prey amount after feeding {game.clan.freshkill_pile.total_amount}")
         
         kittypet_ub = game.config["cotc_generation"]["kittypet_chance"]
         rogue_ub = game.config["cotc_generation"]["rogue_chance"]

--- a/scripts/events_module/freshkill_pile_events.py
+++ b/scripts/events_module/freshkill_pile_events.py
@@ -156,7 +156,7 @@ class Freshkill_Events():
         # check if amount of the freshkill pile is too big and a event will be triggered
         needed_amount = freshkill_pile.amount_food_needed()
         trigger_value = FRESHKILL_EVENT_TRIGGER_FACTOR * needed_amount
-        print(f" -- FRESHKILL: amount {trigger_value} to trigger freshkill event. current amount {freshkill_pile.total_amount}")
+        #print(f" -- FRESHKILL: amount {trigger_value} to trigger freshkill event. current amount {freshkill_pile.total_amount}")
         if freshkill_pile.total_amount < trigger_value:
             return
 
@@ -164,7 +164,7 @@ class Freshkill_Events():
         chance = 10 - factor
         if chance <= 0:
             chance = 1
-        print(f" -- FRESHKILL: trigger chance of 1/{chance}")
+        #print(f" -- FRESHKILL: trigger chance of 1/{chance}")
         choice = random.randint(1,chance)
         if choice != 1:
             return


### PR DESCRIPTION
commented out fresh-kill moonskip prints for the time being as the fresh-kill system is not active and all they do is clog the prints atm