### PR TITLE
Little fixes

### DIFF
--- a/resources/dicts/conditions/condition_got_strings/gain_permanent_condition_strings.json
+++ b/resources/dicts/conditions/condition_got_strings/gain_permanent_condition_strings.json
@@ -167,7 +167,7 @@
             "Eventually m_c just accepts the truth that has made itself apparent, {PRONOUN/m_c/poss} vision will never come back. This is life now, this fog of shadows and shapes."
         ],
         "one bad eye": [
-            "r_c breaks the new gently, that m_c is never going to see out of that eye again. This doesn't have to hinder {PRONOUN/m_c/subject}, though! {PRONOUN/m_c/subject/CAP} still {VERB/m_c/have/has} one good eye and {PRONOUN/m_c/subject} {VERB/m_c/plan/plans} to make full use of it.",
+            "r_c breaks the new gently, that m_c is never going to see out of that eye again. This doesn't have to hinder {PRONOUN/m_c/object}, though! {PRONOUN/m_c/subject/CAP} still {VERB/m_c/have/has} one good eye and {PRONOUN/m_c/subject} {VERB/m_c/plan/plans} to make full use of it.",
             "m_c growls when r_c tells {PRONOUN/m_c/object} that the lack of vision in {PRONOUN/m_c/poss} eye is permanent. It feels unfair, to have half of {PRONOUN/m_c/poss} vision stolen away.",
             "m_c won't let this hold {PRONOUN/m_c/object} back, {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} determined to adapt to {PRONOUN/m_c/poss} newly limited eyesight and continue living as normal."
         ],

