### PR TITLE
Add multi-line support to Debug, change certain commands slightly

### DIFF
--- a/scripts/debugmode.py
+++ b/scripts/debugmode.py
@@ -96,7 +96,7 @@ class debugConsole(pygame_gui.windows.UIConsoleWindow):
                 if len(args) == 2:
                     if args[0] in self.debug_class.settings:
                         try:
-                            if args[1] in ['true', 'false']:
+                            if args[1].lower() in ['true', 'false']:
                                 args[1] = args[1].capitalize()
                             self.debug_class.settings[args[0]] = literal_eval(args[1])
                             self.add_output_line_to_log(f"{args[0]} set to {args[1]}")
@@ -105,7 +105,7 @@ class debugConsole(pygame_gui.windows.UIConsoleWindow):
                     else:
                         self.add_output_line_to_log(f"Unknown setting {args[0]}")
                 elif len(args) == 3:
-                    if args[2] in ['true', 'false']:
+                    if args[2].lower() in ['true', 'false']:
                         args[2] = args[2].capitalize()
                     if args[0] == 'game':
                         if args[1] in game.settings:

--- a/scripts/debugmode.py
+++ b/scripts/debugmode.py
@@ -18,7 +18,17 @@ class debugConsole(pygame_gui.windows.UIConsoleWindow):
         # Force it to print help txt
         ev = pygame.event.Event(pygame_gui.UI_CONSOLE_COMMAND_ENTERED, {"command": "help"})
         self.process_event(ev)
-    
+
+    def add_multiple_lines_to_log(self, lines: str):
+        """Function to add multiple lines from a mutliline string to the log. 
+        Automatically trims whitespace.
+
+        Args:
+            lines (str)
+        """
+        for line in lines.split("\n"):
+            self.add_output_line_to_log(line.strip())
+
     def process_event(self, event):
         if event.type == pygame_gui.UI_CONSOLE_COMMAND_ENTERED:
             command = event.command.split(" ")
@@ -28,26 +38,26 @@ class debugConsole(pygame_gui.windows.UIConsoleWindow):
             # TODO: Use a switch statement here once we phase out python 3.7    pylint: disable=fixme
 
             if command == "help":
-                self.add_output_line_to_log("Available commands:")
-                self.add_output_line_to_log("help")
-                self.add_output_line_to_log("toggle <setting>")
-                self.add_output_line_to_log("toggle game <setting>")
-                self.add_output_line_to_log("toggle switch <setting>")
-                self.add_output_line_to_log("set <setting> <value>")
-                self.add_output_line_to_log("set game <setting> <value>")
-                self.add_output_line_to_log("set switch <setting> <value>")
-                self.add_output_line_to_log("get <setting>")
-                self.add_output_line_to_log("get game <setting>")
-                self.add_output_line_to_log("get switch <setting>")
-                self.add_output_line_to_log("eval <code>")
-                self.add_output_line_to_log("understandrisks")
-                self.add_output_line_to_log("fps")
-                self.add_output_line_to_log("fps <value>")
-                self.add_output_line_to_log("clear")
-                self.add_output_line_to_log("")
-                self.add_output_line_to_log("You can obtain a list of all settings by typing \"get\", \"get game\", and \"get switch\".")
-                self.add_output_line_to_log("")
-                self.add_output_line_to_log("Note: You can use tab to autocomplete commands, up/down to scroll through history, in eval scripts you can use \\n to create a new line.")
+                self.add_multiple_lines_to_log("""Available commands:
+                                                  help
+                                                  toggle <setting>
+                                                  toggle game <setting>
+                                                  toggle switch <setting>
+                                                  set <setting> <value>
+                                                  set game <setting> <value>
+                                                  set switch <setting> <value>
+                                                  get <setting>
+                                                  get game <setting>
+                                                  get switch <setting>
+                                                  eval <code>
+                                                  understandrisks
+                                                  fps
+                                                  fps <value>
+                                                  clear
+                                                  
+                                                  You can obtain a list of all settings by typing \"get\", \"get game\", and \"get switch\".
+
+                                                  Note: You can use tab to autocomplete commands, up/down to scroll through history, in eval scripts you can use \\n to create a new line.""")
 
 
 
@@ -73,11 +83,11 @@ class debugConsole(pygame_gui.windows.UIConsoleWindow):
                         else:
                             self.add_output_line_to_log(f"Unknown switch {args[1]}")
                 else:
