### PR TITLE
FIXED - random dice crash, family tree scollbar

### DIFF
--- a/scripts/game_structure/windows.py
+++ b/scripts/game_structure/windows.py
@@ -379,9 +379,13 @@ class ChangeCatName(UIWindow):
                     self.the_cat.name.specsuffix_hidden = False
                 self.heading.set_text(f"-Change {self.the_cat.name}'s Name-")
             elif event.ui_element == self.random_prefix:
+                if self.suffix_entry_box.text:
+                    use_suffix = self.suffix_entry_box.text
+                else:
+                    use_suffix = self.the_cat.name.suffix
                 self.prefix_entry_box.set_text(Name(self.the_cat.status,
                                                     None,
-                                                    self.suffix_entry_box.text,
+                                                    use_suffix,
                                                     self.the_cat.pelt.colour,
                                                     self.the_cat.eye_colour,
                                                     self.the_cat.pelt.name,
@@ -390,8 +394,12 @@ class ChangeCatName(UIWindow):
                                                     (self.the_cat.name.status in self.the_cat.name.names_dict[
                                                         "special_suffixes"])).prefix)
             elif event.ui_element == self.random_suffix:
+                if self.prefix_entry_box.text:
+                    use_prefix = self.prefix_entry_box.text
+                else:
+                    use_prefix = self.the_cat.name.prefix
                 self.suffix_entry_box.set_text(Name(self.the_cat.status,
-                                                    self.prefix_entry_box.text,
+                                                    use_prefix,
                                                     None,
                                                     self.the_cat.pelt.colour,
                                                     self.the_cat.eye_colour,

--- a/scripts/screens/relation_screens.py
+++ b/scripts/screens/relation_screens.py
@@ -776,8 +776,8 @@ class FamilyTreeScreen(Screens):
             name = short_name + '...'
         self.cat_elements["center_cat_name"] = pygame_gui.elements.UITextBox(name,
                                                                              scale(
-                                                                                 pygame.Rect((15 + x_pos, 118 + y_pos),
-                                                                                             (135, 100))),
+                                                                                 pygame.Rect((10 + x_pos, 118 + y_pos),
+                                                                                             (145, 100))),
                                                                              object_id=get_text_box_theme(
                                                                                  "#text_box_22_horizcenter"),
                                                                              manager=MANAGER,


### PR DESCRIPTION
FIXED:
- random dice in "change name" crashes
- names in family trees will no longer generate scrollbars if too wide