### PR TITLE
Fix for fst_hunt_climbtree1

### DIFF
--- a/resources/dicts/patrols/forest/hunting/greenleaf.json
+++ b/resources/dicts/patrols/forest/hunting/greenleaf.json
@@ -3786,7 +3786,7 @@
                 "text": "Surprising everyone, r_c begins stalking. As they guessed, the squirrel notices something amiss and hops onto the tree for safety. r_c, not willing to let the prey go, climbs right after it! Everyone is rather impressed when {PRONOUN/r_c/subject} {VERB/r_c/return/returns}, the squirrel firmly clutched in {PRONOUN/r_c/poss} jaws.",
                 "exp": 25,
                 "weight": 20,
-                "stat_skill": ["CLIMB,1"],
+                "stat_skill": ["CLIMBING,1"],
                 "can_have_stat": ["r_c"],
                 "prey": ["medium"]
             }


### PR DESCRIPTION
So if I remember correctly, it's "CLIMBING" and not "CLIMB". I've been putting this off since I first found the bug and went to check and fix it, but the patrol hasn't shown up again since I identified the issue.