### PR TITLE
Tweaks: Apprentice Graduation Balancing

### DIFF
--- a/resources/game_config.json
+++ b/resources/game_config.json
@@ -209,13 +209,13 @@
 		"comment": "Set this to -1 for it to be infinite"
 	},
 	"graduation": {
-		"base_app_timeskip_ex": [[3, 4, 5, 6, 7, 8, 9], [5, 10, 15, 40, 15, 10, 5]],
-		"base_med_app_timeskip_ex": [[1, 2, 3, 4, 5, 6, 7], [5, 10, 15, 40, 15, 10, 5]],
+		"base_app_timeskip_ex": [[3, 10],[5, 6]],
+		"base_med_app_timeskip_ex": [[2, 7],[2, 3]],
 		"max_apprentice_age": {
 			"medicine cat apprentice": 30,
 			"apprentice": 25,
 			"mediator apprentice": 25
 		},
-		"min_graduating_age": 9
+		"min_graduating_age": 10
 	}
 }

--- a/resources/gamesettings.json
+++ b/resources/gamesettings.json
@@ -96,7 +96,7 @@
             ""
         ],
         "first_cousin_mates": [
-            "Allow first cousins to mate",
+            "Allow first cousins to be mates and have romantic interactions",
             ""
         ]
     }

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -2291,23 +2291,27 @@ class Cat():
         else:
             apply_bonus = True
             # EX gain on success
-            EX_gain = randint(5, 12)
+            if mediator.status != "mediator apprentice":
+                EX_gain = randint(10, 24)
 
-            gm_modifier = 1
-            if game.clan.game_mode == 'expanded':
-                gm_modifier = 3
-            elif game.clan.game_mode == 'cruel season':
-                gm_modifier = 6
+                gm_modifier = 1
+                if game.clan.game_mode == 'expanded':
+                    gm_modifier = 3
+                elif game.clan.game_mode == 'cruel season':
+                    gm_modifier = 6
 
-            if mediator.experience_level == "average":
-                lvl_modifier = 1.25
-            elif mediator.experience_level == "high":
-                lvl_modifier = 1.75
-            elif mediator.experience_level == "master":
-                lvl_modifier = 2
-            else:
-                lvl_modifier = 1
-            mediator.experience += EX_gain / lvl_modifier / gm_modifier
+                if mediator.experience_level == "average":
+                    lvl_modifier = 1.25
+                elif mediator.experience_level == "high":
+                    lvl_modifier = 1.75
+                elif mediator.experience_level == "master":
+                    lvl_modifier = 2
+                else:
+                    lvl_modifier = 1
+                mediator.experience += EX_gain / lvl_modifier / gm_modifier
+
+        if mediator.status == "mediator apprentice":
+            mediator.experience += max(random.randint(1, 6), 1)
 
         no_romantic_mentor = False
         if not game.settings['romantic with former mentor']:

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -400,9 +400,10 @@ class Cat():
                 m = self.moons
                 self.experience = 0
                 while m > Cat.age_moons['adolescent'][0]:
-                    base_ex = 0.6 * random.choices(game.config["graduation"]["base_app_timeskip_ex"][0],
-                                          weights=game.config["graduation"]["base_app_timeskip_ex"][1], k=1)[0]
-                    self.experience += base_ex
+                    ran = game.config["graduation"]["base_app_timeskip_ex"]
+                    exp = random.choice(
+                        list(range(ran[0][0], ran[0][1] + 1)) + list(range(ran[1][0], ran[1][1] + 1)) * 2)
+                    self.experience += exp + 3
                     m -= 1
             elif self.age in ['young adult', 'adult']:
                 self.experience = randint(Cat.experience_levels_range["prepared"][0],

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -1506,34 +1506,27 @@ class Events():
                 "apprentice", "medicine cat apprentice", "mediator apprentice"
         ]:
 
-            if cat.not_working():
-                # print(f"{cat.name} not working, no EX gain")
+            if cat.not_working() and int(random.random() * 3):
                 return
 
-            if cat.experience > cat.experience_levels_range["trainee"][0]:
+            if cat.experience > cat.experience_levels_range["trainee"][1]:
                 return
 
             if cat.status == "medicine cat apprentice":
-                base_ex = random.choices(
-                    game.config["graduation"]["base_med_app_timeskip_ex"][0],
-                    weights=game.config["graduation"]
-                    ["base_med_app_timeskip_ex"][1],
-                    k=1)[0]
+                ran = game.config["graduation"]["base_med_app_timeskip_ex"]
             else:
