### PR TITLE
Content: Refactoring Acc Display and Bugfixes

### DIFF
--- a/resources/dicts/acc_display.json
+++ b/resources/dicts/acc_display.json
@@ -1,0 +1,422 @@
+{
+  "INFO": [
+    "default should be what you'd like to display on the cat profile",
+    "plural and singular will be used on events"
+  ],
+  "MAPLE LEAF": {
+    "default": "maple leaf",
+    "plural": "maple leaves",
+    "singular": "maple leaf"
+  },
+  "HOLLY": {
+    "default": "holly",
+    "plural": "holly",
+    "singular": "holly"
+  },
+  "BLUE BERRIES": {
+    "default": "blue berries",
+    "plural": "blue berries",
+    "singular": "blue berry"
+  },
+  "FORGET ME NOTS": {
+    "default": "forget-me-not flowers",
+    "plural": "forget-me-not flowers",
+    "singular": "forget-me-not flower"
+  },
+  "RYE STALK": {
+    "default": "rye stalk",
+    "plural": "rye stalks",
+    "singular": "rye stalk"
+  },
+  "LAUREL": {
+    "default": "laurel",
+    "plural": "laurels",
+    "singular": "laurel"
+  },
+  "BLUEBELLS": {
+    "default": "bluebells",
+    "plural": "bluebells",
+    "singular": "bluebell"
+  },
+  "NETTLE": {
+    "default": "nettle",
+    "plural": "nettles",
+    "singular": "nettle"
+  },
+  "POPPY": {
+    "default": "poppy",
+    "plural": "poppies",
+    "singular": "poppy"
+  },
+  "LAVENDER": {
+    "default": "lavender",
+    "plural": "lavender flowers",
+    "singular": "lavender"
+  },
+  "HERBS": {
+    "default": "herb-covered pelt",
+    "plural": "herbs",
+    "singular": "bunch of herbs",
+    "comment": ["just 'herb' sounds wrong, since the acc is visually multiple leaves on the cat. so i've structured",
+      "this in a way that allows it to sound correct when used for the singular_acc abbreviation"]
+  },
+  "PETALS": {
+    "default": "petal-covered pelt",
+    "plural": "petals",
+    "singular": "bunch of petals",
+    "comment": ["just 'petal' sounds wrong, since the acc is visually multiple petals on the cat. so i've structured",
+      "this in a way that allows it to sound correct when used for the singular_acc abbreviation"]
+  },
+  "DRY HERBS": {
+    "default": "herb-covered pelt",
+    "plural": "dry herbs",
+    "singular": "bunch of dry herbs",
+    "comment": ["just 'dry herb' sounds wrong, since the acc is visually multiple leaves on the cat. so i've structured",
+      "this in a way that allows it to sound correct when used for the singular_acc abbreviation"]
+  },
+  "OAK LEAVES": {
+    "default": "oak leaves",
+    "plural": "oak leaves",
+    "singular": "oak leaf"
+  },
+  "CATMINT": {
+    "default": "catmint",
+    "plural": "catmint",
+    "singular": "catmint"
+  },
+  "MAPLE SEED": {
+    "default": "maple seed",
+    "plural": "maple seeds",
+    "singular": "maple seed"
+  },
+  "JUNIPER": {
+    "default": "juniper",
+    "plural": "juniper",
+    "singular": "juniper"
+  },
+  "RED FEATHERS": {
+    "default": "cardinal feathers",
+    "plural": "cardinal feathers",
+    "singular": "cardinal feather"
+  },
+  "BLUE FEATHERS": {
+    "default": "crow feathers",
+    "plural": "crow feathers",
+    "singular": "crow feather"
+  },
+  "JAY FEATHERS": {
+    "default": "jay feathers",
+    "plural": "jay feathers",
+    "singular": "jay feather"
+  },
+  "MOTH WINGS": {
+    "default": "moth wings",
+    "plural": "moth wings",
+    "singular": "moth wing"
+  },
+  "CICADA WINGS": {
+    "default": "cicada wings",
+    "plural": "cicada wings",
+    "singular": "cicada wing"
+  },
+  "CRIMSON": {
+    "default": "crimson leather collar",
+    "plural": "crimson leather collars",
+    "singular": "crimson leather collar"
+  },
+  "BLUE": {
+    "default": "blue leather collar",
+    "plural": "blue leather collars",
+    "singular": "blue leather collar"
+  },
+  "CYAN": {
+    "default": "cyan leather collar",
+    "plural": "cyan leather collars",
+    "singular": "cyan leather collar"
+  },
+  "YELLOW": {
+    "default": "yellow leather collar",
+    "plural": "yellow leather collars",
+    "singular": "yellow leather collar"
+  },
+  "LIME": {
+    "default": "lime leather collar",
+    "plural": "lime leather collars",
+    "singular": "lime leather collar"
+  },
+  "GREEN": {
+    "default": "green leather collar",
+    "plural": "green leather collars",
+    "singular": "green leather collar"
+  },
+  "RED": {
+    "default": "red leather collar",
+    "plural": "red leather collars",
+    "singular": "red leather collar"
+  },
+  "RAINBOW": {
+    "default": "rainbow leather collar",
+    "plural": "rainbow leather collars",
+    "singular": "rainbow leather collar"
+  },
+  "BLACK": {
+    "default": "black leather collar",
+    "plural": "black leather collars",
+    "singular": "black leather collar"
+  },
+  "SPIKES": {
+    "default": "spiky leather collar",
+    "plural": "spiky leather collars",
+    "singular": "spiky leather collar"
+  },
+  "WHITE": {
+    "default": "white leather collar",
+    "plural": "white leather collars",
+    "singular": "white leather collar"
+  },
+  "PINK": {
+    "default": "pink leather collar",
+    "plural": "pink leather collars",
+    "singular": "pink leather collar"
+  },
+  "PURPLE": {
+    "default": "purple leather collar",
+    "plural": "purple leather collars",
+    "singular": "purple leather collar"
+  },
+  "MULTI": {
+    "default": "lilac leather collar",
+    "plural": "lilac leather collars",
+    "singular": "lilac leather collar"
+  },
+  "INDIGO": {
+    "default": "indigo leather collar",
+    "plural": "indigo leather collars",
+    "singular": "indigo leather collar"
+  },
+  "CRIMSONBELL": {
+    "default": "crimson bell collar",
+    "plural": "crimson bell collars",
+    "singular": "crimson bell collar"
+  },
+  "BLUEBELL": {
+    "default": "blue bell collar",
+    "plural": "blue bell collars",
+    "singular": "blue bell collar"
+  },
+  "CYANBELL": {
+    "default": "cyan bell collar",
+    "plural": "cyan bell collars",
+    "singular": "cyan bell collar"
+  },
+  "YELLOWBELL": {
+    "default": "yellow bell collar",
+    "plural": "yellow bell collars",
+    "singular": "yellow bell collar"
+  },
+  "LIMEBELL": {
+    "default": "lime bell collar",
+    "plural": "lime bell collars",
+    "singular": "lime bell collar"
+  },
+  "GREENBELL": {
+    "default": "green bell collar",
+    "plural": "green bell collars",
+    "singular": "green bell collar"
+  },
+  "REDBELL": {
+    "default": "red bell collar",
+    "plural": "red bell collars",
+    "singular": "red bell collar"
+  },
+  "RAINBOWBELL": {
+    "default": "rainbow bell collar",
+    "plural": "rainbow bell collars",
+    "singular": "rainbow bell collar"
+  },
+  "BLACKBELL": {
+    "default": "black bell collar",
+    "plural": "black bell collars",
+    "singular": "black bell collar"
+  },
+  "SPIKESBELL": {
+    "default": "spiky bell collar",
+    "plural": "spiky bell collars",
+    "singular": "spikybell collar"
+  },
+  "WHITEBELL": {
+    "default": "white bell collar",
+    "plural": "white bell collars",
+    "singular": "white bell collar"
+  },
+  "PINKBELL": {
+    "default": "pink bell collar",
+    "plural": "pink bell collars",
+    "singular": "pink bell collar"
+  },
+  "PURPLEBELL": {
+    "default": "purple bell collar",
+    "plural": "purple bell collars",
+    "singular": "purple bell collar"
+  },
+  "MULTIBELL": {
+    "default": "lilac bell collar",
+    "plural": "lilac bell collars",
+    "singular": "lilac bell collar"
+  },
+  "INDIGOBELL": {
+    "default": "indigo bell collar",
+    "plural": "indigo bell collars",
+    "singular": "indigo bell collar"
+  },
+  "CRIMSONBOW": {
+    "default": "crimson bow collar",
+    "plural": "crimson bow collars",
+    "singular": "crimson bow collar"
+  },
+  "BLUEBOW": {
+    "default": "blue bow collar",
+    "plural": "blue bow collars",
+    "singular": "blue bow collar"
+  },
+  "CYANBOW": {
+    "default": "cyan bow collar",
+    "plural": "cyan bow collars",
+    "singular": "cyan bow collar"
+  },
+  "YELLOWBOW": {
+    "default": "yellow bow collar",
+    "plural": "yellow bow collars",
+    "singular": "yellow bow collar"
+  },
+  "LIMEBOW": {
+    "default": "lime bow collar",
+    "plural": "lime bow collars",
+    "singular": "lime bow collar"
+  },
+  "GREENBOW": {
+    "default": "green bow collar",
+    "plural": "green bow collars",
+    "singular": "green bow collar"
+  },
+  "REDBOW": {
+    "default": "red bow collar",
+    "plural": "red bow collars",
+    "singular": "red bow collar"
+  },
+  "RAINBOWBOW": {
+    "default": "rainbow bow collar",
+    "plural": "rainbow bow collars",
+    "singular": "rainbow bow collar"
+  },
+  "BLACKBOW": {
+    "default": "black bow collar",
+    "plural": "black bow collars",
+    "singular": "black bow collar"
+  },
+  "SPIKESBOW": {
+    "default": "gold foil bow collar",
+    "plural": "gold foil bow collars",
+    "singular": "gold foil bow collar"
+  },
+  "WHITEBOW": {
+    "default": "white bow collar",
+    "plural": "white bow collars",
+    "singular": "white bow collar"
+  },
+  "PINKBOW": {
+    "default": "pink bow collar",
+    "plural": "pink bow collars",
+    "singular": "pink bow collar"
+  },
+  "PURPLEBOW": {
+    "default": "purple bow collar",
+    "plural": "purple bow collars",
+    "singular": "purple bow collar"
+  },
+  "MULTIBOW": {
+    "default": "lilac bow collar",
+    "plural": "lilac bow collars",
+    "singular": "lilac bow collar"
+  },
+  "INDIGOBOW": {
+    "default": "indigo bow collar",
+    "plural": "indigo bow collars",
+    "singular": "indigo bow collar"
+  },
+  "CRIMSONNYLON": {
+    "default": "crimson nylon collar",
+    "plural": "crimson nylon collars",
+    "singular": "crimson nylon collar"
+  },
+  "BLUENYLON:": {
+    "default": "blue nylon collar",
+    "plural": "blue nylon collars",
+    "singular": "blue nylon collar"
+  },
+  "CYANNYLON": {
+    "default": "cyan nylon collar",
+    "plural": "cyan nylon collars",
+    "singular": "cyan nylon collar"
+  },
+  "YELLOWNYLON": {
+    "default": "yellow nylon collar",
+    "plural": "yellow nylon collars",
+    "singular": "yellow nylon collar"
+  },
+  "LIMENYLON": {
+    "default": "lime nylon collar",
+    "plural": "lime nylon collars",
+    "singular": "lime nylon collar"
+  },
+  "GREENNYLON": {
+    "default": "green nylon collar",
+    "plural": "green nylon collars",
+    "singular": "green nylon collar"
+  },
+  "REDNYLON": {
+    "default": "red nylon collar",
+    "plural": "red nylon collars",
+    "singular": "red nylon collar"
+  },
+  "RAINBOWNYLON": {
+    "default": "rainbow nylon collar",
+    "plural": "rainbow nylon collars",
+    "singular": "rainbow nylon collar"
+  },
+  "BLACKNYLON": {
+    "default": "black nylon collar",
+    "plural": "black nylon collars",
+    "singular": "black nylon collar"
+  },
+  "SPIKESNYLON": {
+    "default": "blue and gold nylon collar",
+    "plural": "blue and gold nylon collars",
+    "singular": "blue and gold nylon collar"
+  },
+  "WHITENYLON": {
+    "default": "white nylon collar",
+    "plural": "white nylon collars",
+    "singular": "white nylon collar"
+  },
+  "PINKNYLON": {
+    "default": "pink nylon collar",
+    "plural": "pink nylon collars",
+    "singular": "pink nylon collar"
+  },
+  "PURPLENYLON": {
+    "default": "purple nylon collar",
+    "plural": "purple nylon collars",
+    "singular": "purple nylon collar"
+  },
+  "MULTINYLON": {
+    "default": "lilac nylon collar",
+    "plural": "lilac nylon collars",
+    "singular": "lilac nylon collar"
+  },
+  "INDIGONYLON": {
+    "default": "indigo nylon collar",
+    "plural": "indigo nylon collars",
+    "singular": "indigo nylon collar"
+  }
+}

