### PR TITLE
fix for unrelated cat tagged in leader death event

### DIFF
--- a/resources/dicts/events/death/general/leader.json
+++ b/resources/dicts/events/death/general/leader.json
@@ -1120,7 +1120,6 @@
     },
     {
         "tags": [
-            "other_cat",
             "Newleaf",
             "Greenleaf",
             "Leaf-fall",


### PR DESCRIPTION
a fix for when an unrelated cat would be tagged in a leader's death event (curiosity killed the cat)

reported here: https://github.com/ClanGenOfficial/clangen/issues/1939