### PR TITLE
Fixes: Skin color

### DIFF
--- a/scripts/cat/sprites.py
+++ b/scripts/cat/sprites.py
@@ -302,7 +302,7 @@ class Sprites():
             self.make_group('tortiepatchesmasks', (a, 3), f"tortiemask{i}")
 
         # SKINS
-        for a, i in enumerate(['BLACK', 'PINK', 'DARKBROWN', 'BROWN', 'LIGHTBROWN', "RED"]):
+        for a, i in enumerate(['BLACK', "RED", 'PINK', 'DARKBROWN', 'BROWN', 'LIGHTBROWN']):
             self.make_group('skin', (a, 0), f"skin{i}")
         for a, i in enumerate(['DARK', 'DARKGREY', 'GREY', 'DARKSALMON', 'SALMON', 'PEACH']):
             self.make_group('skin', (a, 1), f"skin{i}")


### PR DESCRIPTION
Skin color was previously incorrect, below is an example of a cat with "DARKBROWN" skin.
To verify, compare any cat with a "RED", 'PINK', 'DARKBROWN', 'BROWN', or 'LIGHTBROWN' skin color with their sprite.
Thanks chibigalaxies!
![image](https://github.com/Thlumyn/clangen/assets/110428732/a4a7bda2-b3c6-41c6-9301-f8b268e2ac23)
