### PR TITLE
Fixed issue with layering sprites over UI elements

### DIFF
--- a/scripts/screens/catlist_screens.py
+++ b/scripts/screens/catlist_screens.py
@@ -130,7 +130,7 @@ class ClanScreen(Screens):
                         UISpriteButton(scale(pygame.Rect(tuple(Cat.all_cats[x].placement), (100, 100))),
                                        Cat.all_cats[x].sprite,
                                        cat_id=x,
-                                       starting_height=i)
+                                       starting_height=1)
                     )
                 except:
                     print(f"ERROR: placing {Cat.all_cats[x].name}\'s sprite on Clan page")


### PR DESCRIPTION
- Changed the starting_height of the cats' sprite buttons to 1 instead of i

This fixes an inconsistent issue with clicking on "main menu" or "save" from the camp screen. The cats' sprite buttons were being layered incrementally, meaning that if a cat was underneath the UI buttons, the player can't properly select them.