### PR TITLE
Fixes crash on moon skip, minor save error, and minor display issue

### DIFF
--- a/scripts/clan.py
+++ b/scripts/clan.py
@@ -1170,7 +1170,8 @@ class Clan():
         if not clan.name:
             return
         file_path = get_save_dir() + f"/{clan.name}/disasters/primary.json"
-
+        if not os.path.isdir(f'{get_save_dir()}/{clan.name}/disasters'):
+            os.mkdir(f'{get_save_dir()}/{clan.name}/disasters')
         if clan.primary_disaster:
             disaster = {
                 "event": clan.primary_disaster.event,

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -183,7 +183,7 @@ class Events():
                             lambda kitty: (kitty.status != "leader" and not kitty.dead and
                                            not kitty.outside and not kitty.exiled), Cat.all_cats.values()))
                     # finds a percentage of the living clan to become shaken
-                    shaken_cats = random.sample(alive_cats, k=int((len(alive_cats) * random.choice([4, 5, 6])) / 100))
+                    shaken_cats = random.sample(alive_cats, k=max(int((len(alive_cats) * random.choice([4, 5, 6])) / 100), 1))
 
                     shaken_cat_names = []
                     for cat in shaken_cats:

--- a/scripts/screens/event_screens.py
+++ b/scripts/screens/event_screens.py
@@ -445,6 +445,10 @@ class EventsScreen(Screens):
         self.event_container.kill()
         self.make_events_container()
 
+        # Stop if clan is new, so that events from previously loaded clan don't show up
+        if game.clan.age == 0:
+            return
+
         # Make display, with buttons and all that.
         box_length = self.event_container.get_relative_rect()[2]
         i = 0


### PR DESCRIPTION
Fixes:
- Crash in `events.py`, where when generating `shaken_cats` for when a cat is dead, where it would return 0 if the clan has less than 16, 20, or 25 members (depending on which choice is pulled) and try to run `adjust_list_text` on an empty list. Now returns at least 1.
- Minor save error in `screens/clans.py` **(tested only on windows as of now)**, where when a clan is first created (or hasn't experienced any disasters?), it will not update the disasters, as the `./saves/${name}/disasters/` folder doesn't exist. Now checks for it, and creates the directory if it doesn't exist
  - i fixed this mostly just because the error notification was annoying, i don't think it actually matters
- `screens/event_screens.py`, events from the previous clan still being rendered when a new clan is generated, now is empty