### PR TITLE
Bugfixes

### DIFF
--- a/scripts/events.py
+++ b/scripts/events.py
@@ -768,6 +768,7 @@ class Events():
             cat.thoughts()
             return
 
+        self.handle_apprentice_EX(cat) # This must be before perform_ceremonies! 
         # this HAS TO be before the cat.is_disabled() so that disabled kits can choose a med cat or mediator position
         self.perform_ceremonies(cat)
 
@@ -779,7 +780,6 @@ class Events():
 
         self.coming_out(cat)
         self.pregnancy_events.handle_having_kits(cat, clan=game.clan)
-        self.handle_apprentice_EX(cat)
         cat.create_interaction()
 
         # this is the new interaction function, currently not active

--- a/scripts/events_module/relationship/pregnancy_events.py
+++ b/scripts/events_module/relationship/pregnancy_events.py
@@ -136,9 +136,8 @@ class Pregnancy_Events():
                     elif average_trust >= 35:
                         chance += 13
                 else:
-                    chance = int(200/living_cats) + 2
+                    chance = int(75/living_cats) + 2
 
-                old_male = False
                 if cat.gender == 'male' and cat.age == 'senior':
                     chance = int(chance / 2)
                 elif second_parent is not None and second_parent.gender == 'male' and second_parent.age == 'senior':

--- a/scripts/game_structure/windows.py
+++ b/scripts/game_structure/windows.py
@@ -311,8 +311,7 @@ class ChangeCatName(UIWindow):
         # 636
         self.toggle_spec_block_on = UIImageButton(scale(pygame.Rect((405 + x_pos, 160 + y_pos), (68, 68))), "",
                                                   object_id="#unchecked_checkbox",
-                                                  tool_tip_text=f"Temporarily remove the cat's special suffix, so "
-                                                                f"that you can change the hidden suffix beneath",
+                                                  tool_tip_text=f"Remove the cat's special suffix",
                                                   manager=MANAGER,
                                                   container=self)
 

--- a/scripts/screens/organizational_screens.py
+++ b/scripts/screens/organizational_screens.py
@@ -742,30 +742,17 @@ class SettingsScreen(Screens):
         self.sub_menu = 'info'
         self.save_settings_button.hide()
 
-        self.info_container = pygame_gui.elements.UIScrollingContainer(
+        self.checkboxes_text["info_container"] = pygame_gui.elements.UIScrollingContainer(
             scale(pygame.Rect((200, 300), (1200, 1000))),
             manager=MANAGER
         )
 
         self.checkboxes_text['info_text_box'] = pygame_gui.elements.UITextBox(
             self.info_text,
-            scale(pygame.Rect((100, 0), (1200, -1))),
-            object_id=get_text_box_theme("#text_box_30_horizcenter"),
-            container=self.info_container,
-            manager=MANAGER)
-
-        rel_rect = self.checkboxes_text['info_text_box'].get_relative_rect()
-        print(rel_rect)
-        self.checkboxes_text['info_text_box'].kill()
-
-        self.checkboxes_text['info_text_box'] = pygame_gui.elements.UITextBox(
-            self.info_text,
             scale(pygame.Rect((0, 0), (1200, 8000))),
             object_id=get_text_box_theme("#text_box_30_horizcenter"),
-            container=self.info_container,
+            container=self.checkboxes_text["info_container"],
             manager=MANAGER)
-
-        print(self.info_text)
 
         self.checkboxes_text['info_text_box'].disable()
 
@@ -777,7 +764,7 @@ class SettingsScreen(Screens):
                     scale(pygame.Rect((400, i * 56 + y_pos), (400, 56))),
                     "",
                     object_id="#blank_button",
-                    container=self.info_container,
+                    container=self.checkboxes_text["info_container"],
                     manager=MANAGER,
                 ),
             else:
@@ -785,13 +772,13 @@ class SettingsScreen(Screens):
                     scale(pygame.Rect((400, i * 56 + y_pos), (400, 56))),
                     "",
                     object_id="#blank_button",
-                    container=self.info_container,
+                    container=self.checkboxes_text["info_container"],
                     manager=MANAGER,
                     tool_tip_text=tooltip
                 ),
 
             i += 1
-        self.info_container.set_scrollable_area_dimensions(
+        self.checkboxes_text["info_container"].set_scrollable_area_dimensions(
             (1150 / 1600 * screen_x, 4300 / 1400 * screen_y))
 
     def open_lang_settings(self):

--- a/scripts/screens/organizational_screens.py
+++ b/scripts/screens/organizational_screens.py
@@ -551,9 +551,17 @@ class SettingsScreen(Screens):
                         "relation": self.open_relation_settings
                     }
                     
+                    scroll_pos = None
+                    if "container_general" in self.checkboxes_text and \
+                            self.checkboxes_text["container_general"].vert_scroll_bar:
+                        scroll_pos = self.checkboxes_text["container_general"].vert_scroll_bar.start_percentage
+                    
                     if self.sub_menu in opens:
                         opens[self.sub_menu]()
-                    
+                        
+                    if scroll_pos is not None:
+                        self.checkboxes_text["container_general"].vert_scroll_bar.set_scroll_from_start_percentage(scroll_pos)
+                        
                     break
 
     def screen_switches(self):

--- a/scripts/screens/patrol_screens.py
+++ b/scripts/screens/patrol_screens.py
@@ -794,8 +794,7 @@ class PatrolScreen(Screens):
             count = 0
             while count <= 20:  # conceivably with a 6 cat patrol, 20 is the number of possible 3 cat combinations
                 print('counting')
-                if (patrol.patrol_win_stat_cat or patrol.patrol_fail_stat_cat) == patrol.patrol_random_cat \
-                        or patrol.patrol_random_cat == patrol.patrol_leader:
+                if patrol.patrol_random_cat in (patrol.patrol_win_stat_cat, patrol.patrol_fail_stat_cat, patrol.patrol_leader):
                     if len(patrol.patrol_cats) == 2:
                         print('remove all stat cats')
                         patrol.patrol_fail_stat_cat = None

--- a/scripts/screens/relation_screens.py
+++ b/scripts/screens/relation_screens.py
@@ -2555,7 +2555,7 @@ class MediationScreen(Screens):
                                                      manager=MANAGER)
 
         self.error = pygame_gui.elements.UITextBox("",
-                                                   scale(pygame.Rect((560, 100), (458, 100))),
+                                                   scale(pygame.Rect((560, 75), (458, 115))),
                                                    object_id=get_text_box_theme("#text_box_22_horizcenter_spacing_95"),
                                                    manager=MANAGER)
 


### PR DESCRIPTION
- The box for mediate error message ("this mediator has already worked, this couple has already been mediated") has been enlarged so it doesn't overflow. 
- When clicking a checkbox on the settings screen, the scroll bar will no longer reset to the top position. 
- Moved apprentice passive EX to occur before preform ceremonies. It got moved as some point. 
- Made kit cancel chance for second-parent-unknown pregnancies drop faster with population. 
- Fixed incorrect logic in find_stat_cats. 
- Fix bug with scrolling container on info screen not being killed. 