### PR TITLE
Bugfix/Content: Track Dead Mates, Dead Cat Mates

### DIFF
--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -525,7 +525,6 @@ class Cat():
         self.injuries.clear()
         self.illnesses.clear()
 
-
         # Deal with leader death
         text = ""
         if self.status == 'leader':
@@ -564,8 +563,6 @@ class Cat():
 
         if game.clan.game_mode != 'classic':
             self.grief(body)
-
-        print(self.mate)
 
         return text
 
@@ -2113,10 +2110,8 @@ class Cat():
     def unset_mate(self, other_cat: Cat, breakup: bool = False, fight: bool = False):
         """Unset the mate from both self and other_cat"""   
 
-        print("unsetting mate")
         # Both cats must have mates for this to work
         if not self.mate or not other_cat.mate:
-            print("One cat doesn't have a mate. ")
             return
         
         # AND they must be mates with each other. 

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -543,14 +543,8 @@ class Cat():
             self.dead = True
             self.thought = 'Is surprised to find themselves walking the stars of Silverpelt'
 
-        """if self.mate is not None:
-            if isinstance(self.mate, str):
-                mate_cat: Cat = Cat.all_cats[self.mate]
-                if isinstance(mate_cat, Cat):
-                    mate_cat.mate = None
-            elif isinstance(self.mate, Cat):
-                self.mate.mate = None
-            self.mate = None"""
+        # Clear Relationships. 
+        self.relationships = {}
 
         for app in self.apprentice.copy():
             Cat.fetch_cat(app).update_mentor()
@@ -1047,7 +1041,7 @@ class Cat():
     def create_interaction(self):
         """Creates an interaction between this cat and another, which effects relationship values. """
         # if the cat has no relationships, skip
