### PR TITLE
Bugfix: fix ocean_newcatkits

### DIFF
--- a/resources/dicts/patrols/beach/border/leaf-bare.json
+++ b/resources/dicts/patrols/beach/border/leaf-bare.json
@@ -33,16 +33,16 @@
     ]
 },
 {
-        "patrol_id": "bch_ bord_ocean_newcatkits1",
+        "patrol_id": "bch_bord_ocean_newcatkits1",
         "biome": "beach",
         "season": "leaf-bare",
-        "tags": ["border", "new_cat_litter1_dead", "new_cat_litter4_dead", "platonic", "comfort", "warrior", "shivering", "frostbite", "injure_all"],
+        "tags": ["border", "new_cat_litter0_litter3_dead", "platonic", "comfort", "warrior", "shivering", "frostbite", "injure_all"],
         "intro_text": "p_l hears desperate mewling coming from the ocean. ",
         "decline_text": "They decide that their imagination is just playing tricks on them and continue the patrol.",
         "chance_of_success": 20,
         "exp": 15,
         "success_text": [
-        "p_l and the rest of their patrol race towards the section of beach they heard the wailing coming from. To their absolute horror they see several kits just barely keeping their heads above water, the remains of a Twoleg thing trapping them into place. p_l and r_c leap into the water and quickly get rid of that blasted twoleg contraption. They grab the kits by their scruff and hand them over to the rest of the patrol so they can be kept warm until they can reach camp.",
+        "The patrol races towards the section of beach they heard the wailing coming from. To their horror they see several kits just barely keeping their heads above water, the remains of a Twoleg thing trapping them into place. p_l and r_c leap into the water, grabbing the kits by their scruff and handing them over to the rest of the patrol.",
         null,
         null,
         "s_c, upon seeing several kits trapped by a Twoleg contraption, immediately jumps into the cold harsh water of the sea. They use a piece of wood as a makeshift raft and paddle the kits back to shore where the rest of the patrol can keep them warm, before racing them back to camp to be cuddled into the pelt of a loving queen."
@@ -51,7 +51,7 @@
         "To the cat's horror they were too late, the bodies of several kits washing ashore. They mutter a prayer before gently picking up the kits, the patrol swims the little bodies back out into the cold ocean, ensuring that the kits rest within the ocean's embrace."
         ],
         "win_skills": ["wise", "thoughtful"],
-        "min_cats": 2,
+        "min_cats": 3,
         "max_cats": 6,
         "antagonize_text": null,
         "antagonize_fail_text": null

--- a/scripts/utility.py
+++ b/scripts/utility.py
@@ -255,7 +255,7 @@ def create_new_cat(Cat,
     if not litter:
         number_of_cats = 1
     else:
-        number_of_cats = choices([1, 2, 3, 4, 5], [2, 5, 4, 1, 1], k=1)
+        number_of_cats = choices([2, 3, 4, 5], [5, 4, 1, 1], k=1)
         number_of_cats = number_of_cats[0]
     # setting age
     if not age and age != 0:


### PR DESCRIPTION
- shortened win outcome0 slightly since it was over the character limit
- fixed it's new_cat tag so that it would work properly
- adjusted create_new_cat utility function so that litters would always have at least 2 kits, this is to make writing patrols easier (i.e. you can reference multiple kits in an outcome and still have it make sense)