### PR TITLE
Fix for patrol cat selection bug

### DIFF
--- a/resources/dicts/events/ceremonies/ceremony-master.json
+++ b/resources/dicts/events/ceremonies/ceremony-master.json
@@ -834,7 +834,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "(mentor) calls a meeting. {PRONOUN/(mentor)/subject} {VERB/(mentor)/have/has} been watching (old_name) for a while now, and have decided to mentor {PRONOUN/m_c/object} personally. m_c's eyes shine with pride. "
+    "(mentor) calls a meeting. {PRONOUN/(mentor)/subject/CAP} {VERB/(mentor)/have/has} been watching (old_name) for a while now, and {VERB/(mentor)/have/has} decided to mentor {PRONOUN/m_c/object} personally. m_c's eyes shine with pride. "
   ],
   "app_54":[
     [
@@ -2128,7 +2128,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "(previous_mentor) gives (old_name) a friendly nudge when the leader calls the young cat's name. {PRONOUN/(previous_mentor)/subject/CAP} {VERB/(previous_mentor)/watch/watches} with pride as (old_name) steps forward to receive {PRONOUN/m_c/poss} new name, m_c, and are honored for {PRONOUN/m_c/poss} r_h."
+    "(previous_mentor) gives (old_name) a friendly nudge when the leader calls the young cat's name. {PRONOUN/(previous_mentor)/subject/CAP} {VERB/(previous_mentor)/watch/watches} with pride as (old_name) steps forward to receive {PRONOUN/m_c/poss} new name, m_c, and {VERB/m_c/are/is} honored for {PRONOUN/m_c/poss} r_h."
   ],
   "warrior_8": [
     [
@@ -2191,7 +2191,7 @@
       "arrogant",
       "cunning"
     ],
-    "(old_name) stands tall and puffs out {PRONOUN/m_c/poss} chest as l_n announces {PRONOUN/m_c/subject} {VERB/m_c/are/is} ready for {PRONOUN/m_c/subject} warrior name. {PRONOUN/m_c/subject/CAP} {VERB/m_c/are/is} given the name m_c after {PRONOUN/m_c/poss} r_h."
+    "(old_name) stands tall and puffs out {PRONOUN/m_c/poss} chest as l_n announces {PRONOUN/m_c/subject} {VERB/m_c/are/is} ready for {PRONOUN/m_c/poss} warrior name. {PRONOUN/m_c/subject/CAP} {VERB/m_c/are/is} given the name m_c after {PRONOUN/m_c/poss} r_h."
   ],
   "warrior_13": [
     [
@@ -2739,7 +2739,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "p1 and p2's eyes meet, and they purr with pride as (old_name) steps forward to receive {PRONOUN/m_c/poss} new name, m_c, and are honored for {PRONOUN/m_c/poss} r_h."
+    "p1 and p2's eyes meet, and they purr with pride as (old_name) steps forward to receive {PRONOUN/m_c/poss} new name, m_c, and {VERB/m_c/are/is} honored for {PRONOUN/m_c/poss} r_h."
   ],
   "warrior_57": [
     [

--- a/resources/dicts/events/new_cat/general/general.json
+++ b/resources/dicts/events/new_cat/general/general.json
@@ -531,7 +531,7 @@
         "reputation": [
             "welcoming"
         ],
-        "event_text": "A o_c queen decides to leave their litter with you. m_c takes them as {PRONOUN/m_c/subject} own.",
+        "event_text": "A o_c queen decides to leave their litter with you. m_c takes them as {PRONOUN/m_c/poss} own.",
         "other_clan": true,
         "litter": true,
         "backstory": [

--- a/resources/dicts/thoughts/alive/general.json
+++ b/resources/dicts/thoughts/alive/general.json
@@ -1414,7 +1414,7 @@
             "Finds that today is going to be a better day than the last",
             "Is making {PRONOUN/m_c/poss} friends laugh at the expense of {PRONOUN/m_c/self}",
             "Finds that {PRONOUN/m_c/subject} {VERB/m_c/are/is} really good at making {PRONOUN/m_c/poss} mentor laugh",
-            "Is complimenting another apprentice on {PRONOUN/m_c/poss} hunting crouch",
+            "Is complimenting another apprentice on their hunting crouch",
             "Is unsure that this is what {PRONOUN/m_c/subject} {VERB/m_c/want/wants} to do"
         ],
         "main_status_constraint": [

--- a/scripts/screens/PatrolScreen.py
+++ b/scripts/screens/PatrolScreen.py
@@ -138,9 +138,11 @@ class PatrolScreen(Screens):
         elif event.ui_element == self.elements["next_page"]:
             self.current_page += 1
             self.update_cat_images_buttons()
+            self.update_button()
         elif event.ui_element == self.elements["last_page"]:
             self.current_page -= 1
             self.update_cat_images_buttons()
+            self.update_button()
         elif event.ui_element == self.elements["paw"]:
             if self.patrol_type == 'training':
                 self.patrol_type = 'general'
@@ -688,6 +690,7 @@ class PatrolScreen(Screens):
                 pos_x = 100
                 pos_y += 100
             i += 1
+            print(f"Button Index: {i}, Cat: {cat.name}, X-pos: {pos_x}, Y-pos: {pos_y}")
 
         if self.patrol_screen == 'patrol_cats':
             # Hide Skills Info

--- a/scripts/screens/PatrolScreen.py
+++ b/scripts/screens/PatrolScreen.py
@@ -690,7 +690,6 @@ class PatrolScreen(Screens):
                 pos_x = 100
                 pos_y += 100
             i += 1
-            print(f"Button Index: {i}, Cat: {cat.name}, X-pos: {pos_x}, Y-pos: {pos_y}")
 
         if self.patrol_screen == 'patrol_cats':
             # Hide Skills Info


### PR DESCRIPTION
Before, if you went straight to the patrol screen, clicked for the next page, and tried to select cats in the fifth column, it wouldn't work. Now it does!