### PR TITLE
Tweaks: Change vitiligo determination

### DIFF
--- a/scripts/cat/appearance_utility.py
+++ b/scripts/cat/appearance_utility.py
@@ -487,24 +487,17 @@ def white_patches_inheritance(cat, parents: tuple):
 
     par_whitepatches = set()
     par_points = []
-    par_vit = []
     for p in parents:
         if p:
             if p.white_patches:
                 par_whitepatches.add(p.white_patches)
             if p.points:
                 par_points.append(p.points)
-            if p.vitiligo:
-                par_vit.append(p.vitiligo)
 
     if not parents:
         print("Error - no parents. Randomizing white patches.")
         randomize_white_patches(cat)
         return
-
-    vit_chance = max(game.config["cat_generation"]["vit_chance"] - len(par_vit), 0)
-    if not random.getrandbits(vit_chance):
-        cat.vitiligo = choice(vit)
 
     # Direct inheritance. Will only work if at least one parent has white patches, otherwise continue on.
     if par_whitepatches and not randint(0, game.config["cat_generation"]["direct_inheritance"]):
@@ -597,12 +590,6 @@ def white_patches_inheritance(cat, parents: tuple):
 
 def randomize_white_patches(cat):
 
-    # Vet determination
-    if not random.getrandbits(game.config["cat_generation"]["vit_chance"]):
-        cat.vitiligo = choice(vit)
-    else:
-        cat.vitiligo = None
-
     # Points determination. Tortie can't be pointed
     if cat.pelt.name != "Tortie" and not random.getrandbits(game.config["cat_generation"]["random_point_chance"]):
         # Cat has colorpoint!
@@ -630,18 +617,31 @@ def init_white_patches(cat):
     if cat.pelt is None:
         init_pelt(cat)
 
-    if cat.white_patches:
+    #Gather parents
+    par1 = None
+    par2 = None
+    if cat.parent1 in cat.all_cats:
+        par1 = cat.all_cats[cat.parent1]
+    if cat.parent2 in cat.all_cats:
+        par2 = cat.all_cats[cat.parent2]
+
+    # Vit can rool for anyone, not just cats who rolled to have white in their pelt. 
+    par_vit = []
+    for p in (par1, par2):
+        if p:
+            if p.vitiligo:
+                par_vit.append(p.vitiligo)
+    
+    vit_chance = max(game.config["cat_generation"]["vit_chance"] - len(par_vit), 0)
+    if not random.getrandbits(vit_chance):
+        cat.vitiligo = choice(vit)
+
+    if cat.white_patches or cat.points:
         return
 
+    # If the cat was rolled previously to have white patches, then determine the patch they will have
+    # these functions also handle points. 
     if cat.pelt.white:
-
-        par1 = None
-        par2 = None
-        if cat.parent1 in cat.all_cats:
-            par1 = cat.all_cats[cat.parent1]
-        if cat.parent2 in cat.all_cats:
-            par2 = cat.all_cats[cat.parent2]
-
         if par1 or par2:
             white_patches_inheritance(cat, (par1, par2))
         else:

--- a/scripts/cat/appearance_utility.py
+++ b/scripts/cat/appearance_utility.py
@@ -600,6 +600,8 @@ def randomize_white_patches(cat):
     # Adjust weights for torties, since they can't have anything greater than mid_white:
     if cat.pelt.name == "Tortie":
         weights = (2, 1, 0, 0, 0)
+    elif cat.pelt.name == "Calico":
+        weights = (0, 0, 20, 15, 1)
     else:
         weights = (10, 10, 10, 10, 1)
 


### PR DESCRIPTION
- Cats can now have vitiligo even if they didn't roll to have white in their pelt.
- Randomized calicos will now have white patches restrictions that match inheritance. 