### PR TITLE
Grief Tweaks

### DIFF
--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -544,8 +544,7 @@ class Cat():
                 grief_type = "minor" if int(random() * major_chance) else "major"
             elif high_values:
                 
-                # If this triggers, the cat is only eligable for minor grief
-                
+                # If this triggers, the cat can only get minor grief
                 grief_type = "minor"
                 
             if grief_type == "major":
@@ -604,7 +603,10 @@ class Cat():
                     )
                 
                 text = event_text_adjust(Cat, choice(possible_strings), self, cat)
-                Cat.grief_strings[cat.ID] = (text, (self.ID, cat.ID), "negative")
+                if cat.ID not in Cat.grief_strings:
+                    Cat.grief_strings[cat.ID] = []
+                
+                Cat.grief_strings[cat.ID].append((text, (self.ID, cat.ID), grief_type))
                 
 
     def familial_grief(self, living_cat: Cat):

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -606,7 +606,7 @@ class Cat():
                 if cat.ID not in Cat.grief_strings:
                     Cat.grief_strings[cat.ID] = []
                 
-                Cat.grief_strings[cat.ID].append((text, (self.ID, cat.ID), grief_type))
+                Cat.grief_strings[cat.ID].append((text, (self.ID, cat.ID), "negative"))
                 
 
     def familial_grief(self, living_cat: Cat):

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -510,7 +510,7 @@ class Cat():
                 possible_strings.extend(
                     self.generate_events.possible_death_reactions(family_relation, "platonic", cat.personality.trait,
                                                                   body_status)
-                 )proformant
+                 )
             
             if to_self.admiration > 70:
                 possible_strings.extend(

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -465,7 +465,7 @@ class Cat():
             if fetched_cat:
                 fetched_cat.update_mentor()
         self.update_mentor()
-
+    
     def grief(self, body: bool):
         """
         compiles grief moon event text
@@ -474,20 +474,10 @@ class Cat():
             body_status = 'body'
         else:
             body_status = 'no_body'
-
-        # major, cat won't patrol
-        grief_major = [
-            'loving', 'compassionate', 'empathetic', 'insecure', 'lonesome', 'nervous'
-        ]
-        # minor, cat will patrol
-        grief_minor = [
-            'daring', 'cold', 'bold', 'ambitious', 'bloodthirsty', 'responsible', 'loyal', 'strict', 'vengeful'
-        ]
-
-        text = None
-
-        
-        
+    
+        # Keep track is the body was treated with rosemary. 
+        body_treated = False
+    
         # apply grief to cats with high positive relationships to dead cat
         for cat in Cat.all_cats.values():
             if cat.dead or cat.outside or cat.moons < 1:
@@ -497,98 +487,124 @@ class Cat():
             if not isinstance(to_self, Relationship):
                 continue
             
-            possible_strings = []
+            
+            # FIRST, MAJOR GRIEF, which results in it's own message and the 
+            # condition. It also has a chance to "fail" to minor grief. 
+            
             family_relation = self.familial_grief(living_cat=cat)
+            very_high_values = []
+            high_values = []
             
             if to_self.romantic_love > 55:
-                possible_strings.extend(
-                    self.generate_events.possible_death_reactions(family_relation, "romantic", cat.personality.trait,
-                                                                  body_status)
-                 )
+                very_high_values.append("romantic")
+            if to_self.romantic_love > 20:
+                high_values.append("romantic")
             
             if to_self.platonic_like > 50:
-                possible_strings.extend(
-                    self.generate_events.possible_death_reactions(family_relation, "platonic", cat.personality.trait,
-                                                                  body_status)
-                 )
+                very_high_values.append("platonic")
+            if to_self.platonic_like > 15:
+                high_values.append("platonic")
             
             if to_self.admiration > 70:
-                possible_strings.extend(
-                    self.generate_events.possible_death_reactions(family_relation, "admiration", cat.personality.trait,
-                                                                  body_status)
-                 )
+                very_high_values.append("admiration")
+            if to_self.admiration > 30:
+                high_values.append("admiration")
                 
             if to_self.comfortable > 60:
-                possible_strings.extend(
-                    self.generate_events.possible_death_reactions(family_relation, "comfort", cat.personality.trait,
-                                                                  body_status)
-                 )
+                very_high_values.append("comfort")
+            if to_self.comfortable > 30:
+                high_values.append("comfort")
                 
             if to_self.trust > 70:
-                possible_strings.extend(
-                    self.generate_events.possible_death_reactions(family_relation, "trust", cat.personality.trait,
-                                                                  body_status)
-                 )
+                very_high_values.append("trust")
+            if to_self.trust > 30:
+                high_values.append("trust")
             
-            if possible_strings:
-                # choose string
-                text = [choice(possible_strings)]
-
-                # check if the cat will get Major or Minor severity for grief
-                weights = [1, 1]
-                if cat.personality.trait in grief_major:
-                    weights = [3, 1]
-                if cat.personality.trait in grief_minor:
-                    weights = [1, 3]
-                if "rosemary" in game.clan.herbs:  # decrease major grief chance if grave herbs are used
-                    weights = [1, 6]
-                    amount_used = choice([1, 2])
-                    game.clan.herbs["rosemary"] -= amount_used
+            
+            grief_type = None
+            if very_high_values:
+                # major grief eligable cats. 
+                
+                major_chance = 3
+                if cat.personality.stability < 8:
+                    major_chance -= 1
+                
+                # decrease major grief chance if grave herbs are used
+                if not body_treated and "rosemary" in game.clan.herbs:  
+                    body_treated = True
+                    game.clan.herbs["rosemary"] -= 1
                     if game.clan.herbs["rosemary"] <= 0:
                         game.clan.herbs.pop("rosemary")
-                    if f"Rosemary was used for {self.name}'s body." not in game.herb_events_list:
-                        game.herb_events_list.append(f"Rosemary was used for {self.name}'s body.")
-
-                severity = choices(['major', 'minor'], weights=weights, k=1)
-                # give the cat the relevant severity text
-                severity = severity[0]
-                if severity == 'major':
-                    text.append(choice(
-                        MINOR_MAJOR_REACTION["major"]
-                    ))
-                elif severity == 'minor':
-                    text.append(choice(
-                        MINOR_MAJOR_REACTION["minor"]
-                    ))
-
-                #Generate the event:
-                event = event_text_adjust(Cat, ' '.join(text), self, cat)
-                Cat.grief_strings[cat.ID] = (event, (self.ID, cat.ID))
+                    game.herb_events_list.append(f"Rosemary was used for {self.name}'s body.")
+                
+                if body_treated:
+                    major_chance -= 1
+                
+                # Chance for a cat with major grief to fail to minor    
+                grief_type = "minor" if int(random() * major_chance) else "major"
+            elif high_values:
+                
+                # If this triggers, the cat is only eligable for minor grief
+                
+                grief_type = "minor"
+                
+            if grief_type == "major":
+                possible_strings = []
+                for x in high_values:
+                    possible_strings.extend(
+                        self.generate_events.possible_death_reactions(family_relation, x, cat.personality.trait,
+                                                                body_status)
+                    )
+                
+                text = [choice(possible_strings)]
+                text.append(choice(
+                    MINOR_MAJOR_REACTION["major"]
+                ))
+                text = event_text_adjust(Cat, ' '.join(text), self, cat)
                 
                 # grief the cat
                 if game.clan.game_mode != 'classic':
-                    cat.get_ill("grief stricken", event_triggered=True, severity=severity)
-
+                    cat.get_ill("grief stricken", event_triggered=True, severity="major")
+            elif grief_type == "minor":
                 
+                # These minor grief message will be applied as throughts. 
+                minor_grief_messages = (
+                        "Tells a fond story at r_c's vigil",
+                        "Bargins with StarClan, begging them to send r_c back",
+                        "Sat all night at r_c's vigil",
+                        "Helped bury r_c, bringing {PRONOUN/r_c/poss} favorite prey to leave at the grave"
+                    )
+                
+                text = choice(minor_grief_messages)
+                
+            if grief_type:
+                #Generate the event:
+                if cat.ID not in Cat.grief_strings:
+                    Cat.grief_strings[cat.ID] = []
+                
+                Cat.grief_strings[cat.ID].append((text, (self.ID, cat.ID), grief_type))
                 continue
             
             
+            # Negative "grief" messages are just for flavor. 
+            possible_strings = []
             if to_self.dislike > 50:
-                possible_strings.extend(
-                    self.generate_events.possible_death_reactions(family_relation, "dislike", cat.personality.trait,
-                                                                  body_status)
-                 )
+                high_values.append("dislike")
                 
             if to_self.jealousy > 50:
-                possible_strings.extend(
-                    self.generate_events.possible_death_reactions(family_relation, "jealousy", cat.personality.trait,
-                                                                  body_status)
-                 )
+                high_values.append("jealousy")
             
-            if possible_strings:
+            if high_values:
                 #Generate the event:
-                event = event_text_adjust(Cat, choice(possible_strings), self, cat)
-                Cat.grief_strings[cat.ID] = (event, (self.ID, cat.ID))
+                possible_strings = []
+                for x in high_values:
+                    possible_strings.extend(
+                        self.generate_events.possible_death_reactions(family_relation, x, cat.personality.trait,
+                                                                body_status)
+                    )
+                
+                text = event_text_adjust(Cat, choice(possible_strings), self, cat)
+                Cat.grief_strings[cat.ID] = (text, (self.ID, cat.ID), "negative")
                 
 
     def familial_grief(self, living_cat: Cat):

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -602,7 +602,6 @@ class Cat():
                 #Generate the event:
                 possible_strings = []
                 for x in high_values:
-                    possible_strings = []
                     possible_strings.extend(
                         self.generate_events.possible_death_reactions(family_relation, x, cat.personality.trait,
                                                                 body_status)

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -592,6 +592,8 @@ class Cat():
             
             
             # Negative "grief" messages are just for flavor. 
+            high_values = []
+            very_high_values = []
             if to_self.dislike > 50:
                 high_values.append("dislike")
                 

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -540,7 +540,7 @@ class Cat():
                 if body_treated:
                     major_chance -= 1
                 
-                # Chance for a cat with major grief to fail to minor    
+                # Chance for a cat with major grief to fail to minor.    
                 grief_type = "minor" if int(random() * major_chance) else "major"
             elif high_values:
                 
@@ -549,11 +549,15 @@ class Cat():
                 
             if grief_type == "major":
                 possible_strings = []
-                for x in high_values:
+                for x in very_high_values:
                     possible_strings.extend(
                         self.generate_events.possible_death_reactions(family_relation, x, cat.personality.trait,
                                                                 body_status)
                     )
+                
+                if not possible_strings:
+                    print("No grief strings")
+                    return
                 
                 text = [choice(possible_strings)]
                 text.append(choice(
@@ -568,10 +572,14 @@ class Cat():
                 
                 # These minor grief message will be applied as throughts. 
                 minor_grief_messages = (
-                        "Tells a fond story at r_c's vigil",
+                        "Told a fond story at r_c's vigil",
                         "Bargins with StarClan, begging them to send r_c back",
                         "Sat all night at r_c's vigil",
-                        "Helped bury r_c, bringing {PRONOUN/r_c/poss} favorite prey to leave at the grave"
+                        "Helped bury r_c, leaving {PRONOUN/r_c/poss} favorite prey at the grave",
+                        "Will never forget r_c",
+                        "Prays that r_c is safe in StarClan",
+                        "Misses the warmth that r_c brought to {PRONOUN/m_c/poss} life",
+                        "Is mourning r_c"
                     )
                 
                 text = choice(minor_grief_messages)

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -557,13 +557,11 @@ class Cat():
                 
                 if not possible_strings:
                     print("No grief strings")
-                    return
+                    continue
                 
-                text = [choice(possible_strings)]
-                text.append(choice(
-                    MINOR_MAJOR_REACTION["major"]
-                ))
-                text = event_text_adjust(Cat, ' '.join(text), self, cat)
+                text = choice(possible_strings)
+                text += ' ' + choice(MINOR_MAJOR_REACTION["major"])
+                text = event_text_adjust(Cat, text, self, cat)
                 
                 # grief the cat
                 if game.clan.game_mode != 'classic':
@@ -594,7 +592,6 @@ class Cat():
             
             
             # Negative "grief" messages are just for flavor. 
-            possible_strings = []
             if to_self.dislike > 50:
                 high_values.append("dislike")
                 
@@ -605,6 +602,7 @@ class Cat():
                 #Generate the event:
                 possible_strings = []
                 for x in high_values:
+                    possible_strings = []
                     possible_strings.extend(
                         self.generate_events.possible_death_reactions(family_relation, x, cat.personality.trait,
                                                                 body_status)

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -145,29 +145,28 @@ class Events:
 
         # Handle grief events.
         if Cat.grief_strings:
-            remove_cats = []
-            death_report_cats = []
-
             # Grab all the dead or outside cats, who should not have grief text
-            for ID in Cat.grief_strings:
+            for ID in Cat.grief_strings.copy():
                 check_cat = Cat.all_cats.get(ID)
-                if check_cat:
+                if isinstance(check_cat, Cat):
                     if check_cat.dead or check_cat.outside:
-                        remove_cats.append(check_cat.ID)
-                    else:
-                        death_report_cats.append(check_cat.ID)
-
-            # Remove the dead or outside cats
-            for ID in remove_cats:
-                if ID in Cat.grief_strings:
-                    Cat.grief_strings.pop(ID)
+                        Cat.grief_strings.pop(ID)
 
             # Generate events
-            for item in Cat.grief_strings.values():
-                game.cur_events_list.append(
-                    Single_Event(item[0], ["birth_death", "relation"],
-                                 item[1]))
-
+            
+            for cat_id, values in Cat.grief_strings.items():
+                for _val in values:
+                    if _val[2] == "minor":
+                        # Apply the grief message as a thought to the cat
+                        text = event_text_adjust(Cat, _val[0], Cat.fetch_cat(cat_id), Cat.fetch_cat(_val[1][0]))
+                        Cat.fetch_cat(cat_id).thought = text
+                    else:
+                        game.cur_events_list.append(
+                            Single_Event(_val[0], ["birth_death", "relation"],
+                                        _val[1]))
+            
+            
+                
             Cat.grief_strings.clear()
 
         if Cat.dead_cats:


### PR DESCRIPTION
- Improve the performance of grief a bit. Might help in large clans. 
- Experimental grief changes - these are still being considered. Minor grief (ie, grief that doesn't prevent a cat from working) is no longer a condition, nor does it give a grief message. Rather, instead of a grief message, cats who would get minor grief get a special grief thought, which is assigned at moon-skip. There are only a handful right now, it's still experimental. 
- The relationship requirements for minor grief thoughts is much lower than for major grief. 