### PR TITLE
Other: Test for Incorrect Pronoun and Verb Tags in Resources

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,20 +85,20 @@ jobs:
         run: poetry install
       - name: Check json validity
         run: poetry run python3 tests/test_json.py
-pronoun_test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Setup Python 3.11 x64
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.11'
-          architecture: 'x64'
-      - name: Install poetry
-        uses: abatilo/actions-poetry@v2
-        with:
-          poetry-version: 1.4.1
-      - name: install dependencies
-        run: poetry install
-      - name: Check for pronoun tag errors in resources
-        run: poetry run python3 tests/test_pronouns.py
+  pronoun_test:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v3
+        - name: Setup Python 3.11 x64
+          uses: actions/setup-python@v4
+          with:
+            python-version: '3.11'
+            architecture: 'x64'
+        - name: Install poetry
+          uses: abatilo/actions-poetry@v2
+          with:
+            poetry-version: 1.4.1
+        - name: install dependencies
+          run: poetry install
+        - name: Check for pronoun tag errors in resources
+          run: poetry run python3 tests/test_pronouns.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,4 +101,4 @@ jobs:
         - name: install dependencies
           run: poetry install
         - name: Check for pronoun tag errors in resources
-          run: poetry run python3 tests/test_pronouns.py
+          run: poetry run python3 -m unittest tests/test_pronouns.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,3 +85,20 @@ jobs:
         run: poetry install
       - name: Check json validity
         run: poetry run python3 tests/test_json.py
+pronoun_test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Python 3.11 x64
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+          architecture: 'x64'
+      - name: Install poetry
+        uses: abatilo/actions-poetry@v2
+        with:
+          poetry-version: 1.4.1
+      - name: install dependencies
+        run: poetry install
+      - name: Check for pronoun tag errors in resources
+        run: poetry run python3 tests/test_pronouns.py

--- a/resources/dicts/events/ceremonies/ceremony-master.json
+++ b/resources/dicts/events/ceremonies/ceremony-master.json
@@ -1525,7 +1525,7 @@
       "general_backstory",
       "compassionate"
     ],
-    "Helping cats heal is what (old_name) does best. {PRONOUN/m_c/poss/CAP} full name of m_c proves to the Clan that {PRONOUN/m_c/subject}{VERB/m_c/'re's} fully qualified to do so, and that StarClan has accepted {PRONOUN/m_c/object}."
+    "Helping cats heal is what (old_name) does best. {PRONOUN/m_c/poss/CAP} full name of m_c proves to the Clan that {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} fully qualified to do so, and that StarClan has accepted {PRONOUN/m_c/object}."
   ],
   "med_13": [
     [
@@ -2703,7 +2703,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "{PRONOUN/(previous_mentor)/subject/CAP} {VERB/(previous_mentor)/don't/doesn't) care if there's no leader, (previous_mentor) knows that (old_name) is deserving of {PRONOUN/m_c/poss} full name. {PRONOUN/(previous_mentor)/subject/CAP} {VERB/(previous_mentor)/gather/gathers} the Clan to hold a ceremony for (old_name), and names {PRONOUN/m_c/object} m_c, honoring {PRONOUN/m_c/poss} r_h."
+    "{PRONOUN/(previous_mentor)/subject/CAP} {VERB/(previous_mentor)/don't/doesn't} care if there's no leader, (previous_mentor) knows that (old_name) is deserving of {PRONOUN/m_c/poss} full name. {PRONOUN/(previous_mentor)/subject/CAP} {VERB/(previous_mentor)/gather/gathers} the Clan to hold a ceremony for (old_name), and names {PRONOUN/m_c/object} m_c, honoring {PRONOUN/m_c/poss} r_h."
   ],
   "warrior_54": [
     [

--- a/resources/dicts/events/death/general/medicine.json
+++ b/resources/dicts/events/death/general/medicine.json
@@ -98,6 +98,6 @@
             "mc_to_rc",
             "dislike"
         ],
-        "event_text": "m_c is getting increasingly annoyed with r_c because {PRONOUN/r_c/subject} {VERB/keep/keeps} bothering {PRONOUN/m_c/object} about the most trivial of wounds and aches."
+        "event_text": "m_c is getting increasingly annoyed with r_c because {PRONOUN/r_c/subject} {VERB/r_c/keep/keeps} bothering {PRONOUN/m_c/object} about the most trivial of wounds and aches."
     }
 ]

