### PR TITLE
bugfix: pronoun, grammar, outcome, tag fixes

### DIFF
--- a/resources/dicts/patrols/beach/hunting/any.json
+++ b/resources/dicts/patrols/beach/hunting/any.json
@@ -2825,7 +2825,7 @@
                 "prey": ["large"],
                 "relationships": [
                     {
-                        "cats_to": ["patrol",],
+                        "cats_to": ["patrol"],
                         "cats_from": ["patrol"],
                         "mutual": false,
                         "values": ["trust"],
@@ -3367,7 +3367,7 @@
                 "prey": ["large"],
                 "relationships": [
                     {
-                        "cats_to": ["patrol",],
+                        "cats_to": ["patrol"],
                         "cats_from": ["patrol"],
                         "mutual": false,
                         "values": ["trust"],
@@ -3559,7 +3559,7 @@
                 "prey": ["large"],
                 "relationships": [
                     {
-                        "cats_to": ["patrol",],
+                        "cats_to": ["patrol"],
                         "cats_from": ["patrol"],
                         "mutual": false,
                         "values": ["trust"],

--- a/resources/dicts/patrols/beach/hunting/any.json
+++ b/resources/dicts/patrols/beach/hunting/any.json
@@ -169,7 +169,11 @@
                 "text": "s_c tells the patrol to roll in a patch of garlic to disguise their scent, which works perfectly. It's a funny taste to wash off their pelts though.",
                 "exp": 20,
                 "weight": 20,
-                "stat_trait": ["strange"],
+                "stat_trait": [
+                    "strange",
+                    "cunning",
+                    "wise"
+                ],
                 "prey": ["large"],
                 "relationships": [
                     {
@@ -237,7 +241,7 @@
                 "prey": ["large"],
                 "relationships": [
                     {
-                        "cats_to": ["r_c"],
+                        "cats_to": ["app1"],
                         "cats_from": ["clan"],
                         "mutual": false,
                         "values": ["respect"],
@@ -252,7 +256,7 @@
                 "prey": ["large"],
                 "relationships": [
                     {
-                        "cats_to": ["r_c"],
+                        "cats_to": ["app1"],
                         "cats_from": ["clan"],
                         "mutual": false,
                         "values": ["respect"],
@@ -267,15 +271,14 @@
                 "stat_trait": [
                     "calm",
                     "careful",
-                    "insecure",
                     "lonesome",
                     "loyal",
-                    "nervous",
                     "sneaky",
                     "strange",
-                    "patient",
+                    "cunning",
                     "thoughtful",
-                    "wise"
+                    "wise",
+                    "gloomy"
                 ],
                 "can_have_stat": ["app"],
                 "prey": ["large"],
@@ -292,12 +295,12 @@
         ],
         "fail_outcomes": [
             {
-                "text": "Hunting is poor, and while app1's mentor is disappointed, they don't expect r_c to be able to catch what isn't there.",
+                "text": "Hunting is poor, and while app1's mentor is disappointed, they don't expect {PRONOUN/app1/object} to be able to catch what isn't there.",
                 "exp": 0,
                 "weight": 20,
                 "relationships": [
                     {
-                        "cats_to": ["r_c"],
+                        "cats_to": ["app1"],
                         "cats_from": ["clan"],
                         "mutual": false,
                         "values": ["respect"],
@@ -317,7 +320,10 @@
                     "confident",
                     "daring",
                     "playful",
-                    "righteous"
+                    "righteous",
+                    "arrogant",
+                    "insecure",
+                    "rebellious"
                 ],
                 "can_have_stat": ["app"],
                 "relationships": [
@@ -331,7 +337,7 @@
                 ]
             },
             {
-                "text": "While on the hunt, app1 tumbles right down into a rock pool while {PRONOUN/app1/poss} attention is elsewhere. Bruised and sore, r_c has to report to the medicine cat den when {PRONOUN/app1/subject} {VERB/app1/return/returns} to camp.",
+                "text": "While on the hunt, app1 tumbles right down into a rock pool while {PRONOUN/app1/poss} attention is elsewhere. Bruised and sore, app1 has to report to the medicine cat den when {PRONOUN/app1/subject} {VERB/app1/return/returns} to camp.",
                 "exp": 0,
                 "weight": 10,
                 "injury": [
@@ -341,10 +347,12 @@
                         "scars": ["BRIDGE"]
                     }
                 ],
-                "history_text": { "scar": "m_c got injured as an apprentice, exploring alone." },
+                "history_text": { 
+                    "scar": "m_c got injured as an apprentice, exploring alone." 
+                },
                 "relationships": [
                     {
-                        "cats_to": ["r_c"],
+                        "cats_to": ["app1"],
                         "cats_from": ["clan"],
                         "mutual": false,
                         "values": ["respect"],
@@ -372,7 +380,7 @@
         "chance_of_success": 40,
         "success_outcomes": [
             {
-                "text": "r_c heads off to one of {PRONOUN/r_c/poss} favorite spots on the beach, a rocky shore with high highs and low lows, providing excellent ambush chances. And what do you know, {PRONOUN/r_c/subject} are bush! Or {PRONOUN/r_c/subject} {VERB/r_c/were/was}, as far as that big crab thought.",
+                "text": "r_c heads off to one of {PRONOUN/r_c/poss} favorite spots on the beach, a rocky shore with high highs and low lows, providing excellent ambush chances. And what do you know, {PRONOUN/r_c/subject} {VERB/r_c/are/is} bush! Or {PRONOUN/r_c/subject} {VERB/r_c/were/was}, as far as that big crab thought.",
                 "exp": 20,
                 "weight": 20,
                 "prey": ["large"]
@@ -384,7 +392,7 @@
                 "prey": ["large"]
             },
             {
-                "text": "s_c gets the chance to try out an idea {PRONOUN/s_c/subject}{VERB/s_c/'ve/'s} been sitting on for a while. There's a rabbit warren in the sand dunes that {PRONOUN/s_c/subject}{VERB/s_c/'ve/'s} spotted that's particularly badly built, and {PRONOUN/s_c/subject} {VERB/s_c/manage/magages} to dig down into one of the dens, fishing baby rabbits out by the pawful.",
+                "text": "s_c gets the chance to try out an idea {PRONOUN/s_c/subject}{VERB/s_c/'ve/'s} been sitting on for a while. There's a rabbit warren in the sand dunes that {PRONOUN/s_c/subject}{VERB/s_c/'ve/'s} spotted that's particularly badly built, and {PRONOUN/s_c/subject} {VERB/s_c/manage/manages} to dig down into one of the dens, fishing baby rabbits out by the pawful.",
                 "exp": 20,
                 "weight": 20,
                 "stat_skill": ["CLEVER,1"],
@@ -397,15 +405,14 @@
                 "stat_trait": [
                     "calm",
                     "careful",
-                    "insecure",
                     "lonesome",
                     "loyal",
-                    "nervous",
                     "sneaky",
                     "strange",
-                    "patient",
+                    "cunning",
                     "thoughtful",
-                    "wise"
+                    "wise",
+                    "gloomy"
                 ],
                 "prey": ["large"]
             }
@@ -420,7 +427,14 @@
                 "text": "s_c starts the day with endless energy, but as one hunt fails after another, it very quickly runs dry. {PRONOUN/s_c/subject/CAP} {VERB/s_c/come/comes} back to camp, empty-pawed and prickling with frustration.",
                 "exp": 0,
                 "weight": 20,
-                "stat_trait": ["bold", "childish", "confident", "daring", "playful"]
+                "stat_trait": [
+                    "bold", 
+                    "childish", 
+                    "confident", 
+                    "daring", 
+                    "playful",
+                    "flamboyant"
+                ]
             }
         ]
     },
@@ -442,7 +456,7 @@
         "chance_of_success": 40,
         "success_outcomes": [
             {
-                "text": "r_c heads off to one of {PRONOUN/r_c/poss} favorite spots on the beach, a rocky shore with high highs and low lows, providing excellent ambush chances. And what do you know, {PRONOUN/r_c/subject} are bush! Or {PRONOUN/r_c/subject} {VERB/r_c/were/was}, as far as that big crab thought. {PRONOUN/r_c/subject/CAP} {VERB/r_c/snicker/snickers} to {PRONOUN/r_c/self} as {PRONOUN/r_c/subject} {VERB/r_c/pad/pads} back to camp.",
+                "text": "r_c heads off to one of {PRONOUN/r_c/poss} favorite spots on the beach, a rocky shore with high highs and low lows, providing excellent ambush chances. And what do you know, {PRONOUN/r_c/subject} {VERB/r_c/are/is} bush! Or {PRONOUN/r_c/subject} {VERB/r_c/were/was}, as far as that big crab thought. {PRONOUN/r_c/subject/CAP} {VERB/r_c/snicker/snickers} to {PRONOUN/r_c/self} as {PRONOUN/r_c/subject} {VERB/r_c/pad/pads} back to camp.",
                 "exp": 20,
                 "weight": 20,
                 "prey": ["large"]
@@ -467,15 +481,14 @@
                 "stat_trait": [
                     "calm",
                     "careful",
-                    "insecure",
                     "lonesome",
                     "loyal",
-                    "nervous",
                     "sneaky",
                     "strange",
-                    "patient",
+                    "cunning",
                     "thoughtful",
-                    "wise"
+                    "wise",
+                    "gloomy"
                 ],
                 "prey": ["large"]
             }
@@ -490,7 +503,14 @@
                 "text": "s_c starts the day with endless energy, but as one hunt fails after another, it very quickly runs dry. {PRONOUN/s_c/subject/CAP} {VERB/s_c/give/gives} up and {VERB/s_c/return/returns} to camp, to try and at least make progress on all the work piling up there.",
                 "exp": 0,
                 "weight": 20,
-                "stat_trait": ["bold", "childish", "confident", "daring", "playful"]
+                "stat_trait": [
+                    "bold", 
+                    "childish", 
+                    "confident", 
+                    "daring", 
+                    "playful",
+                    "flamboyant"
+                ]
             }
         ]
     },
@@ -512,7 +532,7 @@
         "chance_of_success": 40,
         "success_outcomes": [
             {
-                "text": "r_c heads off to one of {PRONOUN/r_c/poss} favorite spots on the beach, a rocky shore with high highs and low lows, providing excellent ambush chances. And what do you know, {PRONOUN/r_c/subject} are bush! Or {PRONOUN/r_c/subject} {VERB/r_c/were/was}, as far as that big crab thought. {PRONOUN/r_c/subject/CAP} {VERB/r_c/snicker/snickers} to {PRONOUN/r_c/self} as {PRONOUN/r_c/subject} {VERB/r_c/pad/pads} back to camp.",
+                "text": "r_c heads off to one of {PRONOUN/r_c/poss} favorite spots on the beach, a rocky shore with high highs and low lows, providing excellent ambush chances. And what do you know, {PRONOUN/r_c/subject} {VERB/r_c/are/is} bush! Or {PRONOUN/r_c/subject} {VERB/r_c/were/was}, as far as that big crab thought. {PRONOUN/r_c/subject/CAP} {VERB/r_c/snicker/snickers} to {PRONOUN/r_c/self} as {PRONOUN/r_c/subject} {VERB/r_c/pad/pads} back to camp.",
                 "exp": 20,
                 "weight": 20,
                 "prey": ["large"]
@@ -537,15 +557,14 @@
                 "stat_trait": [
                     "calm",
                     "careful",
-                    "insecure",
                     "lonesome",
                     "loyal",
-                    "nervous",
                     "sneaky",
                     "strange",
-                    "patient",
+                    "cunning",
                     "thoughtful",
-                    "wise"
+                    "wise",
+                    "gloomy"
                 ],
                 "prey": ["large"]
             }
@@ -560,7 +579,14 @@
                 "text": "s_c starts the day with endless energy, but as one hunt fails after another, it very quickly runs dry. {PRONOUN/s_c/subject/CAP} {VERB/s_c/give/gives} up and {VERB/s_c/return/returns} to camp, to try and at least make progress on all the work piling up there.",
                 "exp": 0,
                 "weight": 20,
-                "stat_trait": ["bold", "childish", "confident", "daring", "playful"]
+                "stat_trait": [
+                    "bold", 
+                    "childish", 
+                    "confident", 
+                    "daring", 
+                    "playful",
+                    "flamboyant"
+                ]
             }
         ]
     },
@@ -604,7 +630,15 @@
                 "text": "s_c doesn't hesitate before splitting from the patrol to check on the source of the noise. {PRONOUN/s_c/subject/CAP} {VERB/s_c/regret/regrets} {PRONOUN/s_c/poss} impulsivity, however, when the crab inside the grass begins clacking its claws, nearly catching s_c's nose in its grasp! s_c gets quite the scare, but thankfully the crab only wants to get away from {PRONOUN/s_c/object} and quickly retreats back into the grass.",
                 "exp": 0,
                 "weight": 20,
-                "stat_trait": ["daring", "bold", "ambitious"],
+                "stat_trait": [
+                    "daring", 
+                    "bold", 
+                    "ambitious",
+                    "arrogant",
+                    "competitive",
+                    "oblivious",
+                    "rebellious"
+                ],
                 "prey": ["very_small"]
             },
             {
@@ -618,7 +652,11 @@
                         "scars": ["NECKBITE"]
                     }
                 ],
-                "history_text": { "scar": "m_c gained a scar from a fox." },
+                "history_text": { 
+                    "scar": "m_c gained a scar from a fox.",
+                    "reg_death": "m_c died from a fox bite.",
+                    "lead_death": "died from a fox bite"
+                },
                 "prey": ["very_small"]
             }
         ]
@@ -662,17 +700,24 @@
                 "text": "s_c doesn't hesitate before splitting from the patrol to check on the source of the noise. {PRONOUN/s_c/subject/CAP} {VERB/s_c/regret/regrets} {PRONOUN/s_c/poss} impulsivity, however, when the crab inside the grass begins clacking its claws, nearly catching s_c's nose in its grasp! s_c gets quite the scare, but thankfully the crab only wants to get away from {PRONOUN/s_c/object} and quickly retreats back into the grass.",
                 "exp": 0,
                 "weight": 20,
-                "stat_trait": ["daring", "bold", "ambitious"]
+                "stat_trait": [
+                    "daring", 
+                    "bold", 
+                    "ambitious",
+                    "arrogant",
+                    "competitive",
+                    "oblivious",
+                    "rebellious"
+                ]
             },
             {
-                "text": "r_c takes the lead in checking the source of the noise and comes face to face with a snarling dog! r_c yowls for {PRONOUN/r_c/poss} patrol, but the other cats aren't quick enough to stop the dog from killing r_c in one quick and deadly swipe.",
+                "text": "r_c takes the lead in checking the source of the noise and comes face to face with a huge, snarling dog! r_c yowls for {PRONOUN/r_c/poss} patrol, but the other cats aren't quick enough to stop the creature from snapping r_c up in its deadly jaws.",
                 "exp": 0,
                 "weight": 10,
                 "dead_cats": ["r_c"],
                 "history_text": {
-                    "scar": "m_c gained a scar from a fox.",
-                    "reg_death": "m_c was killed by a wolverine.",
-                    "lead_death": "{VERB/m_c/were/was} killed by a wolverine"
+                    "reg_death": "m_c was killed by a dog.",
+                    "lead_death": "{VERB/m_c/were/was} killed by a dog"
                 }
             },
             {
@@ -688,8 +733,8 @@
                 ],
                 "history_text": {
                     "scar": "m_c gained a scar from a fox.",
-                    "reg_death": "m_c was killed by a wolverine.",
-                    "lead_death": "{VERB/m_c/were/was} killed by a wolverine"
+                    "reg_death": "m_c died from a fox bite.",
+                    "lead_death": "died from a fox bite"
                 }
             }
         ]
@@ -705,12 +750,12 @@
         "max_cats": 1,
         "min_max_status": {},
         "weight": 20,
-        "intro_text": "As the patrol is checking the border lines, they hear an odd sound coming from a patch of beach grass.",
-        "decline_text": "It's probably nothing. They leave the noise alone and continue searching for prey.",
+        "intro_text": "As p_l is checking the border lines, {PRONOUN/p_l/subject} {VERB/p_l/hear/hears} an odd sound coming from a patch of beach grass.",
+        "decline_text": "It's probably nothing. {PRONOUN/p_l/subject/CAP} {VERB/p_l/leave/leaves} the noise alone and {VERB/p_l/continue/continues} searching for prey.",
         "chance_of_success": 40,
         "success_outcomes": [
             {
-                "text": "r_c drops down into a hunting crouch, certain that a mouse must be the source of the noise. {PRONOUN/r_c/subject/CAP} {VERB/r_c/find/finds} {PRONOUN/r_c/self} to be correct when {PRONOUN/r_c/subject} {VERB/r_c/pounce/pounces} into the grass and {VERB/r_c/return/returns} to the patrol with the tasty morsel dangling from {PRONOUN/r_c/poss} mouth.",
+                "text": "r_c drops down into a hunting crouch, certain that a mouse must be the source of the noise. {PRONOUN/r_c/subject/CAP} {VERB/r_c/find/finds} {PRONOUN/r_c/self} to be correct when {PRONOUN/r_c/subject} {VERB/r_c/pounce/pounces} into the grass and {VERB/r_c/return/returns} to camp with the tasty morsel dangling from {PRONOUN/r_c/poss} mouth.",
                 "exp": 10,
                 "weight": 20,
                 "prey": ["small"]
@@ -725,7 +770,7 @@
         ],
         "fail_outcomes": [
             {
-                "text": "p_l pads towards the rock fall to check on the noise when a rabbit suddenly bursts out! {PRONOUN/p_l/subject/CAP}{VERB/p_l/aren't/isn't} quick enough to catch it, but at least the noise was nothing dangerous.",
+                "text": "p_l pads towards the grass to check on the noise when a rabbit suddenly bursts out! {PRONOUN/p_l/subject/CAP}{VERB/p_l/aren't/isn't} quick enough to catch it, but at least the noise was nothing dangerous.",
                 "exp": 0,
                 "weight": 20
             },
@@ -733,21 +778,28 @@
                 "text": "s_c doesn't even hesitate before going to check on the source of the noise. {PRONOUN/s_c/subject/CAP} {VERB/s_c/regret/regrets} {PRONOUN/s_c/poss} impulsivity, however, when an angry weasel bursts across the rocks, chattering loudly! s_c gets quite the scare, but thankfully the weasel only wants to get away from {PRONOUN/s_c/object} and quickly runs off back behind the rocks.",
                 "exp": 0,
                 "weight": 20,
-                "stat_trait": ["daring", "bold", "ambitious"]
+                "stat_trait": [
+                    "daring", 
+                    "bold", 
+                    "ambitious",
+                    "arrogant",
+                    "competitive",
+                    "oblivious",
+                    "rebellious"
+                ]
             },
             {
-                "text": "r_c takes the lead in checking the source of the noise and comes face to face with a snarling dog! r_c yowls for help, but {PRONOUN/r_c/subject}{VERB/r_c/'re/'s} alone on this patrol, and {PRONOUN/r_c/subject} {VERB/r_c/have/has} the sudden realization that no one can help {PRONOUN/r_c/object} now. The dog kills the lone cat with little trouble.",
+                "text": "r_c doesn't hesitate in checking the source of the noise and comes face to face with a huge, snarling dog! r_c yowls for help, but {PRONOUN/r_c/subject}{VERB/r_c/'re/'s} alone on this patrol, and {PRONOUN/r_c/subject} {VERB/r_c/have/has} the sudden realization that no one can help {PRONOUN/r_c/object} now. The dog kills the lone cat with little trouble.",
                 "exp": 0,
                 "weight": 10,
                 "dead_cats": ["r_c"],
                 "history_text": {
-                    "scar": "m_c gained a scar from a fox.",
                     "reg_death": "m_c was killed by a dog while patrolling alone.",
-                    "lead_death": "{VERB/m_c/were/was} killed while patrolling alone"
+                    "lead_death": "{VERB/m_c/were/was} killed by a dog while patrolling alone"
                 }
             },
             {
-                "text": "r_c  heads toward the source of the noise and comes face to face with an angry fox! Though {PRONOUN/r_c/subject} {VERB/r_c/backpedal/backpedals} rapidly, the fox still manages to take a bite out of {PRONOUN/r_c/object} before {PRONOUN/r_c/subject} can sprint away.",
+                "text": "r_c heads toward the source of the noise and comes face to face with an angry fox! Though {PRONOUN/r_c/subject} {VERB/r_c/backpedal/backpedals} rapidly, the fox still manages to take a bite out of {PRONOUN/r_c/object} before {PRONOUN/r_c/subject} can sprint away.",
                 "exp": 0,
                 "weight": 10,
                 "injury": [
@@ -759,8 +811,8 @@
                 ],
                 "history_text": {
                     "scar": "m_c gained a scar from a fox.",
-                    "reg_death": "m_c was killed by a dog while patrolling alone.",
-                    "lead_death": "{VERB/m_c/were/was} killed while patrolling alone"
+                    "reg_death": "m_c died from a fox bite.",
+                    "lead_death": "died from a fox bite"
                 }
             }
         ]
@@ -810,13 +862,14 @@
                     "shameless",
                     "strict",
                     "troublesome",
-                    "vengeful"
+                    "vengeful",
+                    "grumpy"
                 ]
             }
         ],
         "fail_outcomes": [
             {
-                "text": "The patrol mostly ignores the Twolegs. As they hunt they hear a yelp from r_c. {PRONOUN/r_c/subject/CAP}{VERB/r_c/'ve/'s} crawled into a metal Twolegs box, and there's nothing {PRONOUN/r_c/subject} or the rest of the patrol can do to get {PRONOUN/r_c/object} out - eventually the Twolegs notice, and r_c is taken by them.",
+                "text": "The patrol mostly ignores the Twolegs. As they hunt they hear a yelp from r_c. {PRONOUN/r_c/subject/CAP}{VERB/r_c/'ve/'s} crawled into a metal Twoleg box, and there's nothing {PRONOUN/r_c/subject} or the rest of the patrol can do to get {PRONOUN/r_c/object} out - eventually the Twolegs notice, and r_c is taken by them.",
                 "exp": 0,
                 "weight": 10,
                 "lost_cats": ["r_c"]
@@ -826,15 +879,14 @@
                 "exp": 0,
                 "weight": 10,
                 "stat_trait": [
-                    "altruistic",
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
-                    "wise"
+                    "wise",
+                    "lonesome",
+                    "sincere"
                 ],
                 "lost_cats": ["s_c"]
             }
@@ -885,13 +937,14 @@
                     "shameless",
                     "strict",
                     "troublesome",
-                    "vengeful"
+                    "vengeful",
+                    "grumpy"
                 ]
             }
         ],
         "fail_outcomes": [
             {
-                "text": "The patrol mostly ignores the Twolegs. As they hunt they hear a yelp from r_c. {PRONOUN/r_c/subject/CAP}{VERB/r_c/'ve/'s} crawled into a metal Twolegs box, and there's nothing {PRONOUN/r_c/subject} or the rest of the patrol can do to get {PRONOUN/r_c/object} out - eventually the Twolegs notice, and r_c is taken by them.",
+                "text": "The patrol mostly ignores the Twolegs. As they hunt they hear a yelp from r_c. {PRONOUN/r_c/subject/CAP}{VERB/r_c/'ve/'s} crawled into a metal Twoleg box, and there's nothing {PRONOUN/r_c/subject} or the rest of the patrol can do to get {PRONOUN/r_c/object} out - eventually the Twolegs notice, and r_c is taken by them.",
                 "exp": 0,
                 "weight": 10,
                 "lost_cats": ["r_c"]
@@ -901,15 +954,14 @@
                 "exp": 0,
                 "weight": 10,
                 "stat_trait": [
-                    "altruistic",
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
-                    "wise"
+                    "wise",
+                    "lonesome",
+                    "sincere"
                 ],
                 "lost_cats": ["s_c"]
             }
@@ -960,7 +1012,8 @@
                     "shameless",
                     "strict",
                     "troublesome",
-                    "vengeful"
+                    "vengeful",
+                    "grumpy"
                 ]
             }
         ],
@@ -976,15 +1029,14 @@
                 "exp": 0,
                 "weight": 10,
                 "stat_trait": [
-                    "altruistic",
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
-                    "wise"
+                    "wise",
+                    "lonesome",
+                    "sincere"
                 ],
                 "lost_cats": ["multi"]
             }
@@ -1004,7 +1056,7 @@
         },
         "weight": 20,
         "intro_text": "r_c decides to hunt out near the Twoleg dens.",
-        "decline_text": "On second thought, {PRONOUN/r_c/subject} {VERB/r_c/decide/decides} to reline {PRONOUN/r_c/poss} nest today instead.",
+        "decline_text": "On second thought, {PRONOUN/r_c/subject} {VERB/r_c/decide/decides} to recline in {PRONOUN/r_c/poss} nest today instead.",
         "chance_of_success": 40,
         "success_outcomes": [
             {
@@ -1014,12 +1066,12 @@
                 "prey": ["medium"]
             },
             {
-                "text": "A friendly Twolegs makes a psspsspss noise, and pours kittypet food on the ground for r_c. {PRONOUN/r_c/subject/CAP}{VERB/r_c/'ve/'s} always wondered what it might taste like... dry, is the answer. Very odd.",
+                "text": "A friendly Twoleg makes a psspsspss noise and pours kittypet food on the ground for r_c. {PRONOUN/r_c/subject/CAP}{VERB/r_c/'ve/'s} always wondered what it might taste like... dry, is the answer. Very odd.",
                 "exp": 20,
                 "weight": 5
             },
             {
-                "text": "s_c gets distracted from hunting by strange Twoleg activity around one of their dens. They appear to be hauling all their many, many varieties of nest lining out and into a big monster. s_c take the opportunity to grab a little soft thing, something that's almost shaped like prey. It'll be good for the nursery.",
+                "text": "s_c gets distracted from hunting by strange Twoleg activity around one of their dens. They appear to be hauling all their many, many varieties of nest lining out and into a big monster. s_c takes the opportunity to grab a little soft thing, something that's almost shaped like prey. It'll be good for the nursery.",
                 "exp": 20,
                 "weight": 20,
                 "stat_skill": ["CLEVER,1"]
@@ -1031,12 +1083,12 @@
                 "stat_trait": [
                     "calm",
                     "careful",
-                    "insecure",
+                    "cunning",
                     "lonesome",
                     "loyal",
-                    "nervous",
                     "sneaky",
-                    "strange"
+                    "strange",
+                    "wise"
                 ],
                 "prey": ["large"]
             }
@@ -1047,15 +1099,11 @@
                 "exp": 0,
                 "weight": 20,
                 "stat_trait": [
-                    "altruistic",
-                    "compassionate",
-                    "empathetic",
-                    "faithful",
-                    "loving",
-                    "patient",
-                    "responsible",
-                    "thoughtful",
-                    "wise"
+                    "adventurous",
+                    "competitive",
+                    "daring",
+                    "shameless",
+                    "rebellious"
                 ]
             },
             {
@@ -1071,10 +1119,14 @@
                 "injury": [
                     {
                         "cats": ["r_c"],
-                        "injuries": ["blood loss", "scrapes"],
+                        "injuries": ["blood loss", "scrapes", "small cut"],
                         "scars": []
                     }
-                ]
+                ],
+                "history_text": {
+                    "reg_death": "m_c bled out after escaping from a Twoleg den.",
+                    "lead_death": "bled out after escaping from a Twoleg den"
+                }
             }
         ]
     },
@@ -1092,7 +1144,7 @@
         },
         "weight": 20,
         "intro_text": "app1 decides to hunt out near the Twoleg dens.",
-        "decline_text": "On second thought, {PRONOUN/app1/subject} {VERB/r_c/decide/decides} to reline {PRONOUN/app1/poss} nest today instead.",
+        "decline_text": "On second thought, {PRONOUN/app1/subject} {VERB/r_c/decide/decides} to recline in {PRONOUN/app1/poss} nest today instead.",
         "chance_of_success": 40,
         "success_outcomes": [
             {
@@ -1102,21 +1154,18 @@
                 "prey": ["small"]
             },
             {
-                "text": "A friendly Twolegs makes a psspsspss noise, and pours kittypet food on the ground for app1. {PRONOUN/app1/subject/CAP}{VERB/app1/'ve/'s} always wondered what it might taste like... dry, is the answer. It's strangely appealing.",
+                "text": "A friendly Twoleg makes a psspsspss noise and pours kittypet food on the ground for app1. {PRONOUN/app1/subject/CAP}{VERB/app1/'ve/'s} always wondered what it might taste like... dry, is the answer. It's strangely appealing.",
                 "exp": 20,
                 "weight": 5
             },
             {
-                "text": "Tail lashing excitedly, app1 hunts in the strange, forbidden land, ducking around corners and crawling over gardens with {PRONOUN/app1/poss} belly low to the ground. A successful, sneaky hunt.",
+                "text": "Tail lashing excitedly, s_c hunts in the strange, forbidden land, ducking around corners and crawling over gardens with {PRONOUN/s_c/poss} belly low to the ground. A successful, sneaky hunt.",
                 "exp": 20,
                 "weight": 20,
                 "stat_trait": [
-                    "calm",
-                    "careful",
-                    "insecure",
-                    "lonesome",
-                    "loyal",
-                    "nervous",
+                    "bold",
+                    "confident",
+                    "cunning",
                     "sneaky",
                     "strange"
                 ],
@@ -1129,15 +1178,11 @@
                 "exp": 0,
                 "weight": 20,
                 "stat_trait": [
-                    "altruistic",
-                    "compassionate",
-                    "empathetic",
-                    "faithful",
-                    "loving",
-                    "patient",
-                    "responsible",
-                    "thoughtful",
-                    "wise"
+                    "adventurous",
+                    "competitive",
+                    "daring",
+                    "shameless",
+                    "rebellious"
                 ],
                 "can_have_stat": ["app"]
             },
@@ -1145,7 +1190,7 @@
                 "text": "Carelessly, app1 is seen by Twolegs, and taken from c_n.",
                 "exp": 0,
                 "weight": 10,
-                "lost_cats": ["r_c"]
+                "lost_cats": ["app1"]
             },
             {
                 "text": "Carelessly, app1 is seen by Twolegs, and is taken hissing and spitting to be locked in a monster's den. Overnight, {PRONOUN/app1/subject} {VERB/app1/discover/discovers} that a broken window is just wide enough to push {PRONOUN/app1/self} out to safety through, but the glass leaves {PRONOUN/app1/object} bleeding as {PRONOUN/app1/subject} {VERB/app1/run/runs} back to c_n.",
@@ -1154,10 +1199,13 @@
                 "injury": [
                     {
                         "cats": ["app1"],
-                        "injuries": ["blood loss", "scrapes"],
+                        "injuries": ["blood loss", "scrapes", "small cut"],
                         "scars": []
                     }
-                ]
+                ],
+                "history_text": {
+                    "reg_death": "m_c bled out after escaping from a Twoleg den."
+                }
             }
         ]
     },
