### PR TITLE
bugfix: moonskip crash

### DIFF
--- a/scripts/events.py
+++ b/scripts/events.py
@@ -180,7 +180,10 @@ class Events():
                             lambda kitty: (kitty.status != "leader" and not kitty.dead and
                                            not kitty.outside and not kitty.exiled), Cat.all_cats.values()))
                     # finds a percentage of the living clan to become shaken
-                    shaken_cats = random.sample(alive_cats, k=max(int((len(alive_cats) * random.choice([4, 5, 6])) / 100), 1))
+                    if len(alive_cats) == 0:
+                        return
+                    else:
+                        shaken_cats = random.sample(alive_cats, k=max(int((len(alive_cats) * random.choice([4, 5, 6])) / 100), 1))
 
                     shaken_cat_names = []
                     for cat in shaken_cats:

--- a/scripts/version.py
+++ b/scripts/version.py
@@ -6,7 +6,7 @@ from configparser import ConfigParser
 
 logger = logging.getLogger(__name__)
 
-VERSION_NAME = "dev0.8.0"
+VERSION_NAME = "0.8.0"
 SAVE_VERSION_NUMBER = 1  # This is saved in the clan save-file, and is used for save-file converstion. 
 
 def get_version_info():

--- a/scripts/version.py
+++ b/scripts/version.py
@@ -6,7 +6,7 @@ from configparser import ConfigParser
 
 logger = logging.getLogger(__name__)
 
-VERSION_NAME = "0.8.0"
+VERSION_NAME = "dev0.8.0"
 SAVE_VERSION_NUMBER = 1  # This is saved in the clan save-file, and is used for save-file converstion. 
 
 def get_version_info():


### PR DESCRIPTION
fixed a crash that would happen upon skipping a moon after several cats died and the only cat remaining was the leader