### PR TITLE
Content: No silent timeskip failures, move and expand loading. 

### DIFF
--- a/scripts/game_structure/propagating_thread.py
+++ b/scripts/game_structure/propagating_thread.py
@@ -1,8 +1,14 @@
 from threading import Thread
+from time import time
 
 class PropagatingThread(Thread):
     """ Thread that catched any exceptions and re-raised them when .join is called. 
-    Taken from https://stackoverflow.com/questions/2829329/catch-a-threads-exception-in-the-caller-thread """
+    Heavily barrowed from https://stackoverflow.com/questions/2829329/catch-a-threads-exception-in-the-caller-thread """
+    
+    def start(self) -> None:
+        self.start_time = time()
+        
+        return super().start()
     
     def run(self):
         self.exc = None
@@ -16,3 +22,7 @@ class PropagatingThread(Thread):
         if self.exc:
             raise self.exc
         return self.ret
+    
+    def get_time_from_start(self):
+        """Returns the time since the tread started"""
+        return time() - self.start_time

--- a/scripts/game_structure/propagating_thread.py
+++ b/scripts/game_structure/propagating_thread.py
@@ -1,0 +1,18 @@
+from threading import Thread
+
+class PropagatingThread(Thread):
+    """ Thread that catched any exceptions and re-raised them when .join is called. 
+    Taken from https://stackoverflow.com/questions/2829329/catch-a-threads-exception-in-the-caller-thread """
+    
+    def run(self):
+        self.exc = None
+        try:
+            self.ret = self._target(*self._args, **self._kwargs)
+        except BaseException as e:
+            self.exc = e
+            
+    def join(self, timeout=None):
+        super(PropagatingThread, self).join(timeout)
+        if self.exc:
+            raise self.exc
+        return self.ret

--- a/scripts/game_structure/windows.py
+++ b/scripts/game_structure/windows.py
@@ -1185,8 +1185,12 @@ class SaveAsImage(UIWindow):
     
     
 class EventLoading(UIWindow):
