### PR TITLE
Bugfix and Content

### DIFF
--- a/resources/dicts/events/death/general/general.json
+++ b/resources/dicts/events/death/general/general.json
@@ -273,16 +273,5 @@
             "lead_death": "lost a life because of curiosity."
         },
         "backstory_constraint": ["abandoned1", "abandoned2", "abandoned3"]
-    },
-    {
-        "camp": "Any",
-        "tags": ["Newleaf", "Greenleaf", "Leaf-fall", "Leaf-bare", "rc_to_mc", "comfort", "respect", "clan_kits"],
-        "event_text": "m_c calls out to some eager kits, and after they have situated themselves in front of m_c, {PRONOUN/m_c/subject} {VERB/m_c/start/starts} telling the kits a thrilling story of times long past.",
-        "cat_skill": ["good storyteller", "great storyteller", "fantastic storyteller", "lore keeper"]
-    },
-    {
-        "camp": "Any",
-        "tags": ["Leaf-fall", "clan_kits", "other_cat", "other_cat_adult"],
-        "event_text": "The older cats look fondly upon the kits who are dashing in and out of leaf piles at the edge of camp."
     }
 ]

--- a/resources/dicts/events/misc_events/beach/medicine.json
+++ b/resources/dicts/events/misc_events/beach/medicine.json
@@ -2,7 +2,7 @@
   {
     "camp": "any",
     "tags": ["Newleaf", "Greenleaf", "Leaf-fall", "Leaf-bare"],
-    "event_text": "As a storm rages across the beach and waves crash upon the shore, m_c is tucked up in the medicine cat den, their sleep anything but restful. They keep seeing flashes of prophecy_list. They wake with a shiver, wondering what their dreams mean for the Clan.",
+    "event_text": "As a storm rages across the beach and waves crash upon the shore, m_c is tucked up in the medicine cat den, their sleep anything but restful. They keep seeing flashes of prophecy_list_sight. They wake with a shiver, wondering what their dreams mean for the Clan.",
     "cat_trait": null,
     "cat_skill": ["prophet"],
     "other_cat_trait": null,
@@ -11,7 +11,7 @@
   {
     "camp": "any",
     "tags": ["Newleaf", "Greenleaf", "Leaf-fall", "Leaf-bare"],
-    "event_text": "The things they saw today, omen_list... m_c dips a paw in a rockpool, watching the tiny, crawling life inside, and considering what the omens foretell.",
+    "event_text": "The things they saw today: omen_list_sight... m_c dips a paw in a rockpool, watching the tiny, crawling life inside, and considering what the omens foretell.",
     "cat_trait": null,
     "cat_skill": ["omen sight"],
     "other_cat_trait": null,

--- a/resources/dicts/events/misc_events/forest/medicine.json
+++ b/resources/dicts/events/misc_events/forest/medicine.json
@@ -2,7 +2,7 @@
   {
     "camp": "any",
     "tags": ["Newleaf", "Greenleaf", "Leaf-fall"],
-    "event_text": "As a storm rages and the branches of the forest whip around outside, m_c is tucked up in the medicine cat den, their sleep anything but restful. They keep seeing flashes of prophecy_list. They wake with a shiver, wondering what their dreams mean for the Clan.",
+    "event_text": "As a storm rages and the branches of the forest whip around outside, m_c is tucked up in the medicine cat den, their sleep anything but restful. They keep seeing flashes of prophecy_list_sight. They wake with a shiver, wondering what their dreams mean for the Clan.",
     "cat_trait": null,
     "cat_skill": ["prophet"],
     "other_cat_trait": null,
@@ -11,7 +11,7 @@
   {
     "camp": "any",
     "tags": ["Newleaf", "Greenleaf", "Leaf-fall"],
-    "event_text": "The things they saw today, omen_list... m_c conceals themselves in a hidden alcove under branches that drip all the way to the ground, needing privacy as they consider what these new omens foretell.",
+    "event_text": "The things they saw today, omen_list_sight... m_c conceals themselves in a hidden alcove under branches that drip all the way to the ground, needing privacy as they consider what these new omens foretell.",
     "cat_trait": null,
     "cat_skill": ["omen sight"],
     "other_cat_trait": null,

--- a/resources/dicts/events/misc_events/general/apprentice.json
+++ b/resources/dicts/events/misc_events/general/apprentice.json
@@ -198,7 +198,7 @@
   },
   {
     "camp": "any",
-    "tags": ["Newleaf", "Greenleaf", "Leaf-fall", "Leaf-bare", "war"],
+    "tags": ["Newleaf", "Greenleaf", "Leaf-fall", "Leaf-bare", "war", "other_clan"],
     "event_text": "m_c is struggling to cope with the violence and chaos of war surrounding them, finding it difficult to wake up in the morning due to the stress and strain of constant battle training.",
     "cat_trait": ["nervous", "lonesome", "playful", "careful", "compassionate", "loving", "insecure"]
   },

--- a/resources/dicts/events/misc_events/general/general.json
+++ b/resources/dicts/events/misc_events/general/general.json
@@ -128,16 +128,6 @@
         "event_text": "m_c and r_c begin a small camp snowball fight while on guard duty, eventually getting the whole Clan to join in."
     },
     {
-        "camp": "any",
-        "tags": ["Newleaf", "Greenleaf", "Leaf-fall", "Leaf-bare", "war"],
-        "event_text": "The tension between c_n and o_c is palpable, with even the smallest actions potentially leading to violence."
-    },
-    {
-        "camp": "any",
-        "tags": ["Newleaf", "Greenleaf", "Leaf-fall", "Leaf-bare", "war"],
-        "event_text": "The war with o_c is disrupting the daily lives of c_n, forcing them to adapt to new routines and living situations in order to better defend themselves."
-    },
-    {
         "tags": ["Newleaf", "Greenleaf", "Leaf-bare", "Leaf-fall", "other_cat_mate", "clan_kits", "to_both", "platonic", "romantic"],
         "event_text": "m_c and r_c watch the Clan's kits play and daydream about having their own one day."
      },
@@ -156,29 +146,29 @@
      },
      {
         "camp": "any",
-        "tags": ["Newleaf", "Greenleaf", "Leaf-bare", "Leaf-fall", "other_cat_mate", "to_both", "platonic", "romantic", "clan_kits"],
+        "tags": ["Newleaf", "Greenleaf", "Leaf-bare", "Leaf-fall", "other_cat", "other_cat_mate", "to_both", "platonic", "romantic", "clan_kits"],
         "event_text": "m_c listens bashfully as r_c tells the story of how {PRONOUN/r_c/subject} fell in love with {PRONOUN/r_c/poss} mate to a group of starry-eyed kits."
      },
      {
         "camp": "any",
-        "tags": ["Leaf-bare", "other_cat_mate", "to_both", "platonic", "romantic"],
+        "tags": ["Leaf-bare", "other_cat",  "other_cat_mate", "to_both", "platonic", "romantic"],
         "event_text": "m_c and r_c are so cuddled up and cozy in their nest they almost miss the dawn patrol."
      },
      {
         "camp": "any",
-        "tags": ["Leaf-fall", "other_cat_mate", "to_both", "platonic", "romantic"],
+        "tags": ["Leaf-fall", "other_cat",  "other_cat_mate", "to_both", "platonic", "romantic"],
         "event_text": "r_c gives m_c the prettiest fallen leaf {PRONOUN/r_c/subject} can find. m_c wears it with pride.",
         "accessories": ["MAPLE LEAF"]
      },
      {
         "camp": "any",
-        "tags": ["Greenleaf", "other_cat_mate", "to_both", "platonic"],
+        "tags": ["Greenleaf", "other_cat",  "other_cat_mate", "to_both", "platonic"],
         "event_text": "m_c and r_c spend the evening chasing cicadas around camp. m_c keeps a trophy of {PRONOUN/m_c/poss} catch on {PRONOUN/m_c/poss} pelt.",
         "accessories": ["CICADA WINGS"]
      },
      {
         "camp": "any",
-        "tags": ["Greenleaf", "other_cat_mate", "to_both", "platonic"],
+        "tags": ["Greenleaf", "other_cat",  "other_cat_mate", "to_both", "platonic"],
         "event_text": "It's tough working in such extreme heat. m_c and r_c spend their evening relaxing together and cooling down in the shade."
      }
      

--- a/resources/dicts/events/misc_events/general/general.json
+++ b/resources/dicts/events/misc_events/general/general.json
@@ -84,28 +84,18 @@
     },
     {
         "camp": "any",
-        "tags": ["Newleaf", "Greenleaf", "Leaf-fall", "Leaf-bare", "other_cat", "rc_to_mc", "platonic", "comfort"],
-        "event_text": "m_c tossed a snake out of the camp before it could bite r_c."
+        "tags": ["Newleaf", "Greenleaf", "Leaf-fall", "Leaf-bare"],
+        "event_text": "m_c misstepped and slipped from a rock, but landed on {PRONOUN/m_c/poss} feet nimbly, {PRONOUN/m_c/poss} clanmates commenting on the show of dexterity."
     },
     {
         "camp": "any",
         "tags": ["Newleaf", "Greenleaf", "Leaf-fall", "Leaf-bare"],
-        "event_text": "m_c misstepped and slipped from a rock, but landed on their feet before they could dislocate something."
+        "event_text": "m_c wasn't looking where they were going and tripped over a small trunk, but came out of it with only their pride bruised."
     },
     {
         "camp": "any",
         "tags": ["Newleaf", "Greenleaf", "Leaf-fall", "Leaf-bare"],
-        "event_text": "m_c wasn't looking where they were going and tripped over a small trunk, but twisted themselves onto their back before they could sprain a leg."
-    },
-    {
-        "camp": "any",
-        "tags": ["Newleaf", "Greenleaf", "Leaf-fall", "Leaf-bare"],
-        "event_text": "m_c was trying to fluff up their nest when they saw a thorn inside of their bedding. Another prank, but it could not fool them!"
-    },
-    {
-        "camp": "any",
-        "tags": ["Newleaf", "Greenleaf", "Leaf-fall", "Leaf-bare"],
-        "event_text": "m_c slipped on some rocks, but landed on their feet before they could dislocate something."
+        "event_text": "m_c was trying to fluff up {PRONOUN/m_c/poss} nest when they saw a thorn inside of {PRONOUN/m_c/poss} bedding. Another prank, but it could not fool them!"
     },
     {
         "camp": "any",
@@ -129,7 +119,7 @@
     },
     {
         "tags": ["Newleaf", "Greenleaf", "Leaf-bare", "Leaf-fall", "other_cat_mate", "clan_kits", "to_both", "platonic", "romantic"],
-        "event_text": "m_c and r_c watch the Clan's kits play and daydream about having their own one day."
+        "event_text": "m_c and r_c watch the Clan's kits play and daydream about having {PRONOUN/m_c/poss} own one day."
      },
      {
         "camp": "any",
@@ -170,6 +160,33 @@
         "camp": "any",
         "tags": ["Greenleaf", "other_cat",  "other_cat_mate", "to_both", "platonic"],
         "event_text": "It's tough working in such extreme heat. m_c and r_c spend their evening relaxing together and cooling down in the shade."
+     },
+    {
+        "camp": "Any",
+        "tags": ["Newleaf", "Greenleaf", "Leaf-fall", "Leaf-bare", "rc_to_mc", "comfort", "respect", "clan_kits"],
+        "event_text": "m_c calls out to some eager kits, and after they have situated themselves in front of m_c, {PRONOUN/m_c/subject} {VERB/m_c/start/starts} telling the kits a thrilling story of times long past.",
+        "cat_skill": ["good storyteller", "great storyteller", "fantastic storyteller", "lore keeper"]
+    },
+    {
+        "camp": "Any",
+        "tags": ["Leaf-fall", "clan_kits", "other_cat", "other_cat_adult"],
+        "event_text": "The older cats look fondly upon the kits who are dashing in and out of leaf piles at the edge of camp."
+    },
+     {
+        "camp": "any",
+        "tags": ["Newleaf", "Greenleaf", "Leaf-bare", "Leaf-fall"],
+        "event_text": "m_c went for a long walk this morning, deep in thought."
+     },
+     {
+        "camp": "any",
+        "tags": ["Newleaf", "Greenleaf", "Leaf-bare", "Leaf-fall"],
+        "event_text": "The world around them feels smaller lately, m_c looks out at the horizon and yearns for something unnameable.",
+       "cat_trait": ["adventurous", "daring"]
+     },
+     {
+        "camp": "any",
+        "tags": ["Newleaf", "Greenleaf", "Leaf-bare", "Leaf-fall"],
+        "event_text": "m_c considers, as {PRONOUN/m_c/subject} look out over the Clan, if perhaps this isn't where {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} they belong.",
+       "cat_trait": ["adventurous", "daring", "insecure", "nervous"]
      }
