### PR TITLE
Content/Bugfix: Affair Adjustment, Found Litter Genders

### DIFF
--- a/resources/game_config.json
+++ b/resources/game_config.json
@@ -142,8 +142,8 @@
 	"pregnancy": {
 		"primary_chance_mated": 50,
 		"primary_chance_unmated": 110,
-		"random_affair_chance": 70,
-		"unmated_random_affair_chance": 20,
+		"random_affair_chance": 50,
+		"unmated_random_affair_chance": 10,
 		"one_kit_possibility": {"young adult": 8, "adult": 9, "senior adult": 10, "senior": 4},
         "two_kit_possibility": {"young adult": 10, "adult": 13, "senior adult": 15, "senior": 3},
         "three_kit_possibility": {"young adult": 17, "adult": 15, "senior adult": 5, "senior": 1},

--- a/scripts/utility.py
+++ b/scripts/utility.py
@@ -283,13 +283,15 @@ def create_new_cat(Cat,
 
         # setting gender
         if not gender:
-            gender = choice(['female', 'male'])
+            _gender = choice(['female', 'male'])
+        else:
+            _gender = gender
 
         # other clan cats, apps, and kittens (kittens and apps get indoctrinated lmao no old names for them)
         if other_clan or kit or litter or age < 12:
             new_cat = Cat(moons=age,
                           status=status,
-                          gender=gender,
+                          gender=_gender,
                           backstory=backstory)
         else:
             # grab starting names and accs for loners/kittypets
@@ -316,12 +318,12 @@ def create_new_cat(Cat,
                     new_cat = Cat(moons=age,
                                   prefix=name,
                                   status=status,
-                                  gender=gender,
+                                  gender=_gender,
                                   backstory=backstory)
                 else:  # completely new name
                     new_cat = Cat(moons=age,
                                   status=status,
-                                  gender=gender,
+                                  gender=_gender,
                                   backstory=backstory)
             # these cats keep their old names
             else:
@@ -329,7 +331,7 @@ def create_new_cat(Cat,
                               prefix=name,
                               suffix="",
                               status=status,
-                              gender=gender,
+                              gender=_gender,
                               backstory=backstory)
 
         # give em a collar if they got one


### PR DESCRIPTION
- Increased affair chances slightly. 
- Moved unmated love affair to a separate roll that only occurs if the cat doesn't have a mate.  If this roll is triggered, all possible affair partners must also be unmated.  
- Found litters will no longer be all one sex. 