### PR TITLE
Final (?) fix for cat sprite layering issues

### DIFF
--- a/scripts/game_structure/image_button.py
+++ b/scripts/game_structure/image_button.py
@@ -77,7 +77,7 @@ class UISpriteButton():
         self.image.disable()
         # The transparent button. This a subclass that UIButton that also hold the cat_id.
         self.button = CatButton(relative_rect, visible=visible, cat_id=cat_id, cat_object=cat_object,
-                                starting_height=starting_height+1, manager=manager, tool_tip_text=tool_tip_text,
+                                starting_height=starting_height, manager=manager, tool_tip_text=tool_tip_text,
                                 container=container)
 
     def return_cat_id(self):

--- a/scripts/game_structure/windows.py
+++ b/scripts/game_structure/windows.py
@@ -44,14 +44,15 @@ class SaveCheck(UIWindow):
         self.last_screen = last_screen
         self.isMainMenu = isMainMenu
         self.mm_btn = mm_btn
-
+        #adding a variable for starting_height to make sure that this menu is always on top
+        top_stack_menu_layer_height = 10000
         if (self.isMainMenu):
             self.mm_btn.disable()
             self.main_menu_button = UIImageButton(
                 scale(pygame.Rect((146, 310), (305, 60))),
                 "",
                 object_id="#main_menu_button",
-                starting_height=2,
+                starting_height=top_stack_menu_layer_height,
                 container=self
             )
             self.message = f"Would you like to save your game before exiting to the Main Menu? If you don't, progress may be lost!"
@@ -60,7 +61,7 @@ class SaveCheck(UIWindow):
                 scale(pygame.Rect((146, 310), (305, 60))),
                 "",
                 object_id="#smallquit_button",
-                starting_height=2,
+                starting_height=top_stack_menu_layer_height,
                 container=self
             )
             self.message = f"Would you like to save your game before exiting? If you don't, progress may be lost!"
@@ -76,6 +77,7 @@ class SaveCheck(UIWindow):
         self.save_button = UIImageButton(scale(pygame.Rect((186, 230), (228, 60))),
                                          "",
                                          object_id="#save_button",
+                                         starting_height=top_stack_menu_layer_height,
                                          container=self
                                          )
         self.save_button_saved_state = pygame_gui.elements.UIImage(
@@ -97,6 +99,7 @@ class SaveCheck(UIWindow):
             scale(pygame.Rect((540, 10), (44, 44))),
             "",
             object_id="#exit_window_button",
+            starting_height=menu_layer_height,
             container=self
         )
 

--- a/scripts/game_structure/windows.py
+++ b/scripts/game_structure/windows.py
@@ -99,7 +99,7 @@ class SaveCheck(UIWindow):
             scale(pygame.Rect((540, 10), (44, 44))),
             "",
             object_id="#exit_window_button",
-            starting_height=menu_layer_height,
+            starting_height=top_stack_menu_layer_height,
             container=self
         )
 

--- a/scripts/screens/catlist_screens.py
+++ b/scripts/screens/catlist_screens.py
@@ -130,7 +130,7 @@ class ClanScreen(Screens):
                         UISpriteButton(scale(pygame.Rect(tuple(Cat.all_cats[x].placement), (100, 100))),
                                        Cat.all_cats[x].sprite,
                                        cat_id=x,
-                                       starting_height=0)
+                                       starting_height=i)
                     )
                 except:
                     print(f"ERROR: placing {Cat.all_cats[x].name}\'s sprite on Clan page")


### PR DESCRIPTION
- the main menu/save popup will always be on top of the cat sprites
- returned cat sprite starting_height to i, so you actually click on the cat on top now