### PR TITLE
bugfix: various halloween patrol fixes

### DIFF
--- a/resources/dicts/patrols/beach/hunting/any.json
+++ b/resources/dicts/patrols/beach/hunting/any.json
@@ -5287,8 +5287,8 @@
                 }
             ],
             "history_text": {
-                "reg_death": "m_c {VERB/m_c/were/was} killed by the poison in the Bishop-fish's flesh.",
-                "lead_death": "{VERB/m_c/were/was} poisoned by consuming Bishop-fish's flesh."
+                "reg_death": "m_c was killed by the poison in the Bishop-fish's flesh.",
+                "lead_death": "{VERB/m_c/were/was} poisoned by consuming Bishop-fish's flesh"
             }
         }]
     },

--- a/resources/dicts/patrols/forest/border/any.json
+++ b/resources/dicts/patrols/forest/border/any.json
@@ -1947,7 +1947,7 @@
         ],
         "fail_outcomes": [
             {
-                "text": "r_c doesn't want to talk about it when they come back to camp. {PRONOUN/r_c/subject/CAP} {VERB/r_c/don't/doesn't} want to talk about anything.",
+                "text": "r_c doesn't want to talk about it when {PRONOUN/r_c/subject} {VERB/r_c/come/comes} back to camp. {PRONOUN/r_c/subject/CAP} {VERB/r_c/don't/doesn't} want to talk about anything.",
                 "exp": 0,
                 "weight": 20,
                 "injury": [
@@ -1957,7 +1957,7 @@
                     }
                 ],
                 "history_text": {
-                    "reg_death": "m_c died of shock after {PRONOUN/r_c/poss} encounter with the Dover Demon.",
+                    "reg_death": "m_c died of shock after {PRONOUN/m_c/poss} encounter with the Dover Demon.",
                     "lead_death": "died of shock from an encounter with the Dover Demon"
                 }
             }

--- a/resources/dicts/patrols/forest/border/leaf-fall.json
+++ b/resources/dicts/patrols/forest/border/leaf-fall.json
@@ -18,13 +18,17 @@
             "text": "p_l follows the scent and nearly treads on the sticky thing in the grass. Definitely a weird Twoleg thing. {PRONOUN/p_l/subject/CAP} carefully {VERB/p_l/walk/walks} around it, unwilling to get the sticky stuff in {PRONOUN/p_l/poss} fur.",
             "exp": 5,
             "weight": 20
-
         },
         {
             "text": "p_l finds the sticky thing in the grass and looks at it curiously. s_c suddenly appears beside {PRONOUN/p_l/object} and, before p_l can tell {PRONOUN/s_c/object} to be careful, s_c bends down and takes a lick. This proves to be a bad idea. s_c wrinkles {PRONOUN/s_c/poss} nose and gags, trying to spit the disgusting taste out of {PRONOUN/s_c/poss} mouth.",
             "exp": 10,
             "weight": 20,
-            "stat_trait": ["childish", "adventurous", "bold", "shameless"],
+            "stat_trait": [
+                "childish", 
+                "adventurous", 
+                "bold", 
+                "shameless"
+            ],
             "can_have_stat": ["r_c"]
         }
     ],

--- a/resources/dicts/patrols/forest/hunting/any.json
+++ b/resources/dicts/patrols/forest/hunting/any.json
@@ -3131,7 +3131,7 @@
         ],
         "fail_outcomes": [
             {
-                "text": "r_c doesn't want to talk about it when they come back to camp. {PRONOUN/r_c/subject/CAP} {VERB/r_c/don't/doesn't} want to talk about anything.",
+                "text": "r_c doesn't want to talk about it when {PRONOUN/r_c/subject} {VERB/r_c/come/comes} back to camp. {PRONOUN/r_c/subject/CAP} {VERB/r_c/don't/doesn't} want to talk about anything..",
                 "exp": 0,
                 "weight": 20,
                 "injury": [
@@ -3141,7 +3141,7 @@
                     }
                 ],
                 "history_text": {
-                    "reg_death": "m_c died of shock after {PRONOUN/r_c/poss} encounter with the Dover Demon.",
+                    "reg_death": "m_c died of shock after {PRONOUN/m_c/poss} encounter with the Dover Demon.",
                     "lead_death": "died of shock from an encounter with the Dover Demon"
                 }
             }

