### PR TITLE
Force file sync

### DIFF
--- a/scripts/game_structure/game_essentials.py
+++ b/scripts/game_structure/game_essentials.py
@@ -222,6 +222,8 @@ class Game():
                 # Attempt to write to temp file
                 with open(temp_file_path, "w") as write_file:
                     write_file.write(_data)
+                    write_file.flush()
+                    os.fsync(write_file.fileno())
 
                 # Read the entire file back in 
                 with open(temp_file_path, 'r') as read_file:
@@ -243,6 +245,8 @@ class Game():
             os.makedirs(dir_name, exist_ok=True)
             with open(path, 'w') as write_file:
                 write_file.write(_data)
+                write_file.flush()
+                os.fsync(write_file.fileno())
 
     def read_clans(self):
         '''with open(get_save_dir() + '/clanlist.txt', 'r') as read_file:


### PR DESCRIPTION
Attempt at stopping save file nullification, which seems to be caused by computers forcibly shutting down (e.g. by holding down the power button, power outage) before all file operations are complete.

Modifies `save_save()` since it's being called a bunch anyway.