-     
 ]

--- a/resources/dicts/events/misc_events/mountainous/medicine.json
+++ b/resources/dicts/events/misc_events/mountainous/medicine.json
@@ -2,7 +2,7 @@
   {
     "camp": "any",
     "tags": ["Newleaf", "Greenleaf", "Leaf-fall", "Leaf-bare"],
-    "event_text": "As a storm rages across the mountain outside, m_c is tucked up in the medicine cat den, their sleep anything but restful. They keep seeing flashes of prophecy_list. They wake with a shiver, wondering what their dreams mean for the Clan.",
+    "event_text": "As a storm rages across the mountain outside, m_c is tucked up in the medicine cat den, their sleep anything but restful. They keep seeing flashes of prophecy_list_sight. They wake with a shiver, wondering what their dreams mean for the Clan.",
     "cat_trait": null,
     "cat_skill": ["prophet"],
     "other_cat_trait": null,
@@ -11,7 +11,7 @@
   {
     "camp": "any",
     "tags": ["Newleaf", "Greenleaf", "Leaf-fall", "Leaf-bare"],
-    "event_text": "The things they saw today, omen_list... m_c sits on an isolated mountain ledge, considering what the omens foretell.",
+    "event_text": "The things they saw today, omen_list_sight... m_c sits on an isolated mountain ledge, considering what the omens foretell.",
     "cat_trait": null,
     "cat_skill": ["omen sight"],
     "other_cat_trait": null,

--- a/resources/dicts/events/misc_events/plains/medicine.json
+++ b/resources/dicts/events/misc_events/plains/medicine.json
@@ -2,7 +2,7 @@
   {
     "camp": "any",
     "tags": ["Newleaf", "Greenleaf", "Leaf-fall", "Leaf-bare"],
-    "event_text": "As the wind howls on the plains outside, m_c is tucked up in the medicine cat den, their sleep anything but restful. They keep seeing flashes of prophecy_list. They wake with a shiver, wondering what their dreams mean for the Clan.",
+    "event_text": "As the wind howls on the plains outside, m_c is tucked up in the medicine cat den, their sleep anything but restful. They keep seeing flashes of prophecy_list_sight. They wake with a shiver, wondering what their dreams mean for the Clan.",
     "cat_trait": null,
     "cat_skill": ["prophet"],
     "other_cat_trait": null,
@@ -11,7 +11,7 @@
   {
     "camp": "any",
     "tags": ["Newleaf", "Greenleaf", "Leaf-fall", "Leaf-bare"],
-    "event_text": "The things they saw today, omen_list... m_c isolates themselves in the shifting long grass, considering what the omens foretell.",
+    "event_text": "The things they saw today, omen_list_sight... m_c isolates themselves in the shifting long grass, considering what the omens foretell.",
     "cat_trait": null,
     "cat_skill": ["omen sight"],
     "other_cat_trait": null,

--- a/resources/dicts/events/war.json
+++ b/resources/dicts/events/war.json
@@ -25,12 +25,14 @@
       "c_n warriors plan new battle strategies for the war against o_c",
       "c_n wishes the war with o_c would end.",
       "c_n cats reinforce the camp walls in anticipation of o_c attacks.",
-      "c_n warriors evaluate their battle strategies for coming battles against o_c."
+      "c_n warriors evaluate their battle strategies for coming battles against o_c.",
+      "The war with o_c is disrupting the daily lives of c_n, forcing them to adapt to new routines and living situations in order to better defend themselves."
     ],
     "rel_down": [
       "o_c has taken some of c_n's territory.",
       "c_n has taken some of o_c's territory",
-      "War negotiations with o_c went badly at the last Gathering."
+      "War negotiations with o_c went badly at the last Gathering.",
+      "The tension between c_n and o_c is palpable, with even the smallest actions potentially leading to violence."
     ]
   },
   "conclusion_events": [

--- a/resources/dicts/patrols/beach/med/any.json
+++ b/resources/dicts/patrols/beach/med/any.json
@@ -31,6 +31,32 @@
         }
     },
     {
+        "patrol_id": "bch_med_clair1",
+        "biome": "beach",
+        "season": "Any",
+        "tags": [
+            "herb_gathering",
+            "random_herbs"
+        ],
+        "intro_text": "While on a trip to gather herbs, p_l slows to a stop. The random patch of beach {PRONOUN/p_l/subject} {VERB/p_l/linger/lingers} on doesn't look important, but {PRONOUN/p_l/subject}{VERB/p_l/'re/'s} suddenly overcome by an otherworldly feeling of clair_list_emotional. What could this mean?",
+        "decline_text": "p_l is in too much of a hurry, {PRONOUN/p_l/subject} {VERB/p_l/shake/shakes} the feeling off and {VERB/p_l/resolve/resolves} to forget the disconcerting experience.",
+        "chance_of_success": 45,
+        "exp": 10,
+        "success_text": [
+            "{PRONOUn/p_l/subject/CAP} {VERB/p_l/stop/stops} and {VERB/p_l/consider/considers} the feeling for a moment, allowing {PRONOUN/p_l/self} to linger. This might be important for the future, or it could simply be the left-over feelings of an event long past... either way, p_l doesn't stay too long before returning to herb collecting.",
+            "These feelings could prove important, they have in the past, at least. p_l makes {PRONOUN/p_l/self} comfortable on the beach, letting the feelings wash over {PRONOUN/p_l/object} and carry {PRONOUN/p_l/object} away. Eventually {PRONOUN/p_l/subject} {VERB/p_l/return/returns} to herb collecting, content in the new knowledge and understanding {PRONOUN/p_l/subject}{VERB/p_l/'ve/'s} gained."
+        ],
+        "fail_text": [
+            "This is nothing short of disconcerting. p_l does {PRONOUN/p_l/poss} best to shake off the feeling and hurry away from the area. Even so, {PRONOUN/p_l/subject} {VERB/p_l/find/finds} {PRONOUN/p_l/poss} mind occupied with the memory and can't manage to concentrate on herb gathering."
+        ],
+        "win_trait": ["wise"],
+        "min_cats": 1,
+        "max_cats": 1,
+        "constraints": {
+            "skill": ["clairvoyant"]
+        }
+    },
+    {
         "patrol_id": "bch_med_herblocation1",
         "biome": "beach",
         "season": "Any",

--- a/resources/dicts/patrols/beach/med/any.json
+++ b/resources/dicts/patrols/beach/med/any.json
@@ -25,7 +25,10 @@
         ],
         "win_skills": [],
         "min_cats": 1,
-        "max_cats": 1
+        "max_cats": 1,
+        "constraints": {
+            "skill": ["prophet"]
+        }
     },
     {
         "patrol_id": "bch_med_herblocation1",

--- a/resources/dicts/patrols/desert/med/any.json
+++ b/resources/dicts/patrols/desert/med/any.json
@@ -22,7 +22,10 @@
 		"They gaze into the water of the underground spring only to see the weird ripples were caused by a small fish flopping around. p_l feels disappointed because they really could have used some guidance from StarClan."
 	],
 	"min_cats":1,
