### PR TITLE
Content: clairvoyancy, stories, and new kit fix

### DIFF
--- a/resources/dicts/events/misc_events/general/general.json
+++ b/resources/dicts/events/misc_events/general/general.json
@@ -186,5 +186,25 @@
         "cat_skill": null,
         "other_cat_trait": null,
         "other_cat_skill": null
+    },
+    {
+        "camp": "any",
+        "tags": ["clan_kits", "Newleaf", "Greenleaf", "Leaf-fall", "Leaf-bare"],
+        "event_text": "m_c gathered up the kits to tell them stories of story_list.",
+        "cat_trait": null,
+        "cat_skill": ["lore keeper", "good kitsitter", "great kitsitter", "excellent kitsitter","good storyteller", "great storyteller", "fantastic storyteller"],
+        "other_cat_trait": null,
+        "other_cat_skill": null
+    },
+    {
+        "camp": "any",
+        "tags": ["Newleaf", "Greenleaf", "Leaf-fall", "Leaf-bare"],
+        "event_text": "m_c spends the evening regaling the Clan with stories of story_list.",
+        "cat_trait": null,
+        "cat_skill": ["lore keeper", "good kitsitter", "great kitsitter", "excellent kitsitter",
+            "good storyteller", "great storyteller", "fantastic storyteller"
+        ],
+        "other_cat_trait": null,
+        "other_cat_skill": null
     }
 ]

