### PR TITLE
Hopefully fixed a bug

### DIFF
--- a/resources/dicts/patrols/beach/training/any.json
+++ b/resources/dicts/patrols/beach/training/any.json
@@ -22,7 +22,7 @@
     ],
     "win_trait": ["adventurous", "bold", "confident", "daring", "ambitious"],
     "fail_trait": ["troublesome", "playful"],
-    "min_cats": 2,
+    "min_cats": 3,
     "max_cats": 6,
     "antagonize_text": null,
     "antagonize_fail_text": null,
@@ -56,18 +56,86 @@
     "win_skills": ["very smart", "extremely smart"],
     "win_trait": ["altruistic", "compassionate", "empathetic", "faithful", "loving", "patient", "responsible", "thoughtful", "wise", "inquisitive"],
     "fail_trait": ["ambitious", "bloodthirsty", "cold", "fierce", "shameless", "strict", "troublesome", "vengeful"],
-    "min_cats": 2,
+    "min_cats": 3,
     "max_cats": 6,
     "antagonize_text": null,
     "antagonize_fail_text": null,
     "history_text": [
             "r_c carries a scar from being trapped on patrol.",
             "r_c tragically died after being trapped on patrol.",
-      "died after being trapped on patrol"
+            "died after being trapped on patrol"
     ]
 },
 {
-    "patrol_id": "bch_train_stuck2",
+        "patrol_id": "bch_train_stuck2",
+        "biome": "plains",
+        "season": "Any",
+        "tags": ["training", "platonic", "comfort", "trust", "blunt_force_injury", "death", "scar", "LEFTEAR", "p_l_to_r_c", "s_c_to_r_c", "patrol_to_p_l", "patrol_to_r_c"],
+        "intro_text": "Trailing behind p_l, the dune they're crossing shifts beneath r_c's paws. They look around wildly for safe footing - just as the sand caves in beneath them and the world goes dark.",
+        "decline_text": "Thankfully, they're on the edge of the obstruction, and wriggle their way clear.",
+        "chance_of_success": 50,
+        "exp": 20,
+        "success_text": [
+            "p_l comes running at their yowls, and r_c is soon freed, shaken but unharmed. The cats settle down as they comfort each other.",
+            "p_l digs through the loose sand, helping r_c clear it away enough for the other cat to scramble free.",
+            "Without letting themselves panic, s_c carefully assesses the collapsed dune trapping their Clanmate. They find stable footing to dig them out from above, and r_c is recovered, scared but okay.",
+            "Creeping in as close as possible, s_c purrs to r_c, keeping them calm as they carefully dig down to them. r_c blinks up at them, holding on to their presence in the scary situation."
+        ],
+        "fail_text": [
+            "p_l works all day to free r_c and gets nothing else done.",
+            "As s_c rarely has patience for other cats, r_c tells them harshly that they don't have time for some idiot who got stuck, making s_c resentful as they dig themselves out of the sand.",
+            "Hurt and wheezing, r_c hears p_l panicking as they drift to StarClan.",
+            "p_l eventually manages to rescue r_c, but they need to be helped back to camp, battered and injured."
+        ],
+        "win_skills": ["very smart", "extremely smart"],
+        "win_trait": ["altruistic", "compassionate", "empathetic", "faithful", "loving", "patient", "responsible", "thoughtful", "wise", "inquisitive"],
+        "fail_trait": ["ambitious", "bloodthirsty", "cold", "fierce", "shameless", "strict", "troublesome", "vengeful", "bossy"],
+        "min_cats": 2,
+        "max_cats": 2,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from being trapped on patrol",
+            "r_c tragically died after being trapped on patrol.",
+            "died after being trapped on patrol"
+        ]
+},
+{
+        "patrol_id": "bch_train_stuck3",
+        "biome": "plains",
+        "season": "Any",
+        "tags": ["training", "romantic", "comfort", "trust", "blunt_force_injury", "death", "scar", "LEFTEAR", "p_l_to_r_c", "s_c_to_r_c", "patrol_to_p_l", "patrol_to_r_c"],
+        "intro_text": "Trailing behind p_l, the dune they're crossing shifts beneath r_c's paws. They look around wildly for safe footing - just as the sand caves in beneath them and the world goes dark.",
+        "decline_text": "Thankfully, they're on the edge of the obstruction, and wriggle their way clear.",
+        "chance_of_success": 50,
+        "exp": 20,
+        "success_text": [
+            "p_l comes running at their yowls, and r_c is soon freed, shaken but unharmed. r_c has never noticed how strong p_l is before.",
+            "p_l digs through the loose soil, helping r_c clear it away enough for the other cat to scramble free. r_c admires how smart p_l is.",
+            "Without letting themselves panic, s_c carefully assesses the collapsed dune trapping their Clanmate. They find stable footing to dig them out from above, and r_c is recovered, scared but okay. r_c finds themselves seeing s_c in a different light.",
+            "Creeping in as close as possible, s_c purrs to r_c, keeping them calm as they carefully dig down to them. r_c blinks up at them, holding on to their presence in the scary situation."
+        ],
+        "fail_text": [
+            "p_l works all day to free r_c and gets nothing else done.",
+            "As s_c rarely has patience for other cats, r_c tells them harshly that they don't have time for some idiot who got stuck, making s_c resentful as they dig themselves out of the sand.",
+            "Hurt and wheezing, r_c hears p_l panicking as they drift to StarClan.",
+            "p_l eventually manages to rescue r_c, but they need to be helped back to camp, battered and injured."
+        ],
+        "win_skills": ["very smart", "extremely smart"],
+        "win_trait": ["altruistic", "compassionate", "empathetic", "faithful", "loving", "patient", "responsible", "thoughtful", "wise", "inquisitive"],
+        "fail_trait": ["ambitious", "bloodthirsty", "cold", "fierce", "shameless", "strict", "troublesome", "vengeful", "bossy"],
+        "min_cats": 2,
+        "max_cats": 2,
+        "antagonize_text": null,
+        "antagonize_fail_text": null,
+        "history_text": [
+            "r_c carries a scar from being trapped on patrol",
+            "r_c tragically died after being trapped on patrol.",
+            "died after being trapped on patrol"
+        ]
+},
+{
+    "patrol_id": "bch_train_stuck4",
     "biome": "beach",
     "season": "Any",
     "tags": ["training", "blunt_force_injury", "death", "scar", "ONE"],

--- a/resources/dicts/patrols/beach/training/any.json
+++ b/resources/dicts/patrols/beach/training/any.json
@@ -47,7 +47,7 @@
     ],
     "fail_text": [
             "The patrol works all day to free r_c and gets nothing else done.",
-            "Harshly, s_c tells their Clanmate that they're on their own - this patrol is too important to wait for some idiot who got stuck in the sand.",
+            "As s_c rarely has patience for other cats, r_c tells them harshly that they don't have time for some idiot who got stuck, making s_c resentful as they dig themselves out of the sand.",
             "Hurt and wheezing, r_c hears the patrol panicking as they drift to StarClan.",
             "The patrol eventually manages to rescue r_c, but they need to be helped back to camp, battered and injured.",
             "The patrol can't help s_c in time, and as s_c starts to drift off to StarClan, the eyes of r_c glint malevolently. Was this...? r_c doesn't have a chance to finish their last thought.",

--- a/resources/dicts/patrols/beach/training/any.json
+++ b/resources/dicts/patrols/beach/training/any.json
@@ -50,8 +50,8 @@
             "Harshly, s_c tells their Clanmate that they're on their own - this patrol is too important to wait for some idiot who got stuck in the sand.",
             "Hurt and wheezing, r_c hears the patrol panicking as they drift to StarClan.",
             "The patrol eventually manages to rescue r_c, but they need to be helped back to camp, battered and injured.",
-            "The patrol can't help r_c in time, and as r_c starts to drift off to StarClan, the eyes of s_c glint malevolently. Was this...? r_c doesn't have a chance to finish their last thought.",
-            "Even though r_c made it out, they swear someone pushed them in, and blame s_c. s_c denies it and says they should get r_c back to camp to get their injury looked at."
+            "The patrol can't help s_c in time, and as s_c starts to drift off to StarClan, the eyes of r_c glint malevolently. Was this...? r_c doesn't have a chance to finish their last thought.",
+            "Even though s_c made it out, they swear someone pushed them, and blame r_c. r_c denies it and says they should get s_c back to camp to get their injury looked at."
     ],
     "win_skills": ["very smart", "extremely smart"],
     "win_trait": ["altruistic", "compassionate", "empathetic", "faithful", "loving", "patient", "responsible", "thoughtful", "wise", "inquisitive"],

