### PR TITLE
change: tints

### DIFF
--- a/sprites/dicts/tint.json
+++ b/sprites/dicts/tint.json
@@ -13,20 +13,21 @@
     "GOLDEN": "warm",
     "GINGER": "warm",
     "DARKGINGER": "warm",
-    "SIENNA": "warm",
-    "LIGHTBROWN": "warm",
-    "LILAC": "warm",
-    "BROWN": "warm",
-    "GOLDEN-BROWN": "warm",
-    "DARKBROWN": "warm",
-    "CHOCOLATE": "warm"
+    "SIENNA": "brown",
+    "LIGHTBROWN": "brown",
+    "LILAC": "brown",
+    "BROWN": "brown",
+    "GOLDEN-BROWN": "brown",
+    "DARKBROWN": "brown",
+    "CHOCOLATE": "brown"
   },
   "possible_tints": {
-    "basic": ["pink", "gray", "red", "black", "orange", "none"],
+    "basic": ["pink", "gray", "red", "orange", "none"],
     "warm": ["yellow", "purple"],
-    "cool": ["blue", "purple"],
+    "cool": ["blue", "purple", "black"],
     "white": ["yellow"],
-    "monochrome": ["blue"]
+    "monochrome": ["blue", "black"],
+    "brown": ["yellow", "purple", "black"]
   },
   "tint_colours":
   {


### PR DESCRIPTION
changes to possible_tints that were previously discussed and then i forgor about them for way too long
-made the browns into their own category: brown (how creative) 
-removed black from basic tints and added it to the cool, monochrome, and brown categories 
-possible_tints for brown are yellow, purple, and black in addition to the basic tints