### PR TITLE
Balancing: Apprentice EX buff, Patrol balancing.

### DIFF
--- a/resources/game_config.json
+++ b/resources/game_config.json
@@ -215,7 +215,7 @@
 		"comment": "Set this to -1 for it to be infinite"
 	},
 	"graduation": {
-		"base_app_timeskip_ex": [[3, 10],[5, 6]],
+		"base_app_timeskip_ex": [[3, 12],[5, 6]],
 		"base_med_app_timeskip_ex": [[2, 7],[2, 3]],
 		"max_apprentice_age": {
 			"medicine cat apprentice": 30,

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -438,7 +438,7 @@ class Cat():
                 while m > Cat.age_moons['adolescent'][0]:
                     ran = game.config["graduation"]["base_app_timeskip_ex"]
                     exp = random.choice(
-                        list(range(ran[0][0], ran[0][1] + 1)) + list(range(ran[1][0], ran[1][1] + 1)) * 2)
+                        list(range(ran[0][0], ran[0][1] + 1)) + list(range(ran[1][0], ran[1][1] + 1)))
                     self.experience += exp + 3
                     m -= 1
             elif self.age in ['young adult', 'adult']:

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -1482,10 +1482,17 @@ class Events():
                 mentor_modifier = 0.7
             else:
                 mentor_modifier = 1
+                cat_ob = Cat.fetch_cat(cat.mentor)
+                if cat_ob.skill in ['fantastic teacher']:
+                    mentor_skill_modifier = 1
+                else:
+                    mentor_skill_modifier = 0
 
-            exp = random.choice(list(range(ran[0][0], ran[0][1] + 1)) + list(range(ran[1][0], ran[1][1] + 1)) * 2)
+                
 
-            cat.experience += max(exp * mentor_modifier, 1)
+            exp = random.choice(list(range(ran[0][0], ran[0][1] + 1)) + list(range(ran[1][0], ran[1][1] + 1)))
+
+            cat.experience += max(exp * mentor_modifier + mentor_skill_modifier, 1)
             print(f"{cat.name} has gained {int(exp * mentor_modifier)} EX", cat._experience)
 
     def invite_new_cats(self, cat):

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -1477,9 +1477,11 @@ class Events():
             else:
                 ran = game.config["graduation"]["base_app_timeskip_ex"]
 
+
             if not cat.mentor or Cat.fetch_cat(cat.mentor).not_working():
                 # Sick mentor debuff
                 mentor_modifier = 0.7
+                mentor_skill_modifier = 0
             else:
                 mentor_modifier = 1
                 cat_ob = Cat.fetch_cat(cat.mentor)

--- a/scripts/patrol.py
+++ b/scripts/patrol.py
@@ -702,7 +702,11 @@ class Patrol():
         # if patrol contains cats with autowin skill, chance of success is high. otherwise it will calculate the
         # chance by adding the patrol event's chance of success plus the patrol's total exp
         success_chance = self.patrol_event.chance_of_success + int(
-            self.patrol_total_experience / (2 * 2 * gm_modifier))
+            self.patrol_total_experience / (7.5 * gm_modifier))
+        
+        # Auto-wins based on EXP are sorta lame. Often makes it immpossible for large patrols with experiences cats to fail patrols at all. 
+        # EXP alone can only bring success chance up to 95. However, skills/traits can bring it up above that. 
+        success_chance = min(success_chance, 95)
 
         print('starting chance:', self.patrol_event.chance_of_success)
         print('updated chance according to exp: ', success_chance)
@@ -737,7 +741,7 @@ class Patrol():
         # ---------------------------------------------------------------------------- #
         #                                   SUCCESS                                    #
         # ---------------------------------------------------------------------------- #
-
+        
         if c < success_chance:
             self.success = True
             self.patrol_fail_stat_cat = None


### PR DESCRIPTION
- Added a bit of a buff to passive apprentice EX. 
- If an apprentices mentor is a fantastic teacher (and is able to work), they will get an additional 1 passive EX per moon. 
- Adjusted EXP effect on patrol success chance. I had adjusted it earlier, but not enough.  
- EXP alone can now only bring the patrol success chance up to 95. Skills and traits can still bring the bring the success chance above 100. I was noticing most large patrols with decently experienced cats made the success chance rise above 100 often.  95 is almost an autowin, but leaves a small chance of failure anyway. 