### PR TITLE
Run actions on pull requests

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,5 +1,5 @@
 name: Pylint
-on: push
+on: [push, pull_request]
 jobs:
   pylint:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Tests
 
-on: [push, workflow_dispatch]
+on: [push, workflow_dispatch, pull_request]
 
 jobs:
   # Run unittest tests.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,13 +51,13 @@ jobs:
         id: encoding_test
         run: poetry run python3 tests/test_encoding.py test
       - name: Fix the issue hopefully
-        if: failure()
+        if: ${{ failure() && github.event_name == 'push'}}
         id: fixit
         env:
           FILES: ${{ steps.encoding_test.outputs.files  }}
         run: poetry run python3 tests/test_encoding.py fix
       - name: Make a pr
-        if: ${{ failure() && steps.fixit.conclusion == 'success' }}
+        if: ${{ failure() && steps.fixit.conclusion == 'success' && github.event_name == 'push' }}
         uses: peter-evans/create-pull-request@v3
         with:
           commit-message: Fix file encoding


### PR DESCRIPTION
This allows people with write access to see whether tests fail *before* merging, instead of merging and getting the failed email 1m later