-        if len(self.relationships) < 1 or not self.relationships:
+        if not self.relationships or len(self.relationships) < 1:
             return
 
         cats_to_choose = list(
@@ -1131,7 +1125,7 @@ class Cat():
     def relationship_interaction(self):
         """Randomly choose a cat of the clan and have a interaction with them."""
         # if the cat has no relationships, skip
-        if len(self.relationships) < 1 or not self.relationships:
+        if not self.relationships or len(self.relationships) < 1:
             return
 
         cats_to_choose = list(
@@ -2121,25 +2115,27 @@ class Cat():
         
         # If only deal with relationships if this is a breakup. 
         if breakup:
-            if other_cat.ID not in self.relationships:
-                self.relationships[other_cat.ID] = Relationship(self, other_cat, True)
-            if self.ID not in other_cat.relationships:
-                other_cat.relationships[self.ID] = Relationship(other_cat, self, True)
+            if not self.dead:
+                if other_cat.ID not in self.relationships:
+                    self.relationships[other_cat.ID] = Relationship(self, other_cat, True)
+                self_relationship = self.relationships[other_cat.ID]
+                self_relationship.romantic_love -= 40
+                self_relationship.comfortable -= 20
+                self_relationship.trust -= 10
+                self_relationship.mate = False
+                if fight:
+                    self_relationship.platonic_like -= 30
 
-            self_relationship = self.relationships[other_cat.ID]
-            other_relationship = other_cat.relationships[self.ID]
-
-            self_relationship.romantic_love -= 40
-            other_relationship.romantic_love -= 40
-            self_relationship.comfortable -= 20
-            other_relationship.comfortable -= 20
-            self_relationship.trust -= 10
-            other_relationship.trust -= 10
-            self_relationship.mate = False
-            other_relationship.mate = False
-            if fight:
-                self_relationship.platonic_like -= 30
-                other_relationship.platonic_like -= 30
+            if not other_cat.dead:
+                if self.ID not in other_cat.relationships:
+                    other_cat.relationships[self.ID] = Relationship(other_cat, self, True)
+                other_relationship = other_cat.relationships[self.ID]
+                other_relationship.romantic_love -= 40
+                other_relationship.comfortable -= 20
+                other_relationship.trust -= 10
+                other_relationship.mate = False
+                if fight:
+                    other_relationship.platonic_like -= 30
 
         self.mate = None
         other_cat.mate = None
@@ -2166,21 +2162,24 @@ class Cat():
             other_cat.previous_mates.remove(other_cat.mate)
 
         # Set starting relationship values
-        if other_cat.ID not in self.relationships:
-            self.relationships[other_cat.ID] = Relationship(self, other_cat, True)
-        if self.ID not in other_cat.relationships:
-            other_cat.relationships[self.ID] = Relationship(other_cat, self, True)
 
-        self_relationship = self.relationships[other_cat.ID]
-        other_relationship = other_cat.relationships[self.ID]
-        self_relationship.romantic_love += 20
-        other_relationship.romantic_love += 20
-        self_relationship.comfortable += 20
-        other_relationship.comfortable += 20
-        self_relationship.trust += 10
-        other_relationship.trust += 10
-        self_relationship.mate = True
-        other_relationship.mate = True
+        if not self.dead:
+            if other_cat.ID not in self.relationships:
+                self.relationships[other_cat.ID] = Relationship(self, other_cat, True)
+            self_relationship = self.relationships[other_cat.ID]
+            self_relationship.romantic_love += 20
+            self_relationship.comfortable += 20
+            self_relationship.trust += 10
+            self_relationship.mate = True
+
+        if not other_cat.dead:
+            if self.ID not in other_cat.relationships:
+                other_cat.relationships[self.ID] = Relationship(other_cat, self, True)
+            other_relationship = other_cat.relationships[self.ID]
+            other_relationship.romantic_love += 20
+            other_relationship.comfortable += 20
+            other_relationship.trust += 10
+            other_relationship.mate = True
 
     def create_one_relationship(self, other_cat: Cat):
         """Create a new relationship between current cat and other cat. Returns: Relationship"""
@@ -2254,16 +2253,8 @@ class Cat():
                                    trust=trust)
                 self.relationships[the_cat.ID] = rel
 
-    def save_relationship_of_cat(self):
+    def save_relationship_of_cat(self, relationship_dir):
         # save relationships for each cat
-        clanname = None
-        if game.switches['clan_name'] != '':
-            clanname = game.switches['clan_name']
-        elif len(game.switches['clan_name']) > 0:
-            clanname = game.switches['clan_list'][0]
-        elif game.clan is not None:
-            clanname = game.clan.name
-        relationship_dir = get_save_dir() + '/' + clanname + '/relationships'
         if not os.path.exists(relationship_dir):
             os.makedirs(relationship_dir)
 

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -544,9 +544,6 @@ class Cat():
             self.dead = True
             self.thought = 'Is surprised to find themselves walking the stars of Silverpelt'
 
-        # They are not removed from the mate's "mate" property. There is a "cooldown" period, which prevents
-        # cats from getting into relationships the same moon their mates dies.
-        self.mate = None
         """if self.mate is not None:
             if isinstance(self.mate, str):
                 mate_cat: Cat = Cat.all_cats[self.mate]
@@ -567,6 +564,8 @@ class Cat():
 
         if game.clan.game_mode != 'classic':
             self.grief(body)
+
+        print(self.mate)
 
         return text
 
@@ -2114,8 +2113,10 @@ class Cat():
     def unset_mate(self, other_cat: Cat, breakup: bool = False, fight: bool = False):
         """Unset the mate from both self and other_cat"""   
 
+        print("unsetting mate")
         # Both cats must have mates for this to work
         if not self.mate or not other_cat.mate:
+            print("One cat doesn't have a mate. ")
             return
         
         # AND they must be mates with each other. 
@@ -2139,6 +2140,8 @@ class Cat():
             other_relationship.comfortable -= 20
             self_relationship.trust -= 10
             other_relationship.trust -= 10
+            self_relationship.mate = False
+            other_relationship.mate = False
             if fight:
                 self_relationship.platonic_like -= 30
                 other_relationship.platonic_like -= 30
@@ -2181,6 +2184,8 @@ class Cat():
         other_relationship.comfortable += 20
         self_relationship.trust += 10
         other_relationship.trust += 10
+        self_relationship.mate = True
+        other_relationship.mate = True
 
     def create_one_relationship(self, other_cat: Cat):
         """Create a new relationship between current cat and other cat. Returns: Relationship"""

--- a/scripts/clan.py
+++ b/scripts/clan.py
@@ -430,6 +430,7 @@ class Clan():
         other_clans = []
 
         key_copy = tuple(Cat.all_cats.keys())
+        print(key_copy)
         for i in key_copy:  # Going through all currently existing cats
             # cat_class is a Cat-object
             not_found = True

--- a/scripts/clan.py
+++ b/scripts/clan.py
@@ -430,7 +430,6 @@ class Clan():
         other_clans = []
 
         key_copy = tuple(Cat.all_cats.keys())
-        print(key_copy)
         for i in key_copy:  # Going through all currently existing cats
             # cat_class is a Cat-object
             not_found = True

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -613,6 +613,11 @@ class Events():
                 # two with this, so here it is.
                 if cat.ID in game.clan.med_cat_list:
                     game.clan.med_cat_list.remove(cat.ID)
+                    
+                # Unset their mate, if they have one
+                if cat.mate:
+                    if Cat.all_cats.get(cat.mate):
+                        cat.unset_mate(Cat.all_cats.get(cat.mate))
 
                 # If the cat is the current med, leader, or deputy, remove them
                 if game.clan.leader:
@@ -630,8 +635,7 @@ class Events():
                             game.clan.medicine_cat = None
 
                 game.cat_to_fade.append(cat.ID)
-                cat.set_faded(
-                )  # This is a flag to ensure they behave like a faded cat in the meantime.
+                cat.set_faded()  
 
     def one_moon_outside_cat(self, cat):
         """

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -234,7 +234,7 @@ class Events():
     def mediator_events(self, cat):
         """ Check for mediator events """
         # If the cat is a mediator, check if they visited other clans
-        if cat.status in ["mediator", "mediator apprentice"]:
+        if cat.status in ["mediator", "mediator apprentice"] and not cat.not_working():
             # 1 /10 chance
             if not int(random.random() * 10):
                 increase = random.randint(-2, 6)

--- a/scripts/events_module/relation_events.py
+++ b/scripts/events_module/relation_events.py
@@ -51,14 +51,30 @@ class Relation_Events():
         if not randint(0,2):
             self.same_age_events(cat)
 
-        # this has to be handled at first
+        # This is the "big love check", and it must be handled first. 
         if random.random() > 0.8:
             if self.romantic_events_class.big_love_check(cat):
                 return
 
-        # 1/15 for an additional event
+        # 1/16 for an additional event
         if not random.getrandbits(4):
             self.romantic_events(cat)
+
+        cat_mate = None
+        if cat.mate:
+            if cat.mate not in Cat.all_cats:
+                print(f"WARNING: Cat #{cat} has a invalid mate. It will set to none.")
+                cat.mate = None
+            cat_mate = Cat.all_cats.get(cat.mate)
+
+        #Move on from dead mates
+        if cat_mate and "grief stricken" not in cat.illnesses and ((cat_mate.dead and cat_mate.dead_for >= 4) or cat_mate.outside):
+            print("moving on?", str(cat.name))
+            # randint is a slow function, don't call it unless we have to.
+            if random.random() > 0.8: 
+                text = f'{cat.name} will always love {cat_mate.name} but has decided to move on.'
+                game.cur_events_list.append(Single_Event(text, "relation", [cat.ID, cat_mate.ID]))
+                cat.unset_mate(cat_mate)
 
         cats_amount = len(Cat.all_cats)
         # cap the maximal checks
@@ -72,15 +88,13 @@ class Relation_Events():
             # random_index = randint(0, len(cat.relationships)-1)
             random_index = int(random.random() * len(cat.relationships))
             current_relationship = list(cat.relationships.values())[random_index]
-            # get some cats to make easier checks
-            cat_from = current_relationship.cat_from
-            cat_from_mate = None
-            if cat_from.mate:
-                if cat_from.mate not in Cat.all_cats:
-                    print(f"WARNING: Cat #{cat_from} has a invalid mate. It will set to none.")
-                    cat_from.mate = None
-                    return
-                cat_from_mate = Cat.all_cats.get(cat_from.mate)
+
+            cat_mate = None
+            if cat.mate:
+                if cat.mate not in Cat.all_cats:
+                    print(f"WARNING: Cat #{cat} has a invalid mate. It will set to none.")
+                    cat.mate = None
+                cat_mate = Cat.all_cats.get(cat.mate)
 
             cat_to = current_relationship.cat_to
             cat_to_mate = None
@@ -94,26 +108,14 @@ class Relation_Events():
             if not current_relationship.opposite_relationship:
                 current_relationship.link_relationship()
 
-            # overcome dead mates
-            if cat_from_mate and cat_from_mate.dead and cat_from_mate.dead_for >= 4 and "grief stricken" not in cat_from.illnesses:
-                # randint is a slow function, don't call it unless we have to.
-                if random.random() > 0.96:  # Roughly 1/25
-                    self.had_one_event = True
-                    text = f'{cat_from.name} will always love {cat_from_mate.name} but has decided to move on.'
-                    # game.relation_events_list.insert(0, text)
-                    game.cur_events_list.append(Single_Event(text, "relation", [cat_from.ID, cat_from_mate.ID]))
-                    current_relationship.mate = False
-                    cat_from.mate = None
-                    cat_from_mate.mate = None
-
             # new mates
-            if not self.had_one_event and not cat_from_mate:
-                if cat_to.is_potential_mate(cat_from):
-                    self.romantic_events_class.handle_new_mates(current_relationship, cat_from, cat_to)
+            if not self.had_one_event and not cat_mate:
+                if cat_to.is_potential_mate(cat):
+                    self.romantic_events_class.handle_new_mates(current_relationship, cat, cat_to)
 
             # breakup and new mate
-            if (not self.had_one_event and cat_from.mate and
-                    cat_from.is_potential_mate(cat_to) and cat_to.is_potential_mate(cat_from)
+            if (not self.had_one_event and cat.mate and
+                    cat.is_potential_mate(cat_to) and cat_to.is_potential_mate(cat)
             ):
                 love_over_30 = current_relationship.romantic_love > 30 and current_relationship.opposite_relationship.romantic_love > 30
 
@@ -124,17 +126,17 @@ class Relation_Events():
                 bigger_love_chance = int(random.random() * 3)
 
                 mate_relationship = None
-                if cat_from.mate in cat_from.relationships:
-                    mate_relationship = cat_from.relationships[cat_from.mate]
+                if cat.mate in cat.relationships:
+                    mate_relationship = cat.relationships[cat.mate]
                     bigger_than_current = current_relationship.romantic_love > mate_relationship.romantic_love
                 else:
-                    if cat_from_mate:
-                        cat_from_mate.relationships[cat_from.ID] = Relationship(cat_from_mate, cat_from, True)
+                    if cat_mate:
+                        cat_mate.relationships[cat.ID] = Relationship(cat_mate, cat, True)
                     bigger_than_current = True
 
                 # check cat_to values
                 if cat_to_mate:
-                    if cat_from.ID in cat_to.relationships:
+                    if cat.ID in cat_to.relationships:
                         other_mate_relationship = cat_to.relationships[cat_to.mate]
                         bigger_than_current = (bigger_than_current and
                                                current_relationship.romantic_love
@@ -146,9 +148,9 @@ class Relation_Events():
                 if ((love_over_30 and not normal_chance) or (bigger_than_current and not bigger_love_chance)):
                     self.had_one_event = True
                     # break up the old relationships
-                    cat_from_mate = Cat.all_cats.get(cat_from.mate)
-                    self.romantic_events_class.handle_breakup(mate_relationship, mate_relationship.opposite_relationship, cat_from,
-                                        cat_from_mate)
+                    cat_mate = Cat.all_cats.get(cat.mate)
+                    self.romantic_events_class.handle_breakup(mate_relationship, mate_relationship.opposite_relationship, cat,
+                                        cat_mate)
 
                     if cat_to_mate:
                         # relationship_from, relationship_to, cat_from, cat_to
@@ -156,16 +158,16 @@ class Relation_Events():
                                             cat_to, cat_to_mate)
 
                     # new relationship
-                    text = f"{cat_from.name} and {cat_to.name} can't ignore their feelings for each other."
+                    text = f"{cat.name} and {cat_to.name} can't ignore their feelings for each other."
                     # game.relation_events_list.insert(0, text)
-                    game.cur_events_list.append(Single_Event(text, "relation", [cat_from.ID, cat_to.ID]))
-                    self.romantic_events_class.handle_new_mates(current_relationship, cat_from, cat_to)
+                    game.cur_events_list.append(Single_Event(text, "relation", [cat.ID, cat_to.ID]))
+                    self.romantic_events_class.handle_new_mates(current_relationship, cat, cat_to)
 
             # breakup
-            if not self.had_one_event and current_relationship.mates and not cat_from.dead and not cat_to.dead:
-                if self.romantic_events_class.check_if_breakup(current_relationship, current_relationship.opposite_relationship, cat_from,
+            if not self.had_one_event and current_relationship.mates and not cat.dead and not cat_to.dead:
+                if self.romantic_events_class.check_if_breakup(current_relationship, current_relationship.opposite_relationship, cat,
                                          cat_to):
-                    self.romantic_events_class.handle_breakup(current_relationship, current_relationship.opposite_relationship, cat_from,
+                    self.romantic_events_class.handle_breakup(current_relationship, current_relationship.opposite_relationship, cat,
                                         cat_to)
 
     # ---------------------------------------------------------------------------- #

--- a/scripts/events_module/relation_events.py
+++ b/scripts/events_module/relation_events.py
@@ -69,7 +69,6 @@ class Relation_Events():
 
         #Move on from dead mates
         if cat_mate and "grief stricken" not in cat.illnesses and ((cat_mate.dead and cat_mate.dead_for >= 4) or cat_mate.outside):
-            print("moving on?", str(cat.name))
             # randint is a slow function, don't call it unless we have to.
             if random.random() > 0.8: 
                 text = f'{cat.name} will always love {cat_mate.name} but has decided to move on.'
@@ -204,6 +203,11 @@ class Relation_Events():
         # only adding cats which already have SOME relationship with each other
         cat_to_choose_from = []
         for inter_cat in possible_cats:
+            if inter_cat.ID not in cat.relationships:
+                cat.relationships[inter_cat.ID] = Relationship(cat, inter_cat)
+            if cat.ID not in inter_cat.relationships:
+                inter_cat.relationships[cat.ID] = Relationship(inter_cat, cat)
+
             cat_to_inter = cat.relationships[inter_cat.ID].platonic_like > 10 or\
                 cat.relationships[inter_cat.ID].comfortable > 10
             inter_to_cat = inter_cat.relationships[cat.ID].platonic_like > 10 or\

--- a/scripts/game_structure/game_essentials.py
+++ b/scripts/game_structure/game_essentials.py
@@ -353,6 +353,12 @@ class Game():
         directory = get_save_dir() + '/' + clanname
         if not os.path.exists(directory):
             os.makedirs(directory)
+   
+        # Delete all existing relationship files
+        if not os.path.exists(directory + '/relationships'):
+            os.makedirs(directory + '/relationships')
+        for f in os.listdir(directory + '/relationships'):
+            os.remove(os.path.join(directory + '/relationships', f))
 
         self.save_faded_cats(clanname)  # Fades cat and saves them, if needed
 
@@ -432,7 +438,7 @@ class Game():
             clan_cats.append(cat_data)
             inter_cat.save_condition()
             if not inter_cat.dead:
-                inter_cat.save_relationship_of_cat()
+                inter_cat.save_relationship_of_cat(directory + '/relationships')
         try:
             with open(get_save_dir() + '/' + clanname + '/clan_cats.json', 'w') as write_file:
                 json_string = ujson.dumps(clan_cats, indent=4)

--- a/scripts/screens/cat_screens.py
+++ b/scripts/screens/cat_screens.py
@@ -873,13 +873,12 @@ class ProfileScreen(Screens):
                 output += ' moons'
 
         # MATE
-        if the_cat.mate is not None and not the_cat.dead:
+        if the_cat.mate:
             # NEWLINE ----------
             output += "\n"
             if the_cat.mate in Cat.all_cats:
-                if Cat.all_cats.get(
-                        the_cat.mate
-                ).dead:
+                mate_ob = Cat.fetch_cat(the_cat.mate)
+                if mate_ob.dead != self.the_cat.dead or mate_ob.outside != self.the_cat.outside:
                     output += 'former mate: ' + str(Cat.all_cats[the_cat.mate].name)
                 else:
                     output += 'mate: ' + str(Cat.all_cats[the_cat.mate].name)
@@ -1695,7 +1694,7 @@ class ProfileScreen(Screens):
                 self.see_relationships_button.enable()
 
             if self.the_cat.age not in ['young adult', 'adult', 'senior adult', 'senior'
-                                        ] or self.the_cat.dead or self.the_cat.exiled or self.the_cat.outside:
+                                        ] or self.the_cat.exiled or self.the_cat.outside:
                 self.choose_mate_button.disable()
             else:
                 self.choose_mate_button.enable()

--- a/scripts/screens/clan_creation_screens.py
+++ b/scripts/screens/clan_creation_screens.py
@@ -977,6 +977,11 @@ class MakeClanScreen(Screens):
                                                                       object_id=get_text_box_theme(), manager=MANAGER)
 
     def save_clan(self):
+        
+        game.mediated.clear()
+        game.patrolled.clear()
+        game.cat_to_fade.clear()
+        Cat.outside_cats.clear()
         convert_camp = {1: 'camp1', 2: 'camp2', 3: 'camp3'}
         game.clan = Clan(self.clan_name,
                          self.leader,
@@ -987,7 +992,6 @@ class MakeClanScreen(Screens):
                          self.game_mode, self.members,
                          starting_season=self.selected_season)
         game.clan.create_clan()
-        game.mediated.clear()
         game.cur_events_list.clear()
         game.herb_events_list.clear()
         Cat.grief_strings.clear()

--- a/scripts/screens/relation_screens.py
+++ b/scripts/screens/relation_screens.py
@@ -1500,11 +1500,14 @@ class ChooseMateScreen(Screens):
                     (400, 156)))
 
         # Set romantic hearts of current cat towards mate or selected cat.
