### PR TITLE
Bugfixes: Print Remove, Bug Fix

### DIFF
--- a/resources/dicts/events/misc_events/general/elder.json
+++ b/resources/dicts/events/misc_events/general/elder.json
@@ -66,7 +66,7 @@
       {
         "camp": "any",
         "tags": ["Newleaf", "Greenleaf", "Leaf-fall", "Leaf-bare"],
-        "event_text": "m_c awakens with multiple objects stacked on {PRONOUN/m_c/objective}, and the sound of giggling cats in the distance.",
+        "event_text": "m_c awakens with multiple objects stacked on {PRONOUN/m_c/object}, and the sound of giggling cats in the distance.",
         "cat_trait": null,
         "cat_skill": null,
         "other_cat_trait": null,

--- a/resources/dicts/thoughts/alive/alive_outside/kitten.json
+++ b/resources/dicts/thoughts/alive/alive_outside/kitten.json
@@ -1,9 +1,11 @@
-{
-    "id": "lost_kitten_thoughts",
-    "thoughts": [
-        "Misses playing moss ball",
-        "Is looking desperately for {PRONOUN/m_c/poss} parent",
-        "Misses the warm smells of the nursery",
-        "Feels hungrier than {PRONOUN/m_c/subject}{VERB/m_c/'ve/'s} ever felt before"
-    ]
-}
+[
+    {
+        "id": "lost_kitten_thoughts",
+        "thoughts": [
+            "Misses playing moss ball",
+            "Is looking desperately for {PRONOUN/m_c/poss} parent",
+            "Misses the warm smells of the nursery",
+            "Feels hungrier than {PRONOUN/m_c/subject}{VERB/m_c/'ve/'s} ever felt before"
+        ]
+    }
+]

--- a/resources/dicts/thoughts/dead/darkforest/loner.json
+++ b/resources/dicts/thoughts/dead/darkforest/loner.json
@@ -1,13 +1,15 @@
-[{
-    "id": "general_loner_dead_thoughts",
-    "thoughts": [
-        "Feels a sharp pang of hunger",
-        "Wonders how {PRONOUN/m_c/subject} ended up here",
-        "Winces as the mud sucks at {PRONOUN/m_c/poss} paws",
-        "Is looking fruitlessly for prey",
-        "Yowls angrily"
-    ],
-    "main_status_constraint": [
-        "loner"
-    ]
-}]
+[
+    {
+        "id": "general_loner_dead_thoughts",
+        "thoughts": [
+            "Feels a sharp pang of hunger",
+            "Wonders how {PRONOUN/m_c/subject} ended up here",
+            "Winces as the mud sucks at {PRONOUN/m_c/poss} paws",
+            "Is looking fruitlessly for prey",
+            "Yowls angrily"
+        ],
+        "main_status_constraint": [
+            "loner"
+        ]
+    }
+]

--- a/resources/dicts/thoughts/dead/darkforest/rogue.json
+++ b/resources/dicts/thoughts/dead/darkforest/rogue.json
@@ -1,12 +1,14 @@
-[{
-    "id": "general_rogue_dead_thoughts",
-    "thoughts": [
-        "Growls viciously at anything that moves",
-        "Ignores the pain in {PRONOUN/m_c/poss} belly",
-        "Thinks about how {PRONOUN/m_c/subject}'d kill for some prey right now",
-        "Hisses at the muck squelching beneath {PRONOUN/m_c/poss} toes"
-    ],
-    "main_status_constraint": [
-        "rogue"
-    ]
-}]
+[
+    {
+        "id": "general_rogue_dead_thoughts",
+        "thoughts": [
+            "Growls viciously at anything that moves",
+            "Ignores the pain in {PRONOUN/m_c/poss} belly",
+            "Thinks about how {PRONOUN/m_c/subject}'d kill for some prey right now",
+            "Hisses at the muck squelching beneath {PRONOUN/m_c/poss} toes"
+        ],
+        "main_status_constraint": [
+            "rogue"
+        ]
+    }
+]

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -1241,8 +1241,8 @@ class Cat():
         # sort relations by the strength of their relationship
         dead_relations.sort(
             key=lambda rel: rel.romantic_love + rel.platonic_like + rel.admiration + rel.comfortable + rel.trust, reverse=True)
-        for rel in dead_relations:
-            print(self.fetch_cat(rel.cat_to).name)
+        #for rel in dead_relations:
+        #    print(self.fetch_cat(rel.cat_to).name)
 
         # if we have relations, then make sure we only take the top 8
         if dead_relations:
@@ -1273,7 +1273,7 @@ class Cat():
                 else:
                     extra_givers = random.sample(possible_sc_cats, k=amount)
             else:
-                print(game.clan.darkforest_cats)
+                #print(game.clan.darkforest_cats)
                 possible_df_cats = [i for i in game.clan.darkforest_cats if
                                     self.fetch_cat(i) and
                                     i not in life_givers and

--- a/scripts/events_module/condition_events.py
+++ b/scripts/events_module/condition_events.py
@@ -162,7 +162,7 @@ class Condition_Events():
                         involved_cats.append(other_cat.ID)
                         self.handle_relationship_changes(cat, injury_event, other_cat)
 
-                    print(injury_event.event_text)
+                    #print(injury_event.event_text)
                     text = event_text_adjust(Cat, injury_event.event_text, cat, other_cat, other_clan_name)
 
                     if game.clan.game_mode == "classic":
@@ -518,7 +518,7 @@ class Condition_Events():
                     try:
                         # gather potential event strings for gotten condition
                         possible_string_list = INJURY_HEALED_STRINGS[injury]
-                        random_index = int(random.random() * len(possible_string_list))
+                        random_index = random.randrange(0, len(possible_string_list))
                         event = possible_string_list[random_index]
                     except KeyError:
                         print(
@@ -539,18 +539,22 @@ class Condition_Events():
                     possible_string_list = PERMANENT_CONDITION_GOT_STRINGS[injury][condition_got]
 
                     # choose event string and ensure clan's med cat number aligns with event text
-                    random_index = int(random.random() * len(possible_string_list))
+                    random_index = random.randrange(0, len(possible_string_list))
+                    
                     med_list = get_med_cats(Cat)
-                    med_cat = None
-                    if len(med_list) == 0:
-                        if random_index == 0 or random_index == 1:
-                            random_index = 2
-                        else:
-                            med_cat = None
-                    else:
+                    #If the cat is a med cat, don't conister them as one for the event. 
+                    if cat in med_list:
+                        med_list.remove(cat)
+                    
+                    #Choose med cat, if you can
+                    if med_list:
                         med_cat = random.choice(med_list)
-                        if med_cat == cat:
-                            random_index = 2
+                    else:
+                        med_cat = None
+                    
+                    if not med_cat and random_index < 2 and len(possible_string_list) >= 3:
+                        random_index = 2
+        
                     event = possible_string_list[random_index]
                     event = event_text_adjust(Cat, event, cat, other_cat=med_cat)  # adjust the text
                 if event is not None:

--- a/scripts/events_module/death_events.py
+++ b/scripts/events_module/death_events.py
@@ -40,7 +40,7 @@ class Death_Events():
             other_clan_name = f'{other_clan.name}Clan'
 
         possible_short_events = self.generate_events.possible_short_events(cat.status, cat.age, "death")
-        print('death event', cat.ID)
+        #print('death event', cat.ID)
         final_events = self.generate_events.filter_possible_short_events(possible_short_events, cat, other_cat, war,
                                                                          enemy_clan,
                                                                          other_clan, alive_kits, murder=murder)
@@ -54,7 +54,7 @@ class Death_Events():
             print('WARNING: no death events found for', cat.name)
             return
         death_text = event_text_adjust(Cat, death_cause.event_text, cat, other_cat, other_clan_name)
-        print(death_text)
+        #print(death_text)
         additional_event_text = ""
 
         # assign default history

--- a/scripts/events_module/disaster_events.py
+++ b/scripts/events_module/disaster_events.py
@@ -42,7 +42,7 @@ class DisasterEvents():
         final_events = []
 
         for event in possible_events:
-            print(event.event)
+            #print(event.event)
             if event.priority == 'secondary':
                 print('priority')
                 continue
@@ -120,7 +120,7 @@ class DisasterEvents():
                         picked_disasters.append(potential_disaster)
 
                 if picked_disasters:
-                    print(picked_disasters)
+                    #print(picked_disasters)
                     # choose disaster and display trigger event
                     secondary_disaster = random.choice(picked_disasters)
                     print("chosen secondary", secondary_disaster)

--- a/scripts/events_module/generate_events.py
+++ b/scripts/events_module/generate_events.py
@@ -157,9 +157,9 @@ class GenerateEvents:
                 event = None
                 for event in events_dict:
                     if event["event"] != specific_event:
-                        print(event["event"], 'is not', specific_event)
+                        #print(event["event"], 'is not', specific_event)
                         continue
-                    print(event["event"], "is", specific_event)
+                    #print(event["event"], "is", specific_event)
                     event = OngoingEvent(
                         event=event["event"],
                         camp=event["camp"],
@@ -173,7 +173,7 @@ class GenerateEvents:
                         collateral_damage=event["collateral_damage"]
                     )
                     break
-                print(event)
+                #print(event)
                 return event
 
     def possible_short_events(self, cat_type=None, age=None, event_type=None):
@@ -460,7 +460,7 @@ class GenerateEvents:
                     final_events = major
                 else:
                     final_events = severe
-                print(cat.status, severity_chosen[0])
+                #print(cat.status, severity_chosen[0])
 
         return final_events
 
@@ -482,7 +482,7 @@ class GenerateEvents:
                 )"""
                 return event_list
             else:
-                print(specific_event)
+                #print(specific_event)
                 event = (
                     self.generate_ongoing_events(event_type, biome, specific_event)
                 )

--- a/scripts/events_module/misc_events.py
+++ b/scripts/events_module/misc_events.py
@@ -42,7 +42,7 @@ class MiscEvents():
 
             acc_checked_events.append(event)
 
-        print('misc event', cat.ID)
+        #print('misc event', cat.ID)
         final_events = self.generate_events.filter_possible_short_events(acc_checked_events, cat, other_cat, war, enemy_clan, other_clan,
                                                                    alive_kits)
 

--- a/scripts/utility.py
+++ b/scripts/utility.py
@@ -908,7 +908,6 @@ def ongoing_event_text_adjust(Cat, text, clan=None, other_clan_name=None):
         cat_dict["dep_name"] = (str(kitty.name), choice(kitty.pronouns))
     if "med_name" in text:
         kitty = choice(get_med_cats(Cat, working=False))
-        print('med', kitty)
         cat_dict["med_name"] = (str(kitty.name), choice(kitty.pronouns))
 
     if cat_dict:

--- a/scripts/utility.py
+++ b/scripts/utility.py
@@ -1409,9 +1409,11 @@ def generate_sprite(cat, life_state=None, scars_hidden=False, acc_hidden=False, 
         # draw skin and scars2
         blendmode = pygame.BLEND_RGBA_MIN
         new_sprite.blit(sprites.sprites['skin' + cat.skin + cat_sprite], (0, 0))
-        for scar in cat.scars:
-            if scar in scars2:
-                new_sprite.blit(sprites.sprites['scars' + scar + cat_sprite], (0, 0), special_flags=blendmode)
+        
+        if not scars_hidden:
+            for scar in cat.scars:
+                if scar in scars2:
+                    new_sprite.blit(sprites.sprites['scars' + scar + cat_sprite], (0, 0), special_flags=blendmode)
 
         # draw accessories
         if not acc_hidden:        


### PR DESCRIPTION
- Unchecking "show scars(s)" on the sprite inspect screen now properly hides missing-part scars. 
- Commented out some prints
- Fixed a crash that rarely occurred with perm condition events.  
- Fixed issues with lost kit thoughts. 
- Fixed a pronoun issue. 