### PR TITLE
Don't attempt to import the platformdirs module on source

### DIFF
--- a/scripts/datadir.py
+++ b/scripts/datadir.py
@@ -1,8 +1,6 @@
 import os
 import platform
 
-from platformdirs import *
-
 from scripts.version import get_version_info
 
 
@@ -23,7 +21,10 @@ def setup_data_dir():
 def get_data_dir():
     if get_version_info().is_source_build:
         return '.'
-    elif not get_version_info().is_release:
+
+    from platformdirs import user_data_dir
+
+    if not get_version_info().is_release:
         return user_data_dir('ClanGenBeta', 'ClanGen')
     return user_data_dir('ClanGen', 'ClanGen')
 


### PR DESCRIPTION
This avoids the necessity of installing it as dependency in source builds.