### PR TITLE
Bugfix: Fix malformed json (again)

### DIFF
--- a/resources/dicts/patrols/beach/training/any.json
+++ b/resources/dicts/patrols/beach/training/any.json
@@ -481,5 +481,6 @@
     "max_cats": 6,
     "antagonize_text": null,
     "antagonize_fail_text": null
-},
+}
+]
 


### PR DESCRIPTION
There was more than one malformed json in the beach biome, it seems. 
Fixed malformed json patrols/beach/training/any.json