-                    self.add_output_line_to_log("Invalid syntax")
-                    self.add_output_line_to_log("Usage:")
-                    self.add_output_line_to_log("toggle <setting>")
-                    self.add_output_line_to_log("toggle game <setting>")
-                    self.add_output_line_to_log("toggle switch <setting>")
+                    self.add_multiple_lines_to_log("""Invalid syntax
+                                                      Usage:
+                                                      toggle <setting>
+                                                      toggle game <setting>
+                                                      toggle switch <setting>""")
 
 
 
@@ -86,6 +96,8 @@ class debugConsole(pygame_gui.windows.UIConsoleWindow):
                 if len(args) == 2:
                     if args[0] in self.debug_class.settings:
                         try:
+                            if args[1] in ['true', 'false']:
+                                args[1] = args[1].capitalize()
                             self.debug_class.settings[args[0]] = literal_eval(args[1])
                             self.add_output_line_to_log(f"{args[0]} set to {args[1]}")
                         except:
@@ -93,6 +105,8 @@ class debugConsole(pygame_gui.windows.UIConsoleWindow):
                     else:
                         self.add_output_line_to_log(f"Unknown setting {args[0]}")
                 elif len(args) == 3:
+                    if args[2] in ['true', 'false']:
+                        args[2] = args[2].capitalize()
                     if args[0] == 'game':
                         if args[1] in game.settings:
                             try:
@@ -112,12 +126,12 @@ class debugConsole(pygame_gui.windows.UIConsoleWindow):
                         else:
                             self.add_output_line_to_log(f"Unknown switch {args[1]}")
                 else:
-                    self.add_output_line_to_log("Invalid syntax")
-                    self.add_output_line_to_log("Usage:")
-                    self.add_output_line_to_log("set <setting> <value>")
-                    self.add_output_line_to_log("set game <setting> <value>")
-                    self.add_output_line_to_log("set switch <setting> <value>")
-            
+                    self.add_multiple_lines_to_log("""Invalid syntax
+                                                      Usage:
+                                                      set <setting> <value>
+                                                      set game <setting> <value>
+                                                      set switch <setting> <value>""")
+
 
 
 
@@ -131,7 +145,7 @@ class debugConsole(pygame_gui.windows.UIConsoleWindow):
                 if len(args) == 1:
                     if args[0] in self.debug_class.settings:
                         self.add_output_line_to_log(f"{args[0]} is {self.debug_class.settings[args[0]]}")
-                    
+
                     elif args[0] == 'game':
                         self.add_output_line_to_log("Gamesettings:")
                         for setting, val in game.settings.items():
@@ -142,7 +156,7 @@ class debugConsole(pygame_gui.windows.UIConsoleWindow):
                             self.add_output_line_to_log(f"{setting} is {val}")
                     else:
                         self.add_output_line_to_log(f"Unknown setting {args[0]}")
-                
+
                 elif len(args) == 2:
                     if args[0] == 'game':
                         if args[1] in game.settings:
@@ -155,24 +169,24 @@ class debugConsole(pygame_gui.windows.UIConsoleWindow):
                         else:
                             self.add_output_line_to_log(f"Unknown switch {args[1]}")
                 else:
-                    self.add_output_line_to_log("Invalid syntax")
-                    self.add_output_line_to_log("Usage:")
-                    self.add_output_line_to_log("get")
-                    self.add_output_line_to_log("get <setting>")
-                    self.add_output_line_to_log("get game")
-                    self.add_output_line_to_log("get game <setting>")
-                    self.add_output_line_to_log("get switch")
-                    self.add_output_line_to_log("get switch <setting>")
-            
+                    self.add_multiple_lines_to_log("""Invalid syntax
+                                                      Usage:
+                                                      get
+                                                      get <setting>
+                                                      get game
+                                                      get game <setting>
+                                                      get switch
+                                                      get switch <setting>""")
+
 
 
 
             elif command == "eval":
                 if not self.accepted_eval_warning:
-                    self.add_output_line_to_log("WARNING: This command can be used to run code in your game. Only use this if you know what you're doing.")
-                    self.add_output_line_to_log("If you have been told to use this by anyone other than the official clangen discord contributors, BLOCK THEM IMMEDIATELY.")
-                    self.add_output_line_to_log("If you are not sure what this means, DO NOT USE THIS COMMAND.")
-                    self.add_output_line_to_log("To disable this warning, type \"understandrisks\".")
+                    self.add_multiple_lines_to_log("""WARNING: This command can be used to run code in your game. Only use this if you know what you're doing.
+                                                      If you have been told to use this by anyone other than the official clangen discord contributors, BLOCK THEM IMMEDIATELY.
+                                                      If you are not sure what this means, DO NOT USE THIS COMMAND.
+                                                      To disable this warning, type \"understandrisks\".""")
                     self.accepted_eval_warning = True
                 else:
                     def print(*args, **kwargs): # pylint: disable=redefined-builtin
