### PR TITLE
Bugfix: Grief Message Display

### DIFF
--- a/scripts/events.py
+++ b/scripts/events.py
@@ -189,7 +189,6 @@ class Events():
 
             # Generate events
             for item in Cat.grief_strings.values():
-                print(item)
                 game.cur_events_list.append(
                     Single_Event(item[0], ["birth_death", "relation"],
                                  item[1]))

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -188,10 +188,11 @@ class Events():
                     Cat.grief_strings.pop(ID)
 
             # Generate events
-            for item in Cat.grief_strings.items():
+            for item in Cat.grief_strings.values():
+                print(item)
                 game.cur_events_list.append(
-                    Single_Event(item[1], ["birth_death", "relation"],
-                                 item[0]))
+                    Single_Event(item[0], ["birth_death", "relation"],
+                                 item[1]))
 
             Cat.grief_strings.clear()
 


### PR DESCRIPTION
- Grief messages will now properly display as a moon event. They were being processed properly, but were not being displayed due to incorrect data-types in the Single_Event object. The data types must have been changed at some point. 