--- a/resources/dicts/lead_ceremony_df.json
+++ b/resources/dicts/lead_ceremony_df.json
@@ -775,7 +775,7 @@
       "rank": ["warrior", "elder", "medicine cat", "mediator", "apprentice", "deputy", "medicine cat apprentice", "mediator apprentice"],
       "life_giving": [
         {
-          "text": "r_c watches m_c with piercing eyes, as though the dark spirit can see right through all of m_c's thoughts! {PRONOUN/r_c/subject/CAP} {VERB/cat/are/is} silent as {PRONOUN/r_c/subject} {VERB/r_c/gives/give} a life for [virtue].",
+          "text": "r_c watches m_c with piercing eyes, as though the dark spirit can see right through all of m_c's thoughts! {PRONOUN/r_c/subject/CAP} {VERB/r_c/are/is} silent as {PRONOUN/r_c/subject} {VERB/r_c/gives/give} a life for [virtue].",
           "virtue": ["ambition", "bravery", "certainty", "clear judgement", "confidence", "courage",
       "determination", "endurance", "farsightedness", "instincts", "strength", "ferocity", "cunning", "shamelessness", "zealotry", "bloodlust", "restless energy", 
       "stubbornness", "authority"]

--- a/resources/dicts/patrols/desert/med/any.json
+++ b/resources/dicts/patrols/desert/med/any.json
@@ -69,7 +69,7 @@
             "random_herbs"
         ],
         "intro_text": "app1 has been sent out into the desert to try to find some specific herbs alone.",
-        "decline_text": "Nervous and with the hot sun pounding on {PRONOUN/app1/poss} back, {PRONOUN/app1/subject} {VERB/app1/decides} to go back to camp and try again another day, {PRONOUN/app1/poss} tail dragging behind {PRONOUN/app1/object}.",
+        "decline_text": "Nervous and with the hot sun pounding on {PRONOUN/app1/poss} back, {PRONOUN/app1/subject} {VERB/app1/decide/decides} to go back to camp and try again another day, {PRONOUN/app1/poss} tail dragging behind {PRONOUN/app1/object}.",
         "chance_of_success": 40,
         "exp": 10,
         "success_text": {

--- a/resources/dicts/patrols/general/hunting.json
+++ b/resources/dicts/patrols/general/hunting.json
@@ -457,7 +457,7 @@
         },
         "fail_text": {
             "unscathed_common": "r_c gives in to {PRONOUN/r_c/poss} grumbling belly, reasoning that no one will notice, but when the patrol reforms and r_c arrives back empty-pawed with blood on {PRONOUN/r_c/poss} lips, {PRONOUN/r_c/subject} {VERB/r_c/feel/feels} the suspicious stares of the other warriors on {PRONOUN/r_c/poss} pelt.",
-            "unscathed_stat": "{PRONOUN/r_c/subject/CAP} {VERB/r_c/think/thinks} {PRONOUN/r_c/subject}{VERB/r_c/'ve/'s) gotten away with {PRONOUN/r_c/poss} clandestine snacking, but when r_c arrives back at camp, another patrol member pulls the deputy aside for a quiet word, glaring back at r_c. The deputy assigns {PRONOUN/r_c/object} to dig a new trench for the Clan's dirtplace, and r_c hears snide remarks when {PRONOUN/r_c/subject} {VERB/r_c/slink/slinks} in to {PRONOUN/r_c/object} nest that night."
+            "unscathed_stat": "{PRONOUN/r_c/subject/CAP} {VERB/r_c/think/thinks} {PRONOUN/r_c/subject}{VERB/r_c/'ve/'s} gotten away with {PRONOUN/r_c/poss} clandestine snacking, but when r_c arrives back at camp, another patrol member pulls the deputy aside for a quiet word, glaring back at r_c. The deputy assigns {PRONOUN/r_c/object} to dig a new trench for the Clan's dirtplace, and r_c hears snide remarks when {PRONOUN/r_c/subject} {VERB/r_c/slink/slinks} in to {PRONOUN/r_c/object} nest that night."
         },
         "min_cats": 2,
         "max_cats": 6,
@@ -491,7 +491,7 @@
             "unscathed_rare": "After all, the patrol has caught enough on this hunt that {PRONOUN/r_c/subject}'ll have trouble carrying it all back to camp. {PRONOUN/r_c/subject/CAP} {VERB/r_c/stop/stops} for a quick snack and {VERB/r_c/return/returns} to camp laden with prey for the fresh-kill pile."
         },
         "fail_text": {
-            "unscathed_common": "{PRONOUN/r_c/subject/CAP} {VERB/r_c/think/thinks} {PRONOUN/r_c/subject}{VERB/r_c/'ve/'s) gotten away with {PRONOUN/r_c/poss} clandestine snacking, but when r_c arrives back at camp, another patrol member pulls the deputy aside for a quiet word, glaring back at r_c. The deputy assigns {PRONOUN/r_c/object} to dig a new trench for the Clan's dirtplace; r_c prickles with humiliation and terrible smells."
+            "unscathed_common": "{PRONOUN/r_c/subject/CAP} {VERB/r_c/think/thinks} {PRONOUN/r_c/subject}{VERB/r_c/'ve/'s} gotten away with {PRONOUN/r_c/poss} clandestine snacking, but when r_c arrives back at camp, another patrol member pulls the deputy aside for a quiet word, glaring back at r_c. The deputy assigns {PRONOUN/r_c/object} to dig a new trench for the Clan's dirtplace; r_c prickles with humiliation and terrible smells."
         },
         "min_cats": 2,
         "max_cats": 6,

