### PR TITLE
[RELEASE] Log-related crash fix

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+<strong>0.8.8</strong>
+- Fixed a bug related to logs that caused the game to crash on startup.
+
 <strong>v0.8.7</strong>
 - Fixed a bug that prevented the game from installing the update
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,4 @@
-<strong>0.8.8</strong>
+<strong>v0.8.8</strong>
 - Fixed a bug related to logs that caused the game to crash on startup.
 
 <strong>v0.8.7</strong>

--- a/scripts/housekeeping/log_cleanup.py
+++ b/scripts/housekeeping/log_cleanup.py
@@ -1,4 +1,5 @@
 import os
+import traceback
 
 from scripts.datadir import get_log_dir
 
@@ -17,6 +18,9 @@ def prune_logs(logs_to_keep: int, retain_empty_logs: bool):
             log_list[log_type] = 1
         else:
             if log_list[log_type] >= logs_to_keep or not retain_empty_logs and os.stat(f"{get_log_dir()}/{log_file}").st_size == 0:
-                os.remove(f"{get_log_dir()}/{log_file}")
+                try:
+                    os.remove(f"{get_log_dir()}/{log_file}")
+                except PermissionError:
+                    traceback.print_exc()
             else:
                 log_list[log_type] += 1


### PR DESCRIPTION
Sometimes there are permission errors on log cleanup. It seems to be deleting the log files that are being created somehow? Game probably shouldn't crash.