### PR TITLE
Fix for decrease relationship "splash effect"

### DIFF
--- a/scripts/cat_relations/relationship.py
+++ b/scripts/cat_relations/relationship.py
@@ -237,7 +237,7 @@ class Relationship():
             -------
         """
         amount = self.get_amount(in_de_crease, intensity)
-        passive_buff = int(amount/game.config["relationship"]["passive_influence_div"])
+        passive_buff = int(abs(amount/game.config["relationship"]["passive_influence_div"]))
 
         # influence the own relationship
         if rel_type == "romantic":


### PR DESCRIPTION
- The "splash effects" were inversed by mistake - now the "passive_buff" will be an absolute value

Realized that the "buff" was coming out negative when the amount was negative... it's more intuitive when writing the individual buffs for the different type to always assume it's a positive #