### PR TITLE
bugfix: many_herbs outcomes

### DIFF
--- a/resources/dicts/patrols/beach/med/any.json
+++ b/resources/dicts/patrols/beach/med/any.json
@@ -326,7 +326,7 @@
                 "exp": 10,
                 "weight": 20,
                 "stat_skill": ["SENSE,2"],
-                "herbs": ["many_herbs"],
+                "herbs": ["many_herbs", "random_herbs"],
                 "relationships": [
                     {
                         "cats_to": ["patrol"],

--- a/resources/dicts/patrols/desert/med/any.json
+++ b/resources/dicts/patrols/desert/med/any.json
@@ -535,6 +535,7 @@
                 "text": "It takes them all day, but eventually, finally, p_l spots the speckled leaves they've been looking for, so crucial to stock up on before the withering heat of greenleaf. For just a second, {PRONOUN/p_l/subject} {VERB/p_l/feel/feels} the weight of {PRONOUN/p_l/poss} responsibilities lift, the strength of that relief catching {PRONOUN/p_l/object} off guard.",
                 "exp": 20,
                 "weight": 20,
+                "herbs": ["lungwort"],
                 "relationships": [
                     {
                         "cats_to": ["patrol"],
@@ -549,7 +550,7 @@
                 "text": "Not only is the lungwort intact and growing nicely, but there's also a nice patch of plantain growing just nearby. p_l loads up {PRONOUN/p_l/poss} mostly-obliging escort and carries the extensive harvest home, tail waving jovially with {PRONOUN/p_l/poss} good mood.",
                 "exp": 20,
                 "weight": 5,
-                "herbs": ["many_herbs"],
+                "herbs": ["many_herbs", "lungwort", "plantain"],
                 "relationships": [
                     {
                         "cats_to": ["patrol"],
@@ -564,6 +565,7 @@
                 "text": "It takes all of s_c's considerable talent for such things to hunt down the lungwort within their borders, the medicine cat visiting each likely nook and cranny in a carefully planned search pattern until finally those telltale speckled leaves are found.",
                 "exp": 20,
                 "weight": 20,
+                "herbs": ["many_herbs", "lungwort"],
                 "stat_skill": ["SENSE,2", "CLEVER,3"],
                 "relationships": [
                     {
@@ -579,6 +581,7 @@
                 "text": "Night falls, and still s_c insists they keep going - they just can't let c_n go without. Exhausted but determined, the medicine cat persists patiently until they find those precious speckled leaves.",
                 "exp": 20,
                 "weight": 20,
+                "herbs": ["many_herbs", "lungwort"],
                 "stat_trait": ["patient"],
                 "relationships": [
                     {
@@ -887,6 +890,7 @@
                 "text": "It takes them all day, but eventually, finally, p_l spots the speckled leaves they've been looking for, so crucial to harvest while the growing season is upon them. For just a second, {PRONOUN/p_l/subject} {VERB/p_l/feel/feels} the weight of {PRONOUN/p_l/poss} responsibilities lift, the strength of that relief catching {PRONOUN/p_l/object} off guard.",
                 "exp": 20,
                 "weight": 20,
+                "herbs": ["lungwort"],
                 "relationships": [
                     {
                         "cats_to": ["patrol"],
@@ -901,7 +905,7 @@
                 "text": "Not only is the lungwort intact and growing nicely, but there's also a nice patch of plantain growing just nearby. p_l loads up {PRONOUN/p_l/poss} mostly-obliging escort and carries the extensive harvest home, tail waving jovially with {PRONOUN/p_l/poss} good mood.",
                 "exp": 20,
                 "weight": 5,
-                "herbs": ["many_herbs"],
+                "herbs": ["many_herbs", "lungwort", "plantain"],
                 "relationships": [
                     {
                         "cats_to": ["patrol"],
@@ -916,6 +920,7 @@
                 "text": "It takes all of s_c's considerable talent for such things to hunt down the lungwort within their borders, the medicine cat visiting each likely nook and cranny in a carefully planned search pattern until finally those telltale speckled leaves are found.",
                 "exp": 20,
                 "weight": 20,
+                "herbs": ["many_herbs", "lungwort"],
                 "stat_skill": ["SENSE,2", "CLEVER,3"],
                 "relationships": [
                     {
@@ -931,6 +936,7 @@
                 "text": "Night falls, and still s_c insists they keep going - they just can't let c_n go without. Exhausted but determined, the medicine cat persists patiently until they find those precious speckled leaves.",
                 "exp": 20,
                 "weight": 20,
+                "herbs": ["many_herbs", "lungwort"],
                 "stat_trait": ["patient"],
                 "relationships": [
                     {
@@ -1239,6 +1245,7 @@
                 "text": "It takes them all day, but eventually, finally, p_l spots the speckled leaves they've been looking for, so crucial to replenishing the Clan's stores after the long greenleaf. For just a second, {PRONOUN/p_l/subject} {VERB/p_l/feel/feels} the weight of {PRONOUN/p_l/poss} responsibilities lift, the strength of that relief catching {PRONOUN/p_l/subject} off guard.",
                 "exp": 20,
                 "weight": 20,
+                "herbs": ["lungwort"],
                 "relationships": [
                     {
                         "cats_to": ["patrol"],
@@ -1253,7 +1260,7 @@
                 "text": "Not only is the lungwort intact and growing nicely, but there's also a nice patch of plantain growing just nearby. p_l loads up {PRONOUN/p_l/poss} mostly-obliging escort and carries the extensive harvest home, tail waving jovially with {PRONOUN/p_l/poss} good mood.",
                 "exp": 20,
                 "weight": 5,
-                "herbs": ["many_herbs"],
+                "herbs": ["many_herbs", "lungwort", "plantain"],
                 "relationships": [
                     {
                         "cats_to": ["patrol"],
@@ -1268,6 +1275,7 @@
                 "text": "It takes all of s_c's considerable talent for such things to hunt down the lungwort within their borders, the medicine cat visiting each likely nook and cranny in a carefully planned search pattern until finally those telltale speckled leaves are found.",
                 "exp": 20,
                 "weight": 20,
+                "herbs": ["many_herbs", "lungwort"],
                 "stat_skill": ["SENSE,2", "CLEVER,3"],
                 "relationships": [
                     {
@@ -1283,6 +1291,7 @@
                 "text": "Night falls, and still s_c insists they keep going - they just can't let c_n go without. Exhausted but determined, the medicine cat persists patiently until they find those precious speckled leaves.",
                 "exp": 20,
                 "weight": 20,
+                "herbs": ["many_herbs", "lungwort"],
                 "stat_trait": ["patient"],
                 "relationships": [
                     {

--- a/resources/dicts/patrols/forest/med/any.json
+++ b/resources/dicts/patrols/forest/med/any.json
@@ -314,7 +314,7 @@
                 "exp": 10,
                 "weight": 20,
                 "stat_skill": ["SENSE,2"],
-                "herbs": ["many_herbs"],
+                "herbs": ["many_herbs", "random_herbs"],
                 "relationships": [
                     {
                         "cats_to": ["patrol"],

--- a/resources/dicts/patrols/general/medcat.json
+++ b/resources/dicts/patrols/general/medcat.json
@@ -1085,7 +1085,7 @@
                 "exp": 30,
                 "weight": 20,
                 "stat_skill": ["SENSE,2", "CLEVER,2"],
-                "herbs": ["many_herbs"],
+                "herbs": ["many_herbs", "random_herbs"],
                 "relationships": [
                     {
                         "cats_to": ["patrol"],
@@ -1160,7 +1160,7 @@
                 "exp": 30,
                 "weight": 20,
                 "stat_skill": ["SENSE,2", "CLEVER,2"],
-                "herbs": ["many_herbs"],
+                "herbs": ["many_herbs", "random_herbs"],
                 "relationships": [
                     {
                         "cats_to": ["patrol"],
@@ -1220,7 +1220,7 @@
                 "text": "app1 is the first to find some herbs, and smugly waves them in the faces of app2 and app3 - after that it's a bit of a competition, with each cat trying to out-compete the others. It's great for the Clan - in the end, they come back to camp with a sizeable haul!",
                 "exp": 20,
                 "weight": 5,
-                "herbs": ["many_herbs"],
+                "herbs": ["many_herbs", "random_herbs"],
                 "relationships": [
                     {
                         "cats_to": ["patrol"],
@@ -1280,7 +1280,7 @@
                 "text": "app1 is the first to find some herbs, and smugly waves them in the faces of the other three - after that it's a bit of a competition, with each cat trying to out-compete the others. It's great for the Clan - in the end, they come back to camp with a sizeable haul!",
                 "exp": 20,
                 "weight": 5,
-                "herbs": ["many_herbs"],
+                "herbs": ["many_herbs", "random_herbs"],
                 "relationships": [
                     {
                         "cats_to": ["patrol"],
@@ -1340,7 +1340,7 @@
                 "text": "app1 is the first to find some herbs, and smugly waves them in the faces of the other four - after that it's a bit of a competition, with each cat trying to out-compete the others. It's great for the Clan - in the end, they come back to camp with a sizeable haul!",
                 "exp": 20,
                 "weight": 5,
-                "herbs": ["many_herbs"],
+                "herbs": ["many_herbs", "random_herbs"],
                 "relationships": [
                     {
                         "cats_to": ["patrol"],
@@ -1399,7 +1399,7 @@
                 "text": "app1 is the first to find some herbs, and smugly waves them in the faces of the other five - after that it's a bit of a competition, with each cat trying to out-compete the others. It's great for the Clan - in the end, they come back to camp with a sizeable haul!",
                 "exp": 20,
                 "weight": 5,
-                "herbs": ["many_herbs"],
+                "herbs": ["many_herbs", "random_herbs"],
                 "relationships": [
                     {
                         "cats_to": ["patrol"],
@@ -2664,7 +2664,7 @@
                 "text": "The game is afoot! p_l and app2 return to camp, happily spent, with plenty of herbs.",
                 "exp": 10,
                 "weight": 5,
-                "herbs": ["many_herbs"],
+                "herbs": ["many_herbs", "random_herbs"],
                 "relationships": [
                     {
                         "cats_to": ["patrol"],
@@ -2782,7 +2782,7 @@
                 "text": "Driven by the competition, p_l and app2 work extra hard and return to camp with a <i>lot</i> of herbs, to the surprise of their mentors.",
                 "exp": 10,
                 "weight": 5,
-                "herbs": ["many_herbs"]
+                "herbs": ["many_herbs", "random_herbs"]
             }
         ],
         "fail_outcomes": [
@@ -3093,7 +3093,7 @@
                 "text": "Despite being alone, r_c decides to follow the figure. Perhaps it's a StarClan cat. As {PRONOUN/r_c/subject} {VERB/r_c/get/gets} closer, {PRONOUN/r_c/subject} {VERB/r_c/realize/realizes} that no, this cat doesn't have stars in its fur. But it doesn't seem malicious either. The ghostly cat beckons r_c closer and, to {PRONOUN/r_c/poss} surprise, the ghost has led {PRONOUN/r_c/object} to a giant patch of herbs! r_c thanks the spirit and it seems to smile as r_c begins to collect the herbs.",
                 "exp": 10,
                 "weight": 20,
-                "herbs": ["many_herbs"]
+                "herbs": ["many_herbs", "random_herbs"]
             },
             {
                 "text": "Despite being alone, r_c decides to follow the figure. Perhaps it's a StarClan cat. As {PRONOUN/r_c/subject} {VERB/r_c/get/gets} closer, {PRONOUN/r_c/subject} {VERB/r_c/realize/realizes} that no, this cat doesn't have stars in {PRONOUN/r_c/poss} fur. But it doesn't seem malicious either. The ghost waves its tail as if to say 'hello'. r_c nods back at it, and continues {PRONOUN/r_c/poss} herb gathering with the friendly ghost flitting about.",
@@ -3183,13 +3183,12 @@
                 "text": "Calling on StarClan's guidance, p_l instructs the patrol to bow to the black cat. It bows back in return and shows them an abundant patch of rare herbs.",
                 "exp": 30,
                 "weight": 10,
-                "herbs": ["catmint"]
+                "herbs": ["many_herbs", "catmint"]
             },
             {
                 "text": "Sensing the black cat's strong aura, s_c urges it to speak, and listens carefully as it imparts a bone-chilling omen, omen_list.",
                 "exp": 30,
                 "weight": 20,
-                "herbs": ["many_herbs"],
                 "stat_skill": [
                     "INSIGHTFUL,2", 
                     "SENSE,2", 

--- a/resources/dicts/patrols/mountainous/med/any.json
+++ b/resources/dicts/patrols/mountainous/med/any.json
@@ -328,7 +328,7 @@
                 "exp": 10,
                 "weight": 20,
                 "stat_skill": ["SENSE,2"],
-                "herbs": ["many_herbs"],
+                "herbs": ["many_herbs", "random_herbs"],
                 "relationships": [
                     {
                         "cats_to": ["patrol"],

--- a/resources/dicts/patrols/plains/med/any.json
+++ b/resources/dicts/patrols/plains/med/any.json
@@ -306,7 +306,7 @@
                 "exp": 10,
                 "weight": 20,
                 "stat_skill": ["SENSE,2"],
-                "herbs": ["many_herbs"],
+                "herbs": ["many_herbs", "random_herbs"],
                 "relationships": [
                     {
                         "cats_to": ["patrol"],

--- a/resources/dicts/patrols/wetlands/med/any.json
+++ b/resources/dicts/patrols/wetlands/med/any.json
@@ -430,6 +430,7 @@
                 "text": "It takes them all day, but eventually, finally, p_l spots the speckled leaves they've been looking for, so crucial to replenishing the Clan's stores after the long leaf-bare. For just a second, they feel the weight of their responsibilities lift, the strength of that relief catching them off guard.",
                 "exp": 20,
                 "weight": 20,
+                "herbs": ["lungwort"],
                 "relationships": [
                     {
                         "cats_to": ["patrol"],
@@ -444,7 +445,7 @@
                 "text": "Not only is the lungwort intact and growing nicely, but there's also a nice patch of plantain growing just nearby. p_l loads up their mostly-obliging escort and carries the extensive harvest home, tail waving jovially with their good mood.",
                 "exp": 20,
                 "weight": 5,
-                "herbs": ["many_herbs"],
+                "herbs": ["many_herbs", "lungwort", "plantain"],
                 "relationships": [
                     {
                         "cats_to": ["patrol"],
@@ -459,6 +460,7 @@
                 "text": "It takes all of s_c's considerable talent for such things to hunt down the lungwort within their borders, the medicine cat visiting each likely nook and cranny in a carefully planned search pattern until finally those telltale speckled leaves are found.",
                 "exp": 20,
                 "weight": 20,
+                "herbs": ["many_herbs", "lungwort"],
                 "stat_skill": ["SENSE,2", "CLEVER,3"],
                 "relationships": [
                     {
@@ -474,6 +476,7 @@
                 "text": "Night falls, and still s_c insists they keep going - they just can't let c_n go without. Exhausted but determined, the medicine cat persists patiently until they find those precious speckled leaves.",
                 "exp": 20,
                 "weight": 20,
+                "herbs": ["many_herbs", "lungwort"],
                 "stat_trait": ["patient"],
                 "relationships": [
                     {
@@ -782,6 +785,7 @@
                 "text": "It takes them all day, but eventually, finally, p_l spots the speckled leaves they've been looking for, so crucial to harvest while the growing season is upon them. For just a second, they feel the weight of their responsibilities lift, the strength of that relief catching them off guard.",
                 "exp": 20,
                 "weight": 20,
+                "herbs": ["lungwort"],
                 "relationships": [
                     {
                         "cats_to": ["patrol"],
@@ -796,7 +800,7 @@
                 "text": "Not only is the lungwort intact and growing nicely, but there's also a nice patch of plantain growing just nearby. p_l loads up their mostly-obliging escort and carries the extensive harvest home, tail waving jovially with their good mood.",
                 "exp": 20,
                 "weight": 5,
-                "herbs": ["many_herbs"],
+                "herbs": ["many_herbs", "lungwort", "plantain"],
                 "relationships": [
                     {
                         "cats_to": ["patrol"],
@@ -811,6 +815,7 @@
                 "text": "It takes all of s_c's considerable talent for such things to hunt down the lungwort within their borders, the medicine cat visiting each likely nook and cranny in a carefully planned search pattern until finally those telltale speckled leaves are found.",
                 "exp": 20,
                 "weight": 20,
+                "herbs": ["many_herbs", "lungwort"],
                 "stat_skill": ["SENSE,2", "CLEVER,3"],
                 "relationships": [
                     {
@@ -826,6 +831,7 @@
                 "text": "Night falls, and still s_c insists they keep going - they just can't let c_n go without. Exhausted but determined, the medicine cat persists patiently until they find those precious speckled leaves.",
                 "exp": 20,
                 "weight": 20,
+                "herbs": ["many_herbs", "lungwort"],
                 "stat_trait": ["patient"],
                 "relationships": [
                     {
@@ -1134,6 +1140,7 @@
                 "text": "It takes them all day, but eventually, finally, p_l spots the speckled leaves they've been looking for, so crucial to harvest before the plant dies back in leaf-bare. For just a second, they feel the weight of their responsibilities lift, the strength of that relief catching them off guard.",
                 "exp": 20,
                 "weight": 20,
+                "herbs": ["lungwort"],
                 "relationships": [
                     {
                         "cats_to": ["patrol"],
@@ -1148,7 +1155,7 @@
                 "text": "Not only is the lungwort intact and growing nicely, but there's also a nice patch of plantain growing just nearby. p_l loads up their mostly-obliging escort and carries the extensive harvest home, tail waving jovially with their good mood.",
                 "exp": 20,
                 "weight": 5,
-                "herbs": ["many_herbs"],
+                "herbs": ["many_herbs", "lungwort", "plantain"],
                 "relationships": [
                     {
                         "cats_to": ["patrol"],
@@ -1163,6 +1170,7 @@
                 "text": "It takes all of s_c's considerable talent for such things to hunt down the lungwort within their borders, the medicine cat visiting each likely nook and cranny in a carefully planned search pattern until finally those telltale speckled leaves are found.",
                 "exp": 20,
                 "weight": 20,
+                "herbs": ["many_herbs", "lungwort"],
                 "stat_skill": ["SENSE,2", "CLEVER,3"],
                 "relationships": [
                     {
@@ -1178,6 +1186,7 @@
                 "text": "Night falls, and still s_c insists they keep going - they just can't let c_n go without. Exhausted but determined, the medicine cat persists patiently until they find those precious speckled leaves.",
                 "exp": 20,
                 "weight": 20,
+                "herbs": ["many_herbs", "lungwort"],
                 "stat_trait": ["patient"],
                 "relationships": [
                     {
@@ -1486,6 +1495,7 @@
                 "text": "It takes them all day, checking spots where they've seen lungwort growing before, but finally when p_l sweeps back the snow covering they find a plant with leaves still green, if looking a little wilted. For just a second, they feel the weight of their responsibilities lift, the strength of that relief catching them off guard.",
                 "exp": 20,
                 "weight": 20,
+                "herbs": ["lungwort"],
                 "relationships": [
                     {
                         "cats_to": ["patrol"],
@@ -1500,7 +1510,7 @@
                 "text": "Not only is the lungwort intact and still fresh, but there's also a nice patch of plantain nearby. p_l loads up their mostly-obliging escort and carries the extensive harvest home, tail waving jovially with their good mood.",
                 "exp": 20,
                 "weight": 5,
-                "herbs": ["many_herbs"],
+                "herbs": ["many_herbs", "lungwort", "plantain"],
                 "relationships": [
                     {
                         "cats_to": ["patrol"],
@@ -1515,6 +1525,7 @@
                 "text": "It takes all of s_c's considerable talent for such things to hunt down the lungwort within their borders, the medicine cat visiting each likely nook and cranny in a carefully planned search pattern until finally those telltale speckled leaves are found under the blanketing snow.",
                 "exp": 20,
                 "weight": 20,
+                "herbs": ["many_herbs", "lungwort"],
                 "stat_skill": ["SENSE,2", "CLEVER,3"],
                 "relationships": [
                     {
@@ -1530,6 +1541,7 @@
                 "text": "Night falls, and still s_c insists they keep going - they just can't let c_n go without. Exhausted but determined, the medicine cat persists patiently until they find those precious speckled leaves, wilted but still valuable.",
                 "exp": 20,
                 "weight": 20,
+                "herbs": ["many_herbs", "lungwort"],
                 "stat_trait": ["patient"],
                 "relationships": [
                     {

--- a/resources/dicts/patrols/wetlands/med/medcat_wetlands.json
+++ b/resources/dicts/patrols/wetlands/med/medcat_wetlands.json
@@ -429,6 +429,7 @@
                 "text": "It takes them all day, but eventually, finally, p_l spots the speckled leaves they've been looking for, so crucial to replenishing the Clan's stores after the long leaf-bare. For just a second, they feel the weight of their responsibilities lift, the strength of that relief catching them off guard.",
                 "exp": 20,
                 "weight": 20,
+                "herbs": ["lungwort"],
                 "relationships": [
                     {
                         "cats_to": ["patrol"],
@@ -443,7 +444,7 @@
                 "text": "Not only is the lungwort intact and growing nicely, but there's also a nice patch of plantain growing just nearby. p_l loads up their mostly-obliging escort and carries the extensive harvest home, tail waving jovially with their good mood.",
                 "exp": 20,
                 "weight": 5,
-                "herbs": ["many_herbs"],
+                "herbs": ["many_herbs", "lungwort", "plantain"],
                 "relationships": [
                     {
                         "cats_to": ["patrol"],
@@ -458,6 +459,7 @@
                 "text": "It takes all of s_c's considerable talent for such things to hunt down the lungwort within their borders, the medicine cat visiting each likely nook and cranny in a carefully planned search pattern until finally those telltale speckled leaves are found.",
                 "exp": 20,
                 "weight": 20,
+                "herbs": ["many_herbs", "lungwort"],
                 "stat_skill": ["SENSE,2", "CLEVER,3"],
                 "relationships": [
                     {
@@ -473,6 +475,7 @@
                 "text": "Night falls, and still s_c insists they keep going - they just can't let c_n go without. Exhausted but determined, the medicine cat persists patiently until they find those precious speckled leaves.",
                 "exp": 20,
                 "weight": 20,
+                "herbs": ["many_herbs", "lungwort"],
                 "stat_trait": ["patient"],
                 "relationships": [
                     {
@@ -781,6 +784,7 @@
                 "text": "It takes them all day, but eventually, finally, p_l spots the speckled leaves they've been looking for, so crucial to harvest while the growing season is upon them. For just a second, they feel the weight of their responsibilities lift, the strength of that relief catching them off guard.",
                 "exp": 20,
                 "weight": 20,
+                "herbs": ["lungwort"],
                 "relationships": [
                     {
                         "cats_to": ["patrol"],
@@ -795,7 +799,7 @@
                 "text": "Not only is the lungwort intact and growing nicely, but there's also a nice patch of plantain growing just nearby. p_l loads up their mostly-obliging escort and carries the extensive harvest home, tail waving jovially with their good mood.",
                 "exp": 20,
                 "weight": 5,
-                "herbs": ["many_herbs"],
+                "herbs": ["many_herbs", "lungwort", "plantain"],
                 "relationships": [
                     {
                         "cats_to": ["patrol"],
@@ -810,6 +814,7 @@
                 "text": "It takes all of s_c's considerable talent for such things to hunt down the lungwort within their borders, the medicine cat visiting each likely nook and cranny in a carefully planned search pattern until finally those telltale speckled leaves are found.",
                 "exp": 20,
                 "weight": 20,
+                "herbs": ["many_herbs", "lungwort"],
                 "stat_skill": ["SENSE,2", "CLEVER,3"],
                 "relationships": [
                     {
@@ -825,6 +830,7 @@
                 "text": "Night falls, and still s_c insists they keep going - they just can't let c_n go without. Exhausted but determined, the medicine cat persists patiently until they find those precious speckled leaves.",
                 "exp": 20,
                 "weight": 20,
+                "herbs": ["many_herbs", "lungwort"],
                 "stat_trait": ["patient"],
                 "relationships": [
                     {
@@ -1133,6 +1139,7 @@
                 "text": "It takes them all day, but eventually, finally, p_l spots the speckled leaves they've been looking for, so crucial to harvest before the plant dies back in leaf-bare. For just a second, they feel the weight of their responsibilities lift, the strength of that relief catching them off guard.",
                 "exp": 20,
                 "weight": 20,
+                "herbs": ["lungwort"],
                 "relationships": [
                     {
                         "cats_to": ["patrol"],
@@ -1147,7 +1154,7 @@
                 "text": "Not only is the lungwort intact and growing nicely, but there's also a nice patch of plantain growing just nearby. p_l loads up their mostly-obliging escort and carries the extensive harvest home, tail waving jovially with their good mood.",
                 "exp": 20,
                 "weight": 5,
-                "herbs": ["many_herbs"],
+                "herbs": ["many_herbs", "lungwort", "plantain"],
                 "relationships": [
                     {
                         "cats_to": ["patrol"],
@@ -1162,6 +1169,7 @@
                 "text": "It takes all of s_c's considerable talent for such things to hunt down the lungwort within their borders, the medicine cat visiting each likely nook and cranny in a carefully planned search pattern until finally those telltale speckled leaves are found.",
                 "exp": 20,
                 "weight": 20,
+                "herbs": ["many_herbs", "lungwort"],
                 "stat_skill": ["SENSE,2", "CLEVER,3"],
                 "relationships": [
                     {
@@ -1177,6 +1185,7 @@
                 "text": "Night falls, and still s_c insists they keep going - they just can't let c_n go without. Exhausted but determined, the medicine cat persists patiently until they find those precious speckled leaves.",
                 "exp": 20,
                 "weight": 20,
+                "herbs": ["many_herbs", "lungwort"],
                 "stat_trait": ["patient"],
                 "relationships": [
                     {


### PR DESCRIPTION
-added specific herbs to many_herbs outcomes that didnt have any 
-added herbs to lungwort patrols in desert and wetlands 
-moved many_herbs tag on witch patrol to the outcome that gives catmint instead of the omen outcome