### PR TITLE
Bugfixes: Mediator, Their Thoughts, and a Ceremony. 

### DIFF
--- a/resources/dicts/events/ceremonies/ceremony-master.json
+++ b/resources/dicts/events/ceremonies/ceremony-master.json
@@ -681,7 +681,7 @@
       "apprentice",
       "yes_mentor",
       "yes_leader_mentor",
-      "dead1_parents",
+      "dead2_parents",
       "general_leader",
       "general_backstory",
       "all_traits"

--- a/resources/dicts/thoughts/dead/starclan/general.json
+++ b/resources/dicts/thoughts/dead/starclan/general.json
@@ -291,9 +291,7 @@
         "thoughts": [
             "Is trying to mediate StarClan cats' squabbles",
             "Wishes they could help resolve the Clan's issues",
-            "Is watching the Clans for any signs of discord",
-            "Thinks c_n and o_c_n relations might improve",
-            "Thinks c_n and o_c_n relations might worsen"
+            "Is watching the Clans for any signs of discord"
         ],
         "main_status_constraint": [
             "mediator",

--- a/scripts/screens/relation_screens.py
+++ b/scripts/screens/relation_screens.py
@@ -2443,7 +2443,7 @@ class MediationScreen(Screens):
                 self.update_selected_cats()
             elif event.ui_element == self.mediate_button:
                 game.mediated.append([self.selected_cat_1.ID, self.selected_cat_2.ID])
-                game.patrolled.append(self.mediators[self.selected_mediator].ID)
+                game.patrolled.append(self.mediators[self.selected_mediator])
                 output = Cat.mediate_relationship(
                     self.mediators[self.selected_mediator], self.selected_cat_1, self.selected_cat_2,
                     self.allow_romantic)
@@ -2452,7 +2452,7 @@ class MediationScreen(Screens):
                 self.update_mediator_info()
             elif event.ui_element == self.sabotoge_button:
                 game.mediated.append(f"{self.selected_cat_1.ID}, {self.selected_cat_2.ID}")
-                game.patrolled.append(self.mediators[self.selected_mediator].ID)
+                game.patrolled.append(self.mediators[self.selected_mediator])
                 output = Cat.mediate_relationship(
                     self.mediators[self.selected_mediator], self.selected_cat_1, self.selected_cat_2,
                     self.allow_romantic,
@@ -3024,7 +3024,7 @@ class MediationScreen(Screens):
             if self.mediators[self.selected_mediator].not_working():
                 invalid_mediator = True
                 error_message += "This mediator can't work this moon. "
-            elif self.mediators[self.selected_mediator].ID in game.patrolled:
+            elif self.mediators[self.selected_mediator] in game.patrolled:
                 invalid_mediator = True
                 error_message += "This mediator has already worked this moon. "
         else:


### PR DESCRIPTION
- Closing and restarting the game no longer allows a mediator to mediate more than once in a moon. 
- Fixed an incorrectly tagged ceremony. 
- Removed two dead mediator thoughts that used the o_c_n placeholder, since other_clan names currently can not appear in thoughts. 