### PR TITLE
itch: Fix itch toml for linux

### DIFF
--- a/.itch.toml
+++ b/.itch.toml
@@ -1,4 +1,11 @@
 [[actions]]
 name = "play"
+platform = "windows"
 path = "Clangen/Clangen.exe"
+args = ["--launched-through-itch"]
+
+[[actions]]
+name = "play"
+platform = "linux"
+path = "Clangen/Clangen"
 args = ["--launched-through-itch"]


### PR DESCRIPTION
Can specify platform so it doesn't refer to files that don't exist. I don't know if anyone's using the itch.io app on Linux, but it doesn't hurt to fix this issue.