### PR TITLE
Bugfix: Fading, Exile UR Cat. 

### DIFF
--- a/scripts/cat/sprites.py
+++ b/scripts/cat/sprites.py
@@ -205,8 +205,8 @@ sprites.make_group('lineartdead', (0, 0), 'lineartdead')
 sprites.make_group('lineartdf', (0, 0), 'lineartdf')
 
 # Fading Fog
-for i in range(1, 4):
-    sprites.make_group('fademask', (i, 0), f'fademask{i}',)
+for i in range(0, 3):
+    sprites.make_group('fademask', (i, 0), f'fademask{i}')
     sprites.make_group('fadestarclan', (i, 0), f'fadestarclan{i}')
     sprites.make_group('fadedarkforest', (i, 0), f'fadedf{i}')
 

--- a/scripts/screens/cat_screens.py
+++ b/scripts/screens/cat_screens.py
@@ -384,10 +384,12 @@ class ProfileScreen(Screens):
                     self.update_disabled_buttons_and_text()
                 if self.the_cat.dead:
                     if self.the_cat.df is True:
+                        self.the_cat.outside = False
                         self.the_cat.df = False
                         game.clan.add_to_starclan(self.the_cat)
                         self.the_cat.thought = "Is relieved to once again hunt in StarClan"
                     else:
+                        self.the_cat.outside = False
                         self.the_cat.df = True
                         game.clan.add_to_darkforest(self.the_cat)
                         self.the_cat.thought = "Is distraught after being sent to the Place of No Stars"

--- a/scripts/screens/cat_screens.py
+++ b/scripts/screens/cat_screens.py
@@ -384,12 +384,12 @@ class ProfileScreen(Screens):
                     self.update_disabled_buttons_and_text()
                 if self.the_cat.dead:
                     if self.the_cat.df is True:
-                        self.the_cat.outside = False
+                        self.the_cat.outside, self.the_cat.exiled = False, False
                         self.the_cat.df = False
                         game.clan.add_to_starclan(self.the_cat)
                         self.the_cat.thought = "Is relieved to once again hunt in StarClan"
                     else:
-                        self.the_cat.outside = False
+                        self.the_cat.outside, self.the_cat.exiled = False, False
                         self.the_cat.df = True
                         game.clan.add_to_darkforest(self.the_cat)
                         self.the_cat.thought = "Is distraught after being sent to the Place of No Stars"

--- a/scripts/utility.py
+++ b/scripts/utility.py
@@ -1024,13 +1024,14 @@ def update_sprite(cat):
 
         # Apply fading fog
         if cat.opacity <= 97 and not cat.prevent_fading and game.settings["fading"]:
-            stage = "1"
+            
+            stage = "0"
             if 80 >= cat.opacity > 45:
+                # Stage 1
+                stage = "1"
+            elif cat.opacity <= 45:
                 # Stage 2
                 stage = "2"
-            elif cat.opacity <= 45:
-                # Stage 3
-                stage = "3"
 
             new_sprite.blit(sprites.sprites['fademask' + stage + cat_sprite], 
                             (0, 0), special_flags=pygame.BLEND_RGBA_MULT)


### PR DESCRIPTION
- Cats will no longer disappear for the final fading stage. The first stage will now appear properly. 
- When you send a exiled UR resistance cat to DF, they will no longer show up on the UR screen. 