### PR TITLE
Bugfixes: Various

### DIFF
--- a/resources/dicts/events/death/death_reactions/parent/parent_admiration.json
+++ b/resources/dicts/events/death/death_reactions/parent/parent_admiration.json
@@ -12,7 +12,7 @@
     ],
     "no_body": [
       "r_c feels as though {PRONOUN/r_c/subject}{VERB/r_c/'re/'s} living through a nightmare. m_c, {PRONOUN/r_c/poss} kit, can't really be dead.",
-      "When r_c hears the news of m_c's death, {PRONOUN/r_c/poss} {VERB/r_c/collapse/collapses} and {VERB/r_c/wail/wails} as though {PRONOUN/r_c/poss} own life was ending.",
+      "When r_c hears the news of m_c's death, {PRONOUN/r_c/subject} {VERB/r_c/collapse/collapses} and {VERB/r_c/wail/wails} as though {PRONOUN/r_c/poss} own life was ending.",
       "m_c had such a bright future ahead of {PRONOUN/m_c/object}. r_c can still hear {PRONOUN/m_c/object} talking about {PRONOUN/m_c/poss} dreams, can still picture {PRONOUN/m_c/object} running through c_n's territory, and to know that m_c will never get the chance to fulfill that. . .",
       "r_c chokes back wails and tears, trying to get to the end of the story {PRONOUN/r_c/subject}{VERB/r_c/'ve/'s} been telling about m_c's days in the nursery. {PRONOUN/r_c/subject/CAP} can do this, {PRONOUN/r_c/subject} can make sure m_c is honored at {PRONOUN/m_c/poss} vigil, even if r_c can't do anything else for {PRONOUN/m_c/object}."
     ]

--- a/resources/dicts/events/death/death_reactions/parent/parent_comfort.json
+++ b/resources/dicts/events/death/death_reactions/parent/parent_comfort.json
@@ -12,7 +12,7 @@
     ],
     "no_body": [
       "r_c feels as though {PRONOUN/r_c/subject}{VERB/r_c/'re/'s} living through a nightmare. m_c, {PRONOUN/r_c/poss} kit, can't really be dead.",
-      "When r_c hears the news of m_c's death, {PRONOUN/r_c/poss} {VERB/r_c/collapse/collapses} and {VERB/r_c/wail/wails} as though {PRONOUN/r_c/poss} own life was ending.",
+      "When r_c hears the news of m_c's death, {PRONOUN/r_c/subject} {VERB/r_c/collapse/collapses} and {VERB/r_c/wail/wails} as though {PRONOUN/r_c/poss} own life was ending.",
       "m_c had such a bright future ahead of {PRONOUN/m_c/object}. r_c can still hear {PRONOUN/m_c/object} talking about {PRONOUN/m_c/poss} dreams, can still picture {PRONOUN/m_c/object} running through c_n's territory, and to know that m_c will never get the chance to fulfill that. . .",
       "r_c chokes back wails and tears, trying to get to the end of the story {PRONOUN/r_c/subject}{VERB/r_c/'ve/'s} been telling about m_c's days in the nursery. {PRONOUN/r_c/subject/CAP} can do this, {PRONOUN/r_c/subject} can make sure m_c is honored at {PRONOUN/m_c/poss} vigil, even if r_c can't do anything else for {PRONOUN/m_c/object}."
     ]

--- a/resources/dicts/events/death/death_reactions/parent/parent_platonic.json
+++ b/resources/dicts/events/death/death_reactions/parent/parent_platonic.json
@@ -12,7 +12,7 @@
     ],
     "no_body": [
       "r_c feels as though {PRONOUN/r_c/subject}{VERB/r_c/'re/'s} living through a nightmare. m_c, {PRONOUN/r_c/poss} kit, can't really be dead.",
-      "When r_c hears the news of m_c's death, {PRONOUN/r_c/poss} {VERB/r_c/collapse/collapses} and {VERB/r_c/wail/wails} as though {PRONOUN/r_c/poss} own life was ending.",
+      "When r_c hears the news of m_c's death, {PRONOUN/r_c/subject} {VERB/r_c/collapse/collapses} and {VERB/r_c/wail/wails} as though {PRONOUN/r_c/poss} own life was ending.",
       "m_c had such a bright future ahead of {PRONOUN/m_c/object}. r_c can still hear {PRONOUN/m_c/object} talking about {PRONOUN/m_c/poss} dreams, can still picture {PRONOUN/m_c/object} running through c_n's territory, and to know that m_c will never get the chance to fulfill that. . .",
       "r_c chokes back wails and tears, trying to get to the end of the story {PRONOUN/r_c/subject}{VERB/r_c/'ve/'s} been telling about m_c's days in the nursery. {PRONOUN/r_c/subject/CAP} can do this, {PRONOUN/r_c/subject} can make sure m_c is honored at {PRONOUN/m_c/poss} vigil, even if r_c can't do anything else for {PRONOUN/m_c/object}."
     ]