-	"max_cats":1
+	"max_cats":1,
+	"constraints": {
+		"skill": ["prophet"]
+	}
 },
 {
 	"patrol_id":"dst_med_app_herblocation1",

--- a/resources/dicts/patrols/forest/med/any.json
+++ b/resources/dicts/patrols/forest/med/any.json
@@ -22,6 +22,32 @@
     }
 },
 {
+    "patrol_id": "fst_med_clair1",
+    "biome": "forest",
+    "season": "Any",
+    "tags": [
+        "herb_gathering",
+        "random_herbs"
+    ],
+    "intro_text": "While on a trip to gather herbs, p_l slows to a stop. The random clearing {PRONOUN/p_l/subject} {VERB/p_l/linger/lingers} in doesn't look important, but {PRONOUN/p_l/subject}{VERB/p_l/'re/'s} suddenly overcome by an otherworldly feeling of clair_list_emotional. What could this mean?",
+    "decline_text": "p_l is in too much of a hurry, {PRONOUN/p_l/subject} {VERB/p_l/shake/shakes} the feeling off and {VERB/p_l/resolve/resolves} to forget the disconcerting experience.",
+    "chance_of_success": 45,
+    "exp": 10,
+    "success_text": [
+        "{PRONOUn/p_l/subject/CAP} {VERB/p_l/stop/stops} and {VERB/p_l/consider/considers} the feeling for a moment, allowing {PRONOUN/p_l/self} to linger. This might be important for the future, or it could simply be the left-over feelings of an event long past... either way, p_l doesn't stay too long before returning to herb collecting.",
+        "These feelings could prove important, they have in the past, at least. p_l makes {PRONOUN/p_l/self} comfortable in the clearing, letting the feelings wash over {PRONOUN/p_l/object} and carry {PRONOUN/p_l/object} away. Eventually {PRONOUN/p_l/subject} {VERB/p_l/return/returns} to herb collecting, content in the new knowledge and understanding {PRONOUN/p_l/subject}{VERB/p_l/'ve/'s} gained."
+    ],
+    "fail_text": [
+        "This is nothing short of disconcerting. p_l does {PRONOUN/p_l/poss} best to shake off the feeling and hurry away from the area. Even so, {PRONOUN/p_l/subject} {VERB/p_l/find/finds} {PRONOUN/p_l/poss} mind occupied with the memory and can't manage to concentrate on herb gathering."
+    ],
+    "win_trait": ["wise"],
+    "min_cats": 1,
+    "max_cats": 1,
+    "constraints": {
+        "skill": ["clairvoyant"]
+    }
+},
+{
     "patrol_id": "fst_med_herblocation1",
     "biome": "forest",
     "season": "Any",

--- a/resources/dicts/patrols/forest/med/any.json
+++ b/resources/dicts/patrols/forest/med/any.json
@@ -16,7 +16,10 @@
         "They gaze eagerly into the puddle, only to see the weird ripples were caused by a small frog. p_l sighs in disappointment - they really could have used some guidance from StarClan."
     ],
     "min_cats": 1,
-    "max_cats": 1
+    "max_cats": 1,
+    "constraints": {
+        "skill": ["prophet"]
+    }
 },
 {
     "patrol_id": "fst_med_herblocation1",

--- a/resources/dicts/patrols/general/medcat.json
+++ b/resources/dicts/patrols/general/medcat.json
@@ -499,7 +499,9 @@
     ],
     "win_trait": ["loving"],
     "fail_trait": ["lonesome", "insecure"],
-    "relationship_constraint": ["siblings", "platonic_20"],
+    "constraints": {
+        "relationship": ["siblings", "platonic_20"]
+    },
     "min_cats": 2,
     "max_cats": 2,
     "antagonize_text": null,
@@ -527,7 +529,9 @@
     "win_skills": ["keen eye"],
     "win_trait": ["loving"],
     "fail_trait": ["lonesome", "insecure"],
-    "relationship_constraint": ["siblings", "platonic_20"],
+    "constraints": {
+        "relationship": ["siblings", "platonic_20"]
+    },
     "min_cats": 2,
     "max_cats": 2,
     "antagonize_text": null,

--- a/resources/dicts/patrols/general/training.json
+++ b/resources/dicts/patrols/general/training.json
@@ -240,9 +240,9 @@
     "fail_trait":["cold", "ambitious"],
     "min_cats": 2,
     "max_cats": 2,
-    "relationship_constraint": [
-        "parent/child"
-]
+    "constraints": {
+        "relationship": ["parent/child"]
+    }
 },
 {
     "patrol_id": "gen_train_argue1",

--- a/resources/dicts/patrols/mountainous/med/any.json
+++ b/resources/dicts/patrols/mountainous/med/any.json
@@ -18,7 +18,10 @@
     "min_cats": 1,
     "max_cats": 1,
     "antagonize_text": null,
-    "antagonize_fail_text": null
+    "antagonize_fail_text": null,
+    "constraints": {
+        "skill": ["prophet"]
+    }
 },
 {
     "patrol_id": "mtn_med_herblocation1",
@@ -76,14 +79,13 @@
     "chance_of_success": 50,
     "exp": 20,
     "success_text": [
-        "p_l is plucking some rosemary when their attention is suddenly grabbed by a a_sign. The fur on their back begins to prickle slightly, the sound of their heartbeat like thunder in their ears. They turn and hare back to camp, herbs forgotten. They need to tell their mentor about this as soon as possible!"
+        "p_l is plucking some rosemary when their attention is suddenly grabbed by omen_list_emotional_smell_sound. The fur on their back begins to prickle slightly, the sound of their heartbeat like thunder in their ears. They turn and hare back to camp, herbs forgotten. They need to tell their mentor about this as soon as possible!"
     ],
     "fail_text":[
         "app1 feels a pit of dread beginning to form in their belly - they've forgotten where to find the herb their mentor wanted. They taste the air, hoping desperately for some hint of its tell-tale scent, but it's a useless effort. They'll have to swallow their pride and return to ask for directions."
     ],
     "min_cats": 1,
     "max_cats": 1,
-
     "antagonize_text": null,
     "antagonize_fail_text": null
 },