--- a/resources/dicts/conditions/condition_got_strings/gain_permanent_condition_strings.json
+++ b/resources/dicts/conditions/condition_got_strings/gain_permanent_condition_strings.json
@@ -11,7 +11,7 @@
     },
     "broken bone": {
         "weak leg": [
-            "m_c has been impatient, and r_c has noticed {PRONOUN/m_c/subject} {VERB/m_c/have/has}n't been the most diligent with {PRONOUN/m_c/poss} leg strengthening exercises. It's unfortunately having consequences, as {PRONOUN/m_c/poss} healing broken bone has given {PRONOUN/m_c/subject} a weaker leg.",
+            "m_c has been impatient, and r_c has noticed {PRONOUN/m_c/subject} {VERB/m_c/have/has}n't been the most diligent with {PRONOUN/m_c/poss} leg strengthening exercises. It's unfortunately having consequences, as {PRONOUN/m_c/poss} healing broken bone has given {PRONOUN/m_c/object} a weaker leg.",
             "r_c examines m_c's leg and reports that everything seems to be healed, the weakness that m_c has complained about is likely a permanent consequence of the injury.",
             "m_c pads along on all four legs for the first time in a long time, wincing. {PRONOUN/m_c/poss/CAP} healed broken bone has definitely left the leg weaker, but it's manageable as far as {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} concerned.",
             "m_c can't run as long or as quickly as before, but {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} glad that {PRONOUN/m_c/poss} leg healed at all."

--- a/resources/dicts/events/ceremonies/ceremony-master.json
+++ b/resources/dicts/events/ceremonies/ceremony-master.json
@@ -1354,7 +1354,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "Whisperings on the wind tickle at (previous_mentor)'s ears as {PRONOUN/(previous_mentor)/subject} {VERB/(previous_mentor)/gaze/gazes} up to the stars, an echo rolling smoothly off {PRONOUN/(previous_mentor)/poss} tongue. StarClan blesses m_c and welcomes {PRONOUN/(previous_mentor)/object}!"
+    "Whisperings on the wind tickle at (previous_mentor)'s ears as {PRONOUN/(previous_mentor)/subject} {VERB/(previous_mentor)/gaze/gazes} up to the stars, an echo rolling smoothly off {PRONOUN/(previous_mentor)/poss} tongue. StarClan blesses m_c and welcomes {PRONOUN/m_c/object}!"
   ],
   "med_4": [
     [

--- a/resources/dicts/events/death/general/elder.json
+++ b/resources/dicts/events/death/general/elder.json
@@ -172,7 +172,7 @@
             "Leaf-fall",
             "Leaf-bare"
         ],
-        "death_text": "m_c faded more and more as the days went by, until one day, {PRONOUN/m_c/poss} {VERB/m_c/were/was} found dead in {PRONOUN/m_c/poss} nest.",
+        "death_text": "m_c faded more and more as the days went by, until one day, {PRONOUN/m_c/subject} {VERB/m_c/were/was} found dead in {PRONOUN/m_c/poss} nest.",
         "history_text": {
             "reg_death": "m_c died of old age."
         },

--- a/resources/dicts/patrols/beach/border/any.json
+++ b/resources/dicts/patrols/beach/border/any.json
@@ -325,7 +325,7 @@
             "unscathed_common": "The pawprints lead to a trespassing rogue. r_c quickly hides {PRONOUN/r_c/self} in the grass on the sand dunes and sets up an ambush that sends the rogue fleeing off c_n territory.",
             "unscathed_rare": "r_c soon realizes that the pawprints smell of c_n. Someone must have wandered through this section of the border recently, but it's not a threat.",
             "stat_skill": "The pawprints lead to a trespassing rogue. s_c throws {PRONOUN/s_c/self} at the rogue, hissing furiously, and drives {PRONOUN/r_c/object} off c_n territory.",
-            "stat_trait": "Boldy, s_c follows the pawprints to a trespassing rogue and confronts them. Fur puffed up and scowling, {PRONOUN/s_c/subject} {VERB/s_c/demand/demands} the rogue leaves c_n territory. Intimidated by {PRONOUN/s_c/poss} confidence, the rogue gives in and leaves without a fight."
+            "stat_trait": "Boldly, s_c follows the pawprints to a trespassing rogue and confronts them. Fur puffed up and scowling, {PRONOUN/s_c/subject} {VERB/s_c/demand/demands} the rogue leaves c_n territory. Intimidated by {PRONOUN/s_c/poss} confidence, the rogue gives in and leaves without a fight."
         },
         "fail_text": {
             "unscathed_common": "It turns out they were r_c's own pawprints... r_c huffs with embarrassment, suddenly grateful {PRONOUN/r_c/subject}{VERB/r_c/'re/'s} alone.",
@@ -390,7 +390,7 @@
             "unscathed_common": "The pawprints lead to a trespassing rogue. r_c quickly hides {PRONOUN/r_c/self} in the grass on the sand dunes and sets up an ambush that sends the rogue fleeing off c_n territory.",
             "unscathed_rare": "r_c soon realizes that the pawprints smell of c_n. Someone must have wandered through this section of the border recently, but it's not a threat.",
             "stat_skill": "The pawprints lead to a trespassing rogue. s_c sets up a trap by using the tides to cut off the rogue's escape path. It makes the startled intruder cower to realize they've been caught and trapped by c_n, and they're escorted to the border with the lesson firmly learnt.",
-            "stat_trait": "Boldy, s_c follows the pawprints to a trespassing rogue and confronts them. Fur puffed up and scowling, {PRONOUN/s_c/subject} {VERB/s_c/demand/demands} the rogue leaves c_n territory. Intimidated by {PRONOUN/s_c/poss} confidence, the rogue gives in and leaves without a fight."
+            "stat_trait": "Boldly, s_c follows the pawprints to a trespassing rogue and confronts them. Fur puffed up and scowling, {PRONOUN/s_c/subject} {VERB/s_c/demand/demands} the rogue leaves c_n territory. Intimidated by {PRONOUN/s_c/poss} confidence, the rogue gives in and leaves without a fight."
         },
         "fail_text": {
             "unscathed_common": "It turns out they were r_c's own pawprints... r_c huffs with embarrassment, suddenly grateful {PRONOUN/r_c/subject}{VERB/r_c/'re/'s} alone.",
@@ -456,7 +456,7 @@
         },
         "fail_text": {
             "unscathed_common": "It turns out they were app1's own pawprints... app1 huffs with embarrassment, suddenly grateful {PRONOUN/app1/subject}{VERB/app1/'re/'s} alone. {PRONOUN/app1/subject/CAP} {VERB/app1/don't/doesn't} want to look dumb in front of other cats.",
-            "unscathed_stat": "Boldy, s_c follows the pawprints to a trespassing rogue and confronts them. Fur puffed up and scowling, {PRONOUN/app1/subject} {VERB/app1/demand/demands} the rogue leaves c_n territory. The rogue is not impressed by this teenager, and ignores {PRONOUN/app1/object} completely.",
+            "unscathed_stat": "Boldly, s_c follows the pawprints to a trespassing rogue and confronts them. Fur puffed up and scowling, {PRONOUN/app1/subject} {VERB/app1/demand/demands} the rogue leaves c_n territory. The rogue is not impressed by this teenager, and ignores {PRONOUN/app1/object} completely.",
             "death": "Nose to the ground following the trail, app1 doesn't see the blow that kills {PRONOUN/app1/object}.",
             "injury": "Nose to the ground following the trail, app1 doesn't see the blow coming. {PRONOUN/app1/subject/CAP} {VERB/app1/haul/hauls} {PRONOUN/app1/self} to {PRONOUN/app1/poss} feet, squealing with pain, and run for home."
         },
@@ -509,7 +509,7 @@
             "unscathed_common": "The pawprints lead to a trespassing rogue. The patrol quickly hides themselves in the grass on the sand dunes and sets up an ambush, sending the rogue fleeing off c_n territory.",
             "unscathed_rare": "r_c soon realizes that the pawprints smell of c_n. Someone must have wandered through this section of the border recently, but it's not a threat.",
             "stat_skill": "The pawprints lead to a trespassing rogue. s_c throws {PRONOUN/s_c/self} at the rogue, hissing furiously, and together with r_c drives them off c_n territory.",
-            "stat_trait": "Boldy, s_c follows the pawprints to a trespassing rogue and confronts them. Fur puffed up and scowling, s_c and r_c demand the rogue leaves c_n territory. Intimidated by {PRONOUN/s_c/poss} confidence, the rogue gives in and leaves without a fight."
+            "stat_trait": "Boldly, s_c follows the pawprints to a trespassing rogue and confronts them. Fur puffed up and scowling, s_c and r_c demand the rogue leaves c_n territory. Intimidated by {PRONOUN/s_c/poss} confidence, the rogue gives in and leaves without a fight."
         },
         "fail_text": {
             "unscathed_common": "It turns out they were r_c's own pawprints... r_c huffs with embarrassment, suddenly grateful that {PRONOUN/r_c/poss} patrol is so small. Less eyes watching that embarrassing moment.",
@@ -569,7 +569,7 @@
             "unscathed_common": "The pawprints lead to a trespassing rogue. The patrol quickly hides themselves in the grass on the sand dunes and sets up an ambush, sending the rogue fleeing off c_n territory.",
             "unscathed_rare": "r_c soon realizes that the pawprints smell of c_n. Someone must have wandered through this section of the border recently, but it's not a threat.",
             "stat_skill": "The pawprints lead to a trespassing rogue. s_c sets up a trap by using the tides to cut off the rogue's escape path. It makes the startled intruder cower to realize they've been caught and trapped by c_n, and they're escorted to the border with the lesson firmly learnt.",
-            "stat_trait": "Boldy, s_c follows the pawprints to a trespassing rogue and confronts them. Fur puffed up and scowling, s_c and r_c demand the rogue leaves c_n territory. Intimidated by their confidence, the rogue gives in and leaves without a fight."
+            "stat_trait": "Boldly, s_c follows the pawprints to a trespassing rogue and confronts them. Fur puffed up and scowling, s_c and r_c demand the rogue leaves c_n territory. Intimidated by their confidence, the rogue gives in and leaves without a fight."
         },
         "fail_text": {
             "unscathed_common": "It turns out they were r_c's own pawprints... r_c huffs with embarrassment, suddenly grateful {PRONOUN/r_c/poss} patrol is so small. Less eyes watching that embarrassing moment.",
@@ -631,7 +631,7 @@
         },
         "fail_text": {
             "unscathed_common": "It turns out they were app1's own pawprints... app1 huffs with embarrassment, suddenly grateful that {PRONOUN/app1/poss} patrol is so small. Fewer eyes watching that embarrassing moment. {PRONOUN/app1/subject/CAP} {VERB/app1/don't/doesn't} want to look dumb in front of other cats.",
-            "unscathed_stat": "Boldy, s_c follows the pawprints to a trespassing rogue and confronts them. Fur puffed up and scowling, {PRONOUN/app1/subject} {VERB/app1/demand/demands} the rogue leaves c_n territory. The rogue is not impressed by the teenager, but reluctantly leaves c_n territory.",
+            "unscathed_stat": "Boldly, s_c follows the pawprints to a trespassing rogue and confronts them. Fur puffed up and scowling, {PRONOUN/app1/subject} {VERB/app1/demand/demands} the rogue leaves c_n territory. The rogue is not impressed by the teenager, but reluctantly leaves c_n territory.",
             "injury": "Nose to the ground following the trail, app1 doesn't see the blow coming. {PRONOUN/app1/subject/CAP} {VERB/app1/haul/hauls} {PRONOUN/app1/self} to {PRONOUN/app1/poss} feet, squealing with pain, and run for home."
         },
         "fail_trait": [
@@ -678,7 +678,7 @@
             "unscathed_common": "The pawprints lead to a trespassing rogue. The patrol quickly hides themselves in the grass on the sand dunes and sets up an ambush, sending the rogue fleeing off c_n territory.",
             "unscathed_rare": "r_c soon realizes that the pawprints smell of c_n. Someone must have wandered through this section of the border recently, but it's not a threat.",
             "stat_skill": "The pawprints lead to a trespassing rogue. s_c throws themselves at the rogue, hissing furiously, and together with r_c drives them off c_n territory.",
-            "stat_trait": "Boldy, s_c follows the pawprints to a trespassing rogue and confronts them. Fur puffed up and scowling, the patrol demands the rogue leave c_n territory. Intimidated by s_c's confidence and the number of cats, the rogue gives in and leaves without a fight."
+            "stat_trait": "Boldly, s_c follows the pawprints to a trespassing rogue and confronts them. Fur puffed up and scowling, the patrol demands the rogue leave c_n territory. Intimidated by s_c's confidence and the number of cats, the rogue gives in and leaves without a fight."
         },
         "fail_text": {
             "unscathed_common": "It turns out they were r_c's own pawprints... r_c huffs with embarrassment, and can't meet the eyes of the rest of the patrol.",
@@ -733,7 +733,7 @@
             "unscathed_common": "The pawprints lead to a trespassing rogue. The patrol quickly hides themselves in the grass on the sand dunes and sets up an ambush, sending the rogue fleeing off c_n territory.",
             "unscathed_rare": "r_c soon realizes that the pawprints smell of c_n. Someone must have wandered through this section of the border recently, but it's not a threat.",
             "stat_skill": "The pawprints lead to a trespassing rogue. s_c sets up a trap by using the tides to cut off the rogue's escape path. It makes the startled intruder cower to realize they've been caught and trapped by c_n, and they're escorted to the border with the lesson firmly learnt.",
-            "stat_trait": "Boldy, s_c follows the pawprints to a trespassing rogue and confronts them. Fur puffed up and scowling, the patrol demands the rogue leave c_n territory. Intimidated by their confidence and the number of cats, the rogue gives in and leaves without a fight."
+            "stat_trait": "Boldly, s_c follows the pawprints to a trespassing rogue and confronts them. Fur puffed up and scowling, the patrol demands the rogue leave c_n territory. Intimidated by their confidence and the number of cats, the rogue gives in and leaves without a fight."
         },
         "fail_text": {
             "unscathed_common": "It turns out they were r_c's own pawprints... r_c huffs with embarrassment, and can't meet the eyes of the rest of the patrol.",
@@ -791,7 +791,7 @@
         },
         "fail_text": {
             "unscathed_common": "It turns out they were app1's own pawprints... app1 huffs with embarrassment, and can't meet the eyes of the rest of the patrol. {PRONOUN/app1/subject/CAP} {VERB/app1/don't/doesn't} want to look dumb in front of other cats.",
-            "unscathed_stat": "Boldy, s_c follows the pawprints to a trespassing rogue and confronts them. Fur puffed up and scowling, {PRONOUN/s_c/subject} {VERB/s_c/demand/demands} the rogue leaves c_n territory. The rogue is not impressed by the teenager, but with the full patrol backing {PRONOUN/s_c/object} up, leaves c_n territory."
+            "unscathed_stat": "Boldly, s_c follows the pawprints to a trespassing rogue and confronts them. Fur puffed up and scowling, {PRONOUN/s_c/subject} {VERB/s_c/demand/demands} the rogue leaves c_n territory. The rogue is not impressed by the teenager, but with the full patrol backing {PRONOUN/s_c/object} up, leaves c_n territory."
         },
         "fail_trait": [
             "ambitious",

--- a/resources/dicts/patrols/forest/border/any.json
+++ b/resources/dicts/patrols/forest/border/any.json
@@ -351,7 +351,7 @@
             "unscathed_common": "The pawprints lead to a trespassing rogue. r_c quickly hides themselves behind a bush and sets up an ambush that sends the rogue fleeing off c_n territory.",
             "unscathed_rare": "r_c soon realizes that the pawprints smell of c_n. Someone must have wandered through this section of the border recently, but it's not a threat.",
             "stat_skill": "The pawprints lead to a trespassing rogue. s_c throws themselves at the rogue, hissing furiously, and drives them off c_n territory.",
-            "stat_trait": "Boldy, s_c follows the pawprints to a trespassing rogue, and confronts them. Fur puffed up and scowling, they demand the rogue leaves c_n territory. Intimidated by their confidence, the rogue gives in and leaves without a fight."
+            "stat_trait": "Boldly, s_c follows the pawprints to a trespassing rogue, and confronts them. Fur puffed up and scowling, they demand the rogue leaves c_n territory. Intimidated by their confidence, the rogue gives in and leaves without a fight."
         },
         "fail_text": {
             "unscathed_common": "It turns out they were r_c's own pawprints... r_c huffs with embarrassment, suddenly grateful they're alone.",
@@ -413,7 +413,7 @@
             "unscathed_common": "The pawprints lead to a trespassing rogue. r_c quickly hides themselves behind a bush and sets up an ambush that sends the rogue fleeing off c_n territory.",
             "unscathed_rare": "r_c soon realizes that the pawprints smell of c_n. Someone must have wandered through this section of the border recently, but it's not a threat.",
             "stat_skill": "The pawprints lead to a trespassing rogue. s_c sets up a trap, climbing into the trees and breaking a branch onto the rogue's head that sends the startled intruder yowling as they flee c_n territory.",
-            "stat_trait": "Boldy, s_c follows the pawprints to a trespassing rogue, and confronts them. Fur puffed up and scowling, they demand the rogue leaves c_n territory. Intimidated by their confidence, the rogue gives in and leaves without a fight."
+            "stat_trait": "Boldly, s_c follows the pawprints to a trespassing rogue, and confronts them. Fur puffed up and scowling, they demand the rogue leaves c_n territory. Intimidated by their confidence, the rogue gives in and leaves without a fight."
         },
         "fail_text": {
             "unscathed_common": "It turns out they were r_c's own pawprints... r_c huffs with embarrassment, suddenly grateful they're alone.",
@@ -479,7 +479,7 @@
         },
         "fail_text": {
             "unscathed_common": "It turns out they were app1's own pawprints... app1 huffs with embarrassment, suddenly grateful they're alone. They don't want to look dumb in front of other cats.",
-            "unscathed_stat": "Boldy, s_c follows the pawprints to a trespassing rogue, and confronts them. Fur puffed up and scowling, they demand the rogue leaves c_n territory. The rogue is not impressed by this teenager, and ignores them completely.",
+            "unscathed_stat": "Boldly, s_c follows the pawprints to a trespassing rogue, and confronts them. Fur puffed up and scowling, they demand the rogue leaves c_n territory. The rogue is not impressed by this teenager, and ignores them completely.",
             "death": "Nose to the ground following the trail, app1 doesn't see the blow that kills them.",
             "injury": "Nose to the ground following the trail, app1 doesn't see the blow coming. They haul themselves to their feet, squealing with pain, and run for home."
         },
@@ -532,7 +532,7 @@
             "unscathed_common": "The pawprints lead to a trespassing rogue. The patrol quickly hides themselves behind a bush and sets up an ambush that sends the rogue fleeing off c_n territory.",
             "unscathed_rare": "r_c soon realizes that the pawprints smell of c_n. Someone must have wandered through this section of the border recently, but it's not a threat.",
             "stat_skill": "The pawprints lead to a trespassing rogue. s_c throws themselves at the rogue, hissing furiously, and together with r_c drives them off c_n territory.",
