### PR TITLE
Bugfixes: Fading Cats, Scars, Typos, 

### DIFF
--- a/resources/dicts/conditions/injuries.json
+++ b/resources/dicts/conditions/injuries.json
@@ -1355,6 +1355,7 @@
             "juniper"
         ]
     },
+
     "severe headache": {
         "duration": 1,
         "severity": "major",
@@ -1381,6 +1382,7 @@
             "juniper"
         ]
     },
+    
     "pregnant": {
         "duration": 2,
         "severity": "major",

--- a/resources/dicts/events/new_cat/general/general.json
+++ b/resources/dicts/events/new_cat/general/general.json
@@ -684,7 +684,7 @@
         "reputation": [
             "hostile"
         ],
-        "event_text": "A member of o_c defects in the war and chooses to join c_n. {PRONOUN/m_c/subject} {VERB/decide/decides} to keep {PRONOUN/m_c/poss} name.",
+        "event_text": "A member of o_c defects in the war and chooses to join c_n. {PRONOUN/n_c/subject/CAP} {VERB/n_c/decide/decides} to keep {PRONOUN/n_c/poss} name.",
         "other_clan": true,
         "backstory": [
             "otherclan2",
@@ -705,7 +705,7 @@
         "reputation": [
             "hostile"
         ],
-        "event_text": "A member of o_c defects from their birth Clan and chooses to join c_n. {PRONOUN/m_c/subject} {VERB/decide/decides} to keep {PRONOUN/m_c/poss} name.",
+        "event_text": "A member of o_c defects from their birth Clan and chooses to join c_n. {PRONOUN/n_c/subject/CAP} {VERB/n_c/decide/decides} to keep {PRONOUN/n_c/poss} name.",
         "other_clan": true,
         "backstory": [
             "otherclan2",
@@ -728,7 +728,7 @@
         "reputation": [
             "hostile"
         ],
-        "event_text": "n_c, the deputy of o_c, has defected to c_n in the war. {PRONOUN/m_c/subject} {VERB/decide/decides} to keep {PRONOUN/m_c/poss} name.",
+        "event_text": "n_c, the deputy of o_c, has defected to c_n in the war. {PRONOUN/n_c/subject/CAP} {VERB/n_c/decide/decides} to keep {PRONOUN/n_c/poss} name.",
         "other_clan": true,
         "backstory": [
             "otherclan1",
@@ -751,7 +751,7 @@
         "reputation": [
             "hostile"
         ],
-        "event_text": "n_c, the medicine cat of o_c, has defected to c_n in the war. {PRONOUN/m_c/subject} {VERB/decide/decides} to keep {PRONOUN/m_c/poss} name.",
+        "event_text": "n_c, the medicine cat of o_c, has defected to c_n in the war. {PRONOUN/n_c/subject/CAP} {VERB/n_c/decide/decides} to keep {PRONOUN/n_c/poss} name.",
         "other_clan": true,
         "backstory": [
             "medicine_cat",

--- a/resources/dicts/patrols/desert/hunting/hunting.json
+++ b/resources/dicts/patrols/desert/hunting/hunting.json
@@ -225,7 +225,9 @@
         "tags": [
             "hunting",
             "poison_clan",
-            "large_prey0"
+            "large_prey0",
+            "injury",
+            "poisoned"
         ],
         "intro_text": "r_c spots a rabbit up ahead but it seems to be acting strange. The patrol can see its tremors from a few fox-lengths away.",
         "success_text": {

--- a/resources/dicts/patrols/general/hunting.json
+++ b/resources/dicts/patrols/general/hunting.json
@@ -223,7 +223,9 @@
         "tags": [
             "hunting",
             "poison_clan",
-            "large_prey0"
+            "large_prey0",
+            "injury",
+            "poisoned"
         ],
         "intro_text": "r_c spots a rabbit up ahead but it seems to be acting strange. The patrol can see its tremors from a few fox-lengths away.",
         "success_text": {

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -402,7 +402,7 @@ class Cat():
         """
         self.injuries.clear()
         self.illnesses.clear()
-        # print('DEATH', self.name)
+        
         # Deal with leader death
         text = ""
         if self.status == 'leader':
@@ -421,7 +421,6 @@ class Cat():
         else:
             self.dead = True
             game.just_died.append(self.ID)
-            print(game.just_died)
             self.thought = 'Is surprised to find themselves walking the stars of Silverpelt'
 
         # Clear Relationships. 
@@ -570,7 +569,6 @@ class Cat():
 
             if text:
                 # adjust and append text to grief string list
-                # print(text)
                 text = ' '.join(text)
                 text = event_text_adjust(Cat, text, self, cat)
                 Cat.grief_strings[cat.ID] = (text, (self.ID, cat.ID))
@@ -947,8 +945,6 @@ class Cat():
         # sort relations by the strength of their relationship
         dead_relations.sort(
             key=lambda rel: rel.romantic_love + rel.platonic_like + rel.admiration + rel.comfortable + rel.trust, reverse=True)
-        #for rel in dead_relations:
-        #    print(self.fetch_cat(rel.cat_to).name)
 
         # if we have relations, then make sure we only take the top 8
         if dead_relations:

--- a/scripts/clan.py
+++ b/scripts/clan.py
@@ -645,15 +645,15 @@ class Clan():
 
         if ID in Cat.all_cats:
             Cat.all_cats.pop(ID)
-            if ID in self.clan_cats:
-                self.clan_cats.remove(ID)
-            
-            if ID in self.starclan_cats:
-                self.starclan_cats.remove(ID)
-            if ID in self.unknown_cats:
-                self.unknown_cats.remove(ID)
-            if ID in self.darkforest_cats:
-                self.darkforest_cats.remove(ID)
+        
+        if ID in self.clan_cats:
+            self.clan_cats.remove(ID)
+        if ID in self.starclan_cats:
+            self.starclan_cats.remove(ID)
+        if ID in self.unknown_cats:
+            self.unknown_cats.remove(ID)
+        if ID in self.darkforest_cats:
+            self.darkforest_cats.remove(ID)
 
     def __repr__(self):
         if self.name is not None:

--- a/scripts/clan.py
+++ b/scripts/clan.py
@@ -647,8 +647,13 @@ class Clan():
             Cat.all_cats.pop(ID)
             if ID in self.clan_cats:
                 self.clan_cats.remove(ID)
+            
             if ID in self.starclan_cats:
                 self.starclan_cats.remove(ID)
+            if ID in self.unknown_cats:
+                self.unknown_cats.remove(ID)
+            if ID in self.darkforest_cats:
+                self.darkforest_cats.remove(ID)
 
     def __repr__(self):
         if self.name is not None:

--- a/scripts/events_module/condition_events.py
+++ b/scripts/events_module/condition_events.py
@@ -373,8 +373,6 @@ class Condition_Events():
         # making a copy, so we can iterate through copy and modify the real dict at the same time
         illnesses = deepcopy(cat.illnesses)
         for illness in illnesses:
-            # print('SAVE FILE', cat.name, cat.illnesses)
-            # print('COPY', cat.name, illnesses)
             if illness in game.switches['skip_conditions']:
                 continue
 
@@ -465,8 +463,6 @@ class Condition_Events():
             if injury in game.switches['skip_conditions']:
                 continue
 
-            # print('SAVE FILE', cat.name, cat.injuries)
-            # print('COPY', cat.name, injuries)
             self.use_herbs(cat, injury, injuries, INJURIES)
 
             skipped = cat.moon_skip_injury(injury)
@@ -783,7 +779,6 @@ class Condition_Events():
                                 old_risk["chance"] = 0
                             else:
                                 old_risk['chance'] = risk["chance"] + 10
-                            #print('RISK UPDATED', risk['chance'], old_risk['chance'])
 
                 med_cat = None
                 removed_condition = False

--- a/scripts/events_module/death_events.py
+++ b/scripts/events_module/death_events.py
@@ -39,7 +39,7 @@ class Death_Events():
             other_clan_name = f'{other_clan.name}Clan'
 
         possible_short_events = self.generate_events.possible_short_events(cat.status, cat.age, "death")
-        #print('death event', cat.ID)
+
         final_events = self.generate_events.filter_possible_short_events(possible_short_events, cat, other_cat, war,
                                                                          enemy_clan,
                                                                          other_clan, alive_kits, murder=murder)
@@ -53,7 +53,6 @@ class Death_Events():
             print('WARNING: no death events found for', cat.name)
             return
         death_text = event_text_adjust(Cat, death_cause.event_text, cat, other_cat, other_clan_name)
-        #print(death_text)
         additional_event_text = ""
 
         # assign default history

--- a/scripts/events_module/disaster_events.py
+++ b/scripts/events_module/disaster_events.py
@@ -42,7 +42,6 @@ class DisasterEvents():
         final_events = []
 
         for event in possible_events:
-            #print(event.event)
             if event.priority == 'secondary':
                 print('priority')
                 continue
@@ -120,7 +119,6 @@ class DisasterEvents():
                         picked_disasters.append(potential_disaster)
 
                 if picked_disasters:
-                    #print(picked_disasters)
                     # choose disaster and display trigger event
                     secondary_disaster = random.choice(picked_disasters)
                     print("chosen secondary", secondary_disaster)

--- a/scripts/events_module/generate_events.py
+++ b/scripts/events_module/generate_events.py
@@ -173,7 +173,6 @@ class GenerateEvents:
                         collateral_damage=event["collateral_damage"]
                     )
                     break
-                #print(event)
                 return event
 
     def possible_short_events(self, cat_type=None, age=None, event_type=None):
@@ -548,7 +547,6 @@ class GenerateEvents:
                     final_events = major
                 else:
                     final_events = severe
-                #print(cat.status, severity_chosen[0])
 
         return final_events
 

--- a/scripts/events_module/scar_events.py
+++ b/scripts/events_module/scar_events.py
@@ -31,7 +31,8 @@ class Scar_Events():
     ]
     claw_scars = [
         "ONE", "TWO", "SNOUT", "TAILSCAR", "CHEEK",
-        "SIDE", "THROAT", "TAILBASE", "BELLY", "FACE"
+        "SIDE", "THROAT", "TAILBASE", "BELLY", "FACE",
+        "BRIDGE"
     ]
     leg_scars = [
         "NOPAW", "TOETRAP", "MANLEG"
@@ -55,21 +56,35 @@ class Scar_Events():
     quill_scars = [
         "QUILLCHUNK", "QUILLSCRATCH"
     ]
+    head_scars = [
+        "SNOUT", "CHEEK", "BRIDGE", "BEAKCHEEK"
+    ]
+    bone_scars = [
+        "MANLEG",  "TOETRAP"
+    ]
+    back_scars = [
+        "TWO", "TAILBASE"
+    ]
     
     scar_allowed = {
         "bite-wound": canid_scars,
         "cat-bite": bite_scars,
-        "severe_burn": burn_scars,
+        "severe burn": burn_scars,
         "rat bite": rat_scars,
         "snake bite": snake_scars,
         "mangled tail": tail_scars,
         "mangled leg": leg_scars,
         "torn ear": ear_scars,
         "frostbite": frostbite_scars,
+        "torn pelt": claw_scars + beak_scars,
         "damaged eyes": eye_scars,
         "quilled by porcupine": quill_scars,
         "claw-wound": claw_scars,
-        "beak bite": beak_scars
+        "beak bite": beak_scars,
+        "broken jaw": head_scars,
+        "broken back": back_scars,
+        "broken bone": bone_scars,
+        "head damage": head_scars
     }
     
 
@@ -88,13 +103,14 @@ class Scar_Events():
             return None, None
         
         moons_with = game.clan.age - cat.injuries[injury_name]["moon_start"]
-        chance = max(13 - moons_with, 1)
+        chance = max(7 - moons_with, 1)
         
         amount_per_med = get_amount_cat_for_one_medic(game.clan)
         if medical_cats_condition_fulfilled(game.cat_class.all_cats.values(), amount_per_med):
-            chance += 3
+            chance += 2
+        
         if len(cat.pelt.scars) < 4 and not int(random.random() * chance):
-
+            
             # move potential scar text into displayed scar text
             
 

--- a/scripts/screens/cat_screens.py
+++ b/scripts/screens/cat_screens.py
@@ -1509,7 +1509,7 @@ class ProfileScreen(Screens):
                                 not (self.the_cat.permanent_condition[i]['born_with'] and self.the_cat.permanent_condition[i]["moons_until"] != -2)]
         all_illness_injuries.extend([(i, self.get_condition_details(i)) for i in self.the_cat.injuries])
         all_illness_injuries.extend([(i, self.get_condition_details(i)) for i in self.the_cat.illnesses if
-                                    i not in ("an infected wound", "an festering wound")])
+                                    i not in ("an infected wound", "a festering wound")])
         all_illness_injuries = chunks(all_illness_injuries, 4)
         
         if not all_illness_injuries:

--- a/scripts/screens/catlist_screens.py
+++ b/scripts/screens/catlist_screens.py
@@ -510,7 +510,6 @@ class StarClanScreen(Screens):
             elif event.key == pygame.K_RIGHT:
                 self.change_screen('patrol screen')
 
-
     def exit_screen(self):
         self.hide_menu_buttons()
         self.starclan_button.kill()

--- a/scripts/screens/world_screens.py
+++ b/scripts/screens/world_screens.py
@@ -458,7 +458,6 @@ class UnknownResScreen(Screens):
             elif event.key == pygame.K_RIGHT:
                 self.change_screen('patrol screen')
 
-
     def exit_screen(self):
         self.hide_menu_buttons()
         self.starclan_button.kill()
@@ -488,7 +487,7 @@ class UnknownResScreen(Screens):
     def get_dead_cats(self):
         self.dead_cats = []
         for the_cat in Cat.all_cats_list:
-            if the_cat.ID in game.clan.unknown_cats:
+            if the_cat.ID in game.clan.unknown_cats and not the_cat.faded:
                 self.dead_cats.append(the_cat)
 
     def screen_switches(self):

--- a/scripts/utility.py
+++ b/scripts/utility.py
@@ -370,8 +370,7 @@ def create_new_cat(Cat,
                     if age > leeway:
                         continue
                     possible_conditions.append(condition)
-                # print(possible_conditions, str(new_cat.name), new_cat.moons)
-
+                    
                 if possible_conditions:
                     chosen_condition = choice(possible_conditions)
                     born_with = False


### PR DESCRIPTION
- Fixed mistagged patrol
- Make sure faded cats are removed from unknown and DF lists. 
- Make sure faded cats won't show in the unknown cats list. 
- Increased scar chance in expanded mode, and added a few more conditions that can cause scars. 
- Don't show "a festering wound"
- Some old print clean-up