--- a/resources/dicts/patrols/mountainous/med/any.json
+++ b/resources/dicts/patrols/mountainous/med/any.json
@@ -70,6 +70,32 @@
     "antagonize_fail_text": null
 },
 {
+    "patrol_id": "mtn_med_clair1",
+    "biome": "mountainous",
+    "season": "Any",
+    "tags": [
+        "herb_gathering",
+        "random_herbs"
+    ],
+    "intro_text": "While on a trip to gather herbs, p_l slows to a stop. The random patch of slope {PRONOUN/p_l/subject} {VERB/p_l/linger/lingers} on doesn't look important, but {PRONOUN/p_l/subject}{VERB/p_l/'re/'s} suddenly overcome by an otherworldly feeling of clair_list_emotional. What could this mean?",
+    "decline_text": "p_l is in too much of a hurry, {PRONOUN/p_l/subject} {VERB/p_l/shake/shakes} the feeling off and {VERB/p_l/resolve/resolves} to forget the disconcerting experience.",
+    "chance_of_success": 45,
+    "exp": 10,
+    "success_text": [
+        "{PRONOUn/p_l/subject/CAP} {VERB/p_l/stop/stops} and {VERB/p_l/consider/considers} the feeling for a moment, allowing {PRONOUN/p_l/self} to linger. This might be important for the future, or it could simply be the left-over feelings of an event long past... either way, p_l doesn't stay too long before returning to herb collecting.",
+        "These feelings could prove important, they have in the past, at least. p_l makes {PRONOUN/p_l/self} comfortable on the slope, letting the feelings wash over {PRONOUN/p_l/object} and carry {PRONOUN/p_l/object} away. Eventually {PRONOUN/p_l/subject} {VERB/p_l/return/returns} to herb collecting, content in the new knowledge and understanding {PRONOUN/p_l/subject}{VERB/p_l/'ve/'s} gained."
+    ],
+    "fail_text": [
+        "This is nothing short of disconcerting. p_l does {PRONOUN/p_l/poss} best to shake off the feeling and hurry away from the area. Even so, {PRONOUN/p_l/subject} {VERB/p_l/find/finds} {PRONOUN/p_l/poss} mind occupied with the memory and can't manage to concentrate on herb gathering."
+    ],
+    "win_trait": ["wise"],
+    "min_cats": 1,
+    "max_cats": 1,
+    "constraints": {
+        "skill": ["clairvoyant"]
+    }
+},
+{
     "patrol_id": "mtn_med_appfirstsign1",
     "biome": "mountainous",
     "season": "Any",

--- a/resources/dicts/patrols/new_cat.json
+++ b/resources/dicts/patrols/new_cat.json
@@ -456,9 +456,9 @@
     "max_cats": 2,
     "antagonize_text": "A kittypet kitten approaches the patrol, yowling furiously. p_l bats it aside as the warrior continue hunting, unruffled.",
     "antagonize_fail_text": "The kittypet kittens trying furiously to defend their territory ruin all the hunting to be had, and the patrol returns home, irritated but impressed by the kittens' bravery.",
-    "relationship_constraint": [
-        "mates"
-]
+    "constraints": {
+        "relationship": ["mates"]
+    }
 },
 {
     "patrol_id": "gen_bord_curiouskittypet2",

--- a/resources/dicts/patrols/new_cat_hostile.json
+++ b/resources/dicts/patrols/new_cat_hostile.json
@@ -198,9 +198,9 @@
     "max_cats": 2,
     "antagonize_text": "A kittypet kitten approaches the patrol, yowling furiously. p_l bats it aside as the warriors continue hunting, unruffled.",
     "antagonize_fail_text": "The kittypet kittens trying furiously to defend their territory ruin all the hunting to be had, and the patrol returns home, irritated but impressed by the kittens' bravery.",
-    "relationship_constraint": [
-        "mates"
-]
+    "constraints": {
+        "relationship": ["mates"]
+    }
 },
 {
     "patrol_id": "gen_med_rescue5",

--- a/resources/dicts/patrols/new_cat_welcoming.json
+++ b/resources/dicts/patrols/new_cat_welcoming.json
@@ -333,9 +333,9 @@
     "max_cats": 2,
     "antagonize_text": "A kittypet kitten approaches the patrol, yowling furiously. p_l bats it aside as the warriors continue hunting, unruffled.",
     "antagonize_fail_text": "The kittypet kittens trying furiously to defend their territory ruin all the hunting to be had, and the patrol returns home, irritated but impressed by the kittens' bravery.",
-    "relationship_constraint": [
-        "mates"
-]
+    "constraints": {
+        "relationship": ["mates"]
+    }
 },
 {
     "patrol_id": "gen_bord_curiouskittypet1",

--- a/resources/dicts/patrols/plains/med/any.json
+++ b/resources/dicts/patrols/plains/med/any.json
@@ -19,6 +19,32 @@
     "max_cats": 1
 },
 {
+    "patrol_id": "pln_med_clair1",
+    "biome": "plains",
+    "season": "Any",
+    "tags": [
+        "herb_gathering",
+        "random_herbs"
+    ],
+    "intro_text": "While on a trip to gather herbs, p_l slows to a stop. The random patch of grass {PRONOUN/p_l/subject} {VERB/p_l/linger/lingers} on doesn't look important, but {PRONOUN/p_l/subject}{VERB/p_l/'re/'s} suddenly overcome by an otherworldly feeling of clair_list_emotional. What could this mean?",
+    "decline_text": "p_l is in too much of a hurry, {PRONOUN/p_l/subject} {VERB/p_l/shake/shakes} the feeling off and {VERB/p_l/resolve/resolves} to forget the disconcerting experience.",
+    "chance_of_success": 45,
+    "exp": 10,
+    "success_text": [
+        "{PRONOUn/p_l/subject/CAP} {VERB/p_l/stop/stops} and {VERB/p_l/consider/considers} the feeling for a moment, allowing {PRONOUN/p_l/self} to linger. This might be important for the future, or it could simply be the left-over feelings of an event long past... either way, p_l doesn't stay too long before returning to herb collecting.",
+        "These feelings could prove important, they have in the past, at least. p_l makes {PRONOUN/p_l/self} comfortable on the patch, letting the feelings wash over {PRONOUN/p_l/object} and carry {PRONOUN/p_l/object} away. Eventually {PRONOUN/p_l/subject} {VERB/p_l/return/returns} to herb collecting, content in the new knowledge and understanding {PRONOUN/p_l/subject}{VERB/p_l/'ve/'s} gained."
+    ],
+    "fail_text": [
+        "This is nothing short of disconcerting. p_l does {PRONOUN/p_l/poss} best to shake off the feeling and hurry away from the area. Even so, {PRONOUN/p_l/subject} {VERB/p_l/find/finds} {PRONOUN/p_l/poss} mind occupied with the memory and can't manage to concentrate on herb gathering."
+    ],
+    "win_trait": ["wise"],
+    "min_cats": 1,
+    "max_cats": 1,
+    "constraints": {
+        "skill": ["clairvoyant"]
+    }
+},
+{
     "patrol_id": "pln_med_herblocation1",
     "biome": "plains",
     "season": "Any",

--- a/resources/dicts/patrols/wetlands/med/any.json
+++ b/resources/dicts/patrols/wetlands/med/any.json
@@ -18,8 +18,9 @@
 
     "min_cats": 1,
     "max_cats": 1,
-    "antagonize_text": null,
-    "antagonize_fail_text": null
+    "constraints": {
+        "skill": ["prophet"]
+    }
 },
 {
     "patrol_id": "wtlnd_med_herblocation1",

--- a/resources/dicts/snippet_collections.json
+++ b/resources/dicts/snippet_collections.json
@@ -146,7 +146,7 @@
       "general": [
         ["the excitement of an apprentice", "an apprentice's vigor", "the naivety of an apprentice"],
         ["the strength of a warrior", "the steadfastness of a warrior", "a warrior's loyalty"],
-        ["the ache in an elder's bones", "the wisdom of an elder"],
+        ["the ache of an elder's bones", "the wisdom of an elder"],
         ["the sensation of falling"],
         ["the feeling of flight"],
         ["a half-remembered promise"],
@@ -412,21 +412,20 @@
         ["a story half-remembered"],
         ["the excitement of an apprentice", "an apprentice's vigor", "the naivety of an apprentice"],
         ["the strength of a warrior", "the steadfastness of a warrior", "a warrior's loyalty"],
-        ["the ache in an elder's bones", "an elder's wisdom"],
+        ["the ache of an elder's bones", "an elder's wisdom"],
         ["drowning"],
         ["lingering grief", "grief's sharp impact"],
-        ["a newborn's innocence"],
+        ["a newborn's innocence","the loss of innocence"],
         ["a memory being forgotten", "a fading memory", "a memory long lost"],
         ["forgetting something important", "forgetting a secret once precious"],
         ["wishing for something now missing", "longing for a long lost possession"],
-        ["hatred of a dear friend"],
+        ["hatred for a dear friend"],
         ["knowing a secret that can never be revealed"],
         ["a truth unbelieved", "a truth concealed", "a truth never revealed"],
         ["a weakness in their legs"],
         ["a belly so empty they feel nauseous"],
-        ["the loss of innocence"],
         ["a home no longer welcoming", "a home long lost", "a home once forgotten"],
-        ["the ooze of corruption"]
+        ["oozing corruption"]
       ],
       "forest": [
 
@@ -443,19 +442,17 @@
     },
     "touch": {
       "general": [
-        ["deathly still air", "the heat of a fire unseen"],
-        ["the trembling of stones"],
-        ["falling through the air","flying through the air"],
-        ["the warmth of a parent","the embrace of a family","the warmth of family and love in the darkness before a kit's eyes open"],
-        ["a tail twining with their own","wet fur against their own","the brush of a pelt against their own",
-        "teeth snapping against their hide", "claws against their scruff"],
-        ["the touch of a mentor to an apprentice's forehead"],
-        ["slipping on muddy earth despite the dry ground beneath them", "sinking into muddy earth"],
-        ["the burning of limbs still whole"],
-        ["their paws damp with water", "their paws damp with blood", "their paws heavy with blood"],
-        ["another cat shoving against them"],
-        ["of sharpening one's claws against stone"],
-        ["wind whipping through their fur"]
+        ["deathly still air", "an unseen fire's heat"],
+        ["trembling stones"],
+        ["falling through the air", "flying through the air"],
+        ["the warmth of a parent", "the embrace of a family","the warmth of family in the darkness before a kit's eyes open"],
+        ["tails entwining", "the slip of wet fur", "teeth snapping against fur", "claws against a scruff"],
+        ["a mentor's touch to an apprentice's forehead"],
+        ["slipping on muddy earth despite the dry ground", "sinking into muddy earth"],
+        ["paws damp with water", "paws damp with blood", "paws heavy with blood"],
+        ["another cat's violent shove"],
+        ["sharpening one's claws against stone"],
+        ["wind whipping through fur"]
       ],
       "forest": [
 
@@ -500,15 +497,17 @@
       ["The Thieving Fox"],
       ["The Tenacious Rabbit", "The Rabbit Prince"],
       ["The Hare King", "The Witch Hare"],
-      ["The Lion's Promise","How The Tiger Got It's Stripes","The Leopard's Spots","The Cougar's Claws"],
-      ["The Place of No Stars", "The Stars of Silverpelt"]
+      ["The Lion's Promise", "How The Tiger Got It's Stripes","The Leopard's Spots","The Cougar's Claws"],
+      ["The Place of No Stars", "The Stars of Silverpelt"],
+      ["The Great Tail-Chaser"],
+      ["The Hole In The Sky"]
     ],
     "forest": [
       ["The Cat Who Became a Porcupine", "The Cat Who Carried the Sun", "The Cat Who Grew Into an Oak", "The Willow Cat",
         "The Badger Who Befriended a Cat","The Cats Made of Light"],
       ["The Old Forests of the Ancestors", "The Forest's Origin", "The First Seed","The Squirrel Who Planted the Forest"],
       ["The Star Bugs"],
-      ["The Sun-down Place"]
+      ["The Sun-drown Place"]
 
     ],
     "plains": [
@@ -517,7 +516,8 @@
       ["the Thunderbeasts"],
       ["How The Great Sytowers Came To Be"],
       ["The Metal Trees of the Twolegs"],
-      ["The Weasel's Lie"]
+      ["The Weasel's Lie"],
+      ["The Sun-drown Place"]
 
     ],
     "beach": [
@@ -533,7 +533,8 @@
       ["The Mountain's Shadow"],
       ["The Hummingbird's Feather"],
       ["The Betrayal of the Ravens"],
-      ["The Dancing Sky"]
+      ["The Dancing Sky"],
+      ["The Sun-drown Place"]
 
     ]
   }

--- a/resources/dicts/snippet_collections.json
+++ b/resources/dicts/snippet_collections.json
@@ -274,8 +274,11 @@
     },
     "emotional": {
       "general": [
-        ["a pervasive feeling of dread"]
-
+        ["a pervasive feeling of dread"],
+        ["the feeling of ants crawling through fur", "the drag of a claw through fur"],
+        ["the faint feeling of fangs on skin"],
+        ["the feeling of a hidden onlooker", "the oppressive feeling of eyes unseen"],
+        ["the stillness that comes before disaster"]
       ],
       "forest": [
 

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -1218,7 +1218,7 @@ class Cat():
 
         for rel in relationships:
             kitty = self.fetch_cat(rel.cat_to)
-            if kitty.dead:
+            if kitty.dead and kitty.status != 'newborn':
                 # check where they reside
                 if starclan:
                     if kitty.ID not in game.clan.starclan_cats or kitty.outside:
@@ -1259,7 +1259,7 @@ class Cat():
 
                 possible_sc_cats = [i for i in game.clan.starclan_cats if
                                     i not in life_givers and
-                                    self.fetch_cat(i).status != 'leader']
+                                    self.fetch_cat(i).status not in ['leader', 'newborn']]
 
                 if len(possible_sc_cats) - 1 < amount:
                     extra_givers = possible_sc_cats
@@ -1269,7 +1269,7 @@ class Cat():
                 print(game.clan.darkforest_cats)
                 possible_df_cats = [i for i in game.clan.darkforest_cats if
                                     i not in life_givers and
-                                    self.fetch_cat(i).status != 'leader']
+                                    self.fetch_cat(i).status not in ['leader', 'newborn']]
                 if len(possible_df_cats) - 1 < amount:
                     extra_givers = possible_df_cats
                 else:

--- a/scripts/cat/history.py
+++ b/scripts/cat/history.py
@@ -267,7 +267,7 @@ class History:
         :param cat: cat object
         :param other_cat: if another cat is involved in the event, add them here
         :param text: event history text
-        :param text: the second event string if one exists, this is for use with the murder reveal system
+        :param extra_text: the second event string if one exists, this is for use with the murder reveal system
         :param condition: if it was caused by a condition, add name here
         :param scar: set True if scar
         :param death: set True if death
@@ -278,6 +278,7 @@ class History:
 
         event_type = None
         old_event_type = None
+        other_cat_ID = None
         if scar:
             event_type = "scar_events"
             old_event_type = "possible_scar"
@@ -297,7 +298,7 @@ class History:
                     old_event = cat.history.possible_scar
                 else:
                     old_event = cat.history.possible_death
-                other_cat = old_event[condition]["involved"]
+                other_cat_ID = old_event[condition]["involved"]
                 text = old_event[condition]["text"]
                 # and then remove from possible scar/death dict
                 if condition in old_event:
@@ -315,10 +316,10 @@ class History:
         if other_cat:
             if str(other_cat.name) in text:
                 text = text.replace(str(other_cat.name), "r_c")
-            other_cat = other_cat.ID
+            other_cat_ID = other_cat.ID
 
         history_dict = {
-            "involved": other_cat,
+            "involved": other_cat_ID,
             "text": text,
             "moon": game.clan.age
         }

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -1602,7 +1602,7 @@ class Events():
         TODO: DOCS
         """
 
-        if random.randint(1, 40) != 1:
+        if int(random.random() * 40):
             return
 
         other_cat = random.choice(list(Cat.all_cats.values()))

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -862,6 +862,9 @@ class Events():
         # if there are somehow no other clans, don't proceed
         if not game.clan.all_clans:
             return
+        # prevent wars from starting super early in the game
+        if game.clan.age <= 4:
+            return
 
         # check that the save dict has all the things we need
         if "at_war" not in game.clan.war:
@@ -888,7 +891,7 @@ class Events():
             if self.enemy_clan.temperament in ["mellow", "amiable", "gracious"]:
                 threshold = 3
 
-            threshold -= int(game.clan.war["duration"] / 2)
+            threshold -= int(game.clan.war["duration"] / 1.5)
             print('threshold', threshold)
 
             # check if war should conclude, if not, continue

--- a/scripts/events_module/condition_events.py
+++ b/scripts/events_module/condition_events.py
@@ -163,7 +163,7 @@ class Condition_Events():
                         involved_cats.append(other_cat.ID)
                         self.handle_relationship_changes(cat, injury_event, other_cat)
 
-                    print(text)
+                    print(injury_event.event_text)
                     text = event_text_adjust(Cat, injury_event.event_text, cat, other_cat, other_clan_name)
 
                     if game.clan.game_mode == "classic":

--- a/scripts/events_module/condition_events.py
+++ b/scripts/events_module/condition_events.py
@@ -143,7 +143,6 @@ class Condition_Events():
                     other_clan_name = f'{other_clan.name}Clan'
 
                 possible_events = self.generate_events.possible_short_events(cat.status, cat.age, "injury")
-                print('injury event', cat.ID)
                 final_events = self.generate_events.filter_possible_short_events(possible_events, cat, other_cat, war,
                                                                                  enemy_clan, other_clan, alive_kits)
 
@@ -163,7 +162,6 @@ class Condition_Events():
                         involved_cats.append(other_cat.ID)
                         self.handle_relationship_changes(cat, injury_event, other_cat)
 
-                    print(injury_event.event_text)
                     text = event_text_adjust(Cat, injury_event.event_text, cat, other_cat, other_clan_name)
 
                     if game.clan.game_mode == "classic":

--- a/scripts/events_module/death_events.py
+++ b/scripts/events_module/death_events.py
@@ -92,7 +92,8 @@ class Death_Events():
                 revealed = False
 
             death_history = history_text_adjust(death_history, other_clan_name, game.clan)
-            murder_unrevealed_history = history_text_adjust(murder_unrevealed_history, other_clan_name, game.clan)
+            if murder_unrevealed_history:
+                murder_unrevealed_history = history_text_adjust(murder_unrevealed_history, other_clan_name, game.clan)
             self.history.add_murders(cat, other_cat, revealed, death_history, murder_unrevealed_history)
 
         # check if the cat's body was retrievable

--- a/scripts/events_module/death_events.py
+++ b/scripts/events_module/death_events.py
@@ -57,7 +57,6 @@ class Death_Events():
         additional_event_text = ""
 
         # assign default history
-        print(death_cause.history_text)
         if cat.status == 'leader':
             death_history = death_cause.history_text.get("lead_death")
         else:
@@ -69,8 +68,6 @@ class Death_Events():
         if murder:
             if "kit_manipulated" in death_cause.tags:
                 kit = Cat.fetch_cat(random.choice(get_alive_kits(Cat)))
-                print(get_alive_kits(Cat))
-                print(kit)
                 involved_cats.append(kit.ID)
                 change_relationship_values([other_cat.ID],
                                            [kit],

--- a/scripts/events_module/generate_events.py
+++ b/scripts/events_module/generate_events.py
@@ -269,6 +269,8 @@ class GenerateEvents:
 
             if war_event and ("war" not in event.tags and "hostile" not in event.tags):
                 continue
+            if not war and "war" in event.tags:
+                continue
 
             # some events are classic only
             if game.clan.game_mode in ["expanded", "cruel season"] and "classic" in event.tags:

--- a/scripts/patrol.py
+++ b/scripts/patrol.py
@@ -282,12 +282,18 @@ class Patrol():
         keep = False
         if "relationship" in patrol.constraints:
             keep = self.filter_relationship(patrol)
+        else:
+            keep = True
         if "skill" in patrol.constraints:
             if self.patrol_leader.skill in patrol.constraints["skill"]:
                 keep = True
+        else:
+            keep = True
         if "trait" in patrol.constraints:
             if self.patrol_leader.trait in patrol.constraints["skill"]:
                 keep = True
+        else:
+            keep = True
         return keep
 
     def filter_patrols(self, possible_patrols, biome, patrol_size, current_season, patrol_type):

--- a/scripts/patrol.py
+++ b/scripts/patrol.py
@@ -278,12 +278,26 @@ class Patrol():
 
         return final_patrols, final_romance_patrols
 
+    def check_constraints(self, patrol):
+        keep = False
+        if "relationship" in patrol.constraints:
+            keep = self.filter_relationship(patrol)
+        if "skill" in patrol.constraints:
+            if self.patrol_leader.skill in patrol.constraints["skill"]:
+                keep = True
+        if "trait" in patrol.constraints:
+            if self.patrol_leader.trait in patrol.constraints["skill"]:
+                keep = True
+        return keep
+
     def filter_patrols(self, possible_patrols, biome, patrol_size, current_season, patrol_type):
         filtered_patrols = []
         romantic_patrols = []
 
         # makes sure that it grabs patrols in the correct biomes, season, with the correct number of cats
         for patrol in possible_patrols:
+            if not self.check_constraints(patrol):
+                continue
             if patrol.patrol_id in self.used_patrols:
                 continue
 
@@ -410,8 +424,6 @@ class Patrol():
 
         if patrol_type == 'hunting':
             filtered_patrols = self.balance_hunting(filtered_patrols)
-        filtered_patrols = self.filter_relationship(filtered_patrols)
-        romantic_patrols = self.filter_relationship(romantic_patrols)
 
         if not filtered_patrols:
             if self.filter_count == 1:
@@ -433,152 +445,140 @@ class Patrol():
                                                                  patrol_type)
         return filtered_patrols, romantic_patrols
 
-    def filter_relationship(self, possible_patrols: list):
-        """Filter the incoming patrol list according to the relationship constraints, if there are constraints.
-
-            Parameters
-            ----------
-            possible_patrols : list
-                list of patrols which should be filtered
-
-            Returns
-            ----------
-            filtered_patrols : list
-                list of patrols which is filtered
+    def filter_relationship(self, patrol):
         """
-        filtered_patrols = []
+        Filter the incoming patrol list according to the relationship constraints, if there are constraints.
 
-        for patrol in possible_patrols:
-            # if there are no constraints, add the patrol to the filtered list
-            if len(patrol.relationship_constraint) == 0:
-                filtered_patrols.append(patrol)
-                continue
+        """
 