-                base_ex = random.choices(
-                    game.config["graduation"]["base_app_timeskip_ex"][0],
-                    weights=game.config["graduation"]["base_app_timeskip_ex"]
-                    [1],
-                    k=1)[0]
+                ran = game.config["graduation"]["base_app_timeskip_ex"]
 
             if not cat.mentor or Cat.fetch_cat(cat.mentor).not_working():
                 # Sick mentor debuff
-                mentor_modifier = 0.6
+                mentor_modifier = 0.7
             else:
                 mentor_modifier = 1
 
-            cat.experience += max(base_ex * mentor_modifier, 1)
-            # print(f"{cat.name} has gained {int(base_ex * mentor_modifier)} EX", cat._experience)
+            exp = random.choice(list(range(ran[0][0], ran[0][1] + 1)) + list(range(ran[1][0], ran[1][1] + 1)) * 2)
+
+            cat.experience += max(exp * mentor_modifier, 1)
+            print(f"{cat.name} has gained {int(exp * mentor_modifier)} EX", cat._experience)
 
     def invite_new_cats(self, cat):
         """

--- a/scripts/patrol.py
+++ b/scripts/patrol.py
@@ -756,8 +756,6 @@ class Patrol():
                     if success_text[1]:
                         outcome = 1
 
-            self.handle_exp_gain()
-
             if not antagonize:
                 self.add_new_cats(outcome)
             if self.patrol_event.tags is not None:
@@ -872,6 +870,7 @@ class Patrol():
             if antagonize:
                 self.antagonize_fail = self.patrol_event.antagonize_fail_text
 
+        self.handle_exp_gain(self.success)
         if not antagonize and game.clan.game_mode != "classic":
             self.handle_prey(outcome)
 
@@ -1270,13 +1269,8 @@ class Patrol():
     #                                   Handlers                                   #
     # ---------------------------------------------------------------------------- #
 
-    def handle_exp_gain(self):
-        base_exp = 0
-        if "master" in self.experience_levels:
-            max_boost = 10
-        else:
-            max_boost = 0
-        patrol_exp = 2 * self.patrol_event.exp
+    def handle_exp_gain(self, success: bool):
+
         if game.clan.game_mode == 'classic':
             gm_modifier = 1
         elif game.clan.game_mode == 'expanded':
@@ -1286,13 +1280,31 @@ class Patrol():
         else:
             gm_modifier = 1
 
-        gained_exp = (patrol_exp + base_exp + max_boost)
-        gained_exp = gained_exp * (1 - 0.1 * len(self.patrol_cats)) / gm_modifier
-        if gained_exp < 1:
-            gained_exp = 1
+        if success:
+            base_exp = 0
+            if "master" in self.experience_levels:
+                max_boost = 10
+            else:
+                max_boost = 0
+            patrol_exp = 2 * self.patrol_event.exp
+            gained_exp = (patrol_exp + base_exp + max_boost)
+            gained_exp = max(gained_exp * (1 - 0.1 * len(self.patrol_cats)) / gm_modifier, 1)
+        else:
+            gained_exp = 0
 
-        for cat in self.patrol_cats:
-            cat.experience = cat.experience + gained_exp
+        #Apprentice exp, does not depend on success
+        if "apprentice" in self.patrol_statuses or "medicine cat apprentice" in self.patrol_statuses:
+            app_exp = max(random.randint(1, 7) * (1 - 0.1 * len(self.patrol_cats)), 1)
+        else:
+            app_exp = 0
+
+        if gained_exp or app_exp:
+            for cat in self.patrol_cats:
+                if cat.status in ["apprentice", "medicine cat apprentice"]:
+                    cat.experience = cat.experience + app_exp
+                    print(f"{cat.name} earned {app_exp}. New exp: {cat.experience}")
+                else:
+                    cat.experience = cat.experience + gained_exp
 
     def handle_deaths_and_gone(self, cat):
         if "no_body" in self.patrol_event.tags:


### PR DESCRIPTION
- Passive EX now works. 
- Apprentices now receive patrol EX from a fixed range. They receive this EX on both success and failure. 
- Apprentice now receive EX on mediate fail. 
- Adjusted mediate EX
- Adjusted passive EX range
- Sick apprentices now have a 33% chance to receive passive EX. 
- Raised minimum graduation age to 10 moons. 
- Changed the wording of the first cousin setting back to it's previous text. The changed text was not properly accurate. 

Hopefully this should help a bit with balancing. 