-            "stat_trait": "Boldy, s_c follows the pawprints to a trespassing rogue, and confronts them. Fur puffed up and scowling, s_c and r_c demand the rogue leaves c_n territory. Intimidated by their confidence, the rogue gives in and leaves without a fight."
+            "stat_trait": "Boldly, s_c follows the pawprints to a trespassing rogue, and confronts them. Fur puffed up and scowling, s_c and r_c demand the rogue leaves c_n territory. Intimidated by their confidence, the rogue gives in and leaves without a fight."
         },
         "fail_text": {
             "unscathed_common": "It turns out they were r_c's own pawprints... r_c huffs with embarrassment, suddenly grateful that their patrol is so small. Less eyes watching that embarrassing moment.",
@@ -592,7 +592,7 @@
             "unscathed_common": "The pawprints lead to a trespassing rogue. The patrol quickly hides themselves behind a bush and sets up an ambush that sends the rogue fleeing off c_n territory.",
             "unscathed_rare": "r_c soon realizes that the pawprints smell of c_n. Someone must have wandered through this section of the border recently, but it's not a threat.",
             "stat_skill": "The pawprints lead to a trespassing rogue. s_c sets up a trap, climbing into the trees with r_c and breaking a branch onto the rogue's head that sends the startled intruder yowling as they flee c_n territory.",
-            "stat_trait": "Boldy, s_c follows the pawprints to a trespassing rogue, and confronts them. Fur puffed up and scowling, s_c and r_c demand the rogue leaves c_n territory. Intimidated by their confidence, the rogue gives in and leaves without a fight."
+            "stat_trait": "Boldly, s_c follows the pawprints to a trespassing rogue, and confronts them. Fur puffed up and scowling, s_c and r_c demand the rogue leaves c_n territory. Intimidated by their confidence, the rogue gives in and leaves without a fight."
         },
         "fail_text": {
             "unscathed_common": "It turns out they were r_c's own pawprints... r_c huffs with embarrassment, suddenly grateful that their patrol is so small. Less eyes watching that embarrassing moment.",
@@ -656,7 +656,7 @@
         },
         "fail_text": {
             "unscathed_common": "It turns out they were app1's own pawprints... app1 huffs with embarrassment, suddenly grateful that their patrol is so small. Less eyes watching that embarrassing moment. They don't want to look dumb in front of other cats.",
-            "unscathed_stat": "Boldy, s_c follows the pawprints to a trespassing rogue, and confronts them. Fur puffed up and scowling, they demand the rogue leaves c_n territory. The rogue is not impressed by the teenager, but reluctantly leaves c_n territory.",
+            "unscathed_stat": "Boldly, s_c follows the pawprints to a trespassing rogue, and confronts them. Fur puffed up and scowling, they demand the rogue leaves c_n territory. The rogue is not impressed by the teenager, but reluctantly leaves c_n territory.",
             "injury": "Nose to the ground following the trail, app1 doesn't see the blow coming. They haul themselves to their feet, squealing with pain, and run for home."
         },
         "fail_trait": [
@@ -702,7 +702,7 @@
             "unscathed_common": "The pawprints lead to a trespassing rogue. The patrol quickly hides themselves behind a bush and sets up an ambush that sends the rogue fleeing off c_n territory.",
             "unscathed_rare": "r_c soon realizes that the pawprints smell of c_n. Someone must have wandered through this section of the border recently, but it's not a threat.",
             "stat_skill": "The pawprints lead to a trespassing rogue. s_c throws themselves at the rogue, hissing furiously, and together with r_c drives them off c_n territory.",
-            "stat_trait": "Boldy, s_c follows the pawprints to a trespassing rogue, and confronts them. Fur puffed up and scowling, the patrol demands the rogue leave c_n territory. Intimidated by their confidence and the number of cats, the rogue gives in and leaves without a fight."
+            "stat_trait": "Boldly, s_c follows the pawprints to a trespassing rogue, and confronts them. Fur puffed up and scowling, the patrol demands the rogue leave c_n territory. Intimidated by their confidence and the number of cats, the rogue gives in and leaves without a fight."
         },
         "fail_text": {
             "unscathed_common": "It turns out they were r_c's own pawprints... r_c huffs with embarrassment, and can't meet the eyes of the rest of the patrol.",
@@ -756,7 +756,7 @@
             "unscathed_common": "The pawprints lead to a trespassing rogue. The patrol quickly hides themselves behind a bush and sets up an ambush that sends the rogue fleeing off c_n territory.",
             "unscathed_rare": "r_c soon realizes that the pawprints smell of c_n. Someone must have wandered through this section of the border recently, but it's not a threat.",
             "stat_skill": "The pawprints lead to a trespassing rogue. s_c sets up a trap, climbing into the trees with r_c and breaking a branch onto the rogue's head that sends the startled intruder yowling as they flee c_n territory.",
-            "stat_trait": "Boldy, s_c follows the pawprints to a trespassing rogue, and confronts them. Fur puffed up and scowling, the patrol demands the rogue leave c_n territory. Intimidated by their confidence and the number of cats, the rogue gives in and leaves without a fight."
+            "stat_trait": "Boldly, s_c follows the pawprints to a trespassing rogue, and confronts them. Fur puffed up and scowling, the patrol demands the rogue leave c_n territory. Intimidated by their confidence and the number of cats, the rogue gives in and leaves without a fight."
         },
         "fail_text": {
             "unscathed_common": "It turns out they were r_c's own pawprints... r_c huffs with embarrassment, and can't meet the eyes of the rest of the patrol.",
@@ -815,7 +815,7 @@
         },
         "fail_text": {
             "unscathed_common": "It turns out they were app1's own pawprints... app1 huffs with embarrassment, and can't meet the eyes of the rest of the patrol. They don't want to look dumb in front of other cats.",
-            "unscathed_stat": "Boldy, s_c follows the pawprints to a trespassing rogue, and confronts them. Fur puffed up and scowling, they demand the rogue leaves c_n territory. The rogue is not impressed by the young cat, but with the full patrol backing them up, leaves c_n territory."
+            "unscathed_stat": "Boldly, s_c follows the pawprints to a trespassing rogue, and confronts them. Fur puffed up and scowling, they demand the rogue leaves c_n territory. The rogue is not impressed by the young cat, but with the full patrol backing them up, leaves c_n territory."
         },
         "fail_trait": [
             "ambitious",

--- a/resources/dicts/patrols/forest/hunting/greenleaf.json
+++ b/resources/dicts/patrols/forest/hunting/greenleaf.json
@@ -1143,7 +1143,9 @@
         "antagonize_text": null,
         "antagonize_fail_text": null,
         "history_text": {
-            "scar": "m_c carries a scar from a solo fox fight."
+            "scar": "m_c carries a scar from a solo fox fight.",
+            "reg_death": "m_c fell in a solo battle with a fox.",
+            "lead_death": "died while fighting a fox"
         }
     },
     {

--- a/resources/dicts/patrols/forest/hunting/leaf-bare.json
+++ b/resources/dicts/patrols/forest/hunting/leaf-bare.json
@@ -463,7 +463,9 @@
         "antagonize_text": null,
         "antagonize_fail_text": null,
         "history_text": {
-            "scar": "m_c carries a scar from a solo fox fight."
+            "scar": "m_c carries a scar from a solo fox fight.",
+            "reg_death": "m_c fell in a solo battle with a fox.",
+            "lead_death": "died while fighting a fox"
         }
     },
     {
@@ -1724,7 +1726,9 @@
         "min_cats": 1,
         "max_cats": 1,
         "history_text": {
-            "scar": "m_c carries a scar from a solo fox fight."
+            "scar": "m_c carries a scar from a solo fox fight.",
+            "reg_death": "m_c fell in a solo battle with a fox.",
+            "lead_death": "died while fighting a fox"
         }
     },
     {

--- a/resources/dicts/patrols/forest/hunting/leaf-fall.json
+++ b/resources/dicts/patrols/forest/hunting/leaf-fall.json
@@ -803,7 +803,9 @@
         "antagonize_text": null,
         "antagonize_fail_text": null,
         "history_text": {
-            "scar": "m_c carries a scar from a solo fox fight."
+            "scar": "m_c carries a scar from a solo fox fight.",
+            "reg_death": "m_c fell in a solo battle with a fox.",
+            "lead_death": "died while fighting a fox"
         }
     },
     {

--- a/resources/dicts/patrols/forest/hunting/newleaf.json
+++ b/resources/dicts/patrols/forest/hunting/newleaf.json
@@ -843,7 +843,9 @@
         "antagonize_text": null,
         "antagonize_fail_text": null,
         "history_text": {
-            "scar": "m_c carries a scar from a solo fox fight."
+            "scar": "m_c carries a scar from a solo fox fight.",
+            "reg_death": "m_c fell in a solo battle with a fox.",
+            "lead_death": "died while fighting a fox"
         }
     },
     {

--- a/resources/dicts/patrols/mountainous/border/greenleaf.json
+++ b/resources/dicts/patrols/mountainous/border/greenleaf.json
@@ -19,7 +19,7 @@
             "unscathed_common": "The scent leads to a trespassing rogue. Weird. r_c runs down the scree slope to see what's up with them, but the rogue turns and flees c_n territory.",
             "unscathed_rare": "r_c soon realizes that there are pawprints smelling of fox cubs. One must have wandered through this section of the border recently, but it's not a threat.",
             "stat_skill": "The scent leads to a trespassing rogue. s_c throws {PRONOUN/s_c/self} at the rogue, leaping from the rocky outcrops above, and quickly overwhelms the lone cat. {PRONOUN/s_c/subject/CAP} {VERB/m_c/accept/accepts} the rogue's surrender graciously, and escort them out of c_n territory promptly.",
-            "stat_trait": "Boldy, s_c follows the scent to a trespassing rogue and confronts them, pointing out the clearly marked border which the rogue has crossed. From {PRONOUN/s_c/poss} seat above the rogue, perched on a high rock, {PRONOUN/s_c/subject} {VERB/s_c/listen/listens} to the rogue stutter out an explanation and a quick apology, unimpressed and confident in {PRONOUN/s_c/poss} own strength."
+            "stat_trait": "Boldly, s_c follows the scent to a trespassing rogue and confronts them, pointing out the clearly marked border which the rogue has crossed. From {PRONOUN/s_c/poss} seat above the rogue, perched on a high rock, {PRONOUN/s_c/subject} {VERB/s_c/listen/listens} to the rogue stutter out an explanation and a quick apology, unimpressed and confident in {PRONOUN/s_c/poss} own strength."
         },
         "fail_text": {
             "unscathed_common": "It turns out they were r_c's own pawprints... r_c huffs with embarrassment, suddenly grateful {PRONOUN/r_c/subject} {VERB/r_c/are/is} alone.",
@@ -81,7 +81,7 @@
             "unscathed_common": "The scent leads to a trespassing rogue. Weird. r_c runs down the scree slope to see what's up with them, but the rogue turns and flees c_n territory.",
             "unscathed_rare": "r_c soon realizes that there are pawprints smelling of fox cubs. One must have wandered through this section of the border recently, but it's not a threat.",
             "stat_skill": "The scent leads to a trespassing rogue. s_c sets up a trap, using an unstable slope above the cat to start a rockslide. {PRONOUN/s_c/subject/CAP} yowl a warning and the rogue scrambles out of the way, but it's enough warning. The intruder leaves the mountains.",
-            "stat_trait": "Boldy, s_c follows the scent to a trespassing rogue and confronts them, pointing out the clearly marked border which the rogue has crossed. From {PRONOUN/s_c/poss} seat above the rogue, perched on a high rock, {PRONOUN/s_c/subject} {VERB/s_c/listen/listens} to the rogue stutter out an explanation and a quick apology, unimpressed and confident in {PRONOUN/s_c/poss} own strength."
+            "stat_trait": "Boldly, s_c follows the scent to a trespassing rogue and confronts them, pointing out the clearly marked border which the rogue has crossed. From {PRONOUN/s_c/poss} seat above the rogue, perched on a high rock, {PRONOUN/s_c/subject} {VERB/s_c/listen/listens} to the rogue stutter out an explanation and a quick apology, unimpressed and confident in {PRONOUN/s_c/poss} own strength."
         },
         "fail_text": {
             "unscathed_common": "It turns out they were r_c's own pawprints... r_c huffs with embarrassment, suddenly grateful {PRONOUN/r_c/subject} {VERB/r_c/are/is} alone.",
@@ -147,7 +147,7 @@
         },
         "fail_text": {
             "unscathed_common": "It turns out they were app1's own pawprints... app1 huffs with embarrassment, suddenly grateful {PRONOUN/app1/subject} {VERB/app1/are/is} alone. {PRONOUN/app1/subject/CAP} {VERB/app1/don't/doesn't} want to look dumb in front of other cats.",
-            "unscathed_stat": "Boldy, s_c follows the scent to a trespassing rogue, and confronts them. Fur puffed but ears pricked forward curiously, {PRONOUN/s_c/subject} {VERB/s_c/ask/asks} what the rogue is doing in c_n territory. It seems to embarrass the other cat, who walks off huffily back over the border.",
+            "unscathed_stat": "Boldly, s_c follows the scent to a trespassing rogue, and confronts them. Fur puffed but ears pricked forward curiously, {PRONOUN/s_c/subject} {VERB/s_c/ask/asks} what the rogue is doing in c_n territory. It seems to embarrass the other cat, who walks off huffily back over the border.",
             "death": "Nose to the ground following the trail, app1 doesn't see the blow that kills {PRONOUN/app1/object}.",
             "injury": "Nose to the ground following the trail, app1 doesn't see the blow coming. {PRONOUN/app1/subject/CAP} {VERB/app1/haul/hauls} {PRONOUN/app1/self} to {PRONOUN/app1/poss} feet, squealing with pain, and run for home."
         },
