### PR TITLE
Content: Used Patrols List

### DIFF
--- a/scripts/events.py
+++ b/scripts/events.py
@@ -10,6 +10,8 @@ TODO: Docs
 import random
 import traceback
 
+from scripts.patrol import Patrol
+
 try:
     import ujson as json
 except ImportError:
@@ -66,6 +68,7 @@ class Events():
         self.CEREMONY_TXT = None
         self.load_ceremonies()
         self.disaster_events = DisasterEvents()
+        self.patrols = Patrol()
 
     def one_moon(self):
         """

--- a/scripts/patrol.py
+++ b/scripts/patrol.py
@@ -66,6 +66,8 @@ class Patrol():
         self.app6_name = None
         self.other_clan = None
         self.experience_levels = []
+        self.used_patrols = []
+        self.filter_count = 0
 
     def add_patrol_cats(self, patrol_cats: list, clan: Clan) -> None:
         """Add the list of cats to the patrol class and handles to set all needed values.
@@ -287,18 +289,19 @@ class Patrol():
 
         final_patrols, final_romance_patrols = self.filter_patrols(possible_patrols, biome, patrol_size, current_season,
                                                                    patrol_type)
-        if patrol_type == 'hunting':
-            final_patrols = self.balance_hunting(final_patrols)
-        final_patrols = self.filter_relationship(final_patrols)
-        final_romance_patrols = self.filter_relationship(final_romance_patrols)
 
         return final_patrols, final_romance_patrols
 
     def filter_patrols(self, possible_patrols, biome, patrol_size, current_season, patrol_type):
         filtered_patrols = []
         romantic_patrols = []
+
         # makes sure that it grabs patrols in the correct biomes, season, with the correct number of cats
         for patrol in possible_patrols:
+            if patrol.patrol_id in self.used_patrols:
+                print(patrol.patrol_id, 'was in used patrols')
+                continue
+
             if patrol_size < patrol.min_cats:
                 continue
             if patrol_size > patrol.max_cats:
@@ -420,15 +423,27 @@ class Patrol():
             else:
                 filtered_patrols.append(patrol)
 
-            # making sure related cats don't accidentally go on romantic patrols together
-            '''if "romantic" in patrol.tags:
-                if ("rel_two_apps" and "two_apprentices") in patrol.tags and len(self.patrol_apprentices) >= 2:
-                    if not self.patrol_apprentices[0].is_potential_mate(self.patrol_apprentices[1],
-                                                                        for_love_interest=True):
-                        continue
-                else:
-                    if not self.patrol_random_cat.is_potential_mate(self.patrol_leader, for_patrol=True):
-                        continue'''
+        if patrol_type == 'hunting':
+            filtered_patrols = self.balance_hunting(filtered_patrols)
+        filtered_patrols = self.filter_relationship(filtered_patrols)
+        romantic_patrols = self.filter_relationship(romantic_patrols)
+
+        if not filtered_patrols:
+            if self.filter_count == 1:
+                # error message will print from patrol_screens.py once this is returned
+                return filtered_patrols, romantic_patrols
+            self.filter_count += 1
+            self.used_patrols.clear()
+            print('used patrols cleared', self.used_patrols)
+            filtered_patrols, romantic_patrols = self.repeat_filter(possible_patrols, biome, patrol_size, current_season, patrol_type)
+        else:
+            # reset this when we succeed in finding a patrol
+            self.filter_count = 0
+        return filtered_patrols, romantic_patrols
+
+    def repeat_filter(self, possible_patrols, biome, patrol_size, current_season, patrol_type):
+        print('repeating filter')
+        filtered_patrols, romantic_patrols = self.filter_patrols(possible_patrols, biome, patrol_size, current_season, patrol_type)
         return filtered_patrols, romantic_patrols
 
     def balance_hunting(self, possible_patrols: list):
@@ -630,7 +645,7 @@ class Patrol():
                         rel_above_threshold = [i for i in relevant_relationships if i.platonic_like >= threshold]
                     elif v_type == "dislike":
                         rel_above_threshold = [i for i in relevant_relationships if i.dislike >= threshold]
-                    elif v_type == "comfortable": 
+                    elif v_type == "comfortable":
                         rel_above_threshold = [i for i in relevant_relationships if i.comfortable >= threshold]
                     elif v_type == "jealousy":
                         rel_above_threshold = [i for i in relevant_relationships if i.jealousy >= threshold]
@@ -701,7 +716,7 @@ class Patrol():
         # chance by adding the patrol event's chance of success plus the patrol's total exp
         success_chance = self.patrol_event.chance_of_success + int(
             self.patrol_total_experience / (7.5 * gm_modifier))
-        
+
         # Auto-wins based on EXP are sorta lame. Often makes it immpossible for large patrols with experiences cats to fail patrols at all. 
         # EXP alone can only bring success chance up to 95. However, skills/traits can bring it up above that. 
         success_chance = min(success_chance, 95)
@@ -740,7 +755,7 @@ class Patrol():
         # ---------------------------------------------------------------------------- #
         #                                   SUCCESS                                    #
         # ---------------------------------------------------------------------------- #
-        
+
         if c < success_chance:
             self.success = True
             self.patrol_fail_stat_cat = None
@@ -896,18 +911,18 @@ class Patrol():
         # check for ignore outcome tag
         if f"no_new_cat{outcome}" in tags:
             return
-        
+
         # find the new cat tag and split to get attributes - else return if no tag found
         attribute_list = []
         for tag in tags:
-            #print(tag)
+            # print(tag)
             if "new_cat" in tag and "no_new_cat" not in tag and "new_cat_injury" not in tag:
                 attribute_list = tag.split("_")
                 print('found tag, attributes:', attribute_list)
                 break
         if not attribute_list:
             return
-        
+
         print('new cat creation started')
 
         # setting the defaults
@@ -1315,7 +1330,7 @@ class Patrol():
         else:
             gained_exp = 0
 
-        #Apprentice exp, does not depend on success
+        # Apprentice exp, does not depend on success
         if "apprentice" in self.patrol_statuses or "medicine cat apprentice" in self.patrol_statuses:
             app_exp = max(random.randint(1, 7) * (1 - 0.1 * len(self.patrol_cats)), 1)
         else:

--- a/scripts/screens/patrol_screens.py
+++ b/scripts/screens/patrol_screens.py
@@ -605,6 +605,8 @@ class PatrolScreen(Screens):
 
         self.choose_normal_or_romance()
 
+        patrol.used_patrols.append(patrol.patrol_event.patrol_id)
+        print(patrol.used_patrols)
         print("Chosen Patrol ID: " + str(patrol.patrol_event.patrol_id))
         patrol_size = len(patrol.patrol_cats)
 


### PR DESCRIPTION
Implemented a used_patrols list that tracks all the IDs of patrols that have already been used, then filters by those used IDs during the patrol filtering process.  This means that a patrol isn't repeated until all possible patrols (for that patrol group) have been used.  If ever there are no patrols found, the list is cleared and the filter process repeated with the cleared list, meaning that all patrols are once again available.

I *did* try to make the list clear upon timeskip as well, but for some reason it would print as cleared but then once I patrolled again it still printed the un-cleared list. idk whats up with that, but I also don't necessarily think it's a vital feature.  Though someone else is welcome to try figuring it out, it could be I was just being a lil dumb with it.