### PR TITLE
Bugfix: Reputation Fix

### DIFF
--- a/scripts/clan.py
+++ b/scripts/clan.py
@@ -1302,7 +1302,7 @@ class Clan():
     
     @reputation.setter
     def reputation(self, a: int):
-        self._reputation = int(self._reputation + a)
+        self._reputation = int(a)
         if self._reputation > 100:
             self._reputation = 100
         elif self._reputation < 0:

--- a/scripts/patrol.py
+++ b/scripts/patrol.py
@@ -11,7 +11,6 @@ from scripts.utility import (
     add_children_to_cat,
     event_text_adjust,
     change_clan_relations,
-    change_clan_reputation,
     change_relationship_values, create_new_cat,
     create_outside_cat
 )
@@ -788,7 +787,7 @@ class Patrol():
                 for tag in self.patrol_event.tags:
                     if "new_cat" in tag:
                         if antagonize:
-                            self.handle_reputation(-20)
+                            self.handle_reputation(-10)
                         else:
                             self.handle_reputation(10)
                         break
@@ -900,7 +899,7 @@ class Patrol():
                         self.handle_clan_relations(difference=int(-1), antagonize=False, outcome=outcome)
                 elif "new_cat" in self.patrol_event.tags:
                     if antagonize:
-                        self.handle_reputation(-10)
+                        self.handle_reputation(-5)
                     else:
                         self.handle_reputation(0)
             self.handle_mentor_app_pairing()
@@ -1859,7 +1858,7 @@ class Patrol():
         """
         if "no_change_fail_rep" in self.patrol_event.tags and not self.success:
             difference = 0
-        change_clan_reputation(difference)
+        game.clan.reputation += difference
         if difference > 0:
             insert = "improved"
         elif difference == 0:

--- a/scripts/utility.py
+++ b/scripts/utility.py
@@ -184,19 +184,6 @@ def get_current_season():
     return game.clan.current_season
 
 
-def change_clan_reputation(difference=0):
-    """
-    will change the clan's reputation with outsider cats according to the difference parameter.
-    """
-    # grab rep
-    reputation = int(game.clan.reputation)
-    # ensure this is an int value
-    difference = int(difference)
-    # change rep
-    reputation += difference
-    game.clan.reputation = reputation
-
-
 def change_clan_relations(other_clan, difference=0):
     """
     will change the clan's relation with other clans according to the difference parameter.


### PR DESCRIPTION
- Outsider reputation will now have the ability to go down! The setter was incorrectly written, which was causing issues. 
- Removed change_clan_reputation, since the setter already handled all that. 
- Reduced the reputation lose from antagonize to -10 on success and -5 on fail. Now that everyone was working properly, -20 was too big a jump. 