-        if self.selected_cat.ID in self.the_cat.relationships:
-            relation = self.the_cat.relationships[self.selected_cat.ID]
+        if self.the_cat.dead:
+            romantic_love = 0
         else:
-            relation = self.the_cat.create_one_relationship(self.selected_cat)
-        romantic_love = relation.romantic_love
+            if self.selected_cat.ID in self.the_cat.relationships:
+                relation = self.the_cat.relationships[self.selected_cat.ID]
+            else:
+                relation = self.the_cat.create_one_relationship(self.selected_cat)
+            romantic_love = relation.romantic_love
 
         if 10 <= romantic_love <= 30:
             heart_number = 1
@@ -1526,11 +1529,14 @@ class ChooseMateScreen(Screens):
             x_pos += 54
 
         # Set romantic hearts of mate/selected cat towards current_cat.
-        if self.the_cat.ID in self.selected_cat.relationships:
-            relation = self.selected_cat.relationships[self.the_cat.ID]
+        if self.selected_cat.dead:
+            romantic_love = 0
         else:
-            relation = self.selected_cat.create_one_relationship(self.the_cat)
-        romantic_love = relation.romantic_love
+            if self.the_cat.ID in self.selected_cat.relationships:
+                relation = self.selected_cat.relationships[self.the_cat.ID]
+            else:
+                relation = self.selected_cat.create_one_relationship(self.the_cat)
+            romantic_love = relation.romantic_love
 
         if 10 <= romantic_love <= 30:
             heart_number = 1

--- a/scripts/screens/relation_screens.py
+++ b/scripts/screens/relation_screens.py
@@ -1612,7 +1612,7 @@ class ChooseMateScreen(Screens):
 
             related = direct_related or indirect_related
 
-            not_available = relevant_cat.dead or relevant_cat.outside
+            not_available = (relevant_cat.dead != self.the_cat.dead) or (relevant_cat.outside != self.the_cat.outside) or relevant_cat.faded
 
             if not related and relevant_cat.ID != self.the_cat.ID and invalid_age \
                     and not not_available and relevant_cat.mate is None:


### PR DESCRIPTION
- When a cat's mate dies and they move on, that mate will now be tracked as a previous mate. 
- Moved the "moving on" roll outside the relationship loop, so it only rolls once. 
- You can now give starclan cats mates (only other dead cats). 
- Mediators can only travel to other clans if they can work. 
- Dead cat relationships files are now deleted. 
- Cats will now move on from mates if their mate is lost or exiled.
- When a cat dies, their relationships are now cleared (set to an empty dictionary). Note: There are some situations where a relationship for a dead cat is created. Mostly when creating a opposite relationship.  That is probably fine for now. 
- Fixed the issue of lost cats from previous saves "returning" to a new clan. 