### PR TITLE
Bugfixes - Various

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -3,17 +3,11 @@
   <component name="ChangeListManager">
     <list default="true" id="ce42a407-0f2f-4ee3-bcef-95649ffaedf8" name="Changes" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/resources/dicts/conditions/illnesses.json" beforeDir="false" afterPath="$PROJECT_DIR$/resources/dicts/conditions/illnesses.json" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/resources/dicts/patrols/plains/training/any.json" beforeDir="false" afterPath="$PROJECT_DIR$/resources/dicts/patrols/plains/training/any.json" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/resources/game_config.json" beforeDir="false" afterPath="$PROJECT_DIR$/resources/game_config.json" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/scripts/cat/cats.py" beforeDir="false" afterPath="$PROJECT_DIR$/scripts/cat/cats.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/scripts/events.py" beforeDir="false" afterPath="$PROJECT_DIR$/scripts/events.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/scripts/events_module/generate_events.py" beforeDir="false" afterPath="$PROJECT_DIR$/scripts/events_module/generate_events.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/scripts/events_module/new_cat_events.py" beforeDir="false" afterPath="$PROJECT_DIR$/scripts/events_module/new_cat_events.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/scripts/patrol.py" beforeDir="false" afterPath="$PROJECT_DIR$/scripts/patrol.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/scripts/screens/clan_creation_screens.py" beforeDir="false" afterPath="$PROJECT_DIR$/scripts/screens/clan_creation_screens.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/scripts/events_module/death_events.py" beforeDir="false" afterPath="$PROJECT_DIR$/scripts/events_module/death_events.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/scripts/events_module/relationship/pregnancy_events.py" beforeDir="false" afterPath="$PROJECT_DIR$/scripts/events_module/relationship/pregnancy_events.py" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/scripts/screens/clan_screens.py" beforeDir="false" afterPath="$PROJECT_DIR$/scripts/screens/clan_screens.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/scripts/utility.py" beforeDir="false" afterPath="$PROJECT_DIR$/scripts/utility.py" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -3,14 +3,16 @@
   <component name="ChangeListManager">
     <list default="true" id="ce42a407-0f2f-4ee3-bcef-95649ffaedf8" name="Changes" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/resources/dicts/patrols/forest/med/greenleaf.json" beforeDir="false" afterPath="$PROJECT_DIR$/resources/dicts/patrols/forest/med/greenleaf.json" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/resources/dicts/patrols/forest/med/leaf-bare.json" beforeDir="false" afterPath="$PROJECT_DIR$/resources/dicts/patrols/forest/med/leaf-bare.json" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/resources/dicts/patrols/general/medcat.json" beforeDir="false" afterPath="$PROJECT_DIR$/resources/dicts/patrols/general/medcat.json" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/resources/dicts/conditions/illnesses.json" beforeDir="false" afterPath="$PROJECT_DIR$/resources/dicts/conditions/illnesses.json" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/resources/dicts/patrols/plains/training/any.json" beforeDir="false" afterPath="$PROJECT_DIR$/resources/dicts/patrols/plains/training/any.json" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/resources/game_config.json" beforeDir="false" afterPath="$PROJECT_DIR$/resources/game_config.json" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/scripts/cat/cats.py" beforeDir="false" afterPath="$PROJECT_DIR$/scripts/cat/cats.py" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/scripts/events.py" beforeDir="false" afterPath="$PROJECT_DIR$/scripts/events.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/scripts/events_module/death_events.py" beforeDir="false" afterPath="$PROJECT_DIR$/scripts/events_module/death_events.py" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/scripts/events_module/generate_events.py" beforeDir="false" afterPath="$PROJECT_DIR$/scripts/events_module/generate_events.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/scripts/game_structure/load_cat.py" beforeDir="false" afterPath="$PROJECT_DIR$/scripts/game_structure/load_cat.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/scripts/events_module/new_cat_events.py" beforeDir="false" afterPath="$PROJECT_DIR$/scripts/events_module/new_cat_events.py" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/scripts/patrol.py" beforeDir="false" afterPath="$PROJECT_DIR$/scripts/patrol.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/scripts/screens/clan_creation_screens.py" beforeDir="false" afterPath="$PROJECT_DIR$/scripts/screens/clan_creation_screens.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/scripts/screens/clan_screens.py" beforeDir="false" afterPath="$PROJECT_DIR$/scripts/screens/clan_screens.py" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/scripts/utility.py" beforeDir="false" afterPath="$PROJECT_DIR$/scripts/utility.py" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -2,14 +2,11 @@
 <project version="4">
   <component name="ChangeListManager">
     <list default="true" id="ce42a407-0f2f-4ee3-bcef-95649ffaedf8" name="Changes" comment="">
-      <change afterPath="$PROJECT_DIR$/resources/dicts/snippet_collections.json" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/resources/dicts/events/misc_events/beach/medicine.json" beforeDir="false" afterPath="$PROJECT_DIR$/resources/dicts/events/misc_events/beach/medicine.json" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/resources/dicts/events/misc_events/forest/medicine.json" beforeDir="false" afterPath="$PROJECT_DIR$/resources/dicts/events/misc_events/forest/medicine.json" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/resources/dicts/events/misc_events/general/medicine.json" beforeDir="false" afterPath="$PROJECT_DIR$/resources/dicts/events/misc_events/general/medicine.json" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/resources/dicts/events/misc_events/mountainous/medicine.json" beforeDir="false" afterPath="$PROJECT_DIR$/resources/dicts/events/misc_events/mountainous/medicine.json" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/resources/dicts/events/misc_events/plains/medicine.json" beforeDir="false" afterPath="$PROJECT_DIR$/resources/dicts/events/misc_events/plains/medicine.json" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/scripts/screens/relation_screens.py" beforeDir="false" afterPath="$PROJECT_DIR$/scripts/screens/relation_screens.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/resources/credits_text.json" beforeDir="false" afterPath="$PROJECT_DIR$/resources/credits_text.json" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/resources/dicts/patrols/count_patrols.py" beforeDir="false" afterPath="$PROJECT_DIR$/resources/dicts/patrols/count_patrols.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/scripts/events.py" beforeDir="false" afterPath="$PROJECT_DIR$/scripts/events.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/scripts/patrol.py" beforeDir="false" afterPath="$PROJECT_DIR$/scripts/patrol.py" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/scripts/utility.py" beforeDir="false" afterPath="$PROJECT_DIR$/scripts/utility.py" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
@@ -36,7 +33,54 @@
     &quot;last_opened_file_path&quot;: &quot;C:/Users/tkdbl/Documents/GitHub/clangen&quot;
   }
 }</component>
