### PR TITLE
Death text changes

### DIFF
--- a/scripts/game_structure/windows.py
+++ b/scripts/game_structure/windows.py
@@ -516,6 +516,12 @@ class KillCat(UIWindow):
         game.switches['window_open'] = True
         self.the_cat = cat
         self.take_all = False
+        death_history = History.get_death_or_scars(self.the_cat, death=True)
+        if death_history:
+            death_number = len(death_history)
+        cat_dict = {
+            "m_c": (str(self.the_cat.name), choice(self.the_cat.pronouns))
+        }
         self.back_button = UIImageButton(
             scale(pygame.Rect((840, 10), (44, 44))),
             "",
@@ -576,6 +582,30 @@ class KillCat(UIWindow):
                                                                       manager=MANAGER,
                                                                       container=self)
 
+        elif death_number > 1:
+            self.prompt='This cat died when {PRONOUN/m_c/subject}...'
+            self.initial='{VERB/m_c/were/was} killed by something unknowable to even StarClan'
+            self.prompt_processed = process_text(self.prompt, cat_dict)
+            self.initial_processed = process_text(self.initial, cat_dict)
+            self.all_lives_check.hide()
+            self.one_life_check.hide()
+
+            self.beginning_prompt = pygame_gui.elements.UITextBox(self.prompt_processed,
+                                                                  scale(pygame.Rect((50, 60), (900, 80))),
+                                                                  object_id="#text_box_30_horizleft",
+                                                                  manager=MANAGER,
+                                                                  container=self)
+                                                                  
+            self.death_entry_box = pygame_gui.elements.UITextEntryBox(scale(pygame.Rect((50, 110), (800, 150))),
+                                                                      initial_text=self.initial_processed,
+                                                                      object_id="text_entry_line",
+                                                                      manager=MANAGER,
+                                                                      container=self)
+
+            self.done_button = UIImageButton(scale(pygame.Rect((373, 305), (154, 60))), "",
+                                             object_id="#done_button",
+                                             manager=MANAGER,
+                                             container=self)
         else:
             self.initial = 'It was the will of something even mightier than StarClan that this cat died.'
             self.prompt = None

--- a/scripts/game_structure/windows.py
+++ b/scripts/game_structure/windows.py
@@ -8,6 +8,7 @@ import pygame_gui
 from sys import exit
 from re import sub
 from platform import system
+from random import choice
 import logging
 import subprocess
 
@@ -22,7 +23,7 @@ from scripts.game_structure.game_essentials import game, screen_x, screen_y
 from scripts.game_structure.image_button import UIImageButton, UITextBoxTweaked
 from scripts.housekeeping.progress_bar_updater import UIUpdateProgressBar
 from scripts.housekeeping.update import self_update, UpdateChannel, get_latest_version_number
-from scripts.utility import scale, quit, update_sprite, scale_dimentions, logger
+from scripts.utility import scale, quit, update_sprite, scale_dimentions, logger, process_text
 from scripts.game_structure.game_essentials import game, MANAGER
 from scripts.housekeeping.version import get_version_info
 
@@ -521,6 +522,9 @@ class KillCat(UIWindow):
             object_id="#exit_window_button",
             container=self
         )
+        cat_dict = {
+            "m_c": (str(self.the_cat.name), choice(self.the_cat.pronouns))
+        }
         self.heading = pygame_gui.elements.UITextBox(f"<b>-- How did this cat die? --</b>",
                                                      scale(pygame.Rect((20, 20), (860, 150))),
                                                      object_id="#text_box_30_horizcenter_spacing_95",
@@ -531,7 +535,7 @@ class KillCat(UIWindow):
             (50, 300), (68, 68))),
             "",
             object_id="#unchecked_checkbox",
-            tool_tip_text='If this is checked, the leader will lose all their lives',
+            tool_tip_text = process_text('If this is checked, the leader will lose all {PRONOUN/m_c/poss} lives', cat_dict),
             manager=MANAGER,
             container=self
         )
@@ -539,7 +543,7 @@ class KillCat(UIWindow):
             (50, 300), (68, 68))),
             "",
             object_id="#checked_checkbox",
-            tool_tip_text='If this is checked, the leader will lose all their lives',
+            tool_tip_text = process_text('If this is checked, the leader will lose all {PRONOUN/m_c/poss} lives', cat_dict),
             manager=MANAGER,
             container=self
         )
@@ -549,8 +553,10 @@ class KillCat(UIWindow):
                                              object_id="#done_button",
                                              manager=MANAGER,
                                              container=self)
-            self.prompt = 'This cat died when they...'
-            self.initial = 'were killed by something unknowable to even StarClan'
+            self.prompt='This cat died when {PRONOUN/m_c/subject}...'
+            self.initial='{VERB/m_c/were/was} killed by something unknowable to even StarClan'
+            self.prompt_processed = process_text(self.prompt, cat_dict)
+            self.initial_processed = process_text(self.initial, cat_dict)
 
             self.all_lives_check.hide()
             self.life_text = pygame_gui.elements.UITextBox('Take all the leader\'s lives',
@@ -558,14 +564,14 @@ class KillCat(UIWindow):
                                                            object_id="#text_box_30_horizleft",
                                                            manager=MANAGER,
                                                            container=self)