-            # filtering - relationship status
-            # check if all are siblings
-            if "siblings" in patrol.relationship_constraint:
-                test_cat = self.patrol_cats[0]
-                testing_cats = [cat for cat in self.patrol_cats if cat.ID != test_cat.ID]
+        # if there are no constraints, add the patrol to the filtered list
+        if len(patrol.relationship_constraint) == 0:
+            return True
 
-                siblings = [inter_cat for inter_cat in testing_cats if test_cat.is_sibling(inter_cat)]
-                if len(siblings) + 1 != len(self.patrol_cats):
-                    continue
+        # filtering - relationship status
+        # check if all are siblings
+        if "siblings" in patrol.relationship_constraint:
+            test_cat = self.patrol_cats[0]
+            testing_cats = [cat for cat in self.patrol_cats if cat.ID != test_cat.ID]
 
-            # check if the cats are mates
-            if "mates" in patrol.relationship_constraint:
-                # it should be exactly two cats for a "mate" patrol
-                if len(self.patrol_cats) != 2:
-                    continue
-                else:
-                    cat1 = self.patrol_cats[0]
-                    cat2 = self.patrol_cats[1]
-                    # if one of the cat has no mate, not add this patrol
-                    if len(cat1.mate) < 1 or len(cat1.mate) < 1:
-                        continue
-                    elif cat2.ID not in cat1.mate or cat1.ID not in cat2.mate:
-                        continue
+            siblings = [inter_cat for inter_cat in testing_cats if test_cat.is_sibling(inter_cat)]
+            if len(siblings) + 1 != len(self.patrol_cats):
+                return False
 
-            # check if the cats are in a parent/child relationship
-            if "parent/child" in patrol.relationship_constraint:
-                # it should be exactly two cats for a "parent/child" patrol
-                if len(self.patrol_cats) != 2:
-                    continue
-                # when there are two cats in the patrol, p_l and r_c are different cats per default
-                if not self.patrol_leader.is_parent(self.patrol_random_cat):
-                    continue
+        # check if the cats are mates
+        if "mates" in patrol.relationship_constraint:
+            # it should be exactly two cats for a "mate" patrol
+            if len(self.patrol_cats) != 2:
+                return False
+            else:
+                cat1 = self.patrol_cats[0]
+                cat2 = self.patrol_cats[1]
+                # if one of the cat has no mate, not add this patrol
+                if len(cat1.mate) < 1 or len(cat1.mate) < 1:
+                    return False
+                elif cat2.ID not in cat1.mate or cat1.ID not in cat2.mate:
+                    return False
 
-            # check if the cats are in a child/parent relationship
-            if "child/parent" in patrol.relationship_constraint:
-                # it should be exactly two cats for a "child/parent" patrol
-                if len(self.patrol_cats) != 2:
-                    continue
-                # when there are two cats in the patrol, p_l and r_c are different cats per default
-                if not self.patrol_random_cat.is_parent(self.patrol_leader):
-                    continue
+        # check if the cats are in a parent/child relationship
+        if "parent/child" in patrol.relationship_constraint:
+            # it should be exactly two cats for a "parent/child" patrol
+            if len(self.patrol_cats) != 2:
+                return False
+            # when there are two cats in the patrol, p_l and r_c are different cats per default
+            if not self.patrol_leader.is_parent(self.patrol_random_cat):
+                return False
 
-            # filtering - relationship values
-            # when there will be more relationship values or other tags, this should be updated
-            value_types = ["romantic", "platonic", "dislike", "comfortable", "jealousy", "trust"]
-            break_loop = False
-            for v_type in value_types:
-                patrol_id = patrol.patrol_id
-                # first get all tags for the current value type
-                tags = [constraint for constraint in patrol.relationship_constraint if v_type in constraint]
+        # check if the cats are in a child/parent relationship
+        if "child/parent" in patrol.relationship_constraint:
+            # it should be exactly two cats for a "child/parent" patrol
+            if len(self.patrol_cats) != 2:
+                return False
+            # when there are two cats in the patrol, p_l and r_c are different cats per default
+            if not self.patrol_random_cat.is_parent(self.patrol_leader):
+                return False
 
-                # there is not such a tag for the current value type, check the next one
-                if len(tags) == 0:
-                    continue
+        # filtering - relationship values
+        # when there will be more relationship values or other tags, this should be updated
+        value_types = ["romantic", "platonic", "dislike", "comfortable", "jealousy", "trust"]
+        break_loop = False
+        for v_type in value_types:
+            patrol_id = patrol.patrol_id
+            # first get all tags for the current value type
+            tags = [constraint for constraint in patrol.relationship_constraint if v_type in constraint]
 