--- a/resources/dicts/patrols/plains/med/leaf-fall.json
+++ b/resources/dicts/patrols/plains/med/leaf-fall.json
@@ -57,7 +57,7 @@
     "biome": "plains",
     "season": "leaf-fall",
     "tags": ["herb_gathering", "med_only", "herb", "betony", "many_herbs1", "many_herbs2"],
-    "intro_text": "As the betony plants start to dramatically give up on life as leaf-fall progresses, p_l takes the oportunity to go harvest from them.",
+    "intro_text": "As the betony plants start to dramatically give up on life as leaf-fall progresses, p_l takes the opportunity to go harvest from them.",
     "decline_text": "They have second thoughts leaving their patients behind and decide to go another day.",
     "chance_of_success": 70,
     "exp": 10,

--- a/scripts/cat/appearance_utility.py
+++ b/scripts/cat/appearance_utility.py
@@ -35,131 +35,13 @@ from .pelts import (
     pelt_colours,
     tortiepatterns,
     )
-
+try:
+    import ujson
+except ImportError:
+    import json as ujson
 from scripts.cat.sprites import Sprites
 from scripts.game_structure.game_essentials import game
 
-# ---------------------------------------------------------------------------- #
-#                               utility functions                              #
-# ---------------------------------------------------------------------------- #
-
-def plural_acc_names(accessory, plural, singular):
-    acc_display = accessory.lower()
-    if acc_display == 'maple leaf':
-        if plural:
-            acc_display = 'maple leaves'
-        if singular:
-            acc_display = 'maple leaf'
-    elif acc_display == 'holly':
-        if plural:
-            acc_display = 'holly berries'
-        if singular:
-            acc_display = 'holly berry'
-    elif acc_display == 'blue berries':
-        if plural:
-            acc_display = 'blueberries'
-        if singular:
-            acc_display = 'blueberry'
-    elif acc_display == 'forget me nots':
-        if plural:
-            acc_display = 'forget me nots'
-        if singular:
-            acc_display = 'forget me not flower'
-    elif acc_display == 'rye stalk':
-        if plural:
-            acc_display = 'rye stalks'
-        if singular:
-            acc_display = 'rye stalk'
-    elif acc_display == 'laurel':
-        if plural:
-            acc_display = 'laurel'
-        if singular:
-            acc_display = 'laurel plant'
-    elif acc_display == 'bluebells':
-        if plural:
-            acc_display = 'bluebells'
-        if singular:
-            acc_display = 'bluebell flower'
-    elif acc_display == 'nettle':
-        if plural:
-            acc_display = 'nettles'
-        if singular:
-            acc_display = 'nettle'
-    elif acc_display == 'poppy':
-        if plural:
-            acc_display = 'poppies'
-        if singular:
-            acc_display = 'poppy flower'
-    elif acc_display == 'lavender':
-        if plural:
-            acc_display = 'lavender'
-        if singular:
-            acc_display = 'lavender flower'
-    elif acc_display == 'herbs':
-        if plural:
-            acc_display = 'herbs'
-        if singular:
-            acc_display = 'herb'
-    elif acc_display == 'petals':
-        if plural:
-            acc_display = 'petals'
-        if singular:
-            acc_display = 'petal'
-    elif acc_display == ('dry herbs' or 'dry_herbs'):
-        if plural:
-            acc_display = 'dry herbs'
-        if singular:
-            acc_display = 'dry herb'
-    elif acc_display == 'oak leaves':
-        if plural:
-            acc_display = 'oak leaves'
-        if singular:
-            acc_display = 'oak leaf'
-    elif acc_display == 'catmint':
-        if plural:
-            acc_display = 'catnip'
-        if singular:
-            acc_display = 'catnip sprig'
-    elif acc_display == 'maple seed':
-        if plural:
-            acc_display = 'maple seeds'
-        if singular:
-            acc_display = 'maple seed'
-    elif acc_display == 'juniper':
-        if plural:
-            acc_display = 'juniper berries'
-        if singular:
-            acc_display = 'juniper berry'
-    elif acc_display == 'red feathers':
-        if plural:
-            acc_display = 'cardinal feathers'
-        if singular:
-            acc_display = 'cardinal feather'
-    elif acc_display == 'blue feathers':
-        if plural:
-            acc_display = 'crow feathers'
-        if singular:
-            acc_display = 'crow feather'
-    elif acc_display == 'jay feathers':
-        if plural:
-            acc_display = 'jay feathers'
-        if singular:
-            acc_display = 'jay feather'
-    elif acc_display == 'moth wings':
-        if plural:
-            acc_display = 'moth wings'
-        if singular:
-            acc_display = 'moth wing'
-    elif acc_display == 'cicada wings':
-        if plural:
-            acc_display = 'cicada wings'
-        if singular:
-            acc_display = 'cicada wing'
-
-    if plural is True and singular is False:
-        return acc_display
-    elif singular is True and plural is False:
-        return acc_display
 
 # ---------------------------------------------------------------------------- #
 #                                init functions                                #

