### PR TITLE
Bugfix: README, Hidden Special Suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,4 +30,4 @@ Run `pip install -r requirements.txt` to install dependencies.
 Run `python3 main.py`. If python3 does not exist try running `python main.py` instead.
 
 ### Bug Reporting
-If you're a Beta Tester, please report bugs using the approrate discord channels. Otherwise, if you enounter any bugs, we encourage reporting [using this form.](https://docs.google.com/forms/d/e/1FAIpQLSfl-H-HjSTfZ51DCtIHj8uGKtWF-3uysSaP8R6KMTLp7nzmMw/viewform)
+If you're a Beta Tester, please report bugs using the appropriate discord channels. Otherwise, if you enounter any bugs, we encourage reporting [using this form.](https://docs.google.com/forms/d/e/1FAIpQLSfl-H-HjSTfZ51DCtIHj8uGKtWF-3uysSaP8R6KMTLp7nzmMw/viewform)

--- a/scripts/game_structure/windows.py
+++ b/scripts/game_structure/windows.py
@@ -369,14 +369,9 @@ class ChangeCatName(UIWindow):
                 if sub(r'[^A-Za-z0-9 ]+', '', self.suffix_entry_box.get_text()) != '':
                     self.the_cat.name.suffix = sub(r'[^A-Za-z0-9 ]+', '', self.suffix_entry_box.get_text())
                     self.name_changed.show()
-                    self.the_cat.specsuffix_hidden = True
-                    self.the_cat.name.specsuffix_hidden = True
                 elif sub(r'[^A-Za-z0-9 ]+', '',
                          self.suffix_entry_box.get_text()) == '' and not self.the_cat.name.specsuffix_hidden:
                     self.name_changed.show()
-                else:
-                    self.the_cat.specsuffix_hidden = False
-                    self.the_cat.name.specsuffix_hidden = False
                 self.heading.set_text(f"-Change {self.the_cat.name}'s Name-")
             elif event.ui_element == self.random_prefix:
                 if self.suffix_entry_box.text:
@@ -389,10 +384,7 @@ class ChangeCatName(UIWindow):
                                                     self.the_cat.pelt.colour,
                                                     self.the_cat.eye_colour,
                                                     self.the_cat.pelt.name,
-                                                    self.the_cat.tortiepattern,
-                                                    specsuffix_hidden=
-                                                    (self.the_cat.name.status in self.the_cat.name.names_dict[
-                                                        "special_suffixes"])).prefix)
+                                                    self.the_cat.tortiepattern).prefix)
             elif event.ui_element == self.random_suffix:
                 if self.prefix_entry_box.text:
                     use_prefix = self.prefix_entry_box.text
@@ -404,11 +396,10 @@ class ChangeCatName(UIWindow):
                                                     self.the_cat.pelt.colour,
                                                     self.the_cat.eye_colour,
                                                     self.the_cat.pelt.name,
-                                                    self.the_cat.tortiepattern,
-                                                    specsuffix_hidden=
-                                                    (self.the_cat.name.status in self.the_cat.name.names_dict[
-                                                        "special_suffixes"])).suffix)
+                                                    self.the_cat.tortiepattern).suffix)
             elif event.ui_element == self.toggle_spec_block_on:
+                self.the_cat.specsuffix_hidden = True
+                self.the_cat.name.specsuffix_hidden = True
                 self.suffix_entry_box.enable()
                 self.random_suffix.enable()
                 self.toggle_spec_block_on.disable()
@@ -417,6 +408,8 @@ class ChangeCatName(UIWindow):
                 self.toggle_spec_block_off.show()
                 self.suffix_entry_box.set_text(self.the_cat.name.suffix)
             elif event.ui_element == self.toggle_spec_block_off:
+                self.the_cat.specsuffix_hidden = False
+                self.the_cat.name.specsuffix_hidden = False
                 self.random_suffix.disable()
                 self.toggle_spec_block_off.disable()
                 self.toggle_spec_block_off.hide()

--- a/scripts/screens/base_screens.py
+++ b/scripts/screens/base_screens.py
@@ -89,7 +89,7 @@ class Screens():
 
         # This keeps track of the last list-like screen for the back button on cat profiles
         if self.name in ['clan screen', 'list screen', 'starclan screen', 'dark forest screen', 'events screen',
-                         'med den screen']:
+                         'med den screen', 'unknown residence screen']:
             game.last_screen_forProfile = self.name
 
         game.switches['cur_screen'] = new_screen


### PR DESCRIPTION
- Changing the name of a cat was always setting specsuffix_hidden to True, even if the cat was a warrior.  This corrects that. 
Note: In the future it would be nice to have the specsuffix_hidden checkbox always visible,  since warriors can have it set to True with no way to flip it back to False. But that's a small issue, and it's feature freeze. 
- Clicking BACK on a cat selected from UR screen will now properly return you to the UR screen. 
- Fixed a typo in README