### PR TITLE
Bugfix: classic no longer crashes on patrol

### DIFF
--- a/scripts/screens/PatrolScreen.py
+++ b/scripts/screens/PatrolScreen.py
@@ -469,16 +469,17 @@ class PatrolScreen(Screens):
         self.elements['patrol_start'].disable()
 
         # add prey information
-        current_amount =  round(game.clan.freshkill_pile.total_amount,2)
-        self.elements['current_prey'] = pygame_gui.elements.UITextBox(
-            f"current prey: {current_amount}", scale(pygame.Rect((500, 1260), (600, 800))),
-            object_id=get_text_box_theme("#text_box_30_horizcenter"), manager=MANAGER
-        )
-        needed_amount = round(game.clan.freshkill_pile.amount_food_needed(),2)
-        self.elements['needed_prey'] = pygame_gui.elements.UITextBox(
-            f"needed prey: {needed_amount}", scale(pygame.Rect((500, 1295), (600, 800))),
-            object_id=get_text_box_theme("#text_box_30_horizcenter"), manager=MANAGER
-        )
+        if game.clan.game_mode != 'classic':
+            current_amount =  round(game.clan.freshkill_pile.total_amount,2)
+            self.elements['current_prey'] = pygame_gui.elements.UITextBox(
+                f"current prey: {current_amount}", scale(pygame.Rect((500, 1260), (600, 800))),
+                object_id=get_text_box_theme("#text_box_30_horizcenter"), manager=MANAGER
+            )
+            needed_amount = round(game.clan.freshkill_pile.amount_food_needed(),2)
+            self.elements['needed_prey'] = pygame_gui.elements.UITextBox(
+                f"needed prey: {needed_amount}", scale(pygame.Rect((500, 1295), (600, 800))),
+                object_id=get_text_box_theme("#text_box_30_horizcenter"), manager=MANAGER
+            )
 
         self.update_cat_images_buttons()
         self.update_button()


### PR DESCRIPTION
Classic was crashing when trying to start a patrol because it was checking needed prey amount, this is a very lazy edit that probably either 1. doesnt fix everything or 2. breaks things entirely but eh, Im adding it anyway. 