### PR TITLE
Bugfixes: Handful of Inheritance Issues

### DIFF
--- a/scripts/events_module/generate_events.py
+++ b/scripts/events_module/generate_events.py
@@ -345,7 +345,14 @@ class GenerateEvents:
             # check if clan has kits
             if "clan_kits" in event.tags and not alive_kits:
                 continue
-
+            
+            if "adoption" in event.tags:
+                # If the cat or any of their mates have "no kits" toggled, forgo the adoption event.
+                if cat.no_kits:
+                    continue
+                if any(cat.fetch_cat(i).no_kits for i in cat.mate):
+                    continue
+            
             # check for old age
             if "old_age" in event.tags and cat.moons < 150:
                 continue

--- a/scripts/events_module/new_cat_events.py
+++ b/scripts/events_module/new_cat_events.py
@@ -37,10 +37,8 @@ class NewCatEvents:
             other_clan = game.clan.all_clans[0]
             other_clan_name = f'{other_clan.name}Clan'
 
-        possible_events = self.generate_events.possible_short_events(cat.status, cat.age, "new_cat")
-        final_events = self.generate_events.filter_possible_short_events(possible_events, cat, other_cat, war,
-                                                                         enemy_clan,
-                                                                         other_clan, alive_kits)
+        
+        #Determine
         if self.has_outside_cat():
             if random.randint(1, 3) == 1:
                 outside_cat = self.select_outside_cat()
@@ -68,14 +66,20 @@ class NewCatEvents:
                 game.clan.add_to_clan(outside_cat)
 
                 return [outside_cat]
+
+        
         # ---------------------------------------------------------------------------- #
         #                                cat creation                                  #
         # ---------------------------------------------------------------------------- #
-        try:
-            new_cat_event = (random.choice(final_events))
-        except:
+        possible_events = self.generate_events.possible_short_events(cat.status, cat.age, "new_cat")
+        final_events = self.generate_events.filter_possible_short_events(possible_events, cat, other_cat, war,
+                                                                        enemy_clan,
+                                                                        other_clan, alive_kits)
+        if not final_events:
             print('ERROR: no new cat moon events available')
             return
+        else:
+            new_cat_event = (random.choice(final_events))
 
         involved_cats = []
         created_cats = []
@@ -97,6 +101,8 @@ class NewCatEvents:
         elif "new_med" in new_cat_event.tags:
             status = "medicine cat"
 
+
+        
         created_cats = create_new_cat(Cat,
                                       Relationship,
                                       new_cat_event.new_name,
@@ -108,23 +114,33 @@ class NewCatEvents:
                                       new_cat_event.backstory,
                                       status
                                       )
-        # print(created_cats)
-
-        if "adoption" in new_cat_event.tags:
-            if cat.no_kits:
-                return
-            if len(cat.mate) > 0:
-                for mate_id in cat.mate:
-                    mate = cat.fetch_cat(mate_id)
-                    if mate.no_kits:
-                       return
+        
+        blood_parent = None
+        if new_cat_event.litter:
+            # If we have a litter joining, assign them a blood parent for
+            # relation-tracking purposes
+            thought = "Is happy their kits are safe"
+            blood_parent = create_new_cat(Cat, Relationship,
+                                          status=random.choice(["loner", "kittypet"]),
+                                          alive=False,
+                                          thought=thought,
+                                          age=random.randint(15,120))[0]
+                
+            
         for new_cat in created_cats:
+            
             involved_cats.append(new_cat.ID)
+            
+            # Set the blood parent, if one was created.
+            # Also set adoptive parents if needed. 
+            new_cat.parent1 = blood_parent
             if "adoption" in new_cat_event.tags:
                 new_cat.adoptive_parents.append(cat.ID)
                 if len(cat.mate) > 0:
                     new_cat.adoptive_parents.extend(cat.mate)
-                new_cat.create_inheritance_new_cat()
+            
+            # All parents have been added now, we now create the inheritance. 
+            new_cat.create_inheritance_new_cat()
 
             if "m_c" in new_cat_event.tags:
                 # print('moon event new cat rel gain')

--- a/scripts/patrol.py
+++ b/scripts/patrol.py
@@ -1529,7 +1529,8 @@ class Patrol():
                             trust=parent_to_kit["trust"]
                         )
 
-        # now have the new cats form relationships with the patrol cats
+        # now have the new cats form relationships with the patrol cats and 
+        # update inheritance
         for new_cat in created_cats:
             if new_cat.outside:
                 continue
@@ -1539,8 +1540,11 @@ class Patrol():
                 patrol_cat.relationships[new_cat.ID] = Relationship(patrol_cat, new_cat)
                 new_cat.relationships[patrol_cat.ID] = Relationship(new_cat, patrol_cat)
             self.results_text.append(f"{new_cat.name} has joined the Clan.")
-            # update inheritance
+            
+            # update inheritance!
             new_cat.create_inheritance_new_cat()
+            
+            
             # for each cat increase the relationship towards all patrolling cats
             new_to_clan_cat = game.config["new_cat"]["rel_buff"]["new_to_clan_cat"]
             clan_cat_to_new = game.config["new_cat"]["rel_buff"]["clan_cat_to_new"]

--- a/scripts/screens/relation_screens.py
+++ b/scripts/screens/relation_screens.py
@@ -3628,6 +3628,7 @@ class ChooseAdoptiveParentScreen(Screens):
                 else:
                     self.the_cat.adoptive_parents.remove(self.selected_cat.ID)
                     self.the_cat.create_inheritance_new_cat()
+                    self.selected_cat.create_inheritance_new_cat()
                 
                 self.draw_tab_button()
                 self.update_toggle_button()

--- a/scripts/utility.py
+++ b/scripts/utility.py
@@ -404,7 +404,9 @@ def create_new_cat(Cat,
 
         # create relationships
         new_cat.create_relationships_new_cat()
-        new_cat.create_inheritance_new_cat()
+        # Note - we always update inheritance after the cats are generated, to
+        # allow us to add parents. 
+        #new_cat.create_inheritance_new_cat() 
 
     return created_cats
 


### PR DESCRIPTION
- The "no_kits" toggle now works correctly for kit-adoption event that aren't the same-sex "pregnancy" related adoption events.
- For the type of adoption events mentioned above, generate a blood parent for litters.  They will always be dead to prevent issues, and their status/gender may not match the event. But it's better than nothing - They mainly just exist to make the litter blood related. 
- Cut down on unnecessarily calls to create_new_cat_inheritance() when generating new cats. 
- Upsetting an adoptive parent will properly update the previous-parents inheritance. 