### PR TITLE
Bugfixing

### DIFF
--- a/resources/dicts/events/death/beach/general.json
+++ b/resources/dicts/events/death/beach/general.json
@@ -51,7 +51,9 @@
         "camp": "camp3",
         "tags": ["Newleaf", "Greenleaf", "Leaf-fall", "Leaf-bare", "no_body"],
         "death_text": "m_c found {PRONOUN/m_c/self} staring at an odd shadow in the sea. One distracted paw slipped and {PRONOUN/m_c/subject} fell into the waves where something large and unseen tangled around {PRONOUN/m_c/object}, dragging {PRONOUN/m_c/object} into the abyss. ",
-        "history_text": ["m_c was taken by a mysterious sea creature.", null],
+        "history_text": {
+            "reg_death": "m_c was taken by a mysterious sea creature."
+        },
         "cat_trait": null,
         "cat_skill": null,
         "other_cat_trait": null,

--- a/resources/dicts/events/misc_events/general/kitten.json
+++ b/resources/dicts/events/misc_events/general/kitten.json
@@ -160,7 +160,7 @@
     },
     {
         "camp": "any",
-        "tags": ["Newleaf", "Greenleaf", "Leaf-fall", "Leaf-bare", "war", "clan_kits", "other_cat_parent", "mc_to_rc", "comfort"],
+        "tags": ["Newleaf", "Greenleaf", "Leaf-fall", "Leaf-bare", "war", "clan_kits", "other_cat", "other_cat_parent", "mc_to_rc", "comfort"],
         "event_text": "m_c is being comforted by r_c after having nightmares about the big, bad o_c cats."
     }
 ]