--- a/resources/dicts/events/misc_events/general/medicine.json
+++ b/resources/dicts/events/misc_events/general/medicine.json
@@ -122,7 +122,7 @@
   {
     "camp": "any",
     "tags": ["Newleaf", "Greenleaf", "Leaf-fall", "Leaf-bare"],
-    "event_text": "m_c tosses in their sleep and their dreamself pads through the thoughts of their clanmates, picking up snippets of dream_list. They blink slowly awake, wondering whose dreams they walked in.",
+    "event_text": "m_c tosses in their sleep and their dreamself pads through the thoughts of their Clanmates, picking up snippets of dream_list. They blink slowly awake, wondering whose dreams they walked in.",
     "cat_trait": null,
     "cat_skill": ["dream walker"],
     "other_cat_trait": null,

--- a/resources/dicts/patrols/new_cat.json
+++ b/resources/dicts/patrols/new_cat.json
@@ -72,7 +72,7 @@
     "patrol_id": "gen_gen_newkit2",
     "biome": "Any",
     "season": "Any",
-    "tags": ["border", "new_cat_kit", "reputation", "no_change_fail_rep"],
+    "tags": ["border", "new_cat_kitten", "reputation", "no_change_fail_rep"],
     "intro_text": "r_c finds an abandoned kit whose parents are nowhere to be found.",
     "success_text": [
         "The kit is taken back to camp and nursed back to health."

--- a/resources/dicts/patrols/new_cat_hostile.json
+++ b/resources/dicts/patrols/new_cat_hostile.json
@@ -72,7 +72,7 @@
     "patrol_id": "gen_gen_newkit3",
     "biome": "Any",
     "season": "Any",
-    "tags": ["border", "new_cat_kit", "reputation", "no_change_fail_rep"],
+    "tags": ["border", "new_cat_kitten", "reputation", "no_change_fail_rep"],
     "intro_text": "r_c finds an abandoned kit whose parents are nowhere to be found.",
     "success_text": [
         "The kit is taken back to camp and nursed back to health."

--- a/resources/dicts/patrols/new_cat_welcoming.json
+++ b/resources/dicts/patrols/new_cat_welcoming.json
@@ -72,7 +72,7 @@
     "patrol_id": "gen_gen_newkit1",
     "biome": "Any",
     "season": "Any",
-    "tags": ["border", "new_cat_kit", "reputation", "no_change_fail_rep"],
+    "tags": ["border", "new_cat_kitten", "reputation", "no_change_fail_rep"],
     "intro_text": "r_c finds an abandoned kit whose parents are nowhere to be found.",
     "success_text": [
         "r_c rushes the kit back to camp. The kit is nursed back to health and promised a place in the Clan."

--- a/resources/dicts/snippet_collections.json
+++ b/resources/dicts/snippet_collections.json
@@ -1,11 +1,12 @@
 {
   "comment": [
-    "add new snippets to the relevant list",
+    "add new snippets to the relevant list:",
     "prophecy list can have more amorphous and dreamy concepts",
-    "omen list should more physical, snippets should feel odd and meaningful, but grounded in reality",
+    "omen list should be more physical, should feel odd and meaningful, but grounded in reality",
     "dream list should focus on emotional feelings rather than specific happenings",
+    "clair (clairvoyance) list should focus on amorphous feelings of things that already happened or could happen",
 
-    "be sure to put your snippet in the relevant 'sense' category.",
+    "be sure to put your snippet in the relevant 'sense' category (if the list has sense categories).",
     "general lists are meant to hold the snippets that fit in any biome",
     "the lists within the lists are where we hold the snippets",
     "snippets that are grouped together in one list are similar enough that we don't want them appearing in the same event together",
@@ -37,7 +38,7 @@
         ["the falling petals of a flower", "petals drifting in the breeze", "a flower missing one petal"],
         ["honey dripping", "a dripping honeycomb"],
         ["spreading frost", "a frosty morning", "frost covering the camp"],
-        ["falling trees", "the forest folding in on itself"],
+        ["falling trees"],
         ["a dry river still flowing with water", "a clear pool of water", "a rippling pool of water", "a pool of water with something just below the surface", "claw-marks on a still puddle", "a rainbow on the water"],
         ["deathberries", "wilting herbs", "bountiful herbs"],
         ["the moon", "a blackbird covering the moon", "a bleeding moon"],
@@ -65,6 +66,20 @@
         ["a cat covered in blood"],
         ["a cat standing beside a Twoleg"],
         ["stones dissolving in water"]
+      ],
+      "forest": [
+        ["the forest folding in on itself"]
+
+      ],
+      "plains": [
+        ["a blood soaked field"]
+
+      ],
+      "beach": [
+
+      ],
+      "mountainous": [
+
       ]
     },
     "sound": {
@@ -89,6 +104,18 @@
         ["a dying promise"],
         ["a cat's final words"]
 
+      ],
+      "forest": [
+
+      ],
+      "plains": [
+
+      ],
+      "beach": [
+
+      ],
+      "mountainous": [
+
       ]
     },
     "smell": {
@@ -101,6 +128,18 @@
         ["the scent of traveling herbs"],
         ["pawsteps that smell like no cat"],
         ["the scent of milk far from the nursery"]
+      ],
+      "forest": [
+
+      ],
+      "plains": [
+
+      ],
+      "beach": [
+
+      ],
+      "mountainous": [
+
       ]
     },
     "emotional": {
@@ -113,6 +152,18 @@
         ["a half-remembered promise"],
         ["a foreboding feeling"],
         ["the embrace of a family"]
+      ],
+      "forest": [
+
+      ],
+      "plains": [
+
+      ],
+      "beach": [
+
+      ],
+      "mountainous": [
+
       ]
     },
     "touch": {
@@ -121,6 +172,18 @@
         ["the touch of a mentor to an apprentice's forehead"],
         ["a tail twining with their own"],
         ["the warmth of a parent"]
+      ],
+      "forest": [
+
+      ],
+      "plains": [
+
+      ],
+      "beach": [
+
+      ],
+      "mountainous": [
+
       ]
     }
   },
@@ -131,7 +194,7 @@
         ["a five-pointed leaf", "a star-shaped leaf", "an oddly torn leaf"],
         ["a stone of two halves perfectly fitting together", "a stone with shining chips in it", "a stone with odd patterns on it", "a sparkling stone"],
         ["a crooked-jawed squirrel"],
-        ["an odd pile of sold downy fur", "a tuft of fox fur", "a tuft of badger fur", "a charred scrap of fur"],
+        ["an odd pile of soft downy fur", "a tuft of fox fur", "a tuft of badger fur", "a charred scrap of fur"],
         ["a shard of glass"],
         ["withered deathberries"],
         ["a strangely shaped cloud", "a cat shaped cloud"],
@@ -158,12 +221,36 @@
         ["an abandoned bee-stinger"],
         ["a miraculously burning reed"],
         ["a shed whisker"]
