### PR TITLE
fix error in gen_border_otherclan_meeting1  text referencing nonexistant cat

### DIFF
--- a/resources/dicts/patrols/general/border.json
+++ b/resources/dicts/patrols/general/border.json
@@ -1148,7 +1148,7 @@
         "weight": 20,
         "intro_text": "p_l slinks through c_n's territory, low to the ground and watchful as {PRONOUN/p_l/subject} {VERB/p_l/approach/approaches} the o_c_n border. The moon hangs heavy in the sky, and {PRONOUN/p_l/poss} eyes dart around, taking in {PRONOUN/p_l/poss} surroundings - did {PRONOUN/p_l/subject} make it here unnoticed?",
         "decline_text": "{PRONOUN/p_l/subject/CAP} {VERB/p_l/hear/hears} something shift in the distance. Heart pounding, {PRONOUN/p_l/subject} silently {VERB/p_l/draw/draws} back, not wanting to stay to find out if it was prey or cat.",
-        "chance_of_success": 45,
+        "chance_of_success": -100,
         "success_outcomes": [
             {
                 "text": "{PRONOUN/p_l/subject/CAP} {VERB/p_l/crouch/crouches} out of sight and {VERB/p_l/wait/waits}, still as stone. After a short while, there's a soft call across the border. Perking up, p_l rushes forward, pushing {PRONOUN/p_l/poss} nose into the fur of a cat from o_c_n. Tails entwined, they talk in hushed voices until the stars start to blink out. With a soft goodbye, each returns home, their Clans unknowing of their secret.",
@@ -1209,16 +1209,16 @@
             {
                 "text": "There's movement across the border, and while p_l's heart beats fast at the sight of a certain cat, {PRONOUN/p_l/subject}'{VERB/p_l/re/s} crestfallen to see them accompanied by a Clanmate. What's worse, this cat is one known to be aggressive, and tonight is no different - p_l is sent back to camp with {PRONOUN/p_l/poss} tail between {PRONOUN/p_l/poss} legs, fresh claw-wounds glistening in the moonlight.",
                 "exp": 0,
-                "weight": 10,
+                "weight": 100,
                 "injury": [
                     {
-                        "cats": ["r_c"],
+                        "cats": ["p_l"],
                         "injuries": ["claw-wound"],
                         "scars": ["ONE"]
                     }
                 ],
                 "history_text": {
-                    "scar": "r_c was scarred when {PRONOUN/r_c/subject} tried to sneak across the o_c_n border."
+                    "scar": "p_l was scarred when {PRONOUN/p_l/subject} tried to sneak across the o_c_n border."
                 },
                 "relationships": [
                     {

--- a/resources/dicts/patrols/general/border.json
+++ b/resources/dicts/patrols/general/border.json
@@ -1148,7 +1148,7 @@
         "weight": 20,
         "intro_text": "p_l slinks through c_n's territory, low to the ground and watchful as {PRONOUN/p_l/subject} {VERB/p_l/approach/approaches} the o_c_n border. The moon hangs heavy in the sky, and {PRONOUN/p_l/poss} eyes dart around, taking in {PRONOUN/p_l/poss} surroundings - did {PRONOUN/p_l/subject} make it here unnoticed?",
         "decline_text": "{PRONOUN/p_l/subject/CAP} {VERB/p_l/hear/hears} something shift in the distance. Heart pounding, {PRONOUN/p_l/subject} silently {VERB/p_l/draw/draws} back, not wanting to stay to find out if it was prey or cat.",
-        "chance_of_success": -45,
+        "chance_of_success": 45,
         "success_outcomes": [
             {
                 "text": "{PRONOUN/p_l/subject/CAP} {VERB/p_l/crouch/crouches} out of sight and {VERB/p_l/wait/waits}, still as stone. After a short while, there's a soft call across the border. Perking up, p_l rushes forward, pushing {PRONOUN/p_l/poss} nose into the fur of a cat from o_c_n. Tails entwined, they talk in hushed voices until the stars start to blink out. With a soft goodbye, each returns home, their Clans unknowing of their secret.",
@@ -1234,7 +1234,7 @@
             {
                 "text": "Deciding it looks safe enough, p_l walks across the border... right into a late-night border patrol. {PRONOUN/p_l/subject/CAP}'{VERB/p_l/re/s} dealt with pretty quickly, and {PRONOUN/p_l/poss} fur prickles with embarrassment as {PRONOUN/p_l/subject} {VERB/p_l/scramble/scrambles} back over the border, trying to figure out how {PRONOUN/p_l/subject}'ll explain the fresh claw-wounds scoring {PRONOUN/p_l/poss} pelt to {PRONOUN/p_l/poss} Clanmates.",
                 "exp": 0,
-                "weight": 100,
+                "weight": 10,
                 "stat_trait": [
                     "bold",
                     "daring",

--- a/resources/dicts/patrols/general/border.json
+++ b/resources/dicts/patrols/general/border.json
@@ -1148,7 +1148,7 @@
         "weight": 20,
         "intro_text": "p_l slinks through c_n's territory, low to the ground and watchful as {PRONOUN/p_l/subject} {VERB/p_l/approach/approaches} the o_c_n border. The moon hangs heavy in the sky, and {PRONOUN/p_l/poss} eyes dart around, taking in {PRONOUN/p_l/poss} surroundings - did {PRONOUN/p_l/subject} make it here unnoticed?",
         "decline_text": "{PRONOUN/p_l/subject/CAP} {VERB/p_l/hear/hears} something shift in the distance. Heart pounding, {PRONOUN/p_l/subject} silently {VERB/p_l/draw/draws} back, not wanting to stay to find out if it was prey or cat.",
-        "chance_of_success": 45,
+        "chance_of_success": -45,
         "success_outcomes": [
             {
                 "text": "{PRONOUN/p_l/subject/CAP} {VERB/p_l/crouch/crouches} out of sight and {VERB/p_l/wait/waits}, still as stone. After a short while, there's a soft call across the border. Perking up, p_l rushes forward, pushing {PRONOUN/p_l/poss} nose into the fur of a cat from o_c_n. Tails entwined, they talk in hushed voices until the stars start to blink out. With a soft goodbye, each returns home, their Clans unknowing of their secret.",
@@ -1234,7 +1234,7 @@
             {
                 "text": "Deciding it looks safe enough, p_l walks across the border... right into a late-night border patrol. {PRONOUN/p_l/subject/CAP}'{VERB/p_l/re/s} dealt with pretty quickly, and {PRONOUN/p_l/poss} fur prickles with embarrassment as {PRONOUN/p_l/subject} {VERB/p_l/scramble/scrambles} back over the border, trying to figure out how {PRONOUN/p_l/subject}'ll explain the fresh claw-wounds scoring {PRONOUN/p_l/poss} pelt to {PRONOUN/p_l/poss} Clanmates.",
                 "exp": 0,
-                "weight": 10,
+                "weight": 100,
                 "stat_trait": [
                     "bold",
                     "daring",
@@ -1245,13 +1245,13 @@
                 ],
                 "injury": [
                     {
-                        "cats": ["s_c"],
+                        "cats": ["p_l"],
                         "injuries": ["claw-wound"],
                         "scars": ["ONE"]
                     }
                 ],
                 "history_text": {
-                    "scar": "r_c was scarred when {PRONOUN/r_c/subject} tried to sneak across the o_c_n border."
+                    "scar": "p_l was scarred when {PRONOUN/p_l/subject} tried to sneak across the o_c_n border."
                 },
                 "relationships": [
                     {

--- a/resources/dicts/patrols/general/border.json
+++ b/resources/dicts/patrols/general/border.json
@@ -1148,7 +1148,7 @@
         "weight": 20,
         "intro_text": "p_l slinks through c_n's territory, low to the ground and watchful as {PRONOUN/p_l/subject} {VERB/p_l/approach/approaches} the o_c_n border. The moon hangs heavy in the sky, and {PRONOUN/p_l/poss} eyes dart around, taking in {PRONOUN/p_l/poss} surroundings - did {PRONOUN/p_l/subject} make it here unnoticed?",
         "decline_text": "{PRONOUN/p_l/subject/CAP} {VERB/p_l/hear/hears} something shift in the distance. Heart pounding, {PRONOUN/p_l/subject} silently {VERB/p_l/draw/draws} back, not wanting to stay to find out if it was prey or cat.",
-        "chance_of_success": -100,
+        "chance_of_success": 45,
         "success_outcomes": [
             {
                 "text": "{PRONOUN/p_l/subject/CAP} {VERB/p_l/crouch/crouches} out of sight and {VERB/p_l/wait/waits}, still as stone. After a short while, there's a soft call across the border. Perking up, p_l rushes forward, pushing {PRONOUN/p_l/poss} nose into the fur of a cat from o_c_n. Tails entwined, they talk in hushed voices until the stars start to blink out. With a soft goodbye, each returns home, their Clans unknowing of their secret.",
@@ -1209,7 +1209,7 @@
             {
                 "text": "There's movement across the border, and while p_l's heart beats fast at the sight of a certain cat, {PRONOUN/p_l/subject}'{VERB/p_l/re/s} crestfallen to see them accompanied by a Clanmate. What's worse, this cat is one known to be aggressive, and tonight is no different - p_l is sent back to camp with {PRONOUN/p_l/poss} tail between {PRONOUN/p_l/poss} legs, fresh claw-wounds glistening in the moonlight.",
                 "exp": 0,
-                "weight": 100,
+                "weight": 10,
                 "injury": [
                     {
                         "cats": ["p_l"],


### PR DESCRIPTION
fixes https://github.com/ClanGenOfficial/clangen/issues/1940

(does not address o_c_n mismatch i haven't dug that deep into it yet, but it fixes the issue requester's error)