### PR TITLE
fixes for clan-specific settings typos and patrol typos

### DIFF
--- a/resources/dicts/patrols/beach/med/newleaf.json
+++ b/resources/dicts/patrols/beach/med/newleaf.json
@@ -1418,7 +1418,7 @@
             "normal adult": [1, 6]
         },
         "weight": 20,
-        "intro_text": "With the snows of leaf-bare nearly vanished, newleaf winning its place in the seasonal cycle, p_l heads out to gather daisy leaves. {PRONOUN/p_l/subject/CAP} {VERB/p_l/assemble/assembles} a little group of warriors to help {PRONOUN/p_l/subject} carry the herbs.",
+        "intro_text": "With the snows of leaf-bare nearly vanished, newleaf winning its place in the seasonal cycle, p_l heads out to gather daisy leaves. {PRONOUN/p_l/subject/CAP} {VERB/p_l/assemble/assembles} a little group of warriors to help {PRONOUN/p_l/object} carry the herbs.",
         "decline_text": "{PRONOUN/p_l/subject/CAP}'re stopped before {PRONOUN/p_l/subject} {VERB/p_l/leave/leaves} camp - these warriors are needed elsewhere. p_l's expedition will have to wait.",
         "chance_of_success": 30,
         "success_outcomes": [

--- a/resources/dicts/patrols/general/hunting.json
+++ b/resources/dicts/patrols/general/hunting.json
@@ -1273,7 +1273,7 @@
     ],
     "fail_outcomes": [
         {
-            "text": "Your patrol confronts the strange cat - they are obviously an intruder on c_n territory, and they don't look like the friendly type. The strange cat shrieks, an awful, blood curdling scream that makes r_c 's fur stand on end. Overcome by terror, the patrol flees back to camp.",
+            "text": "Your patrol confronts the strange cat - they are obviously an intruder on c_n territory, and they don't look like the friendly type. The strange cat shrieks, an awful, blood-curdling scream that makes r_c's fur stand on end. Overcome by terror, the patrol flees back to camp.",
             "exp": 0,
             "weight": 10,
             "injury": [

--- a/resources/dicts/patrols/plains/hunting/any.json
+++ b/resources/dicts/patrols/plains/hunting/any.json
@@ -2481,7 +2481,7 @@
                 ]
             },
             {
-                "text": "s_c's stressed nerves can't handle this weird monster, and {PRONOUN/s_c/subject} {VERB/s_c/beg/begs} to go back homeinstead of confronting it.",
+                "text": "s_c's stressed nerves can't handle this weird monster, and {PRONOUN/s_c/subject} {VERB/s_c/beg/begs} to go back home instead of confronting it.",
                 "exp": 0,
                 "weight": 20,
                 "stat_trait": ["childish", "nervous"],

--- a/resources/dicts/patrols/plains/hunting/leaf-fall.json
+++ b/resources/dicts/patrols/plains/hunting/leaf-fall.json
@@ -1791,7 +1791,7 @@
             "normal adult": [1, 6]
         },
         "weight": 20,
-        "intro_text": "app1 catches scent of a mouse nearby. p_l how more mice will be attracted to this area, drawn in by the grass that has gone to seed under the leaf-fall sun.",
+        "intro_text": "app1 catches scent of a mouse nearby. p_l knows how more mice will be attracted to this area, drawn in by the grass that has gone to seed under the leaf-fall sun.",
         "decline_text": "Your patrol ignores the mouse.",
         "chance_of_success": 60,
         "success_outcomes": [

--- a/scripts/screens/ClanSettingsScreen.py
+++ b/scripts/screens/ClanSettingsScreen.py
@@ -25,7 +25,7 @@ with open('resources/clansettings.json', 'r', encoding='utf-8') as f:
 
 class ClanSettingsScreen(Screens):
     """
-    Screen handles all clan-specfic settings
+    Screen handles all Clan-specific settings
     """
     text_size = {
         '0': 'small',
@@ -212,7 +212,7 @@ class ClanSettingsScreen(Screens):
             (1360 / 1600 * screen_x, (n * 78 + 80) / 1400 * screen_y))
 
         self.checkboxes_text['instr'] = pygame_gui.elements.UITextBox(
-            "Change the general clan-specfic settings",
+            "Change the general Clan-specific settings",
             scale(pygame.Rect((200, 370), (1200, 100))),
             object_id=get_text_box_theme("#text_box_30_horizcenter"),
             manager=MANAGER)
@@ -251,7 +251,7 @@ class ClanSettingsScreen(Screens):
             n += 1
 
         self.checkboxes_text['instr'] = pygame_gui.elements.UITextBox(
-            "Change clan-specfic settings regarding cat roles",
+            "Change Clan-specific settings regarding cat roles",
             scale(pygame.Rect((200, 370), (1200, 100))),
             object_id=get_text_box_theme("#text_box_30_horizcenter"),
             manager=MANAGER)
@@ -285,7 +285,7 @@ class ClanSettingsScreen(Screens):
             n += 1
 
         self.checkboxes_text['instr'] = pygame_gui.elements.UITextBox(
-            "Change clan-specfic settings regarding cat relationships",
+            "Change Clan-specific settings regarding cat relationships",
             scale(pygame.Rect((200, 370), (1200, 100))),
             object_id=get_text_box_theme("#text_box_30_horizcenter"),
             manager=MANAGER)


### PR DESCRIPTION
fixed typos in the clan specific settings page and patrols, including two halloween specific patrols

typos reported here:
https://github.com/ClanGenOfficial/clangen/issues/1818#issuecomment-1783286224
https://github.com/ClanGenOfficial/clangen/issues/1818#issuecomment-1783306328
https://github.com/ClanGenOfficial/clangen/issues/1818#issuecomment-1783656637
https://github.com/ClanGenOfficial/clangen/issues/1818#issuecomment-1783900184
https://github.com/ClanGenOfficial/clangen/issues/1818#issuecomment-1806662057