@@ -199,7 +199,7 @@
             "unscathed_common": "The scent leads to a trespassing rogue. Weird. The patrol runs down the scree slope to see what's up with them, but the rogue turns and flees c_n territory.",
             "unscathed_rare": "r_c soon realizes that there are pawprints smelling of fox cubs. One must have wandered through this section of the border recently, but it's not a threat.",
             "stat_skill": "The scent leads to a trespassing rogue. s_c throws {PRONOUN/s_c/self} at the rogue, leaping from the rocky outcrops above, and quickly overwhelms the lone cat. {PRONOUN/s_c/subject/CAP} {VERB/s_c/accept/accepts} the rogue's surrender graciously, and escort them out of c_n territory promptly.",
-            "stat_trait": "Boldy, s_c follows the scent to a trespassing rogue and confronts them, pointing out the clearly marked border which the rogue has crossed. From {PRONOUN/s_c/poss} seat above the rogue, perched on a high rock, {PRONOUN/s_c/subject} {VERB/s_c/listen/listens} to the rogue stutter out an explanation and a quick apology, unimpressed and confident in {PRONOUN/s_c/poss} own strength."
+            "stat_trait": "Boldly, s_c follows the scent to a trespassing rogue and confronts them, pointing out the clearly marked border which the rogue has crossed. From {PRONOUN/s_c/poss} seat above the rogue, perched on a high rock, {PRONOUN/s_c/subject} {VERB/s_c/listen/listens} to the rogue stutter out an explanation and a quick apology, unimpressed and confident in {PRONOUN/s_c/poss} own strength."
         },
         "fail_text": {
             "unscathed_common": "It turns out they were r_c's own pawprints... r_c huffs with embarrassment, suddenly grateful that {PRONOUN/r_c/poss} patrol is so small. Less eyes watching that embarrassing moment.",
@@ -261,7 +261,7 @@
             "unscathed_common": "The scent leads to a trespassing rogue. Weird. The patrol runs down the scree slope to see what's up with them, but the rogue turns and flees c_n territory.",
             "unscathed_rare": "r_c soon realizes that there are pawprints smelling of fox cubs. One must have wandered through this section of the border recently, but it's not a threat.",
             "stat_skill": "The scent leads to a trespassing rogue. s_c sets up a trap, using an unstable slope above the cat to start a rockslide. {PRONOUN/s_c/subject/CAP} yowl a warning and the rogue scrambles out of the way, but it's enough warning. The intruder leaves the mountains.",
-            "stat_trait": "Boldy, s_c follows the scent to a trespassing rogue and confronts them, pointing out the clearly marked border which the rogue has crossed. From {PRONOUN/s_c/poss} seat above the rogue, perched on a high rock, {PRONOUN/s_c/subject} {VERB/s_c/listen/listens} to the rogue stutter out an explanation and a quick apology, unimpressed and confident in {PRONOUN/s_c/poss} own strength."
+            "stat_trait": "Boldly, s_c follows the scent to a trespassing rogue and confronts them, pointing out the clearly marked border which the rogue has crossed. From {PRONOUN/s_c/poss} seat above the rogue, perched on a high rock, {PRONOUN/s_c/subject} {VERB/s_c/listen/listens} to the rogue stutter out an explanation and a quick apology, unimpressed and confident in {PRONOUN/s_c/poss} own strength."
         },
         "fail_text": {
             "unscathed_common": "It turns out they were r_c's own pawprints... r_c huffs with embarrassment, suddenly grateful that {PRONOUN/r_c/poss} patrol is so small. Less eyes watching that embarrassing moment.",
@@ -324,7 +324,7 @@
         },
         "fail_text": {
             "unscathed_common": "It turns out they were app1's own pawprints... app1 huffs with embarrassment, suddenly grateful that {PRONOUN/app1/poss} patrol is so small. Less eyes watching that embarrassing moment. {PRONOUN/app1/subject/CAP} {VERB/app1/don't/doesn't} don't want to look dumb in front of other cats.",
-            "unscathed_stat": "Boldy, s_c follows the scent to a trespassing rogue, and confronts them. Fur puffed but ears pricked forward curiously, {PRONOUN/s_c/subject} {VERB/s_c/ask/asks} what the rogue is doing in c_n territory. It seems to embarrass the other cat, who walks off huffily back over the border.",
+            "unscathed_stat": "Boldly, s_c follows the scent to a trespassing rogue, and confronts them. Fur puffed but ears pricked forward curiously, {PRONOUN/s_c/subject} {VERB/s_c/ask/asks} what the rogue is doing in c_n territory. It seems to embarrass the other cat, who walks off huffily back over the border.",
             "injury": "Nose to the ground following the trail, app1 doesn't see the blow coming. {PRONOUN/app1/subject/CAP} {VERB/app1/haul/hauls} {PRONOUN/app1/self} to {PRONOUN/app1/poss} feet feet, squealing with pain, and run for home."
         },
         "fail_trait": [
@@ -367,7 +367,7 @@
             "unscathed_common": "The scent leads to a trespassing rogue. Weird. The patrol runs down the scree slope to see what's up with them, but the rogue turns and flees c_n territory.",
             "unscathed_rare": "r_c soon realizes that there are pawprints smelling of fox cubs. One must have wandered through this section of the border recently, but it's not a threat.",
             "stat_skill": "The scent leads to a trespassing rogue. s_c throws {PRONOUN/s_c/self} at the rogue, leaping from the rocky outcrops above, and quickly overwhelms the lone cat. {PRONOUN/s_c/subject/CAP} {VERB/s_c/accept/accepts} the rogue's surrender graciously, and escort them out of c_n territory promptly.",
-            "stat_trait": "Boldy, s_c follows the scent to a trespassing rogue and confronts them, pointing out the clearly marked border which the rogue has crossed. From {PRONOUN/s_c/poss} seat above the rogue, perched on a high rock, {PRONOUN/s_c/subject} listen to the rogue stutter out an explanation and a quick apology, unimpressed and confident in {PRONOUN/s_c/poss} own strength."
+            "stat_trait": "Boldly, s_c follows the scent to a trespassing rogue and confronts them, pointing out the clearly marked border which the rogue has crossed. From {PRONOUN/s_c/poss} seat above the rogue, perched on a high rock, {PRONOUN/s_c/subject} listen to the rogue stutter out an explanation and a quick apology, unimpressed and confident in {PRONOUN/s_c/poss} own strength."
         },
         "fail_text": {
             "unscathed_common": "It turns out they were r_c's own pawprints... r_c huffs with embarrassment, and can't meet the eyes of the rest of the patrol.",
@@ -419,7 +419,7 @@
             "unscathed_common": "The scent leads to a trespassing rogue. Weird. The patrol runs down the scree slope to see what's up with them, but the rogue turns and flees c_n territory.",
             "unscathed_rare": "r_c soon realizes that there are pawprints smelling of fox cubs. One must have wandered through this section of the border recently, but it's not a threat.",
             "stat_skill": "The scent leads to a trespassing rogue. s_c sets up a trap, using an unstable slope above the cat to start a rockslide. {PRONOUN/s_c/subject/CAP} yowl a warning and the rogue scrambles out of the way, but it's enough warning. The intruder leaves the mountains.",
-            "stat_trait": "Boldy, s_c follows the scent to a trespassing rogue and confronts them, pointing out the clearly marked border which the rogue has crossed. From {PRONOUN/s_c/poss} seat above the rogue, perched on a high rock, {PRONOUN/s_c/subject} listen to the rogue stutter out an explanation and a quick apology, unimpressed and confident in {PRONOUN/s_c/poss} own strength."
+            "stat_trait": "Boldly, s_c follows the scent to a trespassing rogue and confronts them, pointing out the clearly marked border which the rogue has crossed. From {PRONOUN/s_c/poss} seat above the rogue, perched on a high rock, {PRONOUN/s_c/subject} listen to the rogue stutter out an explanation and a quick apology, unimpressed and confident in {PRONOUN/s_c/poss} own strength."
         },
         "fail_text": {
             "unscathed_common": "It turns out they were r_c's own pawprints... r_c huffs with embarrassment, and can't meet the eyes of the rest of the patrol.",
@@ -475,7 +475,7 @@
         },
         "fail_text": {
             "unscathed_common": "It turns out they were app1's own pawprints... app1 huffs with embarrassment, and can't meet the eyes of the rest of the patrol. {PRONOUN/app1/subject/CAP} {VERB/app1/don't/doesn't} want to look dumb in front of other cats.",
-            "unscathed_stat": "Boldy, s_c follows the scent to a trespassing rogue, and confronts them. Fur puffed but ears pricked forward curiously, {PRONOUN/s_c/subject} {VERB/s_c/ask/asks} what the rogue is doing in c_n territory. It seems to embarrass the other cat, who walks off huffily back over the border."
+            "unscathed_stat": "Boldly, s_c follows the scent to a trespassing rogue, and confronts them. Fur puffed but ears pricked forward curiously, {PRONOUN/s_c/subject} {VERB/s_c/ask/asks} what the rogue is doing in c_n territory. It seems to embarrass the other cat, who walks off huffily back over the border."
         },
         "fail_trait": [
             "ambitious",

--- a/resources/dicts/patrols/mountainous/hunting/any.json
+++ b/resources/dicts/patrols/mountainous/hunting/any.json
@@ -123,7 +123,7 @@
         "fail_text": {
             "unscathed_common": "Hunting is poor, and while r_c's mentor is disappointed, they don't expect r_c to be able to catch what isn't there.",
             "unscathed_stat": "s_c is too hasty, bouncing after first one prey, then another, and it ends with {PRONOUN/s_c/object} empty pawed and exhausted. {PRONOUN/s_c/poss/CAP} mentor is disappointed - {PRONOUN/s_c/subject} clearly need more training.",
-            "injury": "During the hunt, r_c tumbles right down a steep slope while {PRONOUN/r_c/poss} attention is elsewhere. Bruised and sore, r_c has to report to the medicine cat den when {PRONOUN/r_c/subject} {VERB/m_c/return/returns} to camp."
+            "injury": "During the hunt, r_c tumbles right down a steep slope while {PRONOUN/r_c/poss} attention is elsewhere. Bruised and sore, r_c has to report to the medicine cat den when {PRONOUN/r_c/subject} {VERB/r_c/return/returns} to camp."
         },
         "win_trait": [
             "calm",

--- a/resources/dicts/patrols/new_cat.json
+++ b/resources/dicts/patrols/new_cat.json
@@ -321,6 +321,11 @@
         },
         "antagonize_text": "Your patrol watches as the loner climbs up a spindly tree to escape the dog, and then promptly proceed to chase the dog out of the territory and warn the loner not to cross the border.",
         "antagonize_fail_text": "The loner escapes the dog by climbing a tree and scowls at the patrol, who stood by watching.",
+        "history_text": {
+            "scar": "m_c was scarred when a loner attacked {PRONOUN/m_c/object}.",
+            "reg_death": "m_c died after a loner attacked {PRONOUN/m_c/object}.",
+            "lead_death": "{VERB/m_c/were/was} attacked by a loner"
+        },
         "win_skills": [
             "FIGHTER,1"
         ],

--- a/resources/dicts/patrols/new_cat.json
+++ b/resources/dicts/patrols/new_cat.json
@@ -670,7 +670,8 @@
             "border",
             "new_cat_elder_loner",
             "no_new_cat2",
-            "no_new_cat3"
+            "no_new_cat3",
+            "death"
         ],
         "intro_text": "r_c hears some odd noises coming from an abandoned Twoleg nest out on the plains.",
         "decline_text": "r_c decides not to investigate.",

