### PR TITLE
Fix "Pair has already been mediated" sometimes showing up when a pair had not been mediated that moon

### DIFF
--- a/scripts/screens/MediationScreen.py
+++ b/scripts/screens/MediationScreen.py
@@ -64,7 +64,7 @@ class MediationScreen(Screens):
                 self.update_selected_cats()
                 self.update_mediator_info()
             elif event.ui_element == self.sabotoge_button:
-                game.mediated.append(f"{self.selected_cat_1.ID}, {self.selected_cat_2.ID}")
+                game.mediated.append([self.selected_cat_1.ID, self.selected_cat_2.ID])
                 game.patrolled.append(self.mediators[self.selected_mediator].ID)
                 output = Cat.mediate_relationship(
                     self.mediators[self.selected_mediator], self.selected_cat_1, self.selected_cat_2,


### PR DESCRIPTION
Fix issue where cat-pairs who were sabotaged (not mediated!) were not tracked correctly.

Closes #1858