--- a/resources/dicts/events/injury/plains/general.json
+++ b/resources/dicts/events/injury/plains/general.json
@@ -12,7 +12,7 @@
         "event_text": "m_c was grabbed and dropped by an eagle, but {PRONOUN/m_c/subject} somehow survived.",
         "history_text": {
             "scar": "m_c was scarred when an eagle grabbed {PRONOUN/m_c/subject}.",
-            "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after an eagle grabbed {PRONOUN/m_c/subject}."
+            "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after an eagle grabbed {PRONOUN/m_c/object}."
         },
         "cat_trait": null,
         "cat_skill": null,

--- a/resources/dicts/events/misc_events/general/kitten.json
+++ b/resources/dicts/events/misc_events/general/kitten.json
@@ -347,7 +347,7 @@
     },
     {
         "camp": "any",
-        "tags:":[
+        "tags":[
             "Leaf-fall"
         ],
         "event_text": "As the wind brings many fallen leaves in the camp, m_c picks a acc_singular to decorate {PRONOUN/m_c/poss} pelt.",

--- a/resources/dicts/patrols/beach/med/leaf-bare.json
+++ b/resources/dicts/patrols/beach/med/leaf-bare.json
@@ -177,6 +177,7 @@
             "herb_gathering",
             "med_cat",
             "warrior",
+            "injury",
             "cold_injury",
             "scar",
             "FROSTFACE",

--- a/resources/dicts/patrols/forest/hunting/leaf-bare.json
+++ b/resources/dicts/patrols/forest/hunting/leaf-bare.json
@@ -791,16 +791,17 @@
             "patrol_to_r_c",
             "medium_prey3",
             "injure_all",
-            "cold_injury"
+            "cold_injury",
+            "rc_has_stat"
         ],
         "intro_text": "Snow falling around the patrol hushes the world around and between them into a white-tinted haze, and p_l grows increasingly on edge. There's something wrong. Where is r_c?",
         "decline_text": "r_c eventually catches up.",
         "chance_of_success": 40,
         "exp": 20,
         "success_text": {
-            "unscathed_common": "The patrol backtracks. r_c is found, huddled under a bush - they lost the path, and sight of their clanmates, but sensibly remained put. It's one more obstacle in a miserable day of hunting. They return with prey, but it's exhausting and barely worth the effort.",
+            "unscathed_common": "The patrol backtracks. r_c is found, huddled under a bush - they lost the path, and sight of their patrol, but sensibly remained put. It's one more obstacle in a miserable day of hunting. They return with prey, but it's exhausting and barely worth the effort.",
             "unscathed_rare": "p_l nearly jumps out of their pelt when r_c materialises next to them. Where in StarClan have they been?! But no, r_c has found a corpse of trees so thick and overgrown that their branches have protected the leaf litter beneath them from the snowfall. If they can find prey anywhere, it'll be there.",
-            "stat_trait": "p_l, leading the search for r_c, spots tracks headed away form the path. Confused, they signal the rest of the patrol over, only for r_c to pop out of a bush - there's a rabbit here, frosty and cold but edible. Well worth investigating, and a good (albeit chilly) addition to the fresh-kill pile."
+            "stat_trait": "p_l, leading the search for s_c, spots tracks headed away form the path. Confused, {PRONOUN/p_l/subject} hesitates, only for s_c to pop out of a bush - there's a rabbit here, frosty and cold but edible. Well worth investigating, and a good (albeit chilly) addition to the fresh-kill pile."
         },
         "fail_text": {
             "unscathed_common": "p_l is silently furious at r_c when they find them. A snow storm is no time to go haring off by themselves, and it's destroyed the patrol's hunting chances.",

--- a/resources/dicts/patrols/plains/med/greenleaf.json
+++ b/resources/dicts/patrols/plains/med/greenleaf.json
@@ -808,7 +808,7 @@
         "chance_of_success": 30,
         "exp": 10,
         "success_text": {
-            "unscathed_common": "Truly, dandelions are an essential herb to keep in stock, crucial for poisons and stings. Both the potent milk in their roots and stems, and the fast-acting leaves... even the fluffy dandelion heads are useful as a c_n kitten's favourite, short lived toy. The warriors smile at the sight, sharing fond nursery memories about them as they gather.",
+            "unscathed_common": "Truly, dandelions are an essential herb to keep in stock, crucial for poisons and stings. Both the potent milk in their roots and stems, and the fast-acting leaves... even the fluffy dandelion heads are useful as a c_n kitten favorite, short lived toy. The warriors smile at the sight, sharing fond nursery memories about them as they gather.",
             "unscathed_rare": "It's a successful gathering mission, with p_l striding back to camp with a great haul of whole, intact dandelion plants. Later, they'll sort the leaves and roots to be stored separately - the leaves remain fresh for a far shorter time, but for now they make sure to thank the warriors that have helped them bring home so many.",
             "stat_skill": "With warmth in the air and ground, s_c doesn't need to try very hard to find an excellent haul of dandelions to bring back to camp. They help the warriors carefully pluck fluffy dandelions heads to bring back for the nursery."
         },

--- a/resources/game_config.json
+++ b/resources/game_config.json
@@ -308,6 +308,7 @@
 		"best_stat_modifier": 10,
 		"fail_stat_cat_modifier": -15,
 		"chance_of_romance_patrol": 16,
+		"debug_ensure_patrol_id": "gen_bord_smalldog2",
 		"comment": [
 			"the Cruel Season difficulty modifier needs to have a space rather than an underscore,",
 			"due to how it's written in the save files. So don't try to 'fix' it."

--- a/resources/game_config.json
+++ b/resources/game_config.json
@@ -308,7 +308,7 @@
 		"best_stat_modifier": 10,
 		"fail_stat_cat_modifier": -15,
 		"chance_of_romance_patrol": 16,
-		"debug_ensure_patrol_id": "gen_bord_smalldog2",
+		"debug_ensure_patrol_id": null,
 		"comment": [
 			"the Cruel Season difficulty modifier needs to have a space rather than an underscore,",
 			"due to how it's written in the save files. So don't try to 'fix' it."

--- a/scripts/cat/history.py
+++ b/scripts/cat/history.py
@@ -337,7 +337,7 @@ class History:
             # Will probably sound weird, but it's better than nothing
             if not death_text:
                 if cat.status == 'leader':
-                    death_text = f"died from an injury of illness ({condition})"
+                    death_text = f"died from an injury or illness ({condition})"
                 else:
                     death_text = f"m_c died from an injury or illness ({condition})."
             if not scar_text:

--- a/scripts/debugCommands/__init__.py
+++ b/scripts/debugCommands/__init__.py
@@ -4,8 +4,9 @@ from scripts.debugCommands.settings import ToggleCommand, SetCommand, GetCommand
 from scripts.debugCommands.eval import EvalCommand, UnderstandRisksCommand
 from scripts.debugCommands.clear import ClearCommand
 from scripts.debugCommands.fps import FpsCommand
+from typing import List
 
-commandList: list[Command] = [
+commandList: List[Command] = [
     ToggleCommand(),
     SetCommand(),
     GetCommand(),

--- a/scripts/debugCommands/clear.py
+++ b/scripts/debugCommands/clear.py
@@ -1,4 +1,5 @@
 from scripts.debugCommands.command import Command
+from typing import List
 
 from scripts.debugCommands.utils import _debugClass
 
@@ -8,5 +9,5 @@ class ClearCommand(Command):
     description = "Clear the console"
     aliases = ["cls"]
 
-    def callback(self, args: list[str]):
+    def callback(self, args: List[str]):
         _debugClass.clear_log()

--- a/scripts/debugCommands/command.py
+++ b/scripts/debugCommands/command.py
@@ -3,6 +3,7 @@ Base command class for debug mode.
 """
 
 from abc import ABC, abstractmethod
+from typing import List
 
 
 class Command(ABC):
@@ -41,5 +42,5 @@ class Command(ABC):
         return [self.name] + self.aliases
 
     @abstractmethod
-    def callback(self, args: list[str]):
+    def callback(self, args: List[str]):
         """The callback of the command"""

--- a/scripts/debugCommands/eval.py
+++ b/scripts/debugCommands/eval.py
@@ -2,6 +2,7 @@ from scripts.debugCommands.command import Command
 from scripts.debugCommands.utils import add_output_line_to_log, add_multiple_lines_to_log
 
 import builtins
+from typing import List
 
 warningAccepted = False
 
@@ -13,7 +14,7 @@ class EvalCommand(Command):
     aliases = ["e"]
     bypassConjoinedStrings = True
 
-    def callback(self, args: list[str]):
+    def callback(self, args: List[str]):
         if len(args) == 0:
             add_output_line_to_log(f"Usage: {self.name} {self.usage}")
             return
@@ -46,7 +47,7 @@ class UnderstandRisksCommand(Command):
     name = "understandrisks"
     description = "Accept the risks of using the eval command"
 
-    def callback(self, args: list[str]):
+    def callback(self, args: List[str]):
         global warningAccepted  # pylint: disable=global-statement
         warningAccepted = True
         add_output_line_to_log(

--- a/scripts/debugCommands/fps.py
+++ b/scripts/debugCommands/fps.py
@@ -1,5 +1,6 @@
 from scripts.debugCommands.command import Command
 from scripts.debugCommands.utils import add_output_line_to_log
+from typing import List
 
 from scripts.game_structure.game_essentials import game
 
@@ -9,7 +10,7 @@ class FpsCommand(Command):
     description = "Toggle fps counter"
     usage = "[value]"
 
-    def callback(self, args: list[str]):
+    def callback(self, args: List[str]):
         if len(args) == 1:
             if args[0].lower() in ['none', 'null', '0'] or args[0].is_integer() and int(args[0]) <= 0:
                 game.switches['fps'] = 0

--- a/scripts/debugCommands/help.py
+++ b/scripts/debugCommands/help.py
@@ -1,5 +1,6 @@
 from scripts.debugCommands.command import Command
 from scripts.debugCommands.utils import add_output_line_to_log
+from typing import List
 
 # Command is an abstract class
 
@@ -10,12 +11,12 @@ class HelpCommand(Command):
     usage = "[command]"
     aliases = ["h"]
 
-    commandList: list[Command] = []
+    commandList: List[Command] = []
 
-    def __init__(self, commandList: list[Command]):
+    def __init__(self, commandList: List[Command]):
         self.commandList = commandList + [self]
 
-    def callback(self, args: list[str]):
+    def callback(self, args: List[str]):
         if len(args) == 0:
             add_output_line_to_log("Commands:")
             for command in self.commandList:

--- a/scripts/debugCommands/settings.py
+++ b/scripts/debugCommands/settings.py
@@ -1,5 +1,6 @@
 from scripts.debugCommands.command import Command
 from scripts.debugCommands.utils import add_output_line_to_log
+from typing import List
 
 from scripts.game_structure.game_essentials import game
 from ast import literal_eval
@@ -11,7 +12,7 @@ class ToggleCommand(Command):
     usage = "<game|switch|debug> <setting>"
     aliases = ["t"]
 
-    def callback(self, args: list[str]):
+    def callback(self, args: List[str]):
         if len(args) != 2 or args[0] not in ["game", "switch", "debug"]:
             add_output_line_to_log(f"Usage: {self.name} {self.usage}")
             return
@@ -37,7 +38,7 @@ class SetCommand(Command):
     usage = "<game|switch|debug> <setting> <value>"
     aliases = ["s"]
 
-    def callback(self, args: list[str]):
+    def callback(self, args: List[str]):
         if len(args) != 3 or args[0] not in ["game", "switch", "debug"]:
             add_output_line_to_log(f"Usage: {self.name} {self.usage}")
             return
@@ -63,7 +64,7 @@ class GetCommand(Command):
     usage = "<game|switch|debug> <setting>"
     aliases = ["g"]
 
-    def callback(self, args: list[str]):
+    def callback(self, args: List[str]):
         if len(args) == 0 or args[0] not in ["game", "switch", "debug"]:
             add_output_line_to_log(f"Usage: {self.name} {self.usage}")
             return

--- a/scripts/patrol.py
+++ b/scripts/patrol.py
@@ -87,10 +87,8 @@ class Patrol():
         else:
             print("ERROR: NO POSSIBLE NORMAL PATROLS FOUND for: ", self.patrol_statuses)
             raise RuntimeError
-        if final_romance_patrols:
-            romantic_event_choice = choice(final_romance_patrols) 
-        else:
-            romantic_event_choice = None
+        
+        romantic_event_choice = choice(final_romance_patrols) if final_romance_patrols else None
         
         if romantic_event_choice and Patrol.decide_if_romantic(romantic_event_choice, 
                                                                self.patrol_leader, 
@@ -310,9 +308,38 @@ class Patrol():
             elif clan_hostile:
                 possible_patrols.extend(self.generate_patrol_events(self.OTHER_CLAN_HOSTILE))
 
-        final_patrols, final_romance_patrols = self.filter_patrols(possible_patrols, biome, patrol_size, current_season,
-                                                                   patrol_type)
+        final_patrols, final_romance_patrols = self. get_filtered_patrols(possible_patrols, biome, patrol_size, current_season,
+                                                                          patrol_type)
 
+        # This is a debug option. If the patrol_id set isn "debug_ensure_patrol" is possible, 
+        # make it the *only* possible patrol
+        if isinstance(game.config["patrol_generation"]["debug_ensure_patrol_id"], str):
+            for _pat in final_patrols:
+                if _pat.patrol_id == game.config["patrol_generation"]["debug_ensure_patrol_id"]:
+                    final_patrols = [_pat]
+                    print(f"debug_ensure_patrol_id: " 
+                          f'"{game.config["patrol_generation"]["debug_ensure_patrol_id"]}" '
+                           "is a possible normal patrol, and was set as the only "
+                           "normal patrol option")
+                    break
+            else:
+                print(f"debug_ensure_patrol_id: "
+                      f'"{game.config["patrol_generation"]["debug_ensure_patrol_id"]}" '
+                      "is not a possible normal patrol.")
+            
+            for _pat in final_romance_patrols:
+                if _pat.patrol_id == game.config["patrol_generation"]["debug_ensure_patrol_id"]:
+                    final_romance_patrols = [_pat]
+                    print(f"debug_ensure_patrol_id: " 
+                          f'"{game.config["patrol_generation"]["debug_ensure_patrol_id"]}" '
+                           "is a possible romantic patrol, and was set as the only "
+                           "romantic patrol option")
+                    break
+            else:
+                print(f"debug_ensure_patrol_id: "
+                      f'"{game.config["patrol_generation"]["debug_ensure_patrol_id"]}" '
+                      "is not a possible romantic patrol.")
+            
         return final_patrols, final_romance_patrols
 
     def check_constraints(self, patrol):
@@ -621,16 +648,18 @@ class Patrol():
         print("final romance chance:", chance_of_romance_patrol)
         return not int(random.random() * chance_of_romance_patrol)
 
-    def filter_patrols(self, possible_patrols, biome, patrol_size, current_season, patrol_type):
+    def _filter_patrols(self, possible_patrols, biome, patrol_size, current_season, patrol_type):
         filtered_patrols = []
         romantic_patrols = []
-        self.filter_count = 0
 
         # makes sure that it grabs patrols in the correct biomes, season, with the correct number of cats
         for patrol in possible_patrols:
             if not self.check_constraints(patrol):
                 continue
-            if patrol.patrol_id in self.used_patrols:
+            
+            # Don't check for repeat patrols if ensure_patrol_id is being used. 
+            if not isinstance(game.config["patrol_generation"]["debug_ensure_patrol_id"], str) and \
+                    patrol.patrol_id in self.used_patrols:
                 continue
 
             if patrol_size < patrol.min_cats:
@@ -762,24 +791,20 @@ class Patrol():
         if patrol_type == 'hunting':
             filtered_patrols = self.balance_hunting(filtered_patrols)
 
-        if not filtered_patrols:
-            if self.filter_count == 1:
-                # error message will print from patrol_screens.py once this is returned
-                return filtered_patrols, romantic_patrols
-            self.filter_count += 1
-            self.used_patrols.clear()
-            print('used patrols cleared', self.used_patrols)
-            filtered_patrols, romantic_patrols = self.repeat_filter(possible_patrols, biome, patrol_size,
-                                                                    current_season, patrol_type)
-        else:
-            # reset this when we succeed in finding a patrol
-            self.filter_count = 0
         return filtered_patrols, romantic_patrols
 
-    def repeat_filter(self, possible_patrols, biome, patrol_size, current_season, patrol_type):
-        print('repeating filter')
-        filtered_patrols, romantic_patrols = self.filter_patrols(possible_patrols, biome, patrol_size, current_season,
-                                                                 patrol_type)
+    def get_filtered_patrols(self, possible_patrols, biome, patrol_size, current_season, patrol_type):
+        
+        filtered_patrols, romantic_patrols = self._filter_patrols(possible_patrols, biome, patrol_size, current_season,
+                                                                  patrol_type)
+        
+        if not filtered_patrols:
+            print('No normal patrols possible. Repeating filter with used patrols cleared.')
+            self.used_patrols.clear()
+            print('used patrols cleared', self.used_patrols)
+            filtered_patrols, romantic_patrols = self._filter_patrols(possible_patrols, biome, patrol_size,
+                                                                      current_season, patrol_type)    
+        
         return filtered_patrols, romantic_patrols
 
     def get_patrol_art(self):


### PR DESCRIPTION
- Various types and pronoun tag fixes
- Fixed a misplaced `:` in an event that was causing crashes. 
- Switched type hints in the debug commands to pre-3.9 syntax, to support 3.8 builds. 
- Added "debug_ensure_patrol_id" which helps debugging certain patrols. 
- Removed some unnecessary recursion in patrol filtering. 