--- a/resources/dicts/patrols/forest/hunting/leaf-fall.json
+++ b/resources/dicts/patrols/forest/hunting/leaf-fall.json
@@ -3267,7 +3267,7 @@
             	"prey": ["medium"]
         	},
         	{
-            	"text": "p_l watches r_c leap with the thrill of the hunt, quite literally snatching victory from thin air. {PRONOUN/p_l/subject}'d feel sorry for the lover bats - but r_c is just showing who the best potential mates are. Showing the pipistrelles, of course. No one else.",
+            	"text": "p_l watches r_c leap with the thrill of the hunt, quite literally snatching victory from thin air. {PRONOUN/p_l/subject/CAP}'d feel sorry for the lover bats - but r_c is just showing who the best potential mates are. Showing the pipistrelles, of course. No one else.",
             	"exp": 20,
             	"weight": 20,
             	"relationships": [

--- a/resources/dicts/patrols/forest/training/any.json
+++ b/resources/dicts/patrols/forest/training/any.json
@@ -2125,7 +2125,7 @@
         ],
         "fail_outcomes": [
             {
-                "text": "r_c doesn't want to talk about it when they come back to camp. {PRONOUN/r_c/subject/CAP} {VERB/r_c/don't/doesn't} want to talk about anything.",
+                "text": "r_c doesn't want to talk about it when {PRONOUN/r_c/subject} {VERB/r_c/come/comes} back to camp. {PRONOUN/r_c/subject/CAP} {VERB/r_c/don't/doesn't} want to talk about anything.",
                 "exp": 0,
                 "weight": 20,
                 "injury": [
@@ -2135,7 +2135,7 @@
                     }
                 ],
                 "history_text": {
-                    "reg_death": "m_c died of shock after {PRONOUN/r_c/poss} encounter with the Dover Demon.",
+                    "reg_death": "m_c died of shock after {PRONOUN/m_c/poss} encounter with the Dover Demon.",
                     "lead_death": "died of shock from an encounter with the Dover Demon"
                 }
             }
@@ -2157,7 +2157,7 @@
         "chance_of_success": 50,
         "relationship_constraint": [],
         "pl_skill_constraint": [],
-        "intro_text": "app1 gathers their strength, butt wiggling with excitement, legs tense, and throws themself upward, twisting in the air in a massive pounce that surely would bring down the mightiest prey! <i>OoOooo,</i> a voice says mockingly.",
+        "intro_text": "app1 gathers {PRONOUN/app1/poss} strength, butt wiggling with excitement, legs tense, and throws {PRONOUN/app1/self} upward, twisting in the air in a massive pounce that surely would bring down the mightiest prey! <i>OoOooo,</i> a voice says mockingly.",
         "decline_text": "What was that?! StarClan?! app1 is going home, {PRONOUN/app1/subject} {VERB/app1/don't/doesn't} like this!",
         "success_outcomes": [
             {

--- a/resources/dicts/patrols/general/border.json
+++ b/resources/dicts/patrols/general/border.json
@@ -1364,25 +1364,32 @@
                 "text": "As the patrol heads in the direction of the sinister glare of strange, unmoving eyes, the scent of smoke creeps up on the patrol. s_c darts forward, finding the smoke scent coming from an odd pumpkin with some sort of... face? Thinking quickly {PRONOUN/s_c/subject} {VERB/s_c/scratch/scratches} dirt into the holes on the pumpkin, extinguishing the small flames, but leaving the patrol wondering what in the name of StarClan they're looking at.",
                 "exp": 15,
                 "weight": 10,
-                "stat_trait": ["thoughtful", "careful", "responsible", "wise"]
-            },
-            {
-                "text": "As the patrol heads in the direction of the sinister glare of strange, unmoving eyes, the scent of smoke creeps up on the patrol. s_c darts forward, finding the smoke scent coming from an odd pumpkin with some sort of... face? Thinking quickly {PRONOUN/s_c/subject} {VERB/s_c/scratch/scratches} dirt into the holes on the pumpkin, extinguishing the small flames, but leaving the patrol wondering what in the name of StarClan they're looking at.",
-                "exp": 15,
-                "weight": 10,
-                "skill_trait": ["CLEVER,1", "INSIGHTFUL,1", "SENSE,1"]
+                "stat_trait": [
+                    "thoughtful", 
+                    "careful",
+                    "cunning",
+                    "responsible", 
+                    "wise"
+                ],
+                "stat_skill": [
+                    "CLEVER,1", 
+                    "INSIGHTFUL,1", 
+                    "SENSE,1"
+                ]
             },
             {
                 "text": "The patrol nervously heads towards the unblinking eyes, unsure of what lies ahead. As the strange object comes into view, s_c lets out a mrrow of laughter! {PRONOUN/s_c/subject/CAP} {VERB/s_c/explain/explains} that this is a Twoleg ritual performed around the start of leaf-bare. p_l is glad to have a cat with s_c's understanding of Twolegs on this patrol. With this knowledge, unneeded panic was surely avoided!",
                 "exp": 15,
                 "weight": 10,
-                "skill_trait": ["KITTYPET,0", "LONER,0"]
+                "stat_skill": [
+                    "KITTYPET,0", 
+                    "LONER,0"]
             },
             {
                 "text": "The patrol nervously heads towards the unblinking eyes, unsure of what lies ahead. As the strange object comes into view, s_c begins to bristle with unease. {PRONOUN/s_c/subject/CAP} can see strange, mist-like Twolegs floating around the glowing, unblinking face of a... pumpkin? The figures approach s_c, and run their cold, fur-less paws through {PRONOUN/s_c/subject} fur. s_c can hardly hear r_c asking {PRONOUN/s_c/object} why {PRONOUN/s_c/subject}{VERB/s_c/'re/'s} frozen in place.",
                 "exp": 20,
                 "weight": 10,
-                "skill_trait": ["GHOST,1"]
+                "stat_skill": ["GHOST,1"]
             }
         ],
         "fail_outcomes": [
@@ -1395,30 +1402,33 @@
                 "text": "As r_c slowly creeps towards the disturbing face, s_c huffs with frustration. Tail lashing, s_c calls r_c a mouse-heart and stomps in the direction of the unblinking eyes without a shred of fear. s_c rolls {PRONOUN/s_c/poss} eyes and knocks over the harmless pumpkin, ignoring the strange face and the smell of smoke wafting around it.",
                 "exp": 5,
                 "weight": 20,
-                "stat_trait": ["bloodthirsty", "cold", "strict", "grumpy", "fierce"]
+                "stat_trait": [
+                    "bloodthirsty", 
+                    "cold", 
+                    "strict", 
+                    "grumpy", 
+                    "fierce"
+                ]
             },
             {
                 "text": "As r_c slowly creeps towards the disturbing face, s_c recklessly darts forward to get a closer look! {PRONOUN/s_c/subject/CAP} {VERB/s_c/crash/crashes} into some strange pumpkin, knocking it over and obscuring the strange face. The patrol heads home without much left to investigate thanks to s_c's antics.",
                 "exp": 5,
                 "weight": 20,
-                "stat_trait": ["troublesome", "childish", "playful", "shameless"]
+                "stat_trait": [
+                    "troublesome", 
+                    "childish", 
+                    "playful", 
+                    "shameless"
+                ]
             }
         ]
     },
     {
         "patrol_id": "gen_bord_trickortreat",
-        "biome": [
-            "Any"
-        ],
-        "season": [
-            "leaf-fall"
-        ],
-        "types": [
-            "border"
-        ],
-        "tags": [
-            "halloween"
-        ],
+        "biome": ["Any"],
+        "season": ["leaf-fall"],
+        "types": ["border"],
+        "tags": ["halloween"],
         "patrol_art": "bord_general_intro",
         "min_cats": 2,
         "max_cats": 6,
@@ -1487,7 +1497,10 @@
                 "text": "s_c stops the patrol, narrowing {PRONOUN/s_c/poss} eyes. That isn't a Twoleg! {PRONOUN/s_c/subject} came across one before during {PRONOUN/s_c/object} time outside the Clan. It's a 'scarecrow', {PRONOUN/s_c/subject} {VERB/s_c/explain/explains}, meant to protect the Twoleg fields from harm. The patrol continues on their way, giving the scarecrow a wide berth.",
                 "exp": 10,
                 "weight": 20,
-                "stat_skill": ["ROGUE,0", "LONER,0"]
+                "stat_skill": [
+                    "ROGUE,0", 
+                    "LONER,0"
+                ]
             }
         ],
         "fail_outcomes": [

--- a/resources/dicts/patrols/general/hunting.json
+++ b/resources/dicts/patrols/general/hunting.json
@@ -1183,7 +1183,14 @@
             "text": "Boldly, s_c steps forward to interrogate the small lion, who explains that it is a kittypet that must put up with its Twolegs' insistence on something called \"costumes\". It even offers to let s_c try its accessory!",
             "exp": 20,
             "weight": 20,
-            "stat_trait": ["bold", "confident", "daring", "adventurous", "shameless", "playful"],
+            "stat_trait": [
+                "bold", 
+                "confident", 
+                "daring", 
+                "adventurous", 
+                "shameless", 
+                "playful"
+            ],
             "art": ["kittylion_OUTCOME"]
         }
     ],
