### PR TITLE
Game config setting for relationship and dead cat sorting

### DIFF
--- a/resources/game_config.json
+++ b/resources/game_config.json
@@ -73,10 +73,12 @@
 		"chance_for_neutral": 10,
 		"chance_of_special_group": 8,
 		"chance_romantic_not_mate": 15,
+        "sort_by_rel_total": false,
 		"comment":[
 			"chance_for_neutral - how high the chance is to make the interaction of the relationship to a 'neutral' instead of negative or positive",
 			"chance_of_special_group - 1/chance often when a group event is happening not all cats are considered, only a special group, which is defined in group_types.json",
-			"chance_romantic_not_mate - the base chance of an romantic interaction with another cat, when a cat has a mate"
+			"chance_romantic_not_mate - the base chance of an romantic interaction with another cat, when a cat has a mate",
+            "sort_by_rel_total - sort a cat's relationships by the sum of their values. If False, they will be sorted in the order they were added."
 		]
 	},
 	"mates":{

--- a/resources/game_config.json
+++ b/resources/game_config.json
@@ -73,12 +73,10 @@
 		"chance_for_neutral": 10,
 		"chance_of_special_group": 8,
 		"chance_romantic_not_mate": 15,
-        "sort_by_rel_total": true,
 		"comment":[
 			"chance_for_neutral - how high the chance is to make the interaction of the relationship to a 'neutral' instead of negative or positive",
 			"chance_of_special_group - 1/chance often when a group event is happening not all cats are considered, only a special group, which is defined in group_types.json",
-			"chance_romantic_not_mate - the base chance of an romantic interaction with another cat, when a cat has a mate",
-            "sort_by_rel_total - sort a cat's relationships by the sum of their values. If false, they will be sorted in the order they were added."
+			"chance_romantic_not_mate - the base chance of an romantic interaction with another cat, when a cat has a mate"
 		]
 	},
 	"mates":{
@@ -352,6 +350,14 @@
 	},
 	"save_load": {
 		"load_integrity_checks": true
+	},
+	"sorting": {
+		"sort_dead_by_death": false,
+        "sort_by_rel_total": true,
+		"comment": [
+			"sort_by_death - true: the age filter will sort dead cats in the order they died; false: it sorts dead cats in the order they were born. Ranked sorting always sorts by death regardless.",
+            "sort_by_rel_total - true: sort a cat's relationships by the sum of their values; false: they will be sorted in the order they were added."
+		]
 	},
 	"fun": {
 		"april_fools": false,

--- a/resources/game_config.json
+++ b/resources/game_config.json
@@ -73,7 +73,7 @@
 		"chance_for_neutral": 10,
 		"chance_of_special_group": 8,
 		"chance_romantic_not_mate": 15,
-        "sort_by_rel_total": false,
+        "sort_by_rel_total": true,
 		"comment":[
 			"chance_for_neutral - how high the chance is to make the interaction of the relationship to a 'neutral' instead of negative or positive",
 			"chance_of_special_group - 1/chance often when a group event is happening not all cats are considered, only a special group, which is defined in group_types.json",

--- a/resources/game_config.json
+++ b/resources/game_config.json
@@ -78,7 +78,7 @@
 			"chance_for_neutral - how high the chance is to make the interaction of the relationship to a 'neutral' instead of negative or positive",
 			"chance_of_special_group - 1/chance often when a group event is happening not all cats are considered, only a special group, which is defined in group_types.json",
 			"chance_romantic_not_mate - the base chance of an romantic interaction with another cat, when a cat has a mate",
-            "sort_by_rel_total - sort a cat's relationships by the sum of their values. If False, they will be sorted in the order they were added."
+            "sort_by_rel_total - sort a cat's relationships by the sum of their values. If false, they will be sorted in the order they were added."
 		]
 	},
 	"mates":{

--- a/resources/game_config.json
+++ b/resources/game_config.json
@@ -352,7 +352,7 @@
 		"load_integrity_checks": true
 	},
 	"sorting": {
-		"sort_dead_by_death": false,
+		"sort_dead_by_death": true,
         "sort_by_rel_total": true,
 		"comment": [
 			"sort_by_death - true: the age filter will sort dead cats in the order they died; false: it sorts dead cats in the order they were born. Ranked sorting always sorts by death regardless.",

--- a/resources/game_config.json
+++ b/resources/game_config.json
@@ -352,7 +352,7 @@
 		"load_integrity_checks": true
 	},
 	"sorting": {
-		"sort_dead_by_death": true,
+		"sort_dead_by_death": false,
         "sort_by_rel_total": true,
 		"comment": [
 			"sort_by_death - true: the age filter will sort dead cats in the order they died; false: it sorts dead cats in the order they were born. Ranked sorting always sorts by death regardless.",

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -2697,10 +2697,13 @@ class Cat():
         """Returns the dead_for moons rather than the age for dead cats, so dead cats are sorted by how long
         they have been dead, rather than age at death"""
         if cat.dead:
-            if game.sort_type == "rank":
-                return cat.dead_for
+            if game.config["sorting"]["sort_dead_by_death"]:
+                if game.sort_type == "rank":
+                    return cat.dead_for
+                else:
+                    return cat.dead_for + cat.moons
             else:
-                return cat.dead_for + cat.moons
+                return cat.dead_for
         else:
             return cat.moons
         

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -2698,12 +2698,12 @@ class Cat():
         they have been dead, rather than age at death"""
         if cat.dead:
             if game.config["sorting"]["sort_dead_by_death"]:
+                return cat.dead_for
+            else:
                 if game.sort_type == "rank":
                     return cat.dead_for
                 else:
                     return cat.dead_for + cat.moons
-            else:
-                return cat.dead_for
         else:
             return cat.moons
         

--- a/scripts/screens/relation_screens.py
+++ b/scripts/screens/relation_screens.py
@@ -2328,7 +2328,9 @@ class RelationshipScreen(Screens):
 
         # Keep a list of all the relations
         if game.config["relationship"]["sort_by_rel_total"]:
-            self.all_relations = sorted(self.the_cat.relationships.values(), key=lambda x: sum(map(abs, [x.romantic_love, x.platonic_like, x.dislike, x.admiration, x.comfortable, x.jealousy, x.trust])), reverse=True)
+            self.all_relations = sorted(self.the_cat.relationships.values(),
+                                        key=lambda x: sum(map(abs, [x.romantic_love, x.platonic_like, x.dislike, x.admiration, x.comfortable, x.jealousy, x.trust])),
+                                        reverse=True)
         else:
             self.all_relations = list(self.the_cat.relationships.values()).copy()
 

--- a/scripts/screens/relation_screens.py
+++ b/scripts/screens/relation_screens.py
@@ -2327,7 +2327,7 @@ class RelationshipScreen(Screens):
         self.inspect_cat = None
 
         # Keep a list of all the relations
-        if game.config["relationship"]["sort_by_rel_total"]:
+        if game.config["sorting"]["sort_by_rel_total"]:
             self.all_relations = sorted(self.the_cat.relationships.values(),
                                         key=lambda x: sum(map(abs, [x.romantic_love, x.platonic_like, x.dislike, x.admiration, x.comfortable, x.jealousy, x.trust])),
                                         reverse=True)

--- a/scripts/screens/relation_screens.py
+++ b/scripts/screens/relation_screens.py
@@ -2327,7 +2327,10 @@ class RelationshipScreen(Screens):
         self.inspect_cat = None
 
         # Keep a list of all the relations
-        self.all_relations = sorted(self.the_cat.relationships.values(), key=lambda x: sum(map(abs, [x.romantic_love, x.platonic_like, x.dislike, x.admiration, x.comfortable, x.jealousy, x.trust])), reverse=True)
+        if game.config["relationship"]["sort_by_rel_total"]:
+            self.all_relations = sorted(self.the_cat.relationships.values(), key=lambda x: sum(map(abs, [x.romantic_love, x.platonic_like, x.dislike, x.admiration, x.comfortable, x.jealousy, x.trust])), reverse=True)
+        else:
+            self.all_relations = list(self.the_cat.relationships.values()).copy()
 
         self.focus_cat_elements["header"] = pygame_gui.elements.UITextBox(str(self.the_cat.name) + " Relationships",
                                                                           scale(pygame.Rect((150, 150), (800, 100))),


### PR DESCRIPTION
- Now there will be a setting in game_config.json, **sort_by_rel_total**, to set if relationships are sorted by total values or time
- Also added an option, **sort_dead_by_death**, to sort dead cats by death instead of total age (birth) when using the "age" filter (either way, it still sorts by death when using the "rank" filter)

sort_dead_by_death is just a temporary solution until I can add a new filter option to sort by death!