--- a/resources/dicts/patrols/new_cat_welcoming.json
+++ b/resources/dicts/patrols/new_cat_welcoming.json
@@ -755,7 +755,7 @@
         },
         "fail_text": {
             "injury": "As soon as {PRONOUN/r_c/subject} {VERB/r_c/see/sees} the bag wiggling and screaming, {PRONOUN/r_c/subject} {VERB/r_c/jump/jumps} into action. Unfortunately r_c was just a tad too slow and got kicked quite hard against a tree. p_l orders the patrol to protect and carry r_c while they retreat, with pain in their heart for the unknown cat that they couldn't save.",
-            "stat_injury": "Upon seeing the Twoleg and the screeching bag they are holding s_c just can't take it. {PRONOUN/s_c/subject} {VERB/cat/jump/jumps}, into action without waiting for the rest of the patrol to back {PRONOUN/s_c/object} up and {PRONOUN/s_c/subject} {VERB/s_c/pay/pays} the price. Grabbed by the scruff and thrown hard onto the floor the only thing the rest of the patrol can do is grab s_c and flee back to the safety of c_n."
+            "stat_injury": "Upon seeing the Twoleg and the screeching bag they are holding s_c just can't take it. {PRONOUN/s_c/subject} {VERB/s_c/jump/jumps}, into action without waiting for the rest of the patrol to back {PRONOUN/s_c/object} up and {PRONOUN/s_c/subject} {VERB/s_c/pay/pays} the price. Grabbed by the scruff and thrown hard onto the floor the only thing the rest of the patrol can do is grab s_c and flee back to the safety of c_n."
         },
         "win_skills": [
             "CLEVER,2",

--- a/resources/dicts/patrols/plains/border/any.json
+++ b/resources/dicts/patrols/plains/border/any.json
@@ -176,7 +176,7 @@
             "stat_skill": "s_c snarls at the rogues, outnumbered but not cowed. {PRONOUN/s_c/subject/CAP} {VERB/s_c/throw/throws} {PRONOUN/s_c/self} at the intruders with such ferocity and fury that the rogues are taken aback. Alarmed by the lack of fear and self-preservation from the Clan cat, the rogues freeze. s_c sees {PRONOUN/s_c/poss} opportunity to run and takes it, racing back to the camp to gather more warriors and return."
         },
         "fail_text": {
-            "unscathed_stat": "s_c snarls at the rogues, outnumbered but not cowed. {PRONOUN/s_c/subject/CAP} {VERB/s_c/throw/throws} {PRONOUN/s_c/self} at the intruders with such ferocity and fury that the rogues are taken aback. For a moment the rogues are stunned by the reaction, but the shock doesn't last long before they descend upon the warrior once more. Eventually, s_c has no choice but to escape before {PRONOUN/s_c/subject}{PRONOUN/s_c/'re/'s} killed.",
+            "unscathed_stat": "s_c snarls at the rogues, outnumbered but not cowed. {PRONOUN/s_c/subject/CAP} {VERB/s_c/throw/throws} {PRONOUN/s_c/self} at the intruders with such ferocity and fury that the rogues are taken aback. For a moment the rogues are stunned by the reaction, but the shock doesn't last long before they descend upon the warrior once more. Eventually, s_c has no choice but to escape before {PRONOUN/s_c/subject}{VERB/s_c/'re/'s} killed.",
             "death": "The rogues greatly outnumber r_c and have no trouble killing the lone cat. {PRONOUN/r_c/poss/CAP} body is discovered the next day, covered in wounds and cold."
         },
         "win_skills": [

--- a/resources/dicts/thoughts/alive/alive_outside/deputy.json
+++ b/resources/dicts/thoughts/alive/alive_outside/deputy.json
@@ -5,7 +5,7 @@
             "Wonders if {PRONOUN/m_c/subject} {VERB/m_c/are/is} still the deputy",
             "Wonders how the patrols are currently organized without {PRONOUN/m_c/object}",
             "Feels sad by the thought of being replaced",
-            "Is wondering if {PRONOUN/m_c/subject} {VERB/m_c/'ll} still remain deputy after returning"
+            "Is wondering if {PRONOUN/m_c/subject}'ll still remain deputy after returning"
         ]
     }
 ]

