### PR TITLE
Fix Issues with cause_permanent and herbs being mixed up for some Injuries

### DIFF
--- a/resources/dicts/conditions/injuries.json
+++ b/resources/dicts/conditions/injuries.json
@@ -813,15 +813,13 @@
         "cause_permanent": [
             "lost a leg",
             "lost their tail",
-            "moss",
-            "dandelion",
-            "poppy"
         ],
         "herbs": [
             "juniper",
             "ragwort",
             "poppy",
-            "moss"
+            "moss",
+            "dandelion"
         ]
     },
 
@@ -849,12 +847,12 @@
             "blood loss"
         ],
         "cause_permanent": [
+        ],
+        "herbs": [
             "oak_leaves",
             "juniper",
             "ragwort",
-            "moss"
-        ],
-        "herbs": []
+            "moss"]
     },
 
     "water in their lungs":{

--- a/resources/dicts/conditions/injuries.json
+++ b/resources/dicts/conditions/injuries.json
@@ -812,7 +812,7 @@
         "also_got": [],
         "cause_permanent": [
             "lost a leg",
-            "lost their tail",
+            "lost their tail"
         ],
         "herbs": [
             "juniper",
@@ -852,7 +852,8 @@
             "oak_leaves",
             "juniper",
             "ragwort",
-            "moss"]
+            "moss"
+        ]
     },
 
     "water in their lungs":{


### PR DESCRIPTION
In the 'frostbite' and 'recovering from birth' injuries, several herbs were in the 'cause_permanent' section rather than the 'herbs' section.