### PR TITLE
Leader multi-death patrol text change

### DIFF
--- a/resources/dicts/patrols/disaster.json
+++ b/resources/dicts/patrols/disaster.json
@@ -526,10 +526,10 @@
         ],
         "fail_outcomes": [
             {
-                "text": "Your patrol walks into an ambush by a group of rogues and everyone is slaughtered.",
+                "text": "r_c walks into an ambush by a group of rogues and is slaughtered.",
                 "exp": 0,
                 "weight": 10,
-                "dead_cats": ["patrol"],
+                "dead_cats": ["r_c", "some_lives"],
                 "history_text": {
                     "reg_death": "This cat died from being ambushed by rogues while on a solo patrol.",
                     "lead_death": "{VERB/m_c/were/was} ambushed by rogues while on a solo patrol"
@@ -1502,10 +1502,10 @@
         ],
         "fail_outcomes": [
             {
-                "text": "Your patrol walks into an ambush by a group of rogues and everyone is slaughtered.",
+                "text": "r_c walks into an ambush by a group of rogues and is slaughtered.",
                 "exp": 0,
                 "weight": 10,
-                "dead_cats": ["patrol"],
+                "dead_cats": ["r_c", "some_lives"],
                 "history_text": {
                     "reg_death": "This cat died from being ambushed by rogues while on a solo patrol.",
                     "lead_death": "{VERB/m_c/were/was} ambushed by rogues while on a solo patrol"

--- a/resources/dicts/patrols/general/border.json
+++ b/resources/dicts/patrols/general/border.json
@@ -961,7 +961,7 @@
         },
         "weight": 20,
         "intro_text": "The patrol spots a badger making a den on o_c_n territory.",
-        "decline_text": "It's not c_n's problem, but {PRONOUN/p_l/subject}  {VERB/p_l/make/makes} a mental note to mention the badger to {PRONOUN/p_l/poss} leader later.",
+        "decline_text": "It's not c_n's problem, but {PRONOUN/p_l/subject} {VERB/p_l/make/makes} a mental note to mention the badger to {PRONOUN/p_l/poss} leader later.",
         "chance_of_success": 50,
         "success_outcomes": [
             {

--- a/resources/dicts/patrols/new_cat.json
+++ b/resources/dicts/patrols/new_cat.json
@@ -1440,7 +1440,7 @@
                 "text": "p_l decides that a quick peek can't hurt. As {PRONOUN/p_l/subject} {VERB/p_l/venture/ventures} into the nest, ears pricked with curiosity, {PRONOUN/p_l/subject} {VERB/p_l/don't/doesn't} notice the lithe forms of rogues moving to block the entrance until it's too late. p_l never makes it back to camp.",
                 "exp": 0,
                 "weight": 10,
-                "dead_cats": ["r_c"],
+                "dead_cats": ["r_c", "some_lives"],
                 "history_text": {
                     "reg_death": "This cat died in an ambush set by rogues.",
                     "lead_death": "{VERB/m_c/were/was} killed in a rogue ambush"
@@ -1902,7 +1902,7 @@
                 "text": "r_c decides that a quick peek can't hurt. As {PRONOUN/r_c/subject} {VERB/r_c/venture/ventures} into the nest, ears pricked with curiosity, {PRONOUN/r_c/subject} {VERB/r_c/don't/doesn't} notice the lithe forms of rogues moving to block the entrance until it's too late. r_c never makes it back to camp.",
                 "exp": 0,
                 "weight": 10,
-                "dead_cats": ["r_c"],
+                "dead_cats": ["r_c", "some_lives"],
                 "history_text": {
                     "reg_death": "This cat died from being ambushed by rogues while on a solo patrol.",
                     "lead_death": "{VERB/m_c/were/was} killed in a rogue ambush while on a solo patrol"

--- a/resources/dicts/patrols/other_clan.json
+++ b/resources/dicts/patrols/other_clan.json
@@ -656,7 +656,7 @@
                 "text": "r_c follows the scent to a o_c_n cat taking refuge up a tree. The cat yowls a warning, but they aren't quick enough and a large dog suddenly descends upon r_c. r_c is killed before they can run.",
                 "exp": 0,
                 "weight": 10,
-                "dead_cats": ["r_c"],
+                "dead_cats": ["r_c", "some_lives"],
                 "history_text": {
                     "scar": "m_c followed the scent of a trespassing cat and was scarred by a dog.",
                     "reg_death": "m_c followed the scent of a trespassing cat and was killed by a dog.",

--- a/resources/dicts/patrols/other_clan_allies.json
+++ b/resources/dicts/patrols/other_clan_allies.json
@@ -454,7 +454,7 @@
                 "text": "r_c follows the scent to a o_c_n cat taking refuge up a tree. The cat yowls a warning, but they aren't quick enough and a large dog suddenly descends upon r_c. r_c is killed before they can run.",
                 "exp": 0,
                 "weight": 10,
-                "dead_cats": ["r_c"],
+                "dead_cats": ["r_c", "some_lives"],
                 "history_text": {
                     "scar": "m_c followed the scent of a trespassing cat and was scarred by a dog.",
                     "reg_death": "m_c followed the scent of a trespassing cat and was killed by a dog.",

--- a/resources/dicts/patrols/other_clan_hostile.json
+++ b/resources/dicts/patrols/other_clan_hostile.json
@@ -961,7 +961,6 @@
                 "text": "r_c encounters a patrol from o_c_n on the border, and greets them politely, but there's something different here. Something dangerous. They return to camp, blood soaked through their fur and a new hardness in their heart.",
                 "exp": 0,
                 "weight": 10,
-                "dead_cats": ["r_c"],
                 "history_text": {
                     "scar": "m_c got injured patrolling on the border.",
                     "reg_death": "m_c lost a life against a hostile Clan.",
@@ -1263,7 +1262,7 @@
                     "confident",
                     "grumpy"
                 ],
-                "dead_cats": ["s_c"],
+                "dead_cats": ["s_c", "some_lives"],
                 "history_text": {
                     "scar": "m_c got injured patrolling on the border.",
                     "reg_death": "m_c was killed by a hostile Clan.",
@@ -1688,7 +1687,7 @@
                 "text": "r_c encounters a patrol from o_c_n on the border, and greets them politely, but there's something different here. Something dangerous. They return to camp, blood soaked through their fur and a new hardness in their heart.",
                 "exp": 0,
                 "weight": 10,
-                "dead_cats": ["r_c"],
+                "dead_cats": ["r_c", "some_lives"],
                 "history_text": {
                     "scar": "m_c got injured patrolling on the border.",
                     "reg_death": "m_c lost a life against a hostile Clan.",
@@ -2414,7 +2413,7 @@
                 "text": "r_c encounters a patrol from o_c_n on the border, and greets them politely, but there's something different here. Something dangerous. They return to camp, blood soaked through their fur and a new hardness in their heart.",
                 "exp": 0,
                 "weight": 10,
-                "dead_cats": ["r_c"],
+                "dead_cats": ["r_c", "some_lives"],
                 "history_text": {
                     "scar": "m_c got injured patrolling on the border.",
                     "reg_death": "m_c lost a life against a hostile Clan.",
@@ -2454,7 +2453,7 @@
                     "troublesome",
                     "vengeful"
                 ],
-                "dead_cats": ["s_c"],
+                "dead_cats": ["s_c", "some_lives"],
                 "history_text": {
                     "scar": "m_c got injured patrolling on the border.",
                     "reg_death": "m_c lost a life against a hostile Clan.",
@@ -3141,7 +3140,7 @@
                 "text": "r_c encounters a patrol from o_c_n on the border, and greets them politely, but there's something different here. Something dangerous. They return to camp, blood soaked through their fur and a new hardness in their heart.",
                 "exp": 0,
                 "weight": 10,
-                "dead_cats": ["r_c"],
+                "dead_cats": ["r_c", "some_lives"],
                 "history_text": {
                     "scar": "m_c got injured patrolling on the border.",
                     "reg_death": "m_c lost a life against a hostile Clan.",

--- a/scripts/patrol/patrol_outcome.py
+++ b/scripts/patrol/patrol_outcome.py
@@ -394,8 +394,12 @@ class PatrolOutcome():
                     game.clan.leader_lives = 0
                     results.append(f"{_cat.name} lost all of their lives.")
                 elif "some_lives" in self.dead_cats:
-                    game.clan.leader_lives -= random.randint(1, max(1, game.clan.leader_lives - 1))
-                    results.append(f"{_cat.name} lost some lives.")
+                    lives_lost = random.randint(1, max(1, game.clan.leader_lives - 1))
+                    game.clan.leader_lives -= lives_lost
+                    if lives_lost == 1:
+                        results.append(f"{_cat.name} lost one life.")
+                    else:
+                        results.append(f"{_cat.name} lost {lives_lost} lives.")
                 else:
                     game.clan.leader_lives -= 1
                     results.append(f"{_cat.name} lost one life.")


### PR DESCRIPTION
- Now it will show the actual number of lives lost.
- Currently, there are very few uses of "some_lives" in the patrols. I added a few to some of the more "brutal" solo patrols.