--- a/resources/dicts/patrols/general/border.json
+++ b/resources/dicts/patrols/general/border.json
@@ -184,7 +184,7 @@
     }
 },
 {
-    "patrol_id": "gen_bord_abandonedkittypet1",
+    "patrol_id": "gen_bord_abandonedkittypet1_kittypet4",
     "biome": "Any",
     "season": "Any",
     "tags": ["border", "new_cat_injury", "new_cat_kittypet", "nc_sickness",  "respect", "warrior"],

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -377,9 +377,7 @@ class Cat():
                 self.age = 'kitten'
             elif status == 'elder':
                 self.age = 'senior'
-            elif status == 'apprentice':
-                self.age = 'adolescent'
-            elif status == 'medicine cat apprentice':
+            elif status in ['apprentice', 'mediator apprentice', 'medicine cat apprentice']:
                 self.age = 'adolescent'
             else:
                 self.age = choice(['young adult', 'adult', 'adult', 'senior adult'])

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -594,6 +594,7 @@ class Cat():
             game.clan.add_to_starclan(self)
         elif game.clan.instructor.df is True:
             self.df = True
+            self.thought = "Is startled to find themselves wading in the muck of a shadowed forest"
             game.clan.add_to_darkforest(self)
 
         if game.clan.game_mode != 'classic':
@@ -601,6 +602,9 @@ class Cat():
 
         if not self.outside:
             Cat.dead_cats.append(self)
+        else:
+            self.thought = "Is fascinated by the new ghostly world they've stumbled into"
+            game.clan.add_to_unknown(self)
 
         return text
 
@@ -1221,10 +1225,10 @@ class Cat():
             if kitty.dead and kitty.status != 'newborn':
                 # check where they reside
                 if starclan:
-                    if kitty.ID not in game.clan.starclan_cats or kitty.outside:
+                    if kitty.ID not in game.clan.starclan_cats:
                         continue
                 else:
-                    if kitty.ID not in game.clan.darkforest_cats or kitty.outside:
+                    if kitty.ID not in game.clan.darkforest_cats:
                         continue
                 # guides aren't allowed here
                 if kitty == game.clan.instructor:
@@ -1265,7 +1269,7 @@ class Cat():
                     extra_givers = possible_sc_cats
                 else:
                     extra_givers = random.sample(possible_sc_cats, k=amount)
-            else:  #example printdddd
+            else:
                 print(game.clan.darkforest_cats)
                 possible_df_cats = [i for i in game.clan.darkforest_cats if
                                     i not in life_givers and

--- a/scripts/clan.py
+++ b/scripts/clan.py
@@ -55,6 +55,7 @@ class Clan():
     clan_cats = []
     starclan_cats = []
     darkforest_cats = []
+    unknown_cats = []
     seasons = [
         'Newleaf',
         'Newleaf',
@@ -584,6 +585,8 @@ class Clan():
             self.starclan_cats.append(cat.ID)
             if cat.ID in self.darkforest_cats:
                 self.darkforest_cats.remove(cat.ID)
+            if cat.ID in self.unknown_cats:
+                self.unknown_cats.remove(cat.ID)
             if cat.ID in self.med_cat_list:
                 self.med_cat_list.remove(cat.ID)
                 self.med_cat_predecessors += 1
@@ -594,16 +597,33 @@ class Clan():
         Places the dead cat into the dark forest.
         It should not be removed from the list of cats in the clan
         """
-        if cat.ID in Cat.all_cats and cat.dead and cat.df is True:
+        if cat.ID in Cat.all_cats and cat.dead and cat.df:
             self.darkforest_cats.append(cat.ID)
-            cat.thought = "Is distraught after being sent to the Place of No Stars"
             if cat.ID in self.starclan_cats:
                 self.starclan_cats.remove(cat.ID)
+            if cat.ID in self.unknown_cats:
+                self.unknown_cats.remove(cat.ID)
             if cat.ID in self.med_cat_list:
                 self.med_cat_list.remove(cat.ID)
                 self.med_cat_predecessors += 1
             # update_sprite(Cat.all_cats[str(cat)])
             # The dead-value must be set to True before the cat can go to starclan
+
+    def add_to_unknown(self, cat):
+        """
+        Places dead cat into the unknown residence.
+        It should not be removed from the list of cats in the clan
+        :param cat: cat object
+        """
+        if cat.ID in Cat.all_cats and cat.dead and cat.outside:
+            self.unknown_cats.append(cat.ID)
+            if cat.ID in self.starclan_cats:
+                self.starclan_cats.remove(cat.ID)
+            if cat.ID in self.darkforest_cats:
+                self.darkforest_cats.remove(cat.ID)
+            if cat.ID in self.med_cat_list:
+                self.med_cat_list.remove(cat.ID)
+                self.med_cat_predecessors += 1
 
     def add_to_clan(self, cat):
         """
@@ -1049,6 +1069,7 @@ class Clan():
                 game.clan.add_cat(Cat.all_cats[cat])
                 game.clan.add_to_starclan(Cat.all_cats[cat])
                 game.clan.add_to_darkforest(Cat.all_cats[cat])
+                game.clan.add_to_unknown(Cat.all_cats[cat])
             else:
                 print('WARNING: Cat not found:', cat)
         if "war" in clan_data:

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -891,7 +891,7 @@ class Events():
             if self.enemy_clan.temperament in ["mellow", "amiable", "gracious"]:
                 threshold = 3
 
-            threshold -= int(game.clan.war["duration"] / 1.5)
+            threshold -= int(game.clan.war["duration"])
             print('threshold', threshold)
 
             # check if war should conclude, if not, continue

--- a/scripts/patrol.py
+++ b/scripts/patrol.py
@@ -945,9 +945,9 @@ class Patrol():
         # setting the defaults
         new_name = choice([True, False])
         kit_backstory = None
-        if "new_cat_tom" in tags:
+        if "_tom" in tags:
             gender = 'male'
-        elif "new_cat_female" in tags:
+        elif "_female" in tags:
             gender = 'female'
         else:
             gender = None
@@ -964,24 +964,30 @@ class Patrol():
         loner = False
         kittypet = False
         other_clan = None
-        cat_type = None
 
-        if ("kittypet" or "loner" or "clancat" or "rogue") not in attribute_list:
+        if "kittypet" in attribute_list:
+            cat_type = "kittypet"
+        elif "loner" in attribute_list:
+            cat_type = "loner"
+        elif "clancat" in attribute_list:
+            cat_type = "former_clancat"
+        elif "rogue" in attribute_list:
+            cat_type = "rogue"
+        else:
             cat_type = choice(['kittypet', 'loner', 'former_clancat'])
-        if cat_type == 'kittypet' or "kittypet" in attribute_list:
+
+        if cat_type == 'kittypet':
             kittypet = True
             new_name = choice([True, False])
             chosen_backstory = Cat.backstory_categories["kittypet_backstories"]
             if "medcat" in attribute_list:
                 status = 'medicine cat'
                 chosen_backstory = ["wandering_healer1", "wandering_healer2"]
-            if "abandonedkittypet" in self.patrol_event.patrol_id:
-                chosen_backstory = ['kittypet4', 'kittypet4']
             if not success:
                 outsider = create_outside_cat(Cat, "kittypet", backstory=choice(chosen_backstory))
                 self.results_text.append(f"The Clan has met {outsider}.")
                 return
-        elif cat_type == 'loner' or "loner" in attribute_list:
+        elif cat_type == 'loner':
             loner = True
             new_name = choice([True, False])
             chosen_backstory = Cat.backstory_categories["loner_backstories"]
@@ -992,7 +998,7 @@ class Patrol():
                 outsider = create_outside_cat(Cat, "loner", backstory=choice(chosen_backstory))
                 self.results_text.append(f"The Clan has met {outsider}.")
                 return
-        elif cat_type == 'rogue' or 'rogue' in attribute_list:
+        elif cat_type == 'rogue':
             loner = True
             new_name = choice([True, False])
             chosen_backstory = Cat.backstory_categories["rogue_backstories"]
@@ -1003,7 +1009,7 @@ class Patrol():
                 outsider = create_outside_cat(Cat, "rogue", backstory=choice(chosen_backstory))
                 self.results_text.append(f"The Clan has met {outsider}.")
                 return
-        elif cat_type == 'clancat' or "clancat" in attribute_list:
+        elif cat_type == 'clancat':
             other_clan = self.other_clan
             new_name = False
             chosen_backstory = Cat.backstory_categories["former_clancat_backstories"]

--- a/scripts/screens/cat_screens.py
+++ b/scripts/screens/cat_screens.py
@@ -930,7 +930,6 @@ class ProfileScreen(Screens):
                     else:
                         output += 'former mate: ' + prev_mates[0]
 
-
         if not the_cat.dead:
             # NEWLINE ----------
             output += "\n"
@@ -1995,7 +1994,7 @@ class ProfileScreen(Screens):
                     starting_height=2, manager=MANAGER)
                 self.exile_cat_button.disable()
 
-            if not self.the_cat.dead and not self.the_cat.exiled and not self.the_cat.outside:
+            if not self.the_cat.dead:
                 self.kill_cat_button.enable()
             else:
                 self.kill_cat_button.disable()

--- a/scripts/screens/world_screens.py
+++ b/scripts/screens/world_screens.py
@@ -462,8 +462,7 @@ class UnknownResScreen(Screens):
     def get_dead_cats(self):
         self.dead_cats = []
         for the_cat in Cat.all_cats_list:
-            if the_cat.dead and the_cat.ID != game.clan.instructor.ID and not the_cat.faded \
-            and (the_cat.outside):
+            if the_cat.ID in game.clan.unknown_cats:
                 self.dead_cats.append(the_cat)
 
     def screen_switches(self):


### PR DESCRIPTION
- Unknown Residence now has it's own list just like the SC and DF cats do. This fixes the problem with them sneaking into life giving ceremonies and sets the foundation for a "send to unknown residence" button in the future
- Fixed various crashes
- Mediator Apprentice guides will now have an appropriate age for their rank
- New cats found on patrol will now have the correct kittypet/loner/rogue type
- Patrols with relationship constraints are now working again