### PR TITLE
Add a version number and a to-spec bundle id to macos builds

### DIFF
--- a/Clangen.spec
+++ b/Clangen.spec
@@ -58,5 +58,5 @@ app = BUNDLE(
     name='Clangen.app',
     icon='resources/images/icon.png',
     bundle_identifier='com.sablesteel.clangen',
-    version: '0.7.5' # imo we should give dev builds .5
+    version='0.7.5' # imo we should give dev builds .5
 )

--- a/Clangen.spec
+++ b/Clangen.spec
@@ -57,5 +57,6 @@ app = BUNDLE(
     coll,
     name='Clangen.app',
     icon='resources/images/icon.png',
-    bundle_identifier=None,
+    bundle_identifier='com.sablesteel.clangen',
+    version: '0.7.5' # imo we should give dev builds .5
 )


### PR DESCRIPTION
the bundle id generated by pyinstaller *was* "Clangen" but that is not to spec, as it does not follow the tld.author.name format and it has caps in it. I changed it to com.sablesteel.clangen