@@ -1175,7 +1223,7 @@
         },
         "weight": 20,
         "intro_text": "Boldly, eyes daring p_l to say no, r_c suggests hunting by the Twoleg dens.",
-        "decline_text": "On second thought, they decide to reline their nests today instead.",
+        "decline_text": "On second thought, they decide to recline in their nests today instead.",
         "chance_of_success": 40,
         "success_outcomes": [
             {
@@ -1187,21 +1235,21 @@
                     {
                         "cats_to": ["p_l"],
                         "cats_from": ["r_c"],
-                        "mutual": false,
+                        "mutual": true,
                         "values": ["romantic", "platonic"],
                         "amount": 5
                     }
                 ]
             },
             {
-                "text": "A friendly Twolegs makes a psspsspss noise, and pours kittypet food on the ground for r_c. {PRONOUN/r_c/subject/CAP} {VERB/r_c/fetch/fetches} p_l, and both cats investigate the food, loudly proclaiming how much better fresh-kill is, but both a little thrilled by the experience.",
+                "text": "A friendly Twoleg makes a psspsspss noise and pours kittypet food on the ground for r_c. {PRONOUN/r_c/subject/CAP} {VERB/r_c/fetch/fetches} p_l, and both cats investigate the food, loudly proclaiming how much better fresh-kill is, but both a little thrilled by the experience.",
                 "exp": 20,
                 "weight": 5,
                 "relationships": [
                     {
                         "cats_to": ["p_l"],
                         "cats_from": ["r_c"],
-                        "mutual": false,
+                        "mutual": true,
                         "values": ["romantic", "platonic"],
                         "amount": 5
                     }
@@ -1216,7 +1264,7 @@
                     {
                         "cats_to": ["p_l"],
                         "cats_from": ["r_c"],
-                        "mutual": false,
+                        "mutual": true,
                         "values": ["romantic", "platonic"],
                         "amount": 5
                     }
@@ -1227,12 +1275,11 @@
                 "exp": 20,
                 "weight": 20,
                 "stat_trait": [
-                    "calm",
-                    "careful",
-                    "insecure",
-                    "lonesome",
-                    "loyal",
-                    "nervous",
+                    "adventurous",
+                    "arrogant",
+                    "bold",
+                    "daring",
+                    "confident",
                     "sneaky",
                     "strange"
                 ],
@@ -1240,8 +1287,8 @@
                 "relationships": [
                     {
                         "cats_to": ["p_l"],
-                        "cats_from": ["s_c"],
-                        "mutual": false,
+                        "cats_from": ["r_c"],
+                        "mutual": true,
                         "values": ["romantic", "platonic"],
                         "amount": 5
                     }
@@ -1257,31 +1304,28 @@
                     {
                         "cats_to": ["p_l"],
                         "cats_from": ["r_c"],
-                        "mutual": false,
+                        "mutual": true,
                         "values": ["romantic", "platonic"],
                         "amount": 5
                     }
                 ]
             },
             {
-                "text": "The Twolegs here are friendly, and a little carelessly, s_c goes to hunt in their garden. But there's a new thing there, a box, suspicious and strange. Wisely, s_c avoids it, and returns to c_n territory.",
+                "text": "The Twolegs here are friendly, and a little carelessly, s_c takes r_c to hunt in their garden. But there's a new thing there, a box, suspicious and strange. Wisely, s_c avoids it and informs r_c, and the two cats return to c_n territory.",
                 "exp": 0,
                 "weight": 20,
                 "stat_trait": [
-                    "altruistic",
-                    "compassionate",
-                    "empathetic",
-                    "faithful",
-                    "loving",
-                    "patient",
-                    "responsible",
-                    "thoughtful",
-                    "wise"
+                    "adventurous",
+                    "competitive",
+                    "daring",
+                    "shameless",
+                    "rebellious"
                 ],
+                "can_have_stat": ["p_l"],
                 "relationships": [
                     {
                         "cats_to": ["p_l"],
-                        "cats_from": ["s_c"],
+                        "cats_from": ["r_c"],
                         "mutual": false,
                         "values": ["romantic", "platonic"],
                         "amount": -5
@@ -1292,16 +1336,7 @@
                 "text": "Carelessly, r_c is seen by Twolegs, and taken from c_n.",
                 "exp": 0,
                 "weight": 10,
-                "lost_cats": ["r_c"],
-                "relationships": [
-                    {
-                        "cats_to": ["p_l"],
-                        "cats_from": ["r_c"],
-                        "mutual": false,
-                        "values": ["romantic", "platonic"],
-                        "amount": -5
-                    }
-                ]
+                "lost_cats": ["r_c"]
             }
         ]
     },
@@ -1321,7 +1356,7 @@
         },
         "weight": 20,
         "intro_text": "Boldly, eyes daring app1 to say no, app2 suggests hunting by the Twoleg dens. Where apprentices are definitely not allowed.",
-        "decline_text": "On second thought, they decide to reline their nests today instead.",
+        "decline_text": "On second thought, they decide to recline in their nests today instead.",
         "chance_of_success": 30,
         "success_outcomes": [
             {
@@ -1331,8 +1366,8 @@
                 "prey": ["medium"],
                 "relationships": [
                     {
-                        "cats_to": ["p_l"],
-                        "cats_from": ["r_c"],
+                        "cats_to": ["app1"],
+                        "cats_from": ["app2"],
                         "mutual": true,
                         "values": ["romantic", "platonic"],
                         "amount": 5
@@ -1340,13 +1375,13 @@
                 ]
             },
             {
-                "text": "A friendly Twolegs makes a psspsspss noise, and pours kittypet food on the ground for app2. {PRONOUN/app2/subject/CAP} {VERB/app2/fetch/fetches} app1, and both apprentices loudly proclaim how much better fresh-kill is, but both are wide-eyed and thrilled by the experience.",
+                "text": "A friendly Twoleg makes a psspsspss noise and pours kittypet food on the ground for app2. {PRONOUN/app2/subject/CAP} {VERB/app2/fetch/fetches} app1, and both apprentices loudly proclaim how much better fresh-kill is, but both are wide-eyed and thrilled by the experience.",
                 "exp": 20,
                 "weight": 5,
                 "relationships": [
                     {
-                        "cats_to": ["p_l"],
-                        "cats_from": ["r_c"],
+                        "cats_to": ["app1"],
+                        "cats_from": ["app2"],
                         "mutual": true,
                         "values": ["romantic", "platonic"],
                         "amount": 5
@@ -1354,24 +1389,21 @@
                 ]
             },
             {
-                "text": "Tail lashing excitedly, app1 hunts in the strange, forbidden land, ducking around corners and crawling over gardens with {PRONOUN/app1/poss} belly low to the ground. app2 tries to be even sneakier, and so app1 ups {PRONOUN/app1/poss} game, until the two are probably the most obvious pair of cats in the neighborhood.",
+                "text": "Tail lashing excitedly, s_c hunts in the strange, forbidden land, ducking around corners and crawling over gardens with {PRONOUN/s_c/poss} belly low to the ground. app2 tries to be even sneakier, and so s_c ups {PRONOUN/s_c/poss} game, until the two are probably the most obvious pair of cats in the neighborhood.",
                 "exp": 20,
                 "weight": 20,
                 "stat_trait": [
-                    "calm",
-                    "careful",
-                    "insecure",
-                    "lonesome",
-                    "loyal",
-                    "nervous",
+                    "bold",
+                    "confident",
+                    "cunning",
                     "sneaky",
                     "strange"
                 ],
-                "can_have_stat": ["app"],
+                "can_have_stat": ["app1"],
                 "relationships": [
                     {
-                        "cats_to": ["p_l"],
-                        "cats_from": ["r_c"],
+                        "cats_to": ["s_c"],
+                        "cats_from": ["app2"],
                         "mutual": true,
                         "values": ["romantic", "platonic"],
                         "amount": 5
@@ -1386,35 +1418,31 @@
                 "weight": 20,
                 "relationships": [
                     {
-                        "cats_to": ["p_l"],
-                        "cats_from": ["r_c"],
-                        "mutual": false,
+                        "cats_to": ["app1"],
+                        "cats_from": ["app2"],
+                        "mutual": true,
                         "values": ["romantic", "platonic"],
                         "amount": 5
                     }
                 ]
             },
             {
-                "text": "A little carelessly, s_c jumps a fence to hunt in a den's garden. But there's a new thing there, a box, suspicious and strange. Wisely, s_c avoids it, and returns to c_n territory.",
+                "text": "A little carelessly, s_c jumps a fence to hunt in a den's garden. But there's a new thing there, a box, suspicious and strange. Wisely, s_c avoids it, and the two cats return to c_n territory.",
                 "exp": 0,
                 "weight": 20,
                 "stat_trait": [
-                    "altruistic",
-                    "compassionate",
-                    "empathetic",
-                    "faithful",
-                    "loving",
-                    "patient",
-                    "responsible",
-                    "thoughtful",
-                    "wise"
+                    "adventurous",
+                    "competitive",
+                    "daring",
+                    "shameless",
+                    "rebellious"
                 ],
                 "can_have_stat": ["app"],
                 "relationships": [
                     {
-                        "cats_to": ["p_l"],
-                        "cats_from": ["s_c"],
-                        "mutual": true,
+                        "cats_to": ["s_c"],
+                        "cats_from": ["r_c"],
+                        "mutual": false,
                         "values": ["romantic", "platonic"],
                         "amount": -5
                     }
@@ -1424,16 +1452,7 @@
                 "text": "Carelessly, app1 is seen by Twolegs, and taken from c_n.",
                 "exp": 0,
                 "weight": 10,
-                "lost_cats": ["r_c"],
-                "relationships": [
-                    {
-                        "cats_to": ["p_l"],
-                        "cats_from": ["r_c"],
-                        "mutual": true,
-                        "values": ["romantic", "platonic"],
-                        "amount": -5
-                    }
-                ]
+                "lost_cats": ["app1"]
             }
         ]
     },
@@ -1473,14 +1492,14 @@
                 "exp": 20,
                 "weight": 20,
                 "stat_trait": [
-                    "calm",
                     "careful",
+                    "cunning",
                     "insecure",
                     "lonesome",
-                    "loyal",
                     "nervous",
                     "sneaky",
-                    "strange"
+                    "strange",
+                    "wise"
                 ]
             }
         ],
@@ -1489,7 +1508,15 @@
                 "text": "Easily swayed by the delicious smell, s_c wanders recklessly into the sheltered space, only to smack into a metal wall. Inside the trap, a young fox starts up a distressed wail, and s_c feels sympathy {PRONOUN/s_c/subject} never expected to feel for a fox, as well as the heart-stopping realization that it could easily have been {PRONOUN/s_c/object}.",
                 "exp": 0,
                 "weight": 20,
-                "stat_trait": ["adventurous", "bold", "confident", "daring", "playful"]
+                "stat_trait": [
+                    "arrogant",
+                    "adventurous",
+                    "childish", 
+                    "confident",
+                    "oblivious", 
+                    "playful",
+                    "troublesome"
+                ]
             },
             {
                 "text": "r_c is caught in a trap hidden in the sand and is taken by Twolegs shortly after.",
@@ -1535,14 +1562,14 @@
                 "exp": 20,
                 "weight": 20,
                 "stat_trait": [
-                    "calm",
                     "careful",
+                    "cunning",
                     "insecure",
                     "lonesome",
-                    "loyal",
                     "nervous",
                     "sneaky",
-                    "strange"
+                    "strange",
+                    "wise"
                 ]
             }
         ],
@@ -1551,7 +1578,15 @@
                 "text": "Easily swayed by the delicious smell, s_c wanders recklessly into the sheltered space, only to smack into a metal wall. Inside the trap, a young fox starts up a distressed wail, and s_c feels sympathy {PRONOUN/s_c/subject} never expected to feel for a fox, as well as the heart-stopping realization that it could easily have been {PRONOUN/s_c/object}.",
                 "exp": 0,
                 "weight": 20,
-                "stat_trait": ["adventurous", "bold", "confident", "daring", "playful"]
+                "stat_trait": [
+                    "arrogant",
+                    "adventurous",
+                    "childish", 
+                    "confident",
+                    "oblivious", 
+                    "playful",
+                    "troublesome"
+                ]
             },
             {
                 "text": "r_c is caught in a trap hidden in the sand! There's nothing the patrol is able to do to help {PRONOUN/r_c/object}, and r_c is taken by Twolegs shortly after.",
@@ -1568,8 +1603,8 @@
         "types": ["hunting"],
         "tags": ["retirement"],
         "patrol_art": "gen_hunt_thunderpath",
-        "min_cats": 1,
-        "max_cats": 6,
+        "min_cats": 2,
+        "max_cats": 4,
         "min_max_status": {},
         "weight": 20,
         "intro_text": "The patrol comes across a Thunderpath running along the shore.",
@@ -1602,11 +1637,9 @@
                 "stat_trait": [
                     "calm",
                     "careful",
-                    "insecure",
+                    "cunning",
                     "nervous",
                     "sneaky",
-                    "strange",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1626,7 +1659,6 @@
                 "weight": 10,
                 "dead_cats": ["r_c"],
                 "history_text": {
-                    "scar": "m_c was heavily injured by a monster, and carries the scars from it.",
                     "reg_death": "m_c was hit by a monster and killed.",
                     "lead_death": "{VERB/m_c/were/was} hit by a monster"
                 }
@@ -1644,7 +1676,7 @@
                 ],
                 "history_text": {
                     "scar": "m_c was heavily injured by a monster, and carries the scars from it.",
-                    "reg_death": "m_c was hit by a monster and killed.",
+                    "reg_death": "m_c was hit by a monster and later died from {PRONOUN/m_c/poss} injuries.",
                     "lead_death": "{VERB/m_c/were/was} hit by a monster"
                 }
             }
@@ -1657,8 +1689,8 @@
         "types": ["hunting"],
         "tags": ["retirement", "cruel_season"],
         "patrol_art": "gen_hunt_thunderpath",
-        "min_cats": 1,
-        "max_cats": 6,
+        "min_cats": 2,
+        "max_cats": 4,
         "min_max_status": {},
         "weight": 20,
         "intro_text": "The patrol comes across a Thunderpath running along the shore.",
@@ -1691,11 +1723,9 @@
                 "stat_trait": [
                     "calm",
                     "careful",
-                    "insecure",
+                    "cunning",
                     "nervous",
                     "sneaky",
-                    "strange",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1715,7 +1745,6 @@
                 "weight": 10,
                 "dead_cats": ["r_c"],
                 "history_text": {
-                    "scar": "m_c was heavily injured by a monster, and carries the scars from it.",
                     "reg_death": "m_c was hit by a monster and killed.",
                     "lead_death": "{VERB/m_c/were/was} hit by a monster"
                 }
@@ -1733,7 +1762,7 @@
                 ],
                 "history_text": {
                     "scar": "m_c was heavily injured by a monster, and carries the scars from it.",
-                    "reg_death": "m_c was hit by a monster and killed.",
+                    "reg_death": "m_c was hit by a monster and later died from {PRONOUN/m_c/poss} injuries.",
                     "lead_death": "{VERB/m_c/were/was} hit by a monster"
                 }
             }
@@ -1780,11 +1809,9 @@
                 "stat_trait": [
                     "calm",
                     "careful",
-                    "insecure",
+                    "cunning",
                     "nervous",
                     "sneaky",
-                    "strange",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1817,7 +1844,7 @@
                 ],
                 "history_text": {
                     "scar": "m_c was heavily injured by a monster, and carries the scars from it.",
-                    "reg_death": "This cat was hit by a monster and killed.",
+                    "reg_death": "m_c was hit by a monster and later died from {PRONOUN/m_c/poss} injuries.",
                     "lead_death": "{VERB/m_c/were/was} hit by a monster"
                 }
             }
@@ -1851,7 +1878,7 @@
                 "prey": ["large"]
             },
             {
-                "text": "Your patrol stops on the edge of the Thunderpath, and s_c organizes a thorough search that finds a flattened squirrel. It's a reminder of the danger of the Thunderpath, and a good source of scavenged meat.",
+                "text": "Your patrol stops on the edge of the Thunderpath, and s_c organizes a thorough search that finds several flattened pieces of roadkill. It's a reminder of the danger of the Thunderpath, and a good source of scavenged meat.",
                 "exp": 10,
                 "weight": 20,
                 "stat_skill": ["CLEVER,1"],
@@ -1864,11 +1891,9 @@
                 "stat_trait": [
                     "calm",
                     "careful",
-                    "insecure",
+                    "cunning",
                     "nervous",
                     "sneaky",
-                    "strange",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1888,8 +1913,7 @@
                 "weight": 10,
                 "dead_cats": ["multi"],
                 "history_text": {
-                    "scar": "m_c was heavily injured by a monster, and carries the scars from it.",
-                    "reg_death": "This cat was hit by a monster and killed.",
+                    "reg_death": "m_c was hit by a monster and killed.",
                     "lead_death": "{VERB/m_c/were/was} hit by a monster"
                 }
             },
@@ -1906,7 +1930,7 @@
                 ],
                 "history_text": {
                     "scar": "m_c was heavily injured by a monster, and carries the scars from it.",
-                    "reg_death": "This cat was hit by a monster and killed.",
+                    "reg_death": "m_c was hit by a monster and later died from {PRONOUN/m_c/poss} injuries.",
                     "lead_death": "{VERB/m_c/were/was} hit by a monster"
                 }
             }
@@ -1937,7 +1961,7 @@
                         "cats_to": ["patrol"],
                         "cats_from": ["patrol"],
                         "mutual": false,
-                        "values": ["platonic", "comfort"],
+                        "values": ["platonic", "trust"],
                         "amount": 5
                     }
                 ]
@@ -1952,7 +1976,7 @@
                         "cats_to": ["patrol"],
                         "cats_from": ["patrol"],
                         "mutual": false,
-                        "values": ["platonic", "comfort"],
+                        "values": ["platonic", "trust"],
                         "amount": 5
                     }
                 ]
@@ -1965,10 +1989,10 @@
                 "prey": ["small"],
                 "relationships": [
                     {
-                        "cats_to": ["patrol"],
+                        "cats_to": ["s_c"],
                         "cats_from": ["patrol"],
                         "mutual": false,
-                        "values": ["platonic", "comfort"],
+                        "values": ["platonic", "admiration"],
                         "amount": 5
                     }
                 ]
@@ -1977,14 +2001,22 @@
                 "text": "s_c pounces on the octopus enthusiastically. It thwacks its tentacles around {PRONOUN/s_c/poss} head, trying to avoid {PRONOUN/s_c/poss} snapping muzzle, but s_c takes it in stride, prancing out of the rockpool to cheers and hilarity from the patrol, letting {PRONOUN/s_c/poss} friends guide {PRONOUN/s_c/object} and {PRONOUN/s_c/poss} semi-captured prey blindly back to camp as everyone murrps with laughter.",
                 "exp": 15,
                 "weight": 20,
-                "stat_trait": ["charismatic", "childish", "confident", "playful"],
+                "stat_trait": [
+                    "charismatic", 
+                    "confident",
+                    "flamboyant",
+                    "oblivious", 
+                    "playful",
+                    "shameless",
+                    "strange"
+                ],
                 "prey": ["small"],
                 "relationships": [
                     {
-                        "cats_to": ["patrol"],
+                        "cats_to": ["s_c"],
                         "cats_from": ["patrol"],
                         "mutual": false,
-                        "values": ["platonic", "comfort"],
+                        "values": ["platonic", "admiration"],
                         "amount": 5
                     }
                 ]
@@ -2000,7 +2032,7 @@
                         "cats_to": ["patrol"],
                         "cats_from": ["patrol"],
                         "mutual": false,
-                        "values": ["platonic", "comfort"],
+                        "values": ["platonic"],
                         "amount": -5
                     }
                 ],
@@ -2010,13 +2042,21 @@
                 "text": "s_c pounces on the octopus enthusiastically. It thwacks its tentacles around {PRONOUN/s_c/poss} head, trying to avoid {PRONOUN/s_c/poss} snapping muzzle, and s_c skitters backwards, uncoordinated flailing about until the rest of the patrol is able to help {PRONOUN/s_c/object}. The octopus escapes.",
                 "exp": 0,
                 "weight": 20,
-                "stat_trait": ["adventurous", "bold", "daring", "righteous"],
+                "stat_trait": [
+                    "arrogant",
+                    "ambitious",
+                    "childish",
+                    "competitive",
+                    "daring",
+                    "insecure",
+                    "lonesome"
+                ],
                 "relationships": [
                     {
                         "cats_to": ["patrol"],
                         "cats_from": ["patrol"],
                         "mutual": false,
-                        "values": ["platonic", "comfort"],
+                        "values": ["platonic", "trust"],
                         "amount": -5
                     }
                 ],
@@ -2049,7 +2089,7 @@
                         "cats_to": ["patrol"],
                         "cats_from": ["patrol"],
                         "mutual": false,
-                        "values": ["platonic", "comfort"],
+                        "values": ["platonic", "trust"],
                         "amount": 5
                     }
                 ]
@@ -2064,7 +2104,7 @@
                         "cats_to": ["patrol"],
                         "cats_from": ["patrol"],
                         "mutual": false,
-                        "values": ["platonic", "comfort"],
+                        "values": ["platonic", "trust"],
                         "amount": 5
                     }
                 ]
@@ -2073,14 +2113,22 @@
                 "text": "Well, this octopus decided to cross at the wrong time. Ruthlessly, s_c dispatches it, paws squishing through the very squishy squish.",
                 "exp": 15,
                 "weight": 20,
-                "stat_trait": ["bloodthirsty", "cold", "fierce", "strict"],
+                "stat_trait": [
+                    "bloodthirsty", 
+                    "cold", 
+                    "fierce",
+                    "grumpy",
+                    "righteous", 
+                    "strict",
+                    "vengeful"
+                ],
                 "prey": ["small"],
                 "relationships": [
                     {
-                        "cats_to": ["patrol"],
+                        "cats_to": ["s_c"],
                         "cats_from": ["patrol"],
                         "mutual": false,
-                        "values": ["platonic", "comfort"],
+                        "values": ["platonic", "admiration"],
                         "amount": 5
                     }
                 ]
@@ -2096,7 +2144,7 @@
                         "cats_to": ["patrol"],
                         "cats_from": ["patrol"],
                         "mutual": false,
-                        "values": ["platonic", "comfort"],
+                        "values": ["platonic", "trust"],
                         "amount": -5
                     }
                 ],
@@ -2106,13 +2154,20 @@
                 "text": "s_c convinces the patrol to let it go - the poor thing is clearly struggling so much already, this feels unfair.",
                 "exp": 0,
                 "weight": 20,
-                "stat_trait": ["altruistic", "compassionate", "empathetic", "faithful", "loving"],
+                "stat_trait": [
+                    "compassionate",
+                    "childish", 
+                    "faithful", 
+                    "loving",
+                    "sincere",
+                    "strange"
+                ],
                 "relationships": [
                     {
                         "cats_to": ["patrol"],
                         "cats_from": ["patrol"],
                         "mutual": false,
-                        "values": ["platonic", "comfort"],
+                        "values": ["platonic", "trust"],
                         "amount": -5
                     }
                 ],
@@ -2151,7 +2206,15 @@
                 "text": "Well, this octopus decided to cross at the wrong time. Ruthlessly, s_c dispatches it, paws squishing through the very squishy squish.",
                 "exp": 15,
                 "weight": 20,
-                "stat_trait": ["bloodthirsty", "cold", "fierce", "strict"],
+                "stat_trait": [
+                    "bloodthirsty", 
+                    "cold", 
+                    "fierce",
+                    "grumpy",
+                    "righteous", 
+                    "strict",
+                    "vengeful"
+                ],
                 "prey": ["small"]
             }
         ],
@@ -2166,7 +2229,14 @@
                 "text": "s_c lets it go - the poor thing is clearly struggling so much already, this feels unfair.",
                 "exp": 0,
                 "weight": 20,
-                "stat_trait": ["altruistic", "compassionate", "empathetic", "faithful", "loving"],
+                "stat_trait": [
+                    "compassionate",
+                    "childish", 
+                    "faithful", 
+                    "loving",
+                    "sincere",
+                    "strange"
+                ],
                 "prey": ["very_small"]
             }
         ]
@@ -2207,12 +2277,12 @@
                 "weight": 20,
                 "prey": ["large"],
                 "stat_trait": [
-                    "calm",
                     "ambitious",
-                    "compassionate",
-                    "charismatic",
+                    "arrogant",
                     "bold",
-                    "responsible"
+                    "charismatic",
+                    "cunning",
+                    "daring"
                 ],
                 "relationships": [
                     {
@@ -2220,6 +2290,13 @@
                         "cats_from": ["patrol"],
                         "mutual": false,
                         "values": ["trust"],
+                        "amount": 5
+                    },
+                    {
+                        "cats_to": ["patrol"],
+                        "cats_from": ["clan"],
+                        "mutual": false,
+                        "values": ["admiration"],
                         "amount": 5
                     }
                 ]
@@ -2229,12 +2306,27 @@
                 "exp": 30,
                 "weight": 20,
                 "prey": ["large"],
+                "stat_trait": [
+                    "calm",
+                    "confident",
+                    "responsible",
+                    "cold",
+                    "strict",
+                    "wise"
+                ],
                 "relationships": [
                     {
                         "cats_to": ["patrol"],
                         "cats_from": ["patrol"],
                         "mutual": false,
                         "values": ["trust"],
+                        "amount": 5
+                    },
+                    {
+                        "cats_to": ["patrol"],
+                        "cats_from": ["clan"],
+                        "mutual": false,
+                        "values": ["admiration"],
                         "amount": 5
                     }
                 ]
@@ -2266,11 +2358,11 @@
                     "childish",
                     "lonesome",
                     "loving",
