### PR TITLE
Fix backstory thoughts

### DIFF
--- a/resources/dicts/thoughts/alive/apprentice.json
+++ b/resources/dicts/thoughts/alive/apprentice.json
@@ -194,9 +194,7 @@
             "Doesn't miss being a rogue",
             "Is happy to be training as a warrior instead of living as a rogue"
         ],
-        "main_backstory_constraint": {
-            "m_c": ["rogue1", "rogue2", "rogue3", "refugee4", "tragedy_survivor2"]
-        }
+        "main_backstory_constraint": ["rogue1", "rogue2", "rogue3", "refugee4", "tragedy_survivor2"]
     },
     {
         "id": "thoughtful_apprentice",

--- a/resources/dicts/thoughts/alive/apprentice.json
+++ b/resources/dicts/thoughts/alive/apprentice.json
@@ -194,7 +194,7 @@
             "Doesn't miss being a rogue",
             "Is happy to be training as a warrior instead of living as a rogue"
         ],
-        "backstory_constraint": {
+        "main_backstory_constraint": {
             "m_c": ["rogue1", "rogue2", "rogue3", "refugee4", "tragedy_survivor2"]
         }
     },

--- a/resources/dicts/thoughts/alive/general.json
+++ b/resources/dicts/thoughts/alive/general.json
@@ -729,7 +729,7 @@
             "mediator apprentice",
             "medicine cat apprentice"
         ],
-        "backstory_constraint": {
+        "main_backstory_constraint": {
             "m_c": ["rogue1", "rogue2", "rogue3", "refugee4", "tragedy_survivor2"]
         },
         "relationship_constraint": [
@@ -749,7 +749,7 @@
             "mediator apprentice",
             "medicine cat apprentice"
         ],
-        "backstory_constraint": {
+        "main_backstory_constraint": {
             "m_c": ["rogue1", "rogue2", "rogue3", "refugee4", "tragedy_survivor2"]
         },
         "random_status_constraint": [
@@ -826,7 +826,7 @@
             "mediator apprentice",
             "medicine cat apprentice"
         ],
-        "backstory_constraint": {
+        "main_backstory_constraint": {
             "m_c": ["rogue1", "rogue2", "rogue3", "refugee4", "tragedy_survivor2"]
         }
     },

--- a/resources/dicts/thoughts/alive/general.json
+++ b/resources/dicts/thoughts/alive/general.json
@@ -729,9 +729,7 @@
             "mediator apprentice",
             "medicine cat apprentice"
         ],
-        "main_backstory_constraint": {
-            "m_c": ["rogue1", "rogue2", "rogue3", "refugee4", "tragedy_survivor2"]
-        },
+        "main_backstory_constraint": ["rogue1", "rogue2", "rogue3", "refugee4", "tragedy_survivor2"],
         "relationship_constraint": [
             "app/mentor"
         ]
@@ -749,9 +747,7 @@
             "mediator apprentice",
             "medicine cat apprentice"
         ],
-        "main_backstory_constraint": {
-            "m_c": ["rogue1", "rogue2", "rogue3", "refugee4", "tragedy_survivor2"]
-        },
+        "main_backstory_constraint": ["rogue1", "rogue2", "rogue3", "refugee4", "tragedy_survivor2"],
         "random_status_constraint": [
             "apprentice"
         ]
@@ -826,9 +822,7 @@
             "mediator apprentice",
             "medicine cat apprentice"
         ],
-        "main_backstory_constraint": {
-            "m_c": ["rogue1", "rogue2", "rogue3", "refugee4", "tragedy_survivor2"]
-        }
+        "main_backstory_constraint": ["rogue1", "rogue2", "rogue3", "refugee4", "tragedy_survivor2"]
     },
     {
         "id": "shameless_apprentice",

--- a/scripts/cat/thoughts.py
+++ b/scripts/cat/thoughts.py
@@ -139,11 +139,11 @@ class Thoughts():
                 return False
 
         if 'main_backstory_constraint' in thought:
-            if main_cat.backstory not in thought['main_backstory_constraint']["m_c"]:
+            if main_cat.backstory not in thought['main_backstory_constraint']:
                 return False
         
         if 'random_backstory_constraint' in thought:
-            if random_cat and random_cat.backstory not in thought['random_backstory_constraint']["r_c"]:
+            if random_cat and random_cat.backstory not in thought['random_backstory_constraint']:
                 return False
 
         # Filter for the living status of the random cat. The living status of the main cat

--- a/scripts/cat/thoughts.py
+++ b/scripts/cat/thoughts.py
@@ -138,10 +138,12 @@ class Thoughts():
             if not _flag:
                 return False
 
-        if 'backstory_constraint' in thought:
-            if main_cat.backstory not in thought['backstory_constraint']["m_c"]:
+        if 'main_backstory_constraint' in thought:
+            if main_cat.backstory not in thought['main_backstory_constraint']["m_c"]:
                 return False
-            if random_cat and random_cat.backstory not in thought['backstory_constraint']["r_c"]:
+        
+        if 'random_backstory_constraint' in thought:
+            if random_cat and random_cat.backstory not in thought['random_backstory_constraint']["r_c"]:
                 return False
 
         # Filter for the living status of the random cat. The living status of the main cat


### PR DESCRIPTION
Backstory constraints for thoughts weren't working properly, since the m_c and r_c sections were not seperated and with a cat with an available backstory thought the game ran into an error due to there not being any thoughts that had a r_c backstory constraint