@@ -198,28 +212,31 @@ class debugConsole(pygame_gui.windows.UIConsoleWindow):
                 self.accepted_eval_warning = True
 
 
-            
+
             elif command == "fps":
                 if len(args) == 1:
-                    try:
+                    if args[0] in ['None', 'none', '0']:
+                        game.switches['fps'] = 0
+                        self.add_output_line_to_log("FPS cap removed")
+                    elif args[0].is_integer():
                         game.switches['fps'] = int(args[0])
-                        self.add_output_line_to_log(f"FPS set to {args[0]}")
-                    except:
-                        self.add_output_line_to_log(f"Invalid value {args[0]}")
+                        self.add_output_line_to_log(f"FPS cap set to {args[0]}")
+                    else:
+                        self.add_output_line_to_log(f"Invalid value, {args[0]}")
                 elif len(args) == 0:
-                    self.add_output_line_to_log(f"FPS is {game.switches['fps']}")
+                    self.add_output_line_to_log(f"FPS cap is set to {game.switches['fps']}")
                 else:
-                    self.add_output_line_to_log("Invalid syntax")
-                    self.add_output_line_to_log("Usage:")
-                    self.add_output_line_to_log("fps")
-                    self.add_output_line_to_log("fps <value>")
+                    self.add_multiple_lines_to_log("""Invalid syntax
+                                                      Usage:
+                                                      fps
+                                                      fps <value>""")
 
             elif command == "clear":
                 self.clear_log()
 
             else:
                 self.add_output_line_to_log(f"Unknown command {command}")
-        
+
         elif event.type == pygame.KEYDOWN and event.key == pygame.K_TAB:
             cmds = [
                 "help",
@@ -241,10 +258,10 @@ class debugConsole(pygame_gui.windows.UIConsoleWindow):
                         self.command_entry.set_text(f"{cmd}")
                         break
 
-        
+
         return super().process_event(event)
 
-    
+
 
 
 class debugMode:
@@ -278,7 +295,7 @@ class debugMode:
         self.coords_display.disable()
         self.coords_display.rebuild()
         self.coords_display.hide()
-    
+
 
     def toggle_console(self):
         if self.console.visible == 0:
@@ -290,7 +307,7 @@ class debugMode:
             self.console.hide()
             self.console.set_blocking(False)
             game.switches['window_open'] = False
-        
+
 
     def update1(self, clock):
         """
@@ -301,7 +318,7 @@ class debugMode:
         if self.settings['showcoords']:
             if self.coords_display.visible == 0:
                 self.coords_display.show()
-            
+
             _ = pygame.mouse.get_pos()
             if game.settings['fullscreen']:
                 self.coords_display.set_text(f"({_[0]}, {_[1]})")
@@ -314,18 +331,18 @@ class debugMode:
                 self.coords_display.hide()
                 self.coords_display.set_text("(0, 0)")
                 self.coords_display.set_position((0, 0))
-        
+
 
         if self.settings['showfps']:
             if self.fps_display.visible == 0:
                 self.fps_display.show()
-            
+
             self.fps_display.set_text(f"{round(clock.get_fps(), 2)} fps")
         else:
             if self.fps_display.visible == 1:
                 self.fps_display.hide()
                 self.fps_display.set_text("(0, 0)")
-        
+
         # Showbounds
 
 
@@ -338,7 +355,7 @@ class debugMode:
             if MANAGER.visual_debug_active:
                 MANAGER.set_visual_debug_mode(False)
 
-    
+
     def update2(self, screen):
 
         if self.settings['showbounds']:

--- a/scripts/debugmode.py
+++ b/scripts/debugmode.py
@@ -215,7 +215,7 @@ class debugConsole(pygame_gui.windows.UIConsoleWindow):
 
             elif command == "fps":
                 if len(args) == 1:
-                    if args[0] in ['None', 'none', '0']:
+                    if args[0].lower() in ['none', 'null', '0'] or args[0].is_integer() and int(args[0]) <= 0:
                         game.switches['fps'] = 0
                         self.add_output_line_to_log("FPS cap removed")
                     elif args[0].is_integer():


### PR DESCRIPTION
Adds a new method, `add_multiple_lines_to_log`, that allows for printing `"""multi-line blocks"""`, and automatically trims whitespace from them
Command changes include:
 - Setting FPS to (case insensitive) 'none', 'null', '0', or any negative number will print a message saying the FPS cap was removed
 - SET and GET commands now allows for (case insensitive) "true" and "false", not just 1/0 True/False