### PR TITLE
Bugfix: Head Damage Failing to Assign Permanent Conditions

### DIFF
--- a/resources/game_config.json
+++ b/resources/game_config.json
@@ -277,7 +277,7 @@
 		"classic_injury_chance": 450,
 		"expanded_injury_chance": 250,
 		"cruel season_injury_chance": 150,
-		"permanent_condition_chance": 20,
+		"permanent_condition_chance": 15,
 		"war_injury_modifier": 100
 	},
 	"clan_creation": {

--- a/scripts/events_module/condition_events.py
+++ b/scripts/events_module/condition_events.py
@@ -384,7 +384,7 @@ class Condition_Events():
         scarless_conditions = [
             "weak leg", "paralyzed", "raspy lungs", "wasting disease", "blind", "failing eyesight", "one bad eye",
             "partial hearing loss", "deaf", "constant joint pain", "constantly dizzy", "recurring shock",
-            "lasting grief"
+            "lasting grief", "persistent headaches"
         ]
 
         got_condition = False
@@ -409,6 +409,8 @@ class Condition_Events():
                 except KeyError:
                     print(f"WARNING: {injury_name} couldn't be found in injury dict! no permanent condition was given")
                     return perm_condition
+            else:
+                print(f"WARNING: {scar} for {injury_name} is either None or is not in scar_to_condition dict.")
 
         elif condition is not None:
             perm_condition = condition

--- a/scripts/events_module/scar_events.py
+++ b/scripts/events_module/scar_events.py
@@ -84,7 +84,6 @@ class Scar_Events():
         "broken jaw": head_scars,
         "broken back": back_scars,
         "broken bone": bone_scars,
-        "head damage": head_scars
     }
 
     @staticmethod


### PR DESCRIPTION
- The head damage injury can no longer result in scarring, but in return it will more reliably cause permanent conditions
- The persistent headache permanent condition wasn't actually able to appear in game, now it is.
- Slightly increased the chance of injuries without a scar resulting in a permanent condition.
- Added a warning print to hopefully avoid this issue sneaking in under the radar again.