--- a/resources/dicts/patrols/new_cat_hostile.json
+++ b/resources/dicts/patrols/new_cat_hostile.json
@@ -324,6 +324,11 @@
         },
         "antagonize_text": "Your patrol watches as the loner climbs up a spindly tree to escape the dog, and then promptly proceed to chase the dog out of the territory and viciously spit at the loner not to cross the border.",
         "antagonize_fail_text": "The loner escapes the dog by climbing a tree and scowls at the patrol, who stood by watching. The patrol leers back in return. c_n doesn't owe loners anything.",
+        "history_text": {
+            "scar": "m_c was scarred when a loner attacked {PRONOUN/m_c/object}.",
+            "reg_death": "m_c died after a loner attacked {PRONOUN/m_c/object}.",
+            "lead_death": "{VERB/m_c/were/was} attacked by a loner"
+        },
         "chance_of_success": 40,
         "exp": 10,
         "win_skills": [

--- a/resources/dicts/patrols/new_cat_welcoming.json
+++ b/resources/dicts/patrols/new_cat_welcoming.json
@@ -327,7 +327,7 @@
         "antagonize_text": "Your patrol watches as the loner climbs up a spindly tree to escape the dog, and then promptly proceed to chase the dog out of the territory. On their way back, they advise the loner that this is a dangerous area and maybe they shouldn't return.",
         "antagonize_fail_text": "The loner escapes the dog by climbing a tree and scowls at the patrol, who stood by watching. The patrol leaves, guilt pricking at them.",
         "history_text": {
-            "scar": "m_c was scared when a loner attacked {PRONOUN/m_c/object}.",
+            "scar": "m_c was scarred when a loner attacked {PRONOUN/m_c/object}.",
             "reg_death": "m_c died after a loner attacked {PRONOUN/m_c/object}.",
             "lead_death": "{VERB/m_c/were/was} attacked by a loner"
         },

--- a/resources/dicts/patrols/plains/border/any.json
+++ b/resources/dicts/patrols/plains/border/any.json
@@ -11,7 +11,7 @@
             "THREE",
             "comfort",
             "trust",
-            "battle_injury"
+            "big_bite_injury"
         ],
         "intro_text": "The patrol finds an opening to what seems to be a new set of tunnels.",
         "decline_text": "The patrol decides not to check the tunnels. After all, who knows what might be hiding inside?",

--- a/resources/dicts/patrols/plains/border/any.json
+++ b/resources/dicts/patrols/plains/border/any.json
@@ -265,7 +265,7 @@
             "unscathed_common": "The pawprints lead to a trespassing rogue. r_c quickly hides {PRONOUN/r_c/self} in the long grass and sets up an ambush that sends the rogue fleeing off c_n territory.",
             "unscathed_rare": "r_c soon realizes that the pawprints smell of c_n. Someone must have wandered through this section of the border recently, but it's not a threat.",
             "stat_skill": "The pawprints lead to a trespassing rogue. s_c throws {PRONOUN/s_c/self} at the rogue, hissing furiously, and drives them off c_n territory.",
-            "stat_trait": "Boldy, s_c follows the pawprints to a trespassing rogue, and confronts them. Fur puffed up and scowling, {PRONOUN/s_c/subject} {VERB/s_c/demand/demands} the rogue leaves c_n territory. Intimidated by {PRONOUN/s_c/poss} confidence, the rogue gives in and leaves without a fight."
+            "stat_trait": "Boldly, s_c follows the pawprints to a trespassing rogue, and confronts them. Fur puffed up and scowling, {PRONOUN/s_c/subject} {VERB/s_c/demand/demands} the rogue leaves c_n territory. Intimidated by {PRONOUN/s_c/poss} confidence, the rogue gives in and leaves without a fight."
         },
         "fail_text": {
             "unscathed_common": "It turns out they were r_c's own pawprints... r_c huffs with embarrassment, suddenly grateful {PRONOUN/r_c/subject}{VERB/r_c/'re/'s} alone.",
@@ -328,7 +328,7 @@
             "unscathed_common": "The pawprints lead to a trespassing rogue. r_c quickly hides {PRONOUN/r_c/self} in the long grass and sets up an ambush that sends the rogue fleeing off c_n territory.",
             "unscathed_rare": "r_c soon realizes that the pawprints smell of c_n. Someone must have wandered through this section of the border recently, but it's not a threat.",
             "stat_skill": "The pawprints lead to a trespassing rogue. s_c sets up a trap by using grass to cover an abandoned rabbit burrow. It sends the startled intruder yowling as they first fall, then flee c_n territory.",
-            "stat_trait": "Boldy, s_c follows the pawprints to a trespassing rogue, and confronts them. Fur puffed up and scowling, {PRONOUN/s_c/subject} {VERB/s_c/demand/demands} the rogue leaves c_n territory. Intimidated by {PRONOUN/s_c/poss} confidence, the rogue gives in and leaves without a fight."
+            "stat_trait": "Boldly, s_c follows the pawprints to a trespassing rogue, and confronts them. Fur puffed up and scowling, {PRONOUN/s_c/subject} {VERB/s_c/demand/demands} the rogue leaves c_n territory. Intimidated by {PRONOUN/s_c/poss} confidence, the rogue gives in and leaves without a fight."
         },
         "fail_text": {
             "unscathed_common": "It turns out they were r_c's own pawprints... r_c huffs with embarrassment, suddenly grateful {PRONOUN/r_c/subject}{VERB/r_c/'re/'s} alone.",
@@ -394,7 +394,7 @@
         },
         "fail_text": {
             "unscathed_common": "It turns out they were app1's own pawprints... app1 huffs with embarrassment, suddenly grateful {PRONOUN/app1/subject}{VERB/app1/'re/'s} alone. {PRONOUN/app1/subject/CAP} don't want to look dumb in front of other cats.",
-            "unscathed_stat": "Boldy, s_c follows the pawprints to a trespassing rogue, and confronts them. Fur puffed up and scowling, {PRONOUN/s_c/subject} {VERB/s_c/demand/demands} the rogue leaves c_n territory. The rogue is not impressed by this teenager, and ignores {PRONOUN/s_c/object} completely.",
+            "unscathed_stat": "Boldly, s_c follows the pawprints to a trespassing rogue, and confronts them. Fur puffed up and scowling, {PRONOUN/s_c/subject} {VERB/s_c/demand/demands} the rogue leaves c_n territory. The rogue is not impressed by this teenager, and ignores {PRONOUN/s_c/object} completely.",
             "death": "Nose to the ground following the trail, app1 doesn't see the blow that kills {PRONOUN/app1/object}.",
             "injury": "Nose to the ground following the trail, app1 doesn't see the blow coming. {PRONOUN/app1/subject/CAP} {VERB/app1/haul/hauls} {PRONOUN/app1/object} to {PRONOUN/app1/poss} feet, squealing with pain, and run for home."
         },
