### PR TITLE
Added Loading Screen to Patrol Screen, Fix Type Hints

### DIFF
--- a/scripts/debugCommands/cat.py
+++ b/scripts/debugCommands/cat.py
@@ -23,7 +23,7 @@ class removeCatCommand(Command):
     aliases = ["r"]
     usage = "<cat name|id>"
 
-    def callback(self, args: list[str]):
+    def callback(self, args: List[str]):
         if len(args) == 0:
             add_output_line_to_log("Please specify a cat name or ID")
             return
@@ -39,7 +39,7 @@ class listCatsCommand(Command):
     description = "List all cats"
     aliases = ["l"]
 
-    def callback(self, args: list[str]):
+    def callback(self, args: List[str]):
         for cat in Cat.all_cats_list:
             add_output_line_to_log(f"{cat.ID} - {cat.name}, {cat.status}, {cat.moons} moons old")
 
@@ -49,7 +49,7 @@ class ageCatsCommand(Command):
     aliases = ["a"]
     usage = "<cat name|id> [number]"
 
-    def callback(self, args: list[str]):
+    def callback(self, args: List[str]):
         if len(args) == 0:
             add_output_line_to_log("Please specify a cat name or ID")
             return
@@ -81,5 +81,5 @@ class CatsCommand(Command):
         ageCatsCommand()
     ]
 
-    def callback(self, args: list[str]):
+    def callback(self, args: List[str]):
         add_output_line_to_log("Please specify a subcommand")

--- a/scripts/debugMenu.py
+++ b/scripts/debugMenu.py
@@ -9,6 +9,7 @@ from ast import literal_eval
 
 import builtins
 
+from typing import List
 from scripts.game_structure.game_essentials import MANAGER, game
 
 from scripts.utility import get_text_box_theme
@@ -29,7 +30,7 @@ class debugConsole(pygame_gui.windows.UIConsoleWindow):
 
     def process_event(self, event):
         if event.type == pygame_gui.UI_CONSOLE_COMMAND_ENTERED:
-            command: list[str] = event.command.split(" ")
+            command: List[str] = event.command.split(" ")
             args = command[1:]
             command = command[0]
 

--- a/scripts/screens/base_screens.py
+++ b/scripts/screens/base_screens.py
@@ -1,14 +1,14 @@
 import pygame
 
-from scripts.utility import update_sprite, scale, scale_dimentions
+from scripts.utility import update_sprite, scale
 from scripts.cat.cats import Cat
-from scripts.clan import Clan
 from scripts.game_structure.game_essentials import game, screen, screen_x, screen_y, MANAGER
 from scripts.game_structure import image_cache
 from scripts.game_structure.image_button import UIImageButton
 import pygame_gui
 from scripts.game_structure.windows import SaveCheck, EventLoading
 from scripts.game_structure.propagating_thread import PropagatingThread
+from threading import get_ident
 
 class Screens():
     game_screen = screen
@@ -110,38 +110,48 @@ class Screens():
         
         # Place to store the loading window
         self.loading_window = None
-        self.work_done = False
+        
+        # Dictionary of work done, keyed by the target function name
+        self.work_done = {}
         
 
     def loading_screen_start_work(self,
-                                  target) -> PropagatingThread:
+                                  target:callable,
+                                  args:tuple=tuple()) -> PropagatingThread:
         """Creates and starts the work_thread. 
             Returns the started thread. """
 
-        work_thread = PropagatingThread(target=self._work_target, args=(target,), daemon=True)
+        work_thread = PropagatingThread(target=self._work_target, args=(target,args), daemon=True)
         game.switches['window_open'] = True
+        
         work_thread.start()
+        self.work_done[work_thread.ident] = False
         
         return work_thread
         
-    
-    def _work_target(self, target):
+    def _work_target(self, target, args):
         
         try:
-            target()
+            target(*args)
         except:
             raise
         finally:
-            self.work_done = True
+            self.work_done[get_ident()] = True
 
     def loading_screen_on_use(self, 
                               work_thread:PropagatingThread,
-                              final_actions,
+                              final_actions:callable,
                               loading_screen_pos:tuple=None, 
                               delay:float=0.7) -> bool:
         """Handles all actions that must be run every frame for the loading window to work. 
         Also handles creating and killing the loading window. 
          """
+        
+        if not isinstance(work_thread, PropagatingThread):
+            if self.loading_window:
+                self.loading_window.kill()
+                self.loading_window = None
+            return
         
         # Handled the loading animation, both creating and killing it. 
         if not self.loading_window and work_thread.is_alive() \
@@ -152,16 +162,17 @@ class Screens():
             self.loading_window = None
         
         # Handles displaying the events once timeskip is done. 
-        if self.work_done:
+        if self.work_done.get(work_thread.ident, False):
             # By this time, the thread should have already finished.
             # This line allows exceptions in the work thread to be 
             # passed to the main thread, so issues in the work thread are not
             # silent failures. 
             work_thread.join()
             
+            self.work_done.pop(work_thread.ident)
+            
             final_actions()
             game.switches['window_open'] = False
-            self.work_done = False
             
         return self.work_done
         

--- a/scripts/screens/event_screens.py
+++ b/scripts/screens/event_screens.py
@@ -53,7 +53,7 @@ class EventsScreen(Screens):
         self.involved_cat_buttons = []
         self.cat_profile_buttons = {}
         self.scroll_height = {}
-        self.events_thread = PropagatingThread()
+        self.events_thread = None
 
         # Stores the involved cat button that currently has its cat profile buttons open
         self.open_involved_cat_button = None


### PR DESCRIPTION
- Added ability for more than one loading-screen work thread on one screen
- Loading screens now pop up if patrol start or proceed is taking too long. This should almost never happen, but with the ability to make new cats join as the mate of current cats, inheritance re-calculation might cause lagging. 
- Fix wrong type of type hints. 