### PR TITLE
fix: Broken pronoun tags

### DIFF
--- a/resources/dicts/events/misc_events/beach/medicine.json
+++ b/resources/dicts/events/misc_events/beach/medicine.json
@@ -2,7 +2,7 @@
   {
     "camp": "any",
     "tags": ["Newleaf", "Greenleaf", "Leaf-fall", "Leaf-bare"],
-    "event_text": "As a storm rages across the beach and waves crash upon the shore, m_c is tucked up in the medicine cat den, {PRONOUN/m_c/poss} sleep anything but restful. {PRONOUN/m_c/subject} {VERB/m_c/keep/keeps} seeing flashes of prophecy_list_sight. {CAP/PRONOUN/m_c/subject} {VERB/m_c/wake/wakes} with a shiver, wondering what {PRONOUN/m_c/poss} dreams mean for the Clan.",
+    "event_text": "As a storm rages across the beach and waves crash upon the shore, m_c is tucked up in the medicine cat den, {PRONOUN/m_c/poss} sleep anything but restful. {PRONOUN/m_c/subject} {VERB/m_c/keep/keeps} seeing flashes of prophecy_list_sight. {PRONOUN/m_c/subject/CAP} {VERB/m_c/wake/wakes} with a shiver, wondering what {PRONOUN/m_c/poss} dreams mean for the Clan.",
     "cat_trait": null,
     "cat_skill": ["prophet"],
     "other_cat_trait": null,

--- a/resources/dicts/events/misc_events/forest/medicine.json
+++ b/resources/dicts/events/misc_events/forest/medicine.json
@@ -2,7 +2,7 @@
   {
     "camp": "any",
     "tags": ["Newleaf", "Greenleaf", "Leaf-fall"],
-    "event_text": "As a storm rages and the branches of the forest whip around outside, m_c is tucked up in the medicine cat den, {PRONOUN/m_c/poss} sleep anything but restful. {CAP/PRONOUN/m_c/subject} {VERB/m_c/keep/keeps} seeing flashes of prophecy_list_sight. {CAP/PRONOUN/m_c/subject} {VERB/m_c/wake/wakes} with a shiver, wondering what {PRONOUN/m_c/poss} dreams mean for the Clan.",
+    "event_text": "As a storm rages and the branches of the forest whip around outside, m_c is tucked up in the medicine cat den, {PRONOUN/m_c/poss} sleep anything but restful. {PRONOUN/m_c/subject/CAP} {VERB/m_c/keep/keeps} seeing flashes of prophecy_list_sight. {PRONOUN/m_c/subject/CAP} {VERB/m_c/wake/wakes} with a shiver, wondering what {PRONOUN/m_c/poss} dreams mean for the Clan.",
     "cat_trait": null,
     "cat_skill": ["prophet"],
     "other_cat_trait": null,

--- a/resources/dicts/events/misc_events/general/general.json
+++ b/resources/dicts/events/misc_events/general/general.json
@@ -133,7 +133,7 @@
      {
         "camp": "any",
         "tags": ["Newleaf", "Greenleaf", "Leaf-bare", "Leaf-fall", "other_cat_mate"],
-        "event_text": "m_c watches r_c give an elder the best piece of prey on the pile. {CAP/PRONOUN/m_c/subject} {VERB/m_c/feel/feels} lucky to have such a kind cat as {PRONOUN/m_c/poss} mate."
+        "event_text": "m_c watches r_c give an elder the best piece of prey on the pile. {PRONOUN/m_c/subject/CAP} {VERB/m_c/feel/feels} lucky to have such a kind cat as {PRONOUN/m_c/poss} mate."
      },
      {
         "camp": "any",

--- a/resources/dicts/events/misc_events/general/medicine.json
+++ b/resources/dicts/events/misc_events/general/medicine.json
@@ -103,7 +103,7 @@
     {
     "camp": "any",
     "tags": ["Newleaf", "Greenleaf", "Leaf-fall", "Leaf-bare"],
-    "event_text": "m_c tosses in {PRONOUN/m_c/poss} sleep as {PRONOUN/m_c/poss} dreamself pads through the thoughts of {PRONOUN/m_c/poss} Clanmates, picking up snippets of dream_list. {CAP/PRONOUN/m_c/subject} slowly {VERB/m_c/blink/blinks} awake, wondering whose dreams {PRONOUN/m_c/subject} walked in.",
+    "event_text": "m_c tosses in {PRONOUN/m_c/poss} sleep as {PRONOUN/m_c/poss} dreamself pads through the thoughts of {PRONOUN/m_c/poss} Clanmates, picking up snippets of dream_list. {PRONOUN/m_c/subject/CAP} slowly {VERB/m_c/blink/blinks} awake, wondering whose dreams {PRONOUN/m_c/subject} walked in.",
     "cat_trait": null,
     "cat_skill": ["dream walker"],
     "other_cat_trait": null,

--- a/resources/dicts/events/misc_events/mountainous/medicine.json
+++ b/resources/dicts/events/misc_events/mountainous/medicine.json
@@ -2,7 +2,7 @@
   {
     "camp": "any",
     "tags": ["Newleaf", "Greenleaf", "Leaf-fall", "Leaf-bare"],
-    "event_text": "As a storm rages across the mountain outside, m_c is tucked up in the medicine cat den, {PRONOUN/m_c/poss} sleep anything but restful. {CAP/PRONOUN/m_c/subject} {VERB/m_c/keep/keeps} seeing flashes of prophecy_list_sight. {CAP/PRONOUN/m_c/subject} {VERB/m_c/wake/wakes} with a shiver, wondering what {PRONOUN/m_c/poss} dreams mean for the Clan.",
+    "event_text": "As a storm rages across the mountain outside, m_c is tucked up in the medicine cat den, {PRONOUN/m_c/poss} sleep anything but restful. {PRONOUN/m_c/subject/CAP} {VERB/m_c/keep/keeps} seeing flashes of prophecy_list_sight. {PRONOUN/m_c/subject/CAP} {VERB/m_c/wake/wakes} with a shiver, wondering what {PRONOUN/m_c/poss} dreams mean for the Clan.",
     "cat_trait": null,
     "cat_skill": ["prophet"],
     "other_cat_trait": null,

--- a/resources/dicts/events/misc_events/plains/medicine.json
+++ b/resources/dicts/events/misc_events/plains/medicine.json
@@ -2,7 +2,7 @@
   {
     "camp": "any",
     "tags": ["Newleaf", "Greenleaf", "Leaf-fall", "Leaf-bare"],
-    "event_text": "As the wind howls on the plains outside, m_c is tucked up in the medicine cat den, {PRONOUN/m_c/poss} sleep anything but restful. {CAP/PRONOUN/m_c/subject} {VERB/m_c/keep/keeps} seeing flashes of prophecy_list_sight. {CAP/PRONOUN/m_c/subject} {VERB/m_c/wake/wakes} with a shiver, wondering what {PRONOUN/m_c/poss} dreams mean for the Clan.",
+    "event_text": "As the wind howls on the plains outside, m_c is tucked up in the medicine cat den, {PRONOUN/m_c/poss} sleep anything but restful. {PRONOUN/m_c/subject/CAP} {VERB/m_c/keep/keeps} seeing flashes of prophecy_list_sight. {PRONOUN/m_c/subject/CAP} {VERB/m_c/wake/wakes} with a shiver, wondering what {PRONOUN/m_c/poss} dreams mean for the Clan.",
     "cat_trait": null,
     "cat_skill": ["prophet"],
     "other_cat_trait": null,


### PR DESCRIPTION
Some strings were mistagged, causing the `error2` string to show up. `CAP` should be the last tag, not the first.