### PR TITLE
Typo hunting

### DIFF
--- a/resources/dicts/conditions/condition_got_strings/gain_permanent_condition_strings.json
+++ b/resources/dicts/conditions/condition_got_strings/gain_permanent_condition_strings.json
@@ -120,8 +120,8 @@
 
         ],
         "one bad eye": [
-            "r_c peels the cobwebs away from m_c's face and holds back a wince. The eye is un-salvageable and the rest of the skin will likely never grow fur again.",
-            "m_c can only be glad they were able to heal from the devastating burn, though they can't help but feel angry and their now vastly limited vision."
+            "r_c peels the cobwebs away from m_c's face and holds back a wince. The eye is unsalvageable and the rest of the skin will likely never grow fur again.",
+            "m_c can only be glad they were able to heal from the devastating burn, though they can't help but feel angry at their now vastly limited vision."
         ]
     },
     "lingering shock": {

--- a/resources/dicts/thoughts/other.json
+++ b/resources/dicts/thoughts/other.json
@@ -72,7 +72,7 @@
             "Is meowing for food",
             "Was wandering in the backyard when a strange noise scared them back inside",
             "Left their den to go scratch up that tree they've been eyeing",
-            "Glad their housefolk collar them on a leash to walk them outside",
+            "Is glad their housefolk collar them on a leash to walk them outside",
             "Heard the yowls of a recent battle in the distances",
             "Engaging in loaf mode",
             "Is wandering in their neighborhood",


### PR DESCRIPTION
added an "is", "un-salvageable" to "unsalvageable", "and" to "at"