-    def __init__(self):
-        super().__init__(scale(pygame.Rect((800, 700), (200, 200))),
+    def __init__(self, pos):
+        
+        if pos is None: 
+            pos = (800, 700)
+        
+        super().__init__(scale(pygame.Rect(pos, (200, 200))),
                          window_display_title='Game Over',
                          object_id='#loading_window',
                          resizable=False)

--- a/scripts/screens/base_screens.py
+++ b/scripts/screens/base_screens.py
@@ -1,5 +1,4 @@
 import pygame
-from time import time
 
 from scripts.utility import update_sprite, scale, scale_dimentions
 from scripts.cat.cats import Cat

--- a/scripts/screens/base_screens.py
+++ b/scripts/screens/base_screens.py
@@ -1,4 +1,5 @@
 import pygame
+from time import time
 
 from scripts.utility import update_sprite, scale, scale_dimentions
 from scripts.cat.cats import Cat
@@ -7,7 +8,8 @@ from scripts.game_structure.game_essentials import game, screen, screen_x, scree
 from scripts.game_structure import image_cache
 from scripts.game_structure.image_button import UIImageButton
 import pygame_gui
-from scripts.game_structure.windows import SaveCheck
+from scripts.game_structure.windows import SaveCheck, EventLoading
+from scripts.game_structure.propagating_thread import PropagatingThread
 
 class Screens():
     game_screen = screen
@@ -106,7 +108,65 @@ class Screens():
         self.name = name
         if name is not None:
             game.all_screens[name] = self
+        
+        # Place to store the loading window
+        self.loading_window = None
+        self.work_done = False
+        
 
+    def loading_screen_start_work(self,
+                                  target) -> tuple:
+        """Creates and starts the work_thread. 
+            Returns a tuple in the form (work_thread, time_started) """
+
+        work_thread = PropagatingThread(target=self._work_target, args=(target,), daemon=True)
+        game.switches['window_open'] = True
+        work_thread.start()
+        
+        return (work_thread, time())
+        
+    
+    def _work_target(self, target):
+        
+        try:
+            target()
+        except:
+            raise
+        finally:
+            self.work_done = True
+
+    def loading_screen_on_use(self, 
+                              work_thread:PropagatingThread,
+                              final_actions,
+                              loading_screen_pos:tuple=None,
+                              start:float=0, 
+                              delay:float=0.7) -> bool:
+        """Handles all actions that must be run every frame for the loading window to work. 
+        Also handles creating and killing the loading window. 
+         """
+        
+        # Handled the loading animation, both creating and killing it. 
+        if not self.loading_window and work_thread.is_alive() \
+                and time() - start > delay:
+            self.loading_window = EventLoading(loading_screen_pos)
+        elif self.loading_window and not work_thread.is_alive():
+            self.loading_window.kill()
+            self.loading_window = None
+        
+        # Handles displaying the events once timeskip is done. 
+        if self.work_done:
+            # By this time, the thread should have already finished.
+            # This line allows exceptions in the timeskip thread to be 
+            # passed to the main thread, so issues in timeskip are not
+            # silent failures. 
+            work_thread.join()
+            
+            final_actions()
+            game.switches['window_open'] = False
+            self.work_done = False
+            
+        return self.work_done
+        
     def fill(self, tuple):
         pygame.Surface.fill(color=tuple)
 

--- a/scripts/screens/base_screens.py
+++ b/scripts/screens/base_screens.py
@@ -156,8 +156,8 @@ class Screens():
         # Handles displaying the events once timeskip is done. 
         if self.work_done:
             # By this time, the thread should have already finished.
-            # This line allows exceptions in the timeskip thread to be 
-            # passed to the main thread, so issues in timeskip are not
+            # This line allows exceptions in the work thread to be 
+            # passed to the main thread, so issues in the work thread are not
             # silent failures. 
             work_thread.join()
             

--- a/scripts/screens/base_screens.py
+++ b/scripts/screens/base_screens.py
@@ -115,15 +115,15 @@ class Screens():
         
 
     def loading_screen_start_work(self,
-                                  target) -> tuple:
+                                  target) -> PropagatingThread:
         """Creates and starts the work_thread. 
-            Returns a tuple in the form (work_thread, time_started) """
+            Returns the started thread. """
 
         work_thread = PropagatingThread(target=self._work_target, args=(target,), daemon=True)
         game.switches['window_open'] = True
         work_thread.start()
         
-        return (work_thread, time())
+        return work_thread
         
     
     def _work_target(self, target):
@@ -138,8 +138,7 @@ class Screens():
     def loading_screen_on_use(self, 
                               work_thread:PropagatingThread,
                               final_actions,
-                              loading_screen_pos:tuple=None,
-                              start:float=0, 
+                              loading_screen_pos:tuple=None, 
                               delay:float=0.7) -> bool:
         """Handles all actions that must be run every frame for the loading window to work. 
         Also handles creating and killing the loading window. 
@@ -147,7 +146,7 @@ class Screens():
         
         # Handled the loading animation, both creating and killing it. 
         if not self.loading_window and work_thread.is_alive() \
-                and time() - start > delay:
+                and work_thread.get_time_from_start() > delay:
             self.loading_window = EventLoading(loading_screen_pos)
         elif self.loading_window and not work_thread.is_alive():
             self.loading_window.kill()

--- a/scripts/screens/event_screens.py
+++ b/scripts/screens/event_screens.py
@@ -54,7 +54,6 @@ class EventsScreen(Screens):
         self.cat_profile_buttons = {}
         self.scroll_height = {}
         self.events_thread = PropagatingThread()
-        self.start = 0
 
         # Stores the involved cat button that currently has its cat profile buttons open
         self.open_involved_cat_button = None
@@ -83,7 +82,7 @@ class EventsScreen(Screens):
             
             if event.ui_element == self.timeskip_button:
                 
