### PR TITLE
perf: Use subsurfaces for sprites

### DIFF
--- a/scripts/cat/sprites.py
+++ b/scripts/cat/sprites.py
@@ -44,23 +44,6 @@ class Sprites():
         """
         self.spritesheets[name] = pygame.image.load(a_file).convert_alpha()
 
-    def find_sprite(self, group_name, x, y):
-        """
-        Find singular sprite from a group.
-
-        Parameters:
-        group_name -- Name of Pygame group to find sprite from.
-        x -- X-offset of the sprite to get. NOT pixel offset, but offset of other sprites.
-        y -- Y-offset of the sprite to get. NOT pixel offset, but offset of other sprites.
-        """
-        # pixels will be calculated automatically, so for x and y, just use 0, 1, 2, 3 etc.
-        new_sprite = pygame.Surface((self.size, self.size),
-                                    pygame.HWSURFACE | pygame.SRCALPHA)
-        new_sprite.blit(self.groups[group_name], (0, 0),
-                        (x * self.size, y * self.size, (x + 1) * self.size,
-                         (y + 1) * self.size))
-        return new_sprite
-
     def make_group(self,
                    spritesheet,
                    pos,

--- a/scripts/cat/sprites.py
+++ b/scripts/cat/sprites.py
@@ -81,14 +81,11 @@ class Sprites():
         """
 
         # making the group
-        new_group = pygame.Surface(
-            (self.size * sprites_x, self.size * sprites_y),
-            pygame.HWSURFACE | pygame.SRCALPHA)
-        new_group.blit(
-            self.spritesheets[spritesheet], (0, 0),
-            (pos[0] * sprites_x * self.size, pos[1] * sprites_y * self.size,
-             (pos[0] + sprites_x) * self.size,
-             (pos[1] + sprites_y) * self.size))
+        new_group = pygame.Surface.subsurface(self.spritesheets[spritesheet],
+                                              pos[0] * sprites_x * self.size,
+                                              pos[1] * sprites_y * self.size,
+                                              self.size * sprites_x,
+                                              self.size * sprites_y)
 
         self.groups[name] = new_group
 
@@ -96,11 +93,10 @@ class Sprites():
         x_spr = 0
         y_spr = 0
         for x in range(sprites_x * sprites_y):
-            new_sprite = pygame.Surface((self.size, self.size),
-                                        pygame.HWSURFACE | pygame.SRCALPHA)
-            new_sprite.blit(new_group, (0, 0),
-                            (x_spr * self.size, y_spr * self.size,
-                             (x_spr + 1) * self.size, (y_spr + 1) * self.size))
+            new_sprite = pygame.Surface.subsurface(new_group,
+                                                   x_spr * self.size,
+                                                   y_spr * self.size,
+                                                   self.size, self.size)
             self.sprites[name + str(x)] = new_sprite
             x_spr += 1
             if x_spr == sprites_x:

--- a/scripts/cat/sprites.py
+++ b/scripts/cat/sprites.py
@@ -16,7 +16,6 @@ class Sprites():
         self.size = None
         self.spritesheets = {}
         self.images = {}
-        self.groups = {}
         self.sprites = {}
         
         self.load_tints()
@@ -69,8 +68,6 @@ class Sprites():
                                               pos[1] * sprites_y * self.size,
                                               self.size * sprites_x,
                                               self.size * sprites_y)
-
-        self.groups[name] = new_group
 
         # splitting group into singular sprites and storing into self.sprites section
         x_spr = 0


### PR DESCRIPTION
By using `subsurface` instead of performing a blit to new surfaces, it creates a reference to the original data rather than creating a duplicate of it. The only thing to note is that if the original surface is modified so is the subsurface and vice-versa, but the spritesheets aren't directly modified anywhere as far as I know.