@@ -448,7 +448,7 @@
             "unscathed_common": "The pawprints lead to a trespassing rogue. The patrol quickly hides themselves in the long grass and sets up an ambush, sending the rogue fleeing off c_n territory.",
             "unscathed_rare": "r_c soon realizes that the pawprints smell of c_n. Someone must have wandered through this section of the border recently, but it's not a threat.",
             "stat_skill": "The pawprints lead to a trespassing rogue. s_c throws {PRONOUN/r_c/self} at the rogue, hissing furiously, and together with r_c drives them off c_n territory.",
-            "stat_trait": "Boldy, s_c follows the pawprints to a trespassing rogue, and confronts them. Fur puffed up and scowling, s_c and r_c demand the rogue leaves c_n territory. Intimidated by their confidence, the rogue gives in and leaves without a fight."
+            "stat_trait": "Boldly, s_c follows the pawprints to a trespassing rogue, and confronts them. Fur puffed up and scowling, s_c and r_c demand the rogue leaves c_n territory. Intimidated by their confidence, the rogue gives in and leaves without a fight."
         },
         "fail_text": {
             "unscathed_common": "It turns out they were r_c's own pawprints... r_c huffs with embarrassment, suddenly grateful that {PRONOUN/r_c/poss} patrol is so small. Less eyes watching that embarrassing moment.",
@@ -509,7 +509,7 @@
             "unscathed_common": "The pawprints lead to a trespassing rogue. The patrol quickly hides themselves in the long grass and sets up an ambush, sending the rogue fleeing off c_n territory.",
             "unscathed_rare": "r_c soon realizes that the pawprints smell of c_n. Someone must have wandered through this section of the border recently, but it's not a threat.",
             "stat_skill": "The pawprints lead to a trespassing rogue. s_c sets up a trap by using grass to cover an abandoned rabbit burrow. It sends the startled intruder yowling as they first fall, then flee c_n territory.",
-            "stat_trait": "Boldy, s_c follows the pawprints to a trespassing rogue, and confronts {PRONOUN/r_c/object}. Fur puffed up and scowling, s_c and r_c demand the rogue leaves c_n territory. Intimidated by their confidence, the rogue gives in and leaves without a fight."
+            "stat_trait": "Boldly, s_c follows the pawprints to a trespassing rogue, and confronts {PRONOUN/r_c/object}. Fur puffed up and scowling, s_c and r_c demand the rogue leaves c_n territory. Intimidated by their confidence, the rogue gives in and leaves without a fight."
         },
         "fail_text": {
             "unscathed_common": "It turns out they were r_c's own pawprints... r_c huffs with embarrassment, suddenly grateful that {PRONOUN/r_c/poss} patrol is so small. Less eyes watching that embarrassing moment.",
@@ -571,7 +571,7 @@
         },
         "fail_text": {
             "unscathed_common": "It turns out they were app1's own pawprints... app1 huffs with embarrassment, suddenly grateful that {PRONOUN/app1/poss} patrol is so small. Less eyes watching that embarrassing moment. {PRONOUN/app1/subject/CAP} {VERB/app1/do/does}n't want to look dumb in front of other cats.",
-            "unscathed_stat": "Boldy, s_c follows the pawprints to a trespassing rogue, and confronts {PRONOUN/s_c/object}. Fur puffed up and scowling, {PRONOUN/s_c/subject} {VERB/s_c/demand/demands} the rogue leaves c_n territory. The rogue is not impressed by the teenager, but reluctantly leaves c_n territory.",
+            "unscathed_stat": "Boldly, s_c follows the pawprints to a trespassing rogue, and confronts {PRONOUN/s_c/object}. Fur puffed up and scowling, {PRONOUN/s_c/subject} {VERB/s_c/demand/demands} the rogue leaves c_n territory. The rogue is not impressed by the teenager, but reluctantly leaves c_n territory.",
             "injury": "Nose to the ground following the trail, app1 doesn't see the blow coming. {PRONOUN/app1/subject/CAP} {VERB/app1/haul/hauls} {PRONOUN/app1/object} to {PRONOUN/app1/poss} feet, squealing with pain, and run for home."
         },
         "fail_trait": [
@@ -618,7 +618,7 @@
             "unscathed_common": "The pawprints lead to a trespassing rogue. The patrol quickly hides themselves in the long grass and sets up an ambush, sending the rogue fleeing off c_n territory.",
             "unscathed_rare": "r_c soon realizes that the pawprints smell of c_n. Someone must have wandered through this section of the border recently, but it's not a threat.",
             "stat_skill": "The pawprints lead to a trespassing rogue. s_c throws {PRONOUN/r_c/self} at the rogue, hissing furiously, and together with r_c drives them off c_n territory.",
-            "stat_trait": "Boldy, s_c follows the pawprints to a trespassing rogue, and confronts them. Fur puffed up and scowling, the patrol demands the rogue leave c_n territory. Intimidated by their confidence and the number of cats, the rogue gives in and leaves without a fight."
+            "stat_trait": "Boldly, s_c follows the pawprints to a trespassing rogue, and confronts them. Fur puffed up and scowling, the patrol demands the rogue leave c_n territory. Intimidated by their confidence and the number of cats, the rogue gives in and leaves without a fight."
         },
         "fail_text": {
             "unscathed_common": "It turns out they were r_c's own pawprints... r_c huffs with embarrassment, and can't meet the eyes of the rest of the patrol.",
@@ -673,7 +673,7 @@
             "unscathed_common": "The pawprints lead to a trespassing rogue. The patrol quickly hides themselves in the long grass and sets up an ambush, sending the rogue fleeing off c_n territory.",
             "unscathed_rare": "r_c soon realizes that the pawprints smell of c_n. Someone must have wandered through this section of the border recently, but it's not a threat.",
             "stat_skill": "The pawprints lead to a trespassing rogue. s_c sets up a trap by using grass to cover an abandoned rabbit burrow. It sends the startled intruder yowling as they first fall, then flee c_n territory.",
-            "stat_trait": "Boldy, s_c follows the pawprints to a trespassing rogue, and confronts them. Fur puffed up and scowling, the patrol demands the rogue leave c_n territory. Intimidated by {PRONOUN/s_c/poss} confidence and the number of cats, the rogue gives in and leaves without a fight."
+            "stat_trait": "Boldly, s_c follows the pawprints to a trespassing rogue, and confronts them. Fur puffed up and scowling, the patrol demands the rogue leave c_n territory. Intimidated by {PRONOUN/s_c/poss} confidence and the number of cats, the rogue gives in and leaves without a fight."
         },
         "fail_text": {
             "unscathed_common": "It turns out they were r_c's own pawprints... r_c huffs with embarrassment, and can't meet the eyes of the rest of the patrol.",
@@ -733,7 +733,7 @@
         },
         "fail_text": {
             "unscathed_common": "It turns out they were app1's own pawprints... app1 huffs with embarrassment, and can't meet the eyes of the rest of the patrol. {PRONOUN/app1/subject/CAP} don't want to look dumb in front of other cats.",
-            "unscathed_stat": "Boldy, s_c follows the pawprints to a trespassing rogue, and confronts them. Fur puffed up and scowling, {PRONOUN/s_c/subject} {VERB/s_c/demand/demands} the rogue leaves c_n territory. The rogue is not impressed by the teenager, but with the full patrol backing {PRONOUN/s_c/object} up, leaves c_n territory."
+            "unscathed_stat": "Boldly, s_c follows the pawprints to a trespassing rogue, and confronts them. Fur puffed up and scowling, {PRONOUN/s_c/subject} {VERB/s_c/demand/demands} the rogue leaves c_n territory. The rogue is not impressed by the teenager, but with the full patrol backing {PRONOUN/s_c/object} up, leaves c_n territory."
         },
         "fail_trait": [
             "ambitious",

--- a/resources/dicts/patrols/wetlands/border/border_wetlands.json
+++ b/resources/dicts/patrols/wetlands/border/border_wetlands.json
@@ -1117,7 +1117,7 @@
             "unscathed_common": "The pawprints lead to a trespassing rogue. r_c slips into the swamp and sets up an ambush, sending the rogue fleeing off c_n territory.",
             "unscathed_rare": "r_c soon realizes that the pawprints smell of c_n. Someone must have wandered through this section of the border recently, but it's not a threat.",
             "stat_skill": "The pawprints lead to a trespassing rogue. s_c throws themselves at the rogue, hissing furiously, and drives them off c_n territory.",
-            "stat_trait": "Boldy, s_c follows the pawprints to a trespassing rogue, and confronts them. Fur puffed up and scowling, they demand the rogue leaves c_n territory. Intimidated by their confidence, the rogue gives in and leaves without a fight."
+            "stat_trait": "Boldly, s_c follows the pawprints to a trespassing rogue, and confronts them. Fur puffed up and scowling, they demand the rogue leaves c_n territory. Intimidated by their confidence, the rogue gives in and leaves without a fight."
         },
         "fail_text": {
             "unscathed_common": "It turns out they were r_c's own pawprints... r_c huffs with embarrassment, suddenly grateful they're alone.",
@@ -1178,7 +1178,7 @@
             "unscathed_common": "The pawprints lead to a trespassing rogue. r_c slips into the swamp and sets up an ambush, sending the rogue fleeing off c_n territory.",
             "unscathed_rare": "r_c soon realizes that the pawprints smell of c_n. Someone must have wandered through this section of the border recently, but it's not a threat.",
             "stat_skill": "The pawprints lead to a trespassing rogue. s_c sets up a trap by using the tides to cut off the rogue's escape path. It makes the startled intruder cower to realize they've been caught and trapped by c_n, and they're escorted to the border with the lesson firmly learnt.",
-            "stat_trait": "Boldy, s_c follows the pawprints to a trespassing rogue, and confronts them. Fur puffed up and scowling, they demand the rogue leaves c_n territory. Intimidated by their confidence, the rogue gives in and leaves without a fight."
+            "stat_trait": "Boldly, s_c follows the pawprints to a trespassing rogue, and confronts them. Fur puffed up and scowling, they demand the rogue leaves c_n territory. Intimidated by their confidence, the rogue gives in and leaves without a fight."
         },
         "fail_text": {
             "unscathed_common": "It turns out they were r_c's own pawprints... r_c huffs with embarrassment, suddenly grateful they're alone.",
@@ -1243,7 +1243,7 @@
         },
         "fail_text": {
             "unscathed_common": "It turns out they were app1's own pawprints... app1 huffs with embarrassment, suddenly grateful they're alone. They don't want to look dumb in front of other cats.",
-            "unscathed_stat": "Boldy, s_c follows the pawprints to a trespassing rogue, and confronts them. Fur puffed up and scowling, they demand the rogue leaves c_n territory. The rogue is not impressed by this teenager, and ignores them completely.",
+            "unscathed_stat": "Boldly, s_c follows the pawprints to a trespassing rogue, and confronts them. Fur puffed up and scowling, they demand the rogue leaves c_n territory. The rogue is not impressed by this teenager, and ignores them completely.",
             "death": "Nose to the ground following the trail, app1 doesn't see the blow that kills them.",
             "injury": "Nose to the ground following the trail, app1 doesn't see the blow coming. They haul themselves to their feet, squealing with pain, and run for home."
         },