+      ],
+      "forest": [
+
+      ],
+      "plains": [
+
+      ],
+      "beach": [
+
+      ],
+      "mountainous": [
+
       ]
     },
     "sound": {
       "general": [
         ["a whispering on the wind"],
         ["the sound of a cat no longer here"]
+      ],
+      "forest": [
+
+      ],
+      "plains": [
+
+      ],
+      "beach": [
+
+      ],
+      "mountainous": [
+
       ]
     },
     "smell": {
@@ -171,31 +258,280 @@
         ["the scent of spoiled queen's milk"],
         ["the scent of a long dead cat"]
 
+      ],
+      "forest": [
+
+      ],
+      "plains": [
+
+      ],
+      "beach": [
+
+      ],
+      "mountainous": [
+
       ]
     },
     "emotional": {
       "general": [
         ["a pervasive feeling of dread"]
 
+      ],
+      "forest": [
+
+      ],
+      "plains": [
+
+      ],
+      "beach": [
+
+      ],
+      "mountainous": [
+
       ]
     },
     "touch": {
       "general": [
+
+      ],
+      "forest": [
+
+      ],
+      "plains": [
+
+      ],
+      "beach": [
+
+      ],
+      "mountainous": [
 
       ]
     }
   },
 
   "dream_list": [
-        "hunger", "cold", "warmth", "loneliness", "irritation", "want", "loss", "love", "hate", "admiration", "respect",
-        "a crush", "disapproval", "ambition", "self-assurance", "gluttony", "greed", "envy", "parental pride",
-        "confidence", "calm", "anxiety", "happiness", "contentment", "pain", "vengeful thoughts", "achievement",
-        "sorrow", "pride", "turmoil", "worry", "horror", "terror", "fear", "foreboding", "dread", "bloodlust", "hope",
-        "curiosity"
+    ["hunger", "starvation", "gluttony", "ravenous hunger"],
+    ["cold", "warmth", "heat", "burning"],
+    ["loneliness", "apathy"],
+    ["irritation"],
+    ["want", "need"],
+    ["loss", "grief"],
+    ["a crush", "love", "romance"],
+    ["hate", "hatred"],
+    ["admiration", "respect"],
+    ["disapproval"],
+    ["ambition"],
+    ["self-assurance", "confidence", "self-confidence"],
+    ["greed"],
+    ["envy", "jealousy"],
+    ["parental pride", "pride"],
+    ["calm"],
+    ["anxiety", "nervousness"],
+    ["happiness"],
+    ["contentment"],
+    ["pain"],
+    ["vengeful thoughts", "vengeance"],
+    ["achievement"],
+    ["sorrow"],
+    ["turmoil"],
+    ["worry"],
+    ["horror", "terror"],
+    ["fear", "foreboding", "dread"],
+    ["danger"],
+    ["bloodlust"],
+    ["hope"],
+    ["curiosity"],
+    ["excitement", "thrill"],
+    ["secrecy"],
+    ["desperation"]
   ],
 