--- a/resources/dicts/patrols/forest/training/any.json
+++ b/resources/dicts/patrols/forest/training/any.json
@@ -103,7 +103,7 @@
     "tags": ["training", "platonic", "comfort", "trust", "blunt_force_injury", "death", "scar", "SIDE", "p_l_to_r_c", "s_c to r_c", "patrol_to_p_l", "patrol_to_r_c"],
     "intro_text": "Trailing behind the patrol, there's a mighty crash above r_c. They look around wildly - just as the world is blotted out by a tangle of heavy falling branches.",
     "decline_text": "Thankfully, they're on the edge of the obstruction, and wriggle their way clear.",
-    "chance_of_success": 50,
+    "chance_of_success": 30,
     "exp": 20,
     "success_text": [
         "Their Clanmates come running at their yowls, and r_c is soon freed, shaken but unharmed. The patrol settles down as everyone comforts each other.",
@@ -116,8 +116,8 @@
         "Harshly, s_c tells r_c that they're on their own - if they're too much of an idiot to get out from under some branches on their own then they'd probably just mess up the patrol anyway.",
         "Hurt and wheezing, r_c hears the patrol panicking as they drift to StarClan.",
         "The patrol eventually manages to rescue r_c, but they need to be helped back to camp, battered and injured.",
-        "The patrol can't help r_c in time, and as r_c starts to drift off to StarClan, the eyes of s_c glint malevolently. Was this...? r_c doesn't have a chance to finish their last thought.",
-        "Even though r_c made it out, they swear someone pushed them, and blame s_c. s_c denies it and says they should get r_c back to camp to get their injury looked at."
+        "The patrol can't help s_c in time, and as s_c starts to drift off to StarClan, the eyes of r_c glint malevolently. Was this...? r_c doesn't have a chance to finish their last thought.",
+        "Even though s_c made it out, they swear someone pushed them, and blame r_c. r_c denies it and says they should get s_c back to camp to get their injury looked at."
     ],
     "win_skills": ["very smart", "extremely smart"],
     "win_trait": ["altruistic", "compassionate", "empathetic", "faithful", "loving", "patient", "responsible", "thoughtful", "wise"],