@@ -1293,7 +1293,7 @@
             "unscathed_common": "The pawprints lead to a trespassing rogue. The patrol slips into the swamp and sets up an ambush, sending the rogue fleeing off c_n territory.",
             "unscathed_rare": "r_c soon realizes that the pawprints smell of c_n. Someone must have wandered through this section of the border recently, but it's not a threat.",
             "stat_skill": "The pawprints lead to a trespassing rogue. s_c throws themselves at the rogue, hissing furiously, and together with r_c drives them off c_n territory.",
-            "stat_trait": "Boldy, s_c follows the pawprints to a trespassing rogue, and confronts them. Fur puffed up and scowling, s_c and r_c demand the rogue leaves c_n territory. Intimidated by their confidence, the rogue gives in and leaves without a fight."
+            "stat_trait": "Boldly, s_c follows the pawprints to a trespassing rogue, and confronts them. Fur puffed up and scowling, s_c and r_c demand the rogue leaves c_n territory. Intimidated by their confidence, the rogue gives in and leaves without a fight."
         },
         "fail_text": {
             "unscathed_common": "It turns out they were r_c's own pawprints... r_c huffs with embarrassment, suddenly grateful that their patrol is so small. Less eyes watching that embarrassing moment.",
@@ -1351,7 +1351,7 @@
             "unscathed_common": "The pawprints lead to a trespassing rogue. The patrol slips into the swamp and sets up an ambush, sending the rogue fleeing off c_n territory.",
             "unscathed_rare": "r_c soon realizes that the pawprints smell of c_n. Someone must have wandered through this section of the border recently, but it's not a threat.",
             "stat_skill": "The pawprints lead to a trespassing rogue. s_c sets up a trap by using the tides to cut off the rogue's escape path. It makes the startled intruder cower to realize they've been caught and trapped by c_n, and they're escorted to the border with the lesson firmly learnt.",
-            "stat_trait": "Boldy, s_c follows the pawprints to a trespassing rogue, and confronts them. Fur puffed up and scowling, s_c and r_c demand the rogue leaves c_n territory. Intimidated by their confidence, the rogue gives in and leaves without a fight."
+            "stat_trait": "Boldly, s_c follows the pawprints to a trespassing rogue, and confronts them. Fur puffed up and scowling, s_c and r_c demand the rogue leaves c_n territory. Intimidated by their confidence, the rogue gives in and leaves without a fight."
         },
         "fail_text": {
             "unscathed_common": "It turns out they were r_c's own pawprints... r_c huffs with embarrassment, suddenly grateful that their patrol is so small. Less eyes watching that embarrassing moment.",
@@ -1413,7 +1413,7 @@
         },
         "fail_text": {
             "unscathed_common": "It turns out they were app1's own pawprints... app1 huffs with embarrassment, suddenly grateful that their patrol is so small. Less eyes watching that embarrassing moment. They don't want to look dumb in front of other cats.",
-            "unscathed_stat": "Boldy, s_c follows the pawprints to a trespassing rogue, and confronts them. Fur puffed up and scowling, they demand the rogue leaves c_n territory. The rogue is not impressed by the teenager, but reluctantly leaves c_n territory.",
+            "unscathed_stat": "Boldly, s_c follows the pawprints to a trespassing rogue, and confronts them. Fur puffed up and scowling, they demand the rogue leaves c_n territory. The rogue is not impressed by the teenager, but reluctantly leaves c_n territory.",
             "injury": "Nose to the ground following the trail, app1 doesn't see the blow coming. They haul themselves to their feet, squealing with pain, and run for home."
         },
         "fail_trait": [
@@ -1458,7 +1458,7 @@
             "unscathed_common": "The pawprints lead to a trespassing rogue. The patrol slips into the swamp and sets up an ambush, sending the rogue fleeing off c_n territory.",
             "unscathed_rare": "r_c soon realizes that the pawprints smell of c_n. Someone must have wandered through this section of the border recently, but it's not a threat.",
             "stat_skill": "The pawprints lead to a trespassing rogue. s_c throws themselves at the rogue, hissing furiously, and together with r_c drives them off c_n territory.",
-            "stat_trait": "Boldy, s_c follows the pawprints to a trespassing rogue, and confronts them. Fur puffed up and scowling, the patrol demands the rogue leave c_n territory. Intimidated by their confidence and the number of cats, the rogue gives in and leaves without a fight."
+            "stat_trait": "Boldly, s_c follows the pawprints to a trespassing rogue, and confronts them. Fur puffed up and scowling, the patrol demands the rogue leave c_n territory. Intimidated by their confidence and the number of cats, the rogue gives in and leaves without a fight."
         },
         "fail_text": {
             "unscathed_common": "It turns out they were r_c's own pawprints... r_c huffs with embarrassment, and can't meet the eyes of the rest of the patrol.",
@@ -1507,7 +1507,7 @@
             "unscathed_common": "The pawprints lead to a trespassing rogue. The patrol slips into the swamp and sets up an ambush, sending the rogue fleeing off c_n territory.",
             "unscathed_rare": "r_c soon realizes that the pawprints smell of c_n. Someone must have wandered through this section of the border recently, but it's not a threat.",
             "stat_skill": "The pawprints lead to a trespassing rogue. s_c sets up a trap by using the tides to cut off the rogue's escape path. It makes the startled intruder cower to realize they've been caught and trapped by c_n, and they're escorted to the border with the lesson firmly learnt.",
-            "stat_trait": "Boldy, s_c follows the pawprints to a trespassing rogue, and confronts them. Fur puffed up and scowling, the patrol demands the rogue leave c_n territory. Intimidated by their confidence and the number of cats, the rogue gives in and leaves without a fight."
+            "stat_trait": "Boldly, s_c follows the pawprints to a trespassing rogue, and confronts them. Fur puffed up and scowling, the patrol demands the rogue leave c_n territory. Intimidated by their confidence and the number of cats, the rogue gives in and leaves without a fight."
         },
         "fail_text": {
             "unscathed_common": "It turns out they were r_c's own pawprints... r_c huffs with embarrassment, and can't meet the eyes of the rest of the patrol.",
@@ -1563,7 +1563,7 @@
         },
         "fail_text": {
             "unscathed_common": "It turns out they were app1's own pawprints... app1 huffs with embarrassment, and can't meet the eyes of the rest of the patrol. They don't want to look dumb in front of other cats.",
-            "unscathed_stat": "Boldy, s_c follows the pawprints to a trespassing rogue, and confronts them. Fur puffed up and scowling, they demand the rogue leaves c_n territory. The rogue is not impressed by the teenager, but with the full patrol backing them up, leaves c_n territory."
+            "unscathed_stat": "Boldly, s_c follows the pawprints to a trespassing rogue, and confronts them. Fur puffed up and scowling, they demand the rogue leaves c_n territory. The rogue is not impressed by the teenager, but with the full patrol backing them up, leaves c_n territory."
         },
         "fail_trait": [
             "ambitious",

--- a/resources/dicts/relationship_events/normal_interactions/admiration/increase.json
+++ b/resources/dicts/relationship_events/normal_interactions/admiration/increase.json
@@ -225,6 +225,15 @@
 		"interactions": [
 			"m_c saw r_c show off a skill {PRONOUN/m_c/subject} never knew {PRONOUN/r_c/subject} had.",
 			"m_c is wowed by how bravely r_c fought the other day."
+		],
+		"random_status_constraint": [
+			"warrior",
+			"apprentice",
+			"mediator apprentice",
+			"medicine cat apprentice",
+            "medicine cat",
+            "deputy",
+            "leader"
 		]
 	},
 	{

--- a/resources/dicts/relationship_events/normal_interactions/platonic/increase.json
+++ b/resources/dicts/relationship_events/normal_interactions/platonic/increase.json
@@ -105,7 +105,7 @@
 		"id": "platonic_inc_med8",
 		"interactions": [
 			"r_c is playing tag with m_c.",
-			"r_c bats a bit of fluff in front of m_c and gets {PRONOUN/m_c/subject} to play a game."
+			"r_c bats a bit of fluff in front of m_c and gets {PRONOUN/m_c/object} to play a game."
 		],
 		"random_trait_constraint": [
 			"playful"

--- a/resources/dicts/relationship_events/welcoming_events/general.json
+++ b/resources/dicts/relationship_events/welcoming_events/general.json
@@ -3,14 +3,14 @@
 		"id": "gen1",
 		"interactions":[
 			"m_c is welcoming r_c.",
-			"m_c sees r_c arrive in the Clan and offers {PRONOUN/r_c/object} to show {PRONOUN/r_c/object} around.",
+			"m_c sees r_c arrive in the Clan and {PRONOUN/m_c/subject} {VERB/m_c/offer/offers} to show {PRONOUN/r_c/object} around.",
 			"m_c asks r_c if {PRONOUN/r_c/subject} could use some help getting introduced to the other Clan members."
 		]
 	},
   { 
 		"id": "gen2",
 		"interactions":[
-			"m_c offers r_c some feathers as a welcome gift, that {PRONOUN/r_c/subject} can use to decorate {PRONOUN/r_c/poss} new nest.",
+			"m_c offers r_c some feathers as a welcome gift that {PRONOUN/r_c/subject} can use to decorate {PRONOUN/r_c/poss} new nest.",
 			"m_c offers r_c some tips for building a new nest."
 		],
 		"reaction_random_cat": {

--- a/resources/dicts/thoughts/alive/alive_outside/former_Clancat.json
+++ b/resources/dicts/thoughts/alive/alive_outside/former_Clancat.json
@@ -5,10 +5,10 @@
             "Thinks about {PRONOUN/m_c/poss} former clanmates forlornly",
             "Wonders if StarClan still watches over {PRONOUN/m_c/object}",
             "Feels conflicted about hunting in another cat's territory",
-            "Wonders if they could start {PRONOUN/m_c/poss} own Clan",
+            "Wonders if {PRONOUN/m_c/subject} could start {PRONOUN/m_c/poss} own Clan",
             "Thinks wistfully about the Warrior Code",
             "Is glad for {PRONOUN/m_c/poss} sharp hunting skills",
-            "Wishes they had other cats to help protect {PRONOUN/m_c/object}",
+            "Wishes {PRONOUN/m_c/subject} had other cats to help protect {PRONOUN/m_c/object}",
             "Dreams of sleeping in a crowded den",
             "Listens for the alarm calls of birds",
             "Quickly veers away from a fox scent"
@@ -21,7 +21,7 @@
             "Wakes up shaking after a nightmare",
             "Wonders if there's anything left of {PRONOUN/m_c/poss} old Clan",
             "Misses {PRONOUN/m_c/poss} family",
-            "Wishes they could have helped {PRONOUN/m_c/poss} Clan more"
+            "Wishes {PRONOUN/m_c/subject} could have helped {PRONOUN/m_c/poss} Clan more"
         ],
         "backstory_constraint":{
             "m_c": [

--- a/scripts/cat_relations/relationship.py
+++ b/scripts/cat_relations/relationship.py
@@ -165,7 +165,10 @@ class Relationship():
             effect = f" ({intensity} negative effect)"
 
         interaction_str = interaction_str + effect
-        self.log.append(interaction_str + f" - {self.cat_from.name} was {self.cat_from.moons} moon(s) old")
+        if self.cat_from.moons == 1:
+            self.log.append(interaction_str + f" - {self.cat_from.name} was {self.cat_from.moons} moon old")
+        else:
+            self.log.append(interaction_str + f" - {self.cat_from.name} was {self.cat_from.moons} moons old")
         relevant_event_tabs = ["relation", "interaction"]
         if self.chosen_interaction.get_injuries:
             relevant_event_tabs.append("health")

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -1693,10 +1693,10 @@ class Events:
             return True
 
         # chance to die of old age
-        age_change = game.config["death_related"]["old_age_death_chance"]
+        age_chance = game.config["death_related"]["old_age_death_chance"]
         age_start = game.config["death_related"]["old_age_death_start"]
         if cat.moons > int(
-                random.random() * age_change) + age_start:  # cat.moons > 150 <--> 200
+                random.random() * age_chance) + age_start:  # cat.moons > 150 <--> 200
             
             self.death_events.handle_deaths(cat, other_cat, game.clan.war.get("at_war", False),
                                             enemy_clan, alive_kits)

--- a/scripts/events_module/condition_events.py
+++ b/scripts/events_module/condition_events.py
@@ -189,10 +189,10 @@ class Condition_Events():
                                                                    other_clan_name, game.clan, other_cat_rc = other_cat)
                             if cat.status == 'leader' and 'lead_death' in injury_event.history_text:
                                 possible_death = history_text_adjust(injury_event.history_text['lead_death'],
-                                                                    other_clan_name, game.clan)
+                                                                    other_clan_name, game.clan, other_cat_rc = other_cat)
                             elif cat.status != 'leader' and 'reg_death' in injury_event.history_text:
                                 possible_death = history_text_adjust(injury_event.history_text['reg_death'],
-                                                                    other_clan_name, game.clan)
+                                                                    other_clan_name, game.clan, other_cat_rc = other_cat)
 
                             if possible_scar or possible_death:
                                 self.history.add_possible_history(cat, injury_event.injury, scar_text=possible_scar, 

--- a/scripts/events_module/new_cat_events.py
+++ b/scripts/events_module/new_cat_events.py
@@ -8,6 +8,7 @@ from scripts.events_module.generate_events import GenerateEvents
 from scripts.utility import event_text_adjust, change_clan_relations, change_relationship_values, create_new_cat
 from scripts.game_structure.game_essentials import game
 from scripts.event_class import Single_Event
+from scripts.cat.history import History
 
 
 # ---------------------------------------------------------------------------- #
@@ -65,6 +66,8 @@ class NewCatEvents:
 
                 # takes cat out of the outside cat list
                 game.clan.add_to_clan(outside_cat)
+                history = History()
+                history.add_beginning(outside_cat)
 
                 return [outside_cat]
 

--- a/scripts/events_module/relationship/pregnancy_events.py
+++ b/scripts/events_module/relationship/pregnancy_events.py
@@ -645,10 +645,10 @@ class Pregnancy_Events():
                 # No parents provided, give a blood parent - this is an adoption. 
                 if not blood_parent:
                     # Generate a blood parent if we haven't already. 
-                    insert = "their kits"
+                    insert = "their kits are"
                     if kits_amount == 1:
-                        insert = "their kit"
-                    thought = f"Is glad that {insert} are safe"
+                        insert = "their kit is"
+                    thought = f"Is glad that {insert} safe"
                     blood_parent = create_new_cat(Cat, Relationship,
                                                 status=random.choice(["loner", "kittypet"]),
                                                 alive=False,

--- a/scripts/events_module/relationship/romantic_events.py
+++ b/scripts/events_module/relationship/romantic_events.py
@@ -152,11 +152,11 @@ class Romantic_Events():
         ))
 
         # now add the age of the cats before the string is sent to the cats' relationship logs
