### PR TITLE
BUGFIX - kittypet/loner no thoughts

### DIFF
--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -1072,9 +1072,15 @@ class Cat():
                     other_cat = None
                     break
         # for cats currently outside
+        # ----------------------------
+        # FIXED KITTYPETS/LONERS NO THOUGHTS
+        # it appears as for now, kittypets and loners can only think about outsider cats so if
+        # the program gave them a cat who is not an outsider, no thoughts would be available...
+        # (this can be changed in the future as I believe a more efficient thought system can be made)
         elif where_kitty == 'outside':
             while other_cat == self.ID and len(all_cats) > 1\
-            or (other_cat not in self.relationships):
+            or (other_cat not in self.relationships)\
+            or (self.status in ['kittypet','loner'] and not all_cats.get(other_cat).outside):
                 other_cat = choice(list(all_cats.keys()))
                 i += 1
                 if i > 100:

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -1072,10 +1072,7 @@ class Cat():
                     other_cat = None
                     break
         # for cats currently outside
-        
-        # it appears as for now, kittypets and loners can only think about outsider cats so if
-        # the program gave them a cat who is not an outsider, no thoughts would be available...
-        # (this can be changed in the future as I believe a more efficient thought system can be made)
+        # it appears as for now, kittypets and loners can only think about outsider cats
         elif where_kitty == 'outside':
             while other_cat == self.ID and len(all_cats) > 1\
             or (other_cat not in self.relationships)\

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -1072,8 +1072,7 @@ class Cat():
                     other_cat = None
                     break
         # for cats currently outside
-        # ----------------------------
-        # FIXED KITTYPETS/LONERS NO THOUGHTS
+        
         # it appears as for now, kittypets and loners can only think about outsider cats so if
         # the program gave them a cat who is not an outsider, no thoughts would be available...
         # (this can be changed in the future as I believe a more efficient thought system can be made)


### PR DESCRIPTION
[this is blaqqula on Discord]
it appears as for now, kittypets and loners can only think about outsider cats so if the program gave them a cat who is not an outsider, no thoughts would be available...
(this can be changed in the future as I believe a more efficient thought system can be made)