### PR TITLE
Bugfixes: Lost Cats, No More Auto-Murder

### DIFF
--- a/resources/dicts/events/ceremonies/ceremony-master.json
+++ b/resources/dicts/events/ceremonies/ceremony-master.json
@@ -322,7 +322,7 @@
       "fierce",
       "playful"
     ],
-    "(prefix)kit sits in front of the Clan with pride, {PRONOUN/m_c/poss} tiny heart beating so fast {PRONOUN/m_c/subject} {VERB/m_c/think/thinks} it might explode! {PRONOUN/m_c/subject/CAP} very excitedly {VERB/m_c/touch/touches} noses with (mentor), happy to start {PRONOUN/m_c/poss} apprenticeship."
+    "(old_name) sits in front of the Clan with pride, {PRONOUN/m_c/poss} tiny heart beating so fast {PRONOUN/m_c/subject} {VERB/m_c/think/thinks} it might explode! {PRONOUN/m_c/subject/CAP} very excitedly {VERB/m_c/touch/touches} noses with (mentor), happy to start {PRONOUN/m_c/poss} apprenticeship."
   ],
   "app_22": [
     [
@@ -557,7 +557,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "The Clan gathers around and urges (prefix)kit to go to the front of the crowd. Not having a leader isn't an excuse to force a cat to stay in the nursery when they're six moons old. (prefix)kit is renamed m_c, and the Clan votes to make (mentor) {PRONOUN/m_c/poss} mentor."
+    "The Clan gathers around and urges (old_name) to go to the front of the crowd. Not having a leader isn't an excuse to force a cat to stay in the nursery when they're six moons old. (old_name) is renamed m_c, and the Clan votes to make (mentor) {PRONOUN/m_c/poss} mentor."
   ],
   "app_35": [
     [
@@ -602,7 +602,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "(prefix)kit loudly complains as p1 pulls {PRONOUN/m_c/object} over to quickly groom {PRONOUN/m_c/poss} pelt. {PRONOUN/m_c/subject/CAP} {VERB/m_c/manage/manages} to wriggle away and scurry off to the front of the crowd for {PRONOUN/m_c/poss} ceremony, where {PRONOUN/m_c/subject} {VERB/m_c/are/is} renamed to m_c and apprenticed to (mentor). "
+    "(old_name) loudly complains as p1 pulls {PRONOUN/m_c/object} over to quickly groom {PRONOUN/m_c/poss} pelt. {PRONOUN/m_c/subject/CAP} {VERB/m_c/manage/manages} to wriggle away and scurry off to the front of the crowd for {PRONOUN/m_c/poss} ceremony, where {PRONOUN/m_c/subject} {VERB/m_c/are/is} renamed to m_c and apprenticed to (mentor). "
   ],
   "app_39": [
     [
@@ -614,7 +614,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "Even though {PRONOUN/m_c/subject} {VERB/m_c/are/is} excited to finally be made an apprentice, it takes a bit of coaxing by p1 for (prefix)kit to step forward for {PRONOUN/m_c/poss} ceremony. p1 watches in pride as {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} named m_c and {VERB/m_c/touch/touches} noses with (mentor)."
+    "Even though {PRONOUN/m_c/subject} {VERB/m_c/are/is} excited to finally be made an apprentice, it takes a bit of coaxing by p1 for (old_name) to step forward for {PRONOUN/m_c/poss} ceremony. p1 watches in pride as {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} named m_c and {VERB/m_c/touch/touches} noses with (mentor)."
   ],
   "app_40": [
     [
@@ -697,7 +697,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "(prefix)kit runs up to the front of the crowd, eager to get {PRONOUN/m_c/poss} new name. When {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} called m_c for the first time, p1 and p2's voices can be heard the loudest as the Clan welcomes the new apprentice."
+    "(old_name) runs up to the front of the crowd, eager to get {PRONOUN/m_c/poss} new name. When {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} called m_c for the first time, p1 and p2's voices can be heard the loudest as the Clan welcomes the new apprentice."
   ],
   "app_47": [
     [
@@ -780,7 +780,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "(mentor) calls a meeting. {PRONOUN/(mentor)/subject} {VERB/(mentor)/have/has} been watching (prefix)kit for a while now, and have decided to mentor {PRONOUN/m_c/object} personally. m_c's eyes shine with pride. "
+    "(mentor) calls a meeting. {PRONOUN/(mentor)/subject} {VERB/(mentor)/have/has} been watching (old_name) for a while now, and have decided to mentor {PRONOUN/m_c/object} personally. m_c's eyes shine with pride. "
   ],
   "app_54":[
     [
@@ -792,7 +792,7 @@
       "ambitious",
       "daring"
     ],
-    "(prefix)kit has always wished to be the hero of {PRONOUN/m_c/poss} Clan, a warrior admired by all. (mentor) hopes, while m_c touches noses with {PRONOUN/(mentor)/object}, that {PRONOUN/m_c/subject} {VERB/m_c/are/is} going to stay wary of the dangers of their territory and not endanger {PRONOUN/m_c/self}."
+    "(old_name) has always wished to be the hero of {PRONOUN/m_c/poss} Clan, a warrior admired by all. (mentor) hopes, while m_c touches noses with {PRONOUN/(mentor)/object}, that {PRONOUN/m_c/subject} {VERB/m_c/are/is} going to stay wary of the dangers of their territory and not endanger {PRONOUN/m_c/self}."
   ],
   "med_app_0": [
     [
@@ -803,7 +803,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "(prefix)kit, like every young kit, had dreams of becoming a warrior from a young age. However, as {PRONOUN/m_c/subject} grew older, {PRONOUN/m_c/subject} knew that {PRONOUN/m_c/poss} destiny lay in the medicine den. {PRONOUN/m_c/subject/CAP} happily {VERB/m_c/take/takes} up {PRONOUN/m_c/poss} new place as a medicine cat apprentice - looking forward to healing {PRONOUN/m_c/poss} Clanmates for many moons to come."
+    "(old_name), like every young kit, had dreams of becoming a warrior from a young age. However, as {PRONOUN/m_c/subject} grew older, {PRONOUN/m_c/subject} knew that {PRONOUN/m_c/poss} destiny lay in the medicine den. {PRONOUN/m_c/subject/CAP} happily {VERB/m_c/take/takes} up {PRONOUN/m_c/poss} new place as a medicine cat apprentice - looking forward to healing {PRONOUN/m_c/poss} Clanmates for many moons to come."
   ],
   "med_app_1": [
     [
@@ -892,7 +892,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "(mentor) stands before the Clan and announces that {PRONOUN/(mentor)/subject} won't be there forever, and it is time {PRONOUN/(mentor)/subject} took on an apprentice. {PRONOUN/(mentor)/subject/CAP} {VERB/(mentor)/tell/tells} the Clan that {PRONOUN/(mentor)/subject} {VERB/(mentor)/have/has} chosen (prefix)kit, now m_c, to be {PRONOUN/(mentor)/poss} new apprentice."
+    "(mentor) stands before the Clan and announces that {PRONOUN/(mentor)/subject} won't be there forever, and it is time {PRONOUN/(mentor)/subject} took on an apprentice. {PRONOUN/(mentor)/subject/CAP} {VERB/(mentor)/tell/tells} the Clan that {PRONOUN/(mentor)/subject} {VERB/(mentor)/have/has} chosen (old_name), now m_c, to be {PRONOUN/(mentor)/poss} new apprentice."
   ],
   "med_app_9": [
     [
@@ -903,7 +903,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "(mentor) has no doubts in {PRONOUN/(mentor)/poss} mind of who {PRONOUN/(mentor)/poss} new apprentice will be. (prefix)kit has always been looking for an excuse to be in {PRONOUN/(mentor)/poss} den, asking endless questions about what each herb is and what it's used for. And as (mentor) announces that the newly named m_c will be {PRONOUN/(mentor)/poss} apprentice, {PRONOUN/(mentor)/subject} {VERB/(mentor)/see/sees} m_c's eyes shining in delight and excitement, and knows {PRONOUN/(mentor)/subject} {VERB/(mentor)/were/was} right in choosing {PRONOUN/m_c/object}."
+    "(mentor) has no doubts in {PRONOUN/(mentor)/poss} mind of who {PRONOUN/(mentor)/poss} new apprentice will be. (old_name) has always been looking for an excuse to be in {PRONOUN/(mentor)/poss} den, asking endless questions about what each herb is and what it's used for. And as (mentor) announces that the newly named m_c will be {PRONOUN/(mentor)/poss} apprentice, {PRONOUN/(mentor)/subject} {VERB/(mentor)/see/sees} m_c's eyes shining in delight and excitement, and knows {PRONOUN/(mentor)/subject} {VERB/(mentor)/were/was} right in choosing {PRONOUN/m_c/object}."
   ],
   "med_app_10": [
     [
@@ -1238,7 +1238,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "(prefix)kit can't contain the energy flowing through {PRONOUN/m_c/object}: {PRONOUN/m_c/subject} {VERB/m_c/are/is} officially going to begin training to be a mediator! {PRONOUN/m_c/subject/CAP} {VERB/m_c/earn/earns} {PRONOUN/m_c/poss} apprentice name, m_c, and will be guided by (mentor) on {PRONOUN/m_c/poss} journey."
+    "(old_name) can't contain the energy flowing through {PRONOUN/m_c/object}: {PRONOUN/m_c/subject} {VERB/m_c/are/is} officially going to begin training to be a mediator! {PRONOUN/m_c/subject/CAP} {VERB/m_c/earn/earns} {PRONOUN/m_c/poss} apprentice name, m_c, and will be guided by (mentor) on {PRONOUN/m_c/poss} journey."
   ],
   "mediator_app_12": [
     [
@@ -1249,7 +1249,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "(prefix)kit stands alert when called: {PRONOUN/m_c/subject} {VERB/m_c/know/knows} what {PRONOUN/m_c/subject} {VERB/m_c/want/wants} in life - to be a mediator. {PRONOUN/m_c/subject/CAP} {VERB/m_c/are/is} named m_c and given to (mentor) to start {PRONOUN/m_c/poss} training."
+    "(old_name) stands alert when called: {PRONOUN/m_c/subject} {VERB/m_c/know/knows} what {PRONOUN/m_c/subject} {VERB/m_c/want/wants} in life - to be a mediator. {PRONOUN/m_c/subject/CAP} {VERB/m_c/are/is} named m_c and given to (mentor) to start {PRONOUN/m_c/poss} training."
   ],
   "mediator_app_13": [
     [
@@ -1260,7 +1260,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "Knowing that the Clan needed someone to mediate their problems, (prefix)kit decided to become a mediator apprentice. {PRONOUN/m_c/subject/CAP} {VERB/m_c/earn/earns} {PRONOUN/m_c/poss} apprentice name, m_c, and is given (mentor) to mentor {PRONOUN/m_c/object}."
+    "Knowing that the Clan needed someone to mediate their problems, (old_name) decided to become a mediator apprentice. {PRONOUN/m_c/subject/CAP} {VERB/m_c/earn/earns} {PRONOUN/m_c/poss} apprentice name, m_c, and is given (mentor) to mentor {PRONOUN/m_c/object}."
   ],
   "mediator_app_14": [
     [
@@ -1271,7 +1271,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "(prefix)kit had taken to following (mentor) around while {PRONOUN/(mentor)/subject} did {PRONOUN/m_c/poss} tasks, asking questions and listening. It wasn't a surprise {PRONOUN/m_c/subject} chose to become a mediator apprentice under (mentor) after earning {PRONOUN/m_c/poss} apprentice name: m_c."
+    "(old_name) had taken to following (mentor) around while {PRONOUN/(mentor)/subject} did {PRONOUN/m_c/poss} tasks, asking questions and listening. It wasn't a surprise {PRONOUN/m_c/subject} chose to become a mediator apprentice under (mentor) after earning {PRONOUN/m_c/poss} apprentice name: m_c."
   ],
   "mediator_app_15": [
     [
@@ -1282,7 +1282,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "(prefix)kit always dreamed of becoming a mediator: Now that {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} m_c, an apprentice being mentored by (mentor), it feels like a wish come true."
+    "(old_name) always dreamed of becoming a mediator: Now that {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} m_c, an apprentice being mentored by (mentor), it feels like a wish come true."
   ],
   "med_0": [
     [
@@ -1294,7 +1294,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "(prefix)paw is given {PRONOUN/m_c/poss} full name of m_c and welcomed as a full medicine cat. "
+    "(old_name) is given {PRONOUN/m_c/poss} full name of m_c and welcomed as a full medicine cat. "
   ],
   "med_0_a": [
   [
@@ -1306,7 +1306,7 @@
     "general_backstory",
     "all_traits"
   ],
-  "(prefix)paw has struggled to learn the skills of a medicine cat, but {PRONOUN/m_c/subject} {VERB/m_c/refuse/refuses} to train as a warrior. {PRONOUN/m_c/subject/CAP} {VERB/m_c/are/is} too old to remain an apprentice and, as the other medicine cats look with pity, {PRONOUN/m_c/subject} {VERB/m_c/are/is} hesitantly given the name m_c."
+  "(old_name) has struggled to learn the skills of a medicine cat, but {PRONOUN/m_c/subject} {VERB/m_c/refuse/refuses} to train as a warrior. {PRONOUN/m_c/subject/CAP} {VERB/m_c/are/is} too old to remain an apprentice and, as the other medicine cats look with pity, {PRONOUN/m_c/subject} {VERB/m_c/are/is} hesitantly given the name m_c."
 ],
   "med_0_b": [
   [
@@ -1318,7 +1318,7 @@
     "general_backstory",
     "all_traits"
   ],
-  "(prefix)paw's has shown exceptional aptitude and skill during {PRONOUN/m_c/poss} short apprenticeship. Although it's rare for an medicine cat apprentice to be given {PRONOUN/m_c/poss} name so young, m_c more than deserves the honor. "
+  "(old_name)'s has shown exceptional aptitude and skill during {PRONOUN/m_c/poss} short apprenticeship. Although it's rare for an medicine cat apprentice to be given {PRONOUN/m_c/poss} name so young, m_c more than deserves the honor. "
 ],
   "med_1": [
     [
@@ -1330,7 +1330,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "As (prefix)paw is given {PRONOUN/m_c/poss} full name of m_c, and welcomed as the new medicine cat of the Clan, {PRONOUN/m_c/subject} {VERB/m_c/look/looks} to the stars and hope that (deadmentor) will be there with the rest of StarClan in {PRONOUN/m_c/poss} dreams."
+    "As (old_name) is given {PRONOUN/m_c/poss} full name of m_c, and welcomed as the new medicine cat of the Clan, {PRONOUN/m_c/subject} {VERB/m_c/look/looks} to the stars and hope that (deadmentor) will be there with the rest of StarClan in {PRONOUN/m_c/poss} dreams."
   ],
   "med_2": [
     [
@@ -1342,7 +1342,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "(prefix)paw still can't believe that {PRONOUN/m_c/poss} mentor is gone. {PRONOUN/m_c/subject/CAP} {VERB/m_c/don't/doesn't} feel ready to heal the Clan, and so politely decline being given a name yet. However, as {PRONOUN/m_c/subject} {VERB/m_c/visit/visits} StarClan that half moon, (deadmentor) appears to {PRONOUN/m_c/object} in a dream. {PRONOUN/(deadmentor)/subject/CAP} {VERB/(deadmentor)/assure/assures} (prefix)paw that {PRONOUN/m_c/subject}'ll be alright without {PRONOUN/(deadmentor)/object}, and that {PRONOUN/m_c/subject} {VERB/m_c/are/is} ready for {PRONOUN/m_c/poss} full name. Resting {PRONOUN/(deadmentor)/poss} muzzle on (prefix)paw's head, (deadmentor) names {PRONOUN/m_c/object} m_c."
+    "(old_name) still can't believe that {PRONOUN/m_c/poss} mentor is gone. {PRONOUN/m_c/subject/CAP} {VERB/m_c/don't/doesn't} feel ready to heal the Clan, and so politely decline being given a name yet. However, as {PRONOUN/m_c/subject} {VERB/m_c/visit/visits} StarClan that half moon, (deadmentor) appears to {PRONOUN/m_c/object} in a dream. {PRONOUN/(deadmentor)/subject/CAP} {VERB/(deadmentor)/assure/assures} (old_name) that {PRONOUN/m_c/subject}'ll be alright without {PRONOUN/(deadmentor)/object}, and that {PRONOUN/m_c/subject} {VERB/m_c/are/is} ready for {PRONOUN/m_c/poss} full name. Resting {PRONOUN/(deadmentor)/poss} muzzle on (old_name)'s head, (deadmentor) names {PRONOUN/m_c/object} m_c."
   ],
   "med_3": [
     [
@@ -1366,7 +1366,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "With the stars softly shining and lighting their pelts, (previous_mentor) gives (prefix)paw {PRONOUN/m_c/poss} full name of m_c. They both share the rest of the night with StarClan, celebrating their good fortune in having another medicine cat."
+    "With the stars softly shining and lighting their pelts, (previous_mentor) gives (old_name) {PRONOUN/m_c/poss} full name of m_c. They both share the rest of the night with StarClan, celebrating their good fortune in having another medicine cat."
   ],
   "med_5": [
     [
@@ -1378,7 +1378,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "Inspired by (prefix)paw's boundless energy and courage, (previous_mentor) names {PRONOUN/m_c/object} m_c, and welcomes {PRONOUN/m_c/object} as a full medicine cat."
+    "Inspired by (old_name)'s boundless energy and courage, (previous_mentor) names {PRONOUN/m_c/object} m_c, and welcomes {PRONOUN/m_c/object} as a full medicine cat."
   ],
   "med_6": [
     [
@@ -1402,7 +1402,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "(previous_mentor) still remembers when (prefix)paw was just a kit, batting around in the medicine den, and asking endless questions about everything under the sun. (previous_mentor) chuckles with fondness as m_c asks why {PRONOUN/m_c/poss} new name was chosen with shining eyes and twitching whiskers."
+    "(previous_mentor) still remembers when (old_name) was just a kit, batting around in the medicine den, and asking endless questions about everything under the sun. (previous_mentor) chuckles with fondness as m_c asks why {PRONOUN/m_c/poss} new name was chosen with shining eyes and twitching whiskers."
   ],
   "med_8": [
     [
@@ -1414,7 +1414,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "(prefix)paw is taken to speak with StarClan. {PRONOUN/m_c/subject/CAP} {VERB/m_c/are/is} given the name m_c and {VERB/m_c/are/is} now a full medicine cat of the Clan."
+    "(old_name) is taken to speak with StarClan. {PRONOUN/m_c/subject/CAP} {VERB/m_c/are/is} given the name m_c and {VERB/m_c/are/is} now a full medicine cat of the Clan."
   ],
   "med_9": [
     [
@@ -1426,7 +1426,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "The time has come for (prefix)paw to be given {PRONOUN/m_c/poss} full medicine cat name. (prefix)paw requests that one of the other Clans' medicine cats name {PRONOUN/m_c/object}. The eldest of the medicine cats steps forward and gives (prefix)paw the name m_c."
+    "The time has come for (old_name) to be given {PRONOUN/m_c/poss} full medicine cat name. (old_name) requests that one of the other Clans' medicine cats name {PRONOUN/m_c/object}. The eldest of the medicine cats steps forward and gives (old_name) the name m_c."
   ],
   "med_10": [
     [
@@ -1438,7 +1438,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "With {PRONOUN/m_c/poss} training complete, StarClan decides to allow (prefix)paw to choose {PRONOUN/m_c/poss} own name. {PRONOUN/m_c/subject/CAP} {VERB/m_c/name/names} {PRONOUN/m_c/self} m_c, and {VERB/m_c/return/returns} to the Clan the next morning as a full medicine cat."
+    "With {PRONOUN/m_c/poss} training complete, StarClan decides to allow (old_name) to choose {PRONOUN/m_c/poss} own name. {PRONOUN/m_c/subject/CAP} {VERB/m_c/name/names} {PRONOUN/m_c/self} m_c, and {VERB/m_c/return/returns} to the Clan the next morning as a full medicine cat."
   ],
   "med_11": [
     [
@@ -1450,7 +1450,7 @@
       "general_backstory",
       "adventurous"
     ],
-    "As much as the warrior apprentices teased, (prefix)paw knew the truth. There is so much to see and do as a full medicine cat, and m_c could hardly wait to get started, almost charging off before {PRONOUN/m_c/poss} ceremony ended."
+    "As much as the warrior apprentices teased, (old_name) knew the truth. There is so much to see and do as a full medicine cat, and m_c could hardly wait to get started, almost charging off before {PRONOUN/m_c/poss} ceremony ended."
   ],
   "med_12": [
     [
@@ -1462,7 +1462,7 @@
       "general_backstory",
       "compassionate"
     ],
-    "Helping cats heal is what (prefix)paw does best. {PRONOUN/m_c/poss/CAP} full name of m_c proves to the Clan that {PRONOUN/m_c/subject}{VERB/m_c/'re's} fully qualified to do so, and that StarClan has accepted {PRONOUN/m_c/object}."
+    "Helping cats heal is what (old_name) does best. {PRONOUN/m_c/poss/CAP} full name of m_c proves to the Clan that {PRONOUN/m_c/subject}{VERB/m_c/'re's} fully qualified to do so, and that StarClan has accepted {PRONOUN/m_c/object}."
   ],
   "med_13": [
     [
@@ -1474,7 +1474,7 @@
       "general_backstory",
       "ambitious"
     ],
-    "As {PRONOUN/m_c/subject} {VERB/m_c/take/takes} {PRONOUN/m_c/poss} first steps into being a full medicine cat, (prefix)paw quietly reflects that {PRONOUN/m_c/subject} might just have the most powerful position in the Clan, now that {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} m_c. StarClan itself has accepted {PRONOUN/m_c/object}, speaks through {PRONOUN/m_c/object}, and m_c will remember this."
+    "As {PRONOUN/m_c/subject} {VERB/m_c/take/takes} {PRONOUN/m_c/poss} first steps into being a full medicine cat, (old_name) quietly reflects that {PRONOUN/m_c/subject} might just have the most powerful position in the Clan, now that {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} m_c. StarClan itself has accepted {PRONOUN/m_c/object}, speaks through {PRONOUN/m_c/object}, and m_c will remember this."
   ],
   "med_14": [
     [
@@ -1486,7 +1486,7 @@
       "general_backstory",
       "bloodthirsty"
     ],
-    "StarClan gives {PRONOUN/m_c/object} wisdom, {PRONOUN/m_c/poss} Clan gives {PRONOUN/m_c/object} strength. (prefix)paw will use this power to heal {PRONOUN/m_c/poss} warriors well after battle. {PRONOUN/m_c/subject/CAP} {VERB/m_c/are/is} now m_c, and {VERB/m_c/swear/swears} to never turn away from what needs doing."
+    "StarClan gives {PRONOUN/m_c/object} wisdom, {PRONOUN/m_c/poss} Clan gives {PRONOUN/m_c/object} strength. (old_name) will use this power to heal {PRONOUN/m_c/poss} warriors well after battle. {PRONOUN/m_c/subject/CAP} {VERB/m_c/are/is} now m_c, and {VERB/m_c/swear/swears} to never turn away from what needs doing."
   ],
   "med_15": [
     [
@@ -1498,7 +1498,7 @@
       "general_backstory",
       "bold"
     ],
-    "(prefix)paw may have butted heads against nearly every Clan member {PRONOUN/m_c/object} {VERB/m_c/have/has}, but being able to argue was a blessing as a medicine cat, as m_c will have to continue shoving odd mixtures down everyone's throat. StarClan will be watching {PRONOUN/m_c/object} with pride."
+    "(old_name) may have butted heads against nearly every Clan member {PRONOUN/m_c/object} {VERB/m_c/have/has}, but being able to argue was a blessing as a medicine cat, as m_c will have to continue shoving odd mixtures down everyone's throat. StarClan will be watching {PRONOUN/m_c/object} with pride."
   ],
   "med_16": [
     [
@@ -1510,7 +1510,7 @@
       "general_backstory",
       "calm"
     ],
-    "(prefix)paw has proven {PRONOUN/m_c/self} to have one of the most invaluable traits a medicine cat can have - a level head under pressure. The stars of Silverpelt twinkle in joy and acceptance as m_c receives {PRONOUN/m_c/poss} full name and duties as a medicine cat."
+    "(old_name) has proven {PRONOUN/m_c/self} to have one of the most invaluable traits a medicine cat can have - a level head under pressure. The stars of Silverpelt twinkle in joy and acceptance as m_c receives {PRONOUN/m_c/poss} full name and duties as a medicine cat."
   ],
   "med_17": [
     [
@@ -1522,7 +1522,7 @@
       "general_backstory",
       "careful"
     ],
-    "It is (prefix)paw's attention to detail that earns {PRONOUN/m_c/object} {PRONOUN/m_c/poss} medicine cat name of m_c. {PRONOUN/m_c/subject/CAP} will serve the Clan long and well, with no one doubting {PRONOUN/m_c/poss} skill and knowledge of herbs {PRONOUN/m_c/subject}{VERB/m_c/'ve/'s} spent so many moons learning."
+    "It is (old_name)'s attention to detail that earns {PRONOUN/m_c/object} {PRONOUN/m_c/poss} medicine cat name of m_c. {PRONOUN/m_c/subject/CAP} will serve the Clan long and well, with no one doubting {PRONOUN/m_c/poss} skill and knowledge of herbs {PRONOUN/m_c/subject}{VERB/m_c/'ve/'s} spent so many moons learning."
   ],
   "med_18": [
     [
@@ -1534,7 +1534,7 @@
       "general_backstory",
       "charismatic"
     ],
-    "(prefix)paw's charming attitude does as much for {PRONOUN/m_c/poss} patients as {PRONOUN/m_c/poss} skill does. {PRONOUN/m_c/subject/CAP} will continue to heal with words and herbs as m_c now that {PRONOUN/m_c/subject} {VERB/m_c/are/is} a full medicine cat of c_n."
+    "(old_name)'s charming attitude does as much for {PRONOUN/m_c/poss} patients as {PRONOUN/m_c/poss} skill does. {PRONOUN/m_c/subject/CAP} will continue to heal with words and herbs as m_c now that {PRONOUN/m_c/subject} {VERB/m_c/are/is} a full medicine cat of c_n."
   ],
   "med_19": [
     [
@@ -1546,7 +1546,7 @@
       "general_backstory",
       "childish"
     ],
-    "Though {PRONOUN/m_c/poss} actions may come off as lighthearted, (prefix)paw has worked hard to earn {PRONOUN/m_c/poss} name of m_c, and mews that {PRONOUN/m_c/subject}'ll protect c_n as a medicine cat. Though {PRONOUN/m_c/subject} {VERB/m_c/start/starts} giggling right after {PRONOUN/m_c/subject} {VERB/m_c/say/says} it, causing a few purrs of amusement from onlookers both here, and in StarClan."
+    "Though {PRONOUN/m_c/poss} actions may come off as lighthearted, (old_name) has worked hard to earn {PRONOUN/m_c/poss} name of m_c, and mews that {PRONOUN/m_c/subject}'ll protect c_n as a medicine cat. Though {PRONOUN/m_c/subject} {VERB/m_c/start/starts} giggling right after {PRONOUN/m_c/subject} {VERB/m_c/say/says} it, causing a few purrs of amusement from onlookers both here, and in StarClan."
   ],
   "med_20": [
     [
@@ -1558,7 +1558,7 @@
       "general_backstory",
       "cold"
     ],
-    "No one knows what (prefix)paw is thinking as {PRONOUN/m_c/subject} {VERB/m_c/receive/receives} {PRONOUN/m_c/poss} medicine cat name of m_c, only that {PRONOUN/m_c/poss} eyes are focused, clear, and as immovable as ice. No one doubts that {PRONOUN/m_c/subject} will be well suited to the heartbreaks that wait for all medicine cats."
+    "No one knows what (old_name) is thinking as {PRONOUN/m_c/subject} {VERB/m_c/receive/receives} {PRONOUN/m_c/poss} medicine cat name of m_c, only that {PRONOUN/m_c/poss} eyes are focused, clear, and as immovable as ice. No one doubts that {PRONOUN/m_c/subject} will be well suited to the heartbreaks that wait for all medicine cats."
   ],
   "med_21": [
     [
@@ -1570,7 +1570,7 @@
       "general_backstory",
       "compassionate"
     ],
-    "Excellent medicine cats have as much heart as they do brains, and (prefix)paw proves {PRONOUN/m_c/subject} {VERB/m_c/have/has} both by the time {PRONOUN/m_c/subject} {VERB/m_c/earn/earns} {PRONOUN/m_c/poss} name of m_c, proving a gentle touch does as much good as the right herbs."
+    "Excellent medicine cats have as much heart as they do brains, and (old_name) proves {PRONOUN/m_c/subject} {VERB/m_c/have/has} both by the time {PRONOUN/m_c/subject} {VERB/m_c/earn/earns} {PRONOUN/m_c/poss} name of m_c, proving a gentle touch does as much good as the right herbs."
   ],
   "med_22": [
     [
@@ -1582,7 +1582,7 @@
       "general_backstory",
       "confident"
     ],
-    "(prefix)paw is so sure of {PRONOUN/m_c/poss} skill as medicine cat that {PRONOUN/m_c/subject} {VERB/m_c/ask/asks} to choose {PRONOUN/m_c/subject} own name. While it may not be tradition, no one can think of a better fitting name for {PRONOUN/m_c/object} then the one {PRONOUN/m_c/subject} chose {PRONOUN/m_c/self}, and welcome m_c warmly as a full medicine cat."
+    "(old_name) is so sure of {PRONOUN/m_c/poss} skill as medicine cat that {PRONOUN/m_c/subject} {VERB/m_c/ask/asks} to choose {PRONOUN/m_c/subject} own name. While it may not be tradition, no one can think of a better fitting name for {PRONOUN/m_c/object} then the one {PRONOUN/m_c/subject} chose {PRONOUN/m_c/self}, and welcome m_c warmly as a full medicine cat."
   ],
   "med_23": [
     [
@@ -1594,7 +1594,7 @@
       "general_backstory",
       "daring"
     ],
-    "(prefix)paw's methods are a little unconventional, but it's hard to argue with results, and (prefix)paw gets results. {PRONOUN/m_c/subject/CAP} {VERB/m_c/gain/gains} {PRONOUN/m_c/poss} medicine cat name of m_c, and the eldest medicine cat in the Clans warns {PRONOUN/m_c/object} not to do anything too risky."
+    "(old_name)'s methods are a little unconventional, but it's hard to argue with results, and (old_name) gets results. {PRONOUN/m_c/subject/CAP} {VERB/m_c/gain/gains} {PRONOUN/m_c/poss} medicine cat name of m_c, and the eldest medicine cat in the Clans warns {PRONOUN/m_c/object} not to do anything too risky."
   ],
   "med_24": [
     [
@@ -1606,7 +1606,7 @@
       "general_backstory",
       "compassionate"
     ],
-    "There's so much pain that c_n has to endure, and (prefix)paw has decided to heal it all, no matter the cost. StarClan has accepted {PRONOUN/m_c/poss} passion, and supports {PRONOUN/m_c/object} with the name of m_c, hoping that they can help ease some of the burden m_c placed on {PRONOUN/m_c/self}."
+    "There's so much pain that c_n has to endure, and (old_name) has decided to heal it all, no matter the cost. StarClan has accepted {PRONOUN/m_c/poss} passion, and supports {PRONOUN/m_c/object} with the name of m_c, hoping that they can help ease some of the burden m_c placed on {PRONOUN/m_c/self}."
   ],
   "med_25": [
     [
@@ -1618,7 +1618,7 @@
       "general_backstory",
       "faithful"
     ],
-    "(prefix)paw has known that StarClan has been watching over {PRONOUN/m_c/object} since {PRONOUN/m_c/subject} started {PRONOUN/m_c/poss} apprenticeship. {PRONOUN/m_c/subject/CAP} {VERB/m_c/are/is} given the name m_c in honor of {PRONOUN/m_c/poss} faith. Tonight of all nights, as {PRONOUN/m_c/subject} {VERB/m_c/feel/feels} starspeckled pelts weaving around {PRONOUN/m_c/object} and whispering {PRONOUN/m_c/poss} new name, {PRONOUN/m_c/subject} {VERB/m_c/know/knows} that StarClan will guide {PRONOUN/m_c/poss} pawsteps as a full medicine cat."
+    "(old_name) has known that StarClan has been watching over {PRONOUN/m_c/object} since {PRONOUN/m_c/subject} started {PRONOUN/m_c/poss} apprenticeship. {PRONOUN/m_c/subject/CAP} {VERB/m_c/are/is} given the name m_c in honor of {PRONOUN/m_c/poss} faith. Tonight of all nights, as {PRONOUN/m_c/subject} {VERB/m_c/feel/feels} starspeckled pelts weaving around {PRONOUN/m_c/object} and whispering {PRONOUN/m_c/poss} new name, {PRONOUN/m_c/subject} {VERB/m_c/know/knows} that StarClan will guide {PRONOUN/m_c/poss} pawsteps as a full medicine cat."
   ],
   "med_26": [
     [
@@ -1630,7 +1630,7 @@
       "general_backstory",
       "fierce"
     ],
-    "During {PRONOUN/m_c/poss} apprenticeship (prefix)paw struggled with the best way to protect c_n, with teeth or with tinctures, but now that {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} m_c, {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} certain {PRONOUN/m_c/subject}{VERB/m_c/'ve/'s} made the right choice to be a medicine cat. Though {PRONOUN/m_c/subject} will keep practicing that battle move {PRONOUN/m_c/subject}{VERB/m_c/'ve/'s} learned, just in case."
+    "During {PRONOUN/m_c/poss} apprenticeship (old_name) struggled with the best way to protect c_n, with teeth or with tinctures, but now that {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} m_c, {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} certain {PRONOUN/m_c/subject}{VERB/m_c/'ve/'s} made the right choice to be a medicine cat. Though {PRONOUN/m_c/subject} will keep practicing that battle move {PRONOUN/m_c/subject}{VERB/m_c/'ve/'s} learned, just in case."
   ],
   "med_27": [
     [
@@ -1642,7 +1642,7 @@
       "general_backstory",
       "insecure"
     ],
-    "As the end of {PRONOUN/m_c/poss} apprenticeship nears, (prefix)paw is worried StarClan won't accept {PRONOUN/m_c/object} as a full medicine cat. However, the ceremony plays out without a hitch, and m_c is honored as a skilled medicine cat."
+    "As the end of {PRONOUN/m_c/poss} apprenticeship nears, (old_name) is worried StarClan won't accept {PRONOUN/m_c/object} as a full medicine cat. However, the ceremony plays out without a hitch, and m_c is honored as a skilled medicine cat."
   ],
   "med_28": [
     [
@@ -1654,7 +1654,7 @@
       "general_backstory",
       "insecure"
     ],
-    "While the rest of the Clan may not understand it (prefix)paw enjoys {PRONOUN/m_c/poss} time alone in the medicine den. In fact, now {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} m_c, {PRONOUN/m_c/subject} can't wait to get back to it, and away from the center of attention."
+    "While the rest of the Clan may not understand it (old_name) enjoys {PRONOUN/m_c/poss} time alone in the medicine den. In fact, now {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} m_c, {PRONOUN/m_c/subject} can't wait to get back to it, and away from the center of attention."
   ],
   "med_29": [
     [
@@ -1666,7 +1666,7 @@
       "general_backstory",
       "insecure"
     ],
-    "Healing a sprain, comforting a bruised kit, soothing a sore elder - all of these things give (prefix)paw meaning in {PRONOUN/m_c/poss} life as a medicine cat. StarClan honors {PRONOUN/m_c/poss} caring heart with the name m_c."
+    "Healing a sprain, comforting a bruised kit, soothing a sore elder - all of these things give (old_name) meaning in {PRONOUN/m_c/poss} life as a medicine cat. StarClan honors {PRONOUN/m_c/poss} caring heart with the name m_c."
   ],
   "med_30": [
     [
@@ -1678,7 +1678,7 @@
       "general_backstory",
       "loyal"
     ],
-    "c_n has raised and cared for (prefix)paw, and (prefix)paw wants nothing more but to do the same, taking on the name m_c as a full medicine cat of c_n. {PRONOUN/m_c/subject/CAP} will be thinking of how to care for c_n until the day {PRONOUN/m_c/poss} {VERB/m_c/depart/departs} for StarClan, and maybe even after."
+    "c_n has raised and cared for (old_name), and (old_name) wants nothing more but to do the same, taking on the name m_c as a full medicine cat of c_n. {PRONOUN/m_c/subject/CAP} will be thinking of how to care for c_n until the day {PRONOUN/m_c/poss} {VERB/m_c/depart/departs} for StarClan, and maybe even after."
   ],
   "med_31": [
     [
@@ -1690,7 +1690,7 @@
       "general_backstory",
       "nervous"
     ],
-    "(prefix)paw know all the herbs, {PRONOUN/m_c/subject} {VERB/m_c/know/knows} how to treat rat bites, but surely {PRONOUN/m_c/subject} {VERB/m_c/need/needs} to learn more? StarClan assures {PRONOUN/m_c/object} that {PRONOUN/m_c/subject}'ll do fine, and gives {PRONOUN/m_c/object} the name m_c as a sign of trust, even if m_c is sure it's still too soon."
+    "(old_name) know all the herbs, {PRONOUN/m_c/subject} {VERB/m_c/know/knows} how to treat rat bites, but surely {PRONOUN/m_c/subject} {VERB/m_c/need/needs} to learn more? StarClan assures {PRONOUN/m_c/object} that {PRONOUN/m_c/subject}'ll do fine, and gives {PRONOUN/m_c/object} the name m_c as a sign of trust, even if m_c is sure it's still too soon."
   ],
   "med_32": [
     [
@@ -1702,7 +1702,7 @@
       "general_backstory",
       "compassionate"
     ],
-    "It is (prefix)paw's willingness to sit and listen that assures the other medicine cats it's time to give {PRONOUN/m_c/object} {PRONOUN/m_c/poss} name of m_c. m_c thanks them graciously and tucks {PRONOUN/m_c/self} back down to listen to the next cat speak."
+    "It is (old_name)'s willingness to sit and listen that assures the other medicine cats it's time to give {PRONOUN/m_c/object} {PRONOUN/m_c/poss} name of m_c. m_c thanks them graciously and tucks {PRONOUN/m_c/self} back down to listen to the next cat speak."
   ],
   "med_33": [
     [
@@ -1714,7 +1714,7 @@
       "general_backstory",
       "playful"
     ],
-    "No one knows how (prefix)paw got {PRONOUN/m_c/poss} claws on it, but {PRONOUN/m_c/subject} {VERB/m_c/manage/manages} to play with a shiny piece of Twoleg stuff during {PRONOUN/m_c/poss} entire medicine cat ceremony. When asked why, m_c replied that one of {PRONOUN/m_c/poss} patients might like it, and {PRONOUN/m_c/subject} wanted to make sure it was safe."
+    "No one knows how (old_name) got {PRONOUN/m_c/poss} claws on it, but {PRONOUN/m_c/subject} {VERB/m_c/manage/manages} to play with a shiny piece of Twoleg stuff during {PRONOUN/m_c/poss} entire medicine cat ceremony. When asked why, m_c replied that one of {PRONOUN/m_c/poss} patients might like it, and {PRONOUN/m_c/subject} wanted to make sure it was safe."
   ],
   "med_34": [
     [
@@ -1726,7 +1726,7 @@
       "general_backstory",
       "responsible"
     ],
-    "(prefix)paw always owns up to {PRONOUN/m_c/poss} mistakes, and puts the work in to fix them, but {PRONOUN/m_c/subject} {VERB/m_c/are/is} still surprised when {PRONOUN/m_c/subject} {VERB/m_c/get/gets} {PRONOUN/m_c/poss} medicine cat name of m_c. {PRONOUN/m_c/subject/CAP} {VERB/m_c/promise/promises} to work twice as hard to be worthy of it."
+    "(old_name) always owns up to {PRONOUN/m_c/poss} mistakes, and puts the work in to fix them, but {PRONOUN/m_c/subject} {VERB/m_c/are/is} still surprised when {PRONOUN/m_c/subject} {VERB/m_c/get/gets} {PRONOUN/m_c/poss} medicine cat name of m_c. {PRONOUN/m_c/subject/CAP} {VERB/m_c/promise/promises} to work twice as hard to be worthy of it."
   ],
   "med_35": [
     [
@@ -1738,7 +1738,7 @@
       "general_backstory",
       "righteous"
     ],
-    "(prefix)paw says a silent prayer to StarClan as {PRONOUN/m_c/subject} {VERB/m_c/get/gets} {PRONOUN/m_c/poss} medicine cat name of m_c. StarClan protect them, StarClan protect all of them, {PRONOUN/m_c/subject} {VERB/m_c/hope/hopes} {PRONOUN/m_c/subject}'ll receive more guidance in the moons ahead."
+    "(old_name) says a silent prayer to StarClan as {PRONOUN/m_c/subject} {VERB/m_c/get/gets} {PRONOUN/m_c/poss} medicine cat name of m_c. StarClan protect them, StarClan protect all of them, {PRONOUN/m_c/subject} {VERB/m_c/hope/hopes} {PRONOUN/m_c/subject}'ll receive more guidance in the moons ahead."
   ],
   "med_36": [
     [
@@ -1750,7 +1750,7 @@
       "general_backstory",
       "shameless"
     ],
-    "(prefix)paw blurts out {PRONOUN/m_c/poss} new medicine cat name of m_c, cutting off the words of the ceremony mid-meow, not surprising anyone. There's no arguing with m_c, so the other medicine cats cheer for {PRONOUN/m_c/object}, through purrs of amusement."
+    "(old_name) blurts out {PRONOUN/m_c/poss} new medicine cat name of m_c, cutting off the words of the ceremony mid-meow, not surprising anyone. There's no arguing with m_c, so the other medicine cats cheer for {PRONOUN/m_c/object}, through purrs of amusement."
   ],
   "med_37": [
     [
@@ -1762,7 +1762,7 @@
       "general_backstory",
       "sneaky"
     ],
-    "(prefix)paw's eyes glint as {PRONOUN/m_c/subject} {VERB/m_c/get/gets} the medicine cat name of m_c. No one seems to notice that {PRONOUN/m_c/subject} {VERB/m_c/don't/didn't} agree to all of the vows of being a medicine cat, instead only nodding at some, and agreeing to others with a meow."
+    "(old_name)'s eyes glint as {PRONOUN/m_c/subject} {VERB/m_c/get/gets} the medicine cat name of m_c. No one seems to notice that {PRONOUN/m_c/subject} {VERB/m_c/don't/didn't} agree to all of the vows of being a medicine cat, instead only nodding at some, and agreeing to others with a meow."
   ],
   "med_38": [
     [
@@ -1774,7 +1774,7 @@
       "general_backstory",
       "strange"
     ],
-    "No one knows why (prefix)paw brought a mossball to {PRONOUN/m_c/poss} medicine cat naming ceremony. StarClan grants {PRONOUN/m_c/object} the name m_c all the same, welcoming {PRONOUN/m_c/object} into the full mysteries of StarClan."
+    "No one knows why (old_name) brought a mossball to {PRONOUN/m_c/poss} medicine cat naming ceremony. StarClan grants {PRONOUN/m_c/object} the name m_c all the same, welcoming {PRONOUN/m_c/object} into the full mysteries of StarClan."
   ],
   "med_39": [
     [
@@ -1786,7 +1786,7 @@
       "general_backstory",
       "strict"
     ],
-    "The way (prefix)paw is sitting is so stiff you could use {PRONOUN/m_c/object} as reinforcement for the camp walls. Even when {PRONOUN/m_c/subject} {VERB/m_c/get/gets} {PRONOUN/m_c/poss} medicine cat name, m_c, {PRONOUN/m_c/subject} {VERB/m_c/don't/doesn't} loosen up, and only seem to sit even straighter."
+    "The way (old_name) is sitting is so stiff you could use {PRONOUN/m_c/object} as reinforcement for the camp walls. Even when {PRONOUN/m_c/subject} {VERB/m_c/get/gets} {PRONOUN/m_c/poss} medicine cat name, m_c, {PRONOUN/m_c/subject} {VERB/m_c/don't/doesn't} loosen up, and only seem to sit even straighter."
   ],
   "med_40": [
     [
@@ -1798,7 +1798,7 @@
       "general_backstory",
       "thoughtful"
     ],
-    "Even though this is {PRONOUN/m_c/poss} medicine cat naming ceremony, (prefix)paw can only think about {PRONOUN/m_c/poss} Clanmates back at camp, and asks if {PRONOUN/m_c/subject} can return early after {PRONOUN/m_c/subject} {VERB/m_c/get/gets} {PRONOUN/m_c/poss} name of m_c."
+    "Even though this is {PRONOUN/m_c/poss} medicine cat naming ceremony, (old_name) can only think about {PRONOUN/m_c/poss} Clanmates back at camp, and asks if {PRONOUN/m_c/subject} can return early after {PRONOUN/m_c/subject} {VERB/m_c/get/gets} {PRONOUN/m_c/poss} name of m_c."
   ],
   "med_41": [
     [
@@ -1810,7 +1810,7 @@
       "general_backstory",
       "thoughtful"
     ],
-    "StarClan honors the way (prefix)paw always goes the extra step to do {PRONOUN/m_c/poss} best as a medicine cat, and gives {PRONOUN/m_c/object} the name m_c, knowing that m_c will continue to do {PRONOUN/m_c/object} best."
+    "StarClan honors the way (old_name) always goes the extra step to do {PRONOUN/m_c/poss} best as a medicine cat, and gives {PRONOUN/m_c/object} the name m_c, knowing that m_c will continue to do {PRONOUN/m_c/object} best."
   ],
   "med_42": [
     [
@@ -1822,7 +1822,7 @@
       "general_backstory",
       "troublesome"
     ],
-    "This is a serious time for (prefix)paw, {PRONOUN/m_c/poss} medicine cat naming ceremony! Naturally, {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} cracking jokes and being irreverent right up until the moment {PRONOUN/m_c/subject} {VERB/m_c/get/gets} {PRONOUN/m_c/poss} name, m_c, and only quiets down long enough to think of something funny to add."
+    "This is a serious time for (old_name), {PRONOUN/m_c/poss} medicine cat naming ceremony! Naturally, {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} cracking jokes and being irreverent right up until the moment {PRONOUN/m_c/subject} {VERB/m_c/get/gets} {PRONOUN/m_c/poss} name, m_c, and only quiets down long enough to think of something funny to add."
   ],
   "med_43": [
     [
@@ -1834,7 +1834,7 @@
       "general_backstory",
       "vengeful"
     ],
-    "The other medicine cats mistake it as being calm, but (prefix)paw isn't quiet because {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} at peace, but because {PRONOUN/m_c/subject} {VERB/m_c/are/is} angry. Every snide remark, every time someone sneered at {PRONOUN/m_c/object}, every time {PRONOUN/m_c/subject} {VERB/m_c/were/was} treated less than, all of it goes through {PRONOUN/m_c/poss} mind. Now that {PRONOUN/m_c/subject} {VERB/m_c/are/is} m_c, c_n better treat {PRONOUN/m_c/object} with respect, or there will be consequences."
+    "The other medicine cats mistake it as being calm, but (old_name) isn't quiet because {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} at peace, but because {PRONOUN/m_c/subject} {VERB/m_c/are/is} angry. Every snide remark, every time someone sneered at {PRONOUN/m_c/object}, every time {PRONOUN/m_c/subject} {VERB/m_c/were/was} treated less than, all of it goes through {PRONOUN/m_c/poss} mind. Now that {PRONOUN/m_c/subject} {VERB/m_c/are/is} m_c, c_n better treat {PRONOUN/m_c/object} with respect, or there will be consequences."
   ],
   "med_44": [
     [
@@ -1846,7 +1846,7 @@
       "general_backstory",
       "vengeful"
     ],
-    "Medicine cat training had just felt right for (prefix)paw, more like remembering then learning, like {PRONOUN/m_c/subject} had done this before. When it comes time for {PRONOUN/m_c/poss} naming, {PRONOUN/m_c/subject} {VERB/m_c/ask/asks} to name {PRONOUN/m_c/self}, and chose m_c for {PRONOUN/m_c/poss} name. It feels right for {PRONOUN/m_c/object} to be called m_c."
+    "Medicine cat training had just felt right for (old_name), more like remembering then learning, like {PRONOUN/m_c/subject} had done this before. When it comes time for {PRONOUN/m_c/poss} naming, {PRONOUN/m_c/subject} {VERB/m_c/ask/asks} to name {PRONOUN/m_c/self}, and chose m_c for {PRONOUN/m_c/poss} name. It feels right for {PRONOUN/m_c/object} to be called m_c."
   ],
   "med_45": [
     [
@@ -1858,7 +1858,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "(prefix)paw almost sobs as {PRONOUN/m_c/subject} {VERB/m_c/spot/spots} dead_par1 stepping out of the crowd of StarClan cats towards {PRONOUN/m_c/object} to congratulate {PRONOUN/m_c/object} on completing {PRONOUN/m_c/poss} training. dead_par1 rests {PRONOUN/dead_par1/poss} muzzle on (prefix)paw's head, naming {PRONOUN/m_c/object} m_c, and welcoming {PRONOUN/m_c/object} as a full medicine cat."
+    "(old_name) almost sobs as {PRONOUN/m_c/subject} {VERB/m_c/spot/spots} dead_par1 stepping out of the crowd of StarClan cats towards {PRONOUN/m_c/object} to congratulate {PRONOUN/m_c/object} on completing {PRONOUN/m_c/poss} training. dead_par1 rests {PRONOUN/dead_par1/poss} muzzle on (old_name)'s head, naming {PRONOUN/m_c/object} m_c, and welcoming {PRONOUN/m_c/object} as a full medicine cat."
   ],
   "med_46": [
     [
@@ -1870,7 +1870,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "As a StarClan cat steps forward to give (prefix)paw {PRONOUN/m_c/poss} new name of m_c, {PRONOUN/m_c/subject} {VERB/m_c/spot/spots} dead_par1 watching {PRONOUN/m_c/object} proudly from among the StarClan cats."
+    "As a StarClan cat steps forward to give (old_name) {PRONOUN/m_c/poss} new name of m_c, {PRONOUN/m_c/subject} {VERB/m_c/spot/spots} dead_par1 watching {PRONOUN/m_c/object} proudly from among the StarClan cats."
   ],
   "med_47": [
     [
@@ -1882,7 +1882,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "(prefix)paw almost sobs as {PRONOUN/m_c/subject} {VERB/m_c/spot/spots} dead_par1 and dead_par2 step out of the crowd towards {PRONOUN/m_c/object} to congratulate {PRONOUN/m_c/object} on completing {PRONOUN/m_c/poss} training. dead_par1 rests {PRONOUN/dead_par1/poss} muzzle on (prefix)paw's head, naming {PRONOUN/m_c/object} m_c, and welcoming {PRONOUN/m_c/object} as a full medicine cat."
+    "(old_name) almost sobs as {PRONOUN/m_c/subject} {VERB/m_c/spot/spots} dead_par1 and dead_par2 step out of the crowd towards {PRONOUN/m_c/object} to congratulate {PRONOUN/m_c/object} on completing {PRONOUN/m_c/poss} training. dead_par1 rests {PRONOUN/dead_par1/poss} muzzle on (old_name)'s head, naming {PRONOUN/m_c/object} m_c, and welcoming {PRONOUN/m_c/object} as a full medicine cat."
   ],
   "med_48": [
     [
@@ -1894,7 +1894,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "(prefix)paw almost sobs as {PRONOUN/m_c/object} {VERB/m_c/spot/spots} dead_par1 and dead_par2 step out of the starry crowd to congratulate {PRONOUN/m_c/object} on completing {PRONOUN/m_c/poss} training. dead_par2 rests {PRONOUN/dead_par1/poss} muzzle on (prefix)paw's head, naming {PRONOUN/m_c/object} m_c, and welcoming {PRONOUN/m_c/object} as a full medicine cat."
+    "(old_name) almost sobs as {PRONOUN/m_c/object} {VERB/m_c/spot/spots} dead_par1 and dead_par2 step out of the starry crowd to congratulate {PRONOUN/m_c/object} on completing {PRONOUN/m_c/poss} training. dead_par2 rests {PRONOUN/dead_par1/poss} muzzle on (old_name)'s head, naming {PRONOUN/m_c/object} m_c, and welcoming {PRONOUN/m_c/object} as a full medicine cat."
   ],
   "med_50": [
     [
@@ -1906,7 +1906,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "As a StarClan cat steps forward to give (prefix)paw {PRONOUN/m_c/poss} new name of m_c, {PRONOUN/m_c/subject} {VERB/m_c/spot/spots} dead_par1 and dead_par2 watching {PRONOUN/m_c/object} proudly with the other StarClan cats."
+    "As a StarClan cat steps forward to give (old_name) {PRONOUN/m_c/poss} new name of m_c, {PRONOUN/m_c/subject} {VERB/m_c/spot/spots} dead_par1 and dead_par2 watching {PRONOUN/m_c/object} proudly with the other StarClan cats."
   ],
   "med_51": [
     [
@@ -1918,7 +1918,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "(prefix)paw has waited a long time for this day! Heart pounding, {PRONOUN/m_c/subject} {VERB/m_c/listen/listens} intently as (previous_mentor) names {PRONOUN/m_c/object} m_c after {PRONOUN/m_c/poss} r_h."
+    "(old_name) has waited a long time for this day! Heart pounding, {PRONOUN/m_c/subject} {VERB/m_c/listen/listens} intently as (previous_mentor) names {PRONOUN/m_c/object} m_c after {PRONOUN/m_c/poss} r_h."
   ],
   "med_52": [
     [
@@ -1930,7 +1930,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "Inspired by (prefix)paw's r_h, (previous_mentor) names {PRONOUN/m_c/object} m_c, and welcomes {PRONOUN/m_c/object} as a full medicine cat."
+    "Inspired by (old_name)'s r_h, (previous_mentor) names {PRONOUN/m_c/object} m_c, and welcomes {PRONOUN/m_c/object} as a full medicine cat."
   ],
   "warrior_0": [
     [
@@ -1954,7 +1954,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "Although {PRONOUN/m_c/poss} training has been long, (prefix)paw has failed to master the skills needed of a warrior. However, {PRONOUN/m_c/subject} {VERB/m_c/are/is} getting too old to stay in the apprentices den. The mood is tense and awkward as {PRONOUN/m_c/subject} {VERB/m_c/are/is} named m_c and honored for {PRONOUN/m_c/poss} r_h. "
+    "Although {PRONOUN/m_c/poss} training has been long, (old_name) has failed to master the skills needed of a warrior. However, {PRONOUN/m_c/subject} {VERB/m_c/are/is} getting too old to stay in the apprentices den. The mood is tense and awkward as {PRONOUN/m_c/subject} {VERB/m_c/are/is} named m_c and honored for {PRONOUN/m_c/poss} r_h. "
   ],
   "warrior_0_b": [
     [
@@ -1966,7 +1966,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "(prefix)paw has excelled at every task placed before {PRONOUN/m_c/object}. Despite {PRONOUN/m_c/poss} young age, {PRONOUN/m_c/subject} are more than ready to be a warrior. {PRONOUN/m_c/subject/CAP} {VERB/m_c/are/is} given the name m_c, honoring {PRONOUN/m_c/poss} r_h. "
+    "(old_name) has excelled at every task placed before {PRONOUN/m_c/object}. Despite {PRONOUN/m_c/poss} young age, {PRONOUN/m_c/subject} are more than ready to be a warrior. {PRONOUN/m_c/subject/CAP} {VERB/m_c/are/is} given the name m_c, honoring {PRONOUN/m_c/poss} r_h. "
   ],
   "warrior_1": [
     [
@@ -1978,7 +1978,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "l_n calls the Clan to a meeting and declares (prefix)paw to be a warrior. {PRONOUN/m_c/subject/CAP} are now called m_c and are celebrated for {PRONOUN/m_c/poss} r_h."
+    "l_n calls the Clan to a meeting and declares (old_name) to be a warrior. {PRONOUN/m_c/subject/CAP} are now called m_c and are celebrated for {PRONOUN/m_c/poss} r_h."
   ],
   "warrior_2": [
     [
@@ -1990,7 +1990,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "l_n stands above the Clan and proclaims that (prefix)paw shall now be known as m_c, honoring {PRONOUN/m_c/poss} r_h."
+    "l_n stands above the Clan and proclaims that (old_name) shall now be known as m_c, honoring {PRONOUN/m_c/poss} r_h."
   ],
   "warrior_3": [
     [
@@ -2014,7 +2014,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "l_n has been following the progress of (prefix)paw for moons, and feels that it is finally time for {PRONOUN/m_c/object} to get {PRONOUN/m_c/poss} warrior name. {PRONOUN/m_c/subject/CAP} are granted the name m_c in honor of {PRONOUN/m_c/poss} r_h."
+    "l_n has been following the progress of (old_name) for moons, and feels that it is finally time for {PRONOUN/m_c/object} to get {PRONOUN/m_c/poss} warrior name. {PRONOUN/m_c/subject/CAP} are granted the name m_c in honor of {PRONOUN/m_c/poss} r_h."
   ],
   "warrior_5": [
     [
@@ -2026,7 +2026,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "(prefix)paw stands before the leader. {PRONOUN/m_c/subject/CAP} should be happier, but as {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} given {PRONOUN/m_c/poss} warrior name, m_c in honor of {PRONOUN/m_c/poss} r_h, {PRONOUN/m_c/subject} {VERB/m_c/cast/casts} a look to the crowd. {PRONOUN/m_c/subject/CAP} {VERB/m_c/wish/wishes} that (deadmentor) could be there to see {PRONOUN/m_c/object} now."
+    "(old_name) stands before the leader. {PRONOUN/m_c/subject/CAP} should be happier, but as {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} given {PRONOUN/m_c/poss} warrior name, m_c in honor of {PRONOUN/m_c/poss} r_h, {PRONOUN/m_c/subject} {VERB/m_c/cast/casts} a look to the crowd. {PRONOUN/m_c/subject/CAP} {VERB/m_c/wish/wishes} that (deadmentor) could be there to see {PRONOUN/m_c/object} now."
   ],
   "warrior_6": [
     [
@@ -2038,7 +2038,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "(previous_mentor) sits in the crowd, chest puffed out in pride as {PRONOUN/(previous_mentor)/subject} {VERB/(previous_mentor)/watch/watches} (prefix)paw be named m_c, and honored for {PRONOUN/m_c/poss} r_h. {PRONOUN/(previous_mentor)/subject/CAP} {VERB/(previous_mentor)/consider/considers} {PRONOUN/(previous_mentor)/self} lucky to have been able to train such an amazing young cat, and look forward to seeing the warrior {PRONOUN/m_c/subject} {VERB/m_c/become/becomes}."
+    "(previous_mentor) sits in the crowd, chest puffed out in pride as {PRONOUN/(previous_mentor)/subject} {VERB/(previous_mentor)/watch/watches} (old_name) be named m_c, and honored for {PRONOUN/m_c/poss} r_h. {PRONOUN/(previous_mentor)/subject/CAP} {VERB/(previous_mentor)/consider/considers} {PRONOUN/(previous_mentor)/self} lucky to have been able to train such an amazing young cat, and look forward to seeing the warrior {PRONOUN/m_c/subject} {VERB/m_c/become/becomes}."
   ],
   "warrior_7": [
     [
@@ -2050,7 +2050,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "(previous_mentor) gives (prefix)paw a friendly nudge when the leader calls the young cat's name. {PRONOUN/(previous_mentor)/subject/CAP} {VERB/(previous_mentor)/watch/watches} with pride as (prefix)paw steps forward to receive {PRONOUN/m_c/poss} new name, m_c, and are honored for {PRONOUN/m_c/poss} r_h."
+    "(previous_mentor) gives (old_name) a friendly nudge when the leader calls the young cat's name. {PRONOUN/(previous_mentor)/subject/CAP} {VERB/(previous_mentor)/watch/watches} with pride as (old_name) steps forward to receive {PRONOUN/m_c/poss} new name, m_c, and are honored for {PRONOUN/m_c/poss} r_h."
   ],
   "warrior_8": [
     [
@@ -2062,7 +2062,7 @@
       "general_backstory",
       "adventurous"
     ],
-    "(prefix)paw sits in front of the Clan, eager to receive {PRONOUN/m_c/poss} name, but {PRONOUN/m_c/poss} focus seems somewhere else, somewhere beyond the horizon. {PRONOUN/m_c/subject/CAP} barely {VERB/m_c/seem/seems} to be paying attention as {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} named m_c after {PRONOUN/m_c/poss} r_h."
+    "(old_name) sits in front of the Clan, eager to receive {PRONOUN/m_c/poss} name, but {PRONOUN/m_c/poss} focus seems somewhere else, somewhere beyond the horizon. {PRONOUN/m_c/subject/CAP} barely {VERB/m_c/seem/seems} to be paying attention as {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} named m_c after {PRONOUN/m_c/poss} r_h."
   ],
   "warrior_9": [
     [
@@ -2074,7 +2074,7 @@
       "general_backstory",
       "compassionate"
     ],
-    "l_n gazes down proudly upon (prefix)paw. {PRONOUN/m_c/subject/CAP} {VERB/m_c/had/has} spent {PRONOUN/m_c/poss} whole apprenticeship helping the Clan, and so {PRONOUN/m_c/subject} {VERB/m_c/are/is} named m_c after {PRONOUN/m_c/poss} r_h."
+    "l_n gazes down proudly upon (old_name). {PRONOUN/m_c/subject/CAP} {VERB/m_c/had/has} spent {PRONOUN/m_c/poss} whole apprenticeship helping the Clan, and so {PRONOUN/m_c/subject} {VERB/m_c/are/is} named m_c after {PRONOUN/m_c/poss} r_h."
   ],
   "warrior_10": [
     [
@@ -2086,7 +2086,7 @@
       "general_backstory",
       "compassionate"
     ],
-    "(prefix)paw's eyes gleam as {PRONOUN/m_c/subject} stare up at l_n, vowing silently to {PRONOUN/m_c/self} to one day be up there. {PRONOUN/m_c/subject/CAP} {VERB/m_c/are/is} named m_c after {PRONOUN/m_c/poss} r_h."
+    "(old_name)'s eyes gleam as {PRONOUN/m_c/subject} stare up at l_n, vowing silently to {PRONOUN/m_c/self} to one day be up there. {PRONOUN/m_c/subject/CAP} {VERB/m_c/are/is} named m_c after {PRONOUN/m_c/poss} r_h."
   ],
   "warrior_11": [
     [
@@ -2098,7 +2098,7 @@
       "general_backstory",
       "bloodthirsty"
     ],
-    "Although (prefix)paw's eagerness to fight has left l_n a little worried before, {PRONOUN/l_n/subject} {VERB/m_c/know/knows} that the Clan can count on (prefix)paw's bravery and sharp claws when they need them the most. In honor of {PRONOUN/m_c/poss} r_h, (prefix)paw is given the name m_c."
+    "Although (old_name)'s eagerness to fight has left l_n a little worried before, {PRONOUN/l_n/subject} {VERB/m_c/know/knows} that the Clan can count on (old_name)'s bravery and sharp claws when they need them the most. In honor of {PRONOUN/m_c/poss} r_h, (old_name) is given the name m_c."
   ],
   "warrior_12": [
     [
@@ -2110,7 +2110,7 @@
       "general_backstory",
       "bold"
     ],
-    "(prefix)paw stands tall and puffs out {PRONOUN/m_c/poss} chest as l_n announces {PRONOUN/m_c/subject} {VERB/m_c/are/is} ready for {PRONOUN/m_c/subject} warrior name. {PRONOUN/m_c/subject/CAP} {VERB/m_c/are/is} given the name m_c after {PRONOUN/m_c/poss} r_h."
+    "(old_name) stands tall and puffs out {PRONOUN/m_c/poss} chest as l_n announces {PRONOUN/m_c/subject} {VERB/m_c/are/is} ready for {PRONOUN/m_c/subject} warrior name. {PRONOUN/m_c/subject/CAP} {VERB/m_c/are/is} given the name m_c after {PRONOUN/m_c/poss} r_h."
   ],
   "warrior_13": [
     [
@@ -2122,7 +2122,7 @@
       "general_backstory",
       "calm"
     ],
-    "(prefix)paw sits before the Clan, ears pricked forward and gaze calm as l_n addresses the Clan. {PRONOUN/m_c/subject/CAP} {VERB/m_c/bow/bows} {PRONOUN/m_c/poss} head as {PRONOUN/m_c/subject} {VERB/m_c/are/is} named m_c after {PRONOUN/m_c/poss} r_h."
+    "(old_name) sits before the Clan, ears pricked forward and gaze calm as l_n addresses the Clan. {PRONOUN/m_c/subject/CAP} {VERB/m_c/bow/bows} {PRONOUN/m_c/poss} head as {PRONOUN/m_c/subject} {VERB/m_c/are/is} named m_c after {PRONOUN/m_c/poss} r_h."
   ],
   "warrior_14": [
     [
@@ -2134,7 +2134,7 @@
       "general_backstory",
       "careful"
     ],
-    "(prefix)paw sits neatly in front of l_n as {PRONOUN/l_n/subject} {VERB/l_n/talk/talks} about how well (prefix)paw did in {PRONOUN/m_c/poss} assessment. {PRONOUN/m_c/subject/CAP} {VERB/m_c/are/is} named m_c after {PRONOUN/m_c/poss} r_h."
+    "(old_name) sits neatly in front of l_n as {PRONOUN/l_n/subject} {VERB/l_n/talk/talks} about how well (old_name) did in {PRONOUN/m_c/poss} assessment. {PRONOUN/m_c/subject/CAP} {VERB/m_c/are/is} named m_c after {PRONOUN/m_c/poss} r_h."
   ],
   "warrior_15": [
     [
@@ -2146,7 +2146,7 @@
       "general_backstory",
       "charismatic"
     ],
-    "(prefix)paw holds {PRONOUN/m_c/poss} head high as l_n announces it is time for {PRONOUN/m_c/object} to be given {PRONOUN/m_c/poss} warrior name. {PRONOUN/m_c/subject/CAP} {VERB/m_c/are/is} named m_c in honor of {PRONOUN/m_c/poss} r_h, and the Clan explodes into loud cheers."
+    "(old_name) holds {PRONOUN/m_c/poss} head high as l_n announces it is time for {PRONOUN/m_c/object} to be given {PRONOUN/m_c/poss} warrior name. {PRONOUN/m_c/subject/CAP} {VERB/m_c/are/is} named m_c in honor of {PRONOUN/m_c/poss} r_h, and the Clan explodes into loud cheers."
   ],
   "warrior_16": [
     [
@@ -2158,7 +2158,7 @@
       "general_backstory",
       "childish"
     ],
-    "(prefix)paw barely seems to be paying attention, attention focused on a fluttering leaf. l_n has to repeat {PRONOUN/m_c/poss} name a few times before {PRONOUN/m_c/subject} finally {VERB/m_c/pay/pays} attention long enough to give {PRONOUN/m_c/poss} vow. Sighing, the leader names {PRONOUN/m_c/object} m_c after {PRONOUN/m_c/poss} r_h."
+    "(old_name) barely seems to be paying attention, attention focused on a fluttering leaf. l_n has to repeat {PRONOUN/m_c/poss} name a few times before {PRONOUN/m_c/subject} finally {VERB/m_c/pay/pays} attention long enough to give {PRONOUN/m_c/poss} vow. Sighing, the leader names {PRONOUN/m_c/object} m_c after {PRONOUN/m_c/poss} r_h."
   ],
   "warrior_17": [
     [
@@ -2170,7 +2170,7 @@
       "general_backstory",
       "childish"
     ],
-    "While l_n is not quite sure that (prefix)paw has outgrown {PRONOUN/m_c/poss} childish quirks or {PRONOUN/m_c/poss} love of pranks, {PRONOUN/l_n/subject} {VERB/l_n/welcome/welcomes} {PRONOUN/m_c/object} as a full warrior to the Clan and naming {PRONOUN/m_c/object} m_c after {PRONOUN/m_c/poss} lightheartedness and r_h."
+    "While l_n is not quite sure that (old_name) has outgrown {PRONOUN/m_c/poss} childish quirks or {PRONOUN/m_c/poss} love of pranks, {PRONOUN/l_n/subject} {VERB/l_n/welcome/welcomes} {PRONOUN/m_c/object} as a full warrior to the Clan and naming {PRONOUN/m_c/object} m_c after {PRONOUN/m_c/poss} lightheartedness and r_h."
   ],
   "warrior_18": [
     [
@@ -2182,7 +2182,7 @@
       "general_backstory",
       "cold"
     ],
-    "(prefix)paw remains completely quiet as l_n names {PRONOUN/m_c/object} m_c after {PRONOUN/m_c/poss} r_h. Before anyone can congratulate {PRONOUN/m_c/object}, however, {PRONOUN/m_c/subject} {VERB/m_c/turn/turns} and walks away without a word to do {PRONOUN/m_c/poss} silent vigil."
+    "(old_name) remains completely quiet as l_n names {PRONOUN/m_c/object} m_c after {PRONOUN/m_c/poss} r_h. Before anyone can congratulate {PRONOUN/m_c/object}, however, {PRONOUN/m_c/subject} {VERB/m_c/turn/turns} and walks away without a word to do {PRONOUN/m_c/poss} silent vigil."
   ],
   "warrior_19": [
     [
@@ -2194,7 +2194,7 @@
       "general_backstory",
       "cold"
     ],
-    "(prefix)paw stares at l_n as {PRONOUN/l_n/subject} {VERB/l_n/speak/speaks}. l_n is sure it doesn't mean anything, but (prefix)paw's lack of enthusiasm worries {PRONOUN/l_n/object}. Brushing past it, l_n gives {PRONOUN/m_c/object} the name m_c after {PRONOUN/m_c/poss} r_h."
+    "(old_name) stares at l_n as {PRONOUN/l_n/subject} {VERB/l_n/speak/speaks}. l_n is sure it doesn't mean anything, but (old_name)'s lack of enthusiasm worries {PRONOUN/l_n/object}. Brushing past it, l_n gives {PRONOUN/m_c/object} the name m_c after {PRONOUN/m_c/poss} r_h."
   ],
   "warrior_20": [
     [
@@ -2206,7 +2206,7 @@
       "general_backstory",
       "compassionate"
     ],
-    "(prefix)paw was so busy helping another cat {PRONOUN/m_c/subject} {VERB/m_c/were/was} nearly late for {PRONOUN/m_c/poss} own warrior ceremony. {PRONOUN/m_c/subject/CAP} rush to sit down, and l_n gazes proudly down at {PRONOUN/m_c/object} as {PRONOUN/l_n/subject} {VERB/l_n/name/names} {PRONOUN/m_c/object} m_c after {PRONOUN/m_c/poss} r_h."
+    "(old_name) was so busy helping another cat {PRONOUN/m_c/subject} {VERB/m_c/were/was} nearly late for {PRONOUN/m_c/poss} own warrior ceremony. {PRONOUN/m_c/subject/CAP} rush to sit down, and l_n gazes proudly down at {PRONOUN/m_c/object} as {PRONOUN/l_n/subject} {VERB/l_n/name/names} {PRONOUN/m_c/object} m_c after {PRONOUN/m_c/poss} r_h."
   ],
   "warrior_21": [
     [
@@ -2219,7 +2219,7 @@
       "compassionate",
       "loving"
     ],
-    "l_n has always thought (prefix)paw had a kind heart, knowing that {PRONOUN/m_c/subject} {VERB/m_c/are/is} ready for times of peace, but doesn't know how that heart will serve in war. Nevertheless, {PRONOUN/l_n/subject} {VERB/l_n/name/names} {PRONOUN/m_c/object} m_c after {PRONOUN/m_c/poss} r_h."
+    "l_n has always thought (old_name) had a kind heart, knowing that {PRONOUN/m_c/subject} {VERB/m_c/are/is} ready for times of peace, but doesn't know how that heart will serve in war. Nevertheless, {PRONOUN/l_n/subject} {VERB/l_n/name/names} {PRONOUN/m_c/object} m_c after {PRONOUN/m_c/poss} r_h."
   ],
   "warrior_22": [
     [
@@ -2231,7 +2231,7 @@
       "general_backstory",
       "confident"
     ],
-    "(prefix)paw soaks up all of the attention as {PRONOUN/m_c/subject} {VERB/m_c/stand/stands} before {PRONOUN/m_c/poss} Clan, eager for {PRONOUN/m_c/poss} new name. l_n gives {PRONOUN/m_c/object} the name m_c after {PRONOUN/m_c/poss} r_h."
+    "(old_name) soaks up all of the attention as {PRONOUN/m_c/subject} {VERB/m_c/stand/stands} before {PRONOUN/m_c/poss} Clan, eager for {PRONOUN/m_c/poss} new name. l_n gives {PRONOUN/m_c/object} the name m_c after {PRONOUN/m_c/poss} r_h."
   ],
   "warrior_23": [
     [
@@ -2243,7 +2243,7 @@
       "general_backstory",
       "daring"
     ],
-    "(prefix)paw looks up at the leader with pride. {PRONOUN/m_c/subject/CAP} knew all that hard work - proving {PRONOUN/m_c/subject} {VERB/m_c/were/was} the best apprentice in the Clan - was worth it, even if it caused {PRONOUN/m_c/object} a lot of trouble. {PRONOUN/m_c/subject/CAP} {VERB/m_c/hold/holds} {PRONOUN/m_c/poss} head high as {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} named m_c after {PRONOUN/m_c/poss} r_h."
+    "(old_name) looks up at the leader with pride. {PRONOUN/m_c/subject/CAP} knew all that hard work - proving {PRONOUN/m_c/subject} {VERB/m_c/were/was} the best apprentice in the Clan - was worth it, even if it caused {PRONOUN/m_c/object} a lot of trouble. {PRONOUN/m_c/subject/CAP} {VERB/m_c/hold/holds} {PRONOUN/m_c/poss} head high as {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} named m_c after {PRONOUN/m_c/poss} r_h."
   ],
   "warrior_24": [
     [
@@ -2255,7 +2255,7 @@
       "general_backstory",
       "daring"
     ],
-    "(prefix)paw sits with a determined look on {PRONOUN/m_c/poss} face before the Clan. l_n is worried that {PRONOUN/m_c/poss} refusal to back down and tendency to jump headfirst into danger will end poorly for {PRONOUN/m_c/object}, and hopes that sitting vigil overnight will change that. (prefix)paw is named m_c after {PRONOUN/m_c/poss} r_h."
+    "(old_name) sits with a determined look on {PRONOUN/m_c/poss} face before the Clan. l_n is worried that {PRONOUN/m_c/poss} refusal to back down and tendency to jump headfirst into danger will end poorly for {PRONOUN/m_c/object}, and hopes that sitting vigil overnight will change that. (old_name) is named m_c after {PRONOUN/m_c/poss} r_h."
   ],
   "warrior_25": [
     [
@@ -2267,7 +2267,7 @@
       "general_backstory",
       "compassionate"
     ],
-    "(prefix)paw purrs as {PRONOUN/m_c/subject} {VERB/m_c/feel/feels} the joy and pride of {PRONOUN/m_c/poss} Clanmates wash over {PRONOUN/m_c/object}. l_n looks down upon {PRONOUN/m_c/object}, eyes glowing with pride as well as {PRONOUN/l_n/subject} {VERB/l_n/name/names} {PRONOUN/m_c/object} m_c after {PRONOUN/m_c/poss} r_h."
+    "(old_name) purrs as {PRONOUN/m_c/subject} {VERB/m_c/feel/feels} the joy and pride of {PRONOUN/m_c/poss} Clanmates wash over {PRONOUN/m_c/object}. l_n looks down upon {PRONOUN/m_c/object}, eyes glowing with pride as well as {PRONOUN/l_n/subject} {VERB/l_n/name/names} {PRONOUN/m_c/object} m_c after {PRONOUN/m_c/poss} r_h."
   ],
   "warrior_26": [
     [
@@ -2279,7 +2279,7 @@
       "general_backstory",
       "faithful"
     ],
-    "(prefix)paw's eyes glimmer while l_n talks about {PRONOUN/m_c/poss} accomplishments. {PRONOUN/m_c/poss} gaze isn't focused on the leader, however, but the stars shining behind {PRONOUN/l_n/object}. As {PRONOUN/m_c/subject} {VERB/m_c/are/is} given the name m_c, {PRONOUN/m_c/object} {VERB/m_c/wonder/wonders} if StarClan honors {PRONOUN/m_c/poss} r_h, too."
+    "(old_name)'s eyes glimmer while l_n talks about {PRONOUN/m_c/poss} accomplishments. {PRONOUN/m_c/poss} gaze isn't focused on the leader, however, but the stars shining behind {PRONOUN/l_n/object}. As {PRONOUN/m_c/subject} {VERB/m_c/are/is} given the name m_c, {PRONOUN/m_c/object} {VERB/m_c/wonder/wonders} if StarClan honors {PRONOUN/m_c/poss} r_h, too."
   ],
   "warrior_27": [
     [
@@ -2291,7 +2291,7 @@
       "general_backstory",
       "faithful"
     ],
-    "As l_n gives (prefix)paw the name m_c, {PRONOUN/l_n/subject} {VERB/l_n/swear/swears} that {PRONOUN/l_n/subject} {VERB/l_n/see/sees} some starry cats yowling their support amongst {PRONOUN/l_n/poss} other Clanmates."
+    "As l_n gives (old_name) the name m_c, {PRONOUN/l_n/subject} {VERB/l_n/swear/swears} that {PRONOUN/l_n/subject} {VERB/l_n/see/sees} some starry cats yowling their support amongst {PRONOUN/l_n/poss} other Clanmates."
   ],
   "warrior_28": [
     [
@@ -2303,7 +2303,7 @@
       "general_backstory",
       "fierce"
     ],
-    "(prefix)paw sits in front of the leader, tail twitching back and forth as {PRONOUN/m_c/subject} {VERB/m_c/await/awaits} {PRONOUN/m_c/poss} warrior name. {PRONOUN/m_c/subject/CAP}{VERB/m_c/'re/'s} eager for this ceremony to be done so {PRONOUN/m_c/subject} can go back to work and make sure the Clan is safe. Finally, l_n looks down upon {PRONOUN/m_c/object} and names {PRONOUN/m_c/object} m_c after {PRONOUN/m_c/poss} r_h."
+    "(old_name) sits in front of the leader, tail twitching back and forth as {PRONOUN/m_c/subject} {VERB/m_c/await/awaits} {PRONOUN/m_c/poss} warrior name. {PRONOUN/m_c/subject/CAP}{VERB/m_c/'re/'s} eager for this ceremony to be done so {PRONOUN/m_c/subject} can go back to work and make sure the Clan is safe. Finally, l_n looks down upon {PRONOUN/m_c/object} and names {PRONOUN/m_c/object} m_c after {PRONOUN/m_c/poss} r_h."
   ],
   "warrior_29": [
     [
@@ -2315,7 +2315,7 @@
       "general_backstory",
       "insecure"
     ],
-    "{PRONOUN/m_c/poss/CAP} training is done already? (prefix)paw isn't entirely sure if {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} quite as ready to be a warrior as the leader claims {PRONOUN/m_c/object} to be. {PRONOUN/m_c/poss/CAP} voice trembles when {PRONOUN/m_c/subject} {VERB/m_c/take/takes} {PRONOUN/m_c/poss} vow. As {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} renamed to m_c, in honor of {PRONOUN/m_c/poss} r_h, {PRONOUN/m_c/subject} can't help but wonder if that is truly something that describes {PRONOUN/m_c/object}."
+    "{PRONOUN/m_c/poss/CAP} training is done already? (old_name) isn't entirely sure if {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} quite as ready to be a warrior as the leader claims {PRONOUN/m_c/object} to be. {PRONOUN/m_c/poss/CAP} voice trembles when {PRONOUN/m_c/subject} {VERB/m_c/take/takes} {PRONOUN/m_c/poss} vow. As {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} renamed to m_c, in honor of {PRONOUN/m_c/poss} r_h, {PRONOUN/m_c/subject} can't help but wonder if that is truly something that describes {PRONOUN/m_c/object}."
   ],
   "warrior_30": [
     [
@@ -2327,7 +2327,7 @@
       "general_backstory",
       "lonesome"
     ],
-    "(prefix)paw, now m_c, named so for {PRONOUN/m_c/poss} r_h, can only awkwardly thank {PRONOUN/m_c/poss} Clanmates as {PRONOUN/m_c/subject} {VERB/m_c/weave/weaves} through the crowd of purring cats. Once the meeting comes to a close, {PRONOUN/m_c/subject} {VERB/m_c/slink/slinks} out of camp to be alone for a while."
+    "(old_name), now m_c, named so for {PRONOUN/m_c/poss} r_h, can only awkwardly thank {PRONOUN/m_c/poss} Clanmates as {PRONOUN/m_c/subject} {VERB/m_c/weave/weaves} through the crowd of purring cats. Once the meeting comes to a close, {PRONOUN/m_c/subject} {VERB/m_c/slink/slinks} out of camp to be alone for a while."
   ],
   "warrior_31": [
     [
@@ -2339,7 +2339,7 @@
       "general_backstory",
       "loving"
     ],
-    "(prefix)paw is overjoyed to finally be a warrior. After l_n renames {PRONOUN/m_c/object} and honors {PRONOUN/m_c/poss} r_h, m_c nuzzles (previous_mentor), thanking {PRONOUN/(previous_mentor)/object} for {PRONOUN/(previous_mentor)/poss} guidance."
+    "(old_name) is overjoyed to finally be a warrior. After l_n renames {PRONOUN/m_c/object} and honors {PRONOUN/m_c/poss} r_h, m_c nuzzles (previous_mentor), thanking {PRONOUN/(previous_mentor)/object} for {PRONOUN/(previous_mentor)/poss} guidance."
   ],
   "warrior_32": [
     [
@@ -2351,7 +2351,7 @@
       "general_backstory",
       "loyal"
     ],
-    "(prefix)paw looks around at {PRONOUN/m_c/poss} Clanmates with adoration while l_n announces that {PRONOUN/m_c/poss} new name will be m_c after {PRONOUN/m_c/poss} r_h. m_c is happy to be a warrior now, but mostly {PRONOUN/m_c/subject} just {VERB/m_c/want/wants} to celebrate with {PRONOUN/m_c/poss} Clan, whether it's for {PRONOUN/m_c/object} or not."
+    "(old_name) looks around at {PRONOUN/m_c/poss} Clanmates with adoration while l_n announces that {PRONOUN/m_c/poss} new name will be m_c after {PRONOUN/m_c/poss} r_h. m_c is happy to be a warrior now, but mostly {PRONOUN/m_c/subject} just {VERB/m_c/want/wants} to celebrate with {PRONOUN/m_c/poss} Clan, whether it's for {PRONOUN/m_c/object} or not."
   ],
   "warrior_33": [
     [
@@ -2363,7 +2363,7 @@
       "general_backstory",
       "nervous"
     ],
-    "(prefix)paw fidgets nervously as {PRONOUN/m_c/subject} {VERB/m_c/step/steps} forward in front of the Clan. This is an important moment, so {PRONOUN/m_c/subject} {VERB/m_c/try/tries} not to hide {PRONOUN/m_c/poss} face from the crowd as l_n gives {PRONOUN/m_c/object} the name m_c in honor of {PRONOUN/m_c/poss} r_h. {PRONOUN/m_c/subject/CAP} quickly {VERB/m_c/scurry/scurries} back into the crowd once the ceremony is done, silently hoping that this will be the last ceremony {PRONOUN/m_c/subject} ever {VERB/m_c/have/has}."
+    "(old_name) fidgets nervously as {PRONOUN/m_c/subject} {VERB/m_c/step/steps} forward in front of the Clan. This is an important moment, so {PRONOUN/m_c/subject} {VERB/m_c/try/tries} not to hide {PRONOUN/m_c/poss} face from the crowd as l_n gives {PRONOUN/m_c/object} the name m_c in honor of {PRONOUN/m_c/poss} r_h. {PRONOUN/m_c/subject/CAP} quickly {VERB/m_c/scurry/scurries} back into the crowd once the ceremony is done, silently hoping that this will be the last ceremony {PRONOUN/m_c/subject} ever {VERB/m_c/have/has}."
   ],
   "warrior_34": [
     [
@@ -2375,7 +2375,7 @@
       "general_backstory",
       "nervous"
     ],
-    "As (prefix)paw nervously approaches {PRONOUN/m_c/poss} leader, l_n can't help but feel {PRONOUN/m_c/poss} hesitance might cost {PRONOUN/m_c/object} {PRONOUN/m_c/poss} life in battle. Steeling {PRONOUN/l_n/self} against {PRONOUN/l_n/poss} doubts, l_n gives (prefix)paw the name m_c to honor {PRONOUN/m_c/poss} r_h."
+    "As (old_name) nervously approaches {PRONOUN/m_c/poss} leader, l_n can't help but feel {PRONOUN/m_c/poss} hesitance might cost {PRONOUN/m_c/object} {PRONOUN/m_c/poss} life in battle. Steeling {PRONOUN/l_n/self} against {PRONOUN/l_n/poss} doubts, l_n gives (old_name) the name m_c to honor {PRONOUN/m_c/poss} r_h."
   ],
   "warrior_35": [
     [
@@ -2387,7 +2387,7 @@
       "general_backstory",
       "compassionate"
     ],
-    "(prefix)paw sits unbothered as l_n rattles on through the long, formal words of the warrior ceremony. {PRONOUN/l_n/subject/CAP} {VERB/l_n/give/gives} (prefix)paw the name m_c, honoring {PRONOUN/m_c/poss} r_h. m_c has no complaints about the long vigil {PRONOUN/m_c/subject} must sit that night."
+    "(old_name) sits unbothered as l_n rattles on through the long, formal words of the warrior ceremony. {PRONOUN/l_n/subject/CAP} {VERB/l_n/give/gives} (old_name) the name m_c, honoring {PRONOUN/m_c/poss} r_h. m_c has no complaints about the long vigil {PRONOUN/m_c/subject} must sit that night."
   ],
   "warrior_36": [
     [
@@ -2399,7 +2399,7 @@
       "general_backstory",
       "playful"
     ],
-    "(prefix)paw bounces up to the front of the Clan, full of excitement. {PRONOUN/m_c/subject/CAP} {VERB/m_c/try/tries} to take this somewhat seriously, but {PRONOUN/m_c/subject} still {VERB/m_c/crack/cracks} a joke over something the leader says. l_n gently scolds {PRONOUN/m_c/object} for it, but can't help purring along as {PRONOUN/l_n/subject} {VERB/l_n/name/names} {PRONOUN/m_c/object} m_c after {PRONOUN/m_c/poss} r_h."
+    "(old_name) bounces up to the front of the Clan, full of excitement. {PRONOUN/m_c/subject/CAP} {VERB/m_c/try/tries} to take this somewhat seriously, but {PRONOUN/m_c/subject} still {VERB/m_c/crack/cracks} a joke over something the leader says. l_n gently scolds {PRONOUN/m_c/object} for it, but can't help purring along as {PRONOUN/l_n/subject} {VERB/l_n/name/names} {PRONOUN/m_c/object} m_c after {PRONOUN/m_c/poss} r_h."
   ],
   "warrior_37": [
     [
@@ -2411,7 +2411,7 @@
       "general_backstory",
       "responsible"
     ],
-    "(prefix)paw has shown more maturity than most cats {PRONOUN/m_c/poss} age, always offering to take on the worst apprentice jobs first, and counting the prey in the pile to know just how much to catch on patrol. l_n was tempted to make {PRONOUN/m_c/object} a warrior sooner, but now will have to do. {PRONOUN/l_n/subject/CAP} {VERB/l_n/name/names} {PRONOUN/m_c/object} m_c after {PRONOUN/m_c/poss} r_h."
+    "(old_name) has shown more maturity than most cats {PRONOUN/m_c/poss} age, always offering to take on the worst apprentice jobs first, and counting the prey in the pile to know just how much to catch on patrol. l_n was tempted to make {PRONOUN/m_c/object} a warrior sooner, but now will have to do. {PRONOUN/l_n/subject/CAP} {VERB/l_n/name/names} {PRONOUN/m_c/object} m_c after {PRONOUN/m_c/poss} r_h."
   ],
   "warrior_38": [
     [
@@ -2423,7 +2423,7 @@
       "general_backstory",
       "righteous"
     ],
-    "(prefix)paw stands tall before the Clan, gaze determined as l_n says {PRONOUN/m_c/subject} {VERB/m_c/are/is} ready for {PRONOUN/m_c/poss} warrior name. (prefix)paw takes the vow seriously, and promises to always do what is best for everyone. Gaze proud, l_n names {PRONOUN/m_c/object} m_c after {PRONOUN/m_c/poss} r_h."
+    "(old_name) stands tall before the Clan, gaze determined as l_n says {PRONOUN/m_c/subject} {VERB/m_c/are/is} ready for {PRONOUN/m_c/poss} warrior name. (old_name) takes the vow seriously, and promises to always do what is best for everyone. Gaze proud, l_n names {PRONOUN/m_c/object} m_c after {PRONOUN/m_c/poss} r_h."
   ],
   "warrior_39": [
     [
@@ -2435,7 +2435,7 @@
       "general_backstory",
       "shameless"
     ],
-    "(prefix)paw is still messy after tussling with someone else, and doesn't even bother to groom {PRONOUN/m_c/self} before trotting up to the front of the crowd. {PRONOUN/m_c/subject/CAP} {VERB/m_c/are/is} named m_c, and honored for {PRONOUN/m_c/poss} r_h."
+    "(old_name) is still messy after tussling with someone else, and doesn't even bother to groom {PRONOUN/m_c/self} before trotting up to the front of the crowd. {PRONOUN/m_c/subject/CAP} {VERB/m_c/are/is} named m_c, and honored for {PRONOUN/m_c/poss} r_h."
   ],
   "warrior_40": [
     [
@@ -2447,7 +2447,7 @@
       "general_backstory",
       "sneaky"
     ],
-    "(prefix)paw pads forward silently before sitting in front of {PRONOUN/m_c/poss} leader. {PRONOUN/m_c/subject/CAP} {VERB/m_c/remain/remains} as quiet as {PRONOUN/m_c/poss} steps forward for l_n to name {PRONOUN/m_c/object} m_c and honor {PRONOUN/m_c/poss} r_h."
+    "(old_name) pads forward silently before sitting in front of {PRONOUN/m_c/poss} leader. {PRONOUN/m_c/subject/CAP} {VERB/m_c/remain/remains} as quiet as {PRONOUN/m_c/poss} steps forward for l_n to name {PRONOUN/m_c/object} m_c and honor {PRONOUN/m_c/poss} r_h."
   ],
   "warrior_41": [
     [
@@ -2459,7 +2459,7 @@
       "general_backstory",
       "strange"
     ],
-    "(prefix)paw is nearly late for {PRONOUN/m_c/poss} ceremony, having been double checking something for reasons no one knows. l_n remains patient as (prefix)paw sits down in front of {PRONOUN/l_n/object}. l_n names {PRONOUN/m_c/object} m_c, honoring {PRONOUN/m_c/poss} r_h."
+    "(old_name) is nearly late for {PRONOUN/m_c/poss} ceremony, having been double checking something for reasons no one knows. l_n remains patient as (old_name) sits down in front of {PRONOUN/l_n/object}. l_n names {PRONOUN/m_c/object} m_c, honoring {PRONOUN/m_c/poss} r_h."
   ],
   "warrior_42": [
     [
@@ -2471,7 +2471,7 @@
       "general_backstory",
       "strict"
     ],
-    "(prefix)paw grumbles to {PRONOUN/m_c/self} as l_n changes just a single word in the ceremony, but knows better than to correct {PRONOUN/l_n/object} during such an important ceremony. {PRONOUN/m_c/subject/CAP} can speak to l_n about it later. For now, {PRONOUN/m_c/subject} {VERB/m_c/listen/listens} as {PRONOUN/m_c/subject} {VERB/m_c/are/is} given the name m_c, and are honored for {PRONOUN/m_c/poss} r_h."
+    "(old_name) grumbles to {PRONOUN/m_c/self} as l_n changes just a single word in the ceremony, but knows better than to correct {PRONOUN/l_n/object} during such an important ceremony. {PRONOUN/m_c/subject/CAP} can speak to l_n about it later. For now, {PRONOUN/m_c/subject} {VERB/m_c/listen/listens} as {PRONOUN/m_c/subject} {VERB/m_c/are/is} given the name m_c, and are honored for {PRONOUN/m_c/poss} r_h."
   ],
   "warrior_43": [
     [
@@ -2483,7 +2483,7 @@
       "general_backstory",
       "thoughtful"
     ],
-    "l_n hops up onto the meeting spot to find that (prefix)paw has set moss along it in preparation for the meeting so that l_n can be more comfortable through the long ceremony. Purring, l_n gives {PRONOUN/m_c/object} the name m_c for {PRONOUN/m_c/poss} r_h."
+    "l_n hops up onto the meeting spot to find that (old_name) has set moss along it in preparation for the meeting so that l_n can be more comfortable through the long ceremony. Purring, l_n gives {PRONOUN/m_c/object} the name m_c for {PRONOUN/m_c/poss} r_h."
   ],
   "warrior_44": [
     [
@@ -2496,7 +2496,7 @@
       "thoughtful",
       "wise"
     ],
-    "l_n almost feels intimidated by the knowledge (prefix)paw has gathered in {PRONOUN/m_c/poss} months of training and feels confident when {PRONOUN/l_n/subject} {VERB/l_n/name/names} {PRONOUN/m_c/object} m_c in honor of {PRONOUN/m_c/poss} r_h."
+    "l_n almost feels intimidated by the knowledge (old_name) has gathered in {PRONOUN/m_c/poss} months of training and feels confident when {PRONOUN/l_n/subject} {VERB/l_n/name/names} {PRONOUN/m_c/object} m_c in honor of {PRONOUN/m_c/poss} r_h."
   ],
   "warrior_45": [
     [
@@ -2508,7 +2508,7 @@
       "general_backstory",
       "troublesome"
     ],
-    "(prefix)paw's penchant for getting into, and even starting, trouble has almost made l_n hold back on making {PRONOUN/m_c/object} a warrior. However, l_n can tell that (prefix)paw has been trying really hard lately to make up for it, and it would feel cruel to make {PRONOUN/m_c/object} wait any longer. So, l_n names {PRONOUN/m_c/object} m_c in honor of {PRONOUN/m_c/poss} r_h."
+    "(old_name)'s penchant for getting into, and even starting, trouble has almost made l_n hold back on making {PRONOUN/m_c/object} a warrior. However, l_n can tell that (old_name) has been trying really hard lately to make up for it, and it would feel cruel to make {PRONOUN/m_c/object} wait any longer. So, l_n names {PRONOUN/m_c/object} m_c in honor of {PRONOUN/m_c/poss} r_h."
   ],
   "warrior_46": [
     [
@@ -2520,7 +2520,7 @@
       "general_backstory",
       "vengeful"
     ],
-    "As (prefix)paw takes {PRONOUN/m_c/poss} vow and is named m_c after {PRONOUN/m_c/poss} r_h, {PRONOUN/m_c/poss} thoughts are less on protecting the Clan, and more so on ensuring that anyone who harms it will pay in kind."
+    "As (old_name) takes {PRONOUN/m_c/poss} vow and is named m_c after {PRONOUN/m_c/poss} r_h, {PRONOUN/m_c/poss} thoughts are less on protecting the Clan, and more so on ensuring that anyone who harms it will pay in kind."
   ],
   "warrior_47": [
     [
@@ -2532,7 +2532,7 @@
       "general_backstory",
       "wise"
     ],
-    "(prefix)paw's advice has helped many cats throughout {PRONOUN/m_c/poss} days as an apprentice. Even l_n has sought {PRONOUN/m_c/object} out at times. l_n has no doubts in {PRONOUN/l_n/poss} mind that (prefix)paw is ready to be a warrior, and names {PRONOUN/m_c/object} m_c, honoring {PRONOUN/m_c/poss} r_h."
+    "(old_name)'s advice has helped many cats throughout {PRONOUN/m_c/poss} days as an apprentice. Even l_n has sought {PRONOUN/m_c/object} out at times. l_n has no doubts in {PRONOUN/l_n/poss} mind that (old_name) is ready to be a warrior, and names {PRONOUN/m_c/object} m_c, honoring {PRONOUN/m_c/poss} r_h."
   ],
   "warrior_48": [
     [
@@ -2544,7 +2544,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "c_n rallies around (prefix)paw in celebration. Even without a leader, life must go on, and (prefix)paw has proven {PRONOUN/m_c/subject} {VERB/m_c/are/is} ready for {PRONOUN/m_c/poss} warrior name. (prefix)paw is allowed to choose {PRONOUN/m_c/poss} own suffix, and {PRONOUN/m_c/subject} {VERB/m_c/name/names} {PRONOUN/m_c/self} m_c. The Clan cheers for the new warrior, honoring {PRONOUN/m_c/poss} r_h."
+    "c_n rallies around (old_name) in celebration. Even without a leader, life must go on, and (old_name) has proven {PRONOUN/m_c/subject} {VERB/m_c/are/is} ready for {PRONOUN/m_c/poss} warrior name. (old_name) is allowed to choose {PRONOUN/m_c/poss} own suffix, and {PRONOUN/m_c/subject} {VERB/m_c/name/names} {PRONOUN/m_c/self} m_c. The Clan cheers for the new warrior, honoring {PRONOUN/m_c/poss} r_h."
   ],
   "warrior_49": [
     [
@@ -2556,7 +2556,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "(prefix)paw sits with {PRONOUN/m_c/poss} Clan, purring as {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} congratulated on finishing {PRONOUN/m_c/poss} training. When given the option to choose {PRONOUN/m_c/poss} name, however, (prefix)paw can't really think of a suffix, and asks {PRONOUN/m_c/poss} Clanmates for some suggestions. After hearing a few ideas, (prefix)paw decides to be named m_c. The Clan cheers {PRONOUN/m_c/poss} new name, and honors {PRONOUN/m_c/object} for {PRONOUN/m_c/poss} r_h."
+    "(old_name) sits with {PRONOUN/m_c/poss} Clan, purring as {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} congratulated on finishing {PRONOUN/m_c/poss} training. When given the option to choose {PRONOUN/m_c/poss} name, however, (old_name) can't really think of a suffix, and asks {PRONOUN/m_c/poss} Clanmates for some suggestions. After hearing a few ideas, (old_name) decides to be named m_c. The Clan cheers {PRONOUN/m_c/poss} new name, and honors {PRONOUN/m_c/object} for {PRONOUN/m_c/poss} r_h."
   ],
   "warrior_50": [
     [
@@ -2568,7 +2568,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "Leader or no leader, c_n needs more warriors, and (prefix)paw has been working incredibly hard lately. The Clan agrees that {PRONOUN/m_c/subject} should be made a warrior. As {PRONOUN/m_c/subject} {VERB/m_c/are/is} named m_c, honoring {PRONOUN/m_c/poss} r_h, m_c wishes that (deadmentor) could be there to cheer for {PRONOUN/m_c/object}."
+    "Leader or no leader, c_n needs more warriors, and (old_name) has been working incredibly hard lately. The Clan agrees that {PRONOUN/m_c/subject} should be made a warrior. As {PRONOUN/m_c/subject} {VERB/m_c/are/is} named m_c, honoring {PRONOUN/m_c/poss} r_h, m_c wishes that (deadmentor) could be there to cheer for {PRONOUN/m_c/object}."
   ],
   "warrior_51": [
     [
@@ -2580,7 +2580,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "They don't care if there's no leader, the Clan knows that (prefix)paw is deserving of {PRONOUN/m_c/poss} full name. They gather to hold a ceremony for (prefix)paw, and name {PRONOUN/m_c/object} m_c, honoring {PRONOUN/m_c/poss} r_h. m_c is proud of {PRONOUN/m_c/self}, though a part of {PRONOUN/m_c/object} still wishes that (deadmentor) was still there to see {PRONOUN/m_c/object}."
+    "They don't care if there's no leader, the Clan knows that (old_name) is deserving of {PRONOUN/m_c/poss} full name. They gather to hold a ceremony for (old_name), and name {PRONOUN/m_c/object} m_c, honoring {PRONOUN/m_c/poss} r_h. m_c is proud of {PRONOUN/m_c/self}, though a part of {PRONOUN/m_c/object} still wishes that (deadmentor) was still there to see {PRONOUN/m_c/object}."
   ],
   "warrior_52": [
     [
@@ -2592,7 +2592,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "Leader or no leader, c_n needs more warriors, and (prefix)paw has been working incredibly hard lately. The Clan agrees that {PRONOUN/m_c/subject} should be made a warrior. They gather around the apprentice, and (previous_mentor) is nudged forward to do the honor of giving {PRONOUN/m_c/object} {PRONOUN/m_c/poss} name. Purring in pride for {PRONOUN/(previous_mentor)/poss} apprentice, (previous_mentor) rests {PRONOUN/(previous_mentor)/poss} muzzle on (prefix)paw's head, and names {PRONOUN/m_c/object} m_c, honoring {PRONOUN/m_c/poss} r_h."
+    "Leader or no leader, c_n needs more warriors, and (old_name) has been working incredibly hard lately. The Clan agrees that {PRONOUN/m_c/subject} should be made a warrior. They gather around the apprentice, and (previous_mentor) is nudged forward to do the honor of giving {PRONOUN/m_c/object} {PRONOUN/m_c/poss} name. Purring in pride for {PRONOUN/(previous_mentor)/poss} apprentice, (previous_mentor) rests {PRONOUN/(previous_mentor)/poss} muzzle on (old_name)'s head, and names {PRONOUN/m_c/object} m_c, honoring {PRONOUN/m_c/poss} r_h."
   ],
   "warrior_53": [
     [
@@ -2604,7 +2604,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "{PRONOUN/(previous_mentor)/subject/CAP} {VERB/(previous_mentor)/don't/doesn't) care if there's no leader, (previous_mentor) knows that (prefix)paw is deserving of {PRONOUN/m_c/poss} full name. {PRONOUN/(previous_mentor)/subject/CAP} {VERB/(previous_mentor)/gather/gathers} the Clan to hold a ceremony for (prefix)paw, and names {PRONOUN/m_c/object} m_c, honoring {PRONOUN/m_c/poss} r_h."
+    "{PRONOUN/(previous_mentor)/subject/CAP} {VERB/(previous_mentor)/don't/doesn't) care if there's no leader, (previous_mentor) knows that (old_name) is deserving of {PRONOUN/m_c/poss} full name. {PRONOUN/(previous_mentor)/subject/CAP} {VERB/(previous_mentor)/gather/gathers} the Clan to hold a ceremony for (old_name), and names {PRONOUN/m_c/object} m_c, honoring {PRONOUN/m_c/poss} r_h."
   ],
   "warrior_54": [
     [
@@ -2616,7 +2616,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "p1 can hardly believe how quickly time has passed since (prefix)paw was a kit. It still feels like just yesterday that {PRONOUN/m_c/subject} {VERB/m_c/were/was} tumbling around the nursery, chasing after a mossball or some other cat's tail. Misty-eyed with pride and joy, p1 throws {PRONOUN/p1/poss} head back and tries to cheer the loudest as (prefix)paw is named m_c and honored for {PRONOUN/m_c/poss} r_h."
+    "p1 can hardly believe how quickly time has passed since (old_name) was a kit. It still feels like just yesterday that {PRONOUN/m_c/subject} {VERB/m_c/were/was} tumbling around the nursery, chasing after a mossball or some other cat's tail. Misty-eyed with pride and joy, p1 throws {PRONOUN/p1/poss} head back and tries to cheer the loudest as (old_name) is named m_c and honored for {PRONOUN/m_c/poss} r_h."
   ],
   "warrior_55": [
     [
@@ -2640,7 +2640,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "p1 and p2's eyes meet, and they purr with pride as (prefix)paw steps forward to receive {PRONOUN/m_c/poss} new name, m_c, and are honored for {PRONOUN/m_c/poss} r_h."
+    "p1 and p2's eyes meet, and they purr with pride as (old_name) steps forward to receive {PRONOUN/m_c/poss} new name, m_c, and are honored for {PRONOUN/m_c/poss} r_h."
   ],
   "warrior_57": [
     [
@@ -2652,7 +2652,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "Are dead_par1 and dead_par2 watching from StarClan? (prefix)paw wonders this as {PRONOUN/m_c/subject} {VERB/m_c/step/steps} in front of the Clan. {PRONOUN/m_c/subject/CAP} {VERB/m_c/hope/hopes} so. {PRONOUN/m_c/subject/CAP} truly {VERB/m_c/do/does}. As {PRONOUN/m_c/subject} {VERB/m_c/are/is} given the name m_c in honor of {PRONOUN/m_c/poss} r_h, m_c hopes that {PRONOUN/m_c/poss} parents are there, cheering with their Clanmates in the stars for their kit."
+    "Are dead_par1 and dead_par2 watching from StarClan? (old_name) wonders this as {PRONOUN/m_c/subject} {VERB/m_c/step/steps} in front of the Clan. {PRONOUN/m_c/subject/CAP} {VERB/m_c/hope/hopes} so. {PRONOUN/m_c/subject/CAP} truly {VERB/m_c/do/does}. As {PRONOUN/m_c/subject} {VERB/m_c/are/is} given the name m_c in honor of {PRONOUN/m_c/poss} r_h, m_c hopes that {PRONOUN/m_c/poss} parents are there, cheering with their Clanmates in the stars for their kit."
   ],
   "warrior_58": [
     [
@@ -2664,7 +2664,7 @@
       "clanborn",
       "all_traits"
     ],
-    "(prefix)paw tries to keep {PRONOUN/m_c/poss} head high as {PRONOUN/m_c/subject} {VERB/m_c/step/steps} forward, and {VERB/m_c/are/is} given the name m_c in honor of {PRONOUN/m_c/poss} r_h. It doesn't seem fair. dead_par1 and dead_par2 should be here with {PRONOUN/m_c/object}! They promised they would! m_c looks to the stars, and {PRONOUN/m_c/poss} anger and frustration vanishes. It feels as though the stars are brighter, and {PRONOUN/m_c/subject} {VERB/m_c/know/knows} that, even if they cannot be there in body, {PRONOUN/m_c/poss} parents are there in spirit."
+    "(old_name) tries to keep {PRONOUN/m_c/poss} head high as {PRONOUN/m_c/subject} {VERB/m_c/step/steps} forward, and {VERB/m_c/are/is} given the name m_c in honor of {PRONOUN/m_c/poss} r_h. It doesn't seem fair. dead_par1 and dead_par2 should be here with {PRONOUN/m_c/object}! They promised they would! m_c looks to the stars, and {PRONOUN/m_c/poss} anger and frustration vanishes. It feels as though the stars are brighter, and {PRONOUN/m_c/subject} {VERB/m_c/know/knows} that, even if they cannot be there in body, {PRONOUN/m_c/poss} parents are there in spirit."
   ],
   "warrior_59": [
     [
@@ -2676,7 +2676,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "(previous_mentor) gathers the Clan for a meeting. {PRONOUN/(previous_mentor)/subject/CAP} {VERB/(previous_mentor)/have/has} spent many moons training (prefix)paw, and it's time for {PRONOUN/m_c/object} to be granted {PRONOUN/m_c/poss} warrior name. (previous_mentor) gives {PRONOUN/m_c/object} the name m_c and honors {PRONOUN/m_c/poss} r_h."
+    "(previous_mentor) gathers the Clan for a meeting. {PRONOUN/(previous_mentor)/subject/CAP} {VERB/(previous_mentor)/have/has} spent many moons training (old_name), and it's time for {PRONOUN/m_c/object} to be granted {PRONOUN/m_c/poss} warrior name. (previous_mentor) gives {PRONOUN/m_c/object} the name m_c and honors {PRONOUN/m_c/poss} r_h."
   ],
   "mediator_0": [
     [
@@ -2688,7 +2688,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "(prefix)paw has proven {PRONOUN/m_c/self} skilled at handling the Clan's disputes. {PRONOUN/m_c/subject/CAP} {VERB/m_c/are/is} given the name m_c, and the Clan honors {PRONOUN/m_c/poss} new mediator."
+    "(old_name) has proven {PRONOUN/m_c/self} skilled at handling the Clan's disputes. {PRONOUN/m_c/subject/CAP} {VERB/m_c/are/is} given the name m_c, and the Clan honors {PRONOUN/m_c/poss} new mediator."
   ],
   "mediator_0_a": [
     [
@@ -2700,7 +2700,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "Although (prefix)paw is still not ready to become a full mediator, {PRONOUN/m_c/subject} {VERB/m_c/are/is} too old to remain in the apprentices den. A meeting is called, and {PRONOUN/m_c/subject} {VERB/m_c/are/is} given the name m_c. The mood is tense and pitying. "
+    "Although (old_name) is still not ready to become a full mediator, {PRONOUN/m_c/subject} {VERB/m_c/are/is} too old to remain in the apprentices den. A meeting is called, and {PRONOUN/m_c/subject} {VERB/m_c/are/is} given the name m_c. The mood is tense and pitying. "
   ],
   "mediator_0_b": [
     [
@@ -2712,7 +2712,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "(prefix)paw has taken to {PRONOUN/m_c/poss} mediator training like a fish to water. Although young, {PRONOUN/m_c/subject} {VERB/m_c/are/is} ready to take on the duties of a full mediator. {PRONOUN/m_c/subject/CAP} {VERB/m_c/are/is} given the name m_c, and the Clan celebrates."
+    "(old_name) has taken to {PRONOUN/m_c/poss} mediator training like a fish to water. Although young, {PRONOUN/m_c/subject} {VERB/m_c/are/is} ready to take on the duties of a full mediator. {PRONOUN/m_c/subject/CAP} {VERB/m_c/are/is} given the name m_c, and the Clan celebrates."
   ],
   "mediator_1": [
     [
@@ -2736,7 +2736,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "Although some Clan members have doubts of (prefix)paw's abilities, l_n gives {PRONOUN/m_c/object} the name m_c and welcomes {PRONOUN/m_c/object} as the Clan's new mediator."
+    "Although some Clan members have doubts of (old_name)'s abilities, l_n gives {PRONOUN/m_c/object} the name m_c and welcomes {PRONOUN/m_c/object} as the Clan's new mediator."
   ],
   "mediator_3": [
     [
@@ -2748,7 +2748,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "As (prefix)paw has finished {PRONOUN/m_c/poss} mediator training, l_n gives {PRONOUN/m_c/object} the name m_c after {PRONOUN/m_c/poss} r_h, welcoming {PRONOUN/m_c/object} as the Clan's new mediator."
+    "As (old_name) has finished {PRONOUN/m_c/poss} mediator training, l_n gives {PRONOUN/m_c/object} the name m_c after {PRONOUN/m_c/poss} r_h, welcoming {PRONOUN/m_c/object} as the Clan's new mediator."
   ],
   "mediator_4": [
     [
@@ -2759,7 +2759,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "(previous_mentor) tells l_n that (prefix)paw has completed {PRONOUN/m_c/poss} mediator training, and l_n gives {PRONOUN/m_c/object} the name m_c after {PRONOUN/m_c/poss} r_h, welcoming {PRONOUN/m_c/object} as the Clan's new mediator."
+    "(previous_mentor) tells l_n that (old_name) has completed {PRONOUN/m_c/poss} mediator training, and l_n gives {PRONOUN/m_c/object} the name m_c after {PRONOUN/m_c/poss} r_h, welcoming {PRONOUN/m_c/object} as the Clan's new mediator."
   ],
   "elder_0": [
     [

--- a/resources/dicts/events/misc_events/general/general.json
+++ b/resources/dicts/events/misc_events/general/general.json
@@ -511,5 +511,25 @@
             "insecure",
             "nervous"
         ]
+    },
+    {
+        "camp": "any",
+        "tags": [
+            "Newleaf",
+            "Greenleaf",
+            "Leaf-bare",
+            "Leaf-fall",
+            "skill_trait_required"
+        ],
+        "event_text": "m_c's dreams are filled with flashing teeth and blood-scent. {PRONOUN/m_c/subject/CAP} {VERB/m_c/wake/wakes} up screaming.",
+        "cat_trait": [
+            "adventurous",
+            "daring",
+            "insecure",
+            "nervous"
+        ],
+        "cat_skill": [
+            "DARK,0"
+        ]
     }
 ]

--- a/resources/dicts/events/misc_events/general/general.json
+++ b/resources/dicts/events/misc_events/general/general.json
@@ -522,14 +522,24 @@
             "skill_trait_required"
         ],
         "event_text": "m_c's dreams are filled with flashing teeth and blood-scent. {PRONOUN/m_c/subject/CAP} {VERB/m_c/wake/wakes} up screaming.",
-        "cat_trait": [
-            "adventurous",
-            "daring",
-            "insecure",
-            "nervous"
-        ],
+        "cat_trait": null,
         "cat_skill": [
             "DARK,0"
+        ]
+    },
+    {
+        "camp": "any",
+        "tags": [
+            "Newleaf",
+            "Greenleaf",
+            "Leaf-bare",
+            "Leaf-fall",
+            "skill_trait_required"
+        ],
+        "event_text": "m_c thought {PRONOUN/m_c/subject} saw a familar wispy form lingering at the edge of camp, but the ghost disappeared before {PRONOUN/m_c/subject} could be sure.",
+        "cat_trait": null,
+        "cat_skill": [
+            "GHOST,0"
         ]
     }
 ]

--- a/resources/dicts/events/misc_events/general/medicine.json
+++ b/resources/dicts/events/misc_events/general/medicine.json
@@ -23,13 +23,13 @@
             "other_clan"
         ],
         "event_text": "m_c visits o_c to converse with their medicine cats about an omen StarClan sent.",
-        "cat_trait": [
-            "strong connection to StarClan",
-            "omen sight",
-            "clairvoyant",
-            "dream walker"
+        "cat_trait": null,
+        "cat_skill": [
+            "STAR,0",
+            "CLAIRVOYANT,0",
+            "OMEN,0",
+            "DREAM,0"
         ],
-        "cat_skill": [],
         "other_cat_trait": null,
         "other_cat_skill": null
     },
@@ -43,12 +43,10 @@
             "other_clan"
         ],
         "event_text": "m_c visits o_c to congratulate them on their new medicine cat.",
-        "cat_trait": [
-            "good mediator",
-            "great mediator",
-            "excellent mediator"
+        "cat_trait": null,
+        "cat_skill": [
+            "MEDIATE,1"
         ],
-        "cat_skill": [],
         "other_cat_trait": null,
         "other_cat_skill": null
     },
@@ -110,7 +108,7 @@
         "event_text": "m_c speaks to r_c about an omen {PRONOUN/m_c/subject} saw while on patrol recently.",
         "cat_trait": null,
         "cat_skill": [
-            "OMEN,3"
+            "OMEN,0"
         ],
         "other_cat_trait": null,
         "other_cat_skill": null
@@ -128,7 +126,7 @@
         "event_text": "m_c speaks to r_c about a potential omen and what it means.",
         "cat_trait": null,
         "cat_skill": [
-            "OMEN,3"
+            "OMEN,0"
         ],
         "other_cat_trait": null,
         "other_cat_skill": null
@@ -139,7 +137,8 @@
             "Leaf-bare",
             "Newleaf",
             "Greenleaf",
-            "Leaf-fall"
+            "Leaf-fall",
+            "skill_trait_required"
         ],
         "event_text": "m_c walks into the dreams of {PRONOUN/m_c/poss} Clanmates while everyone sleeps.",
         "cat_trait": null,
@@ -155,7 +154,8 @@
             "Leaf-bare",
             "Newleaf",
             "Greenleaf",
-            "Leaf-fall"
+            "Leaf-fall",
+            "skill_trait_required"
         ],
         "event_text": "m_c correctly warns the leader of an ambush, thanks to {PRONOUN/m_c/poss} clairvoyant nature.",
         "cat_trait": null,
@@ -176,7 +176,7 @@
         "event_text": "m_c spends {PRONOUN/m_c/poss} day communing with StarClan, attempting to figure out a recent prophecy.",
         "cat_trait": null,
         "cat_skill": [
-            "PROPHET,3"
+            "PROPHET,2"
         ],
         "other_cat_trait": null,
         "other_cat_skill": null
@@ -194,7 +194,7 @@
         "event_text": "m_c has been worried that c_n will lose the knowledge r_c has gained through {PRONOUN/r_c/poss} long life, but by sitting with r_c and discussing {PRONOUN/r_c/poss} experiences, m_c will ensure the lessons learned in the past are never forgotten.",
         "cat_trait": null,
         "cat_skill": [
-            "LORE,2"
+            "LORE,0"
         ],
         "other_cat_trait": null,
         "other_cat_skill": null
@@ -205,7 +205,8 @@
             "Newleaf",
             "Greenleaf",
             "Leaf-fall",
-            "Leaf-bare"
+            "Leaf-bare",
+            "skill_trait_required"
         ],
         "event_text": "m_c tosses in {PRONOUN/m_c/poss} sleep as {PRONOUN/m_c/poss} dreamself pads through the thoughts of {PRONOUN/m_c/poss} Clanmates, picking up snippets of dream_list. {PRONOUN/m_c/subject/CAP} slowly {VERB/m_c/blink/blinks} awake, wondering whose dreams {PRONOUN/m_c/subject} walked in.",
         "cat_trait": null,
@@ -298,7 +299,7 @@
         ],
         "event_text": "m_c watches every little thing around {PRONOUN/m_c/object} for any omen that indicates what the Clan should do in the war. The losses weigh heavy on the hearts of every cat.",
         "cat_skill": [
-            "OMEN,1"
+            "OMEN,0"
         ]
     },
     {

--- a/resources/dicts/events/misc_events/general/medicine.json
+++ b/resources/dicts/events/misc_events/general/medicine.json
@@ -45,7 +45,7 @@
         "event_text": "m_c visits o_c to congratulate them on their new medicine cat.",
         "cat_trait": null,
         "cat_skill": [
-            "MEDIATE,1"
+            "MEDIATOR,1"
         ],
         "other_cat_trait": null,
         "other_cat_skill": null

--- a/resources/game_config.json
+++ b/resources/game_config.json
@@ -280,7 +280,7 @@
 		}
 	},
 	"lost_cat": {
-		"rejoin_chance": 20
+		"rejoin_chance": 1
 	},
 	"cat_ages": {
 		"newborn": [0, 0],

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -1191,6 +1191,12 @@ class Cat():
         """Handles a moon skip for an alive cat. """
         
         
+        old_age = self.age
+        self.moons += 1
+        if self.moons == 1 and self.status == "newborn":
+            self.status = 'kitten'
+        self.in_camp = 1
+        
         if self.exiled or self.outside:
             # this is handled in events.py
             self.personality.set_kit(self.is_baby())
@@ -1200,12 +1206,6 @@ class Cat():
         if self.dead:
             self.thoughts()
             return
-
-        old_age = self.age
-        self.moons += 1
-        if self.moons == 1:
-            self.status = 'kitten'
-        self.in_camp = 1
         
         if old_age != self.age:
             # Things to do if the age changes
@@ -2742,7 +2742,7 @@ class Cat():
     @moons.setter
     def moons(self, value: int):
         self._moons = value
-
+        
         updated_age = False
         for key_age in self.age_moons.keys():
             if self._moons in range(self.age_moons[key_age][0], self.age_moons[key_age][1] + 1):
@@ -2750,10 +2750,10 @@ class Cat():
                 self.age = key_age
         try:
             if not updated_age and self.age is not None:
-                self.age = "elder"
+                self.age = "senior"
         except AttributeError:
             print("ERROR: cat has no age attribute! Cat ID: " + self.ID)
-            
+        
     @property
     def sprite(self):
         # Update the sprite

--- a/scripts/events_module/generate_events.py
+++ b/scripts/events_module/generate_events.py
@@ -269,7 +269,11 @@ class GenerateEvents:
             war_event = False
 
         for event in possible_events:
-
+            
+            # Normally, there is a chance to bypass skill and trait requirments. 
+            # the "skill_trait_required" tags turns this off. Lets grab this tag once, for simplicity. 
+            prevent_bypass = "skill_trait_required" in event.tags
+            
             if war_event and ("war" not in event.tags and "hostile" not in event.tags):
                 continue
             if not war and "war" in event.tags:
@@ -418,13 +422,13 @@ class GenerateEvents:
                     
                 # There is a small chance to bypass the skill or trait requirments.  
                 if event.other_cat_trait and event.other_cat_skill:
-                    if not (has_trait or has_skill) and int(random.random() * trait_skill_bypass):
+                    if not (has_trait or has_skill) and (prevent_bypass or int(random.random() * trait_skill_bypass)):
                         continue
                 elif event.other_cat_trait:
-                    if not has_trait and int(random.random() * trait_skill_bypass):
+                    if not has_trait and (prevent_bypass or int(random.random() * trait_skill_bypass)):
                         continue
                 elif event.other_cat_skill:
-                    if not has_skill and int(random.random() * trait_skill_bypass):
+                    if not has_skill and (prevent_bypass or int(random.random() * trait_skill_bypass)):
                         continue
                 
                 
@@ -483,13 +487,13 @@ class GenerateEvents:
             
             # There is a small chance to bypass the skill or trait requirments.  
             if event.cat_trait and event.cat_skill:
-                if not (has_trait or has_skill) and int(random.random() * trait_skill_bypass):
+                if not (has_trait or has_skill) and (prevent_bypass or int(random.random() * trait_skill_bypass)):
                     continue
             elif event.cat_trait:
-                if not has_trait and int(random.random() * trait_skill_bypass):
+                if not has_trait and (prevent_bypass or int(random.random() * trait_skill_bypass)):
                     continue
             elif event.cat_skill:
-                if not has_skill and int(random.random() * trait_skill_bypass):
+                if not has_skill and (prevent_bypass or int(random.random() * trait_skill_bypass)):
                     continue
             
             

--- a/scripts/screens/organizational_screens.py
+++ b/scripts/screens/organizational_screens.py
@@ -1017,6 +1017,13 @@ class StatsScreen(Screens):
         """
         TODO: DOCS
         """
+        
+        for x in Cat.all_cats_list:
+            if x.outside or x.dead:
+                continue
+            if x.status in ["kitten", "newborn"]:
+                x.gone()
+        
         self.set_disabled_menu_buttons(["stats"])
         self.show_menu_buttons()
         self.update_heading_text(f'{game.clan.name}Clan')

--- a/scripts/utility.py
+++ b/scripts/utility.py
@@ -1003,13 +1003,13 @@ def leader_ceremony_text_adjust(Cat,
 def ceremony_text_adjust(Cat,
                          text,
                          cat,
+                         old_name=None,
                          dead_mentor=None,
                          mentor=None,
                          previous_alive_mentor=None,
                          random_honor=None,
                          living_parents=(),
                          dead_parents=()):
-    prefix = str(cat.name.prefix)
     clanname = str(game.clan.name + "Clan")
 
     random_honor = random_honor
@@ -1029,8 +1029,10 @@ def ceremony_text_adjust(Cat,
         "l_n": (str(game.clan.leader.name), choice(game.clan.leader.pronouns)) if game.clan.leader else (
             "leader_name", None),
         "c_n": (clanname, None),
-        "(prefix)": (prefix, None),
     }
+    
+    if old_name:
+        cat_dict["(old_name)"] = (old_name, None)
 
     if random_honor:
         cat_dict["r_h"] = (random_honor, None)


### PR DESCRIPTION
- Add a minimum murder chance, to prevent auto-murder is dislike and jealousy are both very high. 
- Added the tag "skill_trait_required" to events, to prevent some events from happening when the cat doesn't have the skill required.  There are some events where it just doesn't make sense for a cat without a skill or trait to have an event. 
- Added a couple flavor-text events for DARK and GHOST skills. 
- Fixed lost cats being labeled as "adult" at 12 moons old only, before being properly given the "young adult" age. 
- Fixed returning kits sometimes not being given a warrior ceremony. 
- Fixed warrior ceremonies for returning lost cats with the "kitten" status being called "___"paw in warrior ceremonies. 
- Fixed really old cats being given "elder" as their age (I swear I already fixed that. How did you sneak back in?)