### PR TITLE
Outside cats gain EXP over time

### DIFF
--- a/scripts/events.py
+++ b/scripts/events.py
@@ -721,6 +721,7 @@ class Events:
         cat.one_moon()
         cat.manage_outside_trait()
             
+       self.handle_outside_EX(cat)
         cat.skills.progress_skill(cat)
         Pregnancy_Events.handle_having_kits(cat, clan=game.clan)
         
@@ -1518,6 +1519,30 @@ class Events:
                 exp += random.randint(0, 3)
 
             cat.experience += max(exp * mentor_modifier, 1)
+
+
+    def handle_outside_EX(self, cat):
+        if cat.status in ["loner", "rogue", "exiled", "kittypet", "lost"] and cat.age != 'kitten':
+            if cat.age == 'adolescent':
+                if cat.status == "kittypet":
+                    exp = random.randint(0, 6)
+                else:
+                    exp = random.randint(2, 8)
+            elif cat.age == 'senior':
+                if cat.status == "kittypet":
+                    exp = random.randint(0, 3)
+                else:
+                    exp = random.randint(1, 4)
+            else:
+                if cat.status == "kittypet":
+                    exp = random.randint(1, 5)
+                else:
+                    exp = random.randint(3, 7)
+
+            if game.clan.game_mode == "classic":
+                exp += random.randint(0, 3)
+                
+            cat.experience += exp
 
     def invite_new_cats(self, cat):
         """


### PR DESCRIPTION
Someone in the dev-version-discussion channel on discord mentioned they thought it was weird that lost cats returned to the Clan with exactly the same EXP as they left with. I've had this code in my game for a while to give all outside cats EXP, simulating that they have a life outside the Clan. It's a lot simpler than the apprentice EXP code, but it works. The values I set are of course subject to change!