-  <component name="RunManager">
+  <component name="RecentsManager">
+    <key name="MoveFile.RECENT_KEYS">
+      <recent name="C:\Users\tkdbl\Documents\GitHub\clangen\resources" />
+    </key>
+  </component>
+  <component name="RunManager" selected="Python.count_patrols (1)">
+    <configuration name="count_patrols (1)" type="PythonConfigurationType" factoryName="Python" temporary="true" nameIsGenerated="true">
+      <module name="clangen" />
+      <option name="INTERPRETER_OPTIONS" value="" />
+      <option name="PARENT_ENVS" value="true" />
+      <envs>
+        <env name="PYTHONUNBUFFERED" value="1" />
+      </envs>
+      <option name="SDK_HOME" value="" />
+      <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/resources/dicts/patrols" />
+      <option name="IS_MODULE_SDK" value="true" />
+      <option name="ADD_CONTENT_ROOTS" value="true" />
+      <option name="ADD_SOURCE_ROOTS" value="true" />
+      <option name="SCRIPT_NAME" value="$PROJECT_DIR$/resources/dicts/patrols/count_patrols.py" />
+      <option name="PARAMETERS" value="" />
+      <option name="SHOW_COMMAND_LINE" value="false" />
+      <option name="EMULATE_TERMINAL" value="false" />
+      <option name="MODULE_MODE" value="false" />
+      <option name="REDIRECT_INPUT" value="false" />
+      <option name="INPUT_FILE" value="" />
+      <method v="2" />
+    </configuration>
+    <configuration name="count_patrols" type="PythonConfigurationType" factoryName="Python" temporary="true" nameIsGenerated="true">
+      <module name="clangen" />
+      <option name="INTERPRETER_OPTIONS" value="" />
+      <option name="PARENT_ENVS" value="true" />
+      <envs>
+        <env name="PYTHONUNBUFFERED" value="1" />
+      </envs>
+      <option name="SDK_HOME" value="" />
+      <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/resources/dicts/patrols" />
+      <option name="IS_MODULE_SDK" value="true" />
+      <option name="ADD_CONTENT_ROOTS" value="true" />
+      <option name="ADD_SOURCE_ROOTS" value="true" />
+      <option name="SCRIPT_NAME" value="C:\Users\tkdbl\Documents\GitHub\clangen\resources\count_patrols.py" />
+      <option name="PARAMETERS" value="" />
+      <option name="SHOW_COMMAND_LINE" value="false" />
+      <option name="EMULATE_TERMINAL" value="false" />
+      <option name="MODULE_MODE" value="false" />
+      <option name="REDIRECT_INPUT" value="false" />
+      <option name="INPUT_FILE" value="" />
+      <method v="2" />
+    </configuration>
     <configuration name="main" type="PythonConfigurationType" factoryName="Python" temporary="true" nameIsGenerated="true">
       <module name="clangen" />
       <option name="INTERPRETER_OPTIONS" value="" />
@@ -60,6 +104,8 @@
     </configuration>
     <recent_temporary>
       <list>
+        <item itemvalue="Python.count_patrols (1)" />
+        <item itemvalue="Python.count_patrols" />
         <item itemvalue="Python.main" />
       </list>
     </recent_temporary>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -3,9 +3,13 @@
   <component name="ChangeListManager">
     <list default="true" id="ce42a407-0f2f-4ee3-bcef-95649ffaedf8" name="Changes" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/resources/credits_text.json" beforeDir="false" afterPath="$PROJECT_DIR$/resources/credits_text.json" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/resources/dicts/patrols/count_patrols.py" beforeDir="false" afterPath="$PROJECT_DIR$/resources/dicts/patrols/count_patrols.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/resources/dicts/patrols/forest/med/greenleaf.json" beforeDir="false" afterPath="$PROJECT_DIR$/resources/dicts/patrols/forest/med/greenleaf.json" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/resources/dicts/patrols/forest/med/leaf-bare.json" beforeDir="false" afterPath="$PROJECT_DIR$/resources/dicts/patrols/forest/med/leaf-bare.json" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/resources/dicts/patrols/general/medcat.json" beforeDir="false" afterPath="$PROJECT_DIR$/resources/dicts/patrols/general/medcat.json" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/scripts/events.py" beforeDir="false" afterPath="$PROJECT_DIR$/scripts/events.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/scripts/events_module/death_events.py" beforeDir="false" afterPath="$PROJECT_DIR$/scripts/events_module/death_events.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/scripts/events_module/generate_events.py" beforeDir="false" afterPath="$PROJECT_DIR$/scripts/events_module/generate_events.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/scripts/game_structure/load_cat.py" beforeDir="false" afterPath="$PROJECT_DIR$/scripts/game_structure/load_cat.py" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/scripts/patrol.py" beforeDir="false" afterPath="$PROJECT_DIR$/scripts/patrol.py" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/scripts/utility.py" beforeDir="false" afterPath="$PROJECT_DIR$/scripts/utility.py" afterDir="false" />
     </list>
@@ -38,7 +42,7 @@
       <recent name="C:\Users\tkdbl\Documents\GitHub\clangen\resources" />
     </key>
   </component>
-  <component name="RunManager" selected="Python.count_patrols (1)">
+  <component name="RunManager" selected="Python.main">
     <configuration name="count_patrols (1)" type="PythonConfigurationType" factoryName="Python" temporary="true" nameIsGenerated="true">
       <module name="clangen" />
       <option name="INTERPRETER_OPTIONS" value="" />
@@ -104,9 +108,9 @@
     </configuration>
     <recent_temporary>
       <list>
+        <item itemvalue="Python.main" />
         <item itemvalue="Python.count_patrols (1)" />
         <item itemvalue="Python.count_patrols" />
-        <item itemvalue="Python.main" />
       </list>
     </recent_temporary>
   </component>

--- a/resources/credits_text.json
+++ b/resources/credits_text.json
@@ -67,6 +67,7 @@
         "DaMoomin",
         "SkylerStarling",
         "lividjesmar",
-        "teutonic"
+        "teutonic",
+        "redhairdl"
     ]
 }