@@ -1245,7 +1252,7 @@
     "types": [ "hunting"],
     "tags": [ "halloween"],
     "patrol_art": "scaryghost_intro",
-    "min_cats": 1,
+    "min_cats": 2,
     "max_cats": 6,
     "min_max_status": {
         "apprentice": [0, 6],
@@ -1253,19 +1260,19 @@
         "normal adult": [0, 6]
     },
     "weight": 20,
-    "intro_text": "As the patrol follows a trail into a darkly shadowed part of the territory, night shadows begin to play with their vision, was that movement up ahead? r_c spots the undisguisable silhouette of a cat ahead. Malicious eyes and bristled fur meet the patrol as they walk amongst the shadows, the stranger's fur is translucent and it moves as though made from a strange dark mist.",
-    "decline_text": "r_c's tail bristles with fear, a cold shiver creeping along {PRONOUN/r_c/poss} back, this is definitely not a normal cat, and {PRONOUN/r_c/subject} quickly {VERB/r_c/turn/turns} the patrol back to camp.",
+    "intro_text": "As the patrol follows a trail into a darkly shadowed part of the territory, night shadows begin to play with their vision. Was that movement up ahead? r_c spots the undisguisable silhouette of a cat ahead. Malicious eyes and bristled fur meet the patrol as they walk amongst the shadows. The stranger's fur is translucent, and it moves as though made from a strange dark mist.",
+    "decline_text": "r_c's tail bristles with fear, a cold shiver creeping along {PRONOUN/r_c/poss} back. This is definitely not a normal cat, and {PRONOUN/r_c/subject} quickly {VERB/r_c/turn/turns} the patrol back to camp.",
     "chance_of_success": 50,
     "success_outcomes": [
         {
-            "text": "Your patrol confronts the strange cat - they are obviously an intruder on c_n territory and they don't look like the friendly type. The dark silhouette seems to flicker in and out of view as the patrol runs toward it, gradually reappearing further and further away. The patrol stops watching the stranger in the distance, white glowing haunted eyes watch them from the shadows. The patrol returns home, mesmerized by the strangeness of what they just witnessed.",
+            "text": "Your patrol confronts the strange cat - they are obviously an intruder on c_n territory, and they don't look like the friendly type. The dark silhouette seems to flicker in and out of view as the patrol runs toward it, gradually reappearing further and further away. The patrol stops, watching the stranger in the distance. Glowing, haunted eyes watch them back from the shadows. The patrol returns home, mesmerized by the strangeness of what they just witnessed.",
             "exp": 10,
             "weight": 20
         }
     ],
     "fail_outcomes": [
         {
-            "text": "Your patrol confronts the strange cat - they are obviously an intruder on c_n territory and they don't look like the friendly type. The strange cat shrieks an awful blood curdling scream that makes r_c 's fur stand on end. Overcome by terror, the patrol flees back to camp.",
+            "text": "Your patrol confronts the strange cat - they are obviously an intruder on c_n territory, and they don't look like the friendly type. The strange cat shrieks, an awful, blood curdling scream that makes r_c 's fur stand on end. Overcome by terror, the patrol flees back to camp.",
             "exp": 0,
             "weight": 10,
             "injury": [

--- a/resources/dicts/patrols/general/medcat.json
+++ b/resources/dicts/patrols/general/medcat.json
@@ -3027,7 +3027,7 @@
         ],
         "fail_outcomes": [
             {
-                "text": "The two trot towards the field, tails raised nonchalantly. Suddenly, p_l hears a shriek and manages to duck out of the way as a crow swoops close. Angry caws ring across the field.  r_c calls for retreat as more crows converge on them. The two cats run away from the field, fur fluffed in both terror and embarrassment.",
+                "text": "The two trot towards the field, tails raised nonchalantly. Suddenly, p_l hears a shriek and manages to duck out of the way as a crow swoops close. Angry caws ring across the field. r_c calls for retreat as more crows converge on them. The two cats run away from the field, fur fluffed in both terror and embarrassment.",
                 "exp": 0,
                 "weight": 20
             }
@@ -3068,7 +3068,7 @@
         ],
         "fail_outcomes": [
             {
-                "text": "The two trot towards the field, tails raised nonchalantly. Suddenly, p_l hears a shriek and manages to duck out of the way as a crow swoops close. Angry caws ring across the field.  r_c calls for retreat as more crows converge on them. The two cats run away from the field, fur fluffed in both terror and embarrassment.",
+                "text": "The two trot towards the field, tails raised nonchalantly. Suddenly, p_l hears a shriek and manages to duck out of the way as a crow swoops close. Angry caws ring across the field. r_c calls for retreat as more crows converge on them. The two cats run away from the field, fur fluffed in both terror and embarrassment.",
                 "exp": 0,
                 "weight": 20
             }
@@ -3090,7 +3090,7 @@
         "chance_of_success": 50,
         "success_outcomes": [
             {
-                "text": "Despite being alone, r_c decides to follow the figure. Perhaps it's a StarClan cat. As {PRONOUN/r_c/subject} {VERB/r_c/get/gets} closer, {PRONOUN/r_c/subject} {VERB/r_c/realize/realizes} that no, this cat doesn't have stars in its fur. But it doesn't seem malicious either. The ghostly cat beckons r_c closer and to {PRONOUN/r_c/poss} surprise, the ghost has led {PRONOUN/r_c/object} to a giant patch of herbs! r_c thanks the spirit and it seems to smile as r_c begins to collect the herbs.",
+                "text": "Despite being alone, r_c decides to follow the figure. Perhaps it's a StarClan cat. As {PRONOUN/r_c/subject} {VERB/r_c/get/gets} closer, {PRONOUN/r_c/subject} {VERB/r_c/realize/realizes} that no, this cat doesn't have stars in its fur. But it doesn't seem malicious either. The ghostly cat beckons r_c closer and, to {PRONOUN/r_c/poss} surprise, the ghost has led {PRONOUN/r_c/object} to a giant patch of herbs! r_c thanks the spirit and it seems to smile as r_c begins to collect the herbs.",
                 "exp": 10,
                 "weight": 20,
                 "herbs": ["many_herbs"]
@@ -3130,19 +3130,19 @@
             "normal adult": [-1, -1]
         },
         "weight": 20,
-        "intro_text": "As r_c follows a trail into a darkly shadowed part of the territory on the hunt for herbs, night shadows begin to play with {PRONOUN/r_c/poss} vision, was that movement up ahead? r_c spots an undisguisable silhouette of a cat ahead. Malicious eyes and bristled fur meets {PRONOUN/r_c/object} as {PRONOUN/r_c/subject} {VERB/r_c/walk/walks} amongst the shadows, the strangers fur is translucent and it moves as though made from a strange dark mist.",
+        "intro_text": "As r_c follows a trail into a darkly shadowed part of the territory on the hunt for herbs, night shadows begin to play with {PRONOUN/r_c/poss} vision. Was that movement up ahead? r_c spots the undisguisable silhouette of a cat ahead. Malicious eyes and bristled fur meet {PRONOUN/r_c/object} as {PRONOUN/r_c/subject} {VERB/r_c/walk/walks} amongst the shadows. The stranger's fur is translucent, and it moves as though made from a strange dark mist.",
         "decline_text": "r_c's tail bristles with fear, a cold shiver creeping along {PRONOUN/r_c/poss} back. This is definitely not a Starclan cat, and {PRONOUN/r_c/subject} quickly {VERB/r_c/turn/turns} the back to camp - herbs can wait until morning.",
         "chance_of_success": 50,
         "success_outcomes": [
             {
-                "text": "r_c approaches the strange cat, they might be a wandering spirit in need of help. The dark silhouette seems to flicker in and out of view as {PRONOUN/r_c/subject} {VERB/r_c/move/moves} toward it, gradually reappearing further and further away. r_c stops, watching the stranger in the distance with confusion, white glowing haunted eyes watch them from the shadows. r_c shivers, and decides to hunt for herbs someplace else.",
+                "text": "r_c approaches the strange cat, thinking that they might be a wandering spirit in need of help. The dark silhouette seems to flicker in and out of view as {PRONOUN/r_c/subject} {VERB/r_c/move/moves} toward it, gradually reappearing further and further away. r_c stops, watching the stranger in the distance with confusion. Glowing, haunted eyes watch {PRONOUN/r_c/object} back from the shadows. r_c shivers, and decides to hunt for herbs someplace else.",
                 "exp": 10,
                 "weight": 20
             }
         ],
         "fail_outcomes": [
             {
-                "text": "r_c approaches the strange cat, they might be a wandering spirit in need of help. But as r_c gets closer, the strange cat shrieks an awful blood curdling scream that makes {PRONOUN/r_c/poss} fur stand on end, overcome by terror {PRONOUN/r_c/subject} {VERB/r_c/flee/flees} back to camp, dropping the little herbs {PRONOUN/r_c/subject} had gathered.",
+                "text": "r_c approaches the strange cat, thinking that they might be a wandering spirit in need of help. But as r_c gets closer, the strange cat shrieks, an awful, blood curdling scream that makes {PRONOUN/r_c/poss} fur stand on end. Overcome by terror, {PRONOUN/r_c/subject} {VERB/r_c/flee/flees} back to camp, dropping what little herbs {PRONOUN/r_c/subject} had gathered.",
                 "exp": 0,
                 "weight": 10,
                 "injury": [
@@ -3190,12 +3190,18 @@
                 "exp": 30,
                 "weight": 20,
                 "herbs": ["many_herbs"],
-                "stat_skill": ["INSIGHTFUL,2", "SENSE,2", "OMEN,2", "STAR,2", "LORE,2"]
+                "stat_skill": [
+                    "INSIGHTFUL,2", 
+                    "SENSE,2", 
+                    "OMEN,2", 
+                    "STAR,2", 
+                    "LORE,2"
+                ]
             }
         ],
         "fail_outcomes": [
             {
-                "text": "Gathering courage, r_c decides to return the black cat's stare... Big mistake. The black cat hisses and mutters, strange and undecipherable, leaving r_c and the rest of the patrol frozen in dread.",
+                "text": "Gathering {PRONOUN/r_c/poss} courage, r_c decides to return the black cat's stare... Big mistake. The black cat hisses and mutters, strange and undecipherable, leaving r_c and the rest of the patrol frozen in dread.",
                 "exp": 0,
                 "weight": 20,
                 "injury": [

--- a/resources/dicts/patrols/general/training.json
+++ b/resources/dicts/patrols/general/training.json
@@ -4275,25 +4275,33 @@
                 "text": "As the patrol heads in the direction of the sinister glare of strange, unmoving eyes, the scent of smoke creeps up on the patrol. s_c darts forward, finding the smoke scent coming from an odd pumpkin with some sort of... face? Thinking quickly {PRONOUN/s_c/subject} {VERB/s_c/scratch/scratches} dirt into the holes on the pumpkin, extinguishing the small flames, but leaving the patrol wondering what in the name of StarClan they're looking at.",
                 "exp": 15,
                 "weight": 10,
-                "stat_trait": ["thoughtful", "careful", "responsible", "wise"]
-            },
-            {
-                "text": "As the patrol heads in the direction of the sinister glare of strange, unmoving eyes, the scent of smoke creeps up on the patrol. s_c darts forward, finding the smoke scent coming from an odd pumpkin with some sort of... face? Thinking quickly {PRONOUN/s_c/subject} {VERB/s_c/scratch/scratches} dirt into the holes on the pumpkin, extinguishing the small flames, but leaving the patrol wondering what in the name of StarClan they're looking at.",
-                "exp": 15,
-                "weight": 10,
-                "skill_trait": ["CLEVER,1", "INSIGHTFUL,1", "SENSE,1"]
+                "stat_trait": [
+                    "thoughtful", 
+                    "careful",
+                    "cunning",
+                    "responsible", 
+                    "wise"
+                ],
+                "stat_skill": [
+                    "CLEVER,1", 
+                    "INSIGHTFUL,1",
+                    "SENSE,1"
+                ]
             },
             {
                 "text": "The patrol nervously heads towards the unblinking eyes, unsure of what lies ahead. As the strange object comes into view, s_c lets out a mrrow of laughter! {PRONOUN/s_c/subject/CAP} {VERB/s_c/explain/explains} that this is a Twoleg ritual performed around the start of leaf-bare. p_l is glad to have a cat with s_c's understanding of Twolegs on this patrol. With this knowledge, unneeded panic was surely avoided!",
                 "exp": 15,
                 "weight": 10,
-                "skill_trait": ["KITTYPET,0", "LONER,0"]
+                "stat_skill": [
+                    "KITTYPET,0", 
+                    "LONER,0"
+                ]
             },
             {
                 "text": "The patrol nervously heads towards the unblinking eyes, unsure of what lies ahead. As the strange object comes into view, s_c begins to bristle with unease. {PRONOUN/s_c/subject/CAP} can see strange, mist-like Twolegs floating around the glowing, unblinking face of a... pumpkin? The figures approach s_c and run their cold, fur-less paws through {PRONOUN/s_c/subject} fur. s_c can hardly hear r_c asking {PRONOUN/s_c/object} why {PRONOUN/s_c/subject}{VERB/s_c/'re/'s} frozen in place.",
                 "exp": 20,
                 "weight": 10,
-                "skill_trait": ["GHOST,1"]
+                "stat_skill": ["GHOST,1"]
             }
         ],
         "fail_outcomes": [
@@ -4306,13 +4314,24 @@
                 "text": "As r_c slowly creeps towards the disturbing face, s_c huffs with frustration. Tail lashing, s_c calls r_c a mouse-heart and stomps in the direction of the unblinking eyes without a shred of fear. s_c rolls {PRONOUN/s_c/poss} eyes and knocks over the harmless pumpkin, ignoring the strange face and the smell of smoke wafting around it.",
                 "exp": 5,
                 "weight": 20,
-                "stat_trait": ["bloodthirsty", "cold", "strict", "grumpy", "fierce"]
+                "stat_trait": [
+                    "bloodthirsty", 
+                    "cold", 
+                    "strict", 
+                    "grumpy", 
+                    "fierce"
+                ]
             },
             {
                 "text": "As r_c slowly creeps towards the disturbing face, s_c recklessly darts forward to get a closer look! {PRONOUN/s_c/subject/CAP} {VERB/s_c/crash/crashes} into some strange pumpkin, knocking it over and obscuring the strange face. The patrol heads home without much left to investigate thanks to s_c's antics.",
                 "exp": 5,
                 "weight": 20,
-                "stat_trait": ["troublesome", "childish", "playful", "shameless"]
+                "stat_trait": [
+                    "troublesome", 
+                    "childish", 
+                    "playful", 
+                    "shameless"
+                ]
             }
         ]
     },

--- a/resources/dicts/patrols/mountainous/border/any.json
+++ b/resources/dicts/patrols/mountainous/border/any.json
@@ -513,13 +513,13 @@
     "chance_of_success": 25,
     "success_outcomes": [
    	 {
-   		 "text": "r_c turns tail and runs, feeling air ruffle their fur as <i>something</i> passes overhead while they pelt for home, without even the breath to waste on wailing.",
+   		 "text": "r_c turns tail and runs, feeling air ruffle {PRONOUN/r_c/poss} fur as <i>something</i> passes overhead while {PRONOUN/r_c/subject} {VERB/r_c/pelt/pelts} for home, without even the breath to waste on wailing.",
    		 "exp": 35,
    		 "weight": 20,
          "art": "mothman_OUTCOME"
    	 },
    	 {
-   		 "text": "r_c returns home from their uneventful patrol.",
+   		 "text": "r_c returns home from {PRONOUN/r_c/poss} uneventful patrol.",
    		 "exp": 35,
    		 "weight": 10,
    		 "injury": [
@@ -534,7 +534,18 @@
    		 "text": "Caution has always been in {PRONOUN/s_c/poss} blood, and this, this has to be why. Frozen to the ground so completely that the frost grows over {PRONOUN/s_c/poss} fur as {PRONOUN/s_c/subject} {VERB/s_c/wait/waits}, s_c refuses to twitch so much as a whisker until the moth-Twoleg leaves.",
    		 "exp": 40,
    		 "weight": 20,
-   		 "stat_trait": ["lonesome", "nervous", "insecure", "calm", "careful", "sneaky", "strange", "wise", "cunning", "gloomy"],
+   		 "stat_trait": [
+            "lonesome", 
+            "nervous", 
+            "insecure", 
+            "calm", 
+            "careful", 
+            "sneaky", 
+            "strange", 
+            "wise", 
+            "cunning", 
+            "gloomy"
+        ],
          "art": "mothman_OUTCOME"
    	 }
     ],
@@ -557,17 +568,19 @@
    		 "weight": 20,
    		 "dead_cats": ["r_c"],
    		 "history_text": {
-   			 "reg_death": "m_c was taken as the Mothman's snack."
+   			 "reg_death": "m_c was taken as the Mothman's snack.",
+             "lead_death": "{PRONOUN/m_c/were/was} taken as the Mothman's snack"
    		 },
          "art": "mothman_OUTCOME"
    	 },
    	 {
-   		 "text": "The vast moth-Twoleg flies off, and r_c tries to shake off the encounter - but the mountain itself seems to be against them tonight, collapsing beneath their feet.",
+   		 "text": "The vast moth-Twoleg flies off, and r_c tries to shake off the encounter - but the mountain itself seems to be against {PRONOUN/r_c/object} tonight, collapsing beneath {PRONOUN/r_c/poss} feet.",
    		 "exp": 0,
    		 "weight": 20,
    		 "dead_cats": ["r_c"],
    		 "history_text": {
-   			 "reg_death": "m_c {VERB/m_c/were/was} killed by the collapsing mountain slopes, an event predicted by the appearance of the Mothman."
+   			 "reg_death": "m_c was killed by the collapsing mountain slopes, an event predicted by the appearance of the Mothman.",
+             "lead_death": "{VERB/m_c/were/was} killed by the collapsing mountain slopes after {PRONOUN/m_c/subject} saw the Mothman"
    		 },
          "art": "mothman_OUTCOME"
    	 }
@@ -612,9 +625,9 @@
             }
      	],
    	    "history_text": {
-            "scar": "m_c was scarred from their frantic escape from a Jersey Devil.",
+            "scar": "m_c was scarred during {PRONOUN/m_c/poss} frantic escape from a Jersey Devil.",
             "reg_death": "m_c died from the shock of meeting a Jersey Devil.",
-            "lead_death": "shocked from meeting a Jersey Devil"
+            "lead_death": "died from the shock of meeting a Jersey Devil"
         }
    	  }
 	]

