### PR TITLE
Fix for patrol scar history

### DIFF
--- a/scripts/cat/history.py
+++ b/scripts/cat/history.py
@@ -326,18 +326,28 @@ class History:
         """
         History.check_load(cat)
 
-        # Use a default is none is provided.
-        # Will probally sound weird, but it's better than nothing
-        if not death_text:
-            death_text = f"m_c died from an injury or illness ({condition})."
-        if not scar_text:
-            scar_text = f"m_c was scarred from an injury or illness ({condition})."        
-        
-        cat.history.possible_history[condition] = {
-            "death_text": death_text,
-            "scar_text": scar_text,
-            "other_cat": other_cat.ID if other_cat is not None else None
-        }
+        # If the condition already exists, we don't want to overwrite it
+        if condition in cat.history.possible_history:
+            if death_text is not None:
+                cat.history.possible_history[condition]["death_text"] = death_text
+            if scar_text is not None:
+                cat.history.possible_history[condition]["scar_text"] = scar_text
+            if other_cat is not None:
+                cat.history.possible_history[condition]["other_cat"] = other_cat.ID
+        else:
+            # Use a default is none is provided.
+            # Will probably sound weird, but it's better than nothing
+            if not death_text:
+                death_text = f"m_c died from an injury or illness ({condition})."
+            if not scar_text:
+                scar_text = f"m_c was scarred from an injury or illness ({condition})."
+            
+            cat.history.possible_history[condition] = {
+                "death_text": death_text,
+                "scar_text": scar_text,
+                "other_cat": other_cat.ID if other_cat is not None else None
+            }
+
 
     @staticmethod
     def remove_possible_history(cat, condition):

--- a/scripts/patrol.py
+++ b/scripts/patrol.py
@@ -1944,7 +1944,7 @@ class Patrol():
             adjust_text = adjust_text.replace("r_c", str(cat.name))
             adjust_text = adjust_text.replace("o_c_n", str(self.other_clan.name))
             if possible:
-                History.add_possible_history(cat, condition, scar_text=adjust_text)
+                History.add_possible_history(cat, condition=condition, scar_text=adjust_text)
             else:
                 History.add_scar(cat, adjust_text)
         if death:
@@ -1954,7 +1954,7 @@ class Patrol():
                     adjust_text = adjust_text.replace("r_c", str(cat.name))
                     adjust_text = adjust_text.replace("o_c_n", str(self.other_clan.name))
                     if possible:
-                        History.add_possible_history(cat,condition=condition, death_text=adjust_text)
+                        History.add_possible_history(cat, condition=condition, death_text=adjust_text)
                     else:
                         History.add_death(cat, adjust_text)
             else:
@@ -1963,7 +1963,7 @@ class Patrol():
                     adjust_text = adjust_text.replace("r_c", str(cat.name))
                     adjust_text = adjust_text.replace("o_c_n", str(self.other_clan.name))
                     if possible:
-                        History.add_possible_history(cat,condition=condition, death_text=adjust_text)
+                        History.add_possible_history(cat, condition=condition, death_text=adjust_text)
                     else:
                         History.add_death(cat, adjust_text)
 


### PR DESCRIPTION
Added checks to add_possible_history to see if scar/death text already exists for a condition before overwriting it.

Also fixed an issue in one line of patrol.py related to passing on the condition to add_possible_history