### PR TITLE
Content: Allegiances

### DIFF
--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -12,7 +12,7 @@ try:
 except ImportError:
     import json as ujson
 
-from .pelts import describe_color, descibe_short_color
+from .pelts import describe_color
 from .names import Name
 from .thoughts import get_thoughts
 from .appearance_utility import (
@@ -883,13 +883,14 @@ class Cat():
         else:
             sex = 'cat'
 
-        if short:
-            description = descibe_short_color(self.pelt, self.white_patches) + " " + sex
-        else:
-            description = str(self.pelt.length).lower() + '-furred'
-            description += ' ' + describe_color(self.pelt, self.tortiecolour, self.tortiepattern,
-                                                self.white_patches) + ' ' + sex
+        description = ""
+        if not short and self.pelt.length == "long":
+            description = str(self.pelt.length).lower() + '-furred ' 
+
+        description += describe_color(self.pelt, self.tortiepattern, self.tortiecolour,
+                                            self.white_patches, short=short) + ' ' + sex
         return description
+        
 
     def describe_eyes(self):
         colour = str(self.eye_colour).lower()

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -12,7 +12,7 @@ try:
 except ImportError:
     import json as ujson
 
-from .pelts import describe_color
+from .pelts import describe_color, descibe_short_color
 from .names import Name
 from .thoughts import get_thoughts
 from .appearance_utility import (
@@ -872,18 +872,23 @@ class Cat():
                         else:
                             self.trait = chosen_trait
 
-    def describe_cat(self):
+    def describe_cat(self, short=False):
         """ Generates a string describing the cat's appearance and gender. Mainly used for generating
-        the allegiances."""
+        the allegiances. If short is true, it will generate a very short one, with the minimal amount of information. """
+
         if self.genderalign == 'male' or self.genderalign == "transmasc" or self.genderalign == "trans male":
             sex = 'tom'
         elif self.genderalign == 'female' or self.genderalign == "transfem" or self.genderalign == "trans female":
             sex = 'she-cat'
         else:
             sex = 'cat'
-        description = str(self.pelt.length).lower() + '-furred'
-        description += ' ' + describe_color(self.pelt, self.tortiecolour, self.tortiepattern,
-                                            self.white_patches) + ' ' + sex
+
+        if short:
+            description = descibe_short_color(self.pelt, self.white_patches) + " " + sex
+        else:
+            description = str(self.pelt.length).lower() + '-furred'
+            description += ' ' + describe_color(self.pelt, self.tortiecolour, self.tortiepattern,
+                                                self.white_patches) + ' ' + sex
         return description
 
     def describe_eyes(self):

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -884,8 +884,11 @@ class Cat():
             sex = 'cat'
 
         description = ""
+        if len(self.scars) >= 4:
+            description += "scarred "
+
         if not short and self.pelt.length == "long":
-            description = str(self.pelt.length).lower() + '-furred ' 
+            description += str(self.pelt.length).lower() + '-furred ' 
 
         description += describe_color(self.pelt, self.tortiepattern, self.tortiecolour,
                                             self.white_patches, short=short) + ' ' + sex

--- a/scripts/cat/pelts.py
+++ b/scripts/cat/pelts.py
@@ -473,41 +473,6 @@ def choose_pelt(colour=None, white=None, pelt=None, length=None, category=None, 
     else:
         return Calico(colour, length)
 
-def descibe_short_color(pelt, white_patches):
-    """Shortened"""
-    special_color_names = {
-        "palegrry": "pale gray",
-        "darkgrey": "dark gray",
-        "paleginger": "pale ginger",
-        "darkginger": "dark ginger",
-        "lightbrown": "light brown",
-        "darkbrown": "dark brown"
-    }
-
-    color_name = str(pelt.colour).lower()
-    
-    if color_name in special_color_names:
-        color_name = special_color_names[color_name]
-
-    if pelt.name in tabbies + exotic:
-        color_name += " tabby"
-    elif pelt.name in spotted:
-        color_name += " spotted"
-    elif pelt.name == "Calico":
-        color_name = "calico"
-    elif pelt.name == "Tortie":
-        color_name = "tortoiseshell"
-
-    if white_patches == 'FULLWHITE':
-        color_name = "white"
-    elif white_patches:
-        if white_patches in point_markings:
-            color_name += " pointed"
-        elif pelt.name != "Calico":
-            color_name += " and white"
-    
-    return color_name
-
 def describe_color(pelt, tortiebase, tortiecolour, white_patches, short=False):
     """ short=True makes everything just slightly shorter, mainly for kit purposes. """
     

--- a/scripts/cat/pelts.py
+++ b/scripts/cat/pelts.py
@@ -508,88 +508,92 @@ def descibe_short_color(pelt, white_patches):
     
     return color_name
 
-
-
-def describe_color(pelt, tortiecolour, tortiepattern, white_patches):
+def describe_color(pelt, tortiebase, tortiecolour, white_patches, short=False):
+    """ short=True makes everything just slightly shorter, mainly for kit purposes. """
     
-    special_color_names = {
-        "palegrry": "pale gray",
-        "darkgrey": "dark gray",
-        "paleginger": "pale ginger",
-        "darkginger": "dark ginger",
-        "lightbrown": "light brown",
-        "darkbrown": "dark brown"
+    if short:
+        renamed_colors = {
+            "palegrey": "gray",
+            "darkgrey": "gray",
+            "paleginger": "ginger",
+            "darkginger": "ginger",
+            "lightbrown": "brown",
+            "darkbrown": "brown",
+            "ghost": "black"
+        }
+    else:
+        renamed_colors = {
+            "palegrey": "pale gray",
+            "darkgrey": "dark gray",
+            "paleginger": "pale ginger",
+            "darkginger": "dark ginger",
+            "lightbrown": "light brown",
+            "darkbrown": "dark brown",
+            "ghost": "black"
+        }
+
+    pattern_des = {
+        "Tabby": "tabby",
+        "Speckled": "speckled",
+        "Bengal": "unusally spotted",
+        "Marbled": "tabby",
+        "Ticked": "ticked",
+        "Smoke": "smoke",
+        "Mackerel": "tabby",
+        "Classic": "tabby",
+        "Agouti": "tabby",
+        "Singlestripe": "striped",
+        "Rosette": "dappled"
     }
-
+    
     color_name = str(pelt.colour).lower()
-    
-    if color_name in special_color_names:
-        color_name = special_color_names[color_name]
-    
-    if pelt.name == "Tabby":
-        color_name = color_name + ' tabby'
-    elif pelt.name == "Speckled":
-        color_name = color_name + ' speckled'
-    elif pelt.name == "Bengal":
-        color_name = color_name + ' bengal'
-    elif pelt.name == "Marbled":
-        color_name = color_name + ' marbled tabby'
-    elif pelt.name == "Rosette":
-        color_name = color_name + ' rosetted'
-    elif pelt.name == "Ticked":
-        color_name = color_name + ' ticked tabby'
-    elif pelt.name == "Smoke":
-        color_name = color_name + ' smoke'
-    elif pelt.name == "Mackerel":
-        color_name = color_name + ' mackerel tabby'
-    elif pelt.name == "Classic":
-        color_name = color_name + ' classic tabby'
-    elif pelt.name == "Sokoke":
-        color_name = color_name + ' sokoke tabby'
-    elif pelt.name == "Agouti":
-        color_name = color_name + ' agouti'
-    elif pelt.name == "Singlestripe":
-        color_name = 'dorsal-striped' + color_name
+    if color_name in renamed_colors:
+        color_name = renamed_colors[color_name]
 
-    elif pelt.name in ["Tortie", "Calcio"]:
-        second_color = tortiecolour.lower()
-        if second_color in special_color_names:
-            second_color = special_color_names[second_color]
+    if pelt.name not in ["SingleColour", "TwoColour", "Tortie", "Calico"] and color_name == "white":
+        color_name = "pale"
 
-        color_name = f"{color_name} and {second_color} "
-        
-        if pelt.name == "Tortie":
-            if tortiepattern not in ["single", "smoke"]:
-                color_name = color_name + ' torbie'
+    if pelt.name in pattern_des:
+        color_name += f" {pattern_des[pelt.name]}"
+    elif pelt.name in ["Tortie", "Calico"]:
+        if short:
+            if pelt.colour in [black_colours, brown_colours, white_colours] and \
+                tortiecolour in [black_colours, brown_colours, white_colours]:
+                color_name = f"mottled"
             else:
-                color_name = color_name + ' tortie'
-        elif pelt.name == "Calico":
-            color_name = color_name + ' calico'
-  
-    if white_patches is not None:
-        if white_patches in little_white + mid_white:
-            color_name = color_name + ' and white'
-        # and white
-        elif white_patches in high_white:
+                color_name = pelt.name.lower()
+        else:
+            base = tortiebase.lower()
+            if base in tabbies:
+                base = 'tabby'
+            elif base in ['bengal', 'rosette', 'speckled']:
+                base = 'spotted'
+            else:
+                base = ''
+
+            if pelt.colour in [black_colours, brown_colours, white_colours] and \
+                tortiecolour in [black_colours, brown_colours, white_colours]:
+                color_name = f"mottled {base}"
+            else:
+                patches = tortiecolour.lower()
+                color_name = f"{color_name} and {patches} {pelt.name.lower()}"
+
+    if white_patches:
+        if white_patches == "FULLWHITE":
+            color_name = "white"
+        if white_patches in mostly_white:
+            if pelt.name != "Calico":
+                color_name = 'white and ' + color_name
+        elif white_patches in vit and not short:
+            # If short, don't include vit information. 
+            color_name = color_name + " with vitilago"
+        elif white_patches in point_markings:
+            color_name = color_name + " point"
+            if color_name == 'dark ginger point' or color_name == 'ginger point':
+                color_name = "flame point"
+        else:
             if pelt.name != "Calico":
                 color_name = color_name + ' and white'
-        # white and
-        elif white_patches in mostly_white:
-            color_name = 'white and ' + color_name
-        # colorpoint
-        elif white_patches in point_markings:
-            color_name = color_name + ' point'
-            if color_name == 'dark ginger point' or color_name == 'ginger point':
-                color_name = 'flame point'
-        # vitiligo
-        elif white_patches in vit:
-            color_name = color_name + ' with vitiligo'
-
-    if color_name == 'tortie':
-        color_name = 'tortoiseshell'
-
-    if white_patches == 'FULLWHITE':
-        color_name = 'white'
 
     if color_name == 'white and white':
         color_name = 'white'

--- a/scripts/cat/pelts.py
+++ b/scripts/cat/pelts.py
@@ -508,7 +508,8 @@ def describe_color(pelt, tortiebase, tortiecolour, white_patches, short=False):
         "Classic": "tabby",
         "Agouti": "tabby",
         "Singlestripe": "striped",
-        "Rosette": "dappled"
+        "Rosette": "dappled",
+        "Sokoke": "tabby"
     }
     
     color_name = str(pelt.colour).lower()
@@ -532,7 +533,7 @@ def describe_color(pelt, tortiebase, tortiecolour, white_patches, short=False):
             if base in tabbies:
                 base = 'tabby'
             elif base in ['bengal', 'rosette', 'speckled']:
-                base = 'spotted'
+                base = 'spotted tabby'
             else:
                 base = ''
 
@@ -541,6 +542,8 @@ def describe_color(pelt, tortiebase, tortiecolour, white_patches, short=False):
                 color_name = f"mottled {base}"
             else:
                 patches = tortiecolour.lower()
+                if patches in renamed_colors:
+                    patches = renamed_colors[patches]
                 color_name = f"{color_name} and {patches} {pelt.name.lower()}"
 
     if white_patches:

--- a/scripts/cat/pelts.py
+++ b/scripts/cat/pelts.py
@@ -473,24 +473,59 @@ def choose_pelt(colour=None, white=None, pelt=None, length=None, category=None, 
     else:
         return Calico(colour, length)
 
+def descibe_short_color(pelt, white_patches):
+    """Shortened"""
+    special_color_names = {
+        "palegrry": "pale gray",
+        "darkgrey": "dark gray",
+        "paleginger": "pale ginger",
+        "darkginger": "dark ginger",
+        "lightbrown": "light brown",
+        "darkbrown": "dark brown"
+    }
+
+    color_name = str(pelt.colour).lower()
+    
+    if color_name in special_color_names:
+        color_name = special_color_names[color_name]
+
+    if pelt.name in tabbies + exotic:
+        color_name += " tabby"
+    elif pelt.name in spotted:
+        color_name += " spotted"
+    elif pelt.name == "Calico":
+        color_name = "calico"
+    elif pelt.name == "Tortie":
+        color_name = "tortoiseshell"
+
+    if white_patches == 'FULLWHITE':
+        color_name = "white"
+    elif white_patches:
+        if white_patches in point_markings:
+            color_name += " pointed"
+        elif pelt.name != "Calico":
+            color_name += " and white"
+    
+    return color_name
+
+
 
 def describe_color(pelt, tortiecolour, tortiepattern, white_patches):
-    color_name = ''
+    
+    special_color_names = {
+        "palegrry": "pale gray",
+        "darkgrey": "dark gray",
+        "paleginger": "pale ginger",
+        "darkginger": "dark ginger",
+        "lightbrown": "light brown",
+        "darkbrown": "dark brown"
+    }
+
     color_name = str(pelt.colour).lower()
-    if tortiecolour is not None:
-        color_name = str(tortiecolour).lower()
-    if color_name == 'palegrey':
-        color_name = 'pale grey'
-    elif color_name == 'darkgrey':
-        color_name = 'dark grey'
-    elif color_name == 'paleginger':
-        color_name = 'pale ginger'
-    elif color_name == 'darkginger':
-        color_name = 'dark ginger'
-    elif color_name == 'lightbrown':
-        color_name = 'light brown'
-    elif color_name == 'darkbrown':
-        color_name = 'dark brown'
+    
+    if color_name in special_color_names:
+        color_name = special_color_names[color_name]
+    
     if pelt.name == "Tabby":
         color_name = color_name + ' tabby'
     elif pelt.name == "Speckled":
@@ -514,19 +549,23 @@ def describe_color(pelt, tortiecolour, tortiepattern, white_patches):
     elif pelt.name == "Agouti":
         color_name = color_name + ' agouti'
     elif pelt.name == "Singlestripe":
-        color_name = color_name + ', with a dorsal stripe,'
+        color_name = 'dorsal-striped' + color_name
 
-    elif pelt.name == "Tortie":
-        if tortiepattern not in ["tortiesolid", "tortiesmoke"]:
-            color_name = color_name + ' torbie'
-        else:
-            color_name = color_name + ' tortie'
-    elif pelt.name == "Calico":
-        if tortiepattern not in ["tortiesolid", "tortiesmoke"]:
-            color_name = color_name + ' tabico'
-        else:
+    elif pelt.name in ["Tortie", "Calcio"]:
+        second_color = tortiecolour.lower()
+        if second_color in special_color_names:
+            second_color = special_color_names[second_color]
+
+        color_name = f"{color_name} and {second_color} "
+        
+        if pelt.name == "Tortie":
+            if tortiepattern not in ["single", "smoke"]:
+                color_name = color_name + ' torbie'
+            else:
+                color_name = color_name + ' tortie'
+        elif pelt.name == "Calico":
             color_name = color_name + ' calico'
-    # enough to comment but not make calico
+  
     if white_patches is not None:
         if white_patches in little_white + mid_white:
             color_name = color_name + ' and white'
@@ -545,8 +584,6 @@ def describe_color(pelt, tortiecolour, tortiepattern, white_patches):
         # vitiligo
         elif white_patches in vit:
             color_name = color_name + ' with vitiligo'
-    else:
-        color_name = color_name
 
     if color_name == 'tortie':
         color_name = 'tortoiseshell'

--- a/scripts/screens/clan_screens.py
+++ b/scripts/screens/clan_screens.py
@@ -1252,160 +1252,19 @@ class AllegiancesScreen(Screens):
         self.show_menu_buttons()
         self.set_disabled_menu_buttons(["allegiances"])
         self.update_heading_text(f'{game.clan.name}Clan')
-        self.allegiance_list = []
+        self.allegiance_list = self.get_allegences_text()
 
-        living_cats = []
-        # Determine the living cats.
-        for the_cat in Cat.all_cats.values():
-            if not the_cat.dead and not the_cat.outside:
-                living_cats.append(the_cat)
-        living_meds = []
-        for the_cat in living_cats:
-            if the_cat.status == 'medicine cat':
-                living_meds.append(the_cat)
-        living_mediators = []
-        for the_cat in living_cats:
-            if the_cat.status == 'mediator':
-                living_mediators.append(the_cat)
+        self.names_temp = "\n".join([k[1] for k in self.allegiance_list])
 
-        # Pull the clan leaders
-        leader = []
-        if game.clan.leader is not None:
-            if not game.clan.leader.dead and not game.clan.leader.outside:
-                self.allegiance_list.append([
-                    '<b><u>LEADER</u></b>',
-                    f"{game.clan.leader.name} - a {game.clan.leader.describe_cat()}"
-                ])
 
-                if len(game.clan.leader.apprentice) > 0:
-                    if len(game.clan.leader.apprentice) == 1:
-                        self.allegiance_list.append([
-                            '', '      Apprentice: ' +
-                                str(Cat.fetch_cat(game.clan.leader.apprentice[0]).name)
-                        ])
-                    else:
-                        app_names = ''
-                        for app in game.clan.leader.apprentice:
-                            app_names += str(Cat.fetch_cat(app).name) + ', '
-                        self.allegiance_list.append(
-                            ['', '      Apprentices: ' + app_names[:-2]])
-        # deputy
-        if game.clan.deputy is not None and not game.clan.deputy.dead and not game.clan.deputy.outside:
-            self.allegiance_list.append([
-                '<b><u>DEPUTY</u></b>',
-                f"{game.clan.deputy.name} - a {game.clan.deputy.describe_cat()}"
-            ])
-
-            if len(game.clan.deputy.apprentice) > 0:
-                if len(game.clan.deputy.apprentice) == 1:
-                    self.allegiance_list.append([
-                        '', '      Apprentice: ' +
-                            str(Cat.fetch_cat(game.clan.deputy.apprentice[0]).name)
-                    ])
-                else:
-                    app_names = ''
-                    for app in game.clan.deputy.apprentice:
-                        app_names += str(Cat.fetch_cat(app).name) + ', '
-                    self.allegiance_list.append(
-                        ['', '      Apprentices: ' + app_names[:-2]])
-        cat_count = self._extracted_from_screen_switches_24(
-            living_cats, 'medicine cat', '<b><u>MEDICINE CATS</u></b>')
-
-        if living_mediators:
-            self._extracted_from_screen_switches_24(
-                living_cats, 'mediator', '<b><u>MEDIATORS</u></b>')
-
-        queens = get_alive_clan_queens(Cat.all_cats)
-        queens = [cat.ID for cat in queens]
-        cat_count = 0
-        for living_cat__ in living_cats:
-            if str(
-                    living_cat__.status
-            ) == 'warrior' and living_cat__.ID not in queens and not living_cat__.outside:
-                if not cat_count:
-                    self.allegiance_list.append([
-                        '<b><u>WARRIORS</u></b>',
-                        f"{living_cat__.name} - a {living_cat__.describe_cat()}"
-                    ])
-                else:
-                    self.allegiance_list.append([
-                        '',
-                        f"{living_cat__.name} - a {living_cat__.describe_cat()}"
-                    ])
-                if len(living_cat__.apprentice) >= 1:
-                    if len(living_cat__.apprentice) == 1:
-                        self.allegiance_list.append([
-                            '', '      Apprentice: ' +
-                                str(Cat.fetch_cat(living_cat__.apprentice[0]).name)
-                        ])
-                    else:
-                        app_names = ''
-                        for app in living_cat__.apprentice:
-                            app_names += str(Cat.fetch_cat(app).name) + ', '
-                        self.allegiance_list.append(
-                            ['', '      Apprentices: ' + app_names[:-2]])
-                cat_count += 1
-        if not cat_count:
-            self.allegiance_list.append(['<b><u>WARRIORS</u></b>', ''])
-        cat_count = 0
-        for living_cat___ in living_cats:
-            if str(living_cat___.status) in [
-                'apprentice', 'medicine cat apprentice', 'mediator apprentice'
-            ]:
-                if cat_count == 0:
-                    self.allegiance_list.append([
-                        '<b><u>APPRENTICES</u></b>',
-                        f"{living_cat___.name} - a {living_cat___.describe_cat()}"
-                    ])
-                else:
-                    self.allegiance_list.append([
-                        '',
-                        f"{living_cat___.name} - a {living_cat___.describe_cat()}"
-                    ])
-                cat_count += 1
-        if not cat_count:
-            self.allegiance_list.append(['<b><u>APPRENTICES</u></b>', ''])
-        cat_count = 0
-        for living_cat____ in living_cats:
-            if living_cat____.ID in queens:
-                if cat_count == 0:
-                    self.allegiance_list.append([
-                        '<b><u>QUEENS</u></b>',
-                        f"{living_cat____.name} - a {living_cat____.describe_cat()}"
-                    ])
-                else:
-                    self.allegiance_list.append([
-                        '',
-                        f"{living_cat____.name} - a {living_cat____.describe_cat()}"
-                    ])
-                cat_count += 1
-                if len(living_cat____.apprentice) > 0:
-                    if len(living_cat____.apprentice) == 1:
-                        self.allegiance_list.append([
-                            '', '      Apprentice: ' +
-                                str(Cat.fetch_cat(living_cat____.apprentice[0]).name)
-                        ])
-                    else:
-                        app_names = ''
-                        for app in living_cat____.apprentice:
-                            app_names += str(Cat.fetch_cat(app).name) + ', '
-                        self.allegiance_list.append(
-                            ['', '      Apprentices: ' + app_names[:-2]])
-        if not cat_count:
-            self.allegiance_list.append(['<b><u>QUEENS</u></b>', ''])
-        cat_count = self._extracted_from_screen_switches_24(
-            living_cats, 'elder', '<b><u>ELDERS</u></b>')
-        cat_count = self._extracted_from_screen_switches_24(
-            living_cats, 'kitten', '<b><u>KITS</u></b>')
-
-        self.scroll_container = pygame_gui.elements.UIScrollingContainer(scale(pygame.Rect((100, 300), (1400, 1000)))
+        self.scroll_container = pygame_gui.elements.UIScrollingContainer(scale(pygame.Rect((100, 300), (1430, 1000)))
                                                                          , manager=MANAGER)
-        self.cat_names_box = pygame_gui.elements.UITextBox("\n".join([i[1] for i in self.allegiance_list]),
+        self.cat_names_box = pygame_gui.elements.UITextBox(self.names_temp,
                                                            scale(pygame.Rect((300, 0), (1100, -1))),
                                                            object_id=get_text_box_theme("#allegiances_box"),
                                                            container=self.scroll_container, manager=MANAGER)
 
-        self.ranks_box = pygame_gui.elements.UITextBox("\n".join([i[0] for i in self.allegiance_list]),
+        self.ranks_box = pygame_gui.elements.UITextBox("",
                                                        scale(pygame.Rect((0, 0), (300, -1))),
                                                        object_id=get_text_box_theme("#allegiances_box"),
                                                        container=self.scroll_container, manager=MANAGER)
@@ -1456,6 +1315,161 @@ class AllegiancesScreen(Screens):
         if not result:
             self.allegiance_list.append([arg2, ''])
         return result
+    
+    def generate_one_entry(self, cat):
+            output = ""
+            output += f"{cat.name} - a {cat.describe_cat()}"
+
+            if len(cat.apprentice) > 0:
+                if len(cat.apprentice) == 1:
+                    output += "\n      Apprentice: "
+                else:
+                    output += "\n      Apprentices: "     
+                output += ", ".join([str(Cat.fetch_cat(i).name) for i in cat.apprentice])
+
+            return output
+
+    def get_allegences_text(self):
+        """Determine Text. Ouputs list of tuples. """
+        spacers_headers = []
+
+        
+        living_cats = [i for i in Cat.all_cats.values() if not (i.dead or i.outside)]
+        living_meds = []
+        living_mediators = []
+        living_warriors = []
+        living_apprentices = []
+        living_kits = []
+        living_elders = []
+        for cat in living_cats:
+            if cat.status == "medicine cat":
+                living_meds.append(cat)
+            elif cat.status == "warrior":
+                living_warriors.append(cat)
+            elif cat.status == "mediator":
+                living_mediators.append(cat)
+            elif cat.status in ["apprentice", "medicine cat apprentice", "mediator apprentice"]:
+                living_apprentices.append(cat)
+            elif cat.status == "kitten":
+                living_kits.append(cat)
+            elif cat.status == "elder":
+                living_elders.append(cat)
+
+        # Find Queens:
+        queen_dict = {}
+        for cat in living_kits.copy():
+            print(str(cat.name))
+            parents = cat.get_parents()
+            parents = [Cat.fetch_cat(i) for i in parents]
+            if not parents:
+                continue
+            
+            if len(parents) == 1 or all(i.gender == "male" for i in parents) or parents[0].gender == "female":
+                if parents[0].ID in queen_dict:
+                    queen_dict[parents[0].ID].append(cat)
+                    living_kits.remove(cat)
+                else:
+                    queen_dict[parents[0].ID] = [cat]
+                    living_kits.remove(cat) 
+            elif len(parents) == 2:
+                if parents[1].ID in queen_dict:
+                    queen_dict[parents[1].ID].append(cat)
+                    living_kits.remove(cat)
+                else:
+                    queen_dict[parents[1].ID] = [cat]
+                    living_kits.remove(cat) 
+
+        #Clan Leader Box:
+        # Pull the clan leaders
+        outputs = []
+        if game.clan.leader and not (game.clan.leader.dead or game.clan.leader.outside):
+                outputs.append([
+                    '<b><u>LEADER</u></b>',
+                    self.generate_one_entry(game.clan.leader)
+                ])
+
+        # Deputy Box:
+        if game.clan.deputy and not (game.clan.deputy.dead or game.clan.deputy.outside):
+            outputs.append([
+                '<b><u>DEPUTY</u></b>',
+                self.generate_one_entry(game.clan.deputy)
+            ])
+        
+        # Medicine Cat Box:
+        if living_meds:
+            _box = ["", ""]
+            if len(living_meds) == 1:
+                _box[0] = '<b><u>MEDICINE CAT</u></b>'
+            else:
+                _box[0] = '<b><u>MEDICINE CATS</u></b>'
+            
+            _box[1] = "\n".join([self.generate_one_entry(i) for i in living_meds])
+            outputs.append(_box)
+        
+        # Mediator Box:
+        if living_mediators:
+            _box = ["", ""]
+            if len(living_mediators) == 1:
+                _box[0] = '<b><u>MEDIATOR</u></b>'
+            else:
+                _box[0] = '<b><u>MEDIATORS</u></b>'
+            
+            _box[1] = "\n".join([self.generate_one_entry(i) for i in living_mediators])
+            outputs.append(_box)
+
+         # Warrior Box:
+        if living_warriors:
+            _box = ["", ""]
+            if len(living_warriors) == 1:
+                _box[0] = '<b><u>WARRIOR</u></b>'
+            else:
+                _box[0] = '<b><u>WARRIORS</u></b>'
+            
+            _box[1] = "\n".join([self.generate_one_entry(i) for i in living_warriors])
+            outputs.append(_box)
+        
+         # Apprentice Box:
+        if living_apprentices:
+            _box = ["", ""]
+            if len(living_apprentices) == 1:
+                _box[0] = '<b><u>APPRENTICE</u></b>'
+            else:
+                _box[0] = '<b><u>APPRENTICES</u></b>'
+            
+            _box[1] = "\n".join([self.generate_one_entry(i) for i in living_apprentices])
+            outputs.append(_box)
+        
+         # Queens and Kits Box:
+        if queen_dict or living_kits:
+            _box = ["", ""]
+            _box[0] = '<b><u>QUEENS AND KITS:</u></b>'
+            
+            # This one is a bit different.  First all the queens, and the kits they are caring for. 
+            all_entries = []
+            for q in queen_dict:
+                queen = Cat.fetch_cat(q)
+                kittens = []
+                for k in queen_dict[q]:
+                    kittens += [f"{k.name} - a {k.describe_cat(short=True)}"]
+                if len(kittens) == 1:
+                    kittens = f" (caring for {kittens[0]})"
+                else:
+                    kittens = f" (caring for {', '.join(kittens[:-1])} and {kittens[-1]})"
+
+                all_entries.append(self.generate_one_entry(queen) + kittens)
+
+            #Now kittens without carers
+            for k in living_kits:
+                all_entries.append(f"{k.name} - a {k.describe_cat(short=True)}")
+
+            _box[1] = "\n".join(all_entries)
+            outputs.append(_box)
+
+        return outputs
+
+            
+            
+
 
 
 class MedDenScreen(Screens):

--- a/scripts/screens/clan_screens.py
+++ b/scripts/screens/clan_screens.py
@@ -1331,7 +1331,6 @@ class AllegiancesScreen(Screens):
         # Find Queens:
         queen_dict = {}
         for cat in living_kits.copy():
-            print(str(cat.name))
             parents = cat.get_parents()
             parents = [Cat.fetch_cat(i) for i in parents]
             if not parents:
@@ -1423,7 +1422,7 @@ class AllegiancesScreen(Screens):
          # Queens and Kits Box:
         if queen_dict or living_kits:
             _box = ["", ""]
-            _box[0] = '<b><u>KITS AND CARETAKERS</u></b>'
+            _box[0] = '<b><u>QUEENS AND KITS</u></b>'
             
             # This one is a bit different.  First all the queens, and the kits they are caring for. 
             all_entries = []


### PR DESCRIPTION
Gave the allegiances screen a much-needed glow-up. 

- The names and role labels will no longer become unaligned if a cat description is longer than one line. 
- Cat names are now all uppercase. 
- Kits are now listed with their parent, if they have one. 
- If there are no cats for a category, that category title will not appear. 
- Queens are removed from warrior and elders lists. 
- Used Ryos's shorter descriptions, with some function clean-up. Added an even shorter appearance description for kits. 
- Cats with four scars will be described as "scarred"