--- a/resources/dicts/conditions/illnesses.json
+++ b/resources/dicts/conditions/illnesses.json
@@ -2,7 +2,7 @@
     "seizure": {
         "severity": "severe",
         "mortality": {
-            "newborn": 10,
+            "newborn": 2,
             "kitten": 5,
             "adolescent": 10,
             "young adult": 20,
@@ -11,7 +11,7 @@
             "senior": 5
         },
         "medicine_mortality": {
-            "newborn": 50,
+            "newborn": 30,
             "kitten": 50,
             "adolescent": 70,
             "young adult": 100,

--- a/resources/dicts/patrols/count_patrols.py
+++ b/resources/dicts/patrols/count_patrols.py
@@ -3,29 +3,34 @@ import collections
 import os
 from os.path import exists as file_exists
 
-
 """ This script exists to count and catalogue all patrols.   """
 
 ALL_PATROLS = []
 DETAILS = {}
 
 SPRITES_USED = []
+EXPLICIT_PATROL_ART = None
+
 
 def get_patrol_details(path):
     global ALL_PATROLS
     global DETAILS
+    global EXPLICIT_PATROL_ART
+    patrols = None
 
-    try:
+    if path == ".\explicit_patrol_art.json":
         with open(path, "r") as read_file:
-            patrols = ujson.loads(read_file.read())
-    except:
-        print(f'Something went wrong with {path}')
+            EXPLICIT_PATROL_ART = ujson.loads(read_file.read())
+    else:
+        try:
+            with open(path, "r") as read_file:
+                patrols = ujson.loads(read_file.read())
+        except:
+            print(f'Something went wrong with {path}')
 
     if not patrols:
         return
 
-    if path == ".\explicit_patrol_art.json":
-        return
     if type(patrols[0]) != dict:
         print(path, "is not in the correct patrol format. It may not be a patrol .json.")
         return
@@ -64,6 +69,7 @@ def get_patrol_details(path):
             DETAILS["MIN_" + str(p_["min_cats"])].add(p_["patrol_id"])
         else:
             DETAILS["MIN_" + str(p_["min_cats"])] = {p_["patrol_id"]}
+
 
 def check_patrol_sprites():
     explicit_sprite = False
@@ -115,19 +121,28 @@ def check_patrol_sprites():
     return explicit_sprite, available_sprite, needs_sprite
 
 
-
 root_dir = "../patrols"
 file_set = set()
 
 for dir_, _, files in os.walk(root_dir):
     for file_name in files:
         rel_dir = os.path.relpath(dir_, root_dir)
+        print(rel_dir)
         rel_file = os.path.join(rel_dir, file_name)
+        print(rel_file)
         if os.path.splitext(rel_file)[-1].lower() == ".json":
             file_set.add(rel_file)
 
 for pa in file_set:
     get_patrol_details(pa)
+
+path = "../resources"
+
+for root, dirs, files in os.walk(path):
+    for name in files:
+        print(os.path.join(root, name))
+    for name in dirs:
+        print(os.path.join(root, name))
 
 # Now that we have everything gathered, lets do some checks.
 
@@ -139,7 +154,7 @@ Check for certain patrols
 """)
 task = input("What would you like to do? ")
 
-if 'patrol ids'.casefold() in task:
+if 'patrol ids' in task.casefold():
     # AT CHECK TO MAKE SURE ALL PATROL IDs ARE UNIQUE
     duplicates = [item for item, count in collections.Counter(ALL_PATROLS).items() if count > 1]
     if duplicates:
@@ -150,12 +165,7 @@ if 'patrol ids'.casefold() in task:
     else:
         print("All patrol IDs are unique. \n\n")
 
-if 'patrol sprites'.casefold() in task:
-    EXPLICIT_PATROL_ART = None
-    with open(f"resources/dicts/patrols/explicit_patrol_art.json", 'r') as read_file:
-        EXPLICIT_PATROL_ART = ujson.loads(read_file.read())
-
-    path = "resources/images/patrol_art/"
+if 'patrol sprite' in task.casefold():
 
     explicit_art = []
     has_patrol_sprite = []
@@ -171,10 +181,9 @@ if 'patrol sprites'.casefold() in task:
         elif need:
             needs_patrol_sprite.append(ID)
 
-
 # We can do a lot with these sets we have just generated! For example:
 
-## FINDING ALL PATROLS IN THE FOREST BIOME WITH NEW_CAT TAG
+'''## FINDING ALL PATROLS IN THE FOREST BIOME WITH NEW_CAT TAG
 
 forest_new_cat = DETAILS["BIOME_forest"].intersection(DETAILS["TAG_new_cat"])
 print("Number of patrols with the new_cat tag in the forest biome: ", len(forest_new_cat))
@@ -184,13 +193,4 @@ print("Patrol IDs: ", forest_new_cat)
 
 looking = DETAILS["TAG_death"].intersection(DETAILS["MIN_1"], DETAILS["MAX_1"])
 print("Number of patrols death tag and min_cat = 1 and max_cats = 1: ", len(looking))
-print("Patrol IDs: ", looking)
-
-
-
-
-
-
-
-
-
+print("Patrol IDs: ", looking)'''

--- a/resources/dicts/patrols/plains/training/any.json
+++ b/resources/dicts/patrols/plains/training/any.json
@@ -366,7 +366,6 @@
             "app1 maintains that bison are obstacles, not weird land protectors or anything like that, just annoying mooing obstacles, and p_l can't get them to take the training session seriously."
     ],
     "win_skills": ["good speaker", "great speaker", "excellent speaker"],
-
     "min_cats": 2,
     "max_cats": 2,
     "antagonize_text": null,
@@ -391,7 +390,6 @@
             "app1 maintains that bison are obstacles, not dangerous or anything like that, just annoying mooing obstacles, and p_l can't get them to take the training session seriously."
     ],
     "win_skills": ["good teacher", "great teacher", "fantastic teacher"],
-
     "min_cats": 2,
     "max_cats": 2,
     "antagonize_text": null,
@@ -416,7 +414,6 @@
             "app1 maintains that bison are obstacles, not weird land protectors or anything like that, just annoying mooing obstacles, and p_l can't get them to take the training session seriously. They distract app2 as well, and eventually p_l has to give up on teaching."
     ],
     "win_skills": ["good speaker", "great speaker", "excellent speaker"],
-
     "min_cats": 3,
     "max_cats": 6,
     "antagonize_text": null,
@@ -441,7 +438,6 @@
             "app1 maintains that bison are obstacles, not dangerous or anything like that, just annoying mooing obstacles, and p_l can't get them to take the training session seriously. They distract app2 as well, and eventually p_l has to give up on teaching."
     ],
     "win_skills": ["good teacher", "great teacher", "fantastic teacher"],
-
     "min_cats": 3,
     "max_cats": 6,
     "antagonize_text": null,
@@ -466,7 +462,6 @@
         "app1 maintains that tunnels aren't useful for anything, just annoying obstacles in the landscape, and p_l can't get them to take the training session seriously."
     ],
     "win_skills": ["good speaker", "great speaker", "excellent speaker"],
-
     "min_cats": 2,
     "max_cats": 2,
     "antagonize_text": null,
@@ -491,7 +486,6 @@
             "app1 maintains that tunnels aren't useful for anything, just annoying obstacles in the landscape, and p_l can't get them to take the training session seriously."
     ],
     "win_skills": ["good teacher", "great teacher", "fantastic teacher"],
-
     "min_cats": 2,
     "max_cats": 2,
     "antagonize_text": null,
@@ -603,7 +597,7 @@
         "biome": "plains",
         "season": "Any",
         "tags": ["app_stat", "training", "romantic", "trust", "big_change", "minor_injury", "apprentice", "two_apprentices"],
-        "intro_text": "Shivering with ilicit excitement, app1 gestures app2 on with their tail. They need to sneak out of camp before anyone notices them in the early morning dark.",
+        "intro_text": "Shivering with illicit excitement, app1 gestures app2 on with their tail. They need to sneak out of camp before anyone notices them in the early morning dark.",
         "decline_text": "Shaking their head, app2 looks back regretfully, tilting their head meaningfully towards where their mentor is already stirring for the day.",
         "chance_of_success": 70,
         "exp": 40,
@@ -620,9 +614,7 @@
                 "As they head out to the border, app1 rushes app2 along. It's too fast in such murky lighting, an app2 hurts themselves tumbling into an unseen hole. Their little outing is called off, and both of the apprentices return home, one limping, disappointed and struggling with feelings of rejection."
         ],
 
-        "win_trait": ["bold", "charismatic", "playful", "empathetic", "faithful", "loving", "insecure", "lonesome", "loyal"],
-        "fail_skills": null,
-
+        "win_trait": ["bold", "charismatic", "playful", "empathetic", "faithful", "loving", "insecure", "lonesome", "loyal"]
         "min_cats": 2,
         "max_cats": 2,
         "antagonize_text": null,

--- a/resources/game_config.json
+++ b/resources/game_config.json
@@ -22,7 +22,7 @@
 			"elder": 1.5,
 			"queen": 4,
 			"kitten": 0.5,
-			"newborn": 0
+			"newborn": 0.2
 		},
 		"feeding_order":[
 			"newborn",

--- a/resources/game_config.json
+++ b/resources/game_config.json
@@ -21,9 +21,11 @@
 			"apprentice": 1.5,
 			"elder": 1.5,
 			"queen": 4,
-			"kitten": 0.5
+			"kitten": 0.5,
+			"newborn": 0
 		},
 		"feeding_order":[
+			"newborn",
 			"kitten",
 			"queen",
 			"elder",

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -514,7 +514,7 @@ class Cat():
         self.injuries.clear()
         self.illnesses.clear()
 
-        self.thought = 'Is surprised to find themselves walking the stars of Silverpelt.'
+        self.thought = 'Is surprised to find themselves walking the stars of Silverpelt'
 
         # Deal with leader death
         text = ""

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -354,7 +354,7 @@ class Cat():
             else:
                 self.trait = choice(self.kit_traits)
 
-        if self.trait in self.kit_traits and self.status != 'kitten':
+        if self.trait in self.kit_traits and self.status not in ['kitten', 'newborn']:
             self.trait = choice(self.traits)
 
         if self.skill is None or self.skill == '???':
@@ -987,6 +987,8 @@ class Cat():
             return
 
         self.moons += 1
+        if self.moons == 1:
+            self.status = 'kitten'
         self.update_traits()
         self.in_camp = 1
 

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -513,6 +513,8 @@ class Cat():
         self.injuries.clear()
         self.illnesses.clear()
 
+        self.thought = 'Is surprised to find themselves walking the stars of Silverpelt.'
+
         # Deal with leader death
         text = ""
         if self.status == 'leader':

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -7,6 +7,7 @@ import itertools
 
 from ..datadir import get_save_dir
 from ..events_module.generate_events import GenerateEvents
+
 try:
     import ujson
 except ImportError:
@@ -24,7 +25,7 @@ from .appearance_utility import (
     init_white_patches,
     init_eyes,
     init_pattern,
-    )
+)
 from scripts.conditions import Illness, Injury, PermanentCondition, get_amount_cat_for_one_medic, \
     medical_cats_condition_fulfilled
 import bisect
@@ -145,15 +146,15 @@ class Cat():
         'loner_backstories': ['loner1', 'loner2', 'refugee2', 'tragedy_survivor4'],
         'rogue_backstories': ['rogue1', 'rogue2', 'rogue3', 'refugee4', 'tragedy_survivor2'],
         'kittypet_backstories': ['kittypet1', 'kittypet2', 'kittypet3', 'refugee3', 'tragedy_survivor3'],
-        'former_clancat_backstories': ['ostracized_warrior', 'disgraced', 'retired_leader', 'refugee', 
-                                        'tragedy_survivor', 'disgraced2', 'disgraced3', 'medicine_cat'],
+        'former_clancat_backstories': ['ostracized_warrior', 'disgraced', 'retired_leader', 'refugee',
+                                       'tragedy_survivor', 'disgraced2', 'disgraced3', 'medicine_cat'],
         'otherclan_backstories': ['otherclan', 'otherclan2', 'otherclan3', 'other_clan1'],
         'healer_backstories': ['medicine_cat', 'wandering_healer1', 'wandering_healer2'],
         'orphaned_backstories': ['orphaned', 'orphaned2', 'orphaned3', 'orphaned4', 'orphaned5'],
         'abandoned_backstories': ['abandoned1', 'abandoned2', 'abandoned3', 'abandoned4']
     }
 
-    #EX levels and ranges.
+    # EX levels and ranges.
     # Ranges are inclusive to both bounds
     experience_levels_range = {
         "untrained": (0, 0),
@@ -555,7 +556,7 @@ class Cat():
             self.grief(body)
 
         return text
-    
+
     def exile(self):
         """This is used to send a cat into exile. This removes the cat's status and gives them a special 'exiled'
         status."""
@@ -617,7 +618,8 @@ class Cat():
                     if cat_to == self:
                         family_relation = self.familial_grief(living_cat=cat)
                         possible_strings.extend(
-                            self.generate_events.possible_death_reactions(family_relation, value, cat.trait, body_status))
+                            self.generate_events.possible_death_reactions(family_relation, value, cat.trait,
+                                                                          body_status))
 
             if possible_strings:
                 # choose string
@@ -663,7 +665,8 @@ class Cat():
                         if cat_to == self:
                             family_relation = self.familial_grief(living_cat=cat)
                             possible_strings.extend(
-                                self.generate_events.possible_death_reactions(family_relation, value, cat.trait, body_status))
+                                self.generate_events.possible_death_reactions(family_relation, value, cat.trait,
+                                                                              body_status))
 
                 if possible_strings:
                     # choose string
@@ -712,7 +715,7 @@ class Cat():
             app_ob.update_mentor()
         self.update_mentor()
         game.clan.add_to_outside(self)
-    
+
     def add_to_clan(self):
         """ Makes a "outside cat" a clan cat. Former leaders, deputies will become warriors. Apprentices will be assigned a mentor."""
         self.outside = False
@@ -722,17 +725,25 @@ class Cat():
         elif self.status == 'apprentice' and self.moons >= 12:
             self.status_change('warrior')
             involved_cats = [self.ID]
-            game.cur_events_list.append(Single_Event('A long overdue warrior ceremony is held for ' + str(self.name.prefix) + 'paw. They smile as they finally become a warrior of the Clan and are now named ' + str(self.name) + '.', "ceremony", involved_cats))
+            game.cur_events_list.append(Single_Event('A long overdue warrior ceremony is held for ' + str(
+                self.name.prefix) + 'paw. They smile as they finally become a warrior of the Clan and are now named ' + str(
+                self.name) + '.', "ceremony", involved_cats))
         elif self.status == 'kitten' and self.moons >= 12:
             self.status_change('warrior')
             involved_cats = [self]
-            game.cur_events_list.append(Single_Event('A long overdue warrior ceremony is held for ' + str(self.name.prefix) + 'kit. They smile as they finally become a warrior of the Clan and are now named ' + str(self.name) + '.', "ceremony", involved_cats))
+            game.cur_events_list.append(Single_Event('A long overdue warrior ceremony is held for ' + str(
+                self.name.prefix) + 'kit. They smile as they finally become a warrior of the Clan and are now named ' + str(
+                self.name) + '.', "ceremony", involved_cats))
         elif self.status == 'kitten' and self.moons >= 6:
             self.status_change('apprentice')
             involved_cats = [self.ID]
-            game.cur_events_list.append(Single_Event('A long overdue apprentice ceremony is held for ' + str(self.name.prefix) + 'kit. They smile as they finally become a warrior of the Clan and are now named ' + str(self.name) + '.', "ceremony", involved_cats))
+            game.cur_events_list.append(Single_Event('A long overdue apprentice ceremony is held for ' + str(
+                self.name.prefix) + 'kit. They smile as they finally become a warrior of the Clan and are now named ' + str(
+                self.name) + '.', "ceremony", involved_cats))
         elif self.status in ['kittypet', 'loner', 'rogue']:
-            if self.moons < 6:
+            if self.moons == 0:
+                self.status = 'newborn'
+            elif self.moons < 6:
                 self.status = "kitten"
             elif self.moons < 12:
                 self.status_change('apprentice')
@@ -921,7 +932,6 @@ class Cat():
             output = f"a {output}"
 
         return output
-        
 
     def describe_eyes(self):
         colour = str(self.eye_colour).lower()
@@ -994,7 +1004,8 @@ class Cat():
 
         # get other cat
         i = 0
-        while other_cat == self.ID and len(all_cats) > 1 or (all_cats.get(other_cat).status in ['kittypet', 'rogue', 'loner']):
+        while other_cat == self.ID and len(all_cats) > 1 or (
+                all_cats.get(other_cat).status in ['kittypet', 'rogue', 'loner']):
             other_cat = random.choice(list(all_cats.keys()))
             i += 1
             if i > 100:
@@ -1002,7 +1013,7 @@ class Cat():
                 break
 
         other_cat = all_cats.get(other_cat)
-            
+
         # get possible thoughts
         thought_possibilities = get_thoughts(self, other_cat)
         chosen_thought = random.choice(thought_possibilities)
@@ -1113,7 +1124,8 @@ class Cat():
             return
 
         cats_to_choose = list(
-            filter(lambda iter_cat: iter_cat.ID != self.ID and not iter_cat.outside and not iter_cat.exiled and not iter_cat.dead,
+            filter(lambda
+                       iter_cat: iter_cat.ID != self.ID and not iter_cat.outside and not iter_cat.exiled and not iter_cat.dead,
                    Cat.all_cats.values())
         )
         # if there are not cats to interact, stop
@@ -1131,7 +1143,6 @@ class Cat():
             relevant_relationship.cat_to.contact_with_ill_cat(self)
         if relevant_relationship.cat_to.is_ill():
             self.contact_with_ill_cat(relevant_relationship.cat_to)
-        
 
     def update_skill(self):
         """Checks for skill and replaces empty skill if cat is old enough
@@ -1196,7 +1207,7 @@ class Cat():
                     if not mentor:
                         print("WARNING: mentor not found")
                         return
-                # give skill from mentor
+                    # give skill from mentor
                     if chance >= 9:
                         for x in possible_groups:
                             if mentor.skill in self.skill_groups[x]:
@@ -1625,12 +1636,13 @@ class Cat():
                 moons_until = 0
 
         if born_with and self.status != 'kitten':
-                moons_until = -2
+            moons_until = -2
         elif born_with is False:
             moons_until = 0
 
         if condition == "paralyzed":
             self.paralyzed = True
+            update_sprite(self)
 
         new_perm_condition = PermanentCondition(
             name=name,
@@ -1813,7 +1825,7 @@ class Cat():
 
             if "paralyzed" in self.permanent_condition and not self.paralyzed:
                 self.paralyzed = True
-                
+
         except Exception as e:
             print(f"WARNING: There was an error reading the condition file of cat #{self}.\n", e)
 
@@ -2569,7 +2581,8 @@ class Cat():
             with open(get_save_dir() + '/' + game.clan.name + '/faded_cats/' + cat + ".json", 'r') as read_file:
                 cat_info = ujson.loads(read_file.read())
         except AttributeError:  # If loading cats is attempted before the clan is loaded, we would need to use this.
-            with open(get_save_dir() + '/' + game.switches['clan_list'][0] + '/faded_cats/' + cat + ".json", 'r') as read_file:
+            with open(get_save_dir() + '/' + game.switches['clan_list'][0] + '/faded_cats/' + cat + ".json",
+                      'r') as read_file:
                 cat_info = ujson.loads(read_file.read())
         except:
             print("ERROR: in loading faded cat")
@@ -2603,7 +2616,7 @@ class Cat():
             Cat.all_cats_list.sort(key=lambda x: int(x.ID), reverse=True)
         elif game.sort_type == "rank":
             Cat.all_cats_list.sort(key=lambda x: (Cat.rank_order(x), Cat.get_adjusted_age(x)), reverse=True)
-        
+
         if game.sort_fav:
             Cat.all_cats_list.sort(key=lambda x: x.favourite, reverse=True)
         return
@@ -2662,7 +2675,6 @@ class Cat():
             if self.experience_levels_range[x][0] <= exp <= self.experience_levels_range[x][1]:
                 self.experience_level = x
                 break
-
 
     @property
     def moons(self):
@@ -2732,11 +2744,8 @@ PERMANENT = None
 with open(f"{resource_directory}permanent_conditions.json", 'r') as read_file:
     PERMANENT = ujson.loads(read_file.read())
 
-
-
 resource_directory = "resources/dicts/events/death/death_reactions/"
 
 MINOR_MAJOR_REACTION = None
 with open(f"{resource_directory}minor_major.json", 'r') as read_file:
     MINOR_MAJOR_REACTION = ujson.loads(read_file.read())
-

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -348,7 +348,7 @@ class Cat():
 
         # personality trait and skill
         if self.trait is None:
-            if self.status != 'kitten':
+            if self.status not in ['newborn', 'kitten']:
                 self.trait = choice(self.traits)
             else:
                 self.trait = choice(self.kit_traits)

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -670,12 +670,26 @@ class Events():
         """
         trigger events
         """
-
         if cat.dead:
             cat.thoughts()
             cat.dead_for += 1
             self.handle_fading(cat)  # Deal with fading.
             return
+
+        # switches between the two death handles
+        self.handle_outbreaks(cat)
+        if random.getrandbits(1):
+            triggered_death = self.handle_injuries_or_general_death(cat)
+            if not triggered_death:
+                self.handle_illnesses_or_illness_deaths(cat)
+            else:
+                return
+        else:
+            triggered_death = self.handle_illnesses_or_illness_deaths(cat)
+            if not triggered_death:
+                self.handle_injuries_or_general_death(cat)
+            else:
+                return
 
         # all actions, which do not trigger an event display and
         # are connected to cats are located in there
@@ -725,6 +739,10 @@ class Events():
         # this is the new interaction function, currently not active
         # cat.relationship_interaction()
         cat.thoughts()
+
+        # relationships have to be handled separately, because of the ceremony name change
+        if not cat.dead or cat.outside:
+            self.relation_events.handle_relationships(cat)
 
     def check_clan_relations(self):
         """

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -717,10 +717,11 @@ class Events():
             if cat.dead:
                 return
 
+        if cat.is_disabled():
+            self.condition_events.handle_already_disabled(cat)
+
         # prevent injured or sick cats from unrealistic clan events
         if cat.is_ill() or cat.is_injured():
-            if cat.is_disabled():
-                self.condition_events.handle_already_disabled(cat)
             self.coming_out(cat)
             self.pregnancy_events.handle_having_kits(cat, clan=game.clan)
             self.handle_apprentice_EX(cat)
@@ -732,13 +733,16 @@ class Events():
             return
 
         # check for death/reveal/risks/retire caused by permanent conditions
-        if cat.is_disabled():
-            self.condition_events.handle_already_disabled(cat)
+
+        if cat.status == 'newborn':
+            cat.create_interaction()
+            cat.thoughts()
+            return
 
         self.coming_out(cat)
         self.pregnancy_events.handle_having_kits(cat, clan=game.clan)
         self.handle_apprentice_EX(cat)
-        self.perform_ceremonies(cat)  # here is age up included
+        self.perform_ceremonies(cat)
         cat.create_interaction()
         self.invite_new_cats(cat)
         self.other_interactions(cat)
@@ -1836,7 +1840,7 @@ class Events():
             if cat.illnesses[illness]["infectiousness"] == 0:
                 continue
             chance = cat.illnesses[illness]["infectiousness"]
-            chance += len(meds) * 5
+            chance += len(meds) * 7
             if not int(random.random() * chance):  # 1/chance to infect
                 # fleas are the only condition allowed to spread outside of cold seasons
                 if game.clan.current_season not in ["Leaf-bare", "Leaf-fall"
@@ -1847,7 +1851,7 @@ class Events():
                     alive_cats = list(
                         filter(
                             lambda kitty:
-                            (kitty.status == "kitten" and not kitty.dead and
+                            (kitty.status in ['kitten', 'newborn'] and not kitty.dead and
                              not kitty.outside), Cat.all_cats.values()))
                     alive_count = len(alive_cats)
 

--- a/scripts/events_module/death_events.py
+++ b/scripts/events_module/death_events.py
@@ -40,7 +40,11 @@ class Death_Events():
         # ---------------------------------------------------------------------------- #
         #                                  kill cats                                   #
         # ---------------------------------------------------------------------------- #
-        death_cause = (random.choice(final_events))
+        try:
+            death_cause = (random.choice(final_events))
+        except IndexError:
+            print('WARNING: no death events found for', cat.name)
+            return
 
         # check if the cat's body was retrievable
         if "no_body" in death_cause.tags:

--- a/scripts/events_module/death_events.py
+++ b/scripts/events_module/death_events.py
@@ -37,7 +37,6 @@ class Death_Events():
         final_events = self.generate_events.filter_possible_short_events(possible_short_events, cat, other_cat, war, enemy_clan,
                                                                          other_clan, alive_kits)
 
-
         # ---------------------------------------------------------------------------- #
         #                                  kill cats                                   #
         # ---------------------------------------------------------------------------- #

--- a/scripts/events_module/generate_events.py
+++ b/scripts/events_module/generate_events.py
@@ -323,7 +323,7 @@ class GenerateEvents:
             # check for old age
             if "old_age" in event.tags and cat.moons < 150:
                 continue
-            # remove some of the non old age events to encourage elders to die of old age more often
+            # remove some non-old age events to encourage elders to die of old age more often
             if "old_age" not in event.tags and cat.moons < 150:
                 if not int(random.random() * 2):
                     continue
@@ -344,9 +344,9 @@ class GenerateEvents:
                     continue
                 elif "other_cat_elder" in event.tags and other_cat.status != "elder":
                     continue
-                elif "other_cat_adult" in event.tags and other_cat.age in ["elder", "kitten"]:
+                elif "other_cat_adult" in event.tags and other_cat.age in ["elder", "kitten", "newborn"]:
                     continue
-                elif "other_cat_kit" in event.tags and other_cat.status != "kitten":
+                elif "other_cat_kit" in event.tags and other_cat.status not in ['newborn', 'kitten']:
                     continue
 
                 if "other_cat_mate" in event.tags and other_cat.ID != cat.mate:

--- a/scripts/events_module/generate_events.py
+++ b/scripts/events_module/generate_events.py
@@ -323,6 +323,10 @@ class GenerateEvents:
             # check for old age
             if "old_age" in event.tags and cat.moons < 150:
                 continue
+            # remove some of the non old age events to encourage elders to die of old age more often
+            if "old_age" not in event.tags and cat.moons < 150:
+                if not int(random.random() * 2):
+                    continue
 
             # check other_cat status and other identifiers
             if other_cat:

--- a/scripts/events_module/new_cat_events.py
+++ b/scripts/events_module/new_cat_events.py
@@ -187,7 +187,7 @@ class NewCatEvents:
             major_injuries = []
             if "major_injury" in new_cat_event.tags:
                 for injury in INJURIES:
-                    if INJURIES[injury]["severity"] == "major":
+                    if INJURIES[injury]["severity"] == "major" and injury != 'pregnant':
                         major_injuries.append(injury)
             for new_cat in created_cats:
                 for tag in new_cat_event.tags:

--- a/scripts/events_module/relationship/pregnancy_events.py
+++ b/scripts/events_module/relationship/pregnancy_events.py
@@ -569,13 +569,13 @@ class Pregnancy_Events():
             kit = None
             if other_cat is not None:
                 if cat.gender == 'female':
-                    kit = Cat(parent1=cat.ID, parent2=other_cat.ID, moons=0)
+                    kit = Cat(parent1=cat.ID, parent2=other_cat.ID, moons=0, status='newborn')
                     kit.thought = f"Snuggles up to the belly of {cat.name}"
                 elif cat.gender == 'male' and other_cat.gender == 'male':
-                    kit = Cat(parent1=cat.ID, parent2=other_cat.ID, moons=0)
+                    kit = Cat(parent1=cat.ID, parent2=other_cat.ID, moons=0, status='newborn')
                     kit.thought = f"Snuggles up to the belly of {cat.name}"
                 else:
-                    kit = Cat(parent1=other_cat.ID, parent2=cat.ID, moons=0)
+                    kit = Cat(parent1=other_cat.ID, parent2=cat.ID, moons=0, status='newborn')
                     kit.thought = f"Snuggles up to the belly of {other_cat.name}"
                 cat.birth_cooldown = 6
                 other_cat.birth_cooldown = 6
@@ -584,7 +584,7 @@ class Pregnancy_Events():
                     backstory = backstory_choice_1
                 else:
                     backstory = backstory_choice_2
-                kit = Cat(parent1=cat.ID, moons=0, backstory=backstory)
+                kit = Cat(parent1=cat.ID, moons=0, backstory=backstory, status='newborn')
                 cat.birth_cooldown = 6
                 kit.thought = f"Snuggles up to the belly of {cat.name}"
             all_kitten.append(kit)

--- a/scripts/game_structure/load_cat.py
+++ b/scripts/game_structure/load_cat.py
@@ -81,6 +81,8 @@ def json_load():
                         loading_cat=True)
             new_cat.eye_colour2 = cat["eye_colour2"] if "eye_colour2" in cat else None
             new_cat.age = cat["age"]
+            if new_cat.age == 'elder':
+                new_cat.age = 'senior'
             new_cat.genderalign = cat["gender_align"]
             new_cat.backstory = cat["backstory"] if "backstory" in cat else None
             new_cat.birth_cooldown = cat["birth_cooldown"] if "birth_cooldown" in cat else 0

--- a/scripts/patrol.py
+++ b/scripts/patrol.py
@@ -1032,6 +1032,7 @@ class Patrol():
             if "litternewborn" in attribute_list:
                 print('litter is newborn')
                 kit_age = 0
+                status = 'newborn'
                 kit_thought = "Mewls quietly for milk"
             else:
                 print('litter is not newborn')

--- a/scripts/patrol.py
+++ b/scripts/patrol.py
@@ -986,6 +986,7 @@ class Patrol():
         # handing out ages
         if "newborn" in attribute_list:
             age = 0
+            status = 'newborn'
         elif "adolescent" in attribute_list:
             age = randint(6, 11)
         elif "youngadult" in attribute_list:

--- a/scripts/patrol.py
+++ b/scripts/patrol.py
@@ -1032,7 +1032,6 @@ class Patrol():
             if "litternewborn" in attribute_list:
                 print('litter is newborn')
                 kit_age = 0
-                status = 'newborn'
                 kit_thought = "Mewls quietly for milk"
             else:
                 print('litter is not newborn')
@@ -1104,7 +1103,7 @@ class Patrol():
                                                litter=True,
                                                other_clan=other_clan,
                                                backstory=kit_backstory,
-                                               status='kitten',
+                                               status=None,
                                                age=kit_age,
                                                gender=None,
                                                thought=kit_thought,

--- a/scripts/screens/clan_creation_screens.py
+++ b/scripts/screens/clan_creation_screens.py
@@ -390,7 +390,7 @@ class MakeClanScreen(Screens):
                 self.elements['next_step'].enable()
         # Show the error message if you try to choose a child for leader, deputy, or med cat.
         elif self.sub_screen in ['choose leader', 'choose deputy', 'choose med cat']:
-            if self.selected_cat.age in ["kitten", "adolescent"]:
+            if self.selected_cat.age in ["newborn", "kitten", "adolescent"]:
                 self.elements['select_cat'].hide()
                 self.elements['error_message'].show()
             else:

--- a/scripts/screens/clan_screens.py
+++ b/scripts/screens/clan_screens.py
@@ -1323,7 +1323,7 @@ class AllegiancesScreen(Screens):
                 living_mediators.append(cat)
             elif cat.status in ["apprentice", "medicine cat apprentice", "mediator apprentice"]:
                 living_apprentices.append(cat)
-            elif cat.status == "kitten":
+            elif cat.status in ["kitten", "newborn"]:
                 living_kits.append(cat)
             elif cat.status == "elder":
                 living_elders.append(cat)
@@ -1649,20 +1649,22 @@ class MedDenScreen(Screens):
             for cat in self.injured_and_sick_cats:
                 if cat.injuries:
                     for injury in cat.injuries:
-                        if cat.injuries[injury]["severity"] != 'minor' and injury not in ['recovering from birth',
+                        if cat.injuries[injury]["severity"] != 'minor' and injury not in ["pregnant", 'recovering from birth',
                                                                                           "sprain", "lingering shock"]:
-                            self.in_den_cats.append(cat)
+                            if cat not in self.in_den_cats:
+                                self.in_den_cats.append(cat)
                             if cat in self.out_den_cats:
                                 self.out_den_cats.remove(cat)
                             elif cat in self.minor_cats:
                                 self.minor_cats.remove(cat)
                             break
-                        elif injury in ['recovering from birth', "sprain", "lingering shock"]:
-                            self.out_den_cats.append(cat)
+                        elif injury in ['recovering from birth', "sprain", "lingering shock", "pregnant"] and cat not in self.in_den_cats:
+                            if cat not in self.out_den_cats:
+                                self.out_den_cats.append(cat)
                             if cat in self.minor_cats:
                                 self.minor_cats.remove(cat)
                             break
-                        else:
+                        elif cat not in (self.in_den_cats or self.out_den_cats):
                             if cat not in self.minor_cats:
                                 self.minor_cats.append(cat)
                 if cat.illnesses:
@@ -1909,7 +1911,9 @@ class MedDenScreen(Screens):
             if cat.illnesses:
                 condition_list.extend(cat.illnesses.keys())
             if cat.permanent_condition:
-                condition_list.extend(cat.permanent_condition.keys())
+                for condition in cat.permanent_condition:
+                    if cat.permanent_condition[condition]["moons_until"] == -2:
+                        condition_list.extend(cat.permanent_condition.keys())
             conditions = ",<br>".join(condition_list)
 
             self.cat_buttons["able_cat" + str(i)] = UISpriteButton(scale(pygame.Rect

--- a/scripts/screens/clan_screens.py
+++ b/scripts/screens/clan_screens.py
@@ -94,7 +94,7 @@ class ClanScreen(Screens):
         i = 0
         for x in game.clan.clan_cats:
             if not Cat.all_cats[x].dead and Cat.all_cats[x].in_camp and \
-                    not Cat.all_cats[x].exiled and not Cat.all_cats[x].outside:
+                    not Cat.all_cats[x].exiled and not Cat.all_cats[x].outside and Cat.all_cats[x].status != 'newborn':
 
                 i += 1
                 if i > self.max_sprites_displayed:
@@ -304,6 +304,9 @@ class ClanScreen(Screens):
             if Cat.all_cats[x].dead or Cat.all_cats[x].outside:
                 continue
 
+            if Cat.all_cats[x].status == 'newborn':
+                continue
+            print(Cat.all_cats[x].status)
             if Cat.all_cats[x].status in ['apprentice', 'mediator apprentice']:
                 Cat.all_cats[x].placement = self.choose_nonoverlapping_positions(first_choices, all_dens,
                                                                                  [1, 50, 1, 1, 100, 100, 1])

--- a/scripts/utility.py
+++ b/scripts/utility.py
@@ -247,7 +247,7 @@ def create_new_cat(Cat,
         number_of_cats = choices([1, 2, 3, 4, 5], [2, 5, 4, 1, 1], k=1)
         number_of_cats = number_of_cats[0]
     # setting age
-    if not age:
+    if not age and age != 0:
         if litter or kit:
             age = randint(0, 5)
         elif status == 'apprentice':
@@ -925,6 +925,8 @@ def update_sprite(cat):
         else:
             cat_sprite = str(18)
     else:
+        if cat.age == 'elder':
+            cat.age = 'senior'
         cat_sprite = str(cat.cat_sprites[cat.age])
 
 # generating the sprite

--- a/scripts/utility.py
+++ b/scripts/utility.py
@@ -72,7 +72,7 @@ def get_alive_kits(Cat):
     returns a list of all living kittens in the clan
     """
     alive_kits = list(filter(
-        lambda kitty: (kitty.age == "kitten"
+        lambda kitty: (kitty.age in ['kitten', 'newborn']
                        and not kitty.dead
                        and not kitty.outside),
         Cat.all_cats.values()

--- a/scripts/utility.py
+++ b/scripts/utility.py
@@ -262,7 +262,9 @@ def create_new_cat(Cat,
         age = age
     # setting status
     if not status:
-        if age < 6:
+        if age == 0:
+            status = "newborn"
+        elif age < 6:
             status = "kitten"
         elif 6 <= age <= 11:
             status = "apprentice"


### PR DESCRIPTION
i'm back bay-bee

- newborn kits found on patrol will now actually be newborn
- when a cat dies, their thought is now reset to 'Is surprised to find themselves walking the stars of Silverpelt'
- newborns are now given kit traits instead of adult traits
- added redhairdl to the credits
- fixed a few typos
- fixed a patrol crash
- fixed a crash related to 'elder' > 'senior' age  name change
- fixed a crash related to newborns and freshkill
- newborns should no longer participate in moon events
- newborns can no longer run about the camp
- newborns weren't actually getting the newborn status upon birth, now they do
- likewise, now they switch to the kitten status upon becoming 1 moon old
- paralyzed from birth cats should now display the correct sprites
- new cats that come with an injury will no longer come with the "pregnant" injury
- fixed quite a few spots in the code where kittens were referenced but newborns were not
- pregnant cats should no longer display in the Med Den as being in the med den
- cats should no longer reveal their unrevealed congenital conditions in the Med Den tool-tip
- old age deaths should hopefully be more common for elders, rather than the more violent deaths that are available