### PR TITLE
Bugfix/Other: Fix Crash, add new skill path

### DIFF
--- a/scripts/cat/skills.py
+++ b/scripts/cat/skills.py
@@ -102,9 +102,15 @@ class SkillPath(Enum):
     )
     STAR = (
         "curious about StarClan",
-        "innate connection to StarClan",
-        "strong connection to StarClan",
-        "unbreakable connection to StarClan"
+        "connection to Starclan",
+        "deep StarClan bond",
+        "unshakable StarClan link",
+    )
+    DARK = (
+        "interested in the Dark Forest",
+        "Dark Forest affinity",
+        "deep Dark Forest bond",
+        "unshakable Dark Forest link",
     )
     OMEN = (
         "interested in oddities",
@@ -143,7 +149,8 @@ class SkillPath(Enum):
         
         uncommon_paths = [i for i in [SkillPath.GHOST, SkillPath.PROPHET, 
                           SkillPath.CLAIRVOYANT, SkillPath.DREAM,
-                          SkillPath.OMEN, SkillPath.STAR, SkillPath.HEALER]
+                          SkillPath.OMEN, SkillPath.STAR, SkillPath.HEALER, 
+                          SkillPath.DARK]
                           if i not in exclude]
         
         
@@ -191,12 +198,13 @@ class Skill():
         SkillPath.LORE: "lorekeeping",
         SkillPath.CAMP: "campkeeping",
         SkillPath.HEALER: "healing",
-        SkillPath.STAR: "starclan",
+        SkillPath.STAR: "StarClan",
         SkillPath.OMEN: "omen",
         SkillPath.DREAM: "dreaming",
         SkillPath.CLAIRVOYANT: "predicting",
         SkillPath.PROPHET: "prophesying",
-        SkillPath.GHOST: "ghosts"
+        SkillPath.GHOST: "ghosts",
+        SkillPath.DARK: "dark forest"
     }
     
     
@@ -332,7 +340,8 @@ class CatSkills:
         SkillPath.DREAM: SkillTypeFlag.SUPERNATURAL,
         SkillPath.CLAIRVOYANT: SkillTypeFlag.SUPERNATURAL | SkillTypeFlag.OBSERVANT,
         SkillPath.PROPHET: SkillTypeFlag.SUPERNATURAL,
-        SkillPath.GHOST: SkillTypeFlag.SUPERNATURAL
+        SkillPath.GHOST: SkillTypeFlag.SUPERNATURAL,
+        SkillPath.DARK: SkillTypeFlag.SUPERNATURAL
     }
     # pylint: enable=unsupported-binary-operation
     
@@ -420,13 +429,6 @@ class CatSkills:
                 output.append(self.primary.skill)
             if self.secondary:
                 output.append(self.secondary.skill)
-        
-        if game.clan.instructor.df:
-            for string in output:
-                if 'StarClan' in string:
-                    str_index = output.index(string)
-                    string = string.replace('StarClan', 'the Dark Forest')
-                    output[str_index] = string
 
         if not output:
             return "???"

--- a/scripts/screens/clan_creation_screens.py
+++ b/scripts/screens/clan_creation_screens.py
@@ -706,7 +706,7 @@ class MakeClanScreen(Screens):
             self.elements['cat_info'].set_text(selected.gender + "\n" +
                                                str(selected.age + "\n" +
                                                    str(selected.personality.trait) + "\n" +
-                                                   str(selected.skills.skill_string())))
+                                                   str(selected.skills.skill_string(short=True))))
             self.elements['cat_info'].show()
         else:
             self.elements['next_step'].disable()


### PR DESCRIPTION
- Fixed crash upon new clan
- Removed text replacement in skills.
- Added new "DARK" skill path
- Switched to "short" skill description on clan creation page (it was sometimes overflowing the box when a cat has certain skills) 
- Rewording of some Starclan skill tiers. 