### PR TITLE
Content: Allegiances polish

### DIFF
--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -12,7 +12,7 @@ try:
 except ImportError:
     import json as ujson
 
-from .pelts import describe_color
+from .pelts import describe_appearance
 from .names import Name
 from .thoughts import get_thoughts
 from .appearance_utility import (
@@ -899,24 +899,14 @@ class Cat():
     def describe_cat(self, short=False):
         """ Generates a string describing the cat's appearance and gender. Mainly used for generating
         the allegiances. If short is true, it will generate a very short one, with the minimal amount of information. """
-
-        if self.genderalign == 'male' or self.genderalign == "transmasc" or self.genderalign == "trans male":
-            sex = 'tom'
-        elif self.genderalign == 'female' or self.genderalign == "transfem" or self.genderalign == "trans female":
-            sex = 'she-cat'
+        output = describe_appearance(self, short)
+        # Add "a" or "an"
+        if output[0].lower() in "aiou":
+            output = f"an {output}"
         else:
-            sex = 'cat'
+            output = f"a {output}"
 
-        description = ""
-        if len(self.scars) >= 4:
-            description += "scarred "
-
-        if not short and self.pelt.length == "long":
-            description += str(self.pelt.length).lower() + '-furred ' 
-
-        description += describe_color(self.pelt, self.tortiepattern, self.tortiecolour,
-                                            self.white_patches, self.points, self.vitiligo, short=short) + ' ' + sex
-        return description
+        return output
         
 
     def describe_eyes(self):

--- a/scripts/screens/clan_screens.py
+++ b/scripts/screens/clan_screens.py
@@ -1293,7 +1293,7 @@ class AllegiancesScreen(Screens):
     
     def generate_one_entry(self, cat, extra_details = ""):
             """ Extra Details will be placed after the cat description, but before the apprentice (if they have one. )"""
-            output = f"{str(cat.name).upper()} - a {cat.describe_cat()} {extra_details}"
+            output = f"{str(cat.name).upper()} - {cat.describe_cat()} {extra_details}"
 
             if len(cat.apprentice) > 0:
                 if len(cat.apprentice) == 1:
@@ -1431,7 +1431,7 @@ class AllegiancesScreen(Screens):
                 queen = Cat.fetch_cat(q)
                 kittens = []
                 for k in queen_dict[q]:
-                    kittens += [f"{k.name} - a {k.describe_cat(short=True)}"]
+                    kittens += [f"{k.name} - {k.describe_cat(short=True)}"]
                 if len(kittens) == 1:
                     kittens = f" <i>(caring for {kittens[0]})</i>"
                 else:
@@ -1441,12 +1441,12 @@ class AllegiancesScreen(Screens):
 
             #Now kittens without carers
             for k in living_kits:
-                all_entries.append(f"{str(k.name).upper()} - a {k.describe_cat(short=True)}")
+                all_entries.append(f"{str(k.name).upper()} - {k.describe_cat(short=True)}")
 
             _box[1] = "\n".join(all_entries)
             outputs.append(_box)
 
-         # Elder Box:
+        # Elder Box:
         if living_elders:
             _box = ["", ""]
             if len(living_elders) == 1:


### PR DESCRIPTION
- Allowed the color name to come after the pattern description in some cases. This allows some descriptions to flow better. 
- Descriptions now contain info on missing limbs. 
- vitiligo now goes after cat gender, alongside missing limbs. 
- Color descriptions for torties and calicos are now formatting like: "{patches_color}/{base_color}" to reduce confusion. 
- Cat described as "mottled" now get the same patches color descriptions as other calico/torties. 
- Changed the description of Bengal to "unusually dappled" and Rosette to "unusually spotted". 
- Changed the description of SingleStripe to "dorsal-striped" 