### PR TITLE
Limit the competence of med cats in unit tests

### DIFF
--- a/tests/test_conditions.py
+++ b/tests/test_conditions.py
@@ -58,6 +58,7 @@ class TestsMedCondition(unittest.TestCase):
 
         med = Cat(moons=20)
         med.status = "medicine cat"
+        med.experience = 100
         med.experience_level = 'competent'
 
         all_cats = [cat1, cat2, cat3, cat4, med]

--- a/tests/test_conditions.py
+++ b/tests/test_conditions.py
@@ -58,6 +58,7 @@ class TestsMedCondition(unittest.TestCase):
 
         med = Cat(moons=20)
         med.status = "medicine cat"
+        med.experience_level = 'competent'
 
         all_cats = [cat1, cat2, cat3, cat4, med]
         self.assertFalse(medical_cats_condition_fulfilled(all_cats, 2))


### PR DESCRIPTION
Sometimes they're just too competent and don't fail as they're supposed to.