### PR TITLE
Adjust Patrol New_Cat Joining, some other

### DIFF
--- a/resources/dicts/patrols/new_cat.json
+++ b/resources/dicts/patrols/new_cat.json
@@ -867,7 +867,7 @@
                 "exp": 10,
                 "weight": 20,
                 "new_cat": [
-                    ["status:warrior"],
+                    ["status:warrior", "can_birth"],
                     ["litter", "parent:0", "status:newborn"]
                 ],
                 "relationships": [
@@ -885,7 +885,7 @@
                 "exp": 10,
                 "weight": 5,
                 "new_cat": [
-                    ["status:warrior"],
+                    ["status:warrior", "can_birth"],
                     ["litter", "parent:0", "status:newborn"]
                 ],
                 "relationships": [
@@ -948,7 +948,7 @@
                 "exp": 10,
                 "weight": 20,
                 "new_cat": [
-                    ["status:warrior", "dead", "meeting"],
+                    ["status:warrior", "dead", "meeting", "can_birth"],
                     ["litter", "parent:0", "status:newborn", "backstory:orphaned1,orphaned2"]
                 ],
                 "relationships": [
@@ -966,7 +966,7 @@
                 "exp": 10,
                 "weight": 5,
                 "new_cat": [
-                    ["status:warrior", "dead", "meeting"],
+                    ["status:warrior", "dead", "meeting", "can_birth"],
                     ["litter", "parent:0", "status:newborn", "backstory:orphaned1,orphaned2"]
                 ],
                 "relationships": [
@@ -1031,7 +1031,7 @@
                 "exp": 10,
                 "weight": 20,
                 "new_cat": [
-                    ["status:warrior"],
+                    ["status:warrior", "can_birth"],
                     ["litter", "parent:0", "status:newborn"]
                 ],
                 "relationships": [
@@ -1049,7 +1049,7 @@
                 "exp": 10,
                 "weight": 5,
                 "new_cat": [
-                    ["status:warrior"],
+                    ["status:warrior", "can_birth"],
                     ["litter", "parent:0", "status:newborn"]
                 ],
                 "relationships": [
@@ -1114,7 +1114,7 @@
                 "exp": 10,
                 "weight": 20,
                 "new_cat": [
-                    ["status:warrior", "dead", "meeting"],
+                    ["status:warrior", "dead", "meeting", "can_birth"],
                     ["litter", "parent:0", "status:newborn", "backstory:orphaned1,orphaned2"]
                 ],
                 "relationships": [
@@ -1132,7 +1132,7 @@
                 "exp": 10,
                 "weight": 5,
                 "new_cat": [
-                    ["status:warrior", "dead", "meeting"],
+                    ["status:warrior", "dead", "meeting", "can_birth"],
                     ["litter", "parent:0", "status:newborn", "backstory:orphaned1,orphaned2"]
                 ],
                 "relationships": [
@@ -1196,7 +1196,7 @@
                 "exp": 10,
                 "weight": 20,
                 "new_cat": [
-                    ["status:warrior"],
+                    ["status:warrior", "can_birth"],
                     ["litter", "parent:0", "status:newborn"]
                 ],
                 "relationships": [
@@ -1214,7 +1214,7 @@
                 "exp": 10,
                 "weight": 5,
                 "new_cat": [
-                    ["status:warrior"],
+                    ["status:warrior", "can_birth"],
                     ["litter", "parent:0", "status:newborn"]
                 ],
                 "relationships": [
@@ -1285,7 +1285,7 @@
                 "exp": 10,
                 "weight": 20,
                 "new_cat": [
-                    ["status:warrior", "dead", "meeting"],
+                    ["status:warrior", "dead", "meeting", "can_birth"],
                     ["litter", "parent:0", "status:newborn", "backstory:orphaned1,orphaned2"]
                 ],
                 "relationships": [
@@ -1303,7 +1303,7 @@
                 "exp": 10,
                 "weight": 5,
                 "new_cat": [
-                    ["status:warrior", "dead", "meeting"],
+                    ["status:warrior", "dead", "meeting", "can_birth"],
                     ["litter", "parent:0", "status:newborn", "backstory:orphaned1,orphaned2"]
                 ],
                 "relationships": [

--- a/resources/dicts/patrols/new_cat_hostile.json
+++ b/resources/dicts/patrols/new_cat_hostile.json
@@ -1027,7 +1027,7 @@
                 "exp": 10,
                 "weight": 20,
                 "new_cat": [
-                    ["status:warrior"],
+                    ["status:warrior", "can_birth"],
                     ["litter", "parent:0", "status:newborn"]
                 ],
                 "relationships": [
@@ -1045,7 +1045,7 @@
                 "exp": 10,
                 "weight": 5,
                 "new_cat": [
-                    ["status:warrior"],
+                    ["status:warrior", "can_birth"],
                     ["litter", "parent:0", "status:newborn"]
                 ],
                 "relationships": [
@@ -1108,7 +1108,7 @@
                 "exp": 10,
                 "weight": 20,
                 "new_cat": [
-                    ["status:warrior", "dead", "meeting"],
+                    ["status:warrior", "dead", "meeting", "can_birth"],
                     ["litter", "parent:0", "status:newborn", "backstory:orphaned1,orphaned2"]
                 ],
                 "relationships": [
@@ -1126,7 +1126,7 @@
                 "exp": 10,
                 "weight": 5,
                 "new_cat": [
-                    ["status:warrior", "dead", "meeting"],
+                    ["status:warrior", "dead", "meeting", "can_birth", "can_birth"],
                     ["litter", "parent:0", "status:newborn", "backstory:orphaned1,orphaned2"]
                 ],
                 "relationships": [
@@ -1191,7 +1191,7 @@
                 "exp": 10,
                 "weight": 20,
                 "new_cat": [
-                    ["status:warrior"],
+                    ["status:warrior", "can_birth"],
                     ["litter", "parent:0", "status:newborn"]
                 ],
                 "relationships": [
@@ -1209,7 +1209,7 @@
                 "exp": 10,
                 "weight": 5,
                 "new_cat": [
-                    ["status:warrior"],
+                    ["status:warrior", "can_birth"],
                     ["litter", "parent:0", "status:newborn"]
                 ],
                 "relationships": [
@@ -1274,7 +1274,7 @@
                 "exp": 10,
                 "weight": 20,
                 "new_cat": [
-                    ["status:warrior", "dead", "meeting"],
+                    ["status:warrior", "dead", "meeting", "can_birth"],
                     ["litter", "parent:0", "status:newborn", "backstory:orphaned1,orphaned2"]
                 ],
                 "relationships": [
@@ -1292,7 +1292,7 @@
                 "exp": 10,
                 "weight": 5,
                 "new_cat": [
-                    ["status:warrior", "dead", "meeting"],
+                    ["status:warrior", "dead", "meeting", "can_birth"],
                     ["litter", "parent:0", "status:newborn", "backstory:orphaned1,orphaned2"]
                 ],
                 "relationships": [
@@ -1356,7 +1356,7 @@
                 "exp": 10,
                 "weight": 20,
                 "new_cat": [
-                    ["status:warrior"],
+                    ["status:warrior", "can_birth"],
                     ["litter", "parent:0", "status:newborn"]
                 ],
                 "relationships": [
@@ -1374,7 +1374,7 @@
                 "exp": 10,
                 "weight": 5,
                 "new_cat": [
-                    ["status:warrior"],
+                    ["status:warrior", "can_birth"],
                     ["litter", "parent:0", "status:newborn"]
                 ],
                 "relationships": [
@@ -1438,7 +1438,7 @@
                 "exp": 10,
                 "weight": 20,
                 "new_cat": [
-                    ["status:warrior", "dead", "meeting"],
+                    ["status:warrior", "dead", "meeting", "can_birth"],
                     ["litter", "parent:0", "status:newborn", "backstory:orphaned1,orphaned2"]
                 ],
                 "relationships": [
@@ -1456,7 +1456,7 @@
                 "exp": 10,
                 "weight": 5,
                 "new_cat": [
-                    ["status:warrior", "dead", "meeting"],
+                    ["status:warrior", "dead", "meeting", "can_birth"],
                     ["litter", "parent:0", "status:newborn", "backstory:orphaned1,orphaned2"]
                 ],
                 "relationships": [

--- a/resources/dicts/patrols/new_cat_welcoming.json
+++ b/resources/dicts/patrols/new_cat_welcoming.json
@@ -845,7 +845,7 @@
                 "exp": 10,
                 "weight": 20,
                 "new_cat": [
-                    ["status:warrior", "loner"],
+                    ["status:warrior", "loner", "can_birth"],
                     ["litter", "parent:0", "status:newborn"]
                 ],
                 "relationships": [
@@ -863,7 +863,7 @@
                 "exp": 10,
                 "weight": 5,
                 "new_cat": [
-                    ["status:warrior", "loner"],
+                    ["status:warrior", "loner", "can_birth"],
                     ["litter", "parent:0", "status:newborn"]
                 ],
                 "relationships": [
@@ -882,7 +882,7 @@
                 "weight": 20,
                 "stat_trait": ["compassionate", "empathetic", "loving", "calm"],
                 "new_cat": [
-                    ["status:warrior", "loner"],
+                    ["status:warrior", "loner", "can_birth"],
                     ["litter", "parent:0", "status:newborn"]
                 ],
                 "relationships": [
@@ -966,7 +966,7 @@
                 "exp": 10,
                 "weight": 20,
                 "new_cat": [
-                    ["status:warrior"],
+                    ["status:warrior", "can_birth"],
                     ["litter", "parent:0", "status:newborn"]
                 ],
                 "relationships": [
@@ -984,7 +984,7 @@
                 "exp": 10,
                 "weight": 5,
                 "new_cat": [
-                    ["status:warrior"],
+                    ["status:warrior", "can_birth"],
                     ["litter", "parent:0", "status:newborn"]
                 ],
                 "relationships": [
@@ -1047,7 +1047,7 @@
                 "exp": 10,
                 "weight": 20,
                 "new_cat": [
-                    ["status:warrior", "dead", "meeting"],
+                    ["status:warrior", "dead", "meeting", "can_birth"],
                     ["litter", "parent:0", "status:newborn", "backstory:orphaned1,orphaned2"]
                 ],
                 "relationships": [
@@ -1065,7 +1065,7 @@
                 "exp": 10,
                 "weight": 5,
                 "new_cat": [
-                    ["status:warrior", "dead", "meeting"],
+                    ["status:warrior", "dead", "meeting", "can_birth"],
                     ["litter", "parent:0", "status:newborn", "backstory:orphaned1,orphaned2"]
                 ],
                 "relationships": [
@@ -1130,7 +1130,7 @@
                 "exp": 10,
                 "weight": 20,
                 "new_cat": [
-                    ["status:warrior"],
+                    ["status:warrior", "can_birth"],
                     ["litter", "parent:0", "status:newborn"]
                 ],
                 "relationships": [
@@ -1148,7 +1148,7 @@
                 "exp": 10,
                 "weight": 5,
                 "new_cat": [
-                    ["status:warrior"],
+                    ["status:warrior", "can_birth"],
                     ["litter", "parent:0", "status:newborn"]
                 ],
                 "relationships": [
@@ -1213,7 +1213,7 @@
                 "exp": 10,
                 "weight": 20,
                 "new_cat": [
-                    ["status:warrior", "dead", "meeting"],
+                    ["status:warrior", "dead", "meeting", "can_birth"],
                     ["litter", "parent:0", "status:newborn", "backstory:orphaned1,orphaned2"]
                 ],
                 "relationships": [
@@ -1231,7 +1231,7 @@
                 "exp": 10,
                 "weight": 5,
                 "new_cat": [
-                    ["status:warrior", "dead", "meeting"],
+                    ["status:warrior", "dead", "meeting", "can_birth"],
                     ["litter", "parent:0", "status:newborn", "backstory:orphaned1,orphaned2"]
                 ],
                 "relationships": [
@@ -1295,7 +1295,7 @@
                 "exp": 10,
                 "weight": 20,
                 "new_cat": [
-                    ["status:warrior"],
+                    ["status:warrior", "can_birth"],
                     ["litter", "parent:0", "status:newborn"]
                 ],
                 "relationships": [
@@ -1313,7 +1313,7 @@
                 "exp": 10,
                 "weight": 5,
                 "new_cat": [
-                    ["status:warrior"],
+                    ["status:warrior", "can_birth"],
                     ["litter", "parent:0", "status:newborn"]
                 ],
                 "relationships": [
@@ -1384,7 +1384,7 @@
                 "exp": 10,
                 "weight": 20,
                 "new_cat": [
-                    ["status:warrior", "dead", "meeting"],
+                    ["status:warrior", "dead", "meeting", "can_birth"],
                     ["litter", "parent:0", "status:newborn", "backstory:orphaned1,orphaned2"]
                 ],
                 "relationships": [
@@ -1402,7 +1402,7 @@
                 "exp": 10,
                 "weight": 5,
                 "new_cat": [
-                    ["status:warrior", "dead", "meeting"],
+                    ["status:warrior", "dead", "meeting", "can_birth"],
                     ["litter", "parent:0", "status:newborn", "backstory:orphaned1,orphaned2"]
                 ],
                 "relationships": [

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -396,8 +396,6 @@ class Cat():
         body - defaults to True, use this to mark if the body was recovered so
         that grief messages will align with body status
 
-        died_by_condition - defaults to False, use this to mark if the cat is dying via a condition.
-
         May return some additional text to add to the death event.
         """
         self.injuries.clear()

--- a/scripts/patrol/patrol.py
+++ b/scripts/patrol/patrol.py
@@ -545,7 +545,7 @@ class Patrol():
                     print(f"Issue with status limits: {patrol.patrol_id}")
                     continue
                 
-                if not (num[0] <= self.patrol_statuses.get(sta, 0) <= num[1]):
+                if not (num[0] <= self.patrol_statuses.get(sta, -1) <= num[1]):
                     flag = True
                     break
             if flag:

--- a/scripts/patrol/patrol.py
+++ b/scripts/patrol/patrol.py
@@ -66,6 +66,8 @@ class Patrol():
             game.settings.get('disasters')
         )
         
+        print(f'Total Number of Possible Patrols | normal: {len(final_patrols)}, romantic: {len(final_romance_patrols)} ')
+        
         if final_patrols:
             normal_event_choice = choices(final_patrols, weights=[x.weight for x in final_patrols])[0]
         else:
@@ -651,9 +653,7 @@ class Patrol():
         
         final_event, success = self.calculate_success(chosen_success, chosen_failure)
         
-        print(f"PATROL ID: {self.patrol_event.patrol_id}")
-        print(f"Success: {success}")
-        
+        print(f"PATROL ID: {self.patrol_event.patrol_id} | SUCCESS: {success}")        
         
         # Run the chosen outcome
         return final_event.execute_outcome(self)

--- a/scripts/patrol/patrol_outcome.py
+++ b/scripts/patrol/patrol_outcome.py
@@ -883,7 +883,7 @@ class PatrolOutcome():
             gender = "male"
         elif "female" in attribute_list:
             gender = "female"
-        elif "gave_birth" in attribute_list and not game.settings["same sex birth"]:
+        elif "can_birth" in attribute_list and not game.settings["same sex birth"]:
             gender = "female"
         else:
             gender = None
@@ -938,9 +938,6 @@ class PatrolOutcome():
                 chosen_backstory = match.group(1)
                 break
         
-        # Is the cat dead?
-        alive = "dead" not in attribute_list
-        
         #Grabs any relations. Note that any relations to this cat must be generated first! 
         parents = []
         for _tag in attribute_list:
@@ -970,7 +967,13 @@ class PatrolOutcome():
             outside = True
             status = cat_type
             new_name = False
-            thought = choice(["Is curious about the new cats they just meet."])
+            thought = "Is wondering about the new cats they just meet."
+            
+        # Is the cat dead?
+        alive = True
+        if "dead" in attribute_list:
+            alive = False
+            thought = "Explores a new starry world"
         
         # Biological parents can be added if they are created before this cat
         parent1 = None

--- a/scripts/patrol/patrol_outcome.py
+++ b/scripts/patrol/patrol_outcome.py
@@ -813,20 +813,38 @@ class PatrolOutcome():
                     results.append(f"{cat.name} joined the clan.")
             
         
-        # Now, a second time to establish non-biological relations and update inheritance
+        in_patrol_cats = {
+            "p_l": patrol.patrol_leader,
+            "r_c": patrol.patrol_random_cat,
+        }
+        if self.stat_cat:
+            in_patrol_cats["s_c"] = self.stat_cat
+        
+        # Now, a second time to establish non-biological relations
         for i, attribute_list in enumerate(self.new_cat):
             # Mates
             for tag in attribute_list:
-                match = re.match(r"mates:([,0-9]+)", tag)
+                match = re.match(r"mates:([,0-9a-zA-Z]+)", tag)
                 if not match:
                     continue
                 
                 mate_indexes = match.group(1).split(",")
-                if not mate_indexes:
-                    continue
                 
                 # TODO: make this less ugly
                 for index in mate_indexes:
+                    if index in in_patrol_cats:
+                        if in_patrol_cats[index] in ("apprentice", "medicine cat apprentice"):
+                            print("Can't give apprentices mates")
+                            continue
+                        
+                        for cat in cat.patrol.new_cats[i]:
+                            cat.set_mate(in_patrol_cats[index])
+                            
+                    try:
+                        index = int(index)
+                    except ValueError:
+                        print(f"mate-index not correct: {index}")
+                    
                     if index >= len(attribute_list):
                         continue
                     
@@ -834,7 +852,7 @@ class PatrolOutcome():
                         for other in patrol.new_cats[index]:
                             if cat.ID not in other.mate:
                                 cat.set_mate(other)
-            
+                                
         #Update all inheritance
         for sub in patrol.new_cats:
             for cat in sub:
@@ -857,6 +875,8 @@ class PatrolOutcome():
             
     def __create_new_cat_block(self, i:int, attribute_list: List[str], patrol:'Patrol') -> List[Cat]: 
         """Creates a single new_cat block """
+        
+        thought = choice(["Is looking around the camp with wonder", "Is getting used to their new home"])
         
         # Determine gender
         if "male" in attribute_list:
@@ -921,13 +941,6 @@ class PatrolOutcome():
         # Is the cat dead?
         alive = "dead" not in attribute_list
         
-        # If we are meeting this cat, we need to make sure their status is correct
-        # so they aren't a lost cat. 
-        outside = False
-        if "meeting" in attribute_list:
-            outside = True
-            status = cat_type    
-        
         #Grabs any relations. Note that any relations to this cat must be generated first! 
         parents = []
         for _tag in attribute_list:
@@ -943,9 +956,21 @@ class PatrolOutcome():
         litter = False
         if "litter" in attribute_list:
             litter = True
-            if status not in ["kitten", "newborn"]:
+            if status not in ("kitten", "newborn"):
                 status = "kitten"
         
+        # Thought check for kittens
+        if status in ("kitten", "newborn"):
+            thought = "Is snuggled safe in the nursury"
+        
+        # If we are meeting this cat, we need to make sure their status is correct
+        # so they aren't a lost cat. 
+        outside = False
+        if "meeting" in attribute_list:
+            outside = True
+            status = cat_type
+            new_name = False
+            thought = choice(["Is curious about the new cats they just meet."])
         
         # Biological parents can be added if they are created before this cat
         parent1 = None
@@ -965,31 +990,73 @@ class PatrolOutcome():
                     continue
                 
                 if parent1 is None:
-                    parent1 = patrol.new_cats[index][0].ID
+                    parent1 = patrol.new_cats[index][0]
                 else:
-                    parent2 = patrol.new_cats[index][0].ID
+                    parent2 = patrol.new_cats[index][0]
             break
                 
                     
         # Now, it's time to generate the new cat
         # This function needs to be rewritten this is a pain. 
-        return create_new_cat(Cat,
-                              Relationship,
-                              new_name=new_name,
-                              loner=cat_type in ["loner", "rogue"],
-                              kittypet=cat_type == "kittypet",
-                              kit=False if litter else status in ["kitten", "newborn"],  # this is for singular kits, litters need this to be false
-                              litter=litter,
-                              other_clan=patrol.other_clan if cat_type == "former_clancat" else None,
-                              backstory=chosen_backstory,
-                              status=status,
-                              gender=gender,
-                              thought="just joined the clan",
-                              alive=alive,
-                              outside=outside,
-                              parent1=parent1,
-                              parent2=parent2  
-                             )
+        new_cats = create_new_cat(Cat,
+                                Relationship,
+                                new_name=new_name,
+                                loner=cat_type in ["loner", "rogue"],
+                                kittypet=cat_type == "kittypet",
+                                kit=False if litter else status in ["kitten", "newborn"],  # this is for singular kits, litters need this to be false
+                                litter=litter,
+                                other_clan=patrol.other_clan if cat_type == "former_clancat" else None,
+                                backstory=chosen_backstory,
+                                status=status,
+                                gender=gender,
+                                thought=thought,
+                                alive=alive,
+                                outside=outside,
+                                parent1=parent1.ID if parent1 else None,
+                                parent2=parent2.ID if parent2 else None  
+                                 )
+                
+        # Add relations to biological parents, if needed
+        # Also relations to cat generated in the same block - they are littermates
+        # DON'T ADD RELATION TO CAT IN THE PATROL
+        # That is done in the relationships block of the patrol, to give control for writing. 
+        for n_c in new_cats:
+            
+            #Cat in the same block (littermates)
+            for inter_cat in new_cats:
+                if n_c == inter_cat:
+                    continue
+                
+                y = random.randrange(0, 20)
+                start_relation = Relationship(inter_cat, n_c, False, True)
+                start_relation.platonic_like += 30 + y
+                start_relation.comfortable = 10 + y
+                start_relation.admiration = 15 + y
+                start_relation.trust = 10 + y
+                n_c.relationships[inter_cat.ID] = start_relation
+                
+            # Bio parents (if given)
+            for par in (parent1, parent2):
+                if not par:
+                    continue
+                
+                y = random.randrange(0, 20)
+                start_relation = Relationship(par, n_c, False, True)
+                start_relation.platonic_like += 30 + y
+                start_relation.comfortable = 10 + y
+                start_relation.admiration = 15 + y
+                start_relation.trust = 10 + y
+                par.relationships[n_c.ID] = start_relation
+                
+                y = random.randrange(0, 20)
+                start_relation = Relationship(n_c, par, False, True)
+                start_relation.platonic_like += 30 + y
+                start_relation.comfortable = 10 + y
+                start_relation.admiration = 15 + y
+                start_relation.trust = 10 + y
+                n_c.relationships[par.ID] = start_relation
+                
+        return new_cats
                  
     def _handle_mentor_app(self, patrol:'Patrol') -> str:
         """Handles mentor inflence on apprentices """

--- a/scripts/utility.py
+++ b/scripts/utility.py
@@ -407,7 +407,7 @@ def create_new_cat(Cat,
         if outside:
             new_cat.outside = True
         if not alive:
-            new_cat.dead = True
+            new_cat.die()
 
         # newbie thought
         new_cat.thought = thought
@@ -456,7 +456,7 @@ def create_outside_cat(Cat, status, backstory, alive=True, thought=None):
     new_cat.outside = True
 
     if not alive:
-        new_cat.dead = True
+        new_cat.die()
 
     thought = "Wonders about those Clan cats they just met"
     new_cat.thought = thought


### PR DESCRIPTION
- Adjusted new cat joining a bit, so it's a bit less wonky. 
- New cats will now generate with relationships to their parents and littermates.
- Gave new cats proper thoughts
- Ensure dead outside cats, when meet on patrol, join UR
- Ensure queens joining with newborn kittens will be the correct sex to give birth. 
- Added ability to make new_cat the mate of p_l, r_c or s_c.  
- Fixed an issue making any patrol with a [-1, -1] min_max_status entry impossible to roll
- Added patrol print to show the number of possible patrols. 