-                self.events_thread, self.start = self.loading_screen_start_work(events_class.one_moon)
+                self.events_thread = self.loading_screen_start_work(events_class.one_moon)
             
             # Change the type of events displayed
             elif event.ui_element == self.all_events_button:
@@ -235,7 +234,7 @@ class EventsScreen(Screens):
                     self.update_events_display()
             elif event.key == pygame.K_SPACE:
                 
-                self.events_thread, self.start = self.loading_screen_start_work(events_class.one_moon)
+                self.events_thread = self.loading_screen_start_work(events_class.one_moon)
 
     def screen_switches(self):
         # On first open, update display events list
@@ -406,8 +405,7 @@ class EventsScreen(Screens):
 
     def on_use(self):
         
-        self.loading_screen_on_use(self.events_thread, self.timeskip_done,
-                                                    start = self.start)
+        self.loading_screen_on_use(self.events_thread, self.timeskip_done)
             
     def timeskip_done(self):
         """Various sorting and other tasks that must be done with the timeskip is over. """

--- a/scripts/screens/event_screens.py
+++ b/scripts/screens/event_screens.py
@@ -234,14 +234,8 @@ class EventsScreen(Screens):
                     self.display_events = self.misc_events
                     self.update_events_display()
             elif event.key == pygame.K_SPACE:
-                # Save the start time, so the loading animation can be
-                # set to only show up if timeskip is taking a good amount of time. 
-                self.start = time.time() 
-                self.events_thread = threading.Thread(target=self.one_moon)
-                # Set game.switched["window_open"] to true to prevent setting off more than one 
-                # timeskip thread at once. 
-                game.switches['window_open'] = True
-                self.events_thread.start()
+                
+                self.events_thread, self.start = self.loading_screen_start_work(events_class.one_moon)
 
     def screen_switches(self):
         # On first open, update display events list

--- a/scripts/screens/relation_screens.py
+++ b/scripts/screens/relation_screens.py
@@ -12,6 +12,7 @@ from scripts.game_structure import image_cache
 from scripts.game_structure.image_button import UIImageButton, UISpriteButton, UIRelationStatusBar
 from scripts.game_structure.game_essentials import game, screen, screen_x, screen_y, MANAGER
 from scripts.game_structure.windows import RelationshipLog
+from scripts.game_structure.propagating_thread import PropagatingThread
 
 
 class ChooseMentorScreen(Screens):
@@ -1193,6 +1194,10 @@ class ChooseMateScreen(Screens):
         self.tab_buttons = {}
         
         self.no_kits_message = None
+        
+        #Loading screen
+        self.work_thread = PropagatingThread()
+        self.start = 0
 
     def handle_event(self, event):
         """ Handles events. """
@@ -1202,17 +1207,9 @@ class ChooseMateScreen(Screens):
                 self.selected_mate_index = 0
                 self.change_screen('profile screen')
             elif event.ui_element == self.toggle_mate:
-                if not self.selected_cat:
-                    return
                 
-                if self.selected_cat.ID not in self.the_cat.mate:
-                    self.the_cat.set_mate(self.selected_cat)
-                    
-                else:
-                    self.the_cat.unset_mate(self.selected_cat, breakup=True)
+                self.work_thread, self.start = self.loading_screen_start_work(self.change_mate)
                 
-                self.update_current_cat_info(reset_selected_cat=False) # This will also refresh tab contents
-                self.update_selected_cat()
             elif event.ui_element == self.previous_cat_button:
                 if isinstance(Cat.fetch_cat(self.previous_cat), Cat):
                     game.switches["cat"] = self.previous_cat
@@ -1383,6 +1380,23 @@ class ChooseMateScreen(Screens):
         # This will set up everything else on the page. Basically everything that changed with selected or
         # current cat
         self.update_current_cat_info()
