### PR TITLE
Other: Cat Button Tooltip Support

### DIFF
--- a/resources/buttons.json
+++ b/resources/buttons.json
@@ -29,6 +29,36 @@
             "tool_tip_delay": "0"
         }
     },
+    "#cat_button": 
+    {
+		"colours":
+		{
+			"normal_bg":"#00000000",
+            "hovered_bg":"#00000000",
+            "disabled_bg":"#00000000",
+            "selected_bg":"#00000000",
+            "active_bg": "#00000000",
+            "normal_text":"#00000000",
+            "hovered_text":"#00000000",
+            "selected_text":"#00000000",
+            "disabled_text":"#00000000",
+            "link_text": "#00000000",
+            "link_hover": "#00000000",
+            "link_selected": "#00000000",
+            "text_shadow": "#00000000",
+            "normal_border": "#00000000",
+            "hovered_border": "#00000000",
+            "disabled_border": "#00000000",
+			"active_border": "#00000000",
+            "selected_border": "#00000000",
+            "normal_text_shadow": "#00000000"
+		},
+        "misc":
+        {
+            "shadow_width": "0",
+            "tool_tip_delay": "0"
+        }
+    },
     "#continue_button": 
     {
         "prototype": "#image_button",

--- a/resources/buttons_small.json
+++ b/resources/buttons_small.json
@@ -29,6 +29,36 @@
             "tool_tip_delay": "0"
         }
     },
+    "#cat_button": 
+    {
+		"colours":
+		{
+			"normal_bg":"#00000000",
+            "hovered_bg":"#00000000",
+            "disabled_bg":"#00000000",
+            "selected_bg":"#00000000",
+            "active_bg": "#00000000",
+            "normal_text":"#00000000",
+            "hovered_text":"#00000000",
+            "selected_text":"#00000000",
+            "disabled_text":"#00000000",
+            "link_text": "#00000000",
+            "link_hover": "#00000000",
+            "link_selected": "#00000000",
+            "text_shadow": "#00000000",
+            "normal_border": "#00000000",
+            "hovered_border": "#00000000",
+            "disabled_border": "#00000000",
+			"active_border": "#00000000",
+            "selected_border": "#00000000",
+            "normal_text_shadow": "#00000000"
+		},
+        "misc":
+        {
+            "shadow_width": "0",
+            "tool_tip_delay": "0"
+        }
+    },
     "#continue_button": 
     {
         "prototype": "#image_button",

--- a/resources/tool_tips.json
+++ b/resources/tool_tips.json
@@ -21,6 +21,11 @@
             "enable_title_bar": "0"
         }
     },
+    "#cat_button.tool_tip": {
+        "misc": {
+            "rect_width": "200"
+        }
+    },
     "#checked_checkbox_smalltooltip.tool_tip":
     {
         "misc":

--- a/resources/tool_tips_small.json
+++ b/resources/tool_tips_small.json
@@ -21,6 +21,11 @@
             "enable_title_bar": "0"
         }
     },
+    "#cat_button.tool_tip": {
+        "misc": {
+            "rect_width": "100"
+        }
+    },
     "#checked_checkbox_smalltooltip.tool_tip":
     {
         "misc":

--- a/scripts/game_structure/image_button.py
+++ b/scripts/game_structure/image_button.py
@@ -69,7 +69,7 @@ class UISpriteButton():
         For most functions, this can be used exactly like other pygame_gui elements. '''
 
     def __init__(self, relative_rect, sprite, cat_id=None, visible=1, cat_object=None, starting_height=1,
-                 manager=None):
+                 manager=None, tool_tip_text=None):
 
         # We have to scale the image before putting it into the image object. Otherwise, the method of upscaling that UIImage uses will make the pixel art fuzzy
         self.image = pygame_gui.elements.UIImage(relative_rect, pygame.transform.scale(sprite, relative_rect.size),
@@ -77,7 +77,7 @@ class UISpriteButton():
         self.image.disable()
         # The transparent button. This a subclass that UIButton that aslo hold the cat_id.
         self.button = CatButton(relative_rect, visible=visible, cat_id=cat_id, cat_object=cat_object,
-                                starting_height=starting_height, manager=manager)
+                                starting_height=starting_height, manager=manager, tool_tip_text=tool_tip_text)
 
     def return_cat_id(self):
         return self.button.return_cat_id()
@@ -122,11 +122,11 @@ class UISpriteButton():
 class CatButton(pygame_gui.elements.UIButton):
     '''Basic UIButton subclass for at sprite buttons. It stores the cat ID. '''
 
-    def __init__(self, relative_rect, cat_id=None, visible=True, cat_object=None, starting_height=1, manager=None):
+    def __init__(self, relative_rect, cat_id=None, visible=True, cat_object=None, starting_height=1, manager=None, tool_tip_text=None):
         self.cat_id = cat_id
         self.cat_object = cat_object
-        super().__init__(relative_rect, "", object_id="#image_button", visible=visible,
-                         starting_height=starting_height, manager=manager)
+        super().__init__(relative_rect, "", object_id="#cat_button", visible=visible,
+                         starting_height=starting_height, manager=manager, tool_tip_text=tool_tip_text)
 
     def return_cat_id(self):
         return self.cat_id


### PR DESCRIPTION
- Tooltips can now be placed on cat buttons. 
- Cat buttons no longer use the default "image button" themes, but a separate "cat button" theme.  This is to allow customization of cat button tooltips separately from other image buttons. 