-                    "strange"
+                    "careful"
                 ],
                 "relationships": [
                     {
-                        "cats_to": ["patrol"],
+                        "cats_to": ["s_c"],
                         "cats_from": ["patrol"],
                         "mutual": false,
                         "values": ["trust"],
@@ -2287,9 +2379,14 @@
                     {
                         "cats": ["r_c"],
                         "injuries": ["beak_bite"],
-                        "scars": []
+                        "scars": ["beak_scars"]
                     }
                 ],
+                "history_text": {
+                    "scar": "m_c was scarred by an octopus.",
+                    "reg_death": "m_c died from an octopus bite.",
+                    "lead_death": "died from an octopus bite"
+                },
                 "relationships": [
                     {
                         "cats_to": ["patrol"],
@@ -2306,19 +2403,28 @@
                 "exp": 0,
                 "weight": 10,
                 "stat_trait": [
+                    "careful",
+                    "childish",
                     "nervous",
-                    "insecure"
+                    "insecure",
+                    "lonesome",
+                    "loving"
                 ],
                 "injury": [
                     {
                         "cats": ["r_c"],
                         "injuries": ["beak_bite"],
-                        "scars": []
+                        "scars": ["beak_scars"]
                     }
                 ],
+                "history_text": {
+                    "scar": "m_c was scarred by an octopus.",
+                    "reg_death": "m_c died from an octopus bite.",
+                    "lead_death": "died from an octopus bite"
+                },
                 "relationships": [
                     {
-                        "cats_to": ["patrol"],
+                        "cats_to": ["s_c"],
                         "cats_from": ["patrol"],
                         "mutual": false,
                         "values": ["trust"],
@@ -2336,8 +2442,8 @@
         "types": ["hunting"],
         "tags": [],
         "patrol_art": "gen_hunt_eagleswim",
-        "min_cats": 1,
-        "max_cats": 3,
+        "min_cats": 3,
+        "max_cats": 6,
         "min_max_status": {
             "normal adult": [1, 6]
         },
@@ -2347,7 +2453,7 @@
         "chance_of_success": 30,
         "success_outcomes": [
             {
-                "text": "Your patrol uses the eagle as a scout for their own hunt, and eventually manage several smaller catches from the same area that cumulatively are just as impressive as the eagle's massive catch.",
+                "text": "Your patrol uses the eagle as a scout for their own hunt, and eventually manages several smaller catches from the same area that cumulatively are just as impressive as the eagle's massive catch.",
                 "exp": 20,
                 "weight": 20,
                 "prey": ["large"],
@@ -2373,30 +2479,51 @@
                         "mutual": false,
                         "values": ["trust"],
                         "amount": 5
+                    },
+                    {
+                        "cats_to": ["p_l"],
+                        "cats_from": ["patrol"],
+                        "mutual": false,
+                        "values": ["admiration"],
+                        "amount": 5
                     }
                 ]
             },
             {
-                "text": "As the rest of the patrol discuss whether they can steal the catch, s_c fixates on the bird that caught it. The eagle works its way awkwardly towards shore, and just as it's going to climb out s_c pounces, fighting in the shallows where s_c has the edge over the bird in swimming. {PRONOUN/s_c/subject/CAP} {VERB/s_c/win/wins} both the fish and the predator as prey for c_n.",
+                "text": "As the rest of the patrol discusses whether they can steal the catch, s_c fixates on the bird that caught it. The eagle works its way awkwardly towards shore, and just as it's going to climb out s_c pounces, fighting in the shallows where s_c has the edge over the bird in swimming. {PRONOUN/s_c/subject/CAP} {VERB/s_c/win/wins} both the fish and the predator as prey for c_n.",
                 "exp": 20,
                 "weight": 20,
                 "stat_skill": ["FIGHTER,3"],
                 "prey": ["huge"],
                 "relationships": [
                     {
-                        "cats_to": ["patrol"],
+                        "cats_to": ["s_c"],
                         "cats_from": ["patrol"],
                         "mutual": false,
                         "values": ["trust"],
+                        "amount": 10
+                    },
+                    {
+                        "cats_to": ["s_c"],
+                        "cats_from": ["clan"],
+                        "mutual": false,
+                        "values": ["admiration"],
                         "amount": 5
                     }
                 ]
             },
             {
-                "text": "As the rest of the patrol discuss whether they can steal the catch, s_c fixates on the bird that caught it. The eagle works its way awkwardly towards shore, and just as it's going to climb out s_c pounces, fighting in the shallows where s_c has the edge over the bird in swimming. {PRONOUN/s_c/subject/CAP} {VERB/s_c/win/wins} both the fish and the predator as prey for c_n.",
+                "text": "As the rest of the patrol discusses whether they can steal the catch, s_c fixates on the bird that caught it. The eagle works its way awkwardly towards shore, and just as it's going to climb out s_c pounces, fighting in the shallows where s_c has the edge over the bird in swimming. {PRONOUN/s_c/subject/CAP} {VERB/s_c/win/wins} both the fish and the predator as prey for c_n.",
                 "exp": 20,
                 "weight": 20,
-                "stat_trait": ["ambitious"],
+                "stat_trait": [
+                    "ambitious",
+                    "arrogant",
+                    "fierce",
+                    "bloodthirsty",
+                    "daring",
+                    "competitive"
+                ],
                 "prey": ["huge"],
                 "relationships": [
                     {
@@ -2404,6 +2531,13 @@
                         "cats_from": ["patrol"],
                         "mutual": false,
                         "values": ["trust"],
+                        "amount": 10
+                    },
+                    {
+                        "cats_to": ["s_c"],
+                        "cats_from": ["clan"],
+                        "mutual": false,
+                        "values": ["admiration"],
                         "amount": 5
                     }
                 ]
@@ -2411,7 +2545,7 @@
         ],
         "fail_outcomes": [
             {
-                "text": "The patrol dives into the water, keen to make a play to steal the fish, but even though its talons are occupied keeping grip on its prey, the eagle's huge wings pack a buffeting punch and the cats are driven back, giving up on the idea of scavenging.",
+                "text": "The patrol dives into the water, keen to make a play to steal the fish, but even though its talons are occupied keeping a grip on its prey, the eagle's huge wings pack a buffeting punch and the cats are driven back, giving up on the idea of scavenging.",
                 "exp": 0,
                 "weight": 20,
                 "relationships": [
@@ -2433,10 +2567,14 @@
                     {
                         "cats": ["r_c"],
                         "injuries": ["beak_bite"],
-                        "scars": ["BEAKCHEEK"]
+                        "scars": ["beak_scars"]
                     }
                 ],
-                "history_text": { "scar": "m_c carries a scar from an eagle's beak." },
+                "history_text": { 
+                    "scar": "m_c carries a scar from an eagle's beak.",
+                    "reg_death": "m_c died from an eagle bite.",
+                    "lead_death": "died from an eagle bite"
+                },
                 "relationships": [
                     {
                         "cats_to": ["patrol"],
@@ -2455,9 +2593,9 @@
         "biome": ["beach"],
         "season": ["Any"],
         "types": ["hunting"],
-        "tags": [],
+        "tags": ["cruel_season"],
         "patrol_art": "gen_hunt_eagleswim",
-        "min_cats": 4,
+        "min_cats": 3,
         "max_cats": 6,
         "min_max_status": {
             "normal adult": [1, 6]
@@ -2494,11 +2632,18 @@
                         "mutual": false,
                         "values": ["trust"],
                         "amount": 5
+                    },
+                    {
+                        "cats_to": ["p_l"],
+                        "cats_from": ["patrol"],
+                        "mutual": false,
+                        "values": ["admiration"],
+                        "amount": 5
                     }
                 ]
             },
             {
-                "text": "As the rest of the patrol discuss whether they can steal the catch, s_c fixates on the bird that caught it. The eagle works its way awkwardly towards shore, and just as it's going to climb out s_c pounces, fighting in the shallows where s_c has the edge over the bird in swimming. {PRONOUN/s_c/subject/CAP} {VERB/s_c/win/wins} both the fish and the predator as prey for c_n.",
+                "text": "As the rest of the patrol discusses whether they can steal the catch, s_c fixates on the bird that caught it. The eagle works its way awkwardly towards shore, and just as it's going to climb out s_c pounces, fighting in the shallows where s_c has the edge over the bird in swimming. {PRONOUN/s_c/subject/CAP} {VERB/s_c/win/wins} both the fish and the predator as prey for c_n.",
                 "exp": 20,
                 "weight": 20,
                 "stat_skill": ["FIGHTER,3"],
@@ -2509,15 +2654,29 @@
                         "cats_from": ["patrol"],
                         "mutual": false,
                         "values": ["trust"],
+                        "amount": 10
+                    },
+                    {
+                        "cats_to": ["s_c"],
+                        "cats_from": ["clan"],
+                        "mutual": false,
+                        "values": ["admiration"],
                         "amount": 5
                     }
                 ]
             },
             {
-                "text": "As the rest of the patrol discuss whether they can steal the catch, s_c fixates on the bird that caught it. The eagle works its way awkwardly towards shore, and just as it's going to climb out s_c pounces, fighting in the shallows where s_c has the edge over the bird in swimming. {PRONOUN/s_c/subject/CAP} {VERB/s_c/win/wins} both the fish and the predator as prey for c_n.",
+                "text": "As the rest of the patrol discusses whether they can steal the catch, s_c fixates on the bird that caught it. The eagle works its way awkwardly towards shore, and just as it's going to climb out s_c pounces, fighting in the shallows where s_c has the edge over the bird in swimming. {PRONOUN/s_c/subject/CAP} {VERB/s_c/win/wins} both the fish and the predator as prey for c_n.",
                 "exp": 20,
                 "weight": 20,
-                "stat_trait": ["ambitious"],
+                "stat_trait": [
+                    "ambitious",
+                    "arrogant",
+                    "fierce",
+                    "bloodthirsty",
+                    "daring",
+                    "competitive"
+                ],
                 "prey": ["huge"],
                 "relationships": [
                     {
@@ -2525,127 +2684,13 @@
                         "cats_from": ["patrol"],
                         "mutual": false,
                         "values": ["trust"],
-                        "amount": 5
-                    }
-                ]
-            }
-        ],
-        "fail_outcomes": [
-            {
-                "text": "The patrol dives into the water, keen to make a play to steal the fish, but even though its talons are occupied keeping grip on its prey, the eagle's huge wings pack a buffeting punch and the cats are driven back, giving up on the idea of scavenging.",
-                "exp": 0,
-                "weight": 20,
-                "relationships": [
+                        "amount": 10
+                    },
                     {
-                        "cats_to": ["patrol"],
-                        "cats_from": ["patrol"],
+                        "cats_to": ["s_c"],
+                        "cats_from": ["clan"],
                         "mutual": false,
-                        "values": ["trust"],
-                        "amount": -5
-                    }
-                ],
-                "prey": ["very_small"]
-            },
-            {
-                "text": "The patrol decides to fight the eagle in the water for possession of the prey, but while its talons are occupied holding on to its prey, its beak is not, and it takes a nasty chunk out of r_c before the cats retreat.",
-                "exp": 0,
-                "weight": 10,
-                "injury": [
-                    {
-                        "cats": ["r_c"],
-                        "injuries": ["beak_bite"],
-                        "scars": ["BEAKCHEEK"]
-                    }
-                ],
-                "history_text": { "scar": "m_c carries a scar from an eagle's beak." },
-                "relationships": [
-                    {
-                        "cats_to": ["patrol"],
-                        "cats_from": ["patrol"],
-                        "mutual": false,
-                        "values": ["trust"],
-                        "amount": -5
-                    }
-                ],
-                "prey": ["very_small"]
-            }
-        ]
-    },
-    {
-        "patrol_id": "bch_hunt_eagleswim3",
-        "biome": ["beach"],
-        "season": ["Any"],
-        "types": ["hunting"],
-        "tags": ["cruel_season"],
-        "patrol_art": "gen_hunt_eagleswim",
-        "min_cats": 1,
-        "max_cats": 3,
-        "min_max_status": {
-            "normal adult": [1, 6]
-        },
-        "weight": 20,
-        "intro_text": "The hunting patrol spots an eagle on the wing overhead, and watches as it swoops to dig its talons through the spine of an impressively huge fish. But then it doesn't take its catch into the air. Perhaps it's too heavy?",
-        "decline_text": "The patrol moves on, ignoring the eagle to focus on their own hunt.",
-        "chance_of_success": 30,
-        "success_outcomes": [
-            {
-                "text": "Your patrol uses the eagle as a scout for their own hunt, and eventually manage several smaller catches from the same area that cumulatively are just as impressive as the eagle's massive catch.",
-                "exp": 20,
-                "weight": 20,
-                "prey": ["large"],
-                "relationships": [
-                    {
-                        "cats_to": ["patrol"],
-                        "cats_from": ["patrol"],
-                        "mutual": false,
-                        "values": ["trust"],
-                        "amount": 5
-                    }
-                ]
-            },
-            {
-                "text": "The cats' eyes light up with possibility, watching the eagle swimming to shore awkwardly. p_l leads the patrol yowling threats and insults from the shoreline, making a massive racket. Bewildered, the eagle eventually gives up its catch and takes to the air. The massive fish washes ashore into the paws of c_n.",
-                "exp": 20,
-                "weight": 5,
-                "prey": ["large"],
-                "relationships": [
-                    {
-                        "cats_to": ["patrol"],
-                        "cats_from": ["patrol"],
-                        "mutual": false,
-                        "values": ["trust"],
-                        "amount": 5
-                    }
-                ]
-            },
-            {
-                "text": "As the rest of the patrol discuss whether they can steal the catch, s_c fixates on the bird that caught it. The eagle works its way awkwardly towards shore, and just as it's going to climb out s_c pounces, fighting in the shallows where s_c has the edge over the bird in swimming. {PRONOUN/s_c/subject/CAP} {VERB/s_c/win/wins} both the fish and the predator as prey for c_n.",
-                "exp": 20,
-                "weight": 20,
-                "stat_skill": ["FIGHTER,3"],
-                "prey": ["huge"],
-                "relationships": [
-                    {
-                        "cats_to": ["patrol"],
-                        "cats_from": ["patrol"],
-                        "mutual": false,
-                        "values": ["trust"],
-                        "amount": 5
-                    }
-                ]
-            },
-            {
-                "text": "As the rest of the patrol discuss whether they can steal the catch, s_c fixates on the bird that caught it. The eagle works its way awkwardly towards shore, and just as it's going to climb out s_c pounces, fighting in the shallows where s_c has the edge over the bird in swimming. {PRONOUN/s_c/subject/CAP} {VERB/s_c/win/wins} both the fish and the predator as prey for c_n.",
-                "exp": 20,
-                "weight": 20,
-                "stat_trait": ["ambitious"],
-                "prey": ["huge"],
-                "relationships": [
-                    {
-                        "cats_to": ["patrol"],
-                        "cats_from": ["patrol"],
-                        "mutual": false,
-                        "values": ["trust"],
+                        "values": ["admiration"],
                         "amount": 5
                     }
                 ]
@@ -2672,7 +2717,6 @@
                 "weight": 10,
                 "dead_cats": ["r_c"],
                 "history_text": {
-                    "scar": "m_c carries a scar from an eagle's beak.",
                     "reg_death": "m_c was killed by an eagle, scrapping over food.",
                     "lead_death": "{VERB/m_c/were/was} killed by an eagle"
                 },
@@ -2694,166 +2738,14 @@
                     {
                         "cats": ["r_c"],
                         "injuries": ["beak_bite"],
-                        "scars": ["BEAKCHEEK"]
+                        "scars": ["beak_scars"]
                     }
                 ],
                 "history_text": {
                     "scar": "m_c carries a scar from an eagle's beak.",
-                    "reg_death": "m_c was killed by an eagle, scrapping over food.",
-                    "lead_death": "{VERB/m_c/were/was} killed by an eagle"
-                },
-                "relationships": [
-                    {
-                        "cats_to": ["patrol"],
-                        "cats_from": ["patrol"],
-                        "mutual": false,
-                        "values": ["trust"],
-                        "amount": -5
-                    }
-                ]
-            }
-        ]
-    },
-    {
-        "patrol_id": "bch_hunt_eagleswim4",
-        "biome": ["beach"],
-        "season": ["Any"],
-        "types": ["hunting"],
-        "tags": ["cruel_season"],
-        "patrol_art": "gen_hunt_eagleswim",
-        "min_cats": 4,
-        "max_cats": 6,
-        "min_max_status": {
-            "normal adult": [1, 6]
-        },
-        "weight": 20,
-        "intro_text": "The hunting patrol spots an eagle on the wing overhead, and watches as it swoops to dig its talons through the spine of an impressively huge fish. But then it doesn't take its catch into the air. Perhaps it's too heavy?",
-        "decline_text": "The patrol moves on, ignoring the eagle to focus on their own hunt.",
-        "chance_of_success": 30,
-        "success_outcomes": [
-            {
-                "text": "Your patrol uses the eagle as a scout for their own hunt, and eventually manage several smaller catches from the same area that cumulatively are just as impressive as the eagle's massive catch.",
-                "exp": 20,
-                "weight": 20,
-                "prey": ["large"],
-                "relationships": [
-                    {
-                        "cats_to": ["patrol"],
-                        "cats_from": ["patrol"],
-                        "mutual": false,
-                        "values": ["trust"],
-                        "amount": 5
-                    }
-                ]
-            },
-            {
-                "text": "The cats' eyes light up with possibility, watching the eagle swimming to shore awkwardly. p_l leads the patrol yowling threats and insults from the shoreline and making a massive racket. Bewildered, the eagle eventually gives up its catch and takes to the air. The massive fish washes ashore into the paws of c_n.",
-                "exp": 20,
-                "weight": 5,
-                "prey": ["large"],
-                "relationships": [
-                    {
-                        "cats_to": ["patrol"],
-                        "cats_from": ["patrol"],
-                        "mutual": false,
-                        "values": ["trust"],
-                        "amount": 5
-                    }
-                ]
-            },
-            {
-                "text": "As the rest of the patrol discuss whether they can steal the catch, s_c fixates on the bird that caught it. The eagle works its way awkwardly towards shore, and just as it's going to climb out s_c pounces, fighting in the shallows where s_c has the edge over the bird in swimming. {PRONOUN/s_c/subject/CAP} {VERB/s_c/win/wins} both the fish and the predator as prey for c_n.",
-                "exp": 20,
-                "weight": 20,
-                "stat_skill": ["FIGHTER,3"],
-                "prey": ["huge"],
-                "relationships": [
-                    {
-                        "cats_to": ["patrol"],
-                        "cats_from": ["patrol"],
-                        "mutual": false,
-                        "values": ["trust"],
-                        "amount": 5
-                    }
-                ]
-            },
-            {
-                "text": "As the rest of the patrol discuss whether they can steal the catch, s_c fixates on the bird that caught it. The eagle works its way awkwardly towards shore, and just as it's going to climb out s_c pounces, fighting in the shallows where s_c has the edge over the bird in swimming. {PRONOUN/s_c/subject/CAP} {VERB/s_c/win/wins} both the fish and the predator as prey for c_n.",
-                "exp": 20,
-                "weight": 20,
-                "stat_trait": ["ambitious"],
-                "prey": ["huge"],
-                "relationships": [
-                    {
-                        "cats_to": ["patrol"],
-                        "cats_from": ["patrol"],
-                        "mutual": false,
-                        "values": ["trust"],
-                        "amount": 5
-                    }
-                ]
-            }
-        ],
-        "fail_outcomes": [
-            {
-                "text": "The patrol dives into the water, keen to make a play to steal the fish, but even though its talons are occupied keeping grip on its prey, the eagle's huge wings pack a buffeting punch and the cats are driven back, giving up on the idea of scavenging.",
-                "exp": 0,
-                "weight": 20,
-                "relationships": [
-                    {
-                        "cats_to": ["patrol"],
-                        "cats_from": ["patrol"],
-                        "mutual": false,
-                        "values": ["trust"],
-                        "amount": -5
-                    }
-                ]
-            },
-            {
-                "text": "The patrol decides to fight the eagle in the water for possession of the prey, but the bird drops the prey and a furious haphazard swimming fight ensues. The eagle's talons, wings, and beak flail in an uncoordinated, dangerous tangle that brings r_c below the water. It's hard to say what kills {PRONOUN/r_c/object}, the talon wounds or drowning.",
-                "exp": 0,
-                "weight": 10,
-                "dead_cats": ["r_c"],
-                "history_text": {
-                    "scar": "m_c carries a scar from an eagle's beak.",
-                    "reg_death": "m_c was killed by an eagle, scrapping over food.",
-                    "lead_death": "{VERB/m_c/were/was} killed by an eagle"
-                },
-                "relationships": [
-                    {
-                        "cats_to": ["patrol"],
-                        "cats_from": ["patrol"],
-                        "mutual": false,
-                        "values": ["trust"],
-                        "amount": -5
-                    }
-                ]
-            },
-            {
-                "text": "The patrol decides to fight the eagle in the water for possession of the prey, but while its talons are occupied holding on to its prey, its beak is not, and it takes a nasty chunk out of r_c before the cats retreat.",
-                "exp": 0,
-                "weight": 10,
-                "injury": [
-                    {
-                        "cats": ["r_c"],
-                        "injuries": ["beak_bite"],
-                        "scars": ["BEAKCHEEK"]
-                    }
-                ],
-                "history_text": {
-                    "scar": "m_c carries a scar from an eagle's beak.",
-                    "reg_death": "m_c was killed by an eagle, scrapping over food.",
-                    "lead_death": "{VERB/m_c/were/was} killed by an eagle"
-                },
-                "relationships": [
-                    {
-                        "cats_to": ["patrol"],
-                        "cats_from": ["patrol"],
-                        "mutual": false,
-                        "values": ["trust"],
-                        "amount": -5
-                    }
-                ]
+                    "reg_death": "m_c died from an eagle bite.",
+                    "lead_death": "died from an eagle bite"
+                }
             }
         ]
     },

--- a/resources/dicts/patrols/beach/hunting/any.json
+++ b/resources/dicts/patrols/beach/hunting/any.json
@@ -1992,7 +1992,7 @@
                         "cats_to": ["s_c"],
                         "cats_from": ["patrol"],
                         "mutual": false,
-                        "values": ["platonic", "admiration"],
+                        "values": ["platonic", "respect"],
                         "amount": 5
                     }
                 ]
@@ -2016,7 +2016,7 @@
                         "cats_to": ["s_c"],
                         "cats_from": ["patrol"],
                         "mutual": false,
-                        "values": ["platonic", "admiration"],
+                        "values": ["platonic", "respect"],
                         "amount": 5
                     }
                 ]
@@ -2128,7 +2128,7 @@
                         "cats_to": ["s_c"],
                         "cats_from": ["patrol"],
                         "mutual": false,
-                        "values": ["platonic", "admiration"],
+                        "values": ["platonic", "respect"],
                         "amount": 5
                     }
                 ]
@@ -2296,7 +2296,7 @@
                         "cats_to": ["patrol"],
                         "cats_from": ["clan"],
                         "mutual": false,
-                        "values": ["admiration"],
+                        "values": ["respect"],
                         "amount": 5
                     }
                 ]
@@ -2326,7 +2326,7 @@
                         "cats_to": ["patrol"],
                         "cats_from": ["clan"],
                         "mutual": false,
-                        "values": ["admiration"],
+                        "values": ["respect"],
                         "amount": 5
                     }
                 ]
@@ -2484,7 +2484,7 @@
                         "cats_to": ["p_l"],
                         "cats_from": ["patrol"],
                         "mutual": false,
-                        "values": ["admiration"],
+                        "values": ["respect"],
                         "amount": 5
                     }
                 ]
@@ -2507,7 +2507,7 @@
                         "cats_to": ["s_c"],
                         "cats_from": ["clan"],
                         "mutual": false,
-                        "values": ["admiration"],
+                        "values": ["respect"],
                         "amount": 5
                     }
                 ]
@@ -2537,7 +2537,7 @@
                         "cats_to": ["s_c"],
                         "cats_from": ["clan"],
                         "mutual": false,
-                        "values": ["admiration"],
+                        "values": ["respect"],
                         "amount": 5
                     }
                 ]
@@ -2637,7 +2637,7 @@
                         "cats_to": ["p_l"],
                         "cats_from": ["patrol"],
                         "mutual": false,
-                        "values": ["admiration"],
+                        "values": ["respect"],
                         "amount": 5
                     }
                 ]
@@ -2660,7 +2660,7 @@
                         "cats_to": ["s_c"],
                         "cats_from": ["clan"],
                         "mutual": false,
-                        "values": ["admiration"],
+                        "values": ["respect"],
                         "amount": 5
                     }
                 ]
@@ -2690,7 +2690,7 @@
                         "cats_to": ["s_c"],
                         "cats_from": ["clan"],
                         "mutual": false,
-                        "values": ["admiration"],
+                        "values": ["respect"],
                         "amount": 5
                     }
                 ]
@@ -2775,7 +2775,7 @@
                         "cats_to": ["patrol", "patrol"],
                         "cats_from": ["clan", "patrol"],
                         "mutual": false,
-                        "values": ["respect"],
+                        "values": ["respect", "trust"],
                         "amount": 5
                     }
                 ]

--- a/resources/dicts/patrols/beach/hunting/any.json
+++ b/resources/dicts/patrols/beach/hunting/any.json
@@ -2500,7 +2500,7 @@
                         "cats_to": ["s_c"],
                         "cats_from": ["patrol"],
                         "mutual": false,
-                        "values": ["trust"],
+                        "values": ["trust", "respect"],
                         "amount": 10
                     },
                     {
@@ -2530,7 +2530,7 @@
                         "cats_to": ["patrol"],
                         "cats_from": ["patrol"],
                         "mutual": false,
-                        "values": ["trust"],
+                        "values": ["trust", "respect"],
                         "amount": 10
                     },
                     {
@@ -2653,7 +2653,7 @@
                         "cats_to": ["patrol"],
                         "cats_from": ["patrol"],
                         "mutual": false,
-                        "values": ["trust"],
+                        "values": ["trust", "respect"],
                         "amount": 10
                     },
                     {
@@ -2683,7 +2683,7 @@
                         "cats_to": ["patrol"],
                         "cats_from": ["patrol"],
                         "mutual": false,
-                        "values": ["trust"],
+                        "values": ["trust", "respect"],
                         "amount": 10
                     },
                     {
@@ -2772,11 +2772,18 @@
                 "prey": ["large"],
                 "relationships": [
                     {
-                        "cats_to": ["patrol", "patrol"],
-                        "cats_from": ["clan", "patrol"],
+                        "cats_to": ["patrol"],
+                        "cats_from": ["clan"],
+                        "mutual": false,
+                        "values": ["respect"],
+                        "amount": 5
+                    },
+                    {
+                        "cats_to": ["patrol"],
+                        "cats_from": ["patrol"],
                         "mutual": false,
                         "values": ["respect", "trust"],
-                        "amount": 5
+                        "amount": 10
                     }
                 ]
             },
@@ -2788,11 +2795,18 @@
                 "prey": ["large"],
                 "relationships": [
                     {
-                        "cats_to": ["patrol", "patrol"],
-                        "cats_from": ["clan", "patrol"],
+                        "cats_to": ["patrol"],
+                        "cats_from": ["clan"],
                         "mutual": false,
                         "values": ["respect"],
                         "amount": 5
+                    },
+                    {
+                        "cats_to": ["s_c"],
+                        "cats_from": ["patrol"],
+                        "mutual": false,
+                        "values": ["trust", "respect"],
+                        "amount": 10
                     }
                 ]
             },
@@ -2801,23 +2815,28 @@
                 "exp": 20,
                 "weight": 20,
                 "stat_trait": [
-                    "adventurous",
-                    "altruistic",
-                    "ambitious",
+                    "bloodthirsty",
                     "confident",
+                    "bold",
                     "daring",
                     "fierce",
-                    "responsible",
                     "righteous"
                 ],
                 "prey": ["large"],
                 "relationships": [
                     {
-                        "cats_to": ["patrol", "patrol"],
-                        "cats_from": ["clan", "patrol"],
+                        "cats_to": ["patrol",],
+                        "cats_from": ["patrol"],
+                        "mutual": false,
+                        "values": ["trust"],
+                        "amount": 5
+                    },
+                    {
+                        "cats_to": ["s_c"],
+                        "cats_from": ["patrol", "clan"],
                         "mutual": false,
                         "values": ["respect"],
-                        "amount": 5
+                        "amount": 10
                     }
                 ]
             }
@@ -2829,10 +2848,10 @@
                 "weight": 20,
                 "relationships": [
                     {
-                        "cats_to": ["patrol", "patrol"],
-                        "cats_from": ["clan", "patrol"],
+                        "cats_to": ["patrol"],
+                        "cats_from": ["patrol"],
                         "mutual": false,
-                        "values": ["respect"],
+                        "values": ["trust"],
                         "amount": -5
                     }
                 ],
@@ -2849,23 +2868,35 @@
                         "scars": ["NECKBITE"]
                     }
                 ],
-                "history_text": { "scar": "m_c carries a scar from a fox fight." },
+                "history_text": { 
+                    "scar": "m_c carries a scar from a fight with a red fox.",
+                    "reg_death": "m_c died from a red fox bite.",
+                    "lead_death": "died from a red fox bite"
+                 },
                 "relationships": [
                     {
-                        "cats_to": ["patrol", "patrol"],
-                        "cats_from": ["clan", "patrol"],
+                        "cats_to": ["patrol"],
+                        "cats_from": ["patrol"],
                         "mutual": false,
-                        "values": ["respect"],
+                        "values": ["trust"],
                         "amount": -5
                     }
                 ],
                 "prey": ["very_small"]
             },
             {
-                "text": "s_c means well, but {PRONOUN/s_c/subject}{VERB/s_c/'re/'s} overconfident in {PRONOUN/s_c/poss} attack, and the fox manages to sink its teeth into {PRONOUN/s_c/object}. The patrol is forced to retreat, forming a defensive ring around the hurt s_c.",
+                "text": "s_c means well, but {PRONOUN/s_c/subject}{VERB/s_c/'re/'s} overconfident in {PRONOUN/s_c/poss} attack, and the fox manages to sink its teeth into {PRONOUN/s_c/object}. The patrol is forced to retreat, hissing and spitting to ward the fox away from their injured Clanmate.",
                 "exp": 0,
                 "weight": 10,
-                "stat_trait": ["troublesome", "vengeful", "bloodthirsty", "bold"],
+                "stat_trait": [
+                    "ambitious",
+                    "arrogant",
+                    "competitive",
+                    "insecure",
+                    "rebellious",
+                    "troublesome",
+                    "vengeful"
+                ],
                 "injury": [
                     {
                         "cats": ["s_c"],
@@ -2873,13 +2904,17 @@
                         "scars": ["NECKBITE"]
                     }
                 ],
-                "history_text": { "scar": "m_c carries a scar from a fox fight." },
+                "history_text": { 
+                    "scar": "m_c carries a scar from a fight with a red fox.",
+                    "reg_death": "m_c died from a red fox bite.",
+                    "lead_death": "died from a red fox bite"
+                 },
                 "relationships": [
                     {
-                        "cats_to": ["patrol", "patrol"],
-                        "cats_from": ["clan", "patrol"],
+                        "cats_to": ["s_c"],
+                        "cats_from": ["patrol"],
                         "mutual": false,
-                        "values": ["respect"],
+                        "values": ["respect", "trust"],
                         "amount": -5
                     }
                 ],
@@ -2910,10 +2945,17 @@
                 "prey": ["large"],
                 "relationships": [
                     {
-                        "cats_to": ["patrol", "patrol"],
-                        "cats_from": ["clan", "patrol"],
+                        "cats_to": ["patrol"],
+                        "cats_from": ["clan"],
                         "mutual": false,
                         "values": ["respect"],
+                        "amount": 5
+                    },
+                    {
+                        "cats_to": ["patrol"],
+                        "cats_from": ["patrol"],
+                        "mutual": false,
+                        "values": ["respect", "trust"],
                         "amount": 5
                     }
                 ]
@@ -2926,11 +2968,18 @@
                 "prey": ["large"],
                 "relationships": [
                     {
-                        "cats_to": ["patrol", "patrol"],
-                        "cats_from": ["clan", "patrol"],
+                        "cats_to": ["patrol"],
+                        "cats_from": ["patrol"],
+                        "mutual": false,
+                        "values": ["trust"],
+                        "amount": 5
+                    },
+                    {
+                        "cats_to": ["s_c"],
+                        "cats_from": ["patrol", "clan"],
                         "mutual": false,
                         "values": ["respect"],
-                        "amount": 5
+                        "amount": 10
                     }
                 ]
             },
@@ -2939,23 +2988,28 @@
                 "exp": 20,
                 "weight": 20,
                 "stat_trait": [
-                    "adventurous",
-                    "altruistic",
-                    "ambitious",
+                    "bloodthirsty",
                     "confident",
+                    "bold",
                     "daring",
                     "fierce",
-                    "responsible",
                     "righteous"
                 ],
                 "prey": ["large"],
                 "relationships": [
                     {
-                        "cats_to": ["patrol", "patrol"],
-                        "cats_from": ["clan", "patrol"],
+                        "cats_to": ["patrol"],
+                        "cats_from": ["clan"],
                         "mutual": false,
                         "values": ["respect"],
-                        "amount": 5
+                        "amount": 10
+                    },
+                    {
+                        "cats_to": ["patrol"],
+                        "cats_from": ["patrol"],
+                        "mutual": false,
+                        "values": ["trust", "respect"],
+                        "amount": 10
                     }
                 ]
             }
@@ -2987,7 +3041,11 @@
                         "scars": ["NECKBITE"]
                     }
                 ],