-                # there should be only one value constraint for each value type
-                elif len(tags) > 1:
-                    print(f"ERROR: patrol {patrol_id} has multiple relationship constraints for the value {v_type}.")
-                    break_loop = True
+            # there is not such a tag for the current value type, check the next one
+            if len(tags) == 0:
+                return False
+
+
+            # there should be only one value constraint for each value type
+            elif len(tags) > 1:
+                print(f"ERROR: patrol {patrol_id} has multiple relationship constraints for the value {v_type}.")
+                break_loop = True
+                break
+
+            threshold = 0
+            # try to extract the value/threshold from the text
+            try:
+                threshold = int(tags[0].split('_')[1])
+            except Exception as e:
+                print(
+                    f"ERROR: patrol {patrol_id} with the relationship constraint for the value {v_type} follows not the formatting guidelines.")
+                break_loop = True
+                break
+
+            if threshold > 100:
+                print(
+                    f"ERROR: patrol {patrol_id} has a relationship constraints for the value {v_type}, which is higher than the max value of a relationship.")
+                break_loop = True
+                break
+
+            if threshold <= 0:
+                print(
+                    f"ERROR: patrol {patrol_id} has a relationship constraints for the value {v_type}, which is lower than the min value of a relationship or 0.")
+                break_loop = True
+                break
+
+            # each cat has to have relationships with this relationship value above the threshold
+            fulfilled = True
+            for inter_cat in self.patrol_cats:
+                rel_above_threshold = []
+                patrol_cats_ids = [cat.ID for cat in self.patrol_cats]
+                relevant_relationships = list(
+                    filter(lambda rel: rel.cat_to.ID in patrol_cats_ids and rel.cat_to.ID != inter_cat.ID,
+                           list(inter_cat.relationships.values())
+                           )
+                )
+
+                # get the relationships depending on the current value type + threshold
+                if v_type == "romantic":
+                    rel_above_threshold = [i for i in relevant_relationships if i.romantic_love >= threshold]
+                elif v_type == "platonic":
+                    rel_above_threshold = [i for i in relevant_relationships if i.platonic_like >= threshold]
+                elif v_type == "dislike":
+                    rel_above_threshold = [i for i in relevant_relationships if i.dislike >= threshold]
+                elif v_type == "comfortable":
+                    rel_above_threshold = [i for i in relevant_relationships if i.comfortable >= threshold]
+                elif v_type == "jealousy":
+                    rel_above_threshold = [i for i in relevant_relationships if i.jealousy >= threshold]
+                elif v_type == "trust":
+                    rel_above_threshold = [i for i in relevant_relationships if i.trust >= threshold]
+
+                # if the lengths are not equal, one cat has not the relationship value which is needed to another cat of the patrol
+                if len(rel_above_threshold) + 1 != len(self.patrol_cats):
+                    fulfilled = False
                     break
 
-                threshold = 0
-                # try to extract the value/threshold from the text
-                try:
-                    threshold = int(tags[0].split('_')[1])
-                except Exception as e:
-                    print(
-                        f"ERROR: patrol {patrol_id} with the relationship constraint for the value {v_type} follows not the formatting guidelines.")
-                    break_loop = True
-                    break
+            if not fulfilled:
+                break_loop = True
+                break
 
-                if threshold > 100:
-                    print(
-                        f"ERROR: patrol {patrol_id} has a relationship constraints for the value {v_type}, which is higher than the max value of a relationship.")
-                    break_loop = True
-                    break
+        # if break is used in the loop, the condition are not fulfilled
+        # and this patrol should not be added to the filtered list
+        if break_loop:
+            return False
 
-                if threshold <= 0:
-                    print(
-                        f"ERROR: patrol {patrol_id} has a relationship constraints for the value {v_type}, which is lower than the min value of a relationship or 0.")
-                    break_loop = True
-                    break
-
-                # each cat has to have relationships with this relationship value above the threshold
-                fulfilled = True
-                for inter_cat in self.patrol_cats:
-                    rel_above_threshold = []
-                    patrol_cats_ids = [cat.ID for cat in self.patrol_cats]
-                    relevant_relationships = list(
-                        filter(lambda rel: rel.cat_to.ID in patrol_cats_ids and rel.cat_to.ID != inter_cat.ID,
-                               list(inter_cat.relationships.values())
-                               )
-                    )
-
-                    # get the relationships depending on the current value type + threshold
-                    if v_type == "romantic":
-                        rel_above_threshold = [i for i in relevant_relationships if i.romantic_love >= threshold]
-                    elif v_type == "platonic":
-                        rel_above_threshold = [i for i in relevant_relationships if i.platonic_like >= threshold]
-                    elif v_type == "dislike":
-                        rel_above_threshold = [i for i in relevant_relationships if i.dislike >= threshold]
-                    elif v_type == "comfortable":
-                        rel_above_threshold = [i for i in relevant_relationships if i.comfortable >= threshold]
-                    elif v_type == "jealousy":
-                        rel_above_threshold = [i for i in relevant_relationships if i.jealousy >= threshold]
-                    elif v_type == "trust":
-                        rel_above_threshold = [i for i in relevant_relationships if i.trust >= threshold]
-
-                    # if the lengths are not equal, one cat has not the relationship value which is needed to another cat of the patrol
-                    if len(rel_above_threshold) + 1 != len(self.patrol_cats):
-                        fulfilled = False
-                        break
-
-                if not fulfilled:
-                    break_loop = True
-                    break
-
-            # if break is used in the loop, the condition are not fulfilled
-            # and this patrol should not be added to the filtered list
-            if break_loop:
-                continue
-
-            filtered_patrols.append(patrol)
-
-        return filtered_patrols
+        return True
 
     def balance_hunting(self, possible_patrols: list):
         """Filter the incoming hunting patrol list to balance the different kinds of hunting patrols.
@@ -671,8 +671,8 @@ class Patrol():
                 decline_text=patrol["decline_text"],
                 chance_of_success=patrol["chance_of_success"],
                 exp=patrol["exp"],
-                min_cats=patrol["min_cats"],
-                max_cats=patrol["max_cats"],
+                min_cats=patrol["min_cats"] if "min_cats" in patrol else 1,
+                max_cats=patrol["max_cats"] if "max_cats" in patrol else 6,
                 win_skills=patrol["win_skills"] if "win_skills" in patrol else [],
                 win_trait=patrol["win_trait"] if "win_trait" in patrol else [],
                 fail_skills=patrol["fail_skills"] if "fail_skills" in patrol else [],
@@ -680,7 +680,9 @@ class Patrol():
                 antagonize_text=patrol["antagonize_text"] if "antagonize_text" in patrol else None,
                 antagonize_fail_text=patrol["antagonize_fail_text"] if "antagonize_fail_text" in patrol else None,
                 history_text=patrol["history_text"] if "history_text" in patrol else [],
-                relationship_constraint=patrol["relationship_constraint"] if "relationship_constraint" in patrol else [],
+                relationship_constraint=patrol[
+                    "relationship_constraint"] if "relationship_constraint" in patrol else [],
+                constraints=patrol["constraints"] if "constraints" in patrol else {},
                 other_clan=patrol["other_clan"] if "other_clan" in patrol else None
             )
 
@@ -1586,7 +1588,7 @@ class Patrol():
             # check for lethality
             if "non_lethal" in self.patrol_event.tags:
                 lethal = False
-            
+
             # poisons cats
             if "poison_clan" in self.patrol_event.tags:
                 self.living_cats = []
@@ -1655,7 +1657,8 @@ class Patrol():
         :param death: if you want the death history added set this to True, default is False
         """
         if not self.patrol_event.history_text:
-            print(f"WARNING: No history found for {self.patrol_event.patrol_id}, it may not need one but double check please!")
+            print(
+                f"WARNING: No history found for {self.patrol_event.patrol_id}, it may not need one but double check please!")
         if scar and "scar" in self.patrol_event.history_text:
             adjust_text = self.patrol_event.history_text['scar']
             adjust_text = adjust_text.replace("r_c", str(cat.name))
@@ -2037,7 +2040,7 @@ class Patrol():
 # ---------------------------------------------------------------------------- #
 
 
-class PatrolEvent():
+class PatrolEvent:
 
     def __init__(self,
                  patrol_id,
@@ -2060,6 +2063,7 @@ class PatrolEvent():
                  antagonize_fail_text="",
                  history_text=None,
                  relationship_constraint=None,
+                 constraints=None,
                  other_clan=None):
         self.patrol_id = patrol_id
         self.biome = biome or "Any"
@@ -2082,6 +2086,7 @@ class PatrolEvent():
         self.antagonize_fail_text = antagonize_fail_text
         self.other_clan = other_clan
         self.relationship_constraint = relationship_constraint if relationship_constraint else []
+        self.constraints = constraints if constraints else {}
 
 
 # ---------------------------------------------------------------------------- #

