### PR TITLE
Bugfixes, slight history changes

### DIFF
--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -1003,9 +1003,8 @@ class Cat():
                 mentor_influence={},
                 app_ceremony={},
                 lead_ceremony=None,
-                possible_death={},
+                possible_history={},
                 died_by=[],
-                possible_scar={},
                 scar_events=[],
                 murder={},
             )

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -961,9 +961,8 @@ class Cat():
                 mentor_influence={},
                 app_ceremony={},
                 lead_ceremony=None,
-                possible_death={},
+                possible_history={},
                 died_by=[],
-                possible_scar={},
                 scar_events=[],
                 murder={},
             )
@@ -977,9 +976,8 @@ class Cat():
                         'mentor_influence'] if "mentor_influence" in history_data else {},
                     app_ceremony=history_data['app_ceremony'] if "app_ceremony" in history_data else {},
                     lead_ceremony=history_data['lead_ceremony'] if "lead_ceremony" in history_data else None,
-                    possible_death=history_data['possible_death'] if "possible_death" in history_data else {},
+                    possible_history=history_data['possible_history'] if "possible_history" in history_data else {},
                     died_by=history_data['died_by'] if "died_by" in history_data else [],
-                    possible_scar=history_data['possible_scar'] if "possible_scar" in history_data else {},
                     scar_events=history_data['scar_events'] if "scar_events" in history_data else [],
                     murder=history_data['murder'] if "murder" in history_data else {},
                 )

--- a/scripts/cat/history.py
+++ b/scripts/cat/history.py
@@ -14,9 +14,8 @@ class History:
                  mentor_influence=None,
                  app_ceremony=None,
                  lead_ceremony=None,
-                 possible_death=None,
+                 possible_history=None,
                  died_by=None,
-                 possible_scar=None,
                  scar_events=None,
                  murder=None
                  ):
@@ -24,9 +23,8 @@ class History:
         self.mentor_influence = mentor_influence if mentor_influence else {"trait": {}, "skill": {}}
         self.app_ceremony = app_ceremony if app_ceremony else {}
         self.lead_ceremony = lead_ceremony if lead_ceremony else None
-        self.possible_death = possible_death if possible_death else {}
+        self.possible_history = possible_history if possible_history else {}
         self.died_by = died_by if died_by else []
-        self.possible_scar = possible_scar if possible_scar else {}
         self.scar_events = scar_events if scar_events else []
         self.murder = murder if murder else {}
 
@@ -53,14 +51,16 @@ class History:
             "moon": moon
             },
         "lead_ceremony": full ceremony text,
-        "possible_death": {
+        "possible_history": {
             "condition name": {
                 "involved": ID
-                "text": text
+                "death_text": text
+                "scar_text": text
                 },
             "condition name": {
                 "involved": ID
-                "text": text
+                "death_text": text
+                "scar_text": text
                 },
             },
         "died_by": [
@@ -70,16 +70,6 @@ class History:
                 "moon": moon
             }
             ],
-        "possible_scar": {
-            "condition name": {
-                "involved": ID
-                "text": text
-                },
-            "condition name": {
-                "involved": ID
-                "text": text
-                },
-            },
         "scar_events": [
             {
                 'involved': ID,
@@ -134,9 +124,8 @@ class History:
             "mentor_influence": cat.history.mentor_influence,
             "app_ceremony": cat.history.app_ceremony,
             "lead_ceremony": cat.history.lead_ceremony,
-            "possible_death": cat.history.possible_death,
+            "possible_history": cat.history.possible_history,
             "died_by": cat.history.died_by,
-            "possible_scar": cat.history.possible_scar,
             "scar_events": cat.history.scar_events,
             "murder": cat.history.murder,
         }
@@ -237,7 +226,6 @@ class History:
         History.check_load(cat)
         cat.history.mentor_influence["skill"] = skill_influence
         
-
     @staticmethod
     def add_app_ceremony(cat, honor):
         """
@@ -256,51 +244,32 @@ class History:
         }
 
     @staticmethod
-    def add_possible_death_or_scars(cat, condition, text, other_cat=None, scar=False, death=False):
+    def add_possible_history(cat, condition:str, death_text:str=None, scar_text:str=None, other_cat=None):
         """
         this adds the possible death/scar to the cat's history
         :param cat: cat object
-        :param other_cat: if another cat is mentioned in the history, include them here
         :param condition: the condition that is causing the death/scar
-        :param text: the history text for the death/scar
-        :param scar: set to True if this is a scar event
-        :param death: set to True if this is a death event
+        :param death_text: text for death history
+        :param scar_text: text for scar history
+        :param other_cat: cat object of other cat involved. 
         """
         History.check_load(cat)
 
-        event_type = None
-        if scar:
-            event_type = "possible_scar"
-        elif death:
-            event_type = "possible_death"
-
-        if not event_type:
-            print('WARNING: event type was not specified during possible scar/death history writing, '
-                  'did you remember to set scar or death as True?')
-            return
-
-        # now just make sure the names aren't actually in the text and replace as necessary
-        # we can't have the names in the text bc names change over time and so would eventually be out of date
-        # on the history display
-        if str(cat.name) in text:
-            text = text.replace(str(cat.name), "m_c")
-        if other_cat:
-            if str(other_cat.name) in text:
-                text = text.replace(str(other_cat.name), "r_c")
-
-        if event_type == "possible_scar":
-            cat.history.possible_scar[condition] = {
-                "involved": other_cat.ID if other_cat else None,
-                "text": text
-            }
-        elif event_type == 'possible_death':
-            cat.history.possible_death[condition] = {
-                "involved": other_cat.ID if other_cat else None,
-                "text": text
-            }
+        # Use a default is none is provided.
+        # Will probally sound weird, but it's better than nothing
+        if not death_text:
+            death_text = f"m_c died from {condition}"
+        if not scar_text:
+            scar_text = f"m_c was scarred from {condition}"        
+        
+        cat.history.possible_history[condition] = {
+            "death_text": death_text,
+            "scar_text": scar_text,
+            "other_cat": other_cat.ID if other_cat is not None else None
+        }
 
     @staticmethod
-    def remove_possible_death_or_scars(cat, condition):
+    def remove_possible_history(cat, condition):
         """
         use to remove possible death/scar histories
         :param cat: cat object
@@ -311,82 +280,54 @@ class History:
 
         History.check_load(cat)
 
-        if condition in cat.history.possible_scar:
-            cat.history.possible_scar.pop(condition)
-        if condition in cat.history.possible_death:
-            cat.history.possible_death.pop(condition)
-
+        if condition in cat.history.possible_history:
+            cat.history.possible_history.pop(condition)
+    
     @staticmethod
-    def add_death_or_scars(cat, other_cat=None, text=None, extra_text=None, condition=None, scar=False, death=False):
-        """
-        this adds death or scar events to the cat's history, if the condition
-         was already in possible death/scars then it's info is moved to this list
-         and removed from the old dict
-        :param cat: cat object
-        :param other_cat: if another cat is involved in the event, add them here
-        :param text: event history text
-        :param extra_text: the second event string if one exists, this is for use with the murder reveal system
-        :param condition: if it was caused by a condition, add name here
-        :param scar: set True if scar
-        :param death: set True if death
-        """
+    def add_death(cat, death_text, condition=None, other_cat=None, extra_text=None):
+        """ Adds death to cat's history. If a condition is passed, it will look into
+            possible_history to see if anything is saved there, and, if so, use the text and 
+            other_cat there (overriding the 
+            passed death_text and other_cat). """
+        
         if not game.clan:
             return
         History.check_load(cat)
-
-        event_type = None
-        old_event_type = None
-        other_cat_ID = None
-        if scar:
-            event_type = "scar_events"
-            old_event_type = "possible_scar"
-        elif death:
-            event_type = "died_by"
-            old_event_type = "possible_death"
-
-        if not event_type or not old_event_type:
-            print('WARNING: event type was not specified during scar/death history writing, '
-                  'did you remember to set scar or death as True?')
-            return
-
-        # if this was caused by a condition, then we need to get info from the possible scar/death dicts
-        if condition:
-            try:
-                if old_event_type == 'possible_scar':
-                    old_event = cat.history.possible_scar
-                else:
-                    old_event = cat.history.possible_death
-                other_cat_ID = old_event[condition]["involved"]
-                text = old_event[condition]["text"]
-                # and then remove from possible scar/death dict
-                if condition in old_event:
-                    old_event.pop(condition)
-            except KeyError:
-                print(f"WARNING: could not find {condition} in cat's possible death/scar history,"
-                      f" this maybe be due to an expected save conversion change.")
-                return
-
-        # now just make sure the names aren't actually in the text and replace as necessary
-        # we can't have the names in the text bc names change over time and so would eventually be out of date
-        # on the history display
-        if str(cat.name) in text:
-            text = text.replace(str(cat.name), "m_c")
-        if other_cat:
-            if str(other_cat.name) in text:
-                text = text.replace(str(other_cat.name), "r_c")
-            other_cat_ID = other_cat.ID
-
-        history_dict = {
-            "involved": other_cat_ID,
-            "text": text,
+        
+        if other_cat is not None:
+            other_cat = other_cat.ID
+        if condition in cat.history.possible_history:
+            if cat.history.possible_history[condition]["death_text"]:
+                death_text = cat.history.possible_history[condition]["death_text"]
+            other_cat = cat.history.possible_history[condition].get("other_cat")
+            cat.history.remove_possible_history(cat, condition)
+        
+        cat.history.died_by.append({
+            "involved": other_cat,
+            "text": death_text, 
             "moon": game.clan.age
-        }
-
-        if event_type == 'scar_events':
-            cat.history.scar_events.append(history_dict)
-        elif event_type == 'died_by':
-            cat.history.died_by.append(history_dict)
-
+        })
+    
+    @staticmethod
+    def add_scar(cat, scar_text, condition=None, other_cat=None, extra_text=None):
+        if not game.clan:
+            return
+        History.check_load(cat)
+        
+        if other_cat is not None:
+            other_cat = other_cat.id
+        if condition in cat.history.possible_history:
+            if cat.history.possible_history[condition]["scar_text"]:
+                scar_text = cat.history.possible_history[condition]["scar_text"]
+            other_cat = cat.history.possible_history[condition].get("other_cat")
+            cat.history.remove_possible_history(cat, condition)
+        
+        cat.history.scar_events.append({
+            "involved": other_cat,
+            "text": scar_text, 
+            "moon": game.clan.age
+        })
+    
     @staticmethod
     def add_murders(cat, other_cat, revealed, text=None, unrevealed_text=None):
         """
@@ -499,7 +440,7 @@ class History:
         return str(cat.history.lead_ceremony)
 
     @staticmethod
-    def get_possible_death_or_scars(cat, condition=None, death=False, scar=False):
+    def get_possible_history(cat, condition=None, death=False, scar=False):
         """
         Returns the asked for death/scars dict, example of single event structure:
 
@@ -529,31 +470,12 @@ class History:
         """
         History.check_load(cat)
 
-        event_type = None
-        if scar:
-            event_type = "possible_scar"
-        elif death:
-            event_type = "possible_death"
-
-        if not event_type:
-            print('WARNING: event type was not specified during possible scar/death history retrieval, '
-                  'did you remember to set scar or death as True?')
-            return
-
-        if condition:
-            if event_type == 'possible_scar':
-                if condition in cat.history.possible_scar:
-                    return cat.history.possible_scar[condition]
-            elif event_type == 'possible_death':
-                if condition in cat.history.possible_death:
-                    return cat.history.possible_death[condition]
-            else:
-                return None
-
-        if event_type == 'possible_scar':
-            return cat.history.possible_scar
+        if condition in cat.history.possible_history:
+            return cat.history.possible_history[condition]
+        elif condition:
+            return None
         else:
-            return cat.history.possible_death
+            return cat.history.possible_history
 
     @staticmethod
     def get_death_or_scars(cat, death=False, scar=False):

--- a/scripts/cat/history.py
+++ b/scripts/cat/history.py
@@ -440,13 +440,14 @@ class History:
         return str(cat.history.lead_ceremony)
 
     @staticmethod
-    def get_possible_history(cat, condition=None, death=False, scar=False):
+    def get_possible_history(cat, condition=None):
         """
         Returns the asked for death/scars dict, example of single event structure:
 
         {
         "involved": ID
-        "text": text
+        "death_text": text
+        "scar_text": text
         },
 
         example of multi event structure:
@@ -454,19 +455,19 @@ class History:
         {
         "condition name": {
             "involved": ID
-            "text": text
+            "death_text": text
+            "scar_text": text
             },
         "condition name": {
             "involved": ID
-            "text": text
+            "death_text": text
+            "scar_text": text
             },
         },
 
         if possible scar/death is empty, a NoneType is returned
         :param cat: cat object
         :param condition: the name of the condition that caused the death/scar (if looking for specific event, else leave None to get all events)
-        :param death: set True to get deaths
-        :param scar: set True to get scars
         """
         History.check_load(cat)
 

--- a/scripts/cat/history.py
+++ b/scripts/cat/history.py
@@ -258,9 +258,9 @@ class History:
         # Use a default is none is provided.
         # Will probally sound weird, but it's better than nothing
         if not death_text:
-            death_text = f"m_c died from {condition}"
+            death_text = f"m_c died from an injury or illness ({condition})."
         if not scar_text:
-            scar_text = f"m_c was scarred from {condition}"        
+            scar_text = f"m_c was scarred from an injury or illness ({condition})."        
         
         cat.history.possible_history[condition] = {
             "death_text": death_text,

--- a/scripts/cat_relations/relationship.py
+++ b/scripts/cat_relations/relationship.py
@@ -147,13 +147,11 @@ class Relationship():
                 possible_death = self.adjust_interaction_string(injury_dict["death_text"]) if "death_text" in injury_dict else None
                 if injured_cat.status == "leader":
                     possible_death = self.adjust_interaction_string(injury_dict["death_leader_text"]) if "death_leader_text" in injury_dict else None
-                if possible_scar:
+                
+                if possible_scar or possible_death:
                     for condition in injuries:
-                        self.history.add_possible_death_or_scars(injured_cat, condition, possible_scar, scar=True)
-                if possible_death:
-                    for condition in injuries:
-                        self.history.add_possible_death_or_scars(injured_cat, condition, possible_scar, death=True)
-
+                        self.history.add_possible_history(injured_cat, condition, scar_text=possible_scar, death_text=possible_death)
+                
         # get any possible interaction string out of this interaction
         interaction_str = choice(self.chosen_interaction.interactions)
 

--- a/scripts/clan.py
+++ b/scripts/clan.py
@@ -1339,10 +1339,20 @@ class Clan():
         deputy = Cat.fetch_cat(self.deputy) if isinstance(Cat.fetch_cat(self.deputy), Cat) else None
         
         weight = 0.3
-        clan_sociability = round(weight * statistics.mean([i.personality.sociability for i in [leader, deputy] if i]) + \
-            (1-weight) *  statistics.median([i.personality.sociability for i in all_cats]))
-        clan_aggression = round(weight * statistics.mean([i.personality.aggression for i in [leader, deputy] if i]) + \
-            (1-weight) *  statistics.median([i.personality.aggression for i in all_cats]))
+
+        if (leader or deputy) and all_cats:
+            clan_sociability = round(weight * statistics.mean([i.personality.sociability for i in [leader, deputy] if i]) + \
+                (1-weight) *  statistics.median([i.personality.sociability for i in all_cats]))
+            clan_aggression = round(weight * statistics.mean([i.personality.aggression for i in [leader, deputy] if i]) + \
+                (1-weight) *  statistics.median([i.personality.aggression for i in all_cats]))
+        elif (leader or deputy):
+            clan_sociability = round(statistics.mean([i.personality.sociability for i in [leader, deputy] if i]))
+            clan_aggression = round(statistics.mean([i.personality.aggression for i in [leader, deputy] if i]))
+        elif all_cats:
+            clan_sociability = round(statistics.median([i.personality.sociability for i in all_cats]))
+            clan_aggression = round(statistics.median([i.personality.aggression for i in all_cats]))
+        else:
+            return "stoic"
         
         # temperment = ['high_agress', 'med_agress', 'low agress' ]
         if 12 <= clan_sociability:

--- a/scripts/events_module/death_events.py
+++ b/scripts/events_module/death_events.py
@@ -129,7 +129,7 @@ class Death_Events():
                 additional_event_text += cat.die(body)
                 death_history = history_text_adjust(death_history, other_clan_name, game.clan)
 
-            self.history.add_death_or_scars(cat, other_cat, death_history, murder_unrevealed_history, death=True)
+            self.history.add_death(cat, death_history, other_cat=other_cat, extra_text=murder_unrevealed_history)
 
         # give death history to other cat and kill them if they die
         if "other_cat_death" in death_cause.tags or "multi_death" in death_cause.tags:
@@ -149,7 +149,7 @@ class Death_Events():
                 additional_event_text += other_cat.die(body)
                 other_death_history = history_text_adjust(death_cause.history_text.get('reg_death'), other_clan_name, game.clan)
 
-            self.history.add_death_or_scars(other_cat, cat, other_death_history, death=True)
+            self.history.add_death(other_cat, other_death_history, other_cat=cat)
 
         # give injuries to other cat if tagged as such
         if "other_cat_injured" in death_cause.tags:

--- a/scripts/events_module/freshkill_pile_events.py
+++ b/scripts/events_module/freshkill_pile_events.py
@@ -77,7 +77,7 @@ class Freshkill_Events():
             if cat.status == "leader":
                 game.clan.leader_lives -= 1
             cat.die()
-            self.history.add_death_or_scars(cat, text=history_text, death=True)
+            self.history.add_death(cat, history_text)
 
             types = ["birth_death"]
             game.cur_events_list.append(Single_Event(death_text, types, [cat.ID]))
@@ -323,21 +323,21 @@ class Freshkill_Events():
                 history_leader = event_text_adjust(Cat, event.history_text[2], cat, other_cat)
             
             if cat.status == "leader":
-                self.history.add_possible_death_or_scars(cat, event.injury, str(history_leader), other_cat, death=True)
+                self.history.add_possible_history(cat, event.injury, death_text=history_leader, scar_text=scar_text,
+                                                  other_cat=other_cat)
             else:
-                self.history.add_possible_death_or_scars(cat, event.injury, str(history_normal), other_cat, death=True)
+                self.history.add_possible_history(cat, event.injury, death_text=history_normal, scar_text=scar_text,
+                                                  other_cat=other_cat)
 
-            self.history.add_possible_death_or_scars(cat, event.injury, str(scar_text), other_cat, scar=True)
 
             cat.get_injured(event.injury, event_triggered=True)
             if "multi_injury" in event.tags and other_cat:
                 if other_cat.status == "leader":
-                    self.history.add_possible_death_or_scars(other_cat, event.injury, str(history_leader), cat,
-                                                             death=True)
+                    self.history.add_possible_history(other_cat, event.injury, death_text=history_leader, 
+                                                      scar_text=scar_text, other_cat=cat)
                 else:
-                    self.history.add_possible_death_or_scars(other_cat, event.injury, str(history_normal), cat,
-                                                             death=True)
-                self.history.add_possible_death_or_scars(other_cat, event.injury, str(scar_text), cat, scar=True)
+                    self.history.add_possible_history(other_cat, event.injury, death_text=history_normal, 
+                                                      scar_text=scar_text, other_cat=cat)
 
                 other_cat.get_injured(event.injury, event_triggered=True)
 
@@ -352,17 +352,17 @@ class Freshkill_Events():
 
             if cat.status == "leader":
                 game.clan.leader_lives -= 1
-                self.history.add_death_or_scars(cat, other_cat, history_leader, death=True)
+                self.history.add_death(cat, history_leader, other_cat=other_cat)
             else:
-                self.history.add_death_or_scars(cat, other_cat, history_normal, death=True)
+                self.history.add_death(cat, history_normal, other_cat=other_cat)
 
             cat.die()
             if "multi_death" in event.tags and other_cat:
                 if other_cat.status == "leader":
                     game.clan.leader_lives -= 1
-                    self.history.add_death_or_scars(other_cat, cat, history_leader, death=True)
+                    self.history.add_death(other_cat, history_leader, other_cat=cat)
                 else:
-                    self.history.add_death_or_scars(other_cat, cat, history_normal, death=True)
+                    self.history.add_death(other_cat, history_normal, other_cat=cat)
                 other_cat.die()
             if "multi_death" in event.tags and not other_cat:
                 print("WARNING: multi_death event in freshkill pile was triggered, but no other cat was given.")

--- a/scripts/events_module/relationship/group_events.py
+++ b/scripts/events_module/relationship/group_events.py
@@ -541,12 +541,10 @@ class Group_Events():
             possible_death = self.prepare_text(injury_dict["death_text"]) if "death_text" in injury_dict else None
             if injured_cat.status == "leader":
                 possible_death = self.prepare_text(injury_dict["death_leader_text"]) if "death_leader_text" in injury_dict else None
-            if possible_scar:
+            
+            if possible_death or possible_scar:
                 for condition in injuries:
-                    self.history.add_possible_death_or_scars(injured_cat, condition, possible_scar, scar=True)
-            if possible_death:
-                for condition in injuries:
-                    self.history.add_possible_death_or_scars(injured_cat, condition, possible_scar, death=True)
+                    self.history.add_possible_history(injured_cat, condition, death_text=possible_death, scar_text=possible_scar)
 
     def prepare_text(self, text: str) -> str:
         """Prep the text based of the amount of cats and the assigned abbreviations."""

--- a/scripts/events_module/relationship/pregnancy_events.py
+++ b/scripts/events_module/relationship/pregnancy_events.py
@@ -308,7 +308,7 @@ class Pregnancy_Events():
             else:
                 cat.die()
                 death_event = (f"{cat.name} died while kitting.")
-            self.history.add_death_or_scars(cat, text=death_event, death=True)
+            self.history.add_death(cat, text=death_event)
         elif clan.game_mode != 'classic' and not cat.outside:  # if cat doesn't die, give recovering from birth
             cat.get_injured("recovering from birth", event_triggered=True)
             if 'blood loss' in cat.injuries:
@@ -316,7 +316,7 @@ class Pregnancy_Events():
                     death_event = (f" died after a harsh kitting.")
                 else:
                     death_event = (f"{cat.name} after a harsh kitting.")
-                self.history.add_possible_death_or_scars(cat, 'blood loss', death_event, death=True)
+                self.history.add_possible_history(cat, 'blood loss', death_text=death_event)
                 possible_events = events["birth"]["difficult_birth"]
                 # just makin sure meds aren't mentioned if they aren't around or if they are a parent
                 meds = get_med_cats(Cat, working=False)

--- a/scripts/events_module/relationship/pregnancy_events.py
+++ b/scripts/events_module/relationship/pregnancy_events.py
@@ -308,7 +308,7 @@ class Pregnancy_Events():
             else:
                 cat.die()
                 death_event = (f"{cat.name} died while kitting.")
-            self.history.add_death(cat, text=death_event)
+            self.history.add_death(cat, death_text=death_event)
         elif clan.game_mode != 'classic' and not cat.outside:  # if cat doesn't die, give recovering from birth
             cat.get_injured("recovering from birth", event_triggered=True)
             if 'blood loss' in cat.injuries:

--- a/scripts/events_module/relationship/romantic_events.py
+++ b/scripts/events_module/relationship/romantic_events.py
@@ -117,12 +117,10 @@ class Romantic_Events():
                 possible_death = injury_dict["death_text"] if "death_text" in injury_dict else None
                 if injured_cat.status == "leader":
                     possible_death = injury_dict["death_leader_text"] if "death_leader_text" in injury_dict else None
-                if possible_scar:
+                
+                if possible_scar or possible_death:
                     for condition in injuries:
-                        self.history.add_possible_death_or_scars(injured_cat, condition, possible_scar, scar=True)
-                if possible_death:
-                    for condition in injuries:
-                        self.history.add_possible_death_or_scars(injured_cat, condition, possible_scar, death=True)
+                        self.history.add_possible_history(injured_cat, condition, death_text=possible_death, scar_text=possible_scar)
 
         # get any possible interaction string out of this interaction
         interaction_str = choice(chosen_interaction.interactions)

--- a/scripts/events_module/scar_events.py
+++ b/scripts/events_module/scar_events.py
@@ -35,7 +35,7 @@ class Scar_Events():
 
             # move potential scar text into displayed scar text
             self.history.add_scar(cat,
-                                  f"m_c was scarred from an injury ({injury_name})",
+                                  f"m_c was scarred from an injury ({injury_name}).",
                                   condition=injury_name)
 
             specialty = None  # Scar to be set

--- a/scripts/events_module/scar_events.py
+++ b/scripts/events_module/scar_events.py
@@ -22,20 +22,21 @@ class Scar_Events():
         """ 
         This function handles the scars
         """
-
-        chance = int(random.random() * 13 - cat.injuries[injury_name]["moons_with"])
-        if chance <= 0:
-            chance = 1
+    
+        
+        chance = max(int(8 - cat.injuries[injury_name]["moons_with"]), 1)
+        if cat.injuries[injury_name]["severity"] == "minor":
+            chance += 8
+        
         amount_per_med = get_amount_cat_for_one_medic(game.clan)
         if medical_cats_condition_fulfilled(game.cat_class.all_cats.values(), amount_per_med):
             chance += 3
-        if len(cat.pelt.scars) < 4 and chance <= 6:
+        if len(cat.pelt.scars) < 4 and not int(random.random() * chance):
 
             # move potential scar text into displayed scar text
-            self.history.add_death_or_scars(cat,
-                                            condition=injury_name,
-                                            scar=True
-                                            )
+            self.history.add_scar(cat,
+                                  f"m_c was scarred from an injury ({injury_name})",
+                                  condition=injury_name)
 
             specialty = None  # Scar to be set
 
@@ -192,7 +193,7 @@ class Scar_Events():
                     event_string = f"{cat.name}'s {injury_name} has healed so well that you can't even tell it happened."
                 scar_given = None
         else:
-            self.history.remove_possible_death_or_scars(cat, injury_name)
+            self.history.remove_possible_history(cat, injury_name)
             if injury_name == "poisoned":
                 event_string = f"{cat.name} has recovered fully from the poison."
             else:

--- a/scripts/game_structure/windows.py
+++ b/scripts/game_structure/windows.py
@@ -601,7 +601,7 @@ class KillCat(UIWindow):
                     death_message = sub(r"[^A-Za-z0-9<->/.()*'&#!?,| ]+", "", self.death_entry_box.get_text())
 
                 self.the_cat.die()
-                self.history.add_death_or_scars(self.the_cat, text=death_message, death=True)
+                self.history.add_death(self.the_cat, death_message)
                 update_sprite(self.the_cat)
                 game.switches['window_open'] = False
                 game.all_screens['profile screen'].exit_screen()
@@ -1001,6 +1001,7 @@ class SaveError(UIWindow):
             if event.ui_element == self.close_button:
                 game.switches['window_open'] = False
                 self.kill()
+       
                 
 class SaveAsImage(UIWindow):
     def __init__(self, image_to_save, file_name):
@@ -1120,9 +1121,9 @@ class SaveAsImage(UIWindow):
                 self.confirm_text.set_text(f"Saved as {file_name} in the saved_images folder")
             elif event.ui_element == self.small_size_button:
                 self.scale_factor = 1
-                self.small_size_button.enable()
+                self.small_size_button.disable()
                 self.medium_size_button.enable()
-                self.large_size_button.disable()
+                self.large_size_button.enable()
             elif event.ui_element == self.medium_size_button:
                 self.scale_factor = 4
                 self.small_size_button.enable()

--- a/scripts/patrol.py
+++ b/scripts/patrol.py
@@ -1658,32 +1658,26 @@ class Patrol():
             adjust_text = self.patrol_event.history_text['scar']
             adjust_text = adjust_text.replace("r_c", str(cat.name))
             if possible:
-                self.history.add_possible_death_or_scars(cat, condition, adjust_text,
-                                                         scar=True)
+                self.history.add_possible_history(cat, condition, scar_text=adjust_text)
             else:
-                self.history.add_death_or_scars(cat, condition, adjust_text,
-                                                scar=True)
+                self.history.add_scar(cat, adjust_text)
         if death:
             if cat.status == 'leader':
                 if "lead_death" in self.patrol_event.history_text:
                     adjust_text = self.patrol_event.history_text['lead_death']
                     adjust_text = adjust_text.replace("r_c", str(cat.name))
                     if possible:
-                        self.history.add_possible_death_or_scars(cat, condition, adjust_text,
-                                                                 death=True)
+                        self.history.add_possible_history(cat,condition=condition, death_text=adjust_text)
                     else:
-                        self.history.add_death_or_scars(cat, condition, adjust_text,
-                                                        death=True)
+                        self.history.add_death(cat, adjust_text)
             else:
                 if "reg_death" in self.patrol_event.history_text:
                     adjust_text = self.patrol_event.history_text['reg_death']
                     adjust_text = adjust_text.replace("r_c", str(cat.name))
                     if possible:
-                        self.history.add_possible_death_or_scars(cat, condition, adjust_text,
-                                                                 death=True)
+                        self.history.add_possible_history(cat,condition=condition, death_text=adjust_text)
                     else:
-                        self.history.add_death_or_scars(cat, condition, adjust_text,
-                                                        death=True)
+                        self.history.add_death(cat, adjust_text)
 
     def handle_herbs(self, outcome):
         herbs_gotten = []
@@ -1870,8 +1864,9 @@ class Patrol():
             if Cat.fetch_cat(cat.mentor) in self.patrol_cats:
                 cat.patrol_with_mentor += 1
                 affect = cat.personality.mentor_influence(Cat.fetch_cat(cat.mentor))
-                History.add_facet_mentor_influence(cat, affect[0], affect[1], affect[2])
-                print(affect)
+                if affect:
+                    History.add_facet_mentor_influence(cat, affect[0], affect[1], affect[2])
+                    print(affect)
 
     def handle_reputation(self, difference):
         """

--- a/scripts/screens/cat_screens.py
+++ b/scripts/screens/cat_screens.py
@@ -1449,7 +1449,7 @@ class ProfileScreen(Screens):
         if death_history:
             all_deaths = []
             for death in death_history:
-                if murder_history:
+                if murder_history.get("is_victim"):
                     # TODO: this is gross, try to fix so it's not hella nested, seems like the only solution atm
                     for event in murder_history["is_victim"]:
                         if event["text"] == death["text"] and event["moon"] == death["moon"]:
@@ -1551,7 +1551,7 @@ class ProfileScreen(Screens):
                     else:
                         victim_text = f"{self.the_cat.name} murdered {', '.join(name_list[:-1])}, and {name_list[-1]}."
 
-        print(victim_text)
+        #print(victim_text)
         return victim_text
 
     def toggle_conditions_tab(self):

--- a/tests/test_cat.py
+++ b/tests/test_cat.py
@@ -393,9 +393,8 @@ class TestStatusChange(unittest.TestCase):
                 mentor_influence={},
                 app_ceremony={},
                 lead_ceremony=None,
-                possible_death={},
+                possible_history={},
                 died_by=[],
-                possible_scar={},
                 scar_events=[],
                 murder={},
             )


### PR DESCRIPTION
- Combined possible_scar and possible_death into possible_history. There was some serious bugs for that, and combining it made it much easier to fix. This does break old dev saves. 
- Also allowed injured to scar even if they don't have any special history text attached. That was prevented for some reason. Now, it just says "m_c was scarred by an injury (condition_name)." unless there is some other special text stored. 
- Since the above change tended to increase scar chance, reduced the chance of scarring for "minor" conditions. 
- Fixed the wrong button disabling when selecting "small" on the sprite export screen
- Fixed a "scar" crash
- Fixed crash related to mentor influence.
- Fixed crash when saving with no leader or deputy (or only a leader and deputy)
- Fix crash when viewing the history of a murderer (they apparently also murdered the game, hehe)