### PR TITLE
Bugfix: exiled newborns now have newborn thoughts

### DIFF
--- a/scripts/cat/thoughts.py
+++ b/scripts/cat/thoughts.py
@@ -291,15 +291,17 @@ class Thoughts():
             spec_dir = ""
 
         THOUGHTS = []
-        with open(f"{base_path}{life_dir}{spec_dir}/{status}.json", 'r') as read_file:
-            THOUGHTS = ujson.loads(read_file.read())
-        GENTHOUGHTS = []
-        with open(f"{base_path}{life_dir}{spec_dir}/general.json", 'r') as read_file:
-            GENTHOUGHTS = ujson.loads(read_file.read())
         # newborns only pull from their status thoughts. this is done for convenience
         if main_cat.age == 'newborn':
+            with open(f"{base_path}{life_dir}{spec_dir}/newborn.json", 'r') as read_file:
+                THOUGHTS = ujson.loads(read_file.read())
             loaded_thoughts = THOUGHTS
         else:
+            with open(f"{base_path}{life_dir}{spec_dir}/{status}.json", 'r') as read_file:
+                THOUGHTS = ujson.loads(read_file.read())
+            GENTHOUGHTS = []
+            with open(f"{base_path}{life_dir}{spec_dir}/general.json", 'r') as read_file:
+                GENTHOUGHTS = ujson.loads(read_file.read())
             loaded_thoughts = THOUGHTS 
             loaded_thoughts += GENTHOUGHTS
         final_thoughts = Thoughts.create_thoughts(loaded_thoughts, main_cat, other_cat, game_mode, biome, season, camp)


### PR DESCRIPTION
Previously the thought pool was pulling from the cat's status, regardless of age. Which is fine except for the edge case of newborns. _Usually_ newborns have the status of newborn. However exiled newborns, etc, might have other statuses like "exiled" while still having the age of newborn. So exiled newborn had full on "exiled" rank thoughts, such as practicing hunting skills, and exiled dead newborns had no valid thoughts because there's no exiled dead thoughts (and they being potats cannot pick from the general thought pool that non-potats can pick from). This just checks if they are a newborn before creating their thought pool

fixes: #2012 