### PR TITLE
Bump pygame (+ Python for macOS)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -224,10 +224,10 @@ jobs:
         shell: bash -l {0}
     steps:
       - uses: actions/checkout@v3
-      - name: Setup Python 3.10 x64
+      - name: Setup Python 3.11 x64
         uses: conda-incubator/setup-miniconda@v2
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Update pip
         run: python -m pip install --upgrade pip
       - name: Update setuptools and wheel

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-pygame==2.1.3; platform_system != "Darwin"
-pygame==2.1.2; platform_system == "Darwin"
+pygame==2.2.0
 ujson==5.7.0
 pygame_gui==0.6.8


### PR DESCRIPTION
Safely bumping pygame from 2.1.3 (2.1.2 for macOS) to 2.2.0 for all targets.
Also adjust the macOS Python version from 3.10 to 3.11. Compatibility to macOS 10.13 is still maintained.