### PR TITLE
Bugfix: Mediate screen romantic, mate screen crash

### DIFF
--- a/scripts/events.py
+++ b/scripts/events.py
@@ -1617,12 +1617,10 @@ class Events():
 
         clan_size = len(alive_cats)
 
-        base_chance = 200
+        base_chance = 700
         if clan_size < 10:
             base_chance = 200
-        elif clan_size > 50:
-            base_chance = 700
-        elif clan_size > 30:
+        elif clan_size < 50:
             base_chance = 300
 
         reputation = game.clan.reputation

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -1620,7 +1620,7 @@ class Events():
         base_chance = 700
         if clan_size < 10:
             base_chance = 200
-        elif clan_size < 50:
+        elif clan_size < 30:
             base_chance = 300
 
         reputation = game.clan.reputation

--- a/scripts/events_module/new_cat_events.py
+++ b/scripts/events_module/new_cat_events.py
@@ -147,6 +147,8 @@ class NewCatEvents:
 
         if "adoption" in new_cat_event.tags:
             add_children_to_cat(cat, cat_class)
+            if cat.mate:
+                add_children_to_cat(Cat.fetch_cat(cat.mate), cat_class)
             if new_cat_event.litter:
                 for new_cat in created_cats:
                     add_siblings_to_cat(new_cat, cat_class)

--- a/scripts/screens/relation_screens.py
+++ b/scripts/screens/relation_screens.py
@@ -2865,7 +2865,7 @@ class MediationScreen(Screens):
             # ROMANTIC LOVE
             # CHECK AGE DIFFERENCE
             same_age = the_relationship.cat_to.age == cat.age
-            adult_ages = ['young adult', 'adult', 'senior adult', 'elder']
+            adult_ages = ['young adult', 'adult', 'senior adult', 'senior']
             both_adult = the_relationship.cat_to.age in adult_ages and cat.age in adult_ages
             check_age = both_adult or same_age
 

--- a/scripts/screens/relation_screens.py
+++ b/scripts/screens/relation_screens.py
@@ -1388,7 +1388,7 @@ class ChooseMateScreen(Screens):
          # If the number of pages becomes smaller than the number of our current page, set
         #   the current page to the last page
         if self.current_page > len(self.all_pages):
-            self.current_page = len(self.all_pages)
+            self.current_page = max(len(self.all_pages), 1)
 
         # Handle which next buttons are clickable.
         if len(self.all_pages) <= 1:
@@ -1405,14 +1405,10 @@ class ChooseMateScreen(Screens):
             self.next_page_button.enable()
 
         # Display the current page and total pages.
-        total_pages = len(self.all_pages)
-        if total_pages == 0:
-            display_total_pages = 1
-        else:
-            display_total_pages = total_pages
+        display_total_pages = max(1, len(self.all_pages))
         self.page_number.set_text(f"page {self.current_page} / {display_total_pages}")
 
-        if total_pages != 0:
+        if len(self.all_pages) > 0:
             display_cats = self.all_pages[self.current_page - 1]
         else:
             display_cats = []


### PR DESCRIPTION
- Romantic like will now be displayed for senior + non-senior couples on the mediate screen. 
- When kits are adopted, add the adopted kits to the main cat's mate's children list. 
- Fix crash issues with choose mate screen. 
- Made new_cat logic for dependence on clan size clearer 