### PR TITLE
Bugfixes: Faded cats family tree, bugfixes

### DIFF
--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -1383,11 +1383,25 @@ class Cat():
 
     def get_siblings(self):
         """Returns list of the siblings."""
-        return self.siblings
+        if not self.faded:
+            return self.siblings
+        else:
+            # Finding the siblings of faded cats. 
+            siblings = []
+            for par in self.get_parents():
+                par_ob = Cat.fetch_cat(par)
+                siblings.extend(par_ob.get_children())
+            return siblings
+
 
     def get_children(self):
         """Returns list of the children."""
-        return self.children
+        if not self.faded:
+            return self.children
+        else:
+            children = [i.ID for i in Cat.all_cats.values() if self.ID in i.get_parents()]
+            children.extend(self.faded_offspring)
+            return children
 
     def is_grandparent(self, other_cat: Cat):
         """Check if the cat is the grandparent of the other cat."""

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -1390,7 +1390,9 @@ class Cat():
             siblings = []
             for par in self.get_parents():
                 par_ob = Cat.fetch_cat(par)
-                siblings.extend(par_ob.get_children())
+                for x in par_ob.get_children():
+                    if x not in siblings:
+                        siblings.append(x)
             return siblings
 
 


### PR DESCRIPTION
- Fully faded cats will now appear on the family tree.  Extended relationships through faded cats will also be displayed (except for the previous mates of faded cats - those are not stored). 
- Previous mates of siblings will now be displayed. 
- Fixed a few crashes related to switching the displayed-cat pages on the family tree.
- Cats will no longer overflow the box on the family tree page. 
- all the get_{relation} functions have been updated to also return any faded cats that match that relation. 