@@ -139,7 +139,7 @@
     "tags": ["training", "blunt_force_injury", "death", "scar", "SIDE"],
     "intro_text": "r_c is training alone out in the forest when suddenly, a mighty crash sounds from above. They look around wildly - just as the world is blotted out by a tangle of heavy falling branches.",
     "decline_text": "Thankfully, they're on the edge of the obstruction, and wriggle their way clear.",
-    "chance_of_success": 40,
+    "chance_of_success": 20,
     "exp": 20,
     "success_text": [
         "r_c spends the entire day carefully working their way free and gets nothing else done, but at least they're unharmed.",

--- a/resources/dicts/patrols/forest/training/any.json
+++ b/resources/dicts/patrols/forest/training/any.json
@@ -122,18 +122,86 @@
     "win_skills": ["very smart", "extremely smart"],
     "win_trait": ["altruistic", "compassionate", "empathetic", "faithful", "loving", "patient", "responsible", "thoughtful", "wise"],
     "fail_trait": ["ambitious", "bloodthirsty", "cold", "fierce", "shameless", "strict", "troublesome", "vengeful"],
-    "min_cats": 2,
+    "min_cats": 3,
     "max_cats": 6,
     "antagonize_text": null,
     "antagonize_fail_text": null,
     "history_text": [
         "r_c carries a scar from being trapped on patrol.",
         "r_c tragically died after being trapped on patrol.",
-      "died after being trapped on patrol"
+        "died after being trapped on patrol"
     ]
 },
 {
     "patrol_id": "fst_train_stuck2",
+    "biome": "plains",
+    "season": "Any",
+    "tags": ["training", "platonic", "comfort", "trust", "blunt_force_injury", "death", "scar", "LEFTEAR", "p_l_to_r_c", "s_c_to_r_c", "patrol_to_p_l", "patrol_to_r_c"],
+    "intro_text": "Trailing behind p_l , there's a mighty crash above r_c. They look around wildly - just as the world is blotted out by a tangle of heavy falling branches.",
+    "decline_text": "Thankfully, they're on the edge of the obstruction, and wriggle their way clear.",
+    "chance_of_success": 50,
+    "exp": 20,
+    "success_text": [
+        "Their Clanmate comes running at their yowls, and r_c is soon freed, shaken but unharmed. The cats settle down as they comfort each other.",
+        "p_l tugs on just the right branch, lifting the pile off of r_c for long enough for the other cat to scramble free.",
+        "Without letting themselves panic, s_c carefully assesses the branches trapping their Clanmate, then throws their weight onto one. It acts as a lever, forcing the entire pile up and allowing r_c to scrabble free, shaken but grateful.",
+        "Creeping in as close as possible, s_c purrs to r_c, keeping them calm as they carefully dig down to them. r_c blinks up at them, holding on to their presence in the scary situation."
+    ],
+    "fail_text": [
+        "p_l works all day to free r_c and gets nothing else done.",
+        "As s_c rarely has patience for other cats, r_c tells them harshly that they don't have time for some idiot who got stuck, making s_c resentful as they pull themselves out from under the branches.",
+        "Hurt and wheezing, r_c hears p_l panicking as they drift to StarClan.",
+        "p_l eventually manages to rescue r_c, but they need to be helped back to camp, battered and injured."
+    ],
+    "win_skills": ["very smart", "extremely smart"],
+    "win_trait": ["altruistic", "compassionate", "empathetic", "faithful", "loving", "patient", "responsible", "thoughtful", "wise", "inquisitive"],
+    "fail_trait": ["ambitious", "bloodthirsty", "cold", "fierce", "shameless", "strict", "troublesome", "vengeful", "bossy"],
+    "min_cats": 2,
+    "max_cats": 2,
+    "antagonize_text": null,
+    "antagonize_fail_text": null,
+    "history_text": [
+        "r_c carries a scar from being trapped on patrol",
+        "r_c tragically died after being trapped on patrol.",
+        "died after being trapped on patrol"
+    ]
+},
+{
+    "patrol_id": "fst_train_stuck3",
+    "biome": "plains",
+    "season": "Any",
+    "tags": ["training", "romantic", "comfort", "trust", "blunt_force_injury", "death", "scar", "LEFTEAR", "p_l_to_r_c", "s_c_to_r_c", "patrol_to_p_l", "patrol_to_r_c"],
+    "intro_text": "Trailing behind p_l, there's a mighty crash above r_c. They look around wildly - just as the world is blotted out by a tangle of heavy falling branches.",
+    "decline_text": "Thankfully, they're on the edge of the obstruction, and wriggle their way clear.",
+    "chance_of_success": 50,
+    "exp": 20,
+    "success_text": [
+        "p_l comes running at their yowls, and r_c is soon freed, shaken but unharmed. r_c has never noticed how strong p_l is before.",
+        "p_l tugs on just the right branch, lifting the pile off of r_c for long enough for the other cat to scramble free. r_c admires how smart p_l is.",
+        "Without letting themselves panic, s_c carefully assesses the branches trapping their Clanmate, then throws their weight onto one. It acts as a lever, forcing the entire pile up and allowing r_c to scrabble free, shaken but grateful. r_c is impressed by s_c's wits.",
+        "Creeping in as close as possible, s_c purrs to r_c, keeping them calm as they carefully dig down to them. r_c blinks up at them, holding on to their presence in the scary situation."
+    ],
+    "fail_text": [
+        "p_l works all day to free r_c and gets nothing else done.",
+        "As s_c rarely has patience for other cats, r_c tells them harshly that they don't have time for some idiot who got stuck, making s_c resentful as they pull themselves out from under the branches.",
+        "Hurt and wheezing, r_c hears p_l panicking as they drift to StarClan.",
+        "p_l eventually manages to rescue r_c, but they need to be helped back to camp, battered and injured."
+    ],
+    "win_skills": ["very smart", "extremely smart"],
+    "win_trait": ["altruistic", "compassionate", "empathetic", "faithful", "loving", "patient", "responsible", "thoughtful", "wise", "inquisitive"],
+    "fail_trait": ["ambitious", "bloodthirsty", "cold", "fierce", "shameless", "strict", "troublesome", "vengeful", "bossy"],
+    "min_cats": 2,
+    "max_cats": 2,
+    "antagonize_text": null,
+    "antagonize_fail_text": null,
+    "history_text": [
+        "r_c carries a scar from being trapped on patrol",
+        "r_c tragically died after being trapped on patrol.",
+        "died after being trapped on patrol"
+    ]
+},
+{
+    "patrol_id": "fst_train_stuck4",
     "biome": "forest",
     "season": "Any",
     "tags": ["training", "blunt_force_injury", "death", "scar", "SIDE"],
@@ -161,7 +229,7 @@
     "history_text": [
         "r_c carries a scar from being trapped on patrol.",
         "r_c tragically died after being trapped on patrol.",
-      "died after being trapped on patrol"
+        "died after being trapped on patrol"
     ]
 
 },