--- a/scripts/cat/pelts.py
+++ b/scripts/cat/pelts.py
@@ -286,6 +286,7 @@ scars2 = ["LEFTEAR", "RIGHTEAR", "NOTAIL", "HALFTAIL", "NOPAW", "NOLEFTEAR", "NO
 scars3 = ["SNAKE", "TOETRAP", "BURNPAWS", "BURNTAIL", "BURNBELLY", "BURNRUMP", "FROSTFACE", "FROSTTAIL", "FROSTMITT",
           "FROSTSOCK", ]
 
+# make sure to add plural and singular forms of new accs to acc_display.json so that they will display nicely
 plant_accessories = ["MAPLE LEAF", "HOLLY", "BLUE BERRIES", "FORGET ME NOTS", "RYE STALK", "LAUREL",
                      "BLUEBELLS", "NETTLE", "POPPY", "LAVENDER", "HERBS", "PETALS", "DRY HERBS",
                      "OAK LEAVES", "CATMINT", "MAPLE SEED", "JUNIPER"

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -441,7 +441,7 @@ class Events():
                 game.clan.herbs.pop(bad_herb)
                 insert2 = "all of"
 
-            event = f"As the herb stores are inspected by the {insert}, it's noticed" \
+            event = f"As the herb stores are inspected by the {insert}, it's noticed " \
                     f"that {insert2} the {bad_herb.replace('_', ' ')}" \
                     f" went bad. They'll have to be replaced with new ones. "
             game.herb_events_list.append(event)

--- a/scripts/events_module/new_cat_events.py
+++ b/scripts/events_module/new_cat_events.py
@@ -113,6 +113,8 @@ class NewCatEvents:
             involved_cats.append(new_cat.ID)
             if "adoption" in new_cat_event.tags:
                 new_cat.parent1 = cat.ID
+                if cat.mate:
+                    new_cat.parent2 = cat.mate
                 print('parent is', new_cat.parent1, cat.ID)
 
             if "m_c" in new_cat_event.tags:

--- a/scripts/patrol.py
+++ b/scripts/patrol.py
@@ -1065,7 +1065,7 @@ class Patrol():
                     new_cat.get_permanent_condition(new_condition)
 
         # we create any needed litters
-        if litter:
+        if litter or litter_choice:
             created_cats.extend(create_new_cat(Cat,
                                                new_name=new_name,
                                                loner=loner,

--- a/scripts/patrol.py
+++ b/scripts/patrol.py
@@ -1078,7 +1078,7 @@ class Patrol():
                                                age=kit_age,
                                                gender=gender,
                                                thought=thought,
-                                               alive=alive,
+                                               alive=True,
                                                outside=outside
                                                ))
             # giving the mother the necessary condition

--- a/scripts/screens/cat_screens.py
+++ b/scripts/screens/cat_screens.py
@@ -10,7 +10,7 @@ try:
 except ImportError:
     import json as ujson
 
-from scripts.utility import update_sprite, event_text_adjust, scale
+from scripts.utility import update_sprite, event_text_adjust, scale, ACC_DISPLAY
 
 from .base_screens import Screens, cat_profiles
 
@@ -800,9 +800,10 @@ class ProfileScreen(Screens):
         output += "\n"
 
         # ACCESSORY
-        output += 'accessory: ' + str(accessory_display_name(the_cat))
-        # NEWLINE ----------
-        output += "\n"
+        if the_cat.accessory:
+            output += 'accessory: ' + str(ACC_DISPLAY[the_cat.accessory]["default"])
+            # NEWLINE ----------
+            output += "\n"
 
         # PARENTS
         if the_cat.parent1 is None and the_cat.parent2 is None:

--- a/scripts/utility.py
+++ b/scripts/utility.py
@@ -10,8 +10,6 @@ TODO: Docs
 
 from random import choice, choices, randint, random
 import pygame
-
-from scripts.cat.appearance_utility import plural_acc_names
 from scripts.cat.names import names
 
 try:
@@ -628,9 +626,9 @@ def event_text_adjust(Cat,
         adjust_text = adjust_text.replace("n_c_pre", str(new_cat.name.prefix))
         adjust_text = adjust_text.replace("n_c", str(new_cat.name))
     if "acc_plural" in adjust_text:
-        adjust_text = adjust_text.replace("acc_plural", str(plural_acc_names(cat.accessory, True, False)))
+        adjust_text = adjust_text.replace("acc_plural", str(ACC_DISPLAY[cat.accessory]["plural"]))
     if "acc_singular" in adjust_text:
-        adjust_text = adjust_text.replace("acc_singular", str(plural_acc_names(cat.accessory, False, True)))
+        adjust_text = adjust_text.replace("acc_singular", str(ACC_DISPLAY[cat.accessory]["singular"]))
 
     if clan is not None:
         _tmp = clan
@@ -1099,3 +1097,7 @@ def get_text_box_theme(themename=""):
 PERMANENT = None
 with open(f"resources/dicts/conditions/permanent_conditions.json", 'r') as read_file:
     PERMANENT = ujson.loads(read_file.read())
+
+ACC_DISPLAY = None
+with open(f"resources/dicts/acc_display.json", 'r') as read_file:
+    ACC_DISPLAY = ujson.loads(read_file.read())


### PR DESCRIPTION
- Moved acc_display info into the acc_display.json, the json now lists both a plural, singular, and default form for each acc.  The default form is specifically what displays on the cat's profile while the plural and singular are used in events.
- There's no longer an acc display function in appearance_utility, rather you can just grab the form you need from the json dict with ACC_DISPLAY[cat.accessory][form] with form being either "default", "plural", or "singular"
- Fixed a bug where a dead queens litter would also be generated as dead cats
- Fixed a bug where a cat would adopt a new litter, but the cat's mate would not be listed as the litter's other parent
- Fixed a bug where a litter would not be generated even though the patrol mentioned a litter