### PR TITLE
Bugfixes/Tweaks

### DIFF
--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -1823,25 +1823,6 @@ class Cat():
         
         self.status_change("elder")
         return
-        
-        old_status = self.status
-        self.status = 'elder'
-        self.name.status = 'elder'
-        #self.update_traits()
-
-        if old_status == 'leader':
-            game.clan.leader_lives = 0
-            if game.clan.leader:
-                if game.clan.leader.ID == self.ID:
-                    game.clan.leader = None
-                    game.clan.leader_predecessors += 1
-
-        if game.clan.deputy:
-            if game.clan.deputy.ID == self.ID:
-                game.clan.deputy = None
-                game.clan.deputy_predecessors += 1
-
-        self.update_mentor()
 
     def is_ill(self):
         is_ill = True

--- a/scripts/cat/skills.py
+++ b/scripts/cat/skills.py
@@ -173,6 +173,32 @@ class Skill():
     tier_ranges = ((0, 9), (10, 19), (20, 29))
     point_range = (0, 29)
     
+    short_strings = {
+        SkillPath.TEACHER: "teaching",
+        SkillPath.HUNTER: "hunting",
+        SkillPath.FIGHTER: "fighting",
+        SkillPath.RUNNER: "running",
+        SkillPath.CLIMBER: "climbing",
+        SkillPath.SWIMMER: "swimming",
+        SkillPath.SPEAKER: "speaking",
+        SkillPath.MEDIATOR: "mediating",
+        SkillPath.CLEVER: "clever",
+        SkillPath.INSIGHTFUL: "advising",
+        SkillPath.SENSE: "observing",
+        SkillPath.KIT: "caretaking",
+        SkillPath.STORY: "storytelling",
+        SkillPath.LORE: "lorekeeping",
+        SkillPath.CAMP: "campkeeping",
+        SkillPath.HEALER: "healing",
+        SkillPath.STAR: "starclan",
+        SkillPath.OMEN: "omen",
+        SkillPath.DREAM: "dreaming",
+        SkillPath.CLAIRVOYANT: "predicting",
+        SkillPath.PROPHET: "prophesying",
+        SkillPath.GHOST: "ghosts"
+    }
+    
+    
     def __init__(self, path:SkillPath, points:int=0, interest_only:bool=False):
         
         self.path = path
@@ -183,6 +209,9 @@ class Skill():
             self._p = self.point_range[0]
         else:
             self._p = points
+    
+    def get_short_skill(self):
+        return Skill.short_strings.get(self.path, "???")
     
     @staticmethod
     def generate_from_save_string(save_string:str):
@@ -371,12 +400,19 @@ class CatSkills:
             "hidden": self.hidden.name if self.hidden else None
         }
 
-    def skill_string(self):
+    def skill_string(self, short=False):
         output = []
-        if self.primary:
-            output.append(self.primary.skill)
-        if self.secondary:
-            output.append(self.secondary.skill)
+        
+        if short:
+            if self.primary:
+                output.append(self.primary.get_short_skill())
+            if self.secondary:
+                output.append(self.secondary.get_short_skill())
+        else:
+            if self.primary:
+                output.append(self.primary.skill)
+            if self.secondary:
+                output.append(self.secondary.skill)
         
         if not output:
             return "???"

--- a/scripts/cat/skills.py
+++ b/scripts/cat/skills.py
@@ -499,7 +499,7 @@ class CatSkills:
                     self.secondary.interest_only = False
                     
                 # If a cat doesn't can a secondary, have a small change for them to get one. 
-                if not int(random.random() * 200):
+                if not self.secondary and not int(random.random() * 200):
                     self.secondary = Skill.get_random_skill(exclude=self.primary.path)
                 
                 # If a cat is not an apprentice or kit, 

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -657,41 +657,7 @@ class Events:
                 elif x.moons < 120:
                     x.status_change('warrior')
                 else:
-                    x.status_change('elder')
-                    
-            
-            """if self.status in ['leader', 'deputy']: # Just in case -- they should have had their status changes already. 
-                self.status_change('warrior')
-            elif self.status == 'apprentice' and self.moons >= 15:
-                self.status_change('warrior')
-                involved_cats = [self.ID]
-                game.cur_events_list.append(Single_Event('A long overdue warrior ceremony is held for ' + str(
-                    self.name.prefix) + 'paw. They smile as they finally become a warrior of the Clan and are now named ' + str(
-                    self.name) + '.', "ceremony", involved_cats))
-            elif self.status == 'kitten' and self.moons >= 15:
-                self.status_change('warrior')
-                involved_cats = [self.ID]
-                game.cur_events_list.append(Single_Event('A long overdue warrior ceremony is held for ' + str(
-                    self.name.prefix) + 'kit. They smile as they finally become a warrior of the Clan and are now named ' + str(
-                    self.name) + '.', "ceremony", involved_cats))
-            elif self.status == 'kitten' and self.moons >= 6:
-                self.status_change('apprentice')
-                involved_cats = [self.ID]
-                game.cur_events_list.append(Single_Event('A long overdue apprentice ceremony is held for ' + str(
-                    self.name.prefix) + 'kit. They smile as they finally become a warrior of the Clan and are now named ' + str(
-                    self.name) + '.', "ceremony", involved_cats))
-            
-            if self.moons == 0:
-                self.status = 'newborn'
-            elif self.moons < 6:
-                self.status = "kitten"
-            elif self.moons < 12:
-                self.status_change('apprentice')
-            elif self.moons < 120:
-                self.status_change('warrior')
-            else:
-                self.status_change('elder')"""
-            
+                    x.status_change('elder')      
 
     def handle_fading(self, cat):
         """

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -1154,11 +1154,6 @@ class Events:
                             self.ceremony_accessory = True
                             self.gain_accessories(cat)
                         else:
-                            if cat.is_disabled() and not game.settings["retirement"]:
-                                for condition in cat.permanent_condition:
-                                    if cat.permanent_condition[condition]["severity"] == "severe":
-                                        cat.status = 'apprentice'
-                                        return
                             self.ceremony(cat, 'apprentice')
                             self.ceremony_accessory = True
                             self.gain_accessories(cat)

--- a/scripts/events_module/condition_events.py
+++ b/scripts/events_module/condition_events.py
@@ -697,9 +697,9 @@ class Condition_Events():
                         retire_chances = {
                             'newborn': 0,
                             'kitten': 0,
-                            'adolescent': 20,
-                            'young adult': 20,
-                            'adult': 10,
+                            'adolescent': 50,  # This is high so instances where an cat retires the same moon they become an apprentice is rare
+                            'young adult': 10,
+                            'adult': 5,
                             'senior adult': 5,
                             'senior': 5
                         }
@@ -716,13 +716,14 @@ class Condition_Events():
                     
                     chance = int(retire_chances.get(cat.age))
                     if not int(random.random() * chance):
-                        event_types.append('ceremony')
+                        retire_involved = [cat.ID]
                         if cat.age == 'adolescent':
                             event = f"{cat.name} decides they'd rather spend their time helping around camp and entertaining the " \
                                     f"kits, they're warmly welcomed into the elder's den."
                         elif game.clan.leader is not None:
                             if not game.clan.leader.dead and not game.clan.leader.exiled and \
                                     not game.clan.leader.outside and cat.moons < 120:
+                                retire_involved.append(game.clan.leader.ID)
                                 event = f"{game.clan.leader.name}, seeing {cat.name} struggling the last few moons " \
                                         f"approaches them and promises them that no one would think less of them for " \
                                         f"retiring early and that they would still be a valuable member of the Clan " \
@@ -738,7 +739,9 @@ class Condition_Events():
                                      f"of their contributions to {game.clan.name}Clan."
 
                         cat.retire_cat()
-                        event_list.append(event)
+                        # Don't add this to the condition event list: instead make it it's own event, a ceremony. 
+                        game.cur_events_list.append(
+                                Single_Event(event, "ceremony", retire_involved))
 
     def give_risks(self, cat, event_list, condition, progression, conditions, dictionary):
         event_triggered = False

--- a/scripts/events_module/condition_events.py
+++ b/scripts/events_module/condition_events.py
@@ -689,7 +689,31 @@ class Condition_Events():
                  'mediator apprentice', 'elder'] \
                 and game.settings['retirement'] is False:
             for condition in cat.permanent_condition:
-                if cat.permanent_condition[condition]['severity'] == 'major':
+                if cat.permanent_condition[condition]['severity'] in ['major', 'severe']:
+                    
+                    if cat.permanent_condition[condition]['severity'] == "severe":
+                        # Higher changes for "severe". These are meant to be nearly 100% without 
+                        # being 100%
+                        retire_chances = {
+                            'newborn': 0,
+                            'kitten': 0,
+                            'adolescent': 20,
+                            'young adult': 20,
+                            'adult': 10,
+                            'senior adult': 5,
+                            'senior': 5
+                        }
+                    else:
+                        retire_chances = {
+                            'newborn': 0,
+                            'kitten': 0,
+                            'adolescent': 100,
+                            'young adult': 80,
+                            'adult': 70,
+                            'senior adult': 50,
+                            'senior': 10
+                        }
+                    
                     chance = int(retire_chances.get(cat.age))
                     if not int(random.random() * chance):
                         event_types.append('ceremony')
@@ -715,31 +739,6 @@ class Condition_Events():
 
                         cat.retire_cat()
                         event_list.append(event)
-
-                elif cat.permanent_condition[condition]['severity'] == 'severe':
-                    event_types.append('ceremony')
-                    if cat.age == 'adolescent':
-                        event = f"{cat.name} decides they'd rather spend their time helping around camp and entertaining the " \
-                            f"kits, they're warmly welcomed into the elder's den."
-                    elif game.clan.leader is not None:
-                        if not game.clan.leader.dead and not game.clan.leader.exiled \
-                                and not game.clan.leader.outside and cat.moons < 120:
-                            event = f"{game.clan.leader.name}, seeing {cat.name} struggling the last few moons " \
-                                    f"approaches them and promises them that no one would think less of them for " \
-                                    f"retiring early and that they would still be a valuable member of the clan " \
-                                    f"as an elder. {cat.name} agrees and later that day their elder ceremony " \
-                                    f"is held."
-                        else:
-                            event = f'{cat.name} has decided to retire from normal Clan duty.'
-                    else:
-                        event = f'{cat.name} has decided to retire from normal Clan duty.'
-
-                    if cat.age == 'adolescent':
-                        event += f" They are given the name {cat.name.prefix}{cat.name.suffix} in honor " \
-                                 f"of their contributions to {game.clan.name}Clan."
-
-                    cat.retire_cat()
-                    event_list.append(event)
 
     def give_risks(self, cat, event_list, condition, progression, conditions, dictionary):
         event_triggered = False

--- a/scripts/events_module/generate_events.py
+++ b/scripts/events_module/generate_events.py
@@ -402,7 +402,7 @@ class GenerateEvents:
                             print("Cat skill incorrectly formatted", _skill)
                             continue
                         
-                        if other_cat.skills.meets_skill_requirement(split[0], split[1]):
+                        if other_cat.skills.meets_skill_requirement(split[0], int(split[1])):
                             _flag = True
                             break
                     
@@ -423,11 +423,11 @@ class GenerateEvents:
                             print("Cat skill incorrectly formatted", _skill)
                             continue
                         
-                        if other_cat.skills.meets_skill_requirement(split[0], split[1]):
+                        if other_cat.skills.meets_skill_requirement(split[0], int(split[1])):
                             _flag = True
                             break
                     
-                    if not _flag and int(random.random() * 15):
+                    if _flag and int(random.random() * 15):
                         continue
 
             else:
@@ -453,12 +453,12 @@ class GenerateEvents:
                         print("Cat skill incorrectly formatted", _skill)
                         continue
                     
-                    if cat.skills.meets_skill_requirement(split[0], split[1]):
+                    if cat.skills.meets_skill_requirement(split[0], int(split[1])):
                         _flag = True
                         break
                 
                 # If the cat doesn't have the skill, and some random chance, continue. 
-                if not _flag and int(random.random() * 15):
+                if _flag and int(random.random() * 15):
                     continue
 
             had_trait = True
@@ -475,11 +475,11 @@ class GenerateEvents:
                         print("Cat skill incorrectly formatted", _skill)
                         continue
                     
-                    if cat.skills.meets_skill_requirement(split[0], split[1]):
+                    if cat.skills.meets_skill_requirement(split[0], int(split[1])):
                         _flag = True
                         break
                 
-                if not _flag and int(random.random() * 15):
+                if _flag and int(random.random() * 15):
                     continue
 
             # determine injury severity chance

--- a/scripts/events_module/generate_events.py
+++ b/scripts/events_module/generate_events.py
@@ -90,16 +90,16 @@ class GenerateEvents:
                     tags=event["tags"],
                     event_text=event_text,
                     history_text=event["history_text"] if "history_text" in event else {},
-                    cat_trait=event["cat_trait"] if "cat_negate_trait" in event else [],
-                    cat_skill=event["cat_skill"] if "cat_negate_trait" in event else [],
-                    other_cat_trait=event["other_cat_trait"] if "cat_negate_trait" in event else [],
-                    other_cat_skill=event["other_cat_skill"] if "cat_negate_trait" in event else [],
+                    cat_trait= event["cat_trait"] if "cat_trait" in event else [],
+                    cat_skill=event["cat_skill"] if "cat_skill" in event else [],
+                    other_cat_trait=event["other_cat_trait"] if "other_cat_trait" in event else [],
+                    other_cat_skill=event["other_cat_skill"] if "other_cat_skill" in event else [],
                     cat_negate_trait=event["cat_negate_trait"] if "cat_negate_trait" in event else [],
                     cat_negate_skill=event["cat_negate_skill"] if "cat_negate_skill" in event else [],
                     other_cat_negate_trait=event[
                         "other_cat_negate_trait"] if "other_cat_negate_trait" in event else [],
                     other_cat_negate_skill=event[
-                        "other_cat_negate_trait"] if "other_cat_negate_trait" in event else [],
+                        "other_cat_negate_skill"] if "other_cat_negate_skill" in event else [],
                     backstory_constraint=event["backstory_constraint"] if "backstory_constraint" in event else [],
 
                     # injury event only
@@ -589,14 +589,14 @@ class ShortEvent:
         self.tags = tags
         self.event_text = event_text
         self.history_text = history_text
-        self.cat_trait = cat_trait
-        self.cat_skill = cat_skill
-        self.other_cat_trait = other_cat_trait
-        self.other_cat_skill = other_cat_skill
-        self.cat_negate_trait = cat_negate_trait
-        self.cat_negate_skill = cat_negate_skill
-        self.other_cat_negate_trait = other_cat_negate_trait
-        self.other_cat_negate_skill = other_cat_negate_skill
+        self.cat_trait = cat_trait if cat_trait else []
+        self.cat_skill = cat_skill if cat_skill else []
+        self.other_cat_trait = other_cat_trait if other_cat_trait else []
+        self.other_cat_skill = other_cat_skill if other_cat_skill else []
+        self.cat_negate_trait = cat_negate_trait if cat_negate_trait else []
+        self.cat_negate_skill = cat_negate_skill if cat_negate_skill else []
+        self.other_cat_negate_trait = other_cat_negate_trait if other_cat_negate_trait else []
+        self.other_cat_negate_skill = other_cat_negate_skill if other_cat_negate_skill else []
         self.backstory_constraint = backstory_constraint
 
         # for injury event

--- a/scripts/events_module/relationship/pregnancy_events.py
+++ b/scripts/events_module/relationship/pregnancy_events.py
@@ -75,6 +75,11 @@ class Pregnancy_Events():
         if cat.outside:
             return
 
+        # Handle birth cooldown outside of the check_if_can_have_kits function, so it only happens once
+        # for each cat. 
+        if cat.birth_cooldown > 0:
+            cat.birth_cooldown -= 1
+        
         # Check if they can have kits.
         can_have_kits = self.check_if_can_have_kits(cat, game.settings['single parentage'], game.settings['affair'])
         if not can_have_kits:
@@ -129,9 +134,10 @@ class Pregnancy_Events():
         if other_cat and other_cat.ID in clan.pregnancy_data:
             return
         
+        
         amount = self.get_amount_of_kits(cat)
         kits = self.get_kits(amount, None, None, clan)
-
+        
         insert = 'this should not display'
         insert2 = 'this should not display'
         if amount == 1:
@@ -158,10 +164,16 @@ class Pregnancy_Events():
                         kit.adoptive_parents.append(x)
         
         cat.create_inheritance_new_cat()
+        
+        # Normally, birth cooldown is only applied to cat who gave birth
+        # However, if we don't apply birth cooldown to adoption, we get
+        # too much adoption, since adoptive couples are using the increased two-parent 
+        # kits chance. We will only apply it to "cat" in this case
+        # which is enough to stop the couple from adopting about within
+        # the window. 
         cat.birth_cooldown = game.config["pregnancy"]["birth_cooldown"]
         if other_cat:
             other_cat.create_inheritance_new_cat()
-            other_cat.birth_cooldown = game.config["pregnancy"]["birth_cooldown"]
 
         game.cur_events_list.append(Single_Event(print_event, "birth_death", cats_involved))
 
@@ -314,6 +326,9 @@ class Pregnancy_Events():
         else:
             insert = f'litter of {kits_amount} kits'
 
+        # Since cat has given birth, apply the birth cooldown. 
+        cat.birth_cooldown = game.config["pregnancy"]["birth_cooldown"]
+        
         # choose event string
         # TODO: currently they don't choose which 'mate' is the 'blood' parent or not
         # change or leaf as it is? 
@@ -412,7 +427,6 @@ class Pregnancy_Events():
             return False
 
         if cat.birth_cooldown > 0:
-            cat.birth_cooldown -= 1
             return False
 
         if 'recovering from birth' in cat.injuries:
@@ -574,29 +588,54 @@ class Pregnancy_Events():
 
         return None
 
-    def get_kits(self, kits_amount, cat=None, other_cat=None, clan=game.clan):
-        # create amount of kits
+    def get_kits(self, kits_amount, cat=None, other_cat=None, clan=game.clan, birth_cooldown=True):
+        """Create some amount of kits
+           No parents are specifed, it will create a blood parents for all the 
+           kits to be related to. They may be dead or alive, but will always be outside 
+           the clan. 
+           If birth_cooldown is set to false, it will override """
         all_kitten = []
         
-        # blood parent for adoptive kits
-        insert = "their kits"
-        if kits_amount == 1:
-            insert = "their kit"
-        thought = f"Is glad that {insert} are safe"
-        blood_parent = create_new_cat(Cat, Relationship,
-                                      status=random.choice(["loner", "kittypet"]),
-                                      alive=False,
-                                      thought=thought,
-                                      age=randint(15,120))[0]
-        blood_parent.thought = thought
+        #First, just a check: If we have no cat, but an other_cat was provided, 
+        # swap other_cat to cat:
+        # This way, we can ensure that if only one parent is provided, 
+        # it's cat, not other_cat. 
+        # And if cat is None, we know that no parents were provided. 
+        if other_cat and not cat:
+            cat = other_cat
+            other_cat = None
         
+        blood_parent = None
+         
         # select background here to have the same over all kits
-        backstory_1 = choice(['halfclan1', 'outsider_roots1'])
-        backstory_2 = choice(['halfclan2', 'outsider_roots2'])
-        backstory_3 = choice(['abandoned1', 'abandoned2', 'abandoned3', 'abandoned4'])
+        if cat and cat.gender == 'female':
+            backstory = choice(['halfclan1', 'outsider_roots1'])
+        elif cat:
+            backstory = choice(['halfclan2', 'outsider_roots2'])
+        else: # cat is adopted
+            backstory = choice(['abandoned1', 'abandoned2', 'abandoned3', 'abandoned4'])
+        
+        #Generate the kits
         for kit in range(kits_amount):
             kit = None
-            if other_cat is not None:
+            if not cat: 
+                # No parents provided, give a blood parent - this is an adoption. 
+                if not blood_parent:
+                    # Generate a blood parent if we haven't already. 
+                    insert = "their kits"
+                    if kits_amount == 1:
+                        insert = "their kit"
+                    thought = f"Is glad that {insert} are safe"
+                    blood_parent = create_new_cat(Cat, Relationship,
+                                                status=random.choice(["loner", "kittypet"]),
+                                                alive=choice(["True", "False"]),
+                                                thought=thought,
+                                                age=randint(15,120))[0]
+                    blood_parent.thought = thought
+                
+                kit = Cat(parent1=blood_parent.ID ,moons=0, backstory=backstory, status='newborn')
+            elif cat and other_cat:
+                # Two parents provided
                 if cat.gender == 'female':
                     kit = Cat(parent1=cat.ID, parent2=other_cat.ID, moons=0, status='newborn')
                     kit.thought = f"Snuggles up to the belly of {cat.name}"
@@ -606,32 +645,12 @@ class Pregnancy_Events():
                 else:
                     kit = Cat(parent1=other_cat.ID, parent2=cat.ID, moons=0, status='newborn')
                     kit.thought = f"Snuggles up to the belly of {other_cat.name}"
-                
-                # all current mates are adoptive parents
-                kit.adoptive_parents = cat.mate + other_cat.mate
-
-                # remove blood parents from adoptive parents
-                if cat.ID in kit.adoptive_parents:
-                    kit.adoptive_parents.remove(cat.ID)
-                if other_cat.ID in kit.adoptive_parents:
-                    kit.adoptive_parents.remove(other_cat.ID)
-                cat.birth_cooldown = game.config["pregnancy"]["birth_cooldown"]
-                other_cat.birth_cooldown = game.config["pregnancy"]["birth_cooldown"]
             else:
-                if cat and cat.gender == 'female':
-                    backstory = backstory_1
-                elif cat:
-                    backstory = backstory_2
-                else: # cat is adopted
-                    backstory = backstory_3
-
-                if cat:
-                    kit = Cat(parent1=cat.ID, moons=0, backstory=backstory, status='newborn')
-                    cat.birth_cooldown = game.config["pregnancy"]["birth_cooldown"]
-                    kit.adoptive_parents = cat.mate
-                    kit.thought = f"Snuggles up to the belly of {cat.name}"
-                else:
-                    kit = Cat(parent1=blood_parent.ID ,moons=0, backstory=backstory, status='newborn')
+                # One parent provided is the only other option.
+                kit = Cat(parent1=cat.ID, moons=0, backstory=backstory, status='newborn')
+                kit.adoptive_parents = cat.mate
+                kit.thought = f"Snuggles up to the belly of {cat.name}"
+                
             all_kitten.append(kit)
 
             # remove scars
@@ -693,9 +712,10 @@ class Pregnancy_Events():
                 kitten.relationships[second_kitten.ID].trust += 10 + y
             kitten.create_inheritance_new_cat()
 
-        blood_parent.inheritance.update_inheritance()
-        blood_parent.outside = True
-        clan.unknown_cats.append(blood_parent.ID)
+        if blood_parent:
+            blood_parent.inheritance.update_inheritance()
+            blood_parent.outside = True
+            clan.unknown_cats.append(blood_parent.ID)
 
         return all_kitten
 

--- a/scripts/screens/cat_screens.py
+++ b/scripts/screens/cat_screens.py
@@ -2517,8 +2517,6 @@ class RoleScreen(Screens):
                                             manager=MANAGER)
         self.retire = UIImageButton(scale(pygame.Rect((451, 792), (334, 72))), "",
                                     object_id="#retire_button",
-                                    tool_tip_text="If a cat is retired, you will be "
-                                                  "unable to switch them to warrior status. ",
                                     manager=MANAGER)
         self.switch_med_cat = UIImageButton(scale(pygame.Rect((805, 720), (344, 104))), "",
                                             object_id="#switch_med_cat_button",

--- a/scripts/screens/patrol_screens.py
+++ b/scripts/screens/patrol_screens.py
@@ -526,8 +526,8 @@ class PatrolScreen(Screens):
             if x != self.patrol_obj.patrol_leader:
                 members.append(str(x.name))
         for x in self.patrol_obj.patrol_skills:
-            if x not in skills:
-                skills.append(x.skill)
+            if x.get_short_skill() not in skills:
+                skills.append(x.get_short_skill())
         for x in self.patrol_obj.patrol_traits:
             if x not in traits:
                 traits.append(x)
@@ -705,8 +705,12 @@ class PatrolScreen(Screens):
         patrol_traits = []
         if self.current_patrol is not []:
             for x in self.current_patrol:
-                if x.skill not in patrol_skills:
-                    patrol_skills.append(x.skill)
+                if x.skills.primary and x.skills.primary.get_short_skill() not in patrol_skills:
+                    patrol_skills.append(x.skills.primary.get_short_skill())
+                
+                if x.skills.secondary and x.skills.secondary.get_short_skill() not in patrol_skills:
+                    patrol_skills.append(x.skills.secondary.get_short_skill())
+                
                 if x.personality.trait not in patrol_traits:
                     patrol_traits.append(x.personality.trait)
 
@@ -794,7 +798,7 @@ class PatrolScreen(Screens):
 
             self.elements['selected_bio'] = pygame_gui.elements.UITextBox(str(self.selected_cat.status) +
                                                                           "\n" + str(self.selected_cat.personality.trait) +
-                                                                          "\n" + str(self.selected_cat.skills.skill_string()) +
+                                                                          "\n" + str(self.selected_cat.skills.skill_string(short=True)) +
                                                                           "\n" + str(
                 self.selected_cat.experience_level) +
                                                                           (f' ({str(self.selected_cat.experience)})' if

--- a/scripts/screens/relation_screens.py
+++ b/scripts/screens/relation_screens.py
@@ -220,8 +220,8 @@ class ChooseMentorScreen(Screens):
                 (300, 300)),
             manager=MANAGER)
 
-        info = self.the_cat.age + "\n" + self.the_cat.status + "\n" + self.the_cat.genderalign + \
-               "\n" + self.the_cat.personality.trait + "\n" + self.the_cat.skills.skill_string()
+        info = self.the_cat.status + "\n" + self.the_cat.genderalign + \
+               "\n" + self.the_cat.personality.trait + "\n" + self.the_cat.skills.skill_string(short=True)
         self.apprentice_details["apprentice_info"] = pygame_gui.elements.UITextBox(
             info,
             scale(pygame.Rect((980, 325), (210, 250))),
@@ -329,9 +329,9 @@ class ChooseMentorScreen(Screens):
                     self.selected_mentor.sprite,
                     (300, 300)), manager=MANAGER)
 
-            info = self.selected_mentor.age + "\n" + self.selected_mentor.status + "\n" + \
+            info = self.selected_mentor.status + "\n" + \
                    self.selected_mentor.genderalign + "\n" + self.selected_mentor.personality.trait + "\n" + \
-                   self.selected_mentor.skills.skill_string()
+                   self.selected_mentor.skills.skill_string(short=True)
             if len(self.selected_mentor.former_apprentices) >= 1:
                 info += f"\n{len(self.selected_mentor.former_apprentices)} former app(s)"
             if len(self.selected_mentor.apprentice) >= 1:


### PR DESCRIPTION
- Severe conditions now have a high, but not 100%, chance of causing retirement. NOTE: These is a small chance of apprentices retiring the same moon they are apprenticed. That is intended behavior. 
- Fixed birth cooldown being applied inconsistently or not at all. It is now only and correctly applies to cats who gave birth or to two-parent couples who adopt via a "pregnancy event". The later of the two is to prevent rapid-fire adoption, since those adoptions use the increased mated kit chance. 
- Prevent birth cooldown from sometimes decreasing by more than one in a single timeskip. 
- A unknown residence cat will no longer be generated for every pregnancy/adoption. The birth parent generated for same-sex adoptions now has a chance to be alive. 
- Fix skill and trait constraints on events - it looks like they never worked properly. 
- Add short skill display to be used in a few places. 
- Fixed crash on skills tab on the patrol screen