### PR TITLE
Fix unittest relationevents

### DIFF
--- a/tests/test_relation_events.py
+++ b/tests/test_relation_events.py
@@ -1,6 +1,7 @@
 import unittest
 from unittest.mock import patch
 
+from scripts import events
 from scripts.cat_relations.relationship import Relationship
 from scripts.events_module.relation_events import Relation_Events
 from scripts.cat.cats import Cat

--- a/tests/test_relation_events.py
+++ b/tests/test_relation_events.py
@@ -1,9 +1,9 @@
 import unittest
 from unittest.mock import patch
 
+from scripts.cat_relations.relationship import Relationship
 from scripts.events_module.relation_events import Relation_Events
 from scripts.cat.cats import Cat
-from scripts.cat_relations.relationship import Relationship
 from scripts.clan import Clan
 
 class CanHaveKits(unittest.TestCase):


### PR DESCRIPTION
Due to a cyclic import, the unit test pipeline failed. Importing from the scripts module for the side effects fixes this issue for now and causes unit tests to run as expected(?)