--- a/resources/dicts/patrols/forest/training/any.json
+++ b/resources/dicts/patrols/forest/training/any.json
@@ -113,7 +113,7 @@
     ],
     "fail_text": [
         "The patrol works all day to free r_c and gets nothing else done.",
-        "Harshly, s_c tells r_c that they're on their own - if they're too much of an idiot to get out from under some branches on their own then they'd probably just mess up the patrol anyway.",
+        "As s_c rarely has patience for other cats, r_c tells them harshly that they don't have time for some idiot who got stuck, making s_c resentful as they pull themselves out from under the branches.",
         "Hurt and wheezing, r_c hears the patrol panicking as they drift to StarClan.",
         "The patrol eventually manages to rescue r_c, but they need to be helped back to camp, battered and injured.",
         "The patrol can't help s_c in time, and as s_c starts to drift off to StarClan, the eyes of r_c glint malevolently. Was this...? r_c doesn't have a chance to finish their last thought.",

--- a/resources/dicts/patrols/general/medcat.json
+++ b/resources/dicts/patrols/general/medcat.json
@@ -325,7 +325,7 @@
     "success_text": [
         "The cats take turns veering off for herbs, allowing the others time to chat with each other.  By the time they loop back to camp, each cat has a small bundle of herbs in their jaws, and a small bundle of contentment in their hearts.",
         "The patrol decides to collect herbs first, so they have time to idle and chat before heading back to camp. They spend some time in a warm sunbeam, sharing tongues and sunning themselves, and by the time they're ready to go home, every cat is feeling closer to one another.",
-        "As the cats walk and chat, s_c begins to lag behind. p_l looks back to ask them what's up, and spots them veering down a side path. p_l motions for the others as they follow s_c, and find them purring loudly at the sight of a huge herb patch! There's far more than the patrol can carry, and they know this will keep the Clan healthy for ages."
+        "As the cats walk and chat, s_c begins to lag behind. r_c looks back to ask them what's up, and spots them veering down a side path. r_c motions for the others as they follow s_c, and find them purring loudly at the sight of a huge herb patch! There's far more than the patrol can carry, and they know this will keep the Clan healthy for ages."
     ],
     "fail_text": [
         "The medicine cats are too caught up in chatting with one another - they don't collect a single leaf."
@@ -361,7 +361,7 @@
     "success_text": [
         "The cats take turns veering off for herbs, allowing the others time to chat with each other.  They manage to avoid any rain, and by the time they loop back to camp, each cat has a small bundle of herbs in their jaws, and a small bundle of contentment in their hearts.",
         "The patrol decides to collect herbs first, so they have time to idle and chat before heading back to camp. They sit themselves in the cover of a tree to share tongues and chat out of the rain, and by the time they're ready to go home, every cat is feeling closer to one another.",
-        "As the cats walk and chat, s_c begins to lag behind. p_l looks back to ask them what's up, and spots them veering down a side path. p_l motions for the others as they follow s_c, and find them purring loudly at the sight of a huge herb patch! There's far more than the patrol can carry, and they know this will keep the Clan healthy for ages."
+        "As the cats walk and chat, s_c begins to lag behind. r_c looks back to ask them what's up, and spots them veering down a side path. r_c motions for the others as they follow s_c, and find them purring loudly at the sight of a huge herb patch! There's far more than the patrol can carry, and they know this will keep the Clan healthy for ages."
     ],
     "fail_text": [
         "It starts pouring rain while they're out, and even p_l has to admit defeat and lead them home."

--- a/resources/dicts/patrols/mountainous/training/any.json
+++ b/resources/dicts/patrols/mountainous/training/any.json
@@ -103,7 +103,7 @@
     "tags": ["training", "platonic", "comfort", "trust", "blunt_force_injury", "death", "scar", "LEFTEAR", "p_l_to_r_c", "s_c_to_r_c", "patrol_to_p_l", "patrol_to_r_c"],
     "intro_text": "r_c is trailing behind the patrol when there is a mighty clatter of stones from below them. They look around wildly, just in time for the world to tip upside-down as the scree slope beneath them collapses.",
     "decline_text": "Thankfully, they're on the edge of the obstruction, and wriggle their way clear.",
-    "chance_of_success": 50,
+    "chance_of_success": 30,
     "exp": 20,
     "success_text": [
         "Their Clanmates come running at their yowls, and r_c is soon freed, shaken but unharmed. The patrol settles down as everyone comforts each other.",
@@ -116,8 +116,8 @@
         "Harshly, s_c tells r_c that they're on their own - this patrol is too important to wait for some idiot who got stuck.",
         "Hurt and wheezing, r_c hears the patrol panicking as they drift to StarClan.",
         "The patrol eventually manages to rescue r_c, but they need to be helped back to camp, battered and injured.",
-        "The patrol can't help r_c in time, and as r_c starts to drift off to StarClan, the eyes of s_c glint malevolently. Was this...? r_c doesn't have a chance to finish their last thought.",
-        "Even though r_c made it out, they swear someone pushed them, and blame s_c. s_c denies it and says they should get r_c back to camp to get their injury looked at."
+        "The patrol can't help s_c in time, and as s_c starts to drift off to StarClan, the eyes of r_c glint malevolently. Was this...? r_c doesn't have a chance to finish their last thought.",
+            "Even though s_c made it out, they swear someone pushed them, and blame r_c. r_c denies it and says they should get s_c back to camp to get their injury looked at."
     ],
     "win_skills": ["very smart", "extremely smart"],
     "win_trait": ["altruistic", "compassionate", "empathetic", "faithful", "loving", "patient", "responsible", "thoughtful", "wise"],
@@ -139,7 +139,7 @@
     "tags": ["training", "blunt_force_injury", "death", "scar", "TOETRAP"],
     "intro_text": "r_c is training alone out on the mountainside when suddenly, there's a mighty clatter of stones somewhere below them. r_c looks around wildly - just in time for the world to tip upside-down as the scree slope beneath them collapses.",
     "decline_text": "Thankfully, they're on the edge of the obstruction, and wriggle their way clear.",
-    "chance_of_success": 40,
+    "chance_of_success": 20,
     "exp": 20,
     "success_text": [
         "r_c spends the entire day carefully working their way free and gets nothing else done, but at least they're unharmed.",

--- a/resources/dicts/patrols/mountainous/training/any.json
+++ b/resources/dicts/patrols/mountainous/training/any.json
@@ -103,12 +103,12 @@
     "tags": ["training", "platonic", "comfort", "trust", "blunt_force_injury", "death", "scar", "LEFTEAR", "p_l_to_r_c", "s_c_to_r_c", "patrol_to_p_l", "patrol_to_r_c"],
     "intro_text": "r_c is trailing behind the patrol when there is a mighty clatter of stones from below them. They look around wildly, just in time for the world to tip upside-down as the scree slope beneath them collapses.",
     "decline_text": "Thankfully, they're on the edge of the obstruction, and wriggle their way clear.",
-    "chance_of_success": 30,
+    "chance_of_success": 50,
     "exp": 20,
     "success_text": [
         "Their Clanmates come running at their yowls, and r_c is soon freed, shaken but unharmed. The patrol settles down as everyone comforts each other.",
         "p_l digs through the loose rocks, helping r_c clear them away enough for the other cat to scramble free.",
-        "Without letting themselves panic, s_c carefully assesses the collapsed slope trapping their Clanmate. They point out a stable path to dig them out from above, and r_c is recovered, scared but okay.",
+        "Without letting themselves panic, s_c carefully assesses the collapsed slope trapping their Clanmate. They find a stable path to dig them out from above, and r_c is recovered, scared but okay.",
         "Creeping in as close as possible, s_c purrs to r_c, keeping them calm as the patrol carefully digs down to them. r_c blinks up at them, holding on to their presence in the scary situation."
     ],
     "fail_text": [
@@ -117,12 +117,12 @@
         "Hurt and wheezing, r_c hears the patrol panicking as they drift to StarClan.",
         "The patrol eventually manages to rescue r_c, but they need to be helped back to camp, battered and injured.",
         "The patrol can't help s_c in time, and as s_c starts to drift off to StarClan, the eyes of r_c glint malevolently. Was this...? r_c doesn't have a chance to finish their last thought.",
-            "Even though s_c made it out, they swear someone pushed them, and blame r_c. r_c denies it and says they should get s_c back to camp to get their injury looked at."
+        "Even though s_c made it out, they swear someone pushed them, and blame r_c. r_c denies it and says they should get s_c back to camp to get their injury looked at."
     ],
     "win_skills": ["very smart", "extremely smart"],
     "win_trait": ["altruistic", "compassionate", "empathetic", "faithful", "loving", "patient", "responsible", "thoughtful", "wise"],
     "fail_trait": ["ambitious", "bloodthirsty", "cold", "fierce", "shameless", "strict", "troublesome", "vengeful"],
-    "min_cats": 2,
+    "min_cats": 3,
     "max_cats": 6,
     "antagonize_text": null,
     "antagonize_fail_text": null,
@@ -133,13 +133,81 @@
     ]
 },
 {
-    "patrol_id": "mtn_train_stuck2",
+    "patrol_id": "mnt_train_stuck2",
+    "biome": "plains",
+    "season": "Any",
+    "tags": ["training", "platonic", "comfort", "trust", "blunt_force_injury", "death", "scar", "LEFTEAR", "p_l_to_r_c", "s_c_to_r_c", "patrol_to_p_l", "patrol_to_r_c"],
+    "intro_text": "r_c is trailing behind p_l when there is a mighty clatter of stones from below them. They look around wildly, just in time for the world to tip upside-down as the scree slope beneath them collapses.",
+    "decline_text": "Thankfully, they're on the edge of the obstruction, and wriggle their way clear.",
+    "chance_of_success": 50,
+    "exp": 20,
+    "success_text": [
+        "p_l comes running at their yowls, and r_c is soon freed, shaken but unharmed. The cats settle down as they comfort each other.",
+        "p_l digs through the loose rocks, helping r_c clear it away enough for the other cat to scramble free.",
+        "Without letting themselves panic, s_c carefully assesses the collapsed slope trapping their Clanmate. They find a stable path to dig them out from above, and r_c is recovered, scared but okay.",
+        "Creeping in as close as possible, s_c purrs to r_c, keeping them calm as they carefully dig down to them. r_c blinks up at them, holding on to their presence in the scary situation."
+    ],
+    "fail_text": [
+        "p_l works all day to free r_c and gets nothing else done.",
+        "As s_c rarely has patience for other cats, r_c tells them harshly that they don't have time for some idiot who got stuck, making s_c resentful as they dig themselves out.",
+        "Hurt and wheezing, r_c hears p_l panicking as they drift to StarClan.",
+        "p_l eventually manages to rescue r_c, but they need to be helped back to camp, battered and injured."
+    ],
+    "win_skills": ["very smart", "extremely smart"],
+    "win_trait": ["altruistic", "compassionate", "empathetic", "faithful", "loving", "patient", "responsible", "thoughtful", "wise", "inquisitive"],
+    "fail_trait": ["ambitious", "bloodthirsty", "cold", "fierce", "shameless", "strict", "troublesome", "vengeful", "bossy"],
+    "min_cats": 2,
+    "max_cats": 2,
+    "antagonize_text": null,
+    "antagonize_fail_text": null,
+    "history_text": [
+        "r_c carries a scar from being trapped on patrol",
+        "r_c tragically died after being trapped on patrol.",
+        "died after being trapped on patrol"
+    ]
+},
+{
+    "patrol_id": "mtn_train_stuck3",
+    "biome": "plains",
+    "season": "Any",
+    "tags": ["training", "romantic", "comfort", "trust", "blunt_force_injury", "death", "scar", "LEFTEAR", "p_l_to_r_c", "s_c_to_r_c", "patrol_to_p_l", "patrol_to_r_c"],
+    "intro_text": "r_c is trailing behind p_l when there is a mighty clatter of stones from below them. They look around wildly, just in time for the world to tip upside-down as the scree slope beneath them collapses.",
+    "decline_text": "Thankfully, they're on the edge of the obstruction, and wriggle their way clear.",
+    "chance_of_success": 50,
+    "exp": 20,
+    "success_text": [
+        "p_l comes running at their yowls, and r_c is soon freed, shaken but unharmed. r_c has never noticed how strong p_l is before.",
+        "p_l digs through the loose rocks, helping r_c clear it away enough for the other cat to scramble free. r_c admires how smart p_l is.",
+        "Without letting themselves panic, s_c carefully assesses the collapsed slope trapping their Clanmate. They point out a stable path to dig them out from above, and r_c is recovered, scared but okay, and impressed by s_c's wits.",
+        "Creeping in as close as possible, s_c purrs to r_c, keeping them calm as they carefully dig down to them. r_c blinks up at them, holding on to their presence in the scary situation."
+    ],
+    "fail_text": [
+        "p_l works all day to free r_c and gets nothing else done.",
+        "As s_c rarely has patience for other cats, r_c tells them harshly that they don't have time for some idiot who got stuck, making s_c resentful as they dig themselves out.",
+        "Hurt and wheezing, r_c hears p_l panicking as they drift to StarClan.",
+        "p_l eventually manages to rescue r_c, but they need to be helped back to camp, battered and injured."
+    ],
+    "win_skills": ["very smart", "extremely smart"],
+    "win_trait": ["altruistic", "compassionate", "empathetic", "faithful", "loving", "patient", "responsible", "thoughtful", "wise", "inquisitive"],
+    "fail_trait": ["ambitious", "bloodthirsty", "cold", "fierce", "shameless", "strict", "troublesome", "vengeful", "bossy"],
+    "min_cats": 2,
+    "max_cats": 2,
+    "antagonize_text": null,
+    "antagonize_fail_text": null,
+    "history_text": [
+        "r_c carries a scar from being trapped on patrol",
+        "r_c tragically died after being trapped on patrol.",
+        "died after being trapped on patrol"
+    ]
+},
+{
+    "patrol_id": "mtn_train_stuck4",
     "biome": "mountainous",
     "season": "Any",
     "tags": ["training", "blunt_force_injury", "death", "scar", "TOETRAP"],
     "intro_text": "r_c is training alone out on the mountainside when suddenly, there's a mighty clatter of stones somewhere below them. r_c looks around wildly - just in time for the world to tip upside-down as the scree slope beneath them collapses.",
     "decline_text": "Thankfully, they're on the edge of the obstruction, and wriggle their way clear.",
-    "chance_of_success": 20,
+    "chance_of_success": 40,
     "exp": 20,
     "success_text": [
         "r_c spends the entire day carefully working their way free and gets nothing else done, but at least they're unharmed.",

--- a/resources/dicts/patrols/mountainous/training/any.json
+++ b/resources/dicts/patrols/mountainous/training/any.json
@@ -113,7 +113,7 @@
     ],
     "fail_text": [
         "The patrol works all day to free r_c and gets nothing else done.",
-        "Harshly, s_c tells r_c that they're on their own - this patrol is too important to wait for some idiot who got stuck.",
+        "As s_c rarely has patience for other cats, r_c tells them harshly that they don't have time for some idiot who got stuck, making s_c resentful as they dig themselves out.",
         "Hurt and wheezing, r_c hears the patrol panicking as they drift to StarClan.",
         "The patrol eventually manages to rescue r_c, but they need to be helped back to camp, battered and injured.",
         "The patrol can't help s_c in time, and as s_c starts to drift off to StarClan, the eyes of r_c glint malevolently. Was this...? r_c doesn't have a chance to finish their last thought.",

--- a/resources/dicts/patrols/plains/training/any.json
+++ b/resources/dicts/patrols/plains/training/any.json
@@ -116,8 +116,8 @@
         "Harshly, s_c tells r_c that they're on their own - this patrol is too important to wait for some idiot who got stuck.",
         "Hurt and wheezing, r_c hears the patrol panicking as they drift to StarClan.",
         "The patrol eventually manages to rescue r_c, but they need to be helped back to camp, battered and injured.",
-        "The patrol can't help r_c in time, and as r_c starts to drift off to StarClan, the eyes of s_c glint malevolently. Was this...? r_c doesn't have a chance to finish their last thought.",
-        "Even though r_c made it out, they swear someone pushed them, and blame s_c. s_c denies it and says they should get r_c back to camp to get their injury looked at."
+        "The patrol can't help s_c in time, and as s_c starts to drift off to StarClan, the eyes of r_c glint malevolently. Was this...? r_c doesn't have a chance to finish their last thought.",
+        "Even though s_c made it out, they swear someone pushed them, and blame r_c. r_c denies it and says they should get s_c back to camp to get their injury looked at."
     ],
     "win_skills": ["very smart", "extremely smart"],
     "win_trait": ["altruistic", "compassionate", "empathetic", "faithful", "loving", "patient", "responsible", "thoughtful", "wise", "inquisitive"],

--- a/resources/dicts/patrols/plains/training/any.json
+++ b/resources/dicts/patrols/plains/training/any.json
@@ -122,7 +122,7 @@
     "win_skills": ["very smart", "extremely smart"],
     "win_trait": ["altruistic", "compassionate", "empathetic", "faithful", "loving", "patient", "responsible", "thoughtful", "wise", "inquisitive"],
     "fail_trait": ["ambitious", "bloodthirsty", "cold", "fierce", "shameless", "strict", "troublesome", "vengeful", "bossy"],
-    "min_cats": 2,
+    "min_cats": 3,
     "max_cats": 6,
     "antagonize_text": null,
     "antagonize_fail_text": null,
@@ -134,6 +134,74 @@
 },
 {
     "patrol_id": "pln_train_stuck2",
+    "biome": "plains",
+    "season": "Any",
+    "tags": ["training", "platonic", "comfort", "trust", "blunt_force_injury", "death", "scar", "LEFTEAR", "p_l_to_r_c", "s_c_to_r_c", "patrol_to_p_l", "patrol_to_r_c"],
+    "intro_text": "Trailing behind p_l, the ground trembles beneath r_c's paws. They look around wildly for safe footing - just as the earth caves in beneath them and the world goes dark.",
+    "decline_text": "Thankfully, they're on the edge of the obstruction, and wriggle their way clear.",
+    "chance_of_success": 50,
+    "exp": 20,
+    "success_text": [
+        "p_l comes running at their yowls, and r_c is soon freed, shaken but unharmed. The cats settle down as they comfort each other.",
+        "p_l digs through the loose soil, helping r_c clear it away enough for the other cat to scramble free.",
+        "Without letting themselves panic, s_c looks around for anything that could help. They snap a branch off a nearby scrub and clench it between their teeth, offering it to r_c. Between r_c's scrambling and s_c's determination, they're pulled free of the quagmire unharmed.",
+        "Creeping in as close as possible, s_c purrs to r_c, keeping them calm as they carefully dig down to them. r_c blinks up at them, holding on to their presence in the scary situation."
+    ],
+    "fail_text": [
+        "p_l works all day to free r_c and gets nothing else done.",
+        "As s_c rarely has patience for other cats, r_c tells them harshly that they don't have time for some idiot who got stuck, making s_c resentful as they dig themselves out.",
+        "Hurt and wheezing, r_c hears p_l panicking as they drift to StarClan.",
+        "p_l eventually manages to rescue r_c, but they need to be helped back to camp, battered and injured."
+    ],
+    "win_skills": ["very smart", "extremely smart"],
+    "win_trait": ["altruistic", "compassionate", "empathetic", "faithful", "loving", "patient", "responsible", "thoughtful", "wise", "inquisitive"],
+    "fail_trait": ["ambitious", "bloodthirsty", "cold", "fierce", "shameless", "strict", "troublesome", "vengeful", "bossy"],
+    "min_cats": 2,
+    "max_cats": 2,
+    "antagonize_text": null,
+    "antagonize_fail_text": null,
+    "history_text": [
+        "r_c carries a scar from being trapped on patrol",
+        "r_c tragically died after being trapped on patrol.",
+        "died after being trapped on patrol"
+    ]
+},
+{
+    "patrol_id": "pln_train_stuck3",
+    "biome": "plains",
+    "season": "Any",
+    "tags": ["training", "romantic", "comfort", "trust", "blunt_force_injury", "death", "scar", "LEFTEAR", "p_l_to_r_c", "s_c_to_r_c", "patrol_to_p_l", "patrol_to_r_c"],
+    "intro_text": "Trailing behind p_l, the ground trembles beneath r_c's paws. They look around wildly for safe footing - just as the earth caves in beneath them and the world goes dark.",
+    "decline_text": "Thankfully, they're on the edge of the obstruction, and wriggle their way clear.",
+    "chance_of_success": 50,
+    "exp": 20,
+    "success_text": [
+        "P_l comes running at their yowls, and r_c is soon freed, shaken but unharmed. r_c has never noticed how strong p_l is before.",
+        "p_l digs through the loose soil, helping r_c clear it away enough for the other cat to scramble free. r_c admires how smart p_l is.",
+        "Without letting themselves panic, s_c looks around for anything that could help. They snap a branch off a nearby scrub and clench it between their teeth, offering it to r_c. Between r_c's scrambling and s_c's determination, they're pulled free of the quagmire unharmed, r_c a little breathless at the display.",
+        "Creeping in as close as possible, s_c purrs to r_c, keeping them calm as they carefully dig down to them. r_c blinks up at them, holding on to their presence in the scary situation."
+    ],
+    "fail_text": [
+        "p_l works all day to free r_c and gets nothing else done.",
+        "As s_c rarely has patience for other cats, r_c tells them harshly that they don't have time for some idiot who got stuck, making s_c resentful as they dig themselves out.",
+        "Hurt and wheezing, r_c hears p_l panicking as they drift to StarClan.",
+        "p_l eventually manages to rescue r_c, but they need to be helped back to camp, battered and injured."
+    ],
+    "win_skills": ["very smart", "extremely smart"],
+    "win_trait": ["altruistic", "compassionate", "empathetic", "faithful", "loving", "patient", "responsible", "thoughtful", "wise", "inquisitive"],
+    "fail_trait": ["ambitious", "bloodthirsty", "cold", "fierce", "shameless", "strict", "troublesome", "vengeful", "bossy"],
+    "min_cats": 2,
+    "max_cats": 2,
+    "antagonize_text": null,
+    "antagonize_fail_text": null,
+    "history_text": [
+        "r_c carries a scar from being trapped on patrol",
+        "r_c tragically died after being trapped on patrol.",
+        "died after being trapped on patrol"
+    ]
+},
+{
+    "patrol_id": "pln_train_stuck4",
     "biome": "plains",
     "season": "Any",
     "tags": ["training", "blunt_force_injury", "death", "scar", "RIGHTEAR"],

--- a/resources/dicts/patrols/plains/training/any.json
+++ b/resources/dicts/patrols/plains/training/any.json
@@ -113,7 +113,7 @@
     ],
     "fail_text": [
         "The patrol works all day to free r_c and gets nothing else done.",
-        "Harshly, s_c tells r_c that they're on their own - this patrol is too important to wait for some idiot who got stuck.",
+        "As s_c rarely has patience for other cats, r_c tells them harshly that they don't have time for some idiot who got stuck, making s_c resentful as they dig themselves out.",
         "Hurt and wheezing, r_c hears the patrol panicking as they drift to StarClan.",
         "The patrol eventually manages to rescue r_c, but they need to be helped back to camp, battered and injured.",
         "The patrol can't help s_c in time, and as s_c starts to drift off to StarClan, the eyes of r_c glint malevolently. Was this...? r_c doesn't have a chance to finish their last thought.",

--- a/resources/dicts/patrols/plains/training/any.json
+++ b/resources/dicts/patrols/plains/training/any.json
@@ -129,7 +129,7 @@
     "history_text": [
         "r_c carries a scar from being trapped on patrol",
         "r_c tragically died after being trapped on patrol.",
-      "died after being trapped on patrol"
+        "died after being trapped on patrol"
     ]
 },
 {
@@ -161,7 +161,7 @@
     "history_text": [
         "r_c carries a scar from being trapped on patrol.",
         "r_c tragically died after being trapped on patrol.",
-      "died after being trapped on patrol"
+        "died after being trapped on patrol"
     ]
 
 },


### PR DESCRIPTION
medcat patrol had s_c and p_l could be the same cat, changed p_l ro r_c in the outcome so that the code in place to prevent r_c and s_c from being the same cat could trigger.

Also fixed "stuck" outcomes triggering for the wrong cat.

added two new patrols to each biome for "stuck" for two cats. One for general, one for romance. Everyone gets the chance to be thrown down a hole.