### PR TITLE
Print Cleanup

### DIFF
--- a/scripts/events.py
+++ b/scripts/events.py
@@ -1525,7 +1525,6 @@ class Events():
             exp = random.choice(list(range(ran[0][0], ran[0][1] + 1)) + list(range(ran[1][0], ran[1][1] + 1)))
 
             cat.experience += max(exp * mentor_modifier + mentor_skill_modifier, 1)
-            print(f"{cat.name} has gained {int(exp * mentor_modifier)} EX", cat._experience)
 
     def invite_new_cats(self, cat):
         """

--- a/scripts/events_module/relationship/group_events.py
+++ b/scripts/events_module/relationship/group_events.py
@@ -239,7 +239,7 @@ class Group_Events():
                 if abbreviation in interact.status_constraint:
                     # if the cat status is in the status constraint, add the id to the list
                     status_ids = [cat.ID for cat in interact_cats if cat.status in interact.status_constraint[abbreviation]]
-                    print(status_ids)
+                    # print(status_ids)
                 else:
                     # if there is no constraint, add all ids to the list 
                     status_ids = [cat.ID for cat in interact_cats]

--- a/scripts/patrol.py
+++ b/scripts/patrol.py
@@ -693,6 +693,8 @@ class Patrol():
         if self.patrol_event is None:
             return
 
+        print("patrol tags: ", self.patrol_event.tags)
+
         antagonize = antagonize
         success_text = self.patrol_event.success_text
         fail_text = self.patrol_event.fail_text

--- a/scripts/patrol.py
+++ b/scripts/patrol.py
@@ -708,8 +708,8 @@ class Patrol():
         # EXP alone can only bring success chance up to 95. However, skills/traits can bring it up above that. 
         success_chance = min(success_chance, 95)
 
-        print('starting chance:', self.patrol_event.chance_of_success)
-        print('updated chance according to exp: ', success_chance)
+        print('starting chance:', self.patrol_event.chance_of_success, "| EX_updated chance:", success_chance)
+        skill_updates = ""
         for kitty in self.patrol_cats:
             if kitty.skill in self.patrol_event.win_skills:
                 success_chance += game.config["patrol_generation"]["win_stat_cat_modifier"]
@@ -724,7 +724,8 @@ class Patrol():
             if self.patrol_event.fail_trait and kitty.trait in self.patrol_event.fail_trait:
                 success_chance += game.config["patrol_generation"]["fail_stat_cat_modifier"]
 
-            print(kitty.name, 'updated chance to', success_chance)
+            skill_updates += f"{kitty.name} updated chance to {success_chance} | "
+        print(skill_updates)
         print('ending chance', success_chance)
 
         c = randint(0, 100)
@@ -894,21 +895,22 @@ class Patrol():
         :param success: success bool
         """
         tags = self.patrol_event.tags
-        print('new cat creation started')
         # check for ignore outcome tag
         if f"no_new_cat{outcome}" in tags:
             return
-
+        
         # find the new cat tag and split to get attributes - else return if no tag found
         attribute_list = []
         for tag in tags:
-            print(tag)
+            #print(tag)
             if "new_cat" in tag and ("no_new_cat" and "new_cat_injury") not in tag:
                 attribute_list = tag.split("_")
                 print('found tag, attributes:', attribute_list)
                 break
         if not attribute_list:
             return
+        
+        print('new cat creation started')
 
         # setting the defaults
         new_name = choice([True, False])
@@ -1325,7 +1327,6 @@ class Patrol():
             for cat in self.patrol_cats:
                 if cat.status in ["apprentice", "medicine cat apprentice"]:
                     cat.experience = cat.experience + app_exp
-                    print(f"{cat.name} earned {app_exp}. New exp: {cat.experience}")
                 else:
                     cat.experience = cat.experience + gained_exp
 

--- a/scripts/screens/clan_screens.py
+++ b/scripts/screens/clan_screens.py
@@ -304,9 +304,10 @@ class ClanScreen(Screens):
             if Cat.all_cats[x].dead or Cat.all_cats[x].outside:
                 continue
 
+            # Newborns are now meant to be placed. They are hiding. 
             if Cat.all_cats[x].status == 'newborn':
                 continue
-            print(Cat.all_cats[x].status)
+            # print(Cat.all_cats[x].status)
             if Cat.all_cats[x].status in ['apprentice', 'mediator apprentice']:
                 Cat.all_cats[x].placement = self.choose_nonoverlapping_positions(first_choices, all_dens,
                                                                                  [1, 50, 1, 1, 100, 100, 1])


### PR DESCRIPTION
- Remove status prints when visiting clan page. 
- Condensed some patrol prints to a single line. 
- Removed printing of all patrol tags during new_cat creation. Added a print of all patrol tags in a single line, during success calculation to replace them. 
- Removed prints related to apprentice EX, passive and patrol. 
- Commented out prints of lists of IDs during group event determination. 