-                "history_text": { "scar": "m_c carries a scar from a fox fight." },
+                "history_text": { 
+                    "scar": "m_c carries a scar from a fight with a red fox.",
+                    "reg_death": "m_c died from a red fox bite.",
+                    "lead_death": "died from a red fox bite"
+                },
                 "relationships": [
                     {
                         "cats_to": ["patrol", "patrol"],
@@ -3000,10 +3058,18 @@
                 "prey": ["very_small"]
             },
             {
-                "text": "s_c means well, but {PRONOUN/s_c/subject}{VERB/s_c/'re/'s} overconfident in {PRONOUN/s_c/poss} attack, and the fox manages to sink its teeth into {PRONOUN/s_c/object}. The patrol is forced to retreat, forming a defensive ring around the hurt s_c.",
+                "text": "s_c means well, but {PRONOUN/s_c/subject}{VERB/s_c/'re/'s} overconfident in {PRONOUN/s_c/poss} attack, and the fox manages to sink its teeth into {PRONOUN/s_c/object}. The patrol is forced to retreat, forming a defensive ring around their injured Clanmate.",
                 "exp": 0,
                 "weight": 10,
-                "stat_trait": ["troublesome", "vengeful", "bloodthirsty", "bold"],
+                "stat_trait": [
+                    "ambitious",
+                    "arrogant",
+                    "competitive",
+                    "insecure",
+                    "rebellious",
+                    "troublesome",
+                    "vengeful"
+                ],
                 "injury": [
                     {
                         "cats": ["s_c"],
@@ -3011,13 +3077,24 @@
                         "scars": ["NECKBITE"]
                     }
                 ],
-                "history_text": { "scar": "m_c carries a scar from a fox fight." },
+                "history_text": { 
+                    "scar": "m_c carries a scar from fight with a red fox.",
+                    "reg_death": "m_c died from a red fox bite.",
+                    "lead_death": "died from a red fox bite"
+                },
                 "relationships": [
                     {
-                        "cats_to": ["patrol", "patrol"],
-                        "cats_from": ["clan", "patrol"],
+                        "cats_to": ["patrol"],
+                        "cats_from": ["clan"],
                         "mutual": false,
                         "values": ["respect"],
+                        "amount": -5
+                    },
+                    {
+                        "cats_to": ["s_c"],
+                        "cats_from": ["patrol"],
+                        "mutual": false,
+                        "values": ["respect", "trust"],
                         "amount": -5
                     }
                 ],
@@ -3073,18 +3150,23 @@
                 ]
             },
             {
-                "text": "In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks {PRONOUN/s_c/poss} teeth into the fox's throat. But then {PRONOUN/s_c/subject}{VERB/s_c/'re/'s} stuck, unwilling to let go and risk being bitten. {PRONOUN/s_c/subject/CAP}{VERB/s_c/'re/'s} dragged through the forest, over rocks and through bushes, until the fox finally collapses and the battered s_c goes back to proudly claim the shark.",
+                "text": "In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks {PRONOUN/s_c/poss} teeth into the fox's throat. But then {PRONOUN/s_c/subject}{VERB/s_c/'re/'s} stuck, unwilling to let go and risk being bitten. {PRONOUN/s_c/subject/CAP}{VERB/s_c/'re/'s} dragged along the beach, sand casing {PRONOUN/s_c/poss} pelt, until the fox finally throws {PRONOUN/s_c/object} off and the battered s_c goes back to proudly claim the carcass.",
                 "exp": 30,
                 "weight": 20,
                 "stat_trait": [
-                    "adventurous",
-                    "altruistic",
-                    "ambitious",
+                    "bloodthirsty",
                     "confident",
+                    "bold",
                     "daring",
                     "fierce",
-                    "responsible",
                     "righteous"
+                ],
+                "injury": [
+                    {
+                        "cats": ["s_c"],
+                        "injuries": ["bruises", "scrapes"],
+                        "scars": []
+                    }
                 ],
                 "prey": ["large"],
                 "relationships": [
@@ -3093,14 +3175,14 @@
                         "cats_from": ["clan"],
                         "mutual": false,
                         "values": ["respect"],
-                        "amount": 5
+                        "amount": 10
                     }
                 ]
             }
         ],
         "fail_outcomes": [
             {
-                "text": "Your patrol fails to drive away the fox, which keeps possession of the food. However there were no injuries.",
+                "text": "r_c fails to drive away the fox, which keeps possession of the food. However, {PRONOUN/r_c/subject} managed to escape injury.",
                 "exp": 0,
                 "weight": 20,
                 "relationships": [
@@ -3119,19 +3201,9 @@
                 "weight": 10,
                 "dead_cats": ["r_c"],
                 "history_text": {
-                    "scar": "m_c carries a scar from a solo fox fight.",
                     "reg_death": "m_c fell in a solo battle with a fox.",
                     "lead_death": "died fighting a fox"
-                },
-                "relationships": [
-                    {
-                        "cats_to": ["patrol"],
-                        "cats_from": ["clan"],
-                        "mutual": false,
-                        "values": ["respect"],
-                        "amount": -5
-                    }
-                ]
+                }
             },
             {
                 "text": "r_c launches into battle, but is caught with a nasty bite, and retreats to limp back home. The fox doesn't follow, happy enough to eat the shark instead of the foolish cat.",
@@ -3145,9 +3217,9 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c carries a scar from a solo fox fight.",
-                    "reg_death": "m_c fell in a solo battle with a fox.",
-                    "lead_death": "died fighting a fox"
+                    "scar": "m_c carries a scar from a solo fight with a red fox.",
+                    "reg_death": "m_c died from a red fox bite.",
+                    "lead_death": "died from a red fox bite"
                 },
                 "relationships": [
                     {
@@ -3163,7 +3235,15 @@
                 "text": "s_c is overconfident in {PRONOUN/s_c/poss} attack and the fox manages to sink its teeth into {PRONOUN/s_c/object}. {PRONOUN/s_c/subject/CAP} {VERB/s_c/retreat/retreats}, bleeding and in pain, and the fox settles back down to its meal.",
                 "exp": 0,
                 "weight": 10,
-                "stat_trait": ["troublesome", "vengeful", "bloodthirsty", "bold"],
+                "stat_trait": [
+                    "ambitious",
+                    "arrogant",
+                    "competitive",
+                    "insecure",
+                    "rebellious",
+                    "troublesome",
+                    "vengeful"
+                ],
                 "injury": [
                     {
                         "cats": ["s_c"],
@@ -3172,9 +3252,9 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c carries a scar from a solo fox fight.",
-                    "reg_death": "m_c fell in a solo battle with a fox.",
-                    "lead_death": "died fighting a fox"
+                    "scar": "m_c carries a scar from a solo fight with a red fox.",
+                    "reg_death": "m_c died from a red fox bite.",
+                    "lead_death": "died from a red fox bite"
                 },
                 "relationships": [
                     {
@@ -3211,8 +3291,15 @@
                 "prey": ["large"],
                 "relationships": [
                     {
-                        "cats_to": ["patrol", "patrol"],
-                        "cats_from": ["clan", "patrol"],
+                        "cats_to": ["patrol"],
+                        "cats_from": ["patrol"],
+                        "mutual": false,
+                        "values": ["platonic", "comfort"],
+                        "amount": 5
+                    },
+                    {
+                        "cats_to": ["patrol"],
+                        "cats_from": ["clan"],
                         "mutual": false,
                         "values": ["respect"],
                         "amount": 5
@@ -3226,12 +3313,20 @@
                 "prey": ["large"],
                 "relationships": [
                     {
-                        "cats_to": ["patrol", "patrol"],
-                        "cats_from": ["clan", "patrol"],
+                        "cats_to": ["patrol"],
+                        "cats_from": ["patrol"],
+                        "mutual": false,
+                        "values": ["trust"],
+                        "amount": 5
+                    },
+                    {
+                        "cats_to": ["patrol"],
+                        "cats_from": ["clan"],
                         "mutual": false,
                         "values": ["respect"],
                         "amount": 5
                     }
+
                 ]
             },
             {
@@ -3242,11 +3337,18 @@
                 "prey": ["large"],
                 "relationships": [
                     {
-                        "cats_to": ["patrol", "patrol"],
-                        "cats_from": ["clan", "patrol"],
+                        "cats_to": ["patrol"],
+                        "cats_from": ["patrol"],
+                        "mutual": false,
+                        "values": ["trust"],
+                        "amount": 5
+                    },
+                    {
+                        "cats_to": ["s_c"],
+                        "cats_from": ["patrol", "clan"],
                         "mutual": false,
                         "values": ["respect"],
-                        "amount": 5
+                        "amount": 10
                     }
                 ]
             },
@@ -3255,23 +3357,28 @@
                 "exp": 20,
                 "weight": 20,
                 "stat_trait": [
-                    "adventurous",
-                    "altruistic",
-                    "ambitious",
+                    "bloodthirsty",
                     "confident",
+                    "bold",
                     "daring",
                     "fierce",
-                    "responsible",
                     "righteous"
                 ],
                 "prey": ["large"],
                 "relationships": [
                     {
-                        "cats_to": ["patrol", "patrol"],
-                        "cats_from": ["clan", "patrol"],
+                        "cats_to": ["patrol",],
+                        "cats_from": ["patrol"],
+                        "mutual": false,
+                        "values": ["trust"],
+                        "amount": 5
+                    },
+                    {
+                        "cats_to": ["s_c"],
+                        "cats_from": ["patrol", "clan"],
                         "mutual": false,
                         "values": ["respect"],
-                        "amount": 5
+                        "amount": 10
                     }
                 ]
             }
@@ -3283,10 +3390,10 @@
                 "weight": 20,
                 "relationships": [
                     {
-                        "cats_to": ["patrol", "patrol"],
-                        "cats_from": ["clan", "patrol"],
+                        "cats_to": ["patrol"],
+                        "cats_from": ["patrol"],
                         "mutual": false,
-                        "values": ["respect"],
+                        "values": ["trust"],
                         "amount": -5
                     }
                 ],
@@ -3296,13 +3403,21 @@
                 "text": "s_c makes a stupid mistake, too intent on winning the fight to respect {PRONOUN/s_c/poss} enemy's teeth, and it's only being yanked back by the tail that saves {PRONOUN/s_c/object} from injury. The patrol gives up, and settles down to wait a safe distance away until the fox leaves of its own accord.",
                 "exp": 0,
                 "weight": 20,
-                "stat_trait": ["troublesome", "vengeful", "bloodthirsty", "bold"],
+                "stat_trait": [
+                    "ambitious",
+                    "arrogant",
+                    "competitive",
+                    "insecure",
+                    "rebellious",
+                    "troublesome",
+                    "vengeful"
+                ],
                 "relationships": [
                     {
-                        "cats_to": ["patrol", "patrol"],
-                        "cats_from": ["clan", "patrol"],
+                        "cats_to": ["s_c"],
+                        "cats_from": ["patrol"],
                         "mutual": false,
-                        "values": ["respect"],
+                        "values": ["respect", "trust"],
                         "amount": -5
                     }
                 ],
@@ -3312,7 +3427,15 @@
                 "text": "s_c means well, but {PRONOUN/s_c/subject}{VERB/s_c/'re/'s} overconfident in {PRONOUN/s_c/poss} attack and the fox manages to sink its teeth into {PRONOUN/s_c/object}. The patrol is forced to retreat, forming a defensive ring around the hurt s_c.",
                 "exp": 0,
                 "weight": 10,
-                "stat_trait": ["troublesome", "vengeful", "bloodthirsty", "bold"],
+                "stat_trait": [
+                    "ambitious",
+                    "arrogant",
+                    "competitive",
+                    "insecure",
+                    "rebellious",
+                    "troublesome",
+                    "vengeful"
+                ],
                 "injury": [
                     {
                         "cats": ["s_c"],
@@ -3320,13 +3443,17 @@
                         "scars": ["NECKBITE"]
                     }
                 ],
-                "history_text": { "scar": "m_c carries a scar from a gray fox fight." },
+                "history_text": { 
+                    "scar": "m_c carries a scar from a fight with a gray fox.",
+                    "reg_death": "m_c died from a gray fox bite.",
+                    "lead_death": "died from a gray fox bite"
+                },
                 "relationships": [
                     {
-                        "cats_to": ["patrol", "patrol"],
-                        "cats_from": ["clan", "patrol"],
+                        "cats_to": ["s_c"],
+                        "cats_from": ["patrol"],
                         "mutual": false,
-                        "values": ["respect"],
+                        "values": ["respect", "trust"],
                         "amount": -5
                     }
                 ],
@@ -3357,8 +3484,15 @@
                 "prey": ["large"],
                 "relationships": [
                     {
-                        "cats_to": ["patrol", "patrol"],
-                        "cats_from": ["clan", "patrol"],
+                        "cats_to": ["patrol"],
+                        "cats_from": ["patrol"],
+                        "mutual": false,
+                        "values": ["platonic", "comfort"],
+                        "amount": 5
+                    },
+                    {
+                        "cats_to": ["patrol"],
+                        "cats_from": ["clan"],
                         "mutual": false,
                         "values": ["respect"],
                         "amount": 5
@@ -3372,8 +3506,15 @@
                 "prey": ["large"],
                 "relationships": [
                     {
-                        "cats_to": ["patrol", "patrol"],
-                        "cats_from": ["clan", "patrol"],
+                        "cats_to": ["patrol"],
+                        "cats_from": ["patrol"],
+                        "mutual": false,
+                        "values": ["trust"],
+                        "amount": 5
+                    },
+                    {
+                        "cats_to": ["patrol"],
+                        "cats_from": ["clan"],
                         "mutual": false,
                         "values": ["respect"],
                         "amount": 5
@@ -3388,11 +3529,18 @@
                 "prey": ["large"],
                 "relationships": [
                     {
-                        "cats_to": ["patrol", "patrol"],
-                        "cats_from": ["clan", "patrol"],
+                        "cats_to": ["patrol"],
+                        "cats_from": ["patrol"],
+                        "mutual": false,
+                        "values": ["trust"],
+                        "amount": 5
+                    },
+                    {
+                        "cats_to": ["s_c"],
+                        "cats_from": ["patrol", "clan"],
                         "mutual": false,
                         "values": ["respect"],
-                        "amount": 5
+                        "amount": 10
                     }
                 ]
             },
@@ -3401,23 +3549,28 @@
                 "exp": 20,
                 "weight": 20,
                 "stat_trait": [
-                    "adventurous",
-                    "altruistic",
-                    "ambitious",
+                    "bloodthirsty",
                     "confident",
+                    "bold",
                     "daring",
                     "fierce",
-                    "responsible",
                     "righteous"
                 ],
                 "prey": ["large"],
                 "relationships": [
                     {
-                        "cats_to": ["patrol", "patrol"],
-                        "cats_from": ["clan", "patrol"],
+                        "cats_to": ["patrol",],
+                        "cats_from": ["patrol"],
+                        "mutual": false,
+                        "values": ["trust"],
+                        "amount": 5
+                    },
+                    {
+                        "cats_to": ["s_c"],
+                        "cats_from": ["patrol", "clan"],
                         "mutual": false,
                         "values": ["respect"],
-                        "amount": 5
+                        "amount": 10
                     }
                 ]
             }
@@ -3442,13 +3595,28 @@
                 "text": "s_c makes a stupid mistake, too intent on winning the fight to respect {PRONOUN/s_c/poss} enemy's teeth, and it's only being yanked back by the tail that saves {PRONOUN/s_c/object} from injury. The patrol gives up, and settles down to wait a safe distance away until the fox leaves of its own accord.",
                 "exp": 0,
                 "weight": 20,
-                "stat_trait": ["troublesome", "vengeful", "bloodthirsty", "bold"],
+                "stat_trait": [
+                    "ambitious",
+                    "arrogant",
+                    "competitive",
+                    "insecure",
+                    "rebellious",
+                    "troublesome",
+                    "vengeful"
+                ],
                 "relationships": [
                     {
-                        "cats_to": ["patrol", "patrol"],
-                        "cats_from": ["clan", "patrol"],
+                        "cats_to": ["patrol"],
+                        "cats_from": ["clan"],
                         "mutual": false,
                         "values": ["respect"],
+                        "amount": -5
+                    },
+                    {
+                        "cats_to": ["s_c"],
+                        "cats_from": ["patrol"],
+                        "mutual": false,
+                        "values": ["respect", "trust"],
                         "amount": -5
                     }
                 ],
@@ -3523,14 +3691,19 @@
                 "exp": 30,
                 "weight": 20,
                 "stat_trait": [
-                    "adventurous",
-                    "altruistic",
-                    "ambitious",
+                    "bloodthirsty",
                     "confident",
+                    "bold",
                     "daring",
                     "fierce",
-                    "responsible",
                     "righteous"
+                ],
+                "injury": [
+                    {
+                        "cats": ["s_c"],
+                        "injuries": ["bruises", "scrapes"],
+                        "scars": []
+                    }
                 ],
                 "prey": ["large"],
                 "relationships": [
@@ -3539,7 +3712,7 @@
                         "cats_from": ["clan"],
                         "mutual": false,
                         "values": ["respect"],
-                        "amount": 5
+                        "amount": 10
                     }
                 ]
             }
@@ -3564,7 +3737,15 @@
                 "text": "s_c makes a stupid mistake, too intent on winning the fight to respect {PRONOUN/s_c/poss} enemy's teeth, and it's tripping over {PRONOUN/s_c/poss} own feet that saves {PRONOUN/s_c/object}. {PRONOUN/s_c/subject/CAP} {VERB/s_c/give/gives} up, and {VERB/s_c/settle/settles} down to wait a safe distance away until the fox leaves of its own accord.",
                 "exp": 0,
                 "weight": 20,
-                "stat_trait": ["troublesome", "vengeful", "bloodthirsty", "bold"],
+                "stat_trait": [
+                    "ambitious",
+                    "arrogant",
+                    "competitive",
+                    "insecure",
+                    "rebellious",
+                    "troublesome",
+                    "vengeful"
+                ],
                 "relationships": [
                     {
                         "cats_to": ["patrol"],
@@ -3587,7 +3768,11 @@
                         "scars": ["LEGBITE"]
                     }
                 ],
-                "history_text": { "scar": "m_c carries a scar from a solo fight with a gray fox." },
+                "history_text": { 
+                    "scar": "m_c carries a scar from a solo fight with a gray fox.",
+                    "reg_death": "m_c died from a gray fox bite.",
+                    "lead_death": "died from a gray fox bite"
+                },
                 "relationships": [
                     {
                         "cats_to": ["patrol"],
@@ -3603,7 +3788,15 @@
                 "text": "s_c is overconfident in {PRONOUN/s_c/poss} attack, and the fox manages to sink its teeth into {PRONOUN/s_c/object}. {PRONOUN/s_c/subject/CAP} {VERB/s_c/retreat/retreats}, bleeding and in pain, and the gray fox settles back down to its meal.",
                 "exp": 0,
                 "weight": 10,
-                "stat_trait": ["troublesome", "vengeful", "bloodthirsty", "bold"],
+                "stat_trait": [
+                    "ambitious",
+                    "arrogant",
+                    "competitive",
+                    "insecure",
+                    "rebellious",
+                    "troublesome",
+                    "vengeful"
+                ],
                 "injury": [
                     {
                         "cats": ["s_c"],
@@ -3611,17 +3804,11 @@
                         "scars": ["LEGBITE"]
                     }
                 ],
-                "history_text": { "scar": "m_c carries a scar from a solo fight with a gray fox." },
-                "relationships": [
-                    {
-                        "cats_to": ["patrol"],
-                        "cats_from": ["clan"],
-                        "mutual": false,
-                        "values": ["respect"],
-                        "amount": -5
-                    }
-                ],
-                "prey": ["very_small"]
+                "history_text": { 
+                    "scar": "m_c carries a scar from a solo fight with a gray fox.",
+                    "reg_death": "m_c died from a gray fox bite.",
+                    "lead_death": "died from a gray fox bite"
+                }
             }
         ]
     },
@@ -3690,30 +3877,25 @@
                 "exp": 20,
                 "weight": 20,
                 "stat_trait": [
-                    "altruistic",
                     "calm",
                     "careful",
-                    "faithful",
-                    "insecure",
-                    "loyal",
-                    "nervous",
-                    "patient",
-                    "responsible",
-                    "righteous",
+                    "cunning",
+                    "sneaky",
+                    "strange",
                     "thoughtful",
                     "wise"
                 ],
                 "prey": ["small"],
                 "relationships": [
                     {
-                        "cats_to": ["patrol"],
+                        "cats_to": ["s_c"],
                         "cats_from": ["patrol"],
                         "mutual": false,
                         "values": ["platonic", "respect"],
                         "amount": 5
                     },
                     {
-                        "cats_to": ["patrol"],
+                        "cats_to": ["s_c"],
                         "cats_from": ["patrol"],
                         "mutual": false,
                         "values": ["dislike"],
@@ -3752,25 +3934,26 @@
                 "stat_trait": [
                     "adventurous",
                     "ambitious",
+                    "arrogant",
                     "bloodthirsty",
                     "bold",
                     "confident",
+                    "competitive",
                     "daring",
                     "fierce",
-                    "playful",
                     "troublesome",
                     "vengeful"
                 ],
                 "relationships": [
                     {
-                        "cats_to": ["patrol"],
+                        "cats_to": ["s_c"],
                         "cats_from": ["patrol"],
                         "mutual": false,
                         "values": ["platonic", "respect"],
                         "amount": -5
                     },
                     {
-                        "cats_to": ["patrol"],
+                        "cats_to": ["s_c"],
                         "cats_from": ["patrol"],
                         "mutual": false,
                         "values": ["dislike"],
@@ -3790,7 +3973,12 @@
                         "scars": ["LEGBITE"]
                     }
                 ],
-                "history_text": { "scar": "m_c carries a scar from a red fox fight." },
+                "history_text": { 
+                    "scar": "m_c carries a scar from a fight with a red fox.",
+                    "reg_death": "m_c died from a red fox bite.",
+                    "lead_death": "died from a red fox bite"
+
+                },
                 "relationships": [
                     {
                         "cats_to": ["patrol"],
@@ -3816,12 +4004,13 @@
                 "stat_trait": [
                     "adventurous",
                     "ambitious",
+                    "arrogant",
                     "bloodthirsty",
                     "bold",
                     "confident",
+                    "competitive",
                     "daring",
                     "fierce",
-                    "playful",
                     "troublesome",
                     "vengeful"
                 ],
@@ -3832,17 +4021,21 @@
                         "scars": ["LEGBITE"]
                     }
                 ],
-                "history_text": { "scar": "m_c carries a scar from a red fox fight." },
+                "history_text": { 
+                    "scar": "m_c carries a scar from a fight with a red fox.",
+                    "reg_death": "m_c died from a red fox bite.",
+                    "lead_death": "died from a red fox bite"
+                },
                 "relationships": [
                     {
-                        "cats_to": ["patrol"],
+                        "cats_to": ["s_c"],
                         "cats_from": ["patrol"],
                         "mutual": false,
                         "values": ["platonic", "respect"],
                         "amount": -5
                     },
                     {
-                        "cats_to": ["patrol"],
+                        "cats_to": ["s_c"],
                         "cats_from": ["patrol"],
                         "mutual": false,
                         "values": ["dislike"],
@@ -3869,7 +4062,7 @@
         "chance_of_success": 40,
         "success_outcomes": [
             {
-                "text": "p_l leads the patrol to the end of the scent trail, where a red fox sits plucking the feathers off a plump seagull. With careful signals, the cats set up an ambush. While they'd expected having more cats would make it easier, it also makes the patrol far more of a threat to the red fox, and the creature panicks when they reveal themselves. They win the bird, but r_c nearly gets injured, and it's only p_l shoving them both out of the way that saves both their pelts.",
+                "text": "p_l leads the patrol to the end of the scent trail, where a red fox sits plucking the feathers off a plump seagull. With careful signals, the cats set up an ambush. While they'd expected having more cats would make it easier, it also makes the patrol far more of a threat to the red fox, and the creature panics when they reveal themselves. They win the bird, but r_c nearly gets injured, and it's only p_l shoving them both out of the way that saves both their pelts.",
                 "exp": 20,
                 "weight": 20,
                 "prey": ["small"],
@@ -3880,6 +4073,13 @@
                         "mutual": false,
                         "values": ["platonic", "respect"],
                         "amount": 5
+                    },
+                    {
+                        "cats_to": ["patrol"],
+                        "cats_from": ["patrol"],
+                        "mutual": false,
+                        "values": ["dislike"],
+                        "amount": -5
                     }
                 ]
             },
@@ -3896,6 +4096,13 @@
                         "mutual": false,
                         "values": ["platonic", "respect"],
                         "amount": 5
+                    },
+                    {
+                        "cats_to": ["patrol"],
+                        "cats_from": ["patrol"],
+                        "mutual": false,
+                        "values": ["dislike"],
+                        "amount": -5
                     }
                 ]
             },
@@ -3904,27 +4111,29 @@
                 "exp": 20,
                 "weight": 20,
                 "stat_trait": [
-                    "altruistic",
                     "calm",
                     "careful",
-                    "faithful",
-                    "insecure",
-                    "loyal",
-                    "nervous",
-                    "patient",
-                    "responsible",
-                    "righteous",
+                    "cunning",
+                    "sneaky",
+                    "strange",
                     "thoughtful",
                     "wise"
                 ],
                 "prey": ["small"],
                 "relationships": [
                     {
-                        "cats_to": ["patrol"],
+                        "cats_to": ["s_c"],
                         "cats_from": ["patrol"],
                         "mutual": false,
                         "values": ["platonic", "respect"],
                         "amount": 5
+                    },
+                    {
+                        "cats_to": ["s_c"],
+                        "cats_from": ["patrol"],
+                        "mutual": false,
+                        "values": ["dislike"],
+                        "amount": -5
                     }
                 ]
             }
@@ -3941,6 +4150,13 @@
                         "mutual": false,
                         "values": ["platonic", "respect"],
                         "amount": -5
+                    },
+                    {
+                        "cats_to": ["patrol"],
+                        "cats_from": ["patrol"],
+                        "mutual": false,
+                        "values": ["dislike"],
+                        "amount": 5
                     }
                 ],
                 "prey": ["very_small"]
@@ -3952,22 +4168,30 @@
                 "stat_trait": [
                     "adventurous",
                     "ambitious",
+                    "arrogant",
                     "bloodthirsty",
                     "bold",
                     "confident",
+                    "competitive",
                     "daring",
                     "fierce",
-                    "playful",
                     "troublesome",
                     "vengeful"
                 ],
                 "relationships": [
                     {
-                        "cats_to": ["patrol"],
+                        "cats_to": ["s_c"],
                         "cats_from": ["patrol"],
                         "mutual": false,
                         "values": ["platonic", "respect"],
                         "amount": -5
+                    },
+                    {
+                        "cats_to": ["s_c"],
+                        "cats_from": ["patrol"],
+                        "mutual": false,
+                        "values": ["dislike"],
+                        "amount": 5
                     }
                 ],
                 "prey": ["very_small"]
@@ -3983,7 +4207,11 @@
                         "scars": ["LEGBITE"]
                     }
                 ],
-                "history_text": { "scar": "m_c carries a scar from a red fox fight." },
+                "history_text": { 
+                    "scar": "m_c carries a scar from a fight with a red fox.",
+                    "reg_death": "m_c died from a red fox bite.",
+                    "lead_death": "died from a red fox bite"
+                },
                 "relationships": [
                     {
                         "cats_to": ["patrol"],
@@ -3991,6 +4219,13 @@
                         "mutual": false,
                         "values": ["platonic", "respect"],
                         "amount": -5
+                    },
+                    {
+                        "cats_to": ["patrol"],
+                        "cats_from": ["patrol"],
+                        "mutual": false,
+                        "values": ["dislike"],
+                        "amount": 5
                     }
                 ],
                 "prey": ["very_small"]
@@ -4002,12 +4237,13 @@
                 "stat_trait": [
                     "adventurous",
                     "ambitious",
+                    "arrogant",
                     "bloodthirsty",
                     "bold",
                     "confident",
+                    "competitive",
                     "daring",
                     "fierce",
-                    "playful",
                     "troublesome",
                     "vengeful"
                 ],
@@ -4018,14 +4254,25 @@
                         "scars": ["LEGBITE"]
                     }
                 ],
-                "history_text": { "scar": "m_c carries a scar from a red fox fight." },
+                "history_text": { 
+                    "scar": "m_c carries a scar from a fight with a red fox.",
+                    "reg_death": "m_c died from a red fox bite.",
+                    "lead_death":"died from a red fox bite"
+            },
                 "relationships": [
                     {
-                        "cats_to": ["patrol"],
+                        "cats_to": ["s_c"],
                         "cats_from": ["patrol"],
                         "mutual": false,
                         "values": ["platonic", "respect"],
                         "amount": -5
+                    },
+                    {
+                        "cats_to": ["s_c"],
+                        "cats_from": ["patrol"],
+                        "mutual": false,
+                        "values": ["dislike"],
+                        "amount": 5
                     }
                 ],
                 "prey": ["very_small"]
@@ -4083,16 +4330,11 @@
                 "exp": 20,
                 "weight": 20,
                 "stat_trait": [
-                    "altruistic",
                     "calm",
                     "careful",
-                    "faithful",
-                    "insecure",
-                    "loyal",
-                    "nervous",
-                    "patient",
-                    "responsible",
-                    "righteous",
+                    "cunning",
+                    "sneaky",
+                    "strange",
                     "thoughtful",
                     "wise"
                 ],
@@ -4131,12 +4373,13 @@
                 "stat_trait": [
                     "adventurous",
                     "ambitious",
+                    "arrogant",
                     "bloodthirsty",
                     "bold",
                     "confident",
+                    "competitive",
                     "daring",
                     "fierce",
-                    "playful",
                     "troublesome",
                     "vengeful"
                 ],
@@ -4162,7 +4405,11 @@
                         "scars": ["NECKBITE"]
                     }
                 ],
-                "history_text": { "scar": "m_c carries a scar from a solo fight with a red fox." },
+                "history_text": { 
+                    "scar": "m_c carries a scar from a solo fight with a red fox.",
+                    "reg_death": "m_c died from a red fox bite.",
+                    "lead_death":"died from a red fox bite"
+                },
                 "relationships": [
                     {
                         "cats_to": ["patrol"],
@@ -4181,12 +4428,13 @@
                 "stat_trait": [
                     "adventurous",
                     "ambitious",
+                    "arrogant",
                     "bloodthirsty",
                     "bold",
                     "confident",
+                    "competitive",
                     "daring",
                     "fierce",
-                    "playful",
                     "troublesome",
                     "vengeful"
                 ],
@@ -4197,7 +4445,11 @@
                         "scars": ["NECKBITE"]
                     }
                 ],
-                "history_text": { "scar": "m_c carries a scar from a solo fight with a red fox." },
+                "history_text": { 
+                    "scar": "m_c carries a scar from a solo fight with a red fox.",
+                    "reg_death": "m_c died from a red fox bite.",
+                    "lead_death":"died from a red fox bite"
+                },
                 "relationships": [
                     {
                         "cats_to": ["patrol"],
@@ -4238,6 +4490,13 @@
                         "mutual": false,
                         "values": ["platonic", "respect"],
                         "amount": 5
+                    },
+                    {
+                        "cats_to": ["patrol"],
+                        "cats_from": ["patrol"],
+                        "mutual": false,
+                        "values": ["dislike"],
+                        "amount": -5
                     }
                 ]
             },
@@ -4253,6 +4512,13 @@
                         "mutual": false,
                         "values": ["platonic", "respect"],
                         "amount": 5
+                    },
+                    {
+                        "cats_to": ["patrol"],
+                        "cats_from": ["patrol"],
+                        "mutual": false,
+                        "values": ["dislike"],
+                        "amount": -5
                     }
                 ]
             },
@@ -4269,6 +4535,13 @@
                         "mutual": false,
                         "values": ["platonic", "respect"],
                         "amount": 5
+                    },
+                    {
+                        "cats_to": ["patrol"],
+                        "cats_from": ["patrol"],
+                        "mutual": false,
+                        "values": ["dislike"],
+                        "amount": -5
                     }
                 ]
             },
@@ -4277,27 +4550,31 @@
                 "exp": 20,
                 "weight": 20,
                 "stat_trait": [
-                    "altruistic",
                     "calm",
                     "careful",
-                    "faithful",
-                    "insecure",
-                    "loyal",
+                    "cunning",
+                    "lonesome",
                     "nervous",
-                    "patient",
-                    "responsible",
-                    "righteous",
+                    "sneaky",
+                    "strange",
                     "thoughtful",
                     "wise"
                 ],
                 "prey": ["small"],
                 "relationships": [
                     {
-                        "cats_to": ["patrol"],
+                        "cats_to": ["s_c"],
                         "cats_from": ["patrol"],
                         "mutual": false,
                         "values": ["platonic", "respect"],
                         "amount": 5
+                    },
+                    {
+                        "cats_to": ["s_c"],
+                        "cats_from": ["patrol"],
+                        "mutual": false,
+                        "values": ["dislike"],
+                        "amount": -5
                     }
                 ]
             }
