### PR TITLE
spaces, US english, typos

### DIFF
--- a/resources/dicts/conditions/healed_and_death_strings/illness_healed_strings.json
+++ b/resources/dicts/conditions/healed_and_death_strings/illness_healed_strings.json
@@ -52,7 +52,7 @@
     "heat stroke": [
         "m_c is no longer suffering from heat stroke.",
         "m_c has recovered from heat stroke.",
-        "m_c is feeling much better, {PRONOUN/m_c/poss}{VERB/m_c/'ve/'s} recovered from the heat stroke."
+        "m_c is feeling much better, {PRONOUN/m_c/subject}{VERB/m_c/'ve/'s} recovered from the heat stroke."
     ],
     "heat exhaustion": [
         "m_c has recovered from the heat exhaustion.",

--- a/resources/dicts/conditions/pregnancy.json
+++ b/resources/dicts/conditions/pregnancy.json
@@ -90,10 +90,10 @@
       "m_c chokes down the herbs given to {PRONOUN/m_c/object}, retching at the taste but knowing {PRONOUN/m_c/subject} {VERB/m_c/need/need} them to stop the blood loss. "
     ],
 	"outside_alone": [
-		"Rumour's reaches the clan, that m_c gave birth to a {insert}."
+		"Rumors reach the clan that m_c gave birth to a {insert}."
 	],
 	"outside_in_clan":[
-		"r_c heard a rumour, that m_c had a litter.",
+		"r_c heard a rumor that m_c had a litter.",
 		"r_c thinks that m_c should have had {PRONOUN/m_c/poss} litter by now."
 	],
 	"outside_death": [

--- a/resources/dicts/conditions/pregnancy.json
+++ b/resources/dicts/conditions/pregnancy.json
@@ -90,7 +90,7 @@
       "m_c chokes down the herbs given to {PRONOUN/m_c/object}, retching at the taste but knowing {PRONOUN/m_c/subject} {VERB/m_c/need/need} them to stop the blood loss. "
     ],
 	"outside_alone": [
-		"Rumors reach the clan that m_c gave birth to a {insert}."
+		"Rumors reach the Clan that m_c gave birth to a {insert}."
 	],
 	"outside_in_clan":[
 		"r_c heard a rumor that m_c had a litter.",

--- a/resources/dicts/events/ceremonies/ceremony-master.json
+++ b/resources/dicts/events/ceremonies/ceremony-master.json
@@ -697,7 +697,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "(prefix)kit runs up to the front of the crowd, eager to get {PRONOUN/m_c/poss} new name. When {PRONOUN/m_c/poss}{VERB/m_c/'re/'s} called m_c for the first time, p1 and p2's voices can be heard the loudest as the Clan welcomes the new apprentice."
+    "(prefix)kit runs up to the front of the crowd, eager to get {PRONOUN/m_c/poss} new name. When {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} called m_c for the first time, p1 and p2's voices can be heard the loudest as the Clan welcomes the new apprentice."
   ],
   "app_56": [
     [

--- a/resources/dicts/patrols/general/training.json
+++ b/resources/dicts/patrols/general/training.json
@@ -204,7 +204,7 @@
     "exp": 20,
     "success_text": [
         "p_l smiles, inviting app1 to sit down. The apprentice is a little stiff at first, unsure how to act in front of the warrior, but that's actually what p_l wants to work on here. c_n contains cats of all ages, skills, and talents - it's important to work on being comfortable with everyone, just as important as working on respecting them. They're all c_n, after all.",
-        "The pair sit down, app1 a little stiffly, and p_l starts telling them a story of their own apprenticehood, about a time when they made a dumb mistake. They make it sound funny - certianly funnier than it felt like at the time - and slowly, app1 opens up, still respectful, but less wooden in the way they act.",
+        "The pair sit down, app1 a little stiffly, and p_l starts telling them a story of their own apprenticehood, about a time when they made a dumb mistake. They make it sound funny - certainly funnier than it felt like at the time - and slowly, app1 opens up, still respectful, but less wooden in the way they act.",
         null,
         "It's important to take time to rest, s_c tells app1, trying to hit a middle ground between advice and command. They've seen how hard app1 has been working, and commend them for it, but it'll do the Clan no good if app1 burns themself out. All things in their time."
     ],
@@ -304,7 +304,7 @@
     "chance_of_success": 50,
     "exp": 20,
     "success_text": [
-        "With a deep sigh, p_l holds back their temper, and instead sits down to explain their reasoning to the young cat. They can see why app1 thinks differently, but practising this way will help app1 build muscle better than taking the cheap way out. app1 also sighs, apologising for their outburst.",
+        "With a deep sigh, p_l holds back their temper, and instead sits down to explain their reasoning to the young cat. They can see why app1 thinks differently, but practicing this way will help app1 build muscle better than taking the cheap way out. app1 also sighs, apologising for their outburst.",
         "Tired of hearing about how they don't understand, p_l swings around, performing a flawless rendition of the technique. Chastened, app1 lowers their gaze. They'll follow p_l's way of doing things then.",
         "p_l is able to defuse the moment with a joke, and sneak in a quiet remark that has app1 rethinking things. Still, it's not the most fun training session.",
         "This is unlike app1. s_c stops in their tracks, sitting their butt down in the middle of the path and refusing to move until app1 tells them what's bothering them. No, what's <i>actually</i> bothering them."
@@ -331,7 +331,7 @@
     "chance_of_success": 50,
     "exp": 20,
     "success_text": [
-        "With a deep sigh, p_l holds back their temper, and instead sits down to explain their reasoning to the young cat. They can see why app1 thinks differently, but practising this way will help app1 build muscle better than taking the cheap way out. app1 also sighs, apologising for their outburst.",
+        "With a deep sigh, p_l holds back their temper, and instead sits down to explain their reasoning to the young cat. They can see why app1 thinks differently, but practicing this way will help app1 build muscle better than taking the cheap way out. app1 also sighs, apologising for their outburst.",
         "Tired of hearing about how they don't understand, p_l swings around, performing a flawless rendition of the technique. Chastened, app1 lowers their gaze. They'll follow p_l's way of doing things then.",
         "p_l is able to defuse the moment with a joke, and sneak in a quiet remark that has app1 rethinking things. Still, it's not the most fun training session.",
         "s_c has taken valuable time out of their day to personally help app1 with their studies, and this is completely juvenile behaviour. s_c isn't shy about telling app1 so, and by the time they're back in camp the apprentice is cowed, but respectful once more. "
@@ -1028,7 +1028,7 @@
     "exp": 10,
     "success_text": [
         "As p_l and r_c run around c_n's territory, theoretically training, r_c feels wild and free and like {PRONOUN/r_c/subject}{VERB/r_c/'re/'s} going to burst with unexpected happiness! {PRONOUN/r_c/subject/CAP} {VERB/r_c/turn/turns} and {VERB/r_c/pounce/pounces} on p_l, starting a little play fight with their mock-prey.",
-        "As r_c creeps forward, practising {PRONOUN/r_c/poss} stalk, p_l notices {PRONOUN/r_c/poss} butt wiggling in excitement. {PRONOUN/p_l/subject/CAP} {VERB/p_l/laugh/laughs} to {PRONOUN/p_l/self} softly, and {VERB/p_l/pad/pads} over to give r_c a head's up about the bad habit.",
+        "As r_c creeps forward, practicing {PRONOUN/r_c/poss} stalk, p_l notices {PRONOUN/r_c/poss} butt wiggling in excitement. {PRONOUN/p_l/subject/CAP} {VERB/p_l/laugh/laughs} to {PRONOUN/p_l/self} softly, and {VERB/p_l/pad/pads} over to give r_c a head's up about the bad habit.",
         "s_c takes charge and coordinates exercises for the duo. They practice how to bring down prey together, their confidence and admiration for each other growing."
     ],
     "fail_text": [

--- a/scripts/screens/cat_screens.py
+++ b/scripts/screens/cat_screens.py
@@ -1443,18 +1443,18 @@ class ProfileScreen(Screens):
             if self.the_cat.status == 'leader' or death_number > 1:
 
                 if death_number > 2:
-                    deaths = f"{','.join(all_deaths[0:-1])}, and {all_deaths[-1]}"
+                    deaths = f"{', '.join(all_deaths[0:-1])}, and {all_deaths[-1]}"
                 elif death_number == 2:
                     deaths = " and ".join(all_deaths)
                 else:
                     deaths = all_deaths[0]
 
                 if self.the_cat.dead:
-                    insert = 'lost all {PRONOUN/m_c/poss} lives'
+                    insert = ' lost all {PRONOUN/m_c/poss} lives'
                 elif game.clan.leader_lives == 8:
-                    insert = 'lost a life'
+                    insert = ' lost a life'
                 else:
-                    insert = 'lost {PRONOUN/m_c/poss} lives'
+                    insert = ' lost {PRONOUN/m_c/poss} lives'
 
                 text = str(self.the_cat.name) + insert + " when {PRONOUN/m_c/subject} " + deaths + "."
             else:


### PR DESCRIPTION
Here's an example for why the spaces are needed in the leader death history:
![image](https://user-images.githubusercontent.com/16902966/233824212-36910886-1404-4b68-ad24-a857fdcd8b70.png)

also fixed a typo I found, and "practising" is not correct in US English afaik, which is what all user facing text should be right?

edit: oh yeah i also found some uses of "rumour" that I changed, also because of US English

edit 2: fixed this issue too in f296e4b
![image](https://user-images.githubusercontent.com/16902966/233825088-540d8386-54a5-4802-bf7b-419030b95a2d.png)