-            self.beginning_prompt = pygame_gui.elements.UITextBox(self.prompt,
+            self.beginning_prompt = pygame_gui.elements.UITextBox(self.prompt_processed,
                                                                   scale(pygame.Rect((50, 60), (900, 80))),
                                                                   object_id="#text_box_30_horizleft",
                                                                   manager=MANAGER,
                                                                   container=self)
 
             self.death_entry_box = pygame_gui.elements.UITextEntryBox(scale(pygame.Rect((50, 130), (800, 150))),
-                                                                      initial_text=self.initial,
+                                                                      initial_text=self.initial_processed,
                                                                       object_id="text_entry_line",
                                                                       manager=MANAGER,
                                                                       container=self)
@@ -593,14 +599,19 @@ class KillCat(UIWindow):
 
         if event.type == pygame_gui.UI_BUTTON_START_PRESS:
             if event.ui_element == self.done_button:
+                death_text = self.death_entry_box.get_text()
                 if self.the_cat.status == 'leader':
-                    death_message = sub(r"[^A-Za-z0-9<->/()*'&#, ]+", "", self.death_entry_box.get_text())
+                    if death_text.startswith('was'):
+                        death_text = '{VERB/m_c/were/was}' + death_text[3:]
+                    elif death_text.startswith('were'):
+                        death_text = '{VERB/m_c/were/was}' + death_text[4:]
+                    death_message = sub(r"[^A-Za-z0-9<->/.{}()*'&#!?,| ]+_", "", death_text)
                     if self.take_all:
                         game.clan.leader_lives -= 10
                     else:
                         game.clan.leader_lives -= 1
                 else:
-                    death_message = sub(r"[^A-Za-z0-9<->/.()*'&#!?,| ]+", "", self.death_entry_box.get_text())
+                    death_message = sub(r"[^A-Za-z0-9<->/.()*'&#!?,| _]+", "", self.death_entry_box.get_text())
 
                 self.the_cat.die()
                 self.history.add_death(self.the_cat, death_message)

--- a/scripts/screens/cat_screens.py
+++ b/scripts/screens/cat_screens.py
@@ -1408,14 +1408,11 @@ class ProfileScreen(Screens):
                     else:
                         life_text = "lost a life"
                 elif death_number > 1:
-                    print("Non leader")
                     #for retired leaders
                     if index == death_number - 1 and self.the_cat.dead:
                         life_text = "lost {PRONOUN/m_c/poss} last remaining life"
                         # added code
-                        print(text)
                         if "This cat was" in text:
-                            print("test")
                             text = text.replace("This cat was", "{VERB/m_c/were/was}")
                         else:
                             text = text[0].lower() + text[1:]

--- a/scripts/screens/cat_screens.py
+++ b/scripts/screens/cat_screens.py
@@ -1401,8 +1401,24 @@ class ProfileScreen(Screens):
                     if index == death_number - 1 and self.the_cat.dead:
                         if death_number == 9:
                             life_text = "lost {PRONOUN/m_c/poss} final life"
+                        elif death_number == 1:
+                            life_text = "lost all of {PRONOUN/m_c/poss} lives"
                         else:
-                            life_text = "lost {PRONOUN/m_c/poss} final lives"
+                            life_text = "lost the rest of {PRONOUN/m_c/poss} lives"
+                    else:
+                        life_text = "lost a life"
+                elif death_number > 1:
+                    print("Non leader")
+                    #for retired leaders
+                    if index == death_number - 1 and self.the_cat.dead:
+                        life_text = "lost {PRONOUN/m_c/poss} last remaining life"
+                        # added code
+                        print(text)
+                        if "This cat was" in text:
+                            print("test")
+                            text = text.replace("This cat was", "{VERB/m_c/were/was}")
+                        else:
+                            text = text[0].lower() + text[1:]
                     else:
                         life_text = "lost a life"
                 else:
@@ -1427,7 +1443,11 @@ class ProfileScreen(Screens):
                 else:
                     deaths = all_deaths[0]
 
-                text = str(self.the_cat.name) + " " + deaths + "."
+                if not deaths.endswith('.'):
+                    deaths += "."
+
+                text = str(self.the_cat.name) + " " + deaths
+
             else:
                 text = all_deaths[0]
 


### PR DESCRIPTION
**Leader death text changes**:
- If the 9th death: "lost their final life"
- If the only death: "lost all of their lives"
- Otherwise: "lost the rest of their lives"
- Leader death text now works better for retired leaders
- Added code to handle the phrasing incongruency between lead_death and reg_death text for retired leaders that die from a reg_death while having at least one lead_death already (it's not perfect and doesn't cover every case, but this makes it better than it was)

**Custom death changes**:
- Added pronoun tagging to custom deaths, including automatic tagging when using "was" or "were" for the first word
- Retired leaders who have at least one death will have the same default text phrasing as leaders (so it flows better when listing multiple deaths)