@@ -4314,6 +4591,13 @@
                         "mutual": false,
                         "values": ["platonic", "respect"],
                         "amount": -5
+                    },
+                    {
+                        "cats_to": ["patrol"],
+                        "cats_from": ["patrol"],
+                        "mutual": false,
+                        "values": ["dislike"],
+                        "amount": 5
                     }
                 ],
                 "prey": ["very_small"]
@@ -4325,22 +4609,30 @@
                 "stat_trait": [
                     "adventurous",
                     "ambitious",
+                    "arrogant",
                     "bloodthirsty",
                     "bold",
                     "confident",
+                    "competitive",
                     "daring",
                     "fierce",
-                    "playful",
                     "troublesome",
                     "vengeful"
                 ],
                 "relationships": [
                     {
-                        "cats_to": ["patrol"],
+                        "cats_to": ["s_c"],
                         "cats_from": ["patrol"],
                         "mutual": false,
                         "values": ["platonic", "respect"],
                         "amount": -5
+                    },
+                    {
+                        "cats_to": ["s_c"],
+                        "cats_from": ["patrol"],
+                        "mutual": false,
+                        "values": ["dislike"],
+                        "amount": 5
                     }
                 ],
                 "prey": ["very_small"]
@@ -4356,7 +4648,11 @@
                         "scars": ["LEGBITE"]
                     }
                 ],
-                "history_text": { "scar": "m_c carries a scar from a gray fox fight." },
+                "history_text": { 
+                    "scar": "m_c carries a scar from a fight with a gray fox.",
+                    "reg_death": "m_c died from a gray fox bite.",
+                    "lead_death":"died from a gray fox bite"
+                },
                 "relationships": [
                     {
                         "cats_to": ["patrol"],
@@ -4364,6 +4660,13 @@
                         "mutual": false,
                         "values": ["platonic", "respect"],
                         "amount": -5
+                    },
+                    {
+                        "cats_to": ["patrol"],
+                        "cats_from": ["patrol"],
+                        "mutual": false,
+                        "values": ["dislike"],
+                        "amount": 5
                     }
                 ],
                 "prey": ["very_small"]
@@ -4375,12 +4678,13 @@
                 "stat_trait": [
                     "adventurous",
                     "ambitious",
+                    "arrogant",
                     "bloodthirsty",
                     "bold",
                     "confident",
+                    "competitive",
                     "daring",
                     "fierce",
-                    "playful",
                     "troublesome",
                     "vengeful"
                 ],
@@ -4391,14 +4695,25 @@
                         "scars": ["LEGBITE"]
                     }
                 ],
-                "history_text": { "scar": "m_c carries a scar from a gray fox fight." },
+                "history_text": { 
+                    "scar": "m_c carries a scar from a fight with a gray fox.",
+                    "reg_death": "m_c died from a gray fox bite.",
+                    "lead_death": "died from a gray fox bite"
+                 },
                 "relationships": [
                     {
-                        "cats_to": ["patrol"],
+                        "cats_to": ["s_c"],
                         "cats_from": ["patrol"],
                         "mutual": false,
                         "values": ["platonic", "respect"],
                         "amount": -5
+                    },
+                    {
+                        "cats_to": ["s_c"],
+                        "cats_from": ["patrol"],
+                        "mutual": false,
+                        "values": ["dislike"],
+                        "amount": 5
                     }
                 ],
                 "prey": ["very_small"]
@@ -4432,6 +4747,13 @@
                         "mutual": false,
                         "values": ["platonic", "respect"],
                         "amount": 5
+                    },
+                    {
+                        "cats_to": ["patrol"],
+                        "cats_from": ["patrol"],
+                        "mutual": false,
+                        "values": ["dislike"],
+                        "amount": -5
                     }
                 ]
             },
@@ -4447,6 +4769,13 @@
                         "mutual": false,
                         "values": ["platonic", "respect"],
                         "amount": 5
+                    },
+                    {
+                        "cats_to": ["patrol"],
+                        "cats_from": ["patrol"],
+                        "mutual": false,
+                        "values": ["dislike"],
+                        "amount": -5
                     }
                 ]
             },
@@ -4463,6 +4792,13 @@
                         "mutual": false,
                         "values": ["platonic", "respect"],
                         "amount": 5
+                    },
+                    {
+                        "cats_to": ["patrol"],
+                        "cats_from": ["patrol"],
+                        "mutual": false,
+                        "values": ["dislike"],
+                        "amount": -5
                     }
                 ]
             },
@@ -4471,27 +4807,31 @@
                 "exp": 20,
                 "weight": 20,
                 "stat_trait": [
-                    "altruistic",
                     "calm",
                     "careful",
-                    "faithful",
-                    "insecure",
-                    "loyal",
+                    "cunning",
+                    "lonesome",
                     "nervous",
-                    "patient",
-                    "responsible",
-                    "righteous",
+                    "sneaky",
+                    "strange",
                     "thoughtful",
                     "wise"
                 ],
                 "prey": ["small"],
                 "relationships": [
                     {
-                        "cats_to": ["patrol"],
+                        "cats_to": ["s_c"],
                         "cats_from": ["patrol"],
                         "mutual": false,
                         "values": ["platonic", "respect"],
                         "amount": 5
+                    },
+                    {
+                        "cats_to": ["s_c"],
+                        "cats_from": ["patrol"],
+                        "mutual": false,
+                        "values": ["dislike"],
+                        "amount": -5
                     }
                 ]
             }
@@ -4508,6 +4848,13 @@
                         "mutual": false,
                         "values": ["platonic", "respect"],
                         "amount": -5
+                    },
+                    {
+                        "cats_to": ["patrol"],
+                        "cats_from": ["patrol"],
+                        "mutual": false,
+                        "values": ["dislike"],
+                        "amount": 5
                     }
                 ],
                 "prey": ["very_small"]
@@ -4519,28 +4866,36 @@
                 "stat_trait": [
                     "adventurous",
                     "ambitious",
+                    "arrogant",
                     "bloodthirsty",
                     "bold",
                     "confident",
+                    "competitive",
                     "daring",
                     "fierce",
-                    "playful",
                     "troublesome",
                     "vengeful"
                 ],
                 "relationships": [
                     {
-                        "cats_to": ["patrol"],
+                        "cats_to": ["s_c"],
                         "cats_from": ["patrol"],
                         "mutual": false,
                         "values": ["platonic", "respect"],
                         "amount": -5
+                    },
+                    {
+                        "cats_to": ["s_c"],
+                        "cats_from": ["patrol"],
+                        "mutual": false,
+                        "values": ["dislike"],
+                        "amount": 5
                     }
                 ],
                 "prey": ["very_small"]
             },
             {
-                "text": "p_l leads the patrol to the end of the scent trail, where a gray fox sits grooming it's fur in the sunshine. With careful signals, the cats set up an ambush, but the small gray panics beyond anything any cat expected, and as it flees, convinced its life is in danger, it bites at r_c.",
+                "text": "p_l leads the patrol to the end of the scent trail, where a gray fox sits grooming its fur in the sunshine. With careful signals, the cats set up an ambush, but the small gray panics beyond anything any cat expected, and as it flees, convinced its life is in danger, it bites at r_c.",
                 "exp": 0,
                 "weight": 10,
                 "injury": [
@@ -4550,6 +4905,11 @@
                         "scars": ["LEGBITE"]
                     }
                 ],
+                "history_text": {
+                    "scar": "m_c carries a scar from a fight with a gray fox.",
+                    "reg_death": "m_c died from a gray fox bite.",
+                    "lead_death": "died from a gray fox bite"
+                },
                 "relationships": [
                     {
                         "cats_to": ["patrol"],
@@ -4557,6 +4917,13 @@
                         "mutual": false,
                         "values": ["platonic", "respect"],
                         "amount": -5
+                    },
+                    {
+                        "cats_to": ["patrol"],
+                        "cats_from": ["patrol"],
+                        "mutual": false,
+                        "values": ["dislike"],
+                        "amount": 5
                     }
                 ],
                 "prey": ["very_small"]
@@ -4568,12 +4935,13 @@
                 "stat_trait": [
                     "adventurous",
                     "ambitious",
+                    "arrogant",
                     "bloodthirsty",
                     "bold",
                     "confident",
+                    "competitive",
                     "daring",
                     "fierce",
-                    "playful",
                     "troublesome",
                     "vengeful"
                 ],
@@ -4584,13 +4952,25 @@
                         "scars": ["LEGBITE"]
                     }
                 ],
+                "history_text": {
+                    "scar": "m_c carries a scar from a fight with a gray fox.",
+                    "reg_death": "m_c died from a gray fox bite.",
+                    "lead_death": "died from a gray fox bite"
+                },
                 "relationships": [
                     {
-                        "cats_to": ["patrol"],
+                        "cats_to": ["s_c"],
                         "cats_from": ["patrol"],
                         "mutual": false,
                         "values": ["platonic", "respect"],
                         "amount": -5
+                    },
+                    {
+                        "cats_to": ["s_c"],
+                        "cats_from": ["patrol"],
+                        "mutual": false,
+                        "values": ["dislike"],
+                        "amount": 5
                     }
                 ],
                 "prey": ["very_small"]
@@ -4630,16 +5010,11 @@
                 "exp": 15,
                 "weight": 20,
                 "stat_trait": [
-                    "altruistic",
                     "calm",
                     "careful",
-                    "faithful",
-                    "insecure",
-                    "loyal",
-                    "nervous",
-                    "patient",
-                    "responsible",
-                    "righteous",
+                    "cunning",
+                    "sneaky",
+                    "strange",
                     "thoughtful",
                     "wise"
                 ],
@@ -4651,6 +5026,15 @@
                 "text": "It embarrasses {PRONOUN/r_c/object}, but r_c doesn't even manage to find the fox {PRONOUN/r_c/subject} {VERB/r_c/track/tracks}, let alone earn anything useful from the afternoon's attempts.",
                 "exp": 0,
                 "weight": 20,
+                "relationships": [
+                    {
+                        "cats_to": "patrol",
+                        "cats_from": "clan",
+                        "mutual": false,
+                        "values": ["respect"],
+                        "amount": -5
+                    }
+                ],
                 "prey": ["very_small"]
             },
             {
@@ -4660,14 +5044,24 @@
                 "stat_trait": [
                     "adventurous",
                     "ambitious",
+                    "arrogant",
                     "bloodthirsty",
                     "bold",
                     "confident",
+                    "competitive",
                     "daring",
                     "fierce",
-                    "playful",
                     "troublesome",
                     "vengeful"
+                ],
+                "relationships": [
+                    {
+                        "cats_to": "patrol",
+                        "cats_from": "clan",
+                        "mutual": false,
+                        "values": ["respect"],
+                        "amount": -5
+                    }
                 ],
                 "prey": ["very_small"]
             },
@@ -4675,6 +5069,7 @@
                 "text": "Finding a gray fox holding a mouse that would make a nice addition to c_n's fresh-kill pile, r_c goes to attack it. But the fox is just as keen to keep it as r_c is to win it, and {PRONOUN/r_c/subject}{VERB/r_c/'re/'s} injured in the resulting fight.",
                 "exp": 0,
                 "weight": 10,
+                
                 "injury": [
                     {
                         "cats": ["r_c"],
@@ -4682,7 +5077,20 @@
                         "scars": ["LEGBITE"]
                     }
                 ],
-                "history_text": { "scar": "m_c carries a scar from a solo fight with a gray fox." },
+                "history_text": { 
+                    "scar": "m_c carries a scar from a solo fight with a gray fox.",
+                    "reg_death": "m_c died from a gray fox bite.",
+                    "lead_death":"died from a gray fox bite"
+                },
+                "relationships": [
+                    {
+                        "cats_to": "patrol",
+                        "cats_from": "clan",
+                        "mutual": false,
+                        "values": ["respect"],
+                        "amount": -5
+                    }
+                ],
                 "prey": ["very_small"]
             },
             {
@@ -4692,12 +5100,13 @@
                 "stat_trait": [
                     "adventurous",
                     "ambitious",
+                    "arrogant",
                     "bloodthirsty",
                     "bold",
                     "confident",
+                    "competitive",
                     "daring",
                     "fierce",
-                    "playful",
                     "troublesome",
                     "vengeful"
                 ],
@@ -4708,7 +5117,20 @@
                         "scars": ["LEGBITE"]
                     }
                 ],
-                "history_text": { "scar": "m_c carries a scar from a solo fight with a gray fox." },
+                "history_text": { 
+                    "scar": "m_c carries a scar from a solo fight with a gray fox.",
+                    "reg_death": "m_c died from a gray fox bite.",
+                    "lead_death": "died from a gray fox bite"
+                },
+                "relationships": [
+                    {
+                        "cats_to": "patrol",
+                        "cats_from": "clan",
+                        "mutual": false,
+                        "values": ["respect"],
+                        "amount": -5
+                    }
+                ],
                 "prey": ["very_small"]
             }
         ]
@@ -4727,11 +5149,11 @@
         },
         "weight": 20,
         "intro_text": "The patrol, going back to camp with a good haul of fish, sees a pod of dolphins chattering at them.",
-        "decline_text": "p_l bows {PRONOUN/p_l/poss} head and offers {PRONOUN/p_l/poss} apologies to the pod of dolphins, but they will keep those fish for the fresh-kill pile.",
+        "decline_text": "p_l bows {PRONOUN/p_l/poss} head and offers {PRONOUN/p_l/poss} apologies to the pod of dolphins, but {PRONOUN/p_l/subject} will keep these fish for the fresh-kill pile.",
         "chance_of_success": 60,
         "success_outcomes": [
             {
-                "text": "p_l offers the dolphins some of their fish catch. Good relations with the dolphins are more important than a few fish. {PRONOUN/p_l/subject/CAP} {VERB/p_l/are/is} surprised to see the dolphins offering a few soggy wet herbs back in return, and {PRONOUN/p_l/subject} {VERB/p_l/accept/accepts} them with gratitude and grace.",
+                "text": "p_l offers the dolphins some of the patrol's fish catch. Good relations with the dolphins are more important than a few fish. {PRONOUN/p_l/subject/CAP} {VERB/p_l/are/is} surprised to see the dolphins offering a few soggy wet herbs back in return, and {PRONOUN/p_l/subject} {VERB/p_l/accept/accepts} them with gratitude and grace.",
                 "exp": 5,
                 "weight": 20,
                 "herbs": ["random_herbs"],
@@ -4754,7 +5176,7 @@
                 ]
             },
             {
-                "text": "p_l gives the dolphins a few of their fish, and is surprised and grateful when {PRONOUN/p_l/subject} get some useful herbs in return, for the medicine cat den.",
+                "text": "p_l gives the dolphins a few of their fish, and is surprised and grateful when {PRONOUN/p_l/subject} {VERB/p_l/get/gets} some useful herbs in return, for the medicine cat den.",
                 "exp": 5,
                 "weight": 5,
                 "herbs": ["random_herbs"],

--- a/resources/dicts/patrols/beach/med/greenleaf.json
+++ b/resources/dicts/patrols/beach/med/greenleaf.json
@@ -15,7 +15,7 @@
         },
         "weight": 20,
         "intro_text": "p_l goes out with a warrior escort, both for safety as {PRONOUN/p_l/subject} {VERB/p_l/look/looks} to take advantage of the greenleaf growing season, and for carrying capacity should {PRONOUN/p_l/subject} find anything.",