--- a/scripts/screens/patrol_screens.py
+++ b/scripts/screens/patrol_screens.py
@@ -7,7 +7,7 @@ import pygame_gui
 import ujson
 from .base_screens import Screens, cat_profiles
 from scripts.utility import get_text_box_theme, scale, get_personality_compatibility, check_relationship_value, \
-    get_omen_snippet_list, process_text, adjust_prey_abbr, adjust_patrol_text
+    get_special_snippet_list, process_text, adjust_prey_abbr, adjust_patrol_text
 from scripts.game_structure.image_button import UIImageButton, UISpriteButton
 from scripts.patrol import patrol
 from scripts.cat.cats import Cat

--- a/scripts/utility.py
+++ b/scripts/utility.py
@@ -776,7 +776,7 @@ def adjust_prey_abbr(patrol_text):
     return patrol_text
 
 
-def get_omen_snippet_list(chosen_list, amount, sense_groups=None, return_string=True):
+def get_special_snippet_list(chosen_list, amount, sense_groups=None, return_string=True):
     """
     function to grab items from various lists in snippet_collections.json
     list options are:
@@ -839,6 +839,45 @@ def get_omen_snippet_list(chosen_list, amount, sense_groups=None, return_string=
         return final_snippets
 
 
+def find_special_list_types(text):
+    """
+    purely to identify which senses are being called for by a snippet abbreviation
+    returns adjusted text, sense list, and list type
+    """
+    senses = []
+    list_type = None
+    if "omen_list" in text:
+        list_type = "omen_list"
+    if "prophecy_list" in text:
+        list_type = "prophecy_list"
+    if "dream_list" in text:
+        list_type = "dream_list"
+    if "clair_list" in text:
+        list_type = "clair_list"
+    if "story_list" in text:
+        list_type = "story_list"
+
+    if "_sight" in text:
+        senses.append("sight")
+        text.remove("_sight")
+    if "_sound" in text:
+        senses.append("sound")
+        text.remove("_sound")
+    if "_smell" in text:
+        text.remove("_smell")
+        senses.append("smell")
+    if "_emotional" in text:
+        text.remove("_emotional")
+        senses.append("emotional")
+    if "_touch" in text:
+        text.remove("_touch")
+        senses.append("touch")
+    if "_taste" in text:
+        text.remove("_taste")
+        senses.append("taste")
+    return text, senses, list_type
+
+
 def history_text_adjust(text,
                         other_clan_name,
                         clan):
@@ -851,6 +890,7 @@ def history_text_adjust(text,
     if "c_n" in text:
         text = text.replace("c_n", clan.name)
     return text
+
 
 def event_text_adjust(Cat,
                       text,
@@ -878,12 +918,15 @@ def event_text_adjust(Cat,
     if not keep_m_c and cat:
         cat_dict["m_c"] = (str(cat.name), choice(cat.pronouns))
         cat_dict["p_l"] = cat_dict["m_c"]
-    if cat:
-        if cat.accessory:
-            cat_dict["acc_plural"] = (str(ACC_DISPLAY[cat.accessory]["plural"]), None)
-            cat_dict["acc_singular"] = (str(ACC_DISPLAY[cat.accessory]["singular"]), None)
     if other_cat:
         cat_dict["r_c"] = (str(other_cat.name), choice(other_cat.pronouns))
+    if cat:
+        if cat.accessory:
+            if "acc_plural" in text:
+                text = text.replace("acc_plural", str(ACC_DISPLAY[cat.accessory]["plural"]))
+            if "acc_singular" in text:
+                text = text.replace("acc_singular", str(ACC_DISPLAY[cat.accessory]["singular"]))
+
     if other_clan_name:
         cat_dict["o_c"] = (other_clan_name, None)
     if new_cat:
@@ -911,22 +954,10 @@ def event_text_adjust(Cat,
     cat_dict["c_n"] = (_tmp + "Clan", None)
 
     # Dreams and Omens
-    if "omen_list" in text:
-        chosen_omens = get_omen_snippet_list("omen_list", randint(2, 4), sense_groups=["sight"])
-        cat_dict["omen_list"] = (chosen_omens, None)
-    if "prophecy_list" in text:
-        chosen_prophecy = get_omen_snippet_list("prophecy_list", randint(2, 4),
-                                                sense_groups=["sight", "emotional", "touch"])
-        cat_dict["prophecy_list"] = (chosen_prophecy, None)
-    if "dream_list" in text:
-        chosen_dream = get_omen_snippet_list("dream_list", randint(2, 4))
-        cat_dict["dream_list"] = (chosen_dream, None)
-    if "clair_list" in text:
-        chosen_clair = get_omen_snippet_list("clair_list", randint(2, 4))
-        cat_dict["clair_list"] = (chosen_clair, None)
-    if "story_list" in text:
-        chosen_story = get_omen_snippet_list("story_list", randint(1, 2))
-        cat_dict["story_list"] = (chosen_story, None)
+    text, senses, list_type = find_special_list_types(text)
+    if list_type:
+        chosen_items = get_special_snippet_list(list_type, randint(1, 3), sense_groups=senses)
+        text = text.replace(list_type, chosen_items)
 
     adjust_text = process_text(text, cat_dict)
 
@@ -1147,26 +1178,10 @@ def adjust_patrol_text(text, patrol):
                           'red squirrels', 'gray squirrels', 'rats', ]
     text = text.replace('f_mp_p', str(fst_midprey_plural))
 
-    sign_list = get_omen_snippet_list("omen_list", amount=randint(2, 4), return_string=False)
-    sign = choice(sign_list)
-    s = 0
-    pos = 0
-    for x in range(text.count('a_sign')):
-        index = text.index('a_sign', s) or text.index('a_sign.', s)
-        for y in vowels:
-            if str(sign).startswith(y):
-                modify = text.split()
-                if 'a_sign' in modify:
-                    pos = modify.index('a_sign')
-                if 'a_sign.' in modify:
-                    pos = modify.index('a_sign.')
-                if modify[pos - 1] == 'a':
-                    modify.remove('a')
-                    modify.insert(pos - 1, 'an')
-                text = " ".join(modify)
-                break
-        s += index + 3
-    text = text.replace('a_sign', str(sign))
+    text, senses, list_type = find_special_list_types(text)
+    if list_type:
+        sign_list = get_special_snippet_list(list_type, amount=randint(1, 2), sense_groups=senses)
+        text = text.replace('omen_list', str(sign_list))
 
     return text
 

--- a/scripts/utility.py
+++ b/scripts/utility.py
@@ -845,36 +845,38 @@ def find_special_list_types(text):
     returns adjusted text, sense list, and list type
     """
     senses = []
-    list_type = None
     if "omen_list" in text:
         list_type = "omen_list"
-    if "prophecy_list" in text:
+    elif "prophecy_list" in text:
         list_type = "prophecy_list"
-    if "dream_list" in text:
+    elif "dream_list" in text:
         list_type = "dream_list"
-    if "clair_list" in text:
+    elif "clair_list" in text:
         list_type = "clair_list"
-    if "story_list" in text:
+    elif "story_list" in text:
         list_type = "story_list"
+    else:
+        return text, None, None
 
     if "_sight" in text:
         senses.append("sight")
-        text.remove("_sight")
+        text = text.replace("_sight", "")
     if "_sound" in text:
-        senses.append("sound")
-        text.remove("_sound")
+        senses.append("_sight")
+        text = text.replace("_sight", "")
     if "_smell" in text:
-        text.remove("_smell")
+        text = text.replace("_smell", "")
         senses.append("smell")
     if "_emotional" in text:
-        text.remove("_emotional")
+        text = text.replace("_emotional", "")
         senses.append("emotional")
     if "_touch" in text:
-        text.remove("_touch")
+        text = text.replace("_touch", "")
         senses.append("touch")
     if "_taste" in text:
-        text.remove("_taste")
+        text = text.replace("_taste", "")
         senses.append("taste")
+
     return text, senses, list_type
 
 
@@ -1180,8 +1182,8 @@ def adjust_patrol_text(text, patrol):
 
     text, senses, list_type = find_special_list_types(text)
     if list_type:
-        sign_list = get_special_snippet_list(list_type, amount=randint(1, 2), sense_groups=senses)
-        text = text.replace('omen_list', str(sign_list))
+        sign_list = get_special_snippet_list(list_type, amount=randint(1, 3), sense_groups=senses)
+        text = text.replace(list_type, str(sign_list))
 
     return text
 


### PR DESCRIPTION
- fixed some miscellaneous crashes
- added some moon events
- added a clairvoyant patrol
- added trait and skill constraints to patrol: these allow you to make it so a patrol only shows up if the cat has the corresponding trait or skill
- changed how the relationship_constraints work a bit to help these two constraint things mesh better on patrols
- changed up how snippet lists were generated to allow you to specify the "sense" type of the snippet (aka if you only want smell based omens or touch based prophecies, you can specify that now)
- fixed newborns trying to give lives
- moved a couple war misc events into war.json instead cus they fit better there
- somehow some misc events got into death events? fixed
- wars can no longer start until the clan is at least 4 moons old