+
+    def change_mate(self):
+        if not self.selected_cat:
+            return
+        
+        if self.selected_cat.ID not in self.the_cat.mate:
+            self.the_cat.set_mate(self.selected_cat)
+            
+        else:
+            self.the_cat.unset_mate(self.selected_cat, breakup=True)
+        
+
+    def update_both(self):
+        """Updates both the current cat and selected cat info. """
+        
+        self.update_current_cat_info(reset_selected_cat=False) # This will also refresh tab contents
+        self.update_selected_cat()
 
     def update_mates_container(self):
         """Updates everything in the mates container, including the list of current mates,
@@ -2055,6 +2069,9 @@ class ChooseMateScreen(Screens):
     def on_use(self):
         # Due to a bug in pygame, any image with buttons over it must be blited
         screen.blit(self.list_frame, (150 / 1600 * screen_x, 782 / 1400 * screen_y))
+        
+        self.loading_screen_on_use(self.work_thread, self.update_both, 
+                                   start=self.start)
 
     def get_valid_mates(self):
         """Get a list of valid mates for the current cat"""
@@ -3650,6 +3667,9 @@ class ChooseAdoptiveParentScreen(Screens):
         # for the offspring tab, and "mates" for the mate tab. 
         self.open_tab = "potential" 
         self.tab_buttons = {}
+        
+        self.work_thread = PropagatingThread()
+        self.start = 0
 
     def handle_event(self, event):
         """ Handles events. """
@@ -3659,22 +3679,9 @@ class ChooseAdoptiveParentScreen(Screens):
                 self.selected_mate_index = 0
                 self.change_screen('profile screen')
             elif event.ui_element == self.toggle_adoptive_parent:
-                if not self.selected_cat:
-                    return
                 
-                if self.selected_cat.ID not in self.the_cat.adoptive_parents:
-                    self.the_cat.adoptive_parents.append(self.selected_cat.ID)
-                    self.the_cat.create_inheritance_new_cat()
-                    
-                else:
-                    self.the_cat.adoptive_parents.remove(self.selected_cat.ID)
-                    self.the_cat.create_inheritance_new_cat()
-                    self.selected_cat.create_inheritance_new_cat()
+                self.work_thread, self.start = self.loading_screen_start_work(self.change_adoptive_parent)
                 
-                self.draw_tab_button()
-                self.update_toggle_button()
-                self.update_potential_parents_container()
-                self.update_adoptive_parents_container()
             elif event.ui_element == self.previous_cat_button:
                 if isinstance(Cat.fetch_cat(self.previous_cat), Cat):
                     game.switches["cat"] = self.previous_cat
@@ -3823,6 +3830,29 @@ class ChooseAdoptiveParentScreen(Screens):
         # This will set up everything else on the page. Basically everything that changed with selected or
         # current cat
         self.update_current_cat_info()
+
+    def change_adoptive_parent(self):
+        """Make adoptive parent changes"""
+        
+        if not self.selected_cat:
+            return
+        
+        if self.selected_cat.ID not in self.the_cat.adoptive_parents:
+            self.the_cat.adoptive_parents.append(self.selected_cat.ID)
+            self.the_cat.create_inheritance_new_cat()
+            
+        else:
+            self.the_cat.adoptive_parents.remove(self.selected_cat.ID)
+            self.the_cat.create_inheritance_new_cat()
+            self.selected_cat.create_inheritance_new_cat()
+            
+    def update_after_change(self):
+        """Updates that need to be run after setting an adoptive parent """
+        
+        self.draw_tab_button()
+        self.update_toggle_button()
+        self.update_potential_parents_container()
+        self.update_adoptive_parents_container()
 
     def update_birth_container(self):
         """Updates everything in the mates container, including the list of current mates,
@@ -4266,6 +4296,9 @@ class ChooseAdoptiveParentScreen(Screens):
 
         # Due to a bug in pygame, any image with buttons over it must be blited
         screen.blit(self.list_frame, (150 / 1600 * screen_x, 782 / 1400 * screen_y))
+        
+        self.loading_screen_on_use(self.work_thread, self.update_after_change, 
+                                   start = self.start)
 
     def get_valid_adoptive_parents(self):
         """Get a list of valid parents for the current cat"""

