### PR TITLE
Fixed broken mate check

### DIFF
--- a/resources/game_config.json
+++ b/resources/game_config.json
@@ -81,7 +81,7 @@
 	},
 	"mates":{
 		"age_range": 40,
-		"overide_same_age_group": false,
+		"override_same_age_group": false,
 		"chance_fulfilled_condition": 5,
 		"chance_friends_to_lovers": 170,
 		"confession": {

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -2079,7 +2079,7 @@ class Cat():
             # if only one is aged up at this point, later they are more moons apart than the setting defined
             # game_config boolian "override_same_age_group" disables the same-age group check.
             if game.config["mates"].get("override_same_age_group", False) or self.age != other_cat.age:
-                if abs(self.moons - other_cat.moons) > game.config["mates"]["age_range"] + 1:
+                if abs(self.moons - other_cat.moons) or (other_cat.moons - self.moons) > game.config["mates"]["age_range"] + 1:
                     return False
 
         age_restricted_ages = ["newborn", "kitten", "adolescent"]
@@ -2416,7 +2416,7 @@ class Cat():
             valid_age = False
 
         # Small check to prevent huge age gaps. Will be bypassed if the cats are already mates.
-        if abs(cat1.moons - cat2.moons) > 85:
+        if abs(cat1.moons - cat2.moons) or (cat2.moons - cat1.moons) > 85:
             age_diff = False
         else:
             age_diff = True

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -2079,7 +2079,7 @@ class Cat():
             # if only one is aged up at this point, later they are more moons apart than the setting defined
             # game_config boolian "override_same_age_group" disables the same-age group check.
             if game.config["mates"].get("override_same_age_group", False) or self.age != other_cat.age:
-                if abs(self.moons - other_cat.moons) or (other_cat.moons - self.moons) > game.config["mates"]["age_range"] + 1:
+                if abs(self.moons - other_cat.moons)> game.config["mates"]["age_range"] + 1:
                     return False
 
         age_restricted_ages = ["newborn", "kitten", "adolescent"]
@@ -2416,7 +2416,7 @@ class Cat():
             valid_age = False
 
         # Small check to prevent huge age gaps. Will be bypassed if the cats are already mates.
-        if abs(cat1.moons - cat2.moons) or (cat2.moons - cat1.moons) > 85:
+        if abs(cat1.moons - cat2.moons) > 85:
             age_diff = False
         else:
             age_diff = True


### PR DESCRIPTION
one typo was responsible for the age gap of 40 moons not being consistently applied. Fix found by zabe, listed here as ZtheCorgi.