--- a/resources/dicts/patrols/mountainous/border/any.json
+++ b/resources/dicts/patrols/mountainous/border/any.json
@@ -569,7 +569,7 @@
    		 "dead_cats": ["r_c"],
    		 "history_text": {
    			 "reg_death": "m_c was taken as the Mothman's snack.",
-             "lead_death": "{PRONOUN/m_c/were/was} taken as the Mothman's snack"
+             "lead_death": "{VERB/m_c/were/was} taken as the Mothman's snack"
    		 },
          "art": "mothman_OUTCOME"
    	 },

--- a/resources/dicts/patrols/mountainous/hunting/any.json
+++ b/resources/dicts/patrols/mountainous/hunting/any.json
@@ -1072,13 +1072,13 @@
         "chance_of_success": 25,
         "success_outcomes": [
             {
-                "text": "r_c turns tail and runs, feeling air ruffle their fur as <i>something</i> passes overhead while they pelt for home, without even the breath to waste on wailing.",
+                "text": "r_c turns tail and runs, feeling air ruffle {PRONOUN/r_c/poss} fur as <i>something</i> passes overhead while {PRONOUN/r_c/subject} {VERB/r_c/pelt/pelts} for home, without even the breath to waste on wailing.",
                 "exp": 35,
                 "weight": 20,
                 "art": "mothman_OUTCOME"
             },
             {
-                "text": "r_c returns home from their uneventful patrol.",
+                "text": "r_c returns home from {PRONOUN/r_c/poss} uneventful patrol.",
                 "exp": 35,
                 "weight": 20,
                 "injury": [
@@ -1092,7 +1092,18 @@
                 "text": "Caution has always been in {PRONOUN/s_c/poss} blood, and this, this has to be why. Frozen to the ground so completely that the frost grows over {PRONOUN/s_c/poss} fur as {PRONOUN/s_c/subject} {VERB/s_c/wait/waits}, s_c refuses to twitch so much as a whisker until the moth-Twoleg leaves.",
                 "exp": 40,
                 "weight": 20,
-                "stat_trait": ["lonesome", "nervous", "insecure", "calm", "careful", "sneaky", "strange", "wise", "cunning", "gloomy"]
+                "stat_trait": [
+                    "lonesome", 
+                    "nervous", 
+                    "insecure", 
+                    "calm", 
+                    "careful", 
+                    "sneaky", 
+                    "strange", 
+                    "wise", 
+                    "cunning", 
+                    "gloomy"
+                ]
             }
         ],
         "fail_outcomes": [
@@ -1114,17 +1125,19 @@
                 "weight": 20,
                 "dead_cats": ["r_c"],
                 "history_text": {
-                    "reg_death": "m_c {VERB/m_c/were/was} taken as the Mothman's snack."
+                    "reg_death": "m_c was taken as the Mothman's snack.",
+                 "lead_death": "{PRONOUN/m_c/were/was} taken as the Mothman's snack"
                 },
                 "art": "mothman_OUTCOME"
             },
             {
-                "text": "The vast moth-Twoleg flies off, and r_c tries to shake off the encounter - but the mountain itself seems to be against them tonight, collapsing beneath their feet.",
+                "text": "The vast moth-Twoleg flies off, and r_c tries to shake off the encounter - but the mountain itself seems to be against {PRONOUN/r_c/object} tonight, collapsing beneath {PRONOUN/r_c/poss} feet.",
                 "exp": 0,
                 "weight": 20,
                 "dead_cats": ["r_c"],
                 "history_text": {
-                    "reg_death": "m_c {VERB/m_c/were/was} killed by the collapsing mountain slopes, an event predicted by the appearance of the Mothman."
+                    "reg_death": "m_c was killed by the collapsing mountain slopes, an event predicted by the appearance of the Mothman",
+                    "lead_death": "{VERB/m_c/were/was} killed by the collapsing mountain slopes after {PRONOUN/m_c/subject} saw the Mothman"
                 },
                 "art": "mothman_OUTCOME"
             }
@@ -1142,7 +1155,7 @@
         "min_max_status": {},
         "weight": 15,
         "intro_text": "As the patrol heads out across the mountains, a bell tolls from above...",
-        "decline_text": "It's a buzzard, one of the birds the Clan hesitates to hunt, so the patrol ignores the queer bell it wears and moves on with their lives. ",
+        "decline_text": "It's a buzzard, one of the birds the Clan hesitates to hunt, so the patrol ignores the queer bell it wears and moves on with their lives.",
         "chance_of_success": 30,
         "success_outcomes": [
             {

--- a/resources/dicts/patrols/mountainous/hunting/any.json
+++ b/resources/dicts/patrols/mountainous/hunting/any.json
@@ -1126,7 +1126,7 @@
                 "dead_cats": ["r_c"],
                 "history_text": {
                     "reg_death": "m_c was taken as the Mothman's snack.",
-                 "lead_death": "{PRONOUN/m_c/were/was} taken as the Mothman's snack"
+                 "lead_death": "{VERB/m_c/were/was} taken as the Mothman's snack"
                 },
                 "art": "mothman_OUTCOME"
             },

--- a/resources/dicts/patrols/mountainous/hunting/leaf-fall.json
+++ b/resources/dicts/patrols/mountainous/hunting/leaf-fall.json
@@ -1529,7 +1529,7 @@
             	"prey": ["medium"]
         	},
         	{
-            	"text": "p_l watches r_c leap with the thrill of the hunt, quite literally snatching victory from thin air. {PRONOUN/p_l/subject}'d feel sorry for the lover bats - but r_c is just showing who the best potential mates are. Showing the pipistrelles, of course. No one else.",
+            	"text": "p_l watches r_c leap with the thrill of the hunt, quite literally snatching victory from thin air. {PRONOUN/p_l/subject/CAP}'d feel sorry for the lover bats - but r_c is just showing who the best potential mates are. Showing the pipistrelles, of course. No one else.",
             	"exp": 20,
             	"weight": 20,
             	"relationships": [

--- a/resources/dicts/patrols/mountainous/training/any.json
+++ b/resources/dicts/patrols/mountainous/training/any.json
@@ -1999,7 +1999,7 @@
         "chance_of_success": 50,
         "relationship_constraint": [],
         "pl_skill_constraint": [],
-        "intro_text": "app1 gathers their strength, butt wiggling with excitement, legs tense, and throws themself upward, twisting in the air in a massive pounce that surely would bring down the mightiest prey! <i>OoOooo,</i> a voice says mockingly.",
+        "intro_text": "app1 gathers {PRONOUN/app1/poss} strength, butt wiggling with excitement, legs tense, and throws {PRONOUN/app1/self} upward, twisting in the air in a massive pounce that surely would bring down the mightiest prey! <i>OoOooo,</i> a voice says mockingly.",
         "decline_text": "What was that?! StarClan?! app1 is going home, {PRONOUN/app1/subject} {VERB/app1/don't/doesn't} like this!",
         "success_outcomes": [
             {

--- a/resources/dicts/patrols/plains/border/leaf-fall.json
+++ b/resources/dicts/patrols/plains/border/leaf-fall.json
@@ -23,7 +23,12 @@
    		 "text": "p_l finds the sticky thing in the grass and looks at it curiously. s_c suddenly appears beside {PRONOUN/p_l/object} and, before p_l can tell {PRONOUN/s_c/object} to be careful, s_c bends down and takes a lick. This proves to be a bad idea. s_c wrinkles {PRONOUN/s_c/poss} nose and gags, trying to spit the disgusting taste out of {PRONOUN/s_c/poss} mouth.",
    		 "exp": 10,
    		 "weight": 20,
-   		 "stat_trait": ["childish", "adventurous", "bold", "shameless"],
+   		 "stat_trait": [
+            "childish", 
+            "adventurous", 
+            "bold", 
+            "shameless"
+        ],
         "can_have_stat": ["r_c"]
    	 }
     ],

--- a/resources/dicts/patrols/plains/hunting/any.json
+++ b/resources/dicts/patrols/plains/hunting/any.json
@@ -2766,14 +2766,14 @@
         "chance_of_success": 30,
         "success_outcomes": [
             {
-                "text": "The patrol switches to tracking down that annoying voice instead. It takes the rest of the entire afternoon, and the damn voice tricks p_l into pouncing on r_c, but finally they pin down the talking mongoose and make it <i>quite</i> clear how irritating he's been.",
+                "text": "The patrol switches to tracking down that annoying voice instead. It takes the rest of the afternoon, and the damn voice tricks p_l into pouncing on r_c, but finally they pin down the talking mongoose and make it <i>quite</i> clear how irritating he's been.",
                 "exp": 0,
                 "weight": 20
             }
         ],
         "fail_outcomes": [
             {
-                "text": "The voice is coming from behind that bush! No, that one! No, that one over there, p_l's got them, except who p_l actually has is an irritated r_c's tail, and absolutely no one manages any hunting today. Fox dung!",
+                "text": "The voice is coming from behind that bush! No, that one! No, that one over there, p_l's got them, except what p_l actually has is an irritated r_c's tail, and absolutely no one manages any hunting today. Fox dung!",
                 "exp": 0,
                 "weight": 20
             }

--- a/resources/dicts/patrols/plains/hunting/leaf-fall.json
+++ b/resources/dicts/patrols/plains/hunting/leaf-fall.json
@@ -2038,7 +2038,7 @@
             	"prey": ["medium"]
         	},
         	{
-            	"text": "p_l watches r_c leap with the thrill of the hunt, quite literally snatching victory from thin air. {PRONOUN/p_l/subject}'d feel sorry for the lover bats - but r_c is just showing who the best potential mates are. Showing the pipistrelles, of course. No one else.",
+            	"text": "p_l watches r_c leap with the thrill of the hunt, quite literally snatching victory from thin air. {PRONOUN/p_l/subject/CAP}'d feel sorry for the lover bats - but r_c is just showing who the best potential mates are. Showing the pipistrelles, of course. No one else.",
             	"exp": 20,
             	"weight": 20,
             	"relationships": [


### PR DESCRIPTION
-minor fixes and additions to various history texts
-pronoun tags
-formatting standardization
-grammar fixes
-fixed s_c errors in jack o lantern patrols, added "cunning" to stat_traits for a stat outcome, condensed separate identical stat outcomes into a single outcome 
-made gen_hunt_scary_ghost1 available for no less than 2 cats due to implied presence of more than 1 cat based on grammar