### PR TITLE
Sort dead cats by absolute age when filtered by age

### DIFF
--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -2697,7 +2697,10 @@ class Cat():
         """Returns the dead_for moons rather than the age for dead cats, so dead cats are sorted by how long
         they have been dead, rather than age at death"""
         if cat.dead:
-            return cat.dead_for
+            if game.sort_type == "rank":
+                return cat.dead_for
+            else:
+                return cat.dead_for + cat.moons
         else:
             return cat.moons
         

--- a/scripts/screens/catlist_screens.py
+++ b/scripts/screens/catlist_screens.py
@@ -544,6 +544,7 @@ class StarClanScreen(Screens):
                 self.dead_cats.append(the_cat)
 
     def screen_switches(self):
+        Cat.sort_cats()
         # Determine the dead, non-exiled cats.
         self.get_dead_cats()
 

--- a/scripts/screens/relation_screens.py
+++ b/scripts/screens/relation_screens.py
@@ -2327,7 +2327,7 @@ class RelationshipScreen(Screens):
         self.inspect_cat = None
 
         # Keep a list of all the relations
-        self.all_relations = list(self.the_cat.relationships.values()).copy()
+        self.all_relations = sorted(self.the_cat.relationships.values(), key=lambda x: sum(map(abs, [x.romantic_love, x.platonic_like, x.dislike, x.admiration, x.comfortable, x.jealousy, x.trust])), reverse=True)
 
         self.focus_cat_elements["header"] = pygame_gui.elements.UITextBox(str(self.the_cat.name) + " Relationships",
                                                                           scale(pygame.Rect((150, 150), (800, 100))),


### PR DESCRIPTION
- The game will now sort dead cats by their moons+dead_moons

- Kept the original functionality of get_adjusted_age for the rank (default) view so players can still see dead cats in the order they died