-        "decline_text": "{PRONOUN/p_l/poss/CAP} escort is called away on a different mission, and p_l decides to reorganize the herb store instead.",
+        "decline_text": "p_l's escort is called away on a different mission, and {PRONOUN/p_l/subject} {VERB/p_l/decide/decides} to reorganize the herb store instead.",
         "chance_of_success": 60,
         "success_outcomes": [
             {
@@ -324,7 +324,7 @@
         },
         "weight": 20,
         "intro_text": "p_l wanders off into the territory, keeping an eye out for the purple flowers that betony grows.",
-        "decline_text": "They have second thoughts about leaving their patients behind, and decide to go another day.",
+        "decline_text": "{PRONOUN/p_l/poss/CAP} {VERB/p_l/have/has} second thoughts about leaving {PRONOUN/p_l/poss} patients behind, and {VERB/p_l/decide/decides} to go another day.",
         "chance_of_success": 70,
         "success_outcomes": [
             {
@@ -373,11 +373,11 @@
         },
         "weight": 20,
         "intro_text": "p_l wanders off into the territory, keeping an eye out for the purple flowers that betony grows. app1 leads the way, {PRONOUN/app1/poss} tail up and waving jauntily.",
-        "decline_text": "They have second thoughts leaving their patients behind, especially with them also bringing their apprentice, and decide to go another day.",
+        "decline_text": "{PRONOUN/p_l/subject/CAP} {VERB/p_l/have/has} second thoughts about leaving {PRONOUN/p_l/poss} patients behind, especially with {PRONOUN/p_l/poss} apprentice along too, and {VERB/p_l/decide/decides} to go another day.",
         "chance_of_success": 70,
         "success_outcomes": [
             {
-                "text": "The betony shrubs are in full bloom, with bees buzzing busily around {PRONOUN/p_l/object}, and p_l directs app1 to follow their industrious example as they gather.",
+                "text": "The betony shrubs are in full bloom, with bees buzzing busily around them, and p_l directs app1 to follow their industrious example as the cats gather.",
                 "exp": 20,
                 "weight": 20,
                 "herbs": ["betony"],
@@ -489,7 +489,7 @@
         "chance_of_success": 30,
         "success_outcomes": [
             {
-                "text": "The betony shrubs are in full bloom, with bees buzzing busily around {PRONOUN/p_l/object}, and p_l directs {PRONOUN/p_l/poss} patrol to follow their industrious example as they gather.",
+                "text": "The betony shrubs are in full bloom, with bees buzzing busily around them, and p_l directs {PRONOUN/p_l/poss} patrol to follow their industrious example as the cats gather.",
                 "exp": 10,
                 "weight": 20,
                 "herbs": ["betony"],
@@ -533,7 +533,7 @@
                 ]
             },
             {
-                "text": "As ever, s_c's keen eyes pick out {PRONOUN/s_c/poss} target quickly, and {PRONOUN/s_c/subject} {VERB/s_c/organise/organises} {PRONOUN/s_c/poss} patrol to bring back a great haul of betony for the herb stores.",
+                "text": "As ever, s_c's keen eyes pick out {PRONOUN/s_c/poss} target quickly, and {PRONOUN/s_c/subject} {VERB/s_c/organize/organizes} {PRONOUN/s_c/poss} patrol to bring back a great haul of betony for the herb stores.",
                 "exp": 10,
                 "weight": 20,
                 "stat_skill": ["SENSE,2"],
@@ -596,7 +596,7 @@
         },
         "weight": 20,
         "intro_text": "The blackberry brambles will be at their peak leaf growth soon, if they aren't there already. p_l heads out to replenish the Clan's stocks.",
-        "decline_text": "They have second thoughts about leaving their patients behind, and decide to go another day.",
+        "decline_text": "{PRONOUN/p_l/poss/CAP} {VERB/p_l/have/has} second thoughts about leaving {PRONOUN/p_l/poss} patients behind, and {VERB/p_l/decide/decides} to go another day.",
         "chance_of_success": 70,
         "success_outcomes": [
             {
@@ -606,13 +606,13 @@
                 "herbs": ["blackberry"]
             },
             {
-                "text": "Perfect - there's a good crop of blackberry leaves just waiting for {PRONOUN/p_l/object}, and the bramble seems to be sending out new exploratory branches too, promising more growth in the future. As {PRONOUN/p_l/subject} set out the leaves out to dry before they're put away in the herb stores, p_l lets out a purr at the sight of {PRONOUN/p_l/poss} harvest.",
+                "text": "Perfect - there's a good crop of blackberry leaves just waiting for {PRONOUN/p_l/object}, and the bramble seems to be sending out new exploratory branches too, promising more growth in the future. As {PRONOUN/p_l/subject} {VERB/p_l/set/sets} out the leaves out to dry before they're put away in the herb stores, p_l lets out a purr at the sight of {PRONOUN/p_l/poss} harvest.",
                 "exp": 10,
                 "weight": 5,
                 "herbs": ["many_herbs", "blackberry"]
             },
             {
-                "text": "s_c falls into the meditative state that herb-gathering brings, and {PRONOUN/s_c/subject} hum to {PRONOUN/s_c/self} as {PRONOUN/s_c/subject} {VERB/s_c/work/works}, crisply plucking from the blackberry brambles.",
+                "text": "s_c falls into the meditative state that herb-gathering brings, and {PRONOUN/s_c/subject} {VERB/s_c/hum/hums} to {PRONOUN/s_c/self} as {PRONOUN/s_c/subject} {VERB/s_c/work/works}, crisply plucking from the blackberry brambles.",
                 "exp": 10,
                 "weight": 20,
                 "stat_skill": ["SENSE,2"],
@@ -645,7 +645,7 @@
         },
         "weight": 20,
         "intro_text": "The blackberry brambles will be at their peak leaf growth soon, if they aren't there already. p_l heads out to replenish the Clan's stocks, bringing app1 along.",
-        "decline_text": "They have second thoughts leaving their patients behind, especially with them also bringing their apprentice, and decide to go another day.",
+        "decline_text": "{PRONOUN/p_l/subject/CAP} {VERB/p_l/have/has} second thoughts about leaving {PRONOUN/p_l/poss} patients behind, especially with {PRONOUN/p_l/poss} apprentice along too, and {VERB/p_l/decide/decides} to go another day.",
         "chance_of_success": 70,
         "success_outcomes": [
             {
@@ -693,7 +693,7 @@
                 ]
             },
             {
-                "text": "s_c falls into the meditative state that herb-gathering brings, and {PRONOUN/s_c/subject} hum to {PRONOUN/s_c/self} as {PRONOUN/s_c/subject} {VERB/s_c/work/works}, crisply plucking from the blackberry brambles. app1 smiles to hear the quiet sound, comforted by the familiar work and tune.",
+                "text": "s_c falls into the meditative state that herb-gathering brings, and {PRONOUN/s_c/subject} {VERB/s_c/hum/hums} to {PRONOUN/s_c/self} as {PRONOUN/s_c/subject} {VERB/s_c/work/works}, crisply plucking from the blackberry brambles. app1 smiles to hear the quiet sound, comforted by the familiar work and tune.",
                 "exp": 20,
                 "weight": 20,
                 "stat_skill": ["SENSE,2"],
@@ -782,7 +782,7 @@
                 ]
             },
             {
-                "text": "Perfect - there's a good crop of blackberry leaves just waiting for them, and the bramble seems to be sending out new exploratory branches too, promising more growth in the future. {PRONOUN/p_l/poss/CAP} Clanmates send p_l away for a nap in the sunshine, as they organize the blackberry leaves, and p_l smiles appreciatively.",
+                "text": "Perfect - there's a good crop of blackberry leaves just waiting for them, and the bramble seems to be sending out new exploratory branches too, promising more growth in the future. {PRONOUN/p_l/poss/CAP} Clanmates send p_l away for a nap in the sunshine while they organize the blackberry leaves, and p_l smiles appreciatively.",
                 "exp": 10,
                 "weight": 5,
                 "herbs": ["many_herbs", "blackberry"],
@@ -804,7 +804,7 @@
                 ]
             },
             {
-                "text": "s_c falls into the meditative state that herb-gathering brings, and {PRONOUN/s_c/subject} hum to {PRONOUN/s_c/self} as {PRONOUN/s_c/subject} {VERB/s_c/work/works}, crisply plucking from the blackberry brambles. The patrol follows {PRONOUN/s_c/poss} lead, and its a relaxed group that wanders back into camp with a massive haul from the blackberry bushes.",
+                "text": "s_c falls into the meditative state that herb-gathering brings, and {PRONOUN/s_c/subject} {VERB/s_c/hum/hums} to {PRONOUN/s_c/self} as {PRONOUN/s_c/subject} {VERB/s_c/work/works}, crisply plucking from the blackberry brambles. The patrol follows {PRONOUN/s_c/poss} lead, and it's a relaxed group that wanders back into camp with a massive haul from the blackberry bushes.",
                 "exp": 10,
                 "weight": 20,
                 "stat_skill": ["SENSE,2"],
@@ -829,7 +829,7 @@
         ],
         "fail_outcomes": [
             {
-                "text": "p_l manages to avoid a torn pelt only by the grace of StarClan, and isn't going to risk sending anyone else into the brambles with them having so many thorns at the moment. They'll have to try a different blackberry bush on another day.",
+                "text": "p_l manages to avoid a torn pelt only by the grace of StarClan, and isn't going to risk sending anyone else into the brambles with them having so many thorns at the moment. {PRONOUN/p_l/subject/CAP}'ll have to try a different blackberry bush on another day.",
                 "exp": 0,
                 "weight": 20,
                 "relationships": [
@@ -867,7 +867,7 @@
         },
         "weight": 20,
         "intro_text": "With the full sun of greenleaf fueling plant growth everywhere, it's the perfect time to hunt for burdock. p_l heads out to replenish the Clan's stocks.",
-        "decline_text": "They have second thoughts about leaving their patients behind, and decide to go another day.",
+        "decline_text": "{PRONOUN/p_l/poss/CAP} {VERB/p_l/have/has} second thoughts about leaving {PRONOUN/p_l/poss} patients behind, and {VERB/p_l/decide/decides} to go another day.",
         "chance_of_success": 70,
         "success_outcomes": [
             {
@@ -875,12 +875,6 @@
                 "exp": 10,
                 "weight": 20,
                 "herbs": ["burdock"]
-            },
-            {
-                "text": "p_l shows {PRONOUN/p_l/poss} usual talent for spotting herbs, trotting straight over to a burdock plant and digging at its foot.",
-                "exp": 10,
-                "weight": 5,
-                "herbs": ["many_herbs", "burdock"]
             },
             {
                 "text": "s_c shows {PRONOUN/s_c/poss} usual talent for spotting herbs, trotting straight over to a burdock plant and digging at its foot.",
@@ -916,7 +910,7 @@
         },
         "weight": 20,
         "intro_text": "With the full sun of greenleaf fueling plant growth everywhere, it's the perfect time to hunt for burdock. p_l heads out to replenish the Clan's stocks, bringing app1 along.",
-        "decline_text": "They have second thoughts leaving their patients behind, especially with them also bringing their apprentice, and decide to go another day.",
+        "decline_text": "{PRONOUN/p_l/subject/CAP} {VERB/p_l/have/has} second thoughts about leaving {PRONOUN/p_l/poss} patients behind, especially with {PRONOUN/p_l/poss} apprentice along too, and {VERB/p_l/decide/decides} to go another day.",
         "chance_of_success": 70,
         "success_outcomes": [
             {
@@ -1140,19 +1134,13 @@
         },
         "weight": 20,
         "intro_text": "p_l heads out into the sunshine, padding away from camp in a search for one of the most elusive herbs.",
-        "decline_text": "They have second thoughts about leaving their patients behind, and decide to go another day.",
+        "decline_text": "{PRONOUN/p_l/poss/CAP} {VERB/p_l/have/has} second thoughts about leaving {PRONOUN/p_l/poss} patients behind, and {VERB/p_l/decide/decides} to go another day.",
         "chance_of_success": 40,
         "success_outcomes": [
             {
                 "text": "It takes a morning full of careful searching, but eventually one of the catmint plants p_l remembers from seasons past is revisited, and to {PRONOUN/p_l/poss} delight, it's growing well. p_l avoids taking the flowers, giving the plant the chance to spread catmint seed for the future.",
                 "exp": 30,
                 "weight": 20,
-                "herbs": ["catmint"]
-            },
-            {
-                "text": "s_c has a few baby catmint sprouts {PRONOUN/s_c/subject}{VERB/s_c/'ve/'s} been leaving alone through newleaf, and greenleaf means it's time to see if they're harvestable. They are, and s_c is able to bring huge quantities of the valuable herb home.",
-                "exp": 30,
-                "weight": 5,
                 "herbs": ["catmint"]
             },
             {
@@ -1165,7 +1153,7 @@
         ],
         "fail_outcomes": [
             {
-                "text": "It's alright to fail, p_l reminds {PRONOUN/p_l/object}. At least {PRONOUN/p_l/subject} {VERB/p_l/know/knows} where there <i>isn't</i> catmint, and that will make the next patrols to find it easier.",
+                "text": "It's alright to fail, p_l reminds {PRONOUN/p_l/self}. At least {PRONOUN/p_l/subject} {VERB/p_l/know/knows} where there <i>isn't</i> catmint, and that will make the next patrols to find it easier.",
                 "exp": 0,
                 "weight": 20
             }
@@ -1189,7 +1177,7 @@
         },
         "weight": 20,
         "intro_text": "p_l waits until {PRONOUN/p_l/subject}{VERB/p_l/'re/'s} out of camp to reveal to app1 that {PRONOUN/p_l/subject}{VERB/p_l/'re/'s} off to find catmint - a 'helpful' group of 'helpers' can be a little... well, unhelpful. Catmint is just too exciting for many of {PRONOUN/p_l/poss} Clanmates to keep {PRONOUN/p_l/poss} heads around, and p_l wants to take advantage of the peak greenleaf growing season.",
-        "decline_text": "They have second thoughts leaving their patients behind, especially with them also bringing their apprentice, and decide to go another day.",
+        "decline_text": "{PRONOUN/p_l/subject/CAP} {VERB/p_l/have/has} second thoughts about leaving {PRONOUN/p_l/poss} patients behind, especially with {PRONOUN/p_l/poss} apprentice along too, and {VERB/p_l/decide/decides} to go another day.",
         "chance_of_success": 40,
         "success_outcomes": [
             {
@@ -1300,12 +1288,12 @@
             "normal adult": [1, 6]
         },
         "weight": 20,
-        "intro_text": "As p_l looks at the twitching tails and wide eyes of the patrol set up to 'help' {PRONOUN/p_l/object} {VERB/p_l/gather/gathers} catmint, {PRONOUN/p_l/poss} heart sinks. These overly excited warriors don't look like {PRONOUN/p_l/subject}{VERB/p_l/'re/'s} going to be useful, and catmint is too important to be silly about collecting. Yes, it smells wonderful. <i>Please</i> get over it.",
+        "intro_text": "As p_l looks at the twitching tails and wide eyes of the patrol set up to 'help' {PRONOUN/p_l/object} {VERB/p_l/gather/gathers} catmint, {PRONOUN/p_l/poss} heart sinks. These overly excited warriors don't look like they're going to be useful, and catmint is too important to be silly about collecting. Yes, it smells wonderful. <i>Please</i> get over it.",
         "decline_text": "{PRONOUN/p_l/subject/CAP}{VERB/p_l/'re/'s} stopped before {PRONOUN/p_l/subject} {VERB/p_l/leave/leaves} camp - these warriors are needed elsewhere. p_l's expedition will have to wait.",
         "chance_of_success": 30,
         "success_outcomes": [
             {
-                "text": "The warriors keep their heads, with the more experienced of p_l's helpers making themself useful keeping those that are young or more impulsive focused on their task. The medicine cat and {PRONOUN/p_l/poss} team carefully pick out catmint from its known hiding places, carting it back to camp where it will protect the Clan.",
+                "text": "The warriors keep their heads, with the more experienced of p_l's helpers making themselves useful keeping those that are young or more impulsive focused on their task. The medicine cat and {PRONOUN/p_l/poss} team carefully pick out catmint from its known hiding places, carting it back to camp where it will protect the Clan.",
                 "exp": 10,
                 "weight": 20,
                 "herbs": ["catmint"],
@@ -1412,7 +1400,7 @@
         },
         "weight": 20,
         "intro_text": "The heat of greenleaf brings warmth to {PRONOUN/p_l/poss} pelt as p_l wanders, aimlessly searching for daisies to harvest their leaves.",
-        "decline_text": "They have second thoughts about leaving their patients behind, and decide to go another day.",
+        "decline_text": "{PRONOUN/p_l/poss/CAP} {VERB/p_l/have/has} second thoughts about leaving {PRONOUN/p_l/poss} patients behind, and {VERB/p_l/decide/decides} to go another day.",
         "chance_of_success": 70,
         "success_outcomes": [
             {
@@ -1420,12 +1408,6 @@
                 "exp": 10,
                 "weight": 20,
                 "herbs": ["daisy"]
-            },
-            {
-                "text": "Daisies aren't hard to find in the warmer seasons, and s_c collects enough that {PRONOUN/s_c/subject} {VERB/s_c/have/haves} trouble not dropping any on the way back to camp.",
-                "exp": 10,
-                "weight": 5,
-                "herbs": ["many_herbs", "daisy"]
             },
             {
                 "text": "Daisies aren't hard to find in the warmer seasons, and s_c collects enough that {PRONOUN/s_c/subject} {VERB/s_c/have/haves} trouble not dropping any on the way back to camp.",
@@ -1461,7 +1443,7 @@
         },
         "weight": 20,
         "intro_text": "The heat of greenleaf brings warmth to {PRONOUN/p_l/poss} pelt as p_l wanders, aimlessly searching for daisies to harvest their leaves, bringing app1 along for a lesson.",
-        "decline_text": "They have second thoughts leaving their patients behind, especially with them also bringing their apprentice, and decide to go another day.",
+        "decline_text": "{PRONOUN/p_l/subject/CAP} {VERB/p_l/have/has} second thoughts about leaving {PRONOUN/p_l/poss} patients behind, especially with {PRONOUN/p_l/poss} apprentice along too, and {VERB/p_l/decide/decides} to go another day.",
         "chance_of_success": 70,
         "success_outcomes": [
             {
@@ -1487,7 +1469,7 @@
                 ]
             },
             {
-                "text": "Greenleaf brings a veritable explosion of daisies raising little white and yellow flowers around every corner, and p_l barely even needs to leave camp to gather them. It gives them time to let app1 run off and play with {PRONOUN/p_l/poss} friends, and seeing {PRONOUN/p_l/poss} apprentice getting to relax makes {PRONOUN/p_l/subject} smile from {PRONOUN/p_l/poss} favourite basking spot.",
+                "text": "Greenleaf brings a veritable explosion of daisies raising little white and yellow flowers around every corner, and p_l barely even needs to leave camp to gather them. It gives them time to let app1 run off and play with {PRONOUN/app1/poss} friends, and seeing {PRONOUN/p_l/poss} apprentice getting to relax makes {PRONOUN/p_l/subject} smile from {PRONOUN/p_l/poss} favourite basking spot.",
                 "exp": 20,
                 "weight": 5,
                 "herbs": ["many_herbs", "daisy"],
@@ -1682,8 +1664,8 @@
             "normal adult": [-1, -1]
         },
         "weight": 20,
-        "intro_text": "Greenleaf's bounty means that finding dandelions shouldn't be any trouble. ",
-        "decline_text": "They have second thoughts about leaving their patients behind, and decide to go another day.",
+        "intro_text": "Greenleaf's bounty means that finding dandelions shouldn't be any trouble, and p_l heads out to find some.",
+        "decline_text": "{PRONOUN/p_l/poss/CAP} {VERB/p_l/have/has} second thoughts about leaving {PRONOUN/p_l/poss} patients behind, and {VERB/p_l/decide/decides} to go another day.",
         "chance_of_success": 70,
         "success_outcomes": [
             {
@@ -1695,12 +1677,6 @@
             {
                 "text": "With warmth in the air and ground, s_c doesn't need to try very hard to find an excellent haul of dandelions to bring back to camp.",
                 "exp": 10,
-                "weight": 5,
-                "herbs": ["many_herbs", "dandelion"]
-            },
-            {
-                "text": "With warmth in the air and ground, s_c doesn't need to try very hard to find an excellent haul of dandelions to bring back to camp.",
-                "exp": 10,
                 "weight": 20,
                 "stat_skill": ["SENSE,2"],
                 "herbs": ["many_herbs", "dandelion"]
@@ -1708,7 +1684,7 @@
         ],
         "fail_outcomes": [
             {
-                "text": "Unfortunately, c_n doesn't seem to be the only things after dandelions, and p_l can't gather from this patch without killing off the already damaged plants.",
+                "text": "Unfortunately, c_n cats don't seem to be the only things after dandelions, and p_l can't gather from this patch without killing off the already damaged plants.",
                 "exp": 0,
                 "weight": 20
             }
@@ -1731,8 +1707,8 @@
             "normal adult": [-1, -1]
         },
         "weight": 20,
-        "intro_text": "Greenleaf's bounty means that finding dandelions shouldn't be any trouble.  p_l heads out to look for {PRONOUN/p_l/object}, taking app1 to learn about one of the most useful common herbs in their arsenal.",
-        "decline_text": "They have second thoughts leaving their patients behind, especially with them also bringing their apprentice, and decide to go another day.",
+        "intro_text": "Greenleaf's bounty means that finding dandelions shouldn't be any trouble. p_l heads out to look for them, taking app1 to learn about one of the most useful common herbs in their arsenal.",
+        "decline_text": "{PRONOUN/p_l/subject/CAP} {VERB/p_l/have/has} second thoughts about leaving {PRONOUN/p_l/poss} patients behind, especially with {PRONOUN/p_l/poss} apprentice along too, and {VERB/p_l/decide/decides} to go another day.",
         "chance_of_success": 70,
         "success_outcomes": [
             {
@@ -1758,7 +1734,7 @@
                 ]
             },
             {
-                "text": "It's a successful gathering mission, with p_l striding back to camp with a great haul of entire dandelion plants. Later {PRONOUN/p_l/subject}'ll teach app1 to sort the leaves and roots to be stored separately, the leaves remain fresh for a far shorter time.",
+                "text": "It's a successful gathering mission, with p_l striding back to camp with a great haul of entire dandelion plants. Later {PRONOUN/p_l/subject}'ll teach app1 to sort the leaves and roots to be stored separately, as the leaves remain fresh for a far shorter time.",
                 "exp": 20,
                 "weight": 5,
                 "herbs": ["many_herbs", "dandelion"],
@@ -1780,7 +1756,7 @@
                 ]
             },
             {
-                "text": "With warmth in the air and ground, s_c doesn't need to try very hard to find an excellent haul of dandelions to bring back to camp. Instead, {PRONOUN/s_c/subject} let app1 take the lead in finding the plants, praising {PRONOUN/app1/object} for all the progress {PRONOUN/app1/subject}{VERB/app1/'ve/'s} made in herbcraft.",
+                "text": "With warmth in the air and ground, s_c doesn't need to try very hard to find an excellent haul of dandelions to bring back to camp. Instead, {PRONOUN/s_c/subject} {VERB/s_c/let/lets} app1 take the lead in finding the plants, praising {PRONOUN/app1/object} for all the progress {PRONOUN/app1/subject}{VERB/app1/'ve/'s} made in herbcraft.",
                 "exp": 20,
                 "weight": 20,
                 "stat_skill": ["SENSE,2"],
@@ -1806,7 +1782,7 @@
         ],
         "fail_outcomes": [
             {
-                "text": "Unfortunately, c_n doesn't seem to be the only things after dandelions, and p_l can't gather from this patch without killing off the already damaged plants. app1 actually starts an argument about it, insistent that they don't need to worry about protecting the dandelion patch for the future.",
+                "text": "Unfortunately, c_n cats don't seem to be the only things after dandelions, and p_l can't gather from this patch without killing off the already damaged plants. app1 actually starts an argument about it, insistent that they don't need to worry about protecting the dandelion patch for the future.",
                 "exp": 0,
                 "weight": 20,
                 "relationships": [
@@ -1847,32 +1823,10 @@
         "chance_of_success": 30,
         "success_outcomes": [
             {
-                "text": "It's a successful gathering mission, with p_l striding back to camp with a great haul of whole, intact dandelion plants. Later, {PRONOUN/p_l/subject}'ll sort the leaves and roots to be stored separately - the leaves remain fresh for a far shorter time, but for now {PRONOUN/p_l/subject} {VERB/p_l/make/makes} sure to thank the warriors that have helped {PRONOUN/p_l/subject} bring home so many.",
+                "text": "It's a successful gathering mission, with p_l striding back to camp with a great haul of whole, intact dandelion plants. Later, {PRONOUN/p_l/subject}'ll sort the leaves and roots to be stored separately - the leaves remain fresh for a far shorter time, but for now {PRONOUN/p_l/subject} {VERB/p_l/make/makes} sure to thank the warriors that have helped {PRONOUN/p_l/object} bring home so many.",
                 "exp": 10,
                 "weight": 20,
                 "herbs": ["dandelion"],
-                "relationships": [
-                    {
-                        "cats_to": ["patrol"],
-                        "cats_from": ["patrol"],
-                        "mutual": false,
-                        "values": ["platonic", "respect"],
-                        "amount": 10
-                    },
-                    {
-                        "cats_to": ["patrol"],
-                        "cats_from": ["patrol"],
-                        "mutual": false,
-                        "values": ["dislike"],
-                        "amount": -10
-                    }
-                ]
-            },
-            {
-                "text": "With warmth in the air and ground, s_c doesn't need to try very hard to find an excellent haul of dandelions to bring back to camp. {PRONOUN/s_c/subject/CAP} {VERB/s_c/help/helps} the warriors carefully pluck fluffy dandelions heads to bring back for the nursery.",
-                "exp": 10,
-                "weight": 5,
-                "herbs": ["many_herbs", "dandelion"],
                 "relationships": [
                     {
                         "cats_to": ["patrol"],
@@ -1954,7 +1908,7 @@
         },
         "weight": 20,
         "intro_text": "The thick growth of greenleaf will serve c_n well today, p_l decides, thinking about gathering elder leaves. There's a particular tree in a sheltered dip along a stream {PRONOUN/p_l/subject} {VERB/p_l/want/wants} to check on today.",
-        "decline_text": "They have second thoughts about leaving their patients behind, and decide to go another day.",
+        "decline_text": "{PRONOUN/p_l/poss/CAP} {VERB/p_l/have/has} second thoughts about leaving {PRONOUN/p_l/poss} patients behind, and {VERB/p_l/decide/decides} to go another day.",
         "chance_of_success": 60,
         "success_outcomes": [
             {
@@ -1962,12 +1916,6 @@
                 "exp": 10,
                 "weight": 20,
                 "herbs": ["elder_leaves"]
-            },
-            {
-                "text": "s_c has managed to discover, with time and experience, that elder leaf picking is actually better handled by chewing off several low hanging, thin branches, and carting those back to camp instead.",
-                "exp": 10,
-                "weight": 5,
-                "herbs": ["many_herbs", "elder_leaves"]
             },
             {
                 "text": "s_c has managed to discover, with time and experience, that elder leaf picking is actually better handled by chewing off several low hanging, thin branches, and carting those back to camp instead.",
@@ -1986,13 +1934,11 @@
             {
                 "text": "p_l, reaching out just a little too far to try and grab a branch of elder while balanced on another, loses {PRONOUN/p_l/poss} balance and tumbles to the ground.",
                 "exp": 0,
-                "weight": 20
-            },
-            {
-                "text": "p_l, reaching out just a little too far to try and grab a branch of elder while balanced on another, loses {PRONOUN/p_l/poss} balance and tumbles to the ground.",
-                "exp": 0,
                 "weight": 10,
-                "dead_cats": ["r_c"]
+                "dead_cats": ["p_l"],
+                "history_text": {
+                    "reg_death": "p_l died when they fell out of an elder tree."
+                }
             },
             {
                 "text": "p_l, reaching out just a little too far to try and grab a branch of elder while balanced on another, loses {PRONOUN/p_l/poss} balance and tumbles to the ground.",
@@ -2000,7 +1946,7 @@
                 "weight": 10,
                 "injury": [
                     {
-                        "cats": ["r_c"],
+                        "cats": ["p_l"],
                         "injuries": ["minor_injury"],
                         "scars": []
                     }
@@ -2026,11 +1972,11 @@
         },
         "weight": 20,
         "intro_text": "The thick growth of greenleaf will serve c_n well today, p_l decides, thinking about gathering elder leaves. There's a particular tree in a sheltered dip along a stream {PRONOUN/p_l/subject} {VERB/p_l/want/wants} to check on today, bringing app1 to show {PRONOUN/app1/object} why choosing to harvest from a sheltered plant can be helpful.",
-        "decline_text": "They have second thoughts leaving their patients behind, especially with them also bringing their apprentice, and decide to go another day.",
+        "decline_text": "{PRONOUN/p_l/subject/CAP} {VERB/p_l/have/has} second thoughts about leaving {PRONOUN/p_l/poss} patients behind, especially with {PRONOUN/p_l/poss} apprentice along too, and {VERB/p_l/decide/decides} to go another day.",
         "chance_of_success": 60,
         "success_outcomes": [
             {
-                "text": "Elder leaves being used to <i>soothe</i> sprains, and elder leaves having to be gathered in a way that <i>risks</i> sprains, is truly one of StarClan's little ironies, p_l reflects. app1 is more occupied climbing the tree, and p_l isn't going to dissuade {PRONOUN/p_l/poss} pride in plucking from the highest branches, even if they're no more potent than those at the bottom.",
+                "text": "Elder leaves being used to <i>soothe</i> sprains, and elder leaves having to be gathered in a way that <i>risks</i> sprains, is truly one of StarClan's little ironies, p_l reflects. app1 is more occupied climbing the tree, and p_l isn't going to dissuade {PRONOUN/app1/poss} pride in plucking from the highest branches, even if they're no more potent than those at the bottom.",
                 "exp": 20,
                 "weight": 20,
                 "herbs": ["elder_leaves"],
@@ -2074,7 +2020,7 @@
                 ]
             },
             {
-                "text": "s_c has managed to discover, with time and experience, that elder leaf picking is actually better handled by chewing off several low hanging, thin branches, and carting those back to camp instead. {PRONOUN/s_c/subject/CAP} {VERB/s_c/pass/passes} on the trick to app1, and once {PRONOUN/s_c/subject}{VERB/s_c/'re/'s} back at camp both medicine cats strip off the leaves and give them a quick wash.",
+                "text": "s_c has managed to discover, with time and experience, that elder leaf picking is actually better handled by chewing off several low hanging, thin branches, and carting those back to camp instead. {PRONOUN/s_c/subject/CAP} {VERB/s_c/pass/passes} on the trick to app1, and once they're back at camp both medicine cats strip off the leaves and give them a quick wash.",
                 "exp": 20,
                 "weight": 20,
                 "stat_skill": ["SENSE,2"],
@@ -2121,50 +2067,16 @@
                 ]
             },
             {
-                "text": "r_c, reaching out just a little too far to try and grab a branch of elder while balanced on another, loses {PRONOUN/r_c/poss} balance and tumbles to the ground.",
-                "exp": 0,
-                "weight": 20,
-                "relationships": [
-                    {
-                        "cats_to": ["patrol"],
-                        "cats_from": ["patrol"],
-                        "mutual": false,
-                        "values": ["platonic", "respect", "comfort", "trust"],
-                        "amount": -10
-                    },
-                    {
-                        "cats_to": ["patrol"],
-                        "cats_from": ["patrol"],
-                        "mutual": false,
-                        "values": ["dislike"],
-                        "amount": 10
-                    }
-                ]
-            },
-            {
-                "text": "r_c, reaching out just a little too far to try and grab a branch of elder while balanced on another, loses {PRONOUN/r_c/poss} balance and tumbles to the ground.",
+                "text": "app1, reaching out just a little too far to try and grab a branch of elder while balanced on another, loses {PRONOUN/app1/poss} balance and tumbles to the ground.",
                 "exp": 0,
                 "weight": 10,
-                "dead_cats": ["r_c"],
-                "relationships": [
-                    {
-                        "cats_to": ["patrol"],
-                        "cats_from": ["patrol"],
-                        "mutual": false,
-                        "values": ["platonic", "respect", "comfort", "trust"],
-                        "amount": -10
-                    },
-                    {
-                        "cats_to": ["patrol"],
-                        "cats_from": ["patrol"],
-                        "mutual": false,
-                        "values": ["dislike"],
-                        "amount": 10
-                    }
-                ]
+                "dead_cats": ["app1"],
+                "history_text": {
+                    "reg_death": "app1 died before completing their medicine training when they fell out of an elder tree."
+                }
             },
             {
-                "text": "r_c, reaching out just a little too far to try and grab a branch of elder while balanced on another, loses {PRONOUN/r_c/poss} balance and tumbles to the ground.",
+                "text": "app1, reaching out just a little too far to try and grab a branch of elder while balanced on another, loses {PRONOUN/app1/poss} balance and tumbles to the ground.",
                 "exp": 0,
                 "weight": 10,
                 "injury": [
@@ -2172,22 +2084,6 @@
                         "cats": ["app1"],
                         "injuries": ["minor_injury"],
                         "scars": []
-                    }
-                ],
-                "relationships": [
-                    {
-                        "cats_to": ["patrol"],
-                        "cats_from": ["patrol"],
-                        "mutual": false,
-                        "values": ["platonic", "respect", "comfort", "trust"],
-                        "amount": -10
-                    },
-                    {
-                        "cats_to": ["patrol"],
-                        "cats_from": ["patrol"],
-                        "mutual": false,
-                        "values": ["dislike"],
-                        "amount": 10
                     }
                 ]
             }
@@ -2234,29 +2130,7 @@
                 ]
             },
             {
-                "text": "s_c has managed to discover, with time and experience, that elder leaf picking is actually better handled by chewing off several low hanging, thin branches, and carting those back to camp instead. With so many assistants, {PRONOUN/s_c/subject} can bring a truly massive haul home, where the rest of the patrol helps {PRONOUN/s_c/subject} strip the leaves and carefully store them.",
-                "exp": 10,
-                "weight": 5,
-                "herbs": ["many_herbs", "elder_leaves"],
-                "relationships": [
-                    {
-                        "cats_to": ["patrol"],
-                        "cats_from": ["patrol"],
-                        "mutual": false,
-                        "values": ["platonic", "respect"],
-                        "amount": 10
-                    },
-                    {
-                        "cats_to": ["patrol"],
-                        "cats_from": ["patrol"],
-                        "mutual": false,
-                        "values": ["dislike"],
-                        "amount": -10
-                    }
-                ]
-            },
-            {
-                "text": "s_c has managed to discover, with time and experience, that elder leaf picking is actually better handled by chewing off several low hanging, thin branches, and carting those back to camp instead. With so many assistants, {PRONOUN/s_c/subject} can bring a truly massive haul home, where the rest of the patrol helps {PRONOUN/s_c/subject} strip the leaves and carefully store them.",
+                "text": "s_c has managed to discover, with time and experience, that elder leaf picking is actually better handled by chewing off several low hanging, thin branches, and carting those back to camp instead. With so many assistants, {PRONOUN/s_c/subject} can bring a truly massive haul home, where the rest of the patrol helps {PRONOUN/s_c/object} strip the leaves and carefully store them.",
                 "exp": 10,
                 "weight": 20,
                 "stat_skill": ["SENSE,2"],
@@ -2304,45 +2178,11 @@
             {
                 "text": "r_c, reaching out just a little too far to try and grab a branch of elder while balanced on another, loses {PRONOUN/r_c/poss} balance and tumbles to the ground.",
                 "exp": 0,
-                "weight": 20,
-                "relationships": [
-                    {
-                        "cats_to": ["patrol"],
-                        "cats_from": ["patrol"],
-                        "mutual": false,
-                        "values": ["platonic", "respect"],
-                        "amount": -10
-                    },
-                    {
-                        "cats_to": ["patrol"],
-                        "cats_from": ["patrol"],
-                        "mutual": false,
-                        "values": ["dislike"],
-                        "amount": 10
-                    }
-                ]
-            },
-            {
-                "text": "r_c, reaching out just a little too far to try and grab a branch of elder while balanced on another, loses {PRONOUN/r_c/poss} balance and tumbles to the ground.",
-                "exp": 0,
                 "weight": 10,
                 "dead_cats": ["r_c"],
-                "relationships": [
-                    {
-                        "cats_to": ["patrol"],
-                        "cats_from": ["patrol"],
-                        "mutual": false,
-                        "values": ["platonic", "respect"],
-                        "amount": -10
-                    },
-                    {
-                        "cats_to": ["patrol"],
-                        "cats_from": ["patrol"],
-                        "mutual": false,
-                        "values": ["dislike"],
-                        "amount": 10
-                    }
-                ]
+                "history_text": {
+                    "reg_death": "r_c died when they fell out of an elder tree."
+                }
             },
             {
                 "text": "r_c, reaching out just a little too far to try and grab a branch of elder while balanced on another, loses {PRONOUN/r_c/poss} balance and tumbles to the ground.",
@@ -2353,22 +2193,6 @@
                         "cats": ["r_c"],
                         "injuries": ["minor_injury"],
                         "scars": []
-                    }
-                ],
-                "relationships": [
-                    {
-                        "cats_to": ["patrol"],
-                        "cats_from": ["patrol"],
-                        "mutual": false,
-                        "values": ["platonic", "respect"],
-                        "amount": -10
-                    },
-                    {
-                        "cats_to": ["patrol"],
-                        "cats_from": ["patrol"],
-                        "mutual": false,
-                        "values": ["dislike"],
-                        "amount": 10
                     }
                 ]
             }
@@ -2390,7 +2214,7 @@
         },
         "weight": 20,
         "intro_text": "Greenleaf is truly the best time of year to be a medicine cat, with the world so full of flowers and green growth. p_l heads out to gather fresh goldenrod for the stores.",
-        "decline_text": "They have second thoughts about leaving their patients behind, and decide to go another day.",
+        "decline_text": "{PRONOUN/p_l/poss/CAP} {VERB/p_l/have/has} second thoughts about leaving {PRONOUN/p_l/poss} patients behind, and {VERB/p_l/decide/decides} to go another day.",
         "chance_of_success": 70,
         "success_outcomes": [
             {
@@ -2439,7 +2263,7 @@
         },
         "weight": 20,
         "intro_text": "Greenleaf is truly the best time of year to be a medicine cat, with the world so full of flowers and green growth. p_l heads out to gather fresh goldenrod for the stores with app1.",
-        "decline_text": "They have second thoughts leaving their patients behind, especially with them also bringing their apprentice, and decide to go another day.",
+        "decline_text": "{PRONOUN/p_l/subject/CAP} {VERB/p_l/have/has} second thoughts about leaving {PRONOUN/p_l/poss} patients behind, especially with {PRONOUN/p_l/poss} apprentice along too, and {VERB/p_l/decide/decides} to go another day.",
         "chance_of_success": 70,
         "success_outcomes": [
             {
@@ -2661,7 +2485,7 @@
         },
         "weight": 20,
         "intro_text": "p_l heads out to find a juniper tree, wanting to restock on its needles.",
-        "decline_text": "They have second thoughts about leaving their patients behind, and decide to go another day.",
+        "decline_text": "{PRONOUN/p_l/poss/CAP} {VERB/p_l/have/has} second thoughts about leaving {PRONOUN/p_l/poss} patients behind, and {VERB/p_l/decide/decides} to go another day.",
         "chance_of_success": 70,
         "success_outcomes": [
             {
@@ -2710,7 +2534,7 @@
         },
         "weight": 20,
         "intro_text": "p_l heads out to find a juniper tree, wanting to restock on its needles. It's also a good opportunity for app1 to learn more about the plant.",
-        "decline_text": "They have second thoughts leaving their patients behind, especially with them also bringing their apprentice, and decide to go another day.",
+        "decline_text": "{PRONOUN/p_l/subject/CAP} {VERB/p_l/have/has} second thoughts about leaving {PRONOUN/p_l/poss} patients behind, especially with {PRONOUN/p_l/poss} apprentice along too, and {VERB/p_l/decide/decides} to go another day.",
         "chance_of_success": 70,
         "success_outcomes": [
             {
@@ -2736,7 +2560,7 @@
                 ]
             },
             {
-                "text": "Juniper needles have so many uses. Calming minds, easing breath, soothing bellies, as a traveling herb... really, p_l will always feel better having a good store of the stuff, and this patrol has been very successful. {PRONOUN/p_l/subject/CAP} {VERB/p_l/make/makes} sure to send app1 off with both heaps of praise and a little sprig of juniper, to bring its pleasant scent to {PRONOUN/p_l/poss} nest.",
+                "text": "Juniper needles have so many uses. Calming minds, easing breath, soothing bellies, as a traveling herb... really, p_l will always feel better having a good store of the stuff, and this patrol has been very successful. {PRONOUN/p_l/subject/CAP} {VERB/p_l/make/makes} sure to send app1 off with both heaps of praise and a little sprig of juniper, to bring its pleasant scent to {PRONOUN/app1/poss} nest.",
                 "exp": 20,
                 "weight": 5,
                 "herbs": ["many_herbs", "juniper"],
@@ -2820,7 +2644,7 @@
             "normal adult": [1, 6]
         },
         "weight": 20,
-        "intro_text": "p_l heads out to find a juniper tree, wanting to restock on its needles. Some of {PRONOUN/p_l/poss} Clanmates volunteer to come with {PRONOUN/p_l/object}, hoping to keep a few pleasantly smelling needles for scenting {PRONOUN/p_l/poss} own nests, though {PRONOUN/p_l/subject}'ll have to be careful about placing {PRONOUN/p_l/object} so the needles don't spike anyone.",
+        "intro_text": "p_l heads out to find a juniper tree, wanting to restock on its needles. Some of {PRONOUN/p_l/poss} Clanmates volunteer to come with {PRONOUN/p_l/object}, hoping to keep a few pleasantly smelling needles for scenting their own nests, though they'll have to be careful about placing them so the needles don't spike anyone.",
         "decline_text": "{PRONOUN/p_l/subject/CAP}{VERB/p_l/'re/'s} stopped before {PRONOUN/p_l/subject} {VERB/p_l/leave/leaves} camp - these warriors are needed elsewhere. p_l's expedition will have to wait.",
         "chance_of_success": 30,
         "success_outcomes": [
@@ -2829,28 +2653,6 @@
                 "exp": 10,
                 "weight": 20,
                 "herbs": ["juniper"],
-                "relationships": [
-                    {
-                        "cats_to": ["patrol"],
-                        "cats_from": ["patrol"],
-                        "mutual": false,
-                        "values": ["platonic", "respect"],
-                        "amount": 10
-                    },
-                    {
-                        "cats_to": ["patrol"],
-                        "cats_from": ["patrol"],
-                        "mutual": false,
-                        "values": ["dislike"],
-                        "amount": -10
-                    }
-                ]
-            },
-            {
-                "text": "s_c trots off to a good juniper tree, hopping onto a low branch to harvest its needles. {PRONOUN/s_c/poss/CAP} patrol follows {PRONOUN/s_c/poss} lead, pulling twigs off, although a couple times s_c does need to remind them that the carpet of dead needles on the ground wouldn't be useful for the herb stores.",
-                "exp": 10,
-                "weight": 5,
-                "herbs": ["many_herbs", "juniper"],
                 "relationships": [
                     {
                         "cats_to": ["patrol"],
@@ -2938,7 +2740,7 @@
         "chance_of_success": 30,
         "success_outcomes": [
             {
-                "text": "It takes {PRONOUN/p_l/object} all day, but eventually, finally, p_l spots the speckled leaves {PRONOUN/p_l/subject}{VERB/p_l/'ve/'s} been looking for, so crucial to harvest while the growing season is upon them. For just a second, {PRONOUN/p_l/subject} {VERB/p_l/feel/feels} the weight of {PRONOUN/p_l/poss} responsibilities lift, and {PRONOUN/p_l/subject} let out a yowl and stop to play with app1.",
+                "text": "It takes {PRONOUN/p_l/object} all day, but eventually, finally, p_l spots the speckled leaves {PRONOUN/p_l/subject}{VERB/p_l/'ve/'s} been looking for, so crucial to harvest while the growing season is upon them. For just a second, {PRONOUN/p_l/subject} {VERB/p_l/feel/feels} the weight of {PRONOUN/p_l/poss} responsibilities lift, and {PRONOUN/p_l/subject} {VERB/p_l/let/lets} out a yowl and {VERB/p_l/stop/stops} to play with app1.",
                 "exp": 20,
                 "weight": 20,
                 "herbs": ["lungwort"],
@@ -2960,7 +2762,7 @@
                 ]
             },
             {
-                "text": "app1 listens intently as the hours drift slowly by in {PRONOUN/p_l/poss} intense search, and then finally spots a bush with leaves sprinkled with white. It's lungwort! p_l showers {PRONOUN/app1/object} with praise, app1 feeling like {PRONOUN/app1/subject} could burst with pride over {PRONOUN/app1/poss} accomplishment.",
+                "text": "app1 listens intently as the hours drift slowly by in their intense search, and then finally spots a bush with leaves sprinkled with white. It's lungwort! p_l showers {PRONOUN/app1/object} with praise, app1 feeling like {PRONOUN/app1/subject} could burst with pride over {PRONOUN/app1/poss} accomplishment.",
                 "exp": 20,
                 "weight": 5,
                 "herbs": ["lungwort"],
@@ -2982,7 +2784,7 @@
                 ]
             },
             {
-                "text": "It takes all of s_c's considerable talent for such things to hunt down the lungwort within {PRONOUN/s_c/poss} borders, the medicine cats visiting each likely nook and cranny in a carefully planned search pattern until, finally, those telltale speckled leaves are found.",
+                "text": "It takes all of s_c's considerable talent for such things to hunt down the lungwort within c_n's borders, the medicine cats visiting each likely nook and cranny in a carefully planned search pattern until, finally, those telltale speckled leaves are found.",
                 "exp": 20,
                 "weight": 20,
                 "stat_skill": ["SENSE,2", "CLEVER,3"],
@@ -3006,7 +2808,7 @@
                 ]
             },
             {
-                "text": "Night falls, and still s_c insists {PRONOUN/s_c/subject} {VERB/s_c/keep/keeps} going. Lungwort is the only reliable cure for yellowcough, and {PRONOUN/s_c/subject} just can't let c_n go without. Exhausted, but determined, the medicine cats persist patiently until they finally find the precious, speckled leaves.",
+                "text": "Night falls, and still s_c insists they keep going. Lungwort is the only reliable cure for yellowcough, and {PRONOUN/s_c/subject} just can't let c_n go without. Exhausted, but determined, the medicine cats persist patiently until they finally find the precious, speckled leaves.",
                 "exp": 20,
                 "weight": 20,
                 "stat_trait": ["patient"],
@@ -3103,7 +2905,7 @@
                 ]
             },
             {
-                "text": "It takes all of s_c's considerable talent for such things to hunt down the lungwort within {PRONOUN/s_c/poss} borders, the medicine cat visiting each likely nook and cranny in a carefully planned search pattern until, finally, those telltale speckled leaves are found.",
+                "text": "It takes all of s_c's considerable talent for such things to hunt down the lungwort within c_n's borders, the medicine cat visiting each likely nook and cranny in a carefully planned search pattern until, finally, those telltale speckled leaves are found.",
                 "exp": 20,
                 "weight": 20,
                 "stat_skill": ["SENSE,2", "CLEVER,3"],
@@ -3137,21 +2939,7 @@
         ],
         "fail_outcomes": [
             {
-                "text": "p_l searches until {PRONOUN/p_l/poss} pawpads are sore and {PRONOUN/p_l/poss} muscles exhausted, but can't find lungwort anywhere. {PRONOUN/p_l/subject/CAP} {VERB/p_l/return/returns} to camp disappointed, but determined to try again. It's simply too important to not keep a good supply of.",
-                "exp": 0,
-                "weight": 20,
-                "relationships": [
-                    {
-                        "cats_to": ["patrol"],
-                        "cats_from": ["clan"],
-                        "mutual": false,
-                        "values": ["respect"],
-                        "amount": -5
-                    }
-                ]
-            },
-            {
-                "text": "p_l searches until {PRONOUN/p_l/poss} pawpads are sore and {PRONOUN/p_l/poss} muscles exhausted, but can't find lungwort anywhere. {PRONOUN/p_l/subject/CAP} {VERB/p_l/return/returns} to camp disappointed, but determined to try again. It's simply too important to not keep a good supply of.",
+                "text": "p_l seems to have forgotten where to find a lungwort plant, much to {PRONOUN/p_l/poss} embarrassment. It's such an important herb, too! {PRONOUN/p_l/subject/CAP} {VERB/p_l/resolve/resolves} to make a better mental note next time {PRONOUN/p_l/subject} {VERB/p_l/find/finds} some.",
                 "exp": 0,
                 "weight": 20,
                 "relationships": [
@@ -3237,7 +3025,7 @@
                 ]
             },
             {
-                "text": "It takes all of s_c's considerable talent for such things to hunt down the lungwort within {PRONOUN/s_c/poss} borders, the medicine cat visiting each likely nook and cranny in a carefully planned search pattern until, finally, those telltale speckled leaves are found.",
+                "text": "It takes all of s_c's considerable talent for such things to hunt down the lungwort within c_n's borders, the medicine cat visiting each likely nook and cranny in a carefully planned search pattern until, finally, those telltale speckled leaves are found.",
                 "exp": 20,
                 "weight": 20,
                 "stat_skill": ["SENSE,2", "CLEVER,3"],
@@ -3273,7 +3061,7 @@
         ],
         "fail_outcomes": [
             {
-                "text": "The cats search and search until {PRONOUN/p_l/poss} pawpads are sore and {PRONOUN/p_l/poss} muscles exhausted, but {PRONOUN/p_l/subject} just can't find lungwort anywhere. p_l returns to camp disappointed, but determined to try again. It's simply too important to not keep a good supply of.",
+                "text": "p_l seems to have forgotten where to find a lungwort plant, much to {PRONOUN/p_l/poss} embarrassment and the rest of the patrol's frustration. It's such an important herb, too! {PRONOUN/p_l/subject/CAP} {VERB/p_l/resolve/resolves} to make a better mental note next time {PRONOUN/p_l/subject} {VERB/p_l/find/finds} some.",
                 "exp": 0,
                 "weight": 20,
                 "relationships": [
@@ -3303,7 +3091,7 @@
                 ]
             },
             {
-                "text": "The cats search and search until {PRONOUN/p_l/poss} pawpads are sore and {PRONOUN/p_l/poss} muscles exhausted, but {PRONOUN/p_l/subject} just can't find lungwort anywhere. p_l returns to camp disappointed, but determined to try again. It's simply too important to not keep a good supply of.",
+                "text": "The cats search and search until their pawpads are sore and their muscles exhausted, but they just can't find lungwort anywhere. p_l returns to camp disappointed, but determined to try again. It's simply too important to not keep a good supply of.",
                 "exp": 0,
                 "weight": 10,
                 "injury": [
@@ -3341,7 +3129,7 @@
         },
         "weight": 20,
         "intro_text": "Greenleaf is truly the best time of year to be a medicine cat, with the world so full of flowers and green growth. p_l heads out to gather fresh mallow for the stores.",
-        "decline_text": "They have second thoughts about leaving their patients behind, and decide to go another day.",
+        "decline_text": "{PRONOUN/p_l/poss/CAP} {VERB/p_l/have/has} second thoughts about leaving {PRONOUN/p_l/poss} patients behind, and {VERB/p_l/decide/decides} to go another day.",
         "chance_of_success": 70,
         "success_outcomes": [
             {
@@ -3390,7 +3178,7 @@
         },
         "weight": 20,
         "intro_text": "Greenleaf is truly the best time of year to be a medicine cat, with the world so full of flowers and green growth. p_l heads out to gather fresh mallow for the stores with app1.",
-        "decline_text": "They have second thoughts leaving their patients behind, especially with them also bringing their apprentice, and decide to go another day.",
+        "decline_text": "{PRONOUN/p_l/subject/CAP} {VERB/p_l/have/has} second thoughts about leaving {PRONOUN/p_l/poss} patients behind, especially with {PRONOUN/p_l/poss} apprentice along too, and {VERB/p_l/decide/decides} to go another day.",
         "chance_of_success": 70,
         "success_outcomes": [
             {
@@ -3505,7 +3293,7 @@
         "chance_of_success": 30,
         "success_outcomes": [
             {
-                "text": "The soft, rose-like scent of the mallow bushes drifts around p_l and app1 as they work. They snip off clumps of large, fuzzy, three-nubbed leaves, and the occasional pink flower, to be taken back to camp. The patrol chats as they work, exchanging gossip and news as the smell of cut stems wreathes around them.",
+                "text": "The soft, rose-like scent of the mallow bushes drifts around p_l and {PRONOUN/p_l/poss} Clanmates as they work. They snip off clumps of large, fuzzy, three-nubbed leaves, and the occasional pink flower, to be taken back to camp. The patrol chats as they work, exchanging gossip and news as the smell of cut stems wreathes around them.",
                 "exp": 10,
                 "weight": 20,
                 "herbs": ["mallow"],
@@ -3612,7 +3400,7 @@
         },
         "weight": 20,
         "intro_text": "More marigold would be useful, particularly with greenleaf in full swing. The season will bring the marigold to bloom, and the flowers are just as useful as the leaves to p_l, <i>and</i> extremely easy to spot from a distance.",
-        "decline_text": "They have second thoughts about leaving their patients behind, and decide to go another day.",
+        "decline_text": "{PRONOUN/p_l/poss/CAP} {VERB/p_l/have/has} second thoughts about leaving {PRONOUN/p_l/poss} patients behind, and {VERB/p_l/decide/decides} to go another day.",
         "chance_of_success": 70,
         "success_outcomes": [
             {
@@ -3620,12 +3408,6 @@
                 "exp": 10,
                 "weight": 20,
                 "herbs": ["marigold"]
-            },
-            {
-                "text": "s_c finds a patch of marigold, harvests its best leaves and flowers, and pads home, unaware of how much of {PRONOUN/s_c/poss} success rests on {PRONOUN/s_c/poss} talent for herb gathering.",
-                "exp": 10,
-                "weight": 5,
-                "herbs": ["many_herbs", "marigold"]
             },
             {
                 "text": "s_c finds a patch of marigold, harvests its best leaves and flowers, and pads home, unaware of how much of {PRONOUN/s_c/poss} success rests on {PRONOUN/s_c/poss} talent for herb gathering.",
@@ -3661,7 +3443,7 @@
         },
         "weight": 20,
         "intro_text": "More marigold would be useful, particularly with greenleaf in full swing. The season will bring the marigold to bloom, and the flowers are just as useful as the leaves to p_l, <i>and</i> extremely easy to spot from a distance with app1.",
-        "decline_text": "They have second thoughts leaving their patients behind, especially with them also bringing their apprentice, and decide to go another day.",
+        "decline_text": "{PRONOUN/p_l/subject/CAP} {VERB/p_l/have/has} second thoughts about leaving {PRONOUN/p_l/poss} patients behind, especially with {PRONOUN/p_l/poss} apprentice along too, and {VERB/p_l/decide/decides} to go another day.",
         "chance_of_success": 70,
         "success_outcomes": [
             {
@@ -3687,7 +3469,7 @@
                 ]
             },
             {
-                "text": "It stops infection, bleeding, <i>and</i> sore joints - why would any medicine cat ever want to risk running out of it? p_l brings back as much marigold as {PRONOUN/p_l/subject} can stuff into {PRONOUN/p_l/poss} mouth, and app1 actually drops some of the leaves {PRONOUN/p_l/subject} {VERB/p_l/carry/carries} on the way back to camp, a little over-ambitious with how much {PRONOUN/p_l/subject} can carry.",
+                "text": "It stops infection, bleeding, <i>and</i> sore joints - why would any medicine cat ever want to risk running out of it? p_l brings back as much marigold as {PRONOUN/p_l/subject} can stuff into {PRONOUN/p_l/poss} mouth, and app1 actually drops some of the leaves {PRONOUN/app1/subject} {VERB/app1/carry/carries} on the way back to camp, a little over-ambitious with how much {PRONOUN/app1/subject} can carry.",
                 "exp": 20,
                 "weight": 5,
                 "herbs": ["many_herbs", "marigold"],
@@ -3801,28 +3583,6 @@
             {
                 "text": "s_c finds a patch of marigold, harvests its best leaves and flowers, and pads home, unaware of how much of {PRONOUN/s_c/poss} success rests on {PRONOUN/s_c/poss} talent for herb gathering. The patrol, too, is unaware, but it certainly bolsters their faith in their medicine cat to see {PRONOUN/s_c/subject} succeed with such competence.",
                 "exp": 10,
-                "weight": 5,
-                "herbs": ["many_herbs", "marigold"],
-                "relationships": [
-                    {
-                        "cats_to": ["p_l"],
-                        "cats_from": ["patrol"],
-                        "mutual": false,
-                        "values": ["platonic", "respect"],
-                        "amount": 10
-                    },
-                    {
-                        "cats_to": ["p_l"],
-                        "cats_from": ["patrol"],
-                        "mutual": false,
-                        "values": ["dislike"],
-                        "amount": -10
-                    }
-                ]
-            },
-            {
-                "text": "s_c finds a patch of marigold, harvests its best leaves and flowers, and pads home, unaware of how much of {PRONOUN/s_c/poss} success rests on {PRONOUN/s_c/poss} talent for herb gathering. The patrol, too, is unaware, but it certainly bolsters their faith in their medicine cat to see {PRONOUN/s_c/subject} succeed with such competence.",
-                "exp": 10,
                 "weight": 20,
                 "stat_skill": ["SENSE,2"],
                 "herbs": ["many_herbs", "marigold"],
@@ -3884,20 +3644,14 @@
         },
         "weight": 20,
         "intro_text": "As the mullein starts to tower over the other plants, it's a good time to harvest it.",
-        "decline_text": "They have second thoughts about leaving their patients behind, and decide to go another day.",
+        "decline_text": "{PRONOUN/p_l/poss/CAP} {VERB/p_l/have/has} second thoughts about leaving {PRONOUN/p_l/poss} patients behind, and {VERB/p_l/decide/decides} to go another day.",
         "chance_of_success": 70,
         "success_outcomes": [
             {
-                "text": "p_l spots the mullein plants by scrambling up onto a low rock and looking for their sapling-like, fat, towering stems starting to poke over all the other plants. {PRONOUN/p_l/subject/CAP} hop down to trot over and harvest them.",
+                "text": "p_l spots the mullein plants by scrambling up onto a low rock and looking for their sapling-like, fat, towering stems starting to poke over all the other plants. {PRONOUN/p_l/subject/CAP} {VERB/p_l/hop/hops} down to trot over and harvest them.",
                 "exp": 10,
                 "weight": 20,
                 "herbs": ["mullein"]
-            },
-            {
-                "text": "The always-reliable s_c spots mullein plants growing plenty of leaves on their strange central stems, and knocks them over so that the entire bundle can be carried home.",
-                "exp": 10,
-                "weight": 5,
-                "herbs": ["many_herbs", "mullein"]
             },
             {
                 "text": "The always-reliable s_c spots mullein plants growing plenty of leaves on their strange central stems, and knocks them over so that the entire bundle can be carried home.",
@@ -3933,11 +3687,11 @@
         },
         "weight": 20,
         "intro_text": "As the mullein starts to tower over the other plants, it's a good time to harvest it. p_l explains to app1 how mullein's height make it easy to spot from a distance.",
-        "decline_text": "They have second thoughts leaving their patients behind, especially with them also bringing their apprentice, and decide to go another day.",
+        "decline_text": "{PRONOUN/p_l/subject/CAP} {VERB/p_l/have/has} second thoughts about leaving {PRONOUN/p_l/poss} patients behind, especially with {PRONOUN/p_l/poss} apprentice along too, and {VERB/p_l/decide/decides} to go another day.",
         "chance_of_success": 70,
         "success_outcomes": [
             {
-                "text": "p_l spots the mullein plants by scrambling up onto a low rock and looking for their sapling-like, fat, towering stems starting to poke over all the other plants. Once {PRONOUN/p_l/subject}{VERB/p_l/'ve/'s} called app1 up to have a look, {PRONOUN/p_l/subject} hop down to trot over and harvest them.",
+                "text": "p_l spots the mullein plants by scrambling up onto a low rock and looking for their sapling-like, fat, towering stems starting to poke over all the other plants. Once {PRONOUN/p_l/subject}{VERB/p_l/'ve/'s} called app1 up to have a look, {PRONOUN/p_l/subject} {VERB/p_l/hop/hops} down to trot over and harvest them.",
                 "exp": 20,
                 "weight": 20,
                 "herbs": ["mullein"],
@@ -4043,12 +3797,12 @@
             "normal adult": [1, 6]
         },
         "weight": 20,
-        "intro_text": "As the mullein starts to tower over the other plants, it's a good time to harvest it.",
+        "intro_text": "As the mullein starts to tower over the other plants, it's a good time to harvest it. p_l heads out to gather some with a patrol of {PRONOUN/p_l/poss} Clanmates along to assist {PRONOUN/p_l/object}.",
         "decline_text": "{PRONOUN/p_l/subject/CAP}{VERB/p_l/'re/'s} stopped before {PRONOUN/p_l/subject} {VERB/p_l/leave/leaves} camp - these warriors are needed elsewhere. p_l's expedition will have to wait.",
         "chance_of_success": 30,
         "success_outcomes": [
             {
-                "text": "p_l spots the mullein plants by scrambling up onto a low rock and looking for their sapling-like, fat, towering stems starting to poke over all the other plants. {PRONOUN/p_l/subject/CAP} hop down to trot over and harvest them with the rest of the patrol.",
+                "text": "p_l spots the mullein plants by scrambling up onto a low rock and looking for their sapling-like, fat, towering stems starting to poke over all the other plants. {PRONOUN/p_l/subject/CAP} {VERB/p_l/hop/hops} down to trot over and harvest them with the rest of the patrol.",
                 "exp": 10,
                 "weight": 20,
                 "herbs": ["mullein"],
@@ -4070,7 +3824,7 @@
                 ]
             },
             {
-                "text": "Easing the lungs of those with weaker chest muscles or infections, helping with certain sorts of pain, <i>and</i> being used to treat unhappy guts - mullein is a good herb to keep in stock, even without the glamour of catmint or the rarity of lungwort. The warriors helping p_l don't understand the importance, but obligingly help {PRONOUN/p_l/subject} harvest it.",
+                "text": "Easing the lungs of those with weaker chest muscles or infections, helping with certain sorts of pain, <i>and</i> being used to treat unhappy guts - mullein is a good herb to keep in stock, even without the glamour of catmint or the rarity of lungwort. The warriors helping p_l don't understand the importance, but obligingly help {PRONOUN/p_l/object} harvest it.",
                 "exp": 10,
                 "weight": 5,
                 "herbs": ["many_herbs", "mullein"],
@@ -4155,7 +3909,7 @@
         },
         "weight": 20,
         "intro_text": "Greenleaf encourages the oak to reach its full potential, wide and towering, and p_l goes to collect a harvest of its leaves.",
-        "decline_text": "They have second thoughts about leaving their patients behind, and decide to go another day.",
+        "decline_text": "{PRONOUN/p_l/poss/CAP} {VERB/p_l/have/has} second thoughts about leaving {PRONOUN/p_l/poss} patients behind, and {VERB/p_l/decide/decides} to go another day.",
         "chance_of_success": 70,
         "success_outcomes": [
             {
@@ -4163,12 +3917,6 @@
                 "exp": 10,
                 "weight": 20,
                 "herbs": ["oak_leaves"]
-            },
-            {
-                "text": "s_c spots an oak tree that's valiantly trying to sprout leaves from a half fallen branch, one of the casualties of last leaf-bare, and heads to harvest from that, taking the safe option of plucking leaves from the ground rather than clambering up into the towering branches.",
-                "exp": 10,
-                "weight": 5,
-                "herbs": ["many_herbs", "oak_leaves"]
             },
             {
                 "text": "s_c spots an oak tree that's valiantly trying to sprout leaves from a half fallen branch, one of the casualties of last leaf-bare, and heads to harvest from that, taking the safe option of plucking leaves from the ground rather than clambering up into the towering branches.",
@@ -4204,7 +3952,7 @@
         },
         "weight": 20,
         "intro_text": "Greenleaf encourages the oak to reach its full potential, wide and towering, and p_l goes to collect a harvest of its leaves with app1.",
-        "decline_text": "They have second thoughts leaving their patients behind, especially with them also bringing their apprentice, and decide to go another day.",
+        "decline_text": "{PRONOUN/p_l/subject/CAP} {VERB/p_l/have/has} second thoughts about leaving {PRONOUN/p_l/poss} patients behind, especially with {PRONOUN/p_l/poss} apprentice along too, and {VERB/p_l/decide/decides} to go another day.",
         "chance_of_success": 70,
         "success_outcomes": [
             {
@@ -4426,7 +4174,7 @@
         },
         "weight": 20,
         "intro_text": "As the plantain starts to choke off the paths the Clan uses to get about, fuelled by greenleaf, it's a great time to clean up the paths and bring a good harvest home.",
-        "decline_text": "They have second thoughts about leaving their patients behind, and decide to go another day.",
+        "decline_text": "{PRONOUN/p_l/poss/CAP} {VERB/p_l/have/has} second thoughts about leaving {PRONOUN/p_l/poss} patients behind, and {VERB/p_l/decide/decides} to go another day.",
         "chance_of_success": 70,
         "success_outcomes": [
             {
@@ -4474,8 +4222,8 @@
             "normal adult": [-1, -1]
         },
         "weight": 20,
-        "intro_text": "As the plantain starts to choke off the paths the Clan uses to get about, fuelled by greenleaf, it's a great time to clean up the paths and bring a good harvest home. app1 asks why the plant might choose such a strange spot to grow, and p_l gives them {PRONOUN/p_l/poss} best guess.",
-        "decline_text": "They have second thoughts leaving their patients behind, especially with them also bringing their apprentice, and decide to go another day.",
+        "intro_text": "As the plantain starts to choke off the paths the Clan uses to get about, fuelled by greenleaf, it's a great time to clean up the paths and bring a good harvest home. app1 asks why the plant might choose such a strange spot to grow, and p_l gives {PRONOUN/app1/object} {PRONOUN/p_l/poss} best guess.",
+        "decline_text": "{PRONOUN/p_l/subject/CAP} {VERB/p_l/have/has} second thoughts about leaving {PRONOUN/p_l/poss} patients behind, especially with {PRONOUN/p_l/poss} apprentice along too, and {VERB/p_l/decide/decides} to go another day.",
         "chance_of_success": 70,
         "success_outcomes": [
             {
@@ -4501,29 +4249,7 @@
                 ]
             },
             {
-                "text": "Go to where other animals wander through c_n's territory on little, beaten paths, wander around until you bump, nose-first, into a plantain plant, harvest. Simple, p_l teaches app1.",
-                "exp": 20,
-                "weight": 5,
-                "herbs": ["many_herbs", "plantain"],
-                "relationships": [
-                    {
-                        "cats_to": ["patrol"],
-                        "cats_from": ["patrol"],
-                        "mutual": false,
-                        "values": ["platonic", "respect", "comfort", "trust"],
-                        "amount": 10
-                    },
-                    {
-                        "cats_to": ["patrol"],
-                        "cats_from": ["patrol"],
-                        "mutual": false,
-                        "values": ["dislike"],
-                        "amount": -10
-                    }
-                ]
-            },
-            {
-                "text": "Go to where other animals wander through c_n's territory on little, beaten paths, wander around until you bump, nose-first, into a plantain plant, harvest. Simple, p_l teaches app1.",
+                "text": "Go to where other animals wander through c_n's territory on little, beaten paths, wander around until you bump, nose-first, into a plantain plant, harvest. Simple, s_c teaches app1.",
                 "exp": 20,
                 "weight": 20,
                 "stat_skill": ["SENSE,2"],
@@ -4586,7 +4312,7 @@
             "normal adult": [1, 6]
         },
         "weight": 20,
-        "intro_text": "As the plantain starts to choke off the paths the Clan uses to get about, fuelled by greenleaf, it's a great time to clean up the paths and bring a good harvest home. p_l brings along {PRONOUN/p_l/poss} Clanmates, both for carrying and because the deputy has mentioned particular paths {PRONOUN/p_l/subject}'d really like cleared.",
+        "intro_text": "As the plantain starts to choke off the paths the Clan uses to get about, fuelled by greenleaf, it's a great time to clean up the paths and bring a good harvest home. p_l brings along {PRONOUN/p_l/poss} Clanmates, both for carrying and because the deputy has mentioned particular paths they'd really like cleared.",
         "decline_text": "{PRONOUN/p_l/subject/CAP}{VERB/p_l/'re/'s} stopped before {PRONOUN/p_l/subject} {VERB/p_l/leave/leaves} camp - these warriors are needed elsewhere. p_l's expedition will have to wait.",
         "chance_of_success": 30,
         "success_outcomes": [
@@ -4698,7 +4424,7 @@
         },
         "weight": 20,
         "intro_text": "With greenleaf bringing the poppies to seed, and only so much time before the plants die off in leaf-fall, p_l is keen to go collect as much as possible.",
-        "decline_text": "They have second thoughts about leaving their patients behind, and decide to go another day.",
+        "decline_text": "{PRONOUN/p_l/poss/CAP} {VERB/p_l/have/has} second thoughts about leaving {PRONOUN/p_l/poss} patients behind, and {VERB/p_l/decide/decides} to go another day.",
         "chance_of_success": 70,
         "success_outcomes": [
             {
@@ -4747,7 +4473,7 @@
         },
         "weight": 20,
         "intro_text": "With greenleaf bringing the poppies to seed, and only so much time before the plants die off in leaf-fall, p_l is keen to go collect as much as possible. Even app1 knows how much the Clan depends on poppy seeds being in their herb stores.",
-        "decline_text": "They have second thoughts leaving their patients behind, especially with them also bringing their apprentice, and decide to go another day.",
+        "decline_text": "{PRONOUN/p_l/subject/CAP} {VERB/p_l/have/has} second thoughts about leaving {PRONOUN/p_l/poss} patients behind, especially with {PRONOUN/p_l/poss} apprentice along too, and {VERB/p_l/decide/decides} to go another day.",
         "chance_of_success": 70,
         "success_outcomes": [
             {
@@ -4906,7 +4632,7 @@
                 ]
             },
             {
-                "text": "s_c uses the bright flowers to find the plants quickly, determined to bring back as many poppy seeds as possible. The rest of the patrol, knowing how important poppy seeds are as a painkiller, work hard, both for s_c and all of c_n.",
+                "text": "s_c uses the bright flowers to find the plants quickly, determined to bring back as many poppy seeds as possible. The rest of the patrol, knowing how important poppy seeds are as a painkiller, works hard, both for s_c and all of c_n.",
                 "exp": 10,
                 "weight": 20,
                 "stat_skill": ["SENSE,2"],
@@ -4969,7 +4695,7 @@
         },
         "weight": 20,
         "intro_text": "p_l heads out to find ragwort, holding the particular fractal shape of its furled leaves in {PRONOUN/p_l/poss} mind to distinguish it from every other low growing patch of greenery.",
-        "decline_text": "They have second thoughts about leaving their patients behind, and decide to go another day.",
+        "decline_text": "{PRONOUN/p_l/poss/CAP} {VERB/p_l/have/has} second thoughts about leaving {PRONOUN/p_l/poss} patients behind, and {VERB/p_l/decide/decides} to go another day.",
         "chance_of_success": 70,
         "success_outcomes": [
             {
@@ -4979,7 +4705,7 @@
                 "herbs": ["ragwort"]
             },
             {
-                "text": "Ragwort brings strength to cats who need it, and eases aching joints, but StarClan it tastes absolutely <i>foul.</i> p_l's pleased with {PRONOUN/p_l/poss} harvest, but really wishes {PRONOUN/p_l/subject} had a way to bring it back to camp that didn't need {PRONOUN/p_l/subject} to carry it in {PRONOUN/p_l/poss} mouth.",
+                "text": "Ragwort brings strength to cats who need it, and eases aching joints, but StarClan it tastes absolutely <i>foul.</i> p_l's pleased with {PRONOUN/p_l/poss} harvest, but really wishes {PRONOUN/p_l/subject} had a way to bring it back to camp that didn't need {PRONOUN/p_l/object} to carry it in {PRONOUN/p_l/poss} mouth.",
                 "exp": 10,
                 "weight": 5,
                 "herbs": ["many_herbs", "ragwort"]
@@ -5018,7 +4744,7 @@
         },
         "weight": 20,
         "intro_text": "p_l heads out to find ragwort, holding the particular fractal shape of its furled leaves in {PRONOUN/p_l/poss} mind to distinguish it from every other low growing patch of greenery, and doing {PRONOUN/p_l/poss} best to describe the shape to app1.",
-        "decline_text": "They have second thoughts leaving their patients behind, especially with them also bringing their apprentice, and decide to go another day.",
+        "decline_text": "{PRONOUN/p_l/subject/CAP} {VERB/p_l/have/has} second thoughts about leaving {PRONOUN/p_l/poss} patients behind, especially with {PRONOUN/p_l/poss} apprentice along too, and {VERB/p_l/decide/decides} to go another day.",
         "chance_of_success": 70,
         "success_outcomes": [
             {
@@ -5044,7 +4770,7 @@
                 ]
             },
             {
-                "text": "Ragwort brings strength to cats who need it, and eases aching joints, but StarClan it tastes absolutely <i>foul.</i> p_l's pleased with {PRONOUN/p_l/poss} harvest, but really wishes {PRONOUN/p_l/subject} had a way to bring it back to camp that didn't need {PRONOUN/p_l/subject} to carry it in {PRONOUN/p_l/poss} mouth, and has a lot of sympathy for app1's disgusted expression.",
+                "text": "Ragwort brings strength to cats who need it, and eases aching joints, but StarClan it tastes absolutely <i>foul.</i> p_l's pleased with {PRONOUN/p_l/poss} harvest, but really wishes {PRONOUN/p_l/subject} had a way to bring it back to camp that didn't need {PRONOUN/p_l/object} to carry it in {PRONOUN/p_l/poss} mouth, and has a lot of sympathy for app1's disgusted expression.",
                 "exp": 20,
                 "weight": 5,
                 "herbs": ["many_herbs", "ragwort"],
@@ -5066,7 +4792,7 @@
                 ]
             },
             {
-                "text": "s_c has discovered a trick to harvesting the bountiful, but foul, ragwort - using {PRONOUN/s_c/poss} claws to tear leaves from the plant, then carefully carrying {PRONOUN/s_c/object} back to camp without chewing or salivating. It's difficult, but doable, if only just, and app1 is desperately grateful to learn the trick.",
+                "text": "s_c has discovered a trick to harvesting the bountiful, but foul, ragwort - using {PRONOUN/s_c/poss} claws to tear leaves from the plant, then carefully carrying them back to camp without chewing or salivating. It's difficult, but doable, if only just, and app1 is desperately grateful to learn the trick.",
                 "exp": 20,
                 "weight": 20,
                 "stat_skill": ["CLEVER,1"],
@@ -5133,7 +4859,7 @@
         "chance_of_success": 30,
         "success_outcomes": [
             {
-                "text": "Ugh. The ragwort p_l finds is flowering, and the yellow flowers of the plant waft out their scent, leaving a foul taste hanging in the air. There a chorus of long suffering sighs as the cats get to work, accomplishing {PRONOUN/p_l/poss} unpleasant task professionally, but without any joy.",
+                "text": "Ugh. The ragwort p_l finds is flowering, and the yellow flowers of the plant waft out their scent, leaving a foul taste hanging in the air. There a chorus of long suffering sighs as the cats get to work, accomplishing their unpleasant task professionally, but without any joy.",
                 "exp": 10,
                 "weight": 20,
                 "herbs": ["ragwort"],
@@ -5155,7 +4881,7 @@
                 ]
             },
             {
-                "text": "Ragwort brings strength to cats who need it, and eases aching joints, but StarClan it tastes absolutely <i>foul.</i> p_l's pleased with {PRONOUN/p_l/poss} harvest, but really wishes {PRONOUN/p_l/subject} had a way to bring it back to camp that didn't need {PRONOUN/p_l/subject} to carry it in {PRONOUN/p_l/poss} mouth, a sentiment that the patrol helping {PRONOUN/p_l/subject} definitely shares... at length, very descriptively.",
+                "text": "Ragwort brings strength to cats who need it, and eases aching joints, but StarClan it tastes absolutely <i>foul.</i> p_l's pleased with {PRONOUN/p_l/poss} harvest, but really wishes {PRONOUN/p_l/subject} had a way to bring it back to camp that didn't need {PRONOUN/p_l/object} to carry it in {PRONOUN/p_l/poss} mouth, a sentiment that the patrol helping {PRONOUN/p_l/object} definitely shares... at length, very descriptively.",
                 "exp": 10,
                 "weight": 5,
                 "herbs": ["many_herbs", "ragwort"],
@@ -5177,7 +4903,7 @@
                 ]
             },
             {
-                "text": "s_c has discovered a trick to harvesting the bountiful, but foul, ragwort - using {PRONOUN/s_c/poss} claws to tear leaves from the plant, then carefully carrying {PRONOUN/s_c/object} back to camp without chewing or salivating. Some of the warriors are too impatient to follow {PRONOUN/s_c/poss} lead, and end up suffering the taste of ragwort as the patrol brings back loads of the leaves.",
+                "text": "s_c has discovered a trick to harvesting the bountiful, but foul, ragwort - using {PRONOUN/s_c/poss} claws to tear leaves from the plant, then carefully carrying them back to camp without chewing or salivating. Some of the warriors are too impatient to follow {PRONOUN/s_c/poss} lead, and end up suffering the taste of ragwort as the patrol brings back loads of the leaves.",
                 "exp": 10,
                 "weight": 20,
                 "stat_skill": ["CLEVER,1"],
@@ -5266,18 +4992,16 @@
                 "weight": 20
             },
             {
-                "text": "While plucking {PRONOUN/p_l/object} from the bush, p_l feels one of the berries split in {PRONOUN/p_l/poss} mouth, and a deceptively good taste coats {PRONOUN/p_l/poss} tongue. These aren't raspberries. {PRONOUN/p_l/subject/CAP} {VERB/p_l/rush/rushes} to force {PRONOUN/p_l/self} to throw up, and it works, expelling the deathberries from {PRONOUN/p_l/poss} system, but {PRONOUN/p_l/subject}{VERB/p_l/'re/'s} weak and shaky for the rest of the day.",
-                "exp": 0,
-                "weight": 20
-            },
-            {
-                "text": "While plucking {PRONOUN/p_l/object} from the bush, p_l feels one of the berries split in {PRONOUN/p_l/poss} mouth, and a deceptively good taste coats {PRONOUN/p_l/poss} tongue. These aren't raspberries. {PRONOUN/p_l/subject/CAP} {VERB/p_l/rush/rushes} to force {PRONOUN/p_l/self} to throw up, and it works, expelling the deathberries from {PRONOUN/p_l/poss} system, but {PRONOUN/p_l/subject}{VERB/p_l/'re/'s} weak and shaky for the rest of the day.",
+                "text": "While plucking them from the bush, p_l feels one of the berries split in {PRONOUN/p_l/poss} mouth, and a deceptively good taste coats {PRONOUN/p_l/poss} tongue. These aren't raspberries. {PRONOUN/p_l/subject/CAP} {VERB/p_l/rush/rushes} to force {PRONOUN/p_l/self} to throw up, but it's too late. {PRONOUN/p_l/subject/CAP} {VERB/p_l/do/does}n't make it back to camp.",
                 "exp": 0,
                 "weight": 10,
-                "dead_cats": ["r_c"]
+                "dead_cats": ["r_c"],
+                "history_text": {
+                    "reg_death": "r_c died from accidentally eating deathberries."
+                }
             },
             {
-                "text": "While plucking {PRONOUN/p_l/object} from the bush, p_l feels one of the berries split in {PRONOUN/p_l/poss} mouth, and a deceptively good taste coats {PRONOUN/p_l/poss} tongue. These aren't raspberries. {PRONOUN/p_l/subject/CAP} {VERB/p_l/rush/rushes} to force {PRONOUN/p_l/self} to throw up, and it works, expelling the deathberries from {PRONOUN/p_l/poss} system, but {PRONOUN/p_l/subject}{VERB/p_l/'re/'s} weak and shaky for the rest of the day.",
+                "text": "While plucking them from the bush, p_l feels one of the berries split in {PRONOUN/p_l/poss} mouth, and a deceptively good taste coats {PRONOUN/p_l/poss} tongue. These aren't raspberries. {PRONOUN/p_l/subject/CAP} {VERB/p_l/rush/rushes} to force {PRONOUN/p_l/self} to throw up, and it works, expelling the deathberries from {PRONOUN/p_l/poss} system, but {PRONOUN/p_l/subject}{VERB/p_l/'re/'s} weak and shaky for the rest of the day.",
                 "exp": 0,
                 "weight": 10,
                 "injury": [
@@ -5286,7 +5010,10 @@
                         "injuries": ["poisoned"],
                         "scars": []
                     }
-                ]
+                ],
+                "history_text": {
+                    "reg_death": "r_c died from accidentally eating deathberries."
+                }
             }
         ]
     },
@@ -5316,24 +5043,19 @@
                 "herbs": ["raspberry"]
             },
             {
-                "text": "These... could be deathberries. Might be raspberries. But maybe deathberries. It's not worth the risk, they can ask their mentor for more training about it later.",
+                "text": "These... could be deathberries. Might be raspberries. But maybe deathberries. It's not worth the risk, {PRONOUN/app1/subject} can ask {PRONOUN/app1/poss} mentor for more training about it later.",
                 "exp": 30,
                 "weight": 5
             }
         ],
         "fail_outcomes": [
             {
-                "text": "Confidently gathering them and prancing back to camp, app1 is then informed that {PRONOUN/app1/subject}{VERB/app1/'ve/'s} gathered raspberries, not cranberries, and this isn't going to help the Clan's elders with their problems.",
+                "text": "Confidently gathering them and prancing back to camp, app1 is then informed that {PRONOUN/app1/subject}{VERB/app1/'ve/'s} gathered cranberries, not raspberries, and this isn't going to help the Clan's elders with their problems.",
                 "exp": 0,
                 "weight": 20
             },
             {
                 "text": "app1 plucks the berries, several splitting in {PRONOUN/app1/poss} mouth, and is surprised at how good they taste - after all, every herb {PRONOUN/app1/subject}{VERB/app1/'re/'s} trying to learn tastes awful, so it's surprising that one tastes good. As {PRONOUN/app1/subject} {VERB/app1/start/starts} back to camp, however, {PRONOUN/app1/subject} {VERB/app1/wobble/wobbles} a bit, and the world goes dark. {PRONOUN/app1/poss/CAP} body is found soon after, but it's already too late to help.",
-                "exp": 0,
-                "weight": 20
-            },
-            {
-                "text": "app1 carefully plucks the delicious-tasting berries, and as soon as the deceptive taste hits {PRONOUN/app1/poss} tongue, {PRONOUN/app1/subject} {VERB/app1/realize/realizes} {PRONOUN/app1/subject}{VERB/app1/'ve/'s} made a terrible mistake. Trying to force themself to vomit and staggering weakly, {PRONOUN/app1/subject} {VERB/app1/crawl/crawls} back to camp, weakly hoping {PRONOUN/app1/poss} mentor will help {PRONOUN/app1/object}.",
                 "exp": 0,
                 "weight": 10,
                 "dead_cats": ["r_c"],
@@ -5342,7 +5064,7 @@
                 }
             },
             {
-                "text": "app1 carefully plucks the delicious-tasting berries, and as soon as the deceptive taste hits {PRONOUN/app1/poss} tongue, {PRONOUN/app1/subject} {VERB/app1/realize/realizes} {PRONOUN/app1/subject}{VERB/app1/'ve/'s} made a terrible mistake. Trying to force themself to vomit and staggering weakly, {PRONOUN/app1/subject} {VERB/app1/crawl/crawls} back to camp, weakly hoping {PRONOUN/app1/poss} mentor will help {PRONOUN/app1/object}.",
+                "text": "app1 carefully plucks the delicious-tasting berries, and as soon as the deceptive taste hits {PRONOUN/app1/poss} tongue, {PRONOUN/app1/subject} {VERB/app1/realize/realizes} {PRONOUN/app1/subject}{VERB/app1/'ve/'s} made a terrible mistake. Trying to force {PRONOUN/app1/self} to vomit and staggering weakly, {PRONOUN/app1/subject} {VERB/app1/crawl/crawls} back to camp, weakly hoping {PRONOUN/app1/poss} mentor will help {PRONOUN/app1/object}.",
                 "exp": 0,
                 "weight": 10,
                 "injury": [
@@ -5374,7 +5096,7 @@
         },
         "weight": 20,
         "intro_text": "p_l heads out to find tansy, scenting the air for its sharp smell and eyes on the lookout for tansy's strange, orb-like yellow flowers that greenleaf has brought out in abundance.",
-        "decline_text": "They have second thoughts about leaving their patients behind, and decide to go another day.",
+        "decline_text": "{PRONOUN/p_l/poss/CAP} {VERB/p_l/have/has} second thoughts about leaving {PRONOUN/p_l/poss} patients behind, and {VERB/p_l/decide/decides} to go another day.",
         "chance_of_success": 70,
         "success_outcomes": [
             {
@@ -5382,12 +5104,6 @@
                 "exp": 10,
                 "weight": 20,
                 "herbs": ["tansy"]
-            },
-            {
-                "text": "Tansy might smell sharp enough to be enjoyed freshening up dens, but it sure tastes... interesting. s_c isn't sure {PRONOUN/s_c/subject}'ll ever get used to it, but at least it's a reminder to be careful around the potentially poisonous herb.",
-                "exp": 10,
-                "weight": 5,
-                "herbs": ["many_herbs", "tansy"]
             },
             {
                 "text": "Tansy might smell sharp enough to be enjoyed freshening up dens, but it sure tastes... interesting. s_c isn't sure {PRONOUN/s_c/subject}'ll ever get used to it, but at least it's a reminder to be careful around the potentially poisonous herb.",
@@ -5422,12 +5138,12 @@
             "normal adult": [-1, -1]
         },
         "weight": 20,
-        "intro_text": "p_l heads out to find tansy with app1. {PRONOUN/p_l/subject/CAP} {VERB/p_l/instruct/instructs} app1 to scent the air for its sharp smell and keep {PRONOUN/p_l/poss} eyes on the lookout for tansy's strange, orb-like yellow flowers that greenleaf has brought out in abundance.",
-        "decline_text": "They have second thoughts leaving their patients behind, especially with them also bringing their apprentice, and decide to go another day.",
+        "intro_text": "p_l heads out to find tansy with app1. {PRONOUN/p_l/subject/CAP} {VERB/p_l/instruct/instructs} app1 to scent the air for its sharp smell and keep {PRONOUN/app1/poss} eyes on the lookout for tansy's strange, orb-like yellow flowers that greenleaf has brought out in abundance.",
+        "decline_text": "{PRONOUN/p_l/subject/CAP} {VERB/p_l/have/has} second thoughts about leaving {PRONOUN/p_l/poss} patients behind, especially with {PRONOUN/p_l/poss} apprentice along too, and {VERB/p_l/decide/decides} to go another day.",
         "chance_of_success": 70,
         "success_outcomes": [
             {
-                "text": "The yellow dew drops shining merrily in the distance guide app1 in to the tansy patch, where {PRONOUN/p_l/subject} {VERB/p_l/take/takes} a good harvest. p_l is proud of the work {PRONOUN/p_l/subject}{VERB/p_l/'ve/'s} put in to learning so many things so quickly.",
+                "text": "The yellow dew drops shining merrily in the distance guide app1 in to the tansy patch, where the cats take a good harvest. p_l is proud of the work app1 has put in to learning so many things so quickly.",
                 "exp": 20,
                 "weight": 20,
                 "herbs": ["tansy"],
@@ -5538,7 +5254,7 @@
         "chance_of_success": 30,
         "success_outcomes": [
             {
-                "text": "The yellow dew drops shining merrily in the distance guide p_l's patrol in to the tansy patch, where {PRONOUN/p_l/subject} {VERB/p_l/take/takes} a good harvest.",
+                "text": "The yellow dew drops shining merrily in the distance guide p_l's patrol in to the tansy patch, where {PRONOUN/p_l/subject} {VERB/p_l/take/takes} a good harvest with the warriors' help.",
                 "exp": 10,
                 "weight": 20,
                 "herbs": ["tansy"],
@@ -5560,7 +5276,7 @@
                 ]
             },
             {
-                "text": "Good for all coughs, all wounds, and all poisons - but it would be dangerous to assume tansy has no downsides. In small doses, it does help with nearly any ailment, but in <i>large</i> doses, it poisons the body, even to the point of death. p_l carefully guides the patrol in gathering, though unless they try drinking it, there isn't much danger.",
+                "text": "Good for all coughs, all wounds, and all poisons - but it would be dangerous to assume tansy has no downsides. In small doses, it does help with nearly any ailment, but in <i>large</i> doses, it poisons the body, even to the point of death. p_l carefully guides the patrol in gathering, though unless they try drinking its sap, there isn't much danger.",
                 "exp": 10,
                 "weight": 5,
                 "herbs": ["many_herbs", "tansy"],
@@ -5645,7 +5361,7 @@
         },
         "weight": 20,
         "intro_text": "p_l has finally put enough time aside to go search for thyme.",
-        "decline_text": "They have second thoughts about leaving their patients behind, and decide to go another day.",
+        "decline_text": "{PRONOUN/p_l/poss/CAP} {VERB/p_l/have/has} second thoughts about leaving {PRONOUN/p_l/poss} patients behind, and {VERB/p_l/decide/decides} to go another day.",
         "chance_of_success": 70,
         "success_outcomes": [
             {
@@ -5653,12 +5369,6 @@
                 "exp": 10,
                 "weight": 20,
                 "herbs": ["thyme"]
-            },
-            {
-                "text": "Thyme, thyme, thyme, there's never enough thyme. p_l snorts at {PRONOUN/s_c/poss} little joke, mouth crammed full of the herb, as {PRONOUN/p_l/subject} {VERB/p_l/make/makes} {PRONOUN/p_l/poss} way home.",
-                "exp": 10,
-                "weight": 5,
-                "herbs": ["many_herbs", "thyme"]
             },
             {
                 "text": "Thyme, thyme, thyme, there's never enough thyme. s_c snorts at {PRONOUN/s_c/poss} little joke, mouth crammed full of the herb, as {PRONOUN/s_c/subject} {VERB/s_c/make/makes} {PRONOUN/s_c/poss} way home.",
@@ -5694,7 +5404,7 @@
         },
         "weight": 20,
         "intro_text": "p_l has finally put enough time aside to go search for thyme with app1.",
-        "decline_text": "They have second thoughts leaving their patients behind, especially with them also bringing their apprentice, and decide to go another day.",
+        "decline_text": "{PRONOUN/p_l/subject/CAP} {VERB/p_l/have/has} second thoughts about leaving {PRONOUN/p_l/poss} patients behind, especially with {PRONOUN/p_l/poss} apprentice along too, and {VERB/p_l/decide/decides} to go another day.",
         "chance_of_success": 70,
         "success_outcomes": [
             {
@@ -5809,32 +5519,10 @@
         "chance_of_success": 30,
         "success_outcomes": [
             {
-                "text": "It calms racing hearts and minds, bringing cats back from the shock of loss or injury... thyme is always both helpful and pleasant to have around, and p_l decides that this patrol has brought back so much there's no harm in letting the warriors take a stem each for {PRONOUN/p_l/poss} nests.",
+                "text": "It calms racing hearts and minds, bringing cats back from the shock of loss or injury... thyme is always both helpful and pleasant to have around, and p_l decides that this patrol has brought back so much there's no harm in letting the warriors take a stem each for their nests.",
                 "exp": 10,
                 "weight": 20,
                 "herbs": ["thyme"],
-                "relationships": [
-                    {
-                        "cats_to": ["p_l"],
-                        "cats_from": ["patrol"],
-                        "mutual": false,
-                        "values": ["platonic", "respect"],
-                        "amount": 10
-                    },
-                    {
-                        "cats_to": ["p_l"],
-                        "cats_from": ["patrol"],
-                        "mutual": false,
-                        "values": ["dislike"],
-                        "amount": -10
-                    }
-                ]
-            },
-            {
-                "text": "Thyme, thyme, thyme, there's never enough thyme. p_l snorts at {PRONOUN/p_l/poss} little joke, putting down the herbs {PRONOUN/p_l/subject} {VERB/p_l/carry/carries} to explain it to the rest of the patrol.",
-                "exp": 10,
-                "weight": 5,
-                "herbs": ["many_herbs", "thyme"],
                 "relationships": [
                     {
                         "cats_to": ["p_l"],
@@ -5916,7 +5604,7 @@
         },
         "weight": 20,
         "intro_text": "p_l heads out on what promises to be a fragrant patrol, searching for wild garlic.",
-        "decline_text": "They have second thoughts about leaving their patients behind, and decide to go another day.",
+        "decline_text": "{PRONOUN/p_l/poss/CAP} {VERB/p_l/have/has} second thoughts about leaving {PRONOUN/p_l/poss} patients behind, and {VERB/p_l/decide/decides} to go another day.",
         "chance_of_success": 70,
         "success_outcomes": [
             {
@@ -5926,7 +5614,7 @@
                 "herbs": ["wild_garlic"]
             },
             {
-                "text": "The leaves, and especially the bulbs, of wild garlic are the preeminent herb to treat infection, even if using them results each time in either their patient or their loved ones complaining about the smell. p_l, personally, will take a bit of a bad smell over illness, thank you very much.",
+                "text": "The leaves, and especially the bulbs, of wild garlic are the preeminent herb to treat infection, even if using them results each time in either p_l's patient or their loved ones complaining about the smell. p_l, personally, will take a bit of a bad smell over illness, thank you very much.",
                 "exp": 10,
                 "weight": 5,
                 "herbs": ["many_herbs", "wild_garlic"]
@@ -5965,11 +5653,11 @@
         },
         "weight": 20,
         "intro_text": "p_l heads out on what promises to be a fragrant patrol, searching for wild garlic with app1.",
-        "decline_text": "They have second thoughts leaving their patients behind, especially with them also bringing their apprentice, and decide to go another day.",
+        "decline_text": "{PRONOUN/p_l/subject/CAP} {VERB/p_l/have/has} second thoughts about leaving {PRONOUN/p_l/poss} patients behind, especially with {PRONOUN/p_l/poss} apprentice along too, and {VERB/p_l/decide/decides} to go another day.",
         "chance_of_success": 70,
         "success_outcomes": [
             {
-                "text": "This garlic will certainly restock the herb stores... which are close to p_l's nest. Yay... {PRONOUN/p_l/subject} {VERB/p_l/commiserate/commiserates} with app1, both cats sighing but accepting the stink in {PRONOUN/p_l/poss} den as a necessary evil.",
+                "text": "This garlic will certainly restock the herb stores... which are close to p_l's nest. Yay... {PRONOUN/p_l/subject} {VERB/p_l/commiserate/commiserates} with app1, both cats sighing but accepting the stink in their den as a necessary evil.",
                 "exp": 20,
                 "weight": 20,
                 "herbs": ["wild_garlic"],
@@ -5991,7 +5679,7 @@
                 ]
             },
             {
-                "text": "The leaves, and especially the bulbs, of wild garlic are the preeminent herb to treat infection, even if using them results each time in either their patient or their loved ones complaining about the smell. p_l teaches app1 that sometimes, they need to prioritise treating their patients above listening to them.",
+                "text": "The leaves, and especially the bulbs, of wild garlic are the preeminent herb to treat infection, even if using them results each time in either p_l's patient or their loved ones complaining about the smell. p_l teaches app1 that sometimes, they need to prioritise treating their patients above listening to them.",
                 "exp": 20,
                 "weight": 5,
                 "herbs": ["many_herbs", "wild_garlic"],
@@ -6102,7 +5790,7 @@
                 ]
             },
             {
-                "text": "The leaves, and especially the bulbs, of wild garlic are the preeminent herb to treat infection, even if using them results each time in either their patient or their loved ones complaining about the smell. The patrol looks a little disgusted, but they're still a great help to p_l for gathering it.",
+                "text": "The leaves, and especially the bulbs, of wild garlic are the preeminent herb to treat infection, even if using them results each time in either p_l's patient or their loved ones complaining about the smell. The patrol looks a little disgusted, but they're still a great help to p_l for gathering it.",
                 "exp": 10,
                 "weight": 5,
                 "herbs": ["many_herbs", "wild_garlic"],

--- a/resources/dicts/patrols/beach/med/greenleaf.json
+++ b/resources/dicts/patrols/beach/med/greenleaf.json
@@ -1937,7 +1937,7 @@
                 "weight": 10,
                 "dead_cats": ["p_l"],
                 "history_text": {
-                    "reg_death": "p_l died when they fell out of an elder tree."
+                    "reg_death": "m_c died when {PRONOUN/m_c/subject} fell out of an elder tree."
                 }
             },
             {
@@ -2072,7 +2072,7 @@
                 "weight": 10,
                 "dead_cats": ["app1"],
                 "history_text": {
-                    "reg_death": "app1 died before completing their medicine training when they fell out of an elder tree."
+                    "reg_death": "m_c died before completing {PRONOUN/m_c/poss} medicine cat training when {PRONOUN/m_c/subject} fell out of an elder tree."
                 }
             },
             {
@@ -2181,7 +2181,8 @@
                 "weight": 10,
                 "dead_cats": ["r_c"],
                 "history_text": {
-                    "reg_death": "r_c died when they fell out of an elder tree."
+                    "reg_death": "m_c died when {PRONOUN/m_c/subject} fell out of an elder tree.",
+                    "lead_death": "died when {PRONOUN/m_c/subject} fell out of an elder tree"
                 }
             },
             {
@@ -4995,9 +4996,9 @@
                 "text": "While plucking them from the bush, p_l feels one of the berries split in {PRONOUN/p_l/poss} mouth, and a deceptively good taste coats {PRONOUN/p_l/poss} tongue. These aren't raspberries. {PRONOUN/p_l/subject/CAP} {VERB/p_l/rush/rushes} to force {PRONOUN/p_l/self} to throw up, but it's too late. {PRONOUN/p_l/subject/CAP} {VERB/p_l/do/does}n't make it back to camp.",
                 "exp": 0,
                 "weight": 10,
-                "dead_cats": ["r_c"],
+                "dead_cats": ["p_l"],
                 "history_text": {
-                    "reg_death": "r_c died from accidentally eating deathberries."
+                    "reg_death": "m_c died from accidentally eating deathberries."
                 }
             },
             {
@@ -5006,13 +5007,13 @@
                 "weight": 10,
                 "injury": [
                     {
-                        "cats": ["r_c"],
+                        "cats": ["p_l"],
                         "injuries": ["poisoned"],
                         "scars": []
                     }
                 ],
                 "history_text": {
-                    "reg_death": "r_c died from accidentally eating deathberries."
+                    "reg_death": "m_c died from accidentally eating deathberries."
                 }
             }
         ]
@@ -5058,9 +5059,9 @@
                 "text": "app1 plucks the berries, several splitting in {PRONOUN/app1/poss} mouth, and is surprised at how good they taste - after all, every herb {PRONOUN/app1/subject}{VERB/app1/'re/'s} trying to learn tastes awful, so it's surprising that one tastes good. As {PRONOUN/app1/subject} {VERB/app1/start/starts} back to camp, however, {PRONOUN/app1/subject} {VERB/app1/wobble/wobbles} a bit, and the world goes dark. {PRONOUN/app1/poss/CAP} body is found soon after, but it's already too late to help.",
                 "exp": 0,
                 "weight": 10,
-                "dead_cats": ["r_c"],
+                "dead_cats": ["app1"],
                 "history_text": {
-                    "reg_death": "m_c died before completing their medicine cat training, having accidentally eaten deathberries."
+                    "reg_death": "m_c died before completing {PRONOUN/m_c/poss} medicine cat training, having accidentally eaten deathberries."
                 }
             },
             {
@@ -5075,7 +5076,7 @@
                     }
                 ],
                 "history_text": {
-                    "reg_death": "m_c died before completing their medicine cat training, having accidentally eaten deathberries."
+                    "reg_death": "app1 died before completing {PRONOUN/app1/poss} medicine cat training, having accidentally eaten deathberries."
                 }
             }
         ]

--- a/resources/dicts/patrols/desert/hunting/hunting_desert.json
+++ b/resources/dicts/patrols/desert/hunting/hunting_desert.json
@@ -950,12 +950,6 @@
         "chance_of_success": 50,
         "success_outcomes": [
             {
-                "text": "app1 watches from the shade of a large rock formation. Eventually their wait pays off, and they spot a lizard searching for shelter from the sun, but their pounce is too soon, and their prey lives to see another day.",
-                "exp": 15,
-                "weight": 20,
-                "prey": ["small"]
-            },
-            {
                 "text": "app1 considers pushing through to try to find a catch, but it's not worth it. They find a burrow to wait out the heat of the day - except their burrow is occupied, and app1 instead has to wait out the heat in the uncortable shade of a cactus.",
                 "exp": 15,
                 "weight": 5,
@@ -986,7 +980,7 @@
                 "weight": 20
             },
             {
-                "text": "Refusing to stop hunting, app1 bodly decides to go into a canyon where it'll be cooler. They don't find any prey, but don't overheat either.",
+                "text": "Refusing to stop hunting, s_c boldly decides to go into a canyon where it'll be cooler. They don't find any prey, but don't overheat either.",
                 "exp": 0,
                 "weight": 20,
                 "stat_trait": [
@@ -997,13 +991,13 @@
                     "shameless",
                     "troublesome"
                 ],
-                "can_have_stat": ["app"]
+                "can_have_stat": ["app1"]
             },
             {
                 "text": "app1 doesn't make it back to camp. A patrol sent out for them find their body, collapsed in a shadeless part of the territory and already starting to dry out and mummify.",
                 "exp": 0,
                 "weight": 10,
-                "dead_cats": ["r_c"],
+                "dead_cats": ["app1"],
                 "history_text": {
                     "scar": "This cat got heatstroke while on a patrol.",
                     "reg_death": "This cat died from heat stroke.",
@@ -1011,7 +1005,7 @@
                 }
             },
             {
-                "text": "When s_c doesn't return to camp that evening, a search party goes out for them. They find app1 collapsed and badly affected by heat stroke, and carry them back to camp where their might be a way to help them. However, app1's breathing stops on the journey home, and they slip to StarClan.",
+                "text": "When app1 doesn't return to camp that evening, a search party goes out for them. They find app1 collapsed and badly affected by heat stroke, and carry them back to camp where their might be a way to help them. However, app1's breathing stops on the journey home, and they slip to StarClan.",
                 "exp": 0,
                 "weight": 10,
                 "injury": [
@@ -1129,12 +1123,6 @@
         "chance_of_success": 50,
         "success_outcomes": [
             {
-                "text": "app1 watches from the shade of a large rock formation. Eventually their wait pays off, and they spot a lizard searching for shelter from the sun, but their pounce is too soon, and their prey lives to see another day.",
-                "exp": 15,
-                "weight": 20,
-                "prey": ["small"]
-            },
-            {
                 "text": "app1 considers pushing through to try to find a catch, but it's not worth it. They find a burrow to wait out the heat of the day - except their burrow is occupied, and app1 instead has to wait out the heat in the uncortable shade of a cactus.",
                 "exp": 15,
                 "weight": 5,
@@ -1168,7 +1156,7 @@
                 "text": "app1 doesn't make it back to camp. A patrol sent out for them find their body, collapsed in a shadeless part of the territory and already starting to dry out and mummify.",
                 "exp": 0,
                 "weight": 10,
-                "dead_cats": ["r_c"],
+                "dead_cats": ["app1"],
                 "history_text": {
                     "scar": "This cat got heatstroke while on a patrol.",
                     "reg_death": "This cat died from heat stroke.",
@@ -1212,12 +1200,6 @@
         "decline_text": "Giving up on the hunt, r_c finds a burrow to wait out the heat of the day until they can return back to camp.",
         "chance_of_success": 50,
         "success_outcomes": [
-            {
-                "text": "r_c watches from the shade of a large rock formation. Eventually their wait pays off, and they spot a lizard searching for shelter from the sun, but their pounce is too soon, and their prey lives to see another day.",
-                "exp": 15,
-                "weight": 20,
-                "prey": ["small"]
-            },
             {
                 "text": "r_c considers pushing through to try to find a catch, but it's not worth it. They find a burrow to wait out the heat of the day - except this burrow seems occupied. The tortoise inside puts up a fight, but r_c manages to flip their positions and drive it out into the heat, which slowly kills it.",
                 "exp": 15,
@@ -1270,15 +1252,9 @@
         },
         "weight": 20,
         "intro_text": "The sun beats down on the desert, driving every creature away from it's gaze with blinding heat.",
-        "decline_text": "Giving up on the hunt, r_c finds a burrow to wait out the heat of the day until they can return back to camp.",
+        "decline_text": "Giving up on the hunt, app1 finds a burrow to wait out the heat of the day until they can return back to camp.",
         "chance_of_success": 50,
         "success_outcomes": [
-            {
-                "text": "app1 watches from the shade of a large rock formation. Eventually their wait pays off, and they spot a lizard searching for shelter from the sun, but their pounce is too soon, and their prey lives to see another day.",
-                "exp": 15,
-                "weight": 20,
-                "prey": ["small"]
-            },
             {
                 "text": "app1 considers pushing through to try to find a catch, but it's not worth it. They find a burrow to wait out the heat of the day - except their burrow is occupied, and app1 instead has to wait out the heat in the uncortable shade of a cactus.",
                 "exp": 15,
@@ -1313,7 +1289,7 @@
                 "text": "app1 doesn't make it back to camp. A patrol sent out for them find their body, collapsed in a shadeless part of the territory and already starting to dry out and mummify.",
                 "exp": 0,
                 "weight": 10,
-                "dead_cats": ["r_c"],
+                "dead_cats": ["app1"],
                 "history_text": {
                     "scar": "This cat got heatstroke while on a patrol.",
                     "reg_death": "This cat died from heat stroke.",


### PR DESCRIPTION
minor fixes to hunting_desert.json including fixing an errant s_c tag, removing a few duplicate outcomes, and replacing a few incorrect r_c tags with app1. the entire json needs a huge overhaul though

major fixes to the medicine cat beach greenleaf json, including removing duplicate outcomes, fixing grammar errors, adding/fixing pronoun tags, fixing incorrect s_c and r_c tags, clarifying outcomes, etc