### PR TITLE
QOL: Clan creation

### DIFF
--- a/scripts/screens/clan_creation_screens.py
+++ b/scripts/screens/clan_creation_screens.py
@@ -713,6 +713,7 @@ class MakeClanScreen(Screens):
                 self.elements["cat" + str(u)] = UISpriteButton(
                     scale(pygame.Rect((column_poss[0], 260 + 100 * u), (100, 100))),
                     game.choose_cats[u].sprite,
+                    tool_tip_text=self._get_cat_tooltip_string(game.choose_cats[u]),
                     cat_object=game.choose_cats[u], manager=MANAGER)
         for u in range(6, 12):
             if "cat" + str(u) in self.elements:
@@ -732,7 +733,13 @@ class MakeClanScreen(Screens):
                 self.elements["cat" + str(u)] = UISpriteButton(
                     scale(pygame.Rect((column_poss[1], 260 + 100 * (u - 6)), (100, 100))),
                     game.choose_cats[u].sprite,
+                    tool_tip_text=self._get_cat_tooltip_string(game.choose_cats[u]),
                     cat_object=game.choose_cats[u], manager=MANAGER)
+
+    def _get_cat_tooltip_string(self, cat: Cat):
+        """Get tooltip for cat. Tooltip displays name, sex, age group, and trait."""
+
+        return f"<b>{cat.name}</b><br>{cat.gender}<br>{cat.age}<br>{cat.personality.trait}"
 
     def open_game_mode(self):
         # Clear previous screen

--- a/scripts/screens/clan_creation_screens.py
+++ b/scripts/screens/clan_creation_screens.py
@@ -247,9 +247,16 @@ class MakeClanScreen(Screens):
                     event.ui_element.disable()
 
         elif event.ui_element in [self.elements["cat" + str(u)] for u in range(0, 12)]:
-            self.selected_cat = event.ui_element.return_cat_object()
-            self.refresh_cat_images_and_info(self.selected_cat)
-            self.refresh_text_and_buttons()
+            if pygame.key.get_mods() & pygame.KMOD_SHIFT:
+                clicked_cat = event.ui_element.return_cat_object()
+                if clicked_cat.age not in ["newborn", "kitten", "adolescent"]:
+                    self.leader = clicked_cat
+                    self.selected_cat = None
+                    self.open_choose_deputy()
+            else:
+                self.selected_cat = event.ui_element.return_cat_object()
+                self.refresh_cat_images_and_info(self.selected_cat)
+                self.refresh_text_and_buttons()
         elif event.ui_element == self.elements['select_cat']:
             self.leader = self.selected_cat
             self.selected_cat = None
@@ -264,7 +271,13 @@ class MakeClanScreen(Screens):
             self.selected_cat = None
             self.open_choose_leader()
         elif event.ui_element in [self.elements["cat" + str(u)] for u in range(0, 12)]:
-            if event.ui_element.return_cat_object() != self.leader:
+            if pygame.key.get_mods() & pygame.KMOD_SHIFT:
+                clicked_cat = event.ui_element.return_cat_object()
+                if clicked_cat.age not in ["newborn", "kitten", "adolescent"]:
+                    self.deputy = clicked_cat
+                    self.selected_cat = None
+                    self.open_choose_med_cat()
+            elif event.ui_element.return_cat_object() != self.leader:
                 self.selected_cat = event.ui_element.return_cat_object()
                 self.refresh_cat_images_and_info(self.selected_cat)
                 self.refresh_text_and_buttons()
@@ -279,7 +292,13 @@ class MakeClanScreen(Screens):
             self.selected_cat = None
             self.open_choose_deputy()
         elif event.ui_element in [self.elements["cat" + str(u)] for u in range(0, 12)]:
-            if event.ui_element.return_cat_object():
+            if pygame.key.get_mods() & pygame.KMOD_SHIFT:
+                clicked_cat = event.ui_element.return_cat_object()
+                if clicked_cat.age not in ["newborn", "kitten", "adolescent"]:
+                    self.med_cat = clicked_cat
+                    self.selected_cat = None
+                    self.open_choose_members()
+            elif event.ui_element.return_cat_object():
                 self.selected_cat = event.ui_element.return_cat_object()
                 self.refresh_cat_images_and_info(self.selected_cat)
                 self.refresh_text_and_buttons()
@@ -301,9 +320,16 @@ class MakeClanScreen(Screens):
                 self.refresh_text_and_buttons()
         elif event.ui_element in [self.elements["cat" + str(u)] for u in range(0, 12)]:
             if event.ui_element.return_cat_object():
-                self.selected_cat = event.ui_element.return_cat_object()
-                self.refresh_cat_images_and_info(self.selected_cat)
-                self.refresh_text_and_buttons()
+                if pygame.key.get_mods() & pygame.KMOD_SHIFT and len(self.members) < 7:
+                    clicked_cat = event.ui_element.return_cat_object()
+                    self.members.append(clicked_cat)
+                    self.selected_cat = None
+                    self.refresh_cat_images_and_info(None)
+                    self.refresh_text_and_buttons()
+                else:
+                    self.selected_cat = event.ui_element.return_cat_object()
+                    self.refresh_cat_images_and_info(self.selected_cat)
+                    self.refresh_text_and_buttons()
         elif event.ui_element == self.elements['select_cat']:
             self.members.append(self.selected_cat)
             self.selected_cat = None


### PR DESCRIPTION
Adds:
* Tooltips for cats on Clan creation. Hovering over a cat will tell you their name, sex, age group, and trait (i.e. the same information you get by selecting them).
* Keyboard shortcut for Clan creation, where shift+clicking on a cat adds them to the clan. If the cat is too young for a position, the shortcut won't do anything.