### PR TITLE
bugfix: loss of balance -> constantly dizzy

### DIFF
--- a/resources/dicts/conditions/condition_got_strings/gain_permanent_condition_strings.json
+++ b/resources/dicts/conditions/condition_got_strings/gain_permanent_condition_strings.json
@@ -147,7 +147,7 @@
             "m_c hasn't been able to see clearly since {PRONOUN/m_c/subject} {VERB/m_c/were/was} hit in the head, and it only gets worse by the day. Eventually r_c breaks the news that {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} going blind.",
             "m_c stumbles through camp, trying {PRONOUN/m_c/poss} best to learn the layout. It seems like {PRONOUN/m_c/poss} head injury has made {PRONOUN/m_c/object} go blind and {PRONOUN/m_c/poss} vision doesn't seem to be returning any time soon."
         ],
-        "loss of balance": [
+        "constantly dizzy": [
             "m_c stumbles through the medicine den, trying to walk a straight line as r_c instructed. r_c tells {PRONOUN/m_c/object} that the newfound lack of balance might be a permanent result of {PRONOUN/m_c/poss} head injury.",
             "m_c finds that {PRONOUN/m_c/subject} {VERB/m_c/have/has} to concentrate to stay upright while standing and the newfound loss of balance is endlessly frustrating to {PRONOUN/m_c/subject}. {PRONOUN/m_c/subject/CAP} {VERB/m_c/surmise/surmises} that it's likely been caused by {PRONOUN/m_c/poss} head injury.",
             "Though {PRONOUN/m_c/poss} head injury has healed, m_c feels like a newborn kitten on {PRONOUN/m_c/poss} legs as {PRONOUN/m_c/subject} {VERB/m_c/stumble/stumbles} around the medicine den. {PRONOUN/m_c/subject/CAP} {VERB/m_c/sigh/sighs} and {VERB/m_c/accept/accepts} the fact that {PRONOUN/m_c/poss} balance will likely never be the same."

--- a/resources/dicts/conditions/injuries.json
+++ b/resources/dicts/conditions/injuries.json
@@ -1141,7 +1141,7 @@
             "failing eyesight",
             "one bad eye",
             "blind",
-            "loss of balance",
+            "constantly dizzy",
             "partial hearing loss",
             "persistent headaches"
         ],


### PR DESCRIPTION
i believe "loss of balance" is an old name for "constantly dizzy", as the latter is a condition that exists while the former is...well, not. this should allow cats to actually get the "constantly dizzy" permanent condition from the "head damage" injury now