### PR TITLE
Content: Unretire Cat

### DIFF
--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -715,10 +715,7 @@ class Cat():
     
     def rank_change_traits_skill(self, mentor):
         """Updates trait and skill upon ceremony"""  
-        """Updates trait and skill upon ceremony"""  
-        self.personality.set_kit(self.is_baby()) #Update kit trait stuff
-        """Updates trait and skill upon ceremony"""
-        self.personality.set_kit(self.is_baby()) #Update kit trait stuff
+
         if self.status in ["warrior", "medicine cat", "mediator"]:
             # Give a couple doses of mentor inflence:
             if mentor:

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -638,10 +638,9 @@ class Cat():
         ids = []
         for child_id in children:
             child = Cat.all_cats[child_id]
-            if child.outside and not child.exiled and child.moons < 6:
+            if child.outside and not child.exiled and child.moons < 12:
                 child.add_to_clan()
-                if child.moons < 6:
-                    ids.append(child_id)
+                ids.append(child_id)
         
         return ids
 

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -222,7 +222,6 @@ class Cat():
         self.leader_death_heal = None
         self.also_got = False
         self.permanent_condition = {}
-        self.retired = False
         self.df = False
         self.experience_level = None
         self.no_kits = False
@@ -2897,7 +2896,6 @@ class Cat():
                 "former_apprentices": [appr for appr in self.former_apprentices],
                 "df": self.df,
                 "outside": self.outside,
-                "retired": self.retired if self.retired else False,
                 "faded_offspring": self.faded_offspring,
                 "opacity": self.pelt.opacity,
                 "prevent_fading": self.prevent_fading,

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -2071,7 +2071,7 @@ class Events:
     def check_and_promote_deputy(self):
         """Checks if a new deputy needs to be appointed, and appointed them if needed. """
         if (not game.clan.deputy or game.clan.deputy.dead
-                or game.clan.deputy.outside or game.clan.deputy.retired):
+                or game.clan.deputy.outside or game.clan.deputy.status == "elder"):
             if game.settings.get('deputy'):
 
                 # This determines all the cats who are eligible to be deputy.

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -31,7 +31,7 @@ from scripts.events_module.outsider_events import OutsiderEvents
 from scripts.event_class import Single_Event
 from scripts.game_structure.game_essentials import game
 from scripts.utility import get_alive_kits, get_med_cats, ceremony_text_adjust, \
-    get_current_season, adjust_list_text, ongoing_event_text_adjust
+    get_current_season, adjust_list_text, ongoing_event_text_adjust, event_text_adjust
 from scripts.events_module.generate_events import GenerateEvents
 from scripts.events_module.relationship.pregnancy_events import Pregnancy_Events
 from scripts.game_structure.windows import SaveError
@@ -609,15 +609,89 @@ class Events:
             ] and not cat.exiled and not cat.dead:
                 lost_cat = cat
                 break
-        if lost_cat:
-            lost_cat_name = lost_cat.name
-            text = [
-                f'After a long journey, {lost_cat_name} has finally returned home to the Clan.'
-            ]
-            lost_cat.outside = False
-            game.cur_events_list.append(
-                Single_Event(random.choice(text), "misc", [lost_cat.ID]))
-            lost_cat.add_to_clan()
+        
+        if not lost_cat:
+            return
+        
+        text = [
+            'After a long journey, m_c has finally returned home to c_n.',
+            'm_c was found at the border, tired, but happy to be home.',
+            "m_c strides into camp, much to the everyone's suprise. {PRONOUN/m_c/subject/CAP}{VERB/m_c/'re/'s} home!",
+            "{PRONOUN/m_c/subject/CAP} met so many friends on {PRONOUN/m_c/poss} jouney, but c_n is where m_c truly belongs. With a tearful goodbye, " 
+                "{PRONOUN/m_c/subject} {VERB/m_c/return/returns} home."
+        ]
+        lost_cat.outside = False
+        additional_cats = lost_cat.add_to_clan()
+        text = random.choice(text)
+        
+        if additional_cats:
+            text += " {PRONOUN/m_c/subject/CAP} {VERB/m_c/bring/brings} along {PRONOUN/m_c/poss} "
+            if len(additional_cats) > 1:
+                text += str(len(additional_cats)) + "childen."
+            else:
+                text += "child."
+         
+        text = event_text_adjust(Cat, text, lost_cat, clan=game.clan)
+        
+        game.cur_events_list.append(
+                Single_Event(text, "misc", [lost_cat.ID] + additional_cats))
+        
+        # Proform a ceremony if needed
+        for x in [lost_cat] + [Cat.fetch_cat(i) for i in additional_cats]:
+            if x.status in ["apprentice", "medicine cat apprentice", "mediator apprentice", "kitten", "newborn"] and x.moons > 15:
+                if x.status == "medicine cat apprentice":
+                    self.ceremony(lost_cat, "medicine cat")
+                elif x.status == "mediator apprentice":
+                    self.ceremony(lost_cat, "mediator")
+                else:
+                    self.ceremony(lost_cat, "warrior")
+            elif x.status in ["kitten", "newborn"] and x.moons > 6:
+                self.ceremony(lost_cat, "apprentice")
+            else:
+                if x.moons == 0:
+                    x.status = 'newborn'
+                elif x.moons < 6:
+                    x.status = "kitten"
+                elif x.moons < 12:
+                    x.status_change('apprentice')
+                elif x.moons < 120:
+                    x.status_change('warrior')
+                else:
+                    x.status_change('elder')
+                    
+            
+            """if self.status in ['leader', 'deputy']: # Just in case -- they should have had their status changes already. 
+                self.status_change('warrior')
+            elif self.status == 'apprentice' and self.moons >= 15:
+                self.status_change('warrior')
+                involved_cats = [self.ID]
+                game.cur_events_list.append(Single_Event('A long overdue warrior ceremony is held for ' + str(
+                    self.name.prefix) + 'paw. They smile as they finally become a warrior of the Clan and are now named ' + str(
+                    self.name) + '.', "ceremony", involved_cats))
+            elif self.status == 'kitten' and self.moons >= 15:
+                self.status_change('warrior')
+                involved_cats = [self.ID]
+                game.cur_events_list.append(Single_Event('A long overdue warrior ceremony is held for ' + str(
+                    self.name.prefix) + 'kit. They smile as they finally become a warrior of the Clan and are now named ' + str(
+                    self.name) + '.', "ceremony", involved_cats))
+            elif self.status == 'kitten' and self.moons >= 6:
+                self.status_change('apprentice')
+                involved_cats = [self.ID]
+                game.cur_events_list.append(Single_Event('A long overdue apprentice ceremony is held for ' + str(
+                    self.name.prefix) + 'kit. They smile as they finally become a warrior of the Clan and are now named ' + str(
+                    self.name) + '.', "ceremony", involved_cats))
+            
+            if self.moons == 0:
+                self.status = 'newborn'
+            elif self.moons < 6:
+                self.status = "kitten"
+            elif self.moons < 12:
+                self.status_change('apprentice')
+            elif self.moons < 120:
+                self.status_change('warrior')
+            else:
+                self.status_change('elder')"""
+            
 
     def handle_fading(self, cat):
         """

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -627,7 +627,7 @@ class Events:
         if additional_cats:
             text += " {PRONOUN/m_c/subject/CAP} {VERB/m_c/bring/brings} along {PRONOUN/m_c/poss} "
             if len(additional_cats) > 1:
-                text += str(len(additional_cats)) + "childen."
+                text += str(len(additional_cats)) + " childen."
             else:
                 text += "child."
          
@@ -640,13 +640,13 @@ class Events:
         for x in [lost_cat] + [Cat.fetch_cat(i) for i in additional_cats]:
             if x.status in ["apprentice", "medicine cat apprentice", "mediator apprentice", "kitten", "newborn"] and x.moons > 15:
                 if x.status == "medicine cat apprentice":
-                    self.ceremony(lost_cat, "medicine cat")
+                    self.ceremony(x, "medicine cat")
                 elif x.status == "mediator apprentice":
-                    self.ceremony(lost_cat, "mediator")
+                    self.ceremony(x, "mediator")
                 else:
-                    self.ceremony(lost_cat, "warrior")
-            elif x.status in ["kitten", "newborn"] and x.moons > 6:
-                self.ceremony(lost_cat, "apprentice")
+                    self.ceremony(x, "warrior")
+            elif x.status in ["kitten", "newborn"] and x.moons >= 6:
+                self.ceremony(x, "apprentice")
             else:
                 if x.moons == 0:
                     x.status = 'newborn'

--- a/scripts/events_module/condition_events.py
+++ b/scripts/events_module/condition_events.py
@@ -681,12 +681,12 @@ class Condition_Events():
             'young adult': 80,
             'adult': 70,
             'senior adult': 50,
-            'senior': 0
+            'senior': 10
         }
 
-        if not triggered and not cat.dead and not cat.retired and cat.status not in \
+        if not triggered and not cat.dead and cat.status not in \
                 ['leader', 'medicine cat', 'kitten', 'newborn', 'medicine cat apprentice', 'mediator',
-                 'mediator apprentice'] \
+                 'mediator apprentice', 'elder'] \
                 and game.settings['retirement'] is False:
             for condition in cat.permanent_condition:
                 if cat.permanent_condition[condition]['severity'] == 'major':

--- a/scripts/game_structure/load_cat.py
+++ b/scripts/game_structure/load_cat.py
@@ -170,7 +170,6 @@ def json_load():
             new_cat.df = cat["df"] if "df" in cat else False
 
             new_cat.outside = cat["outside"] if "outside" in cat else False
-            new_cat.retired = cat["retired"] if "retired" in cat else False
             new_cat.faded_offspring = cat["faded_offspring"] if "faded_offspring" in cat else []
             new_cat.prevent_fading = cat["prevent_fading"] if "prevent_fading" in cat else False
             new_cat.favourite = cat["favourite"] if "favourite" in cat else False

--- a/scripts/screens/cat_screens.py
+++ b/scripts/screens/cat_screens.py
@@ -2454,7 +2454,6 @@ class RoleScreen(Screens):
                 self.the_cat.status_change("elder", resort=True)
                 # Since you can't "unretire" a cat, apply the skill and trait change
                 # here
-                self.the_cat.update_traits()
                 self.update_selected_cat()
             elif event.ui_element == self.switch_mediator:
                 self.the_cat.status_change("mediator", resort=True)
@@ -2712,12 +2711,7 @@ class RoleScreen(Screens):
             self.promote_leader.disable()
             self.promote_deputy.disable()
 
-            # ADULT CAT ROLES
-            # Keep cats that have retired due to health from being switched to warrior
-            if self.the_cat.retired or self.the_cat.age == "elder":
-                self.switch_warrior.disable()
-            else:
-                self.switch_warrior.enable()
+            self.switch_warrior.enable()
             self.switch_med_cat.disable()
             self.switch_mediator.enable()
             self.retire.enable()
@@ -2732,17 +2726,12 @@ class RoleScreen(Screens):
             else:
                 self.promote_leader.disable()
 
-            if deputy_invalid and self.the_cat.age != "elder":
+            if deputy_invalid:
                 self.promote_deputy.enable()
             else:
                 self.promote_deputy.disable()
 
-            # ADULT CAT ROLES
-            # Keep cats that have retired due to health from being switched to warrior
-            if self.the_cat.retired or self.the_cat.age == "elder":
-                self.switch_warrior.disable()
-            else:
-                self.switch_warrior.enable()
+            self.switch_warrior.enable()
             self.switch_med_cat.enable()
             self.switch_mediator.disable()
             self.retire.enable()
@@ -2752,11 +2741,18 @@ class RoleScreen(Screens):
             self.switch_warrior_app.disable()
             self.switch_mediator_app.disable()
         elif self.the_cat.status == "elder":
-            self.promote_leader.disable()
-            self.promote_deputy.disable()
+            if leader_invalid:
+                self.promote_leader.enable()
+            else:
+                self.promote_leader.disable()
+
+            if deputy_invalid:
+                self.promote_deputy.enable()
+            else:
+                self.promote_deputy.disable()
 
             # ADULT CAT ROLES
-            self.switch_warrior.disable()
+            self.switch_warrior.enable()
             self.switch_med_cat.enable()
             self.switch_mediator.enable()
             self.retire.disable()
@@ -2798,10 +2794,7 @@ class RoleScreen(Screens):
             self.promote_deputy.disable()
 
             # ADULT CAT ROLES
-            if self.the_cat.age != "elder":
-                self.switch_warrior.enable()
-            else:
-                self.switch_warrior.disable()
+            self.switch_warrior.enable()
             self.switch_med_cat.disable()
             self.switch_mediator.disable()
             self.retire.enable()


### PR DESCRIPTION
This was meant to be part of the skill rework, but here it is now!
- You can now "unretire" cats - including those who retire based on permanent conditions! Depending on the severity of their conditions, they might just re-retire the next moon.  They also might quickly re-retire if they are old enough.  Some cats just have a mind of their own. ;)
- You can now promote elders to leader or deputy. 
- Some tweaks to lost cats return. They will now get a proper warrior/apprentice ceremony alongside their return message if they change status. This was done to allow skill updates to work properly. 
- Added a couple flavor text options to the lost cat return message. 
- Remove the "retired" cat property, since it is no longer needed. 