### PR TITLE
Clarify some settings have moved

### DIFF
--- a/scripts/screens/SettingsScreen.py
+++ b/scripts/screens/SettingsScreen.py
@@ -307,8 +307,9 @@ class SettingsScreen(Screens):
             (1360 / 1600 * screen_x, (n * 78 + 80) / 1400 * screen_y))
 
         self.checkboxes_text['instr'] = pygame_gui.elements.UITextBox(
-            "Change the general settings of your game here",
-            scale(pygame.Rect((200, 320), (1200, 100))),
+            """Change the general settings of your game here.\n"""
+            """More settings are available in the settings page of your Clan.""",
+            scale(pygame.Rect((200, 320), (1200, 200))),
             object_id=get_text_box_theme("#text_box_30_horizcenter"),
             manager=MANAGER)
 


### PR DESCRIPTION
![image](https://github.com/Thlumyn/clangen/assets/63805048/e0385664-488e-41a4-a337-82601661840d)

Changes the label on the general settings page to inform users that there are more settings in the Clan settings page, since some users are getting the impression that these settings have been completely removed from the game.