--- a/tests/test_pronouns.py
+++ b/tests/test_pronouns.py
@@ -1,9 +1,8 @@
 """
 
  Please dont put this *unittest* in the tests/unittest github action.
- It is only for local use.
 HOWEVER
- Please keep the raw python script, so it can be run by the tests/pronoun_test github action.
+ Please keep the raw python script and the unittest, so it can be run by the tests/pronoun_test github action.
 
 This test checks that pronoun tags are formated correctly, 
 
@@ -144,7 +143,3 @@ class TestPronouns(unittest.TestCase):
         with self.assertRaises(SystemExit) as cm:
             test()
         self.assertEqual(cm.exception.code, 0)
-
-
-if __name__ == "__main__":
-    test()

--- a/tests/test_pronouns.py
+++ b/tests/test_pronouns.py
@@ -1,0 +1,150 @@
+"""
+
+ Please dont put this *unittest* in the tests/unittest github action.
+ It is only for local use.
+HOWEVER
+ Please keep the raw python script, so it can be run by the tests/pronoun_test github action.
+
+This test checks that pronoun tags are formated correctly, 
+
+"""
+import os
+import sys
+import ujson
+import unittest
+from scripts.cat.cats import Cat
+from scripts.utility import process_text
+import re
+
+import os
+os.environ["SDL_VIDEODRIVER"] = "dummy"
+os.environ["SDL_AUDIODRIVER"] = "dummy"
+
+def test():
+    """Iterate through all files in 'resources'
+    and verify that any detected pronoun tags are 
+    formatted correctly."""
+    failed = False
+    failedFiles = []
+    
+    # Note - we are replacing with a singular-conjugated pronoun,
+    # to ensure that we are catching cases where only one verb conjugation
+    # was provided - since singular-conjugation
+    # should be the second provided conjugation. 
+    _r = ("name", Cat.default_pronouns[1])
+    replacement_dict = {
+        "m_c": _r,
+        "r_c": _r,
+        "r_c1": _r,
+        "r_c2": _r,
+        "n_c": _r,
+        "app1": _r,
+        "app2": _r,
+        "app3": _r,
+        "app4": _r,
+        "app5": _r,
+        "app6": _r,
+        "p_l": _r,
+        "s_c": _r,
+        "(mentor)": _r,
+        "l_n": _r,
+        "dead_par1": _r,
+        "dead_par2": _r,
+        "p1": _r,
+        "p2": _r,
+        "(deadmentor)": _r,
+        "(previous_mentor)": _r,
+        "mur_c": _r
+    }
+    
+    for (root, _, files) in os.walk("resources"):
+        for file in files:
+            if file.endswith(".json") and file != "credits_text.json":
+                path = os.path.join(root, file)
+                
+                if not test_replacement_failure(path, replacement_dict):
+                    failed = True
+                    failedFiles.append(path)
+                
+    if failed:
+        # Set the GITHUB_OUTPUT environment variable to the list of failed files
+        if "GITHUB_OUTPUT" in os.environ:
+            with open(os.environ["GITHUB_OUTPUT"], "a") as handle:
+                print(f"files={':'.join(failedFiles)}", file=handle)
+        else:
+            print(f"files={':'.join(failedFiles)}")
+        sys.exit(1)
+    else:
+        sys.exit(0)
+
+
+
+def test_replacement_failure(path: str, repl_dict: dict) -> bool:
+    """ Reads in a file, and finds strings, and runs pronoun replacment on those strings. 
+    Returns False if there were any issues with the pronoun replacement, or if the
+    json is incorrectly formatted. """
+    
+    success = True
+    
+    with open(path, "r") as file:
+        try:
+            contents = ujson.loads(file.read())
+        except ujson.JSONDecodeError as _e:
+            print(f"::error file={path}::File {path} is invalid json")
+            print(_e)
+            return False
+        
+    for _str in get_all_strings(contents):
+        try:
+            processed = process_text(_str, repl_dict, True)
+        except (KeyError, IndexError) as _e:
+            print(f"::error file={path}: \"{_str}\" contains invalid pronoun or verb tags.")
+            print(_e)
+            success = False
+        else: 
+            ## This test for any pronoun or verb tag fragments that might have
+            ## sneaked through. This is most likely caused by using the incorrect type of
+            ## brackets
+            if re.search(r"\{PRONOUN|\(PRONOUN|\{VERB|\(VERB", processed):
+                print(f"::error file={path}: \"{_str}\" contains pronoun tag fragments after replacment")
+                success = False
+            
+    return success
+
+    
+def get_all_strings(data):
+    """ Will take any combination of list and dicts, 
+    and extract all strings, including dictionary keys. 
+    Recursive. """
+    
+    all_strings = []
+    
+    if isinstance(data, list):
+        for _x in data:
+            all_strings.extend(get_all_strings(_x))
+    elif isinstance(data, dict):
+        for _x in data:
+            all_strings.extend(get_all_strings(data[_x]))
+            all_strings.extend(get_all_strings(_x))
+
+    elif isinstance(data, str):
+        all_strings.append(data)
+        
+    return all_strings
+    
+    
+
+# THE UNITTEST IS ONLY FOR LOCAL USE
+# PLEASE DONT PUT THIS IN THE GITHUB ACTION
+class TestPronouns(unittest.TestCase):
+    """Test for some common pronoun tagging errors in resources"""
+
+    def test_pronouns(self):
+        """Test that all files are ascii decodable."""
+        with self.assertRaises(SystemExit) as cm:
+            test()
+        self.assertEqual(cm.exception.code, 0)
+
+
+if __name__ == "__main__":
+    test()

--- a/tests/test_pronouns.py
+++ b/tests/test_pronouns.py
@@ -131,10 +131,6 @@ def get_all_strings(data):
         
     return all_strings
     
-    
-
-# THE UNITTEST IS ONLY FOR LOCAL USE
-# PLEASE DONT PUT THIS IN THE GITHUB ACTION
 class TestPronouns(unittest.TestCase):
     """Test for some common pronoun tagging errors in resources"""
 


### PR DESCRIPTION
Added a test for pronoun tags - "pronoun_test". Doesn't catch everything, but it will catch most cases where "error1" or "error2" would be inserted, certain cases of using `(` rather than `{` in pronoun tags, and VERB tags were only one conjugation was provided. 

This also corrects a bunch of existing errors that the test detected. 