### PR TITLE
Other: Reduce the number of json reads per timeskip. 

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,14 +5,8 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="59212ee2-daae-4bfe-aec9-c3bc7c8ee83c" name="Changes" comment="">
-      <change beforePath="$PROJECT_DIR$/resources/dicts/names/names.json" beforeDir="false" afterPath="$PROJECT_DIR$/resources/dicts/names/names.json" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/scripts/cat/names.py" beforeDir="false" afterPath="$PROJECT_DIR$/scripts/cat/names.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/scripts/clan.py" beforeDir="false" afterPath="$PROJECT_DIR$/scripts/clan.py" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/scripts/events.py" beforeDir="false" afterPath="$PROJECT_DIR$/scripts/events.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/scripts/events_module/new_cat_events.py" beforeDir="false" afterPath="$PROJECT_DIR$/scripts/events_module/new_cat_events.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/scripts/events_module/relation_events.py" beforeDir="false" afterPath="$PROJECT_DIR$/scripts/events_module/relation_events.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/scripts/patrol.py" beforeDir="false" afterPath="$PROJECT_DIR$/scripts/patrol.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/scripts/screens/cat_screens.py" beforeDir="false" afterPath="$PROJECT_DIR$/scripts/screens/cat_screens.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/scripts/events_module/generate_events.py" beforeDir="false" afterPath="$PROJECT_DIR$/scripts/events_module/generate_events.py" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -22,11 +22,15 @@ from scripts.events_module.freshkill_pile_events import Freshkill_Events
 from scripts.event_class import Single_Event
 from scripts.game_structure.game_essentials import game
 from scripts.utility import get_alive_kits, get_med_cats, ceremony_text_adjust
+from scripts.events_module.generate_events import GenerateEvents
 
 
 class Events():
     all_events = {}
     game.switches['timeskip'] = False
+    #This is so we call call the static function needed to clear the events dict.
+    generate_events = GenerateEvents()
+
 
     def __init__(self, e_type=None, **cats):
         self.e_type = e_type
@@ -101,60 +105,14 @@ class Events():
         if random.randint(1, rejoin_upperbound) == 1:
             self.handle_lost_cats_return()
 
+        # Calling of "one_moon" functions.
         for cat in Cat.all_cats.copy().values():
             if not cat.outside or cat.dead:
                 self.one_moon_cat(cat)
-
             else:
-                # ---------------------------------------------------------------------------- #
-                #                              exiled cat events                               #
-                # ---------------------------------------------------------------------------- #
-                # aging the cat
-                cat.one_moon()
-                cat.moons += 1
-                cat.update_traits()
-                if cat.moons == 6:
-                    cat.age = 'adolescent'
-                elif cat.moons == 12:
-                    cat.age = 'adult'
-                elif cat.moons == 120:
-                    cat.age = 'elder'
+                self.one_moon_outside_cat(cat)
 
-                # killing exiled cats
-                if cat.exiled or cat.outside:
-                    if random.getrandbits(6) == 1 and not cat.dead:
-                        print("Cat Died: " + str(cat.name))
-                        cat.dead = True
-                        if cat.exiled:
-                            text = f'Rumors reach your Clan that the exiled {cat.name} has died recently.'
-                        elif cat.status in ['kittypet', 'loner', 'rogue']:
-                            text = f'Rumors reach your Clan that the {cat.status} {cat.name} has died recently.'
-                        else:
-                            cat.outside = False
-                            text = f"Will they reach StarClan, even so far away? {cat.name} isn't sure, " \
-                                   f"but as they drift away, they hope to see familiar starry fur on the other side."
-                        game.cur_events_list.append(Single_Event(text, "birth_death", cat.ID))
-
-                if cat.exiled and cat.status == 'leader' and not cat.dead and random.randint(
-                        1, 10) == 1:
-                    game.clan.leader_lives -= 1
-                    if game.clan.leader_lives > 0:
-                        text = f'Rumors reach your Clan that the exiled {cat.name} lost a life recently.'
-                        game.cur_events_list.append(Single_Event(text, "birth_death", cat.ID))
-                    else:
-                        text = f'Rumors reach your Clan that the exiled {cat.name} has died recently.'
-                        game.cur_events_list.append(Single_Event(text, "birth_death", cat.ID))
-                        cat.dead = True
-
-                elif cat.exiled and cat.status == 'leader' and not cat.dead and random.randint(
-                        1, 45) == 1:
-                    game.clan.leader_lives -= 10
-                    cat.dead = True
-                    text = f'Rumors reach your Clan that the exiled {cat.name} has died recently.'
-                    game.cur_events_list.append(Single_Event(text, "birth_death", cat.ID))
-                    game.clan.leader_lives = 0
-
-        # Handle injuries and relationships.
+        # Handle injuries and relationships. We must do with in a different all-cats loop.
         for cat in Cat.all_cats.values():
             if cat.dead or cat.outside:
                 continue
@@ -164,11 +122,11 @@ class Events():
             if random.getrandbits(1):
                 triggered_death = self.handle_injuries_or_general_death(cat)
                 if not triggered_death:
-                    triggered_death = self.handle_illnesses_or_illness_deaths(cat)
+                    self.handle_illnesses_or_illness_deaths(cat)
             else:
                 triggered_death = self.handle_illnesses_or_illness_deaths(cat)
                 if not triggered_death:
