### PR TITLE
Bugfix: Infected Wounds

### DIFF
--- a/resources/dicts/conditions/pregnancy.json
+++ b/resources/dicts/conditions/pregnancy.json
@@ -11,7 +11,7 @@
 
   "major_severity": [
     " {PRONOUN/m_c/subject/CAP} {VERB/m_c/decide/decides} to move into the nursery in preparation for {PRONOUN/m_c/poss} soon-to-come kits.",
-    " {PRONOUN/m_c/subject/CAP} {VERB/m_c/don't/doesn't} believe {PRONOUN/m_c/subject} can successfully complete {PRONOUN/m_c/poss} duties while expecting kits and {VERB/m_c/prefer/prefers} to move into the nursery."
+    " {PRONOUN/m_c/subject/CAP} {VERB/m_c/don't/doesn't} believe {PRONOUN/m_c/subject} can efficiently perform {PRONOUN/m_c/poss} duties while expecting kits and {VERB/m_c/decide/decides} to move into the nursery."
   ],
   "minor_severity": [
     " {PRONOUN/m_c/subject/CAP} won't be moving into the nursery just yet.",

--- a/resources/dicts/patrols/plains/border/any.json
+++ b/resources/dicts/patrols/plains/border/any.json
@@ -26,7 +26,7 @@
         "fail_text": {
             "unscathed_common": "Whoops! It seems a fox was calling this home. The patrol backs out of the tunnels and thankfully the fox doesn't follow, just as surprised as they were.",
             "unscathed_stat": "s_c rushes into the tunnels with a gleeful meow! A new place to explore and discover! They're brought up short when the tunnel abruptly ends. It seems this tunnel leads to nothing but a dead end only a few fox-lengths from the entrance.",
-            "death": "It seems this hole is home to a cranky wolverine, a fact that the patrol learns very quickly when p_l, who was leading the group, cries out in pain. The cats back out of the tunnel quickly, but not quickly enough to save their Clanmate.",
+            "death": "It seems this hole is home to a cranky wolverine, a fact that the patrol learns very quickly when r_c cries out in pain. The cats back out of the tunnel quickly, but not quickly enough to save their Clanmate.",
             "injury": "The tunnels prove to be a currently in-use badger sett. The patrol quickly retreats, but not before r_c gains a nasty wound."
         },
         "win_skills": [

--- a/resources/dicts/patrols/plains/med/newleaf.json
+++ b/resources/dicts/patrols/plains/med/newleaf.json
@@ -613,7 +613,7 @@
         "exp": 10,
         "success_text": {
             "unscathed_common": "The many stems of goldenrod surround p_l as they work, snipping off stems and clumps of tiny yellow flowers to bring back to c_n's herb stores. The patrol chats as they work, exchanging gossip and news as the smell of cut stems wreathes around them",
-            "unscathed_rare": "It always amazes p_l how quickly the goldenrod bushes sprout back up after leaf-bare, and they collect more goldenrod than they were anticipating, loading up every cat until the patrol until everyone agrees the medicine cat den can't possibly fit more than this.",
+            "unscathed_rare": "It always amazes p_l how quickly the goldenrod bushes sprout back up after leaf-bare, and they collect more goldenrod than they were anticipating, loading up every cat until everyone agrees the medicine cat den can't possibly fit any more.",
             "stat_skill": "s_c has a good eye for these things, snipping off the best, lushest goldenrod to take back for the Clan's stores. They control what is harvested, while their team works to efficiently carry the herb back to camp, deferring to s_c's expertise."
         },
         "fail_text": {
@@ -957,7 +957,7 @@
         "chance_of_success": 30,
         "exp": 10,
         "success_text": {
-            "unscathed_common": "The soft, rose-like scent of the mallow bushes drifts around p_l and app1 as they work. They snip off clumps of large, fuzzy, three-nubbed leaves, and the occasional pink flower, to be taken back to camp. The patrol chats as they work, exchanging gossip and news as the smell of cut stems wreathes around them.",
+            "unscathed_common": "The soft, rose-like scent of the mallow bushes drifts around p_l and r_c as they work. They snip off clumps of large, fuzzy, three-nubbed leaves, and the occasional pink flower, to be taken back to camp. The patrol chats as they work, exchanging gossip and news as the smell of cut stems wreathes around them.",
             "unscathed_rare": "While the mallow shrubs are soft, both in scent and in touch, the plants are engaged in their own vigorous newleaf competition between each other, leaving p_l with tons to harvest. It's always a relief to bring in so much after a leaf-bare without any fresh mallow sources.",
             "stat_skill": "s_c has a good eye for these things, finding an excellent patch of mallow. They control what is harvested, while their team works to efficiently carry the herb back to camp, deferring to s_c's expertise."
         },

--- a/scripts/screens/cat_screens.py
+++ b/scripts/screens/cat_screens.py
@@ -1507,9 +1507,9 @@ class ProfileScreen(Screens):
         # gather a list of all the conditions and info needed.
         all_illness_injuries = [(i, self.get_condition_details(i)) for i in self.the_cat.permanent_condition if
                                 not (self.the_cat.permanent_condition[i]['born_with'] and self.the_cat.permanent_condition[i]["moons_until"] != -2)]
-        all_illness_injuries.extend([(i, self.get_condition_details(i)) for i in self.the_cat.injuries if
+        all_illness_injuries.extend([(i, self.get_condition_details(i)) for i in self.the_cat.injuries])
+        all_illness_injuries.extend([(i, self.get_condition_details(i)) for i in self.the_cat.illnesses if
                                     i not in ("an infected wound", "an festering wound")])
-        all_illness_injuries.extend([(i, self.get_condition_details(i)) for i in self.the_cat.illnesses])
         all_illness_injuries = chunks(all_illness_injuries, 4)
         
         if not all_illness_injuries:


### PR DESCRIPTION
- Don't show "an infected wound" on the conditions tab (forgot those were illnesses) 
- Fix some incorrect grammar and replacement text on patrols. 