--- a/scripts/screens/relation_screens.py
+++ b/scripts/screens/relation_screens.py
@@ -1197,7 +1197,6 @@ class ChooseMateScreen(Screens):
         
         #Loading screen
         self.work_thread = PropagatingThread()
-        self.start = 0
 
     def handle_event(self, event):
         """ Handles events. """
@@ -1208,7 +1207,7 @@ class ChooseMateScreen(Screens):
                 self.change_screen('profile screen')
             elif event.ui_element == self.toggle_mate:
                 
-                self.work_thread, self.start = self.loading_screen_start_work(self.change_mate)
+                self.work_thread = self.loading_screen_start_work(self.change_mate)
                 
             elif event.ui_element == self.previous_cat_button:
                 if isinstance(Cat.fetch_cat(self.previous_cat), Cat):
@@ -2070,8 +2069,7 @@ class ChooseMateScreen(Screens):
         # Due to a bug in pygame, any image with buttons over it must be blited
         screen.blit(self.list_frame, (150 / 1600 * screen_x, 782 / 1400 * screen_y))
         
-        self.loading_screen_on_use(self.work_thread, self.update_both, 
-                                   start=self.start)
+        self.loading_screen_on_use(self.work_thread, self.update_both)
 
     def get_valid_mates(self):
         """Get a list of valid mates for the current cat"""
@@ -3669,7 +3667,6 @@ class ChooseAdoptiveParentScreen(Screens):
         self.tab_buttons = {}
         
         self.work_thread = PropagatingThread()
-        self.start = 0
 
     def handle_event(self, event):
         """ Handles events. """
@@ -3680,7 +3677,7 @@ class ChooseAdoptiveParentScreen(Screens):
                 self.change_screen('profile screen')
             elif event.ui_element == self.toggle_adoptive_parent:
                 
-                self.work_thread, self.start = self.loading_screen_start_work(self.change_adoptive_parent)
+                self.work_thread = self.loading_screen_start_work(self.change_adoptive_parent)
                 
             elif event.ui_element == self.previous_cat_button:
                 if isinstance(Cat.fetch_cat(self.previous_cat), Cat):
@@ -4297,8 +4294,7 @@ class ChooseAdoptiveParentScreen(Screens):
         # Due to a bug in pygame, any image with buttons over it must be blited
         screen.blit(self.list_frame, (150 / 1600 * screen_x, 782 / 1400 * screen_y))
         
-        self.loading_screen_on_use(self.work_thread, self.update_after_change, 
-                                   start = self.start)
+        self.loading_screen_on_use(self.work_thread, self.update_after_change)
 
     def get_valid_adoptive_parents(self):
         """Get a list of valid parents for the current cat"""

--- a/scripts/screens/relation_screens.py
+++ b/scripts/screens/relation_screens.py
@@ -1200,6 +1200,9 @@ class ChooseMateScreen(Screens):
 
     def handle_event(self, event):
         """ Handles events. """
+        if game.switches["window_open"]:
+            return
+        
         if event.type == pygame_gui.UI_BUTTON_START_PRESS:
             # Cat buttons list
             if event.ui_element == self.back_button:
@@ -3670,6 +3673,9 @@ class ChooseAdoptiveParentScreen(Screens):
 
     def handle_event(self, event):
         """ Handles events. """
+        if game.switches["window_open"]:
+            return
+        
         if event.type == pygame_gui.UI_BUTTON_START_PRESS:
             # Cat buttons list
             if event.ui_element == self.back_button:


### PR DESCRIPTION
- Exceptions in the timeskip thread will now be passed to the main thread, so failures are no longer silent. 
- Move the bulk of code handling the loading screens to base_screen. (not including the start-up loading screen, since that one works differently)
- Add loading screens to the choose mate and choose adoptive parents screen. These are both screens that trigger inheritance recalculations, and can freeze and lag on large clans. 