-                    triggered_death = self.handle_injuries_or_general_death(cat)
+                    self.handle_injuries_or_general_death(cat)
 
             # relationships have to be handled separately, because of the ceremony name change
             if not cat.dead or cat.outside:
@@ -202,8 +160,9 @@ class Events():
 
         self.check_clan_relations()
 
-        # age up the clan
+        # age up the clan, set current season
         game.clan.age += 1
+        game.clan.current_season = game.clan.seasons[game.clan.age % 12]
 
         self.herb_destruction()
         self.herb_gather()
@@ -233,8 +192,8 @@ class Events():
             game.ranks_changed_timeskip = False
             Cat.sort_cats()
 
-        # change season
-        game.clan.current_season = game.clan.seasons[game.clan.age % 12]
+        # Clear all the loaded event dicts.
+        Events.generate_events.clear_loaded_events()
 
         # autosave
         if game.settings.get('autosave') is True and game.clan.age % 5 == 0:
@@ -601,6 +560,55 @@ class Events():
 
                 game.cat_to_fade.append(cat.ID)
                 cat.set_faded()  # This is a flag to ensure they behave like a faded cat in the meantime.
+
+    def one_moon_outside_cat(self, cat):
+        # ---------------------------------------------------------------------------- #
+        #                              exiled cat events                               #
+        # ---------------------------------------------------------------------------- #
+        # aging the cat
+        cat.one_moon()
+        cat.moons += 1
+        cat.update_traits()
+        if cat.moons == 6:
+            cat.age = 'adolescent'
+        elif cat.moons == 12:
+            cat.age = 'adult'
+        elif cat.moons == 120:
+            cat.age = 'elder'
+
+        # killing exiled cats
+        if cat.exiled or cat.outside:
+            if random.getrandbits(6) == 1 and not cat.dead:
+                print("Cat Died: " + str(cat.name))
+                cat.dead = True
+                if cat.exiled:
+                    text = f'Rumors reach your Clan that the exiled {cat.name} has died recently.'
+                elif cat.status in ['kittypet', 'loner', 'rogue']:
+                    text = f'Rumors reach your Clan that the {cat.status} {cat.name} has died recently.'
+                else:
+                    cat.outside = False
+                    text = f"Will they reach StarClan, even so far away? {cat.name} isn't sure, " \
+                           f"but as they drift away, they hope to see familiar starry fur on the other side."
+                game.cur_events_list.append(Single_Event(text, "birth_death", cat.ID))
+
+        if cat.exiled and cat.status == 'leader' and not cat.dead and random.randint(
+                1, 10) == 1:
+            game.clan.leader_lives -= 1
+            if game.clan.leader_lives > 0:
+                text = f'Rumors reach your Clan that the exiled {cat.name} lost a life recently.'
+                game.cur_events_list.append(Single_Event(text, "birth_death", cat.ID))
+            else:
+                text = f'Rumors reach your Clan that the exiled {cat.name} has died recently.'
+                game.cur_events_list.append(Single_Event(text, "birth_death", cat.ID))
+                cat.dead = True
+
+        elif cat.exiled and cat.status == 'leader' and not cat.dead and random.randint(
+                1, 45) == 1:
+            game.clan.leader_lives -= 10
+            cat.dead = True
+            text = f'Rumors reach your Clan that the exiled {cat.name} has died recently.'
+            game.cur_events_list.append(Single_Event(text, "birth_death", cat.ID))
+            game.clan.leader_lives = 0
 
     def one_moon_cat(self, cat):
         # ---------------------------------------------------------------------------- #

--- a/scripts/events_module/generate_events.py
+++ b/scripts/events_module/generate_events.py
@@ -15,6 +15,8 @@ resource_directory = "resources/dicts/events/"
 # ---------------------------------------------------------------------------- #
 
 class GenerateEvents:
+    loaded_events = {}
+
     @staticmethod
     def get_event_dicts(event_triggered, cat_type, biome):
         events = None
@@ -22,15 +24,25 @@ class GenerateEvents:
             file_path = f"{resource_directory}{event_triggered}/{cat_type}.json"
             if biome:
                 file_path = f"{resource_directory}{event_triggered}/{biome}/{cat_type}.json"
+
+            # If this .json has already been loaded sometime in this timeskip, return the stored copy.
+            if file_path in GenerateEvents.loaded_events:
+                return GenerateEvents.loaded_events[file_path]
+
             with open(
                 file_path,
                 "r",
             ) as read_file:
                 events = ujson.loads(read_file.read())
+                GenerateEvents.loaded_events[file_path] = events
         except:
             print(f"ERROR: Unable to load {event_triggered} events for {cat_type} from biome {biome}.")
 
         return events
+
+    @staticmethod
+    def clear_loaded_events():
+        GenerateEvents.loaded_events = {}
 
     def generate_events(self, events_dict):
         event_list = []


### PR DESCRIPTION
- Previously, there a good number of duplicate json reads in a simple timeskip. Every time an event generated, all possible json files were read. After the event was determined, the information was erased. This would continue for every event, and often resulted in lots of duplicate work, especially in large clans.  This adds a static variable to GenerateEvents that contains all the jsons that have been read this moon, key-ed with their file path.  When the code calls for a certain json file, GenerateEvents first checks to see if the needed file path has already been read and stored in the dictionary. If so, it returns the already stored information. If not, it reads the needed json.  The stored event dictionaries are cleared at the end of the timeskip.  This should help cut down on the number of json reads needed. 
- Also - outside cat events were getting long, so they were moved to their own function: one_moon_outside_cat()