### PR TITLE
Fix: Some crashes

### DIFF
--- a/scripts/housekeeping/log_cleanup.py
+++ b/scripts/housekeeping/log_cleanup.py
@@ -1,4 +1,5 @@
 import os
+import traceback
 
 from scripts.housekeeping.datadir import get_log_dir
 
@@ -17,6 +18,9 @@ def prune_logs(logs_to_keep: int, retain_empty_logs: bool):
             log_list[log_type] = 1
         else:
             if log_list[log_type] >= logs_to_keep or not retain_empty_logs and os.stat(f"{get_log_dir()}/{log_file}").st_size == 0:
-                os.remove(f"{get_log_dir()}/{log_file}")
+                try:
+                    os.remove(f"{get_log_dir()}/{log_file}")
+                except PermissionError:
+                    traceback.print_exc()
             else:
                 log_list[log_type] += 1

--- a/scripts/patrol.py
+++ b/scripts/patrol.py
@@ -790,7 +790,7 @@ class Patrol():
 
             try:
                 self.final_success = self.patrol_event.success_text[outcome]
-            except IndexError:
+            except KeyError:
                 self.final_success = self.patrol_event.success_text["unscathed_common"]
 
             if antagonize:


### PR DESCRIPTION
* Catches `PermissionError` on log cleanup so the game doesn't crash if the file's still open somewhere else.
* Fixes patrol KeyError crash. When patrols changed format, the outcomes became a dictionary, so it throws a KeyError instead of an IndexError on fail.