### PR TITLE
Other: Add protection for next and previous cat buttons, load settings

### DIFF
--- a/resources/dicts/patrols/plains/hunting/greenleaf.json
+++ b/resources/dicts/patrols/plains/hunting/greenleaf.json
@@ -62,6 +62,9 @@
             "very smart",
             "extremely smart"
         ],
+        "history_text": [
+            "r_c was scarred by a sharp piece of twoleg garbage. "
+        ],
         "min_cats": 1,
         "max_cats": 6,
         "antagonize_text": null,

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -909,7 +909,7 @@ class Cat():
                         possible_trait = self.personality_groups.get(x)
                         chosen_trait = choice(possible_trait)
                         if chosen_trait in self.kit_traits:
-                            self.trait = self.trait
+                            self.trait = choice(self.traits)
                             self.mentor_influence.insert(0, 'None')
                         else:
                             self.trait = chosen_trait

--- a/scripts/cat/thoughts.py
+++ b/scripts/cat/thoughts.py
@@ -184,7 +184,6 @@ class Thoughts():
                 if main_cat.permanent_condition:
                     if not [i for i in main_cat.permanent_condition if i in thought["perm_conditions"]["m_c"]] and \
                             "any" not in thought['perm_conditions']["m_c"]:
-                        print(thought["perm_conditions"]["m_c"], str(main_cat.name))
                         return False
 
             if "r_c" in thought["perm_conditions"] and random_cat:

--- a/scripts/events_module/relationship/romantic_events.py
+++ b/scripts/events_module/relationship/romantic_events.py
@@ -179,7 +179,7 @@ class Romantic_Events():
         return: bool if event is triggered or not
         """
         # get the highest romantic love relationships and
-        highest_romantic_relation = get_highest_romantic_relation(cat.relationships.values())
+        highest_romantic_relation = get_highest_romantic_relation(cat.relationships.values(), potential_mate=True)
         max_love_value = 0
         if highest_romantic_relation is not None:
             max_love_value = highest_romantic_relation.romantic_love
@@ -188,24 +188,23 @@ class Romantic_Events():
             return False
 
         cat_to = highest_romantic_relation.cat_to
-        if cat_to.is_potential_mate(cat) and cat.is_potential_mate(cat_to):
-            if cat_to.mate is None and cat.mate is None:
-                self.had_one_event = True
-                cat.set_mate(cat_to)
+        if cat_to.mate is None and cat.mate is None:
+            self.had_one_event = True
+            cat.set_mate(cat_to)
 
-                if highest_romantic_relation.opposite_relationship is None:
-                    highest_romantic_relation.link_relationship()
+            if highest_romantic_relation.opposite_relationship is None:
+                highest_romantic_relation.link_relationship()
 
-                if highest_romantic_relation.opposite_relationship.romantic_love <= lower_threshold:
-                    mate_string = choice(MATE_DICTS["rejected"])
-                    mate_string = event_text_adjust(Cat, mate_string, cat, cat_to)
-                    game.cur_events_list.append(Single_Event(mate_string, "relation", [cat.ID, cat_to.ID]))
-                    return False
-                else:
-                    mate_string = choice(MATE_DICTS["high_romantic"])
-                    mate_string = event_text_adjust(Cat, mate_string, cat, cat_to)
-                    game.cur_events_list.append(Single_Event(mate_string, "relation", [cat.ID, cat_to.ID]))
-                    return True
+            if highest_romantic_relation.opposite_relationship.romantic_love <= lower_threshold:
+                mate_string = choice(MATE_DICTS["rejected"])
+                mate_string = event_text_adjust(Cat, mate_string, cat, cat_to)
+                game.cur_events_list.append(Single_Event(mate_string, "relation", [cat.ID, cat_to.ID]))
+                return False
+            else:
+                mate_string = choice(MATE_DICTS["high_romantic"])
+                mate_string = event_text_adjust(Cat, mate_string, cat, cat_to)
+                game.cur_events_list.append(Single_Event(mate_string, "relation", [cat.ID, cat_to.ID]))
+                return True
         return False
 
 

--- a/scripts/game_structure/game_essentials.py
+++ b/scripts/game_structure/game_essentials.py
@@ -294,14 +294,17 @@ class Game():
                     ":")  # first part is setting name, second is value
                 # Turn value into right type (int types stay string and will be turned into int when needed)
                 # And put it into game settings
-                if parts[1] in ['True', 'True ', 'true', ' True']:
-                    self.settings[parts[0]] = True
-                elif parts[1] in ['False', 'False ', 'false', ' False']:
-                    self.settings[parts[0]] = False
-                elif parts[1] in ['None', 'None ', 'none', ' None']:
-                    self.settings[parts[0]] = None
-                else:
-                    self.settings[parts[0]] = parts[1]
+                try:
+                    if parts[1] in ['True', 'True ', 'true', ' True']:
+                        self.settings[parts[0]] = True
+                    elif parts[1] in ['False', 'False ', 'false', ' False']:
+                        self.settings[parts[0]] = False
+                    elif parts[1] in ['None', 'None ', 'none', ' None']:
+                        self.settings[parts[0]] = None
+                    else:
+                        self.settings[parts[0]] = parts[1]
+                except IndexError:
+                    print("error loading setting:", parts)
 
         self.switches['language'] = self.settings['language']
         self.switches['game_mode'] = self.settings['game_mode']

--- a/scripts/patrol.py
+++ b/scripts/patrol.py
@@ -2087,7 +2087,7 @@ class PatrolEvent():
         if history_text:
             self.history_text = history_text
         else:
-            history_text = []
+            self.history_text = []
 
         if relationship_constraint:
             self.relationship_constraint = relationship_constraint

--- a/scripts/screens/cat_screens.py
+++ b/scripts/screens/cat_screens.py
@@ -288,14 +288,20 @@ class ProfileScreen(Screens):
                 self.change_screen(game.last_screen_forProfile)
             elif event.ui_element == self.previous_cat_button:
                 self.clear_profile()
-                game.switches['cat'] = self.previous_cat
-                self.build_profile()
-                self.update_disabled_buttons_and_text()
+                if Cat.fetch_cat(self.previous_cat) is not None:
+                    game.switches['cat'] = self.previous_cat
+                    self.build_profile()
+                    self.update_disabled_buttons_and_text()
+                else:
+                    print("invalid previous cat", self.previous_cat)
             elif event.ui_element == self.next_cat_button:
                 self.clear_profile()
-                game.switches['cat'] = self.next_cat
-                self.build_profile()
-                self.update_disabled_buttons_and_text()
+                if Cat.fetch_cat(self.next_cat) is not None:
+                    game.switches['cat'] = self.next_cat
+                    self.build_profile()
+                    self.update_disabled_buttons_and_text()
+                else:
+                    print("invalid next cat", self.next_cat)
             elif event.ui_element == self.relations_tab_button:
                 self.toggle_relations_tab()
             elif event.ui_element == self.roles_tab_button:
@@ -2352,11 +2358,17 @@ class RoleScreen(Screens):
             if event.ui_element == self.back_button:
                 self.change_screen("profile screen")
             elif event.ui_element == self.next_cat_button:
-                game.switches["cat"] = self.next_cat
-                self.update_selected_cat()
+                if Cat.fetch_cat(self.next_cat) is not None:
+                    game.switches["cat"] = self.next_cat
+                    self.update_selected_cat()
+                else:
+                    print("invalid next cat", self.next_cat)
             elif event.ui_element == self.previous_cat_button:
-                game.switches["cat"] = self.previous_cat
-                self.update_selected_cat()
+                if Cat.fetch_cat(self.previous_cat) is not None:
+                    game.switches["cat"] = self.previous_cat
+                    self.update_selected_cat()
+                else:
+                    print("invalid previous cat", self.previous_cat)  
             elif event.ui_element == self.promote_leader:
                 if self.the_cat == game.clan.deputy:
                     game.clan.deputy = None

--- a/scripts/screens/relation_screens.py
+++ b/scripts/screens/relation_screens.py
@@ -54,15 +54,21 @@ class ChooseMentorScreen(Screens):
             elif event.ui_element == self.back_button:
                 self.change_screen('profile screen')
             elif event.ui_element == self.next_cat_button:
-                game.switches['cat'] = self.next_cat
-                self.update_apprentice()
-                self.update_selected_cat()
-                self.update_buttons()
+                if Cat.fetch_cat(self.next_cat) is not None:
+                    game.switches['cat'] = self.next_cat
+                    self.update_apprentice()
+                    self.update_selected_cat()
+                    self.update_buttons()
+                else:
+                    print("invalid next cat", self.next_cat)
             elif event.ui_element == self.previous_cat_button:
-                game.switches['cat'] = self.previous_cat
-                self.update_apprentice()
-                self.update_selected_cat()
-                self.update_buttons()
+                if Cat.fetch_cat(self.previous_cat) is not None:
+                    game.switches['cat'] = self.previous_cat
+                    self.update_apprentice()
+                    self.update_selected_cat()
+                    self.update_buttons()
+                else:
+                    print("invalid previous cat", self.previous_cat)
             elif event.ui_element == self.next_page_button:
                 self.current_page += 1
                 self.update_cat_list()
@@ -491,15 +497,21 @@ class FamilyTreeScreen(Screens):
                 self.change_screen('profile screen')
                 game.switches['root_cat'] = None
             elif event.ui_element == self.previous_cat_button:
-                game.switches['cat'] = self.previous_cat
-                game.switches['root_cat'] = Cat.all_cats[self.previous_cat]
-                self.exit_screen()
-                self.screen_switches()
+                if Cat.fetch_cat(self.previous_cat) is not None:
+                    game.switches['cat'] = self.previous_cat
+                    game.switches['root_cat'] = Cat.all_cats[self.previous_cat]
+                    self.exit_screen()
+                    self.screen_switches()
+                else:
+                    print("invalid previous cat", self.previous_cat)
             elif event.ui_element == self.next_cat_button:
-                game.switches['cat'] = self.next_cat
-                game.switches['root_cat'] = Cat.all_cats[self.next_cat]
-                self.exit_screen()
-                self.screen_switches()
+                if Cat.fetch_cat(self.next_cat) is not None:
+                    game.switches['cat'] = self.next_cat
+                    game.switches['root_cat'] = Cat.all_cats[self.next_cat]
+                    self.exit_screen()
+                    self.screen_switches()
+                else:
+                    print("invalid next cat", self.next_cat)
             elif event.ui_element == self.parents_button:
                 self.current_group = self.parents
                 self.current_group_name = "parents"
@@ -1147,13 +1159,19 @@ class ChooseMateScreen(Screens):
                     self.update_choose_mate(breakup=True)
                 self.update_cat_list()
             elif event.ui_element == self.previous_cat_button:
-                game.switches["cat"] = self.previous_cat
-                self.update_current_cat_info()
-                self.update_buttons()
+                if Cat.fetch_cat(self.previous_cat) is not None:
+                    game.switches["cat"] = self.previous_cat
+                    self.update_current_cat_info()
+                    self.update_buttons()
+                else:
+                    print("invalid previous cat", self.previous_cat)
             elif event.ui_element == self.next_cat_button:
-                game.switches["cat"] = self.next_cat
-                self.update_current_cat_info()
-                self.update_buttons()
+                if Cat.fetch_cat(self.next_cat) is not None:
+                    game.switches["cat"] = self.next_cat
+                    self.update_current_cat_info()
+                    self.update_buttons()
+                else:
+                    print("invalid next cat", self.next_cat)
             elif event.ui_element == self.previous_page_button:
                 self.current_page -= 1
                 self.update_cat_page()
@@ -1708,11 +1726,17 @@ class RelationshipScreen(Screens):
                 game.switches["cat"] = self.inspect_cat.ID
                 self.change_screen('profile screen')
             elif event.ui_element == self.next_cat_button:
-                game.switches["cat"] = self.next_cat
-                self.update_focus_cat()
+                if Cat.fetch_cat(self.next_cat) is not None:
+                    game.switches["cat"] = self.next_cat
+                    self.update_focus_cat()
+                else:
+                    print("invalid next cat", self.next_cat)
             elif event.ui_element == self.previous_cat_button:
-                game.switches["cat"] = self.previous_cat
-                self.update_focus_cat()
+                if Cat.fetch_cat(self.previous_cat) is not None:
+                    game.switches["cat"] = self.previous_cat
+                    self.update_focus_cat()
+                else:
+                    print("invalid previous cat", self.previous_cat)
             elif event.ui_element == self.previous_page_button:
                 self.current_page -= 1
                 self.update_cat_page()

--- a/scripts/utility.py
+++ b/scripts/utility.py
@@ -452,9 +452,10 @@ with open(f"{resource_directory}personality_compatibility.json", 'r') as read_fi
 def get_highest_romantic_relation(relationships, exclude_mate=False, potential_mate=False):
     """Returns the relationship with the highest romantic value."""
     # Different filters for different
+    
     romantic_relation = list(
-        filter(lambda rel: rel.romantic_love > 0 and (exclude_mate and rel.cat_to.ID != rel.cat_to.mate)
-                           and (potential_mate and rel.cat_to.is_potential_mate(rel.cat_from, for_love_interest=True)),
+        filter(lambda rel: rel.romantic_love > 0 and (not exclude_mate or rel.cat_to.ID != rel.cat_to.mate)
+                           and (not potential_mate or rel.cat_to.is_potential_mate(rel.cat_from, for_love_interest=True)),
                relationships))
 
     if romantic_relation is None or len(romantic_relation) == 0:


### PR DESCRIPTION
- Added so protection from next and previous cat crashing the game navigating to the page of an invalid cat. 
- Added error handling for loading settings, to prevent a crash that occurs when settings are incorrectly formatted. 
- Fixed "big_love_check", so it works properly. 
- Fixed lost kits returning to the clan not getting adult traits. 
- Added history text to patrol that was missing it. 