-  "clair_list": [
-    "dread", "fear", "danger", "loss", "grief", "betrayal", "vengeance", "hate", "blood spilt in battle", "love", "romance",
-    "excitement", "secrecy", "thrill"
-  ]
+  "clair_list": {
+    "comment_clair": [
+    "when the clair_list is called it'll also pull the dream list along with it, this is bc the dream list items are",
+    "appropriate for the clair_list but the clair_list items aren't all appropriate for the dream_list"
+  ],
+    "sound": {
+      "general": [
+        ["the rumble of many paws over the ground"],
+        ["echoes of a past conversation", "echoes of a past argument"],
+        ["whispers of a deed long past", "whispers of a secret long lost"],
+        ["a betrayal on the wind"],
+        ["the crackling of a burning branch"],
+        ["the whisper of voices rapidly fading"],
+        ["the sound of wingbeats in the wind"],
+        ["the sounds of a heated argument"],
+        ["near silent pawsteps"],
+        ["the soft noises of kits nursing"],
+        ["a peel of laughter"],
+        ["distant wails of grief"]
+      ],
+      "forest": [
+
+      ],
+      "plains": [
+
+      ],
+      "beach": [
+
+      ],
+      "mountainous": [
+
+      ]
+    },
+    "smell": {
+      "general": [
+        ["the smell of kittypet food"],
+        ["a strange acidic scent"],
+        ["the smell of dirt baked by the sun"],
+        ["the smell of rain"]
+      ],
+      "forest": [
+
+      ],
+      "plains": [
+
+      ],
+      "beach": [
+
+      ],
+      "mountainous": [
+
+      ]
+    },
+    "emotional": {
+      "general": [
+        ["blood spilt in battle", "a battle from long ago", "the terror of a battle field"],
+        ["a war won", "a battle lost"],
+        ["an old rendezvous", "a friendly meeting", "a truce between enemies"],
+        ["a cat's last breath"],
+        ["a promise kept", "a half-remembered promise", "a promise already broken", "a promise not yet made"],
+        ["a story half-remembered"],
+        ["the excitement of an apprentice", "an apprentice's vigor", "the naivety of an apprentice"],
+        ["the strength of a warrior", "the steadfastness of a warrior", "a warrior's loyalty"],
+        ["the ache in an elder's bones", "an elder's wisdom"],
+        ["drowning"],
+        ["lingering grief", "grief's sharp impact"],
+        ["a newborn's innocence"],
+        ["a memory being forgotten", "a fading memory", "a memory long lost"],
+        ["forgetting something important", "forgetting a secret once precious"],
+        ["wishing for something now missing", "longing for a long lost possession"],
+        ["hatred of a dear friend"],
+        ["knowing a secret that can never be revealed"],
+        ["a truth unbelieved", "a truth concealed", "a truth never revealed"],
+        ["a weakness in their legs"],
+        ["a belly so empty they feel nauseous"],
+        ["the loss of innocence"],
+        ["a home no longer welcoming", "a home long lost", "a home once forgotten"],
+        ["the ooze of corruption"]
+      ],
+      "forest": [
+
+      ],
+      "plains": [
+
+      ],
+      "beach": [
+
+      ],
+      "mountainous": [
+
+      ]
+    },
+    "touch": {
+      "general": [
+        ["deathly still air", "the heat of a fire unseen"],
+        ["the trembling of stones"],
+        ["falling through the air","flying through the air"],
+        ["the warmth of a parent","the embrace of a family","the warmth of family and love in the darkness before a kit's eyes open"],
+        ["a tail twining with their own","wet fur against their own","the brush of a pelt against their own",
+        "teeth snapping against their hide", "claws against their scruff"],
+        ["the touch of a mentor to an apprentice's forehead"],
+        ["slipping on muddy earth despite the dry ground beneath them", "sinking into muddy earth"],
+        ["the burning of limbs still whole"],
+        ["their paws damp with water", "their paws damp with blood", "their paws heavy with blood"],
+        ["another cat shoving against them"],
+        ["of sharpening one's claws against stone"],
+        ["wind whipping through their fur"]
+      ],
+      "forest": [
+
+      ],
+      "plains": [
+
+      ],
+      "beach": [
+
+      ],
+      "mountainous": [
+
+      ]
+    },
+    "taste": {
+      "general": [
+        ["the bitter taste of poppy seeds", "the taste of bitter herbs", "the taste of blood in the air"],
+        ["the lingering taste of iron on the tongue"],
+        ["the volatile taste of berries"]
+      ],
+      "forest": [
+
+      ],
+      "plains": [
+
+      ],
+      "beach": [
+
+      ],
+      "mountainous": [
+
+      ]
+    }
+  },
+
+  "story_list": {
+    "comment_story": [
+    "the general list shouldn't have any 'the cat who ___' snippets, as we don't want to have more than one of these in an event",
+    "only add 'the cat who ___' snippets to biome lists, you can add one snippet to multiple biomes if you feels it fits in more than one"
+    ],
+    "general": [
+      ["The Thieving Fox"],
+      ["The Tenacious Rabbit", "The Rabbit Prince"],
+      ["The Hare King", "The Witch Hare"],
+      ["The Lion's Promise","How The Tiger Got It's Stripes","The Leopard's Spots","The Cougar's Claws"],
+      ["The Place of No Stars", "The Stars of Silverpelt"]
+    ],
+    "forest": [
+      ["The Cat Who Became a Porcupine", "The Cat Who Carried the Sun", "The Cat Who Grew Into an Oak", "The Willow Cat",
+        "The Badger Who Befriended a Cat","The Cats Made of Light"],
+      ["The Old Forests of the Ancestors", "The Forest's Origin", "The First Seed","The Squirrel Who Planted the Forest"],
+      ["The Star Bugs"],
+      ["The Sun-down Place"]
+
+    ],
+    "plains": [
+      ["The Cat Who Dug a Tunnel Through The World", "The Blind Hunter Who Saved The Clan", "The Cat Without a Song",
+        "The Cat Who Carried The Sun", "The Cat Made From The Earth", "The Cats Made of Light", "The Great Worm-cat"],
+      ["the Thunderbeasts"],
+      ["How The Great Sytowers Came To Be"],
+      ["The Metal Trees of the Twolegs"],
+      ["The Weasel's Lie"]
+
+    ],
+    "beach": [
+      ["The Cursed Cat", "The Cat Who Carried The Sun"],
+      ["The Dolphin's Farewell"],
+      ["The Dead's Token"],
+      ["The Ocean's Tears", "The Crying Sky"]
+
+    ],
+    "mountainous": [
+      ["The Eagle Who Became a Cat", "The She-cat Who Traded Her Voice", "The Cat Who Flew", "The Cat Who Carried The Sun",
+      "The Cats Made of Light"],
+      ["The Mountain's Shadow"],
+      ["The Hummingbird's Feather"],
+      ["The Betrayal of the Ravens"],
+      ["The Dancing Sky"]
+
+    ]
+  }
 }

--- a/scripts/patrol.py
+++ b/scripts/patrol.py
@@ -1962,11 +1962,6 @@ class PatrolEvent():
     border patrols - "border", "other_clan", "reputation",
 
     med patrols - "med_cat", "herb", "random_herbs", "many_herbs#"
-            
-    new cat tags - ("kittypet" in the patrol ID will make the cat a kittypet no matter what)                                                              
-    "new_cat", "new_cat_med", "new_cat_queen", "new_cat_female", "new_cat_tom", "new_cat_neutered",
-    "new_cat_elder", "new_cat_majorinjury", "new_cat_kit", "new_cat_kits", "new_cat_newborn",
-    "new_cat_apprentice", "new_cat_adult",
 
     un-used for now - "npc", "gone_cat"
             

--- a/scripts/screens/patrol_screens.py
+++ b/scripts/screens/patrol_screens.py
@@ -9,7 +9,8 @@ try:
 except ImportError:
     import json as ujson
 from .base_screens import Screens, cat_profiles
-from scripts.utility import get_text_box_theme, scale, get_personality_compatibility, check_relationship_value
+from scripts.utility import get_text_box_theme, scale, get_personality_compatibility, check_relationship_value, \
+    get_snippet_list
 from scripts.game_structure.image_button import UIImageButton, UITextBoxTweaked, UISpriteButton
 from scripts.patrol import patrol
 from scripts.cat.cats import Cat
@@ -524,12 +525,7 @@ class PatrolScreen(Screens):
                               'red squirrels', 'grey squirrels', 'rats', ]
         text = text.replace('f_mp_p', str(fst_midprey_plural))
 
-        sign_list = ['strangely-patterned stone', 'sharp stick', 'prey bone', 'cloud shaped like a cat',
-                     'tuft of red fur', 'red feather', 'brown feather', 'black feather', 'white feather',
-                     'star-shaped leaf',
-                     'beetle shell', 'snail shell', 'tuft of badger fur', 'two pawprints overlapping',
-                     'flower missing a petal',
-                     'tuft of fox fur', ]
+        sign_list = get_snippet_list("omen_list", amount=random.randint(2, 4), return_string=False)
         sign = choice(sign_list)
         s = 0
         pos = 0


### PR DESCRIPTION
- added clairvoyant list and story list to the snippet_collections.json and further refined the get_snippet_list() function
- added a couple events to take advantage of the story list
- switched the sign list for the patrols to instead pull from the new omen_list
- fixed the bug where the abandoned kit patrol would give a full grown cat