-        relationship.log.append(interaction_str + f" - {cat_from.name} was {cat_from.moons} moon(s) old")
+        relationship.log.append(interaction_str + f" - {cat_from.name} was {cat_from.moons} moons old")
 
         if not relationship.opposite_relationship and cat_from.ID != cat_to.ID:
             relationship.link_relationship()
-            relationship.opposite_relationship.log.append(interaction_str + f" - {cat_to.name} was {cat_to.moons} moon(s) old")
+            relationship.opposite_relationship.log.append(interaction_str + f" - {cat_to.name} was {cat_to.moons} moons old")
 
         #print(f"ROMANTIC! {cat_from.name} to {cat_to.name}")
         return True

--- a/scripts/events_module/relationship/romantic_events.py
+++ b/scripts/events_module/relationship/romantic_events.py
@@ -156,7 +156,7 @@ class Romantic_Events():
 
         if not relationship.opposite_relationship and cat_from.ID != cat_to.ID:
             relationship.link_relationship()
-            relationship.opposite_relationship.log.append(interaction_str)
+            relationship.opposite_relationship.log.append(interaction_str + f" - {cat_to.name} was {cat_to.moons} moon(s) old")
 
         #print(f"ROMANTIC! {cat_from.name} to {cat_to.name}")
         return True

--- a/scripts/events_module/relationship/welcoming_events.py
+++ b/scripts/events_module/relationship/welcoming_events.py
@@ -53,12 +53,6 @@ class Welcoming_Events():
         # prepare string for display
         interaction_str = event_text_adjust(Cat, interaction_str, clan_cat, new_cat)
 
-        # add to relationship log
-        if new_cat.ID in clan_cat.relationships:
-            clan_cat.relationships[new_cat.ID].log.append(interaction_str)
-        if clan_cat in new_cat.relationships:
-            new_cat.relationships[clan_cat.ID].log.append(interaction_str)
-
         # influence the relationship
         new_to_clan_cat = game.config["new_cat"]["rel_buff"]["new_to_clan_cat"]
         clan_cat_to_new = game.config["new_cat"]["rel_buff"]["clan_cat_to_new"]
@@ -87,8 +81,15 @@ class Welcoming_Events():
 
         # add it to the event list
         game.cur_events_list.append(Single_Event(
-            interaction_str, ["relation", "interaction"], [new_cat.ID, clan_cat.ID]
-        ))
+            interaction_str, ["relation", "interaction"], [new_cat.ID, clan_cat.ID]))
+
+        # add to relationship logs
+        if new_cat.ID in clan_cat.relationships:
+            clan_cat.relationships[new_cat.ID].log.append(interaction_str + f" - {clan_cat.name} was {clan_cat.moons} moon(s) old")
+        if clan_cat.ID in new_cat.relationships:
+            new_cat.relationships[clan_cat.ID].log.append(interaction_str + f" - {new_cat.name} was {new_cat.moons} moon(s) old")
+
+
 
     def filter_welcome_interactions(self, welcome_interactions : list, new_cat: Cat) -> list:
         """Filter welcome events based on states.

--- a/scripts/events_module/relationship/welcoming_events.py
+++ b/scripts/events_module/relationship/welcoming_events.py
@@ -85,11 +85,18 @@ class Welcoming_Events():
 
         # add to relationship logs
         if new_cat.ID in clan_cat.relationships:
-            clan_cat.relationships[new_cat.ID].log.append(interaction_str + f" - {clan_cat.name} was {clan_cat.moons} moon(s) old")
+            if clan_cat.age == 1:
+                clan_cat.relationships[new_cat.ID].log.append(interaction_str + f" - {clan_cat.name} was {clan_cat.moons} moons old")
+            else:
+                clan_cat.relationships[new_cat.ID].log.append(interaction_str + f" - {clan_cat.name} was {clan_cat.moons} moons old")
+
+            new_cat.relationships[clan_cat.ID].link_relationship()
+
         if clan_cat.ID in new_cat.relationships:
-            new_cat.relationships[clan_cat.ID].log.append(interaction_str + f" - {new_cat.name} was {new_cat.moons} moon(s) old")
-
-
+            if new_cat.age == 1:
+                new_cat.relationships[clan_cat.ID].log.append(interaction_str + f" - {new_cat.name} was {new_cat.moons} moon old")
+            else:
+                new_cat.relationships[clan_cat.ID].log.append(interaction_str + f" - {new_cat.name} was {new_cat.moons} moons old")
 
     def filter_welcome_interactions(self, welcome_interactions : list, new_cat: Cat) -> list:
         """Filter welcome events based on states.

--- a/scripts/screens/event_screens.py
+++ b/scripts/screens/event_screens.py
@@ -752,6 +752,7 @@ class EventsScreen(Screens):
         self.ceremony_events = [x for x in game.cur_events_list if "ceremony" in x.types]
         self.birth_death_events = [x for x in game.cur_events_list if "birth_death" in x.types]
         self.relation_events = [x for x in game.cur_events_list if "relation" in x.types]
+        self.health_events = [x for x in game.cur_events_list if "health" in x.types]
         self.other_clans_events = [x for x in game.cur_events_list if "other_clans" in x.types]
         self.misc_events = [x for x in game.cur_events_list if "misc" in x.types]
 


### PR DESCRIPTION
- Outside cats recruited to the Clan will now have the moon they joined saved properly to their history
- "health" events will now display properly after saving, exiting, and reloading the game
- Tweaked event age text: "moon(s)" -> "moon" if 1, otherwise "moons" (romantic events always say "moons")
- Added age in moons to welcoming event relationship log text
- Small text fix for the thoughts of generated "dead bloodparents" when adopting a single kit
- Fixed pronoun tag in ceremony text
- Fixed a patrol (pln_bord_abandontwoleg2) not killing the cat even if you get the death text
- Attempted fix for other cat r_c in death text
- Added constraints to a relationship event to keep it from firing on kits (no, the 1 moon old kit didn't impress you with their fighting skill!)