### PR TITLE
Bugfix: Mates on Family Tree

### DIFF
--- a/scripts/screens/relation_screens.py
+++ b/scripts/screens/relation_screens.py
@@ -704,6 +704,7 @@ class FamilyTreeScreen(Screens):
         # collect mates
         if self.the_cat.mate:
             self.mates = [self.the_cat.mate]
+        if self.the_cat.previous_mates:
             self.mates.extend(self.the_cat.previous_mates)
         self.kits = self.the_cat.get_children()
         if self.mates or self.kits:


### PR DESCRIPTION
-Previous mates now appear in the family tree even when the cat has no current mate.