### PR TITLE
Add support for macOS 10.13 in builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -218,14 +218,16 @@ jobs:
   build_macos64:
     # For commits to the original mac build action see:
     # https://github.com/Thlumyn/clangen/blob/29c9e39fed9a09b8de906f5c3b91dc044fe9b9a5/.github/workflows/main.yml
-    runs-on: macos-11
+    runs-on: macos-latest
+    defaults:
+      run:
+        shell: bash -l {0}
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python 3.10 x64
-        uses: actions/setup-python@v4
+        uses: conda-incubator/setup-miniconda@v2
         with:
-          python-version: '3.10'
-          architecture: 'x64'
+          python-version: "3.10"
       - name: Update pip
         run: python -m pip install --upgrade pip
       - name: Update setuptools and wheel


### PR DESCRIPTION
Since the setup-python action installs libraries built for an macOS 11 SDK, older macOS versions (down to 10.13) weren't supported anymore. Neither pygame nor any of the other dependencies caused any kinds of incompatibilities, so installing a Python version built against a lower SDK (10.13, in this case) restores High Sierra compatibility.

Here, I've used the conda-incubator/setup-miniconda action as replacement.

I've also bumped the runner to use `macos-latest` since there don't seem to be any observable issues regarding backwards-compatibility. Iirc, the PyInstaller documentation mentions some issues regarding code signing for 10.13, but since the builds aren't released on the App Store this seems to be mostly insignificant. The ad-hoc signing required for M1 based macOS versions is unaffected by this issue.

The build has been tested on a macOS 13.2 machine (MacBook Pro 14" (2021, M1)) and on a macOS 10.13.6 virtual machine. Both builds seem to run without further issues.