### PR TITLE
Bugfix: Leader Ceremonies

### DIFF
--- a/resources/dicts/lead_ceremony_df.json
+++ b/resources/dicts/lead_ceremony_df.json
@@ -41,6 +41,10 @@
     }
   },
 
+  "default_life": {
+          "text": "r_c stalks forward, eyes flashing. \"With this life, I grant you [virtue].\" {PRONOUN/r_c/subject} {VERB/r_c/meow/meows}, before disappearing back into the darkness ",
+          "virtue": ["energy", "strength", "determination"]
+        },
 
   "lives": {
     "only_guide": {

--- a/resources/dicts/lead_ceremony_sc.json
+++ b/resources/dicts/lead_ceremony_sc.json
@@ -35,6 +35,11 @@
     }
   },
 
+  "default_life": {
+          "text": "r_c approches, dipping {PRONOUN/r_c/poss} head in greeting. \"I give you a life for [virtue].\" {PRONOUN/r_c/subject/CAP} {VERB/r_c/meow/meows}, before slipping back into the crowd.",
+          "virtue": ["energy", "strength", "widsom"]
+        },
+
   "lives": {
     "only_guide": {
       "tags": ["new_clan", "guide"],

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -1133,16 +1133,20 @@ class Cat():
             chosen_life = {}
             while i < 10:
                 attempted = []
-                try:
+                if life_list:
                     chosen_life = choice(life_list)
-                except IndexError:
-                    print(
-                        f'WARNING: life list had no items for giver #{giver_cat.ID}. If you are a beta tester, please report and ping scribble along with all the info you can about the giver cat mentioned in this warning.')
-                if chosen_life not in used_lives and chosen_life not in attempted:
-                    break
+                    if chosen_life not in used_lives and chosen_life not in attempted:
+                        break
+                    else:
+                        attempted.append(chosen_life)
+                    i += 1
                 else:
-                    attempted.append(chosen_life)
-                i += 1
+                    print(
+                        f'WARNING: life list had no items for giver #{giver_cat.ID}. Using default life. If you are a beta tester, please report and ping scribble along with all the info you can about the giver cat mentioned in this warning.')
+                    chosen_life = ceremony_dict["default_life"]
+                    break
+                
+            
             used_lives.append(chosen_life)
             if "virtue" in chosen_life:
                 poss_virtues = [i for i in chosen_life["virtue"] if i not in used_virtues]

--- a/scripts/cat_relations/inheritance.py
+++ b/scripts/cat_relations/inheritance.py
@@ -122,7 +122,8 @@ class Inheritance():
         """Update all the inheritances of the cats, which are related to the current cat."""
         # only adding/removing parents or kits will use this function, because all inheritances are based on parents
         for cat_id in self.all_involved:
-            if cat_id in self.all_inheritances:
+             # Don't update the inheritance of faded cats - they are not viewable by the player and won't be used in any checks. 
+            if cat_id in self.all_inheritances and not self.cat.fetch_cat(cat_id).faded:
                 self.all_inheritances[cat_id].update_inheritance()
 
     def update_all_mates(self):


### PR DESCRIPTION
- Add a "default life" to use when there are no possible more-specific lives. Prevents crash on leader ceremony if no lives can be found. 
- When updating all related inheritance, don't update the inheritance of faded cats. 