### PR TITLE
Bug fixing: fix scar history event

### DIFF
--- a/scripts/cat/history.py
+++ b/scripts/cat/history.py
@@ -253,7 +253,7 @@ class History:
                 SkillPath.DREAM: [ "understanding dreams" ],
                 SkillPath.CLAIRVOYANT: [ "predicting the future" ],
                 SkillPath.PROPHET: [ "understanding prophecies" ],
-                SkillPath.GHOST: [ "connecting to the afterlife" ],
+                SkillPath.GHOST: [ "connecting to the afterlife" ]
             }
         
         for _ment in cat.history.mentor_influence["skill"]:
@@ -346,7 +346,7 @@ class History:
             cat.history.possible_history[condition] = {
                 "death_text": death_text,
                 "scar_text": scar_text,
-                "other_cat": other_cat.ID if other_cat is not None else None
+                "other_cat": other_cat.ID if other_cat else None
             }
 
 

--- a/scripts/events_module/condition_events.py
+++ b/scripts/events_module/condition_events.py
@@ -252,7 +252,7 @@ class Condition_Events():
 
                             if possible_scar or possible_death:
                                 History.add_possible_history(cat, injury_event.injury, scar_text=possible_scar, 
-                                                             death_text=possible_death)
+                                                             death_text=possible_death, other_cat=other_cat)
                             
                         cat.get_injured(injury_event.injury)
 

--- a/scripts/utility.py
+++ b/scripts/utility.py
@@ -752,8 +752,7 @@ def process_text(text, cat_dict, raise_exception=False):
     adjust_text = re.sub(r"\{(.*?)\}", lambda x: pronoun_repl(x, cat_dict, raise_exception),
                                                               text)
 
-    name_patterns = [re.escape(l) for l in cat_dict]
-
+    name_patterns = [r'(?<!\{)' + re.escape(l) + r'(?!\})' for l in cat_dict]
     adjust_text = re.sub("|".join(name_patterns), lambda x: name_repl(x, cat_dict), adjust_text)
     return adjust_text
 
@@ -906,9 +905,24 @@ def history_text_adjust(text,
     if "c_n" in text:
         text = text.replace("c_n", clan.name)
     if "r_c" in text and other_cat_rc:
-        text = text.replace("r_c", str(other_cat_rc.name))
+        text = selective_replace(text, "r_c", str(other_cat_rc.name))
     return text
 
+def selective_replace(text, pattern, replacement):
+    i = 0
+    while i < len(text):
+        index = text.find(pattern, i)
+        if index == -1:
+            break
+        start_brace = text.rfind('{', 0, index)
+        end_brace = text.find('}', index)
+        if start_brace != -1 and end_brace != -1 and start_brace < index < end_brace:
+            i = index + len(pattern)
+        else:
+            text = text[:index] + replacement + text[index + len(pattern):]
+            i = index + len(replacement)
+
+    return text
 
 def ongoing_event_text_adjust(Cat, text, clan=None, other_clan_name=None):
     """


### PR DESCRIPTION

Fixing scar history event
Additionally added function to ensure r_c is not replaced when inside a pronoun tag.
![image](https://github.com/Thlumyn/clangen/assets/110428732/d15f452a-85bf-49ce-a783-b67d0d3f6aa1)

![image](https://github.com/Thlumyn/clangen/assets/110428732/7e1c1159-a143-4c7a-a9d9-8ad2fdb5b367)
