### PR TITLE
Content update: weights and mates

### DIFF
--- a/resources/dicts/conditions/pregnancy.json
+++ b/resources/dicts/conditions/pregnancy.json
@@ -3,19 +3,37 @@
     "m_c announced that {PRONOUN/m_c/subject} {VERB/m_c/are/is} expecting kits."
   ],
   "litter_guess": [
-    "m_c thinks {PRONOUN/m_c/subject}'ll have a small litter.",
-    "m_c thinks {PRONOUN/m_c/subject}'ll have a large litter.",
-    "m_c is unsure how many kits {PRONOUN/m_c/subject}'ll have."
+    "m_c hopes the litter will be small - {PRONOUN/m_c/subject} {VERB/m_c/feel/feels} overwhelmed at the idea of a big litter.",
+    "m_c is hoping for a big litter!",
+    "m_c is unsure how many kits {PRONOUN/m_c/subject}'ll have.",
+    "m_c wonders how much of {PRONOUN/m_c/poss} expanding belly is kits and how much is pregnancy weight.",
+    "m_c has no idea how big {PRONOUN/m_c/subject} should craft the nest in the nursery {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} creating - but it needs the softest materials, the best moss.",
+    "m_c feels heavy and bloated, {PRONOUN/m_c/poss} joints hurting with the extra weight of the litter held snugly between. Very snugly. Uncomfortably snugly.", 
+    "m_c wonders how many names {PRONOUN/m_c/subject} should think about, for {PRONOUN/m_c/poss} kits. {PRONOUN/m_c/subject/CAP} have no idea how many {PRONOUN/m_c/subject}'ll need, and what if {PRONOUN/m_c/subject} meet {PRONOUN/m_c/poss} litter for the first time and one of the names just doesn't fit?!",
+    "m_c feels like {PRONOUN/m_c/poss} entire existence is one long trip between water and the dirtplace, again and again. This pregnancy is so much harder than {PRONOUN/m_c/subject} were expecting.",
+    "m_c curls up, purring at {PRONOUN/m_c/poss} belly, hoping the unknown number of kittens within can hear {PRONOUN/m_c/poss} love for them - {PRONOUN/m_c/subject} can't wait to meet them." 
   ],
 
 
   "major_severity": [
     " {PRONOUN/m_c/subject/CAP} {VERB/m_c/decide/decides} to move into the nursery in preparation for {PRONOUN/m_c/poss} soon-to-come kits.",
-    " {PRONOUN/m_c/subject/CAP} {VERB/m_c/don't/doesn't} believe {PRONOUN/m_c/subject} can efficiently perform {PRONOUN/m_c/poss} duties while expecting kits and {VERB/m_c/decide/decides} to move into the nursery."
+    " {PRONOUN/m_c/subject/CAP} {VERB/m_c/don't/doesn't} believe {PRONOUN/m_c/subject} can efficiently perform {PRONOUN/m_c/poss} duties while expecting kits and {VERB/m_c/decide/decides} to move into the nursery.",
+    " Time to move to the nursery and relax before the new arrivals make their appearance.",
+    " When one waddles more than pads around camp, one has to accept that one should move into the nursery.",
+    " {PRONOUN/m_c/subject/CAP}{VERB/m_c/'ve/'s} been moved into the nursery, against {PRONOUN/m_c/poss} grumbling protests.",
+    " Pregnancy sucks. m_c gives in, and moves into the nursery.",
+    " It's time to settle into the nursery, and make sure everything is perfectly prepared.",
+    " {PRONOUN/m_c/subject/CAP}{VERB/m_c/'re/'s} scolded into taking up a nest in the nursery, despite {PRONOUN/m_c/poss} best protests.",
+    " {PRONOUN/m_c/subject/CAP}{VERB/m_c/'re/'s} keen to move into the nursery quickly, as though by doing so {PRONOUN/m_c/poss} litter will get the message and appear sooner."
   ],
   "minor_severity": [
     " {PRONOUN/m_c/subject/CAP} won't be moving into the nursery just yet.",
-    " {PRONOUN/m_c/subject/CAP} {VERB/m_c/choose/chooses} to continue {PRONOUN/m_c/poss} duties as usual for now."
+    " {PRONOUN/m_c/subject/CAP} {VERB/m_c/choose/chooses} to continue {PRONOUN/m_c/poss} duties as usual for now.",
+    " {PRONOUN/m_c/subject/CAP} snap that this doesn't make {PRONOUN/m_c/object} an invalid, and {PRONOUN/m_c/subject} aren't moving {PRONOUN/m_c/poss} nest yet!",
+    " {PRONOUN/m_c/subject/CAP} {VERB/m_c/aren't/isn't} keen on being confined to the nursery just yet.",
+    " Life goes on for now - {PRONOUN/m_c/subject}'ll move into the nursery, but not this moon.",
+    " {PRONOUN/m_c/subject/CAP}{VERB/m_c/'re/'s} still full of energy, and moving to the nursery would feel stifling - maybe next moon.",
+    " Surely it's not time to move into the nursery, though."
   ],
   "comment": [
     "both the minor and major severity strings will appear in conjunction with either a litter guess or an announcement. Write them accordingly!",

--- a/resources/dicts/patrols/general/hunting.json
+++ b/resources/dicts/patrols/general/hunting.json
@@ -1203,7 +1203,7 @@
     "min_max_status": {
         "normal adult": [1, 1]
     },
-    "weight": 20,
+    "weight": 1,
     "intro_text": "p_l puts {PRONOUN/p_l/poss} nose to the ground, checking for prey scent as {PRONOUN/p_l/subject} {VERB/p_l/hunt/hunts}.",
     "decline_text": "It's not a great day for hunting, p_l decides, and calls it off before {PRONOUN/p_l/subject} even {VERB/p_l/start/starts}.",
     "chance_of_success": 50,
@@ -1269,7 +1269,7 @@
     "min_max_status": {
         "normal adult": [1, 1]
     },
-    "weight": 20,
+    "weight": 1,
     "intro_text": "p_l stretches, digging {PRONOUN/p_l/poss} claws into the ground as {PRONOUN/p_l/subject} {VERB/p_l/warm/warms} up. Without needing to coordinate a group, this hunting patrol can proceed entirely at their own schedule.",
     "decline_text": "Actually, p_l wants to do something with company. {PRONOUN/p_l/subject/CAP} {VERB/p_l/join/joins} up with a bigger patrol instead of going out on {PRONOUN/p_l/poss} own.",
     "chance_of_success": 50,
@@ -1336,7 +1336,7 @@
     "min_max_status": {
         "normal adult": [1, 1]
     },
-    "weight": 20,
+    "weight": 1,
     "intro_text": "Sometimes it's nice to go out alone - there's nothing to distract p_l from the hunt.",
     "decline_text": "It's not a great day for hunting, p_l decides, and calls it off before {PRONOUN/p_l/subject} even {VERB/p_l/start/starts}.",
     "chance_of_success": 50,
@@ -1443,7 +1443,7 @@
     "min_max_status": {
         "normal adult": [1, 1]
     },
-    "weight": 20,
+    "weight": 1,
     "intro_text": "p_l thinks {PRONOUN/p_l/subject}{VERB/p_l/'ve/'s} found a promising hunting spot to focus on for {PRONOUN/p_l/poss} solo patrol.",
     "decline_text": "{PRONOUN/p_l/subject/CAP} decide to move on instead.",
     "chance_of_success": 50,
@@ -1516,7 +1516,7 @@
     "min_max_status": {
         "normal adult": [1, 1]
     },
-    "weight": 20,
+    "weight": 1,
     "intro_text": "p_l's glad to go out on a solo hunting patrol - there's an ambush spot {PRONOUN/p_l/subject}{VERB/p_l/'ve/'s} been itching to try out on {PRONOUN/p_l/poss} own.",
     "decline_text": "{PRONOUN/p_l/subject/CAP} encounter an herb gathering patrol on the way there and get swept up into it.",
     "chance_of_success": 50,
@@ -1589,7 +1589,7 @@
     "min_max_status": {
         "apprentice": [1, 1]
     },
-    "weight": 20,
+    "weight": 1,
     "intro_text": "app1 has snuck out late, timed with the last flares of the sunset, to try to hunt alone.",
     "decline_text": "It's not a great day for hunting, app1 decides, and calls it off before someone figures out {PRONOUN/app1/subject}{VERB/app1/'ve/'s} snuck out of camp.",
     "chance_of_success": 50,
@@ -1659,7 +1659,7 @@
     "min_max_status": {
         "apprentice": [1, 1]
     },
-    "weight": 20,
+    "weight": 1,
     "intro_text": "Look, {PRONOUN/app1/subject}{VERB/app1/'re/'s} so close to perfecting {PRONOUN/app1/poss} pounce, app1 can <i>feel</i> it. {PRONOUN/app1/subject/CAP} head out to prove so.",
     "decline_text": "Just as {PRONOUN/app1/subject}{VERB/app1/'re/'s} about to leave camp, someone calls out and offers to share something from the fresh-kill pile with {PRONOUN/app1/object}. app1 can't refuse, even if {PRONOUN/app1/subject}'d like to, and {PRONOUN/app1/poss} clandestine hunt is cancelled.",
     "chance_of_success": 50,
@@ -1729,7 +1729,7 @@
     "min_max_status": {
         "apprentice": [1, 1]
     },
-    "weight": 20,
+    "weight": 1,
     "intro_text": "app1 is tired of being treated like {PRONOUN/app1/subject} {VERB/app1/don't/doesn't} know anything - {PRONOUN/app1/subject} {VERB/app1/stalk/stalks} off to hunt alone.",
     "decline_text": "Just as {PRONOUN/app1/subject}{VERB/app1/'re/'s} about to leave camp, someone calls out and offers to share something from the fresh-kill pile with {PRONOUN/app1/object}. app1 can't refuse, even if {PRONOUN/app1/subject}'d like to, and {PRONOUN/app1/poss} clandestine hunt is cancelled.",
     "chance_of_success": 50,
@@ -1799,7 +1799,7 @@
     "min_max_status": {
         "apprentice": [1, 1]
     },
-    "weight": 20,
+    "weight": 1,
     "intro_text": "app1 doesn't want to be in the apprentice's den until {PRONOUN/app1/poss} muzzle grays - {PRONOUN/app1/subject} {VERB/app1/need/needs} to prove lead_name should pay attention to {PRONOUN/app1/object}.",
     "decline_text": "Just as {PRONOUN/app1/subject}{VERB/app1/'re/'s} about to leave camp, someone calls out and offers to share something from the fresh-kill pile with {PRONOUN/app1/object}. app1 can't refuse, even if {PRONOUN/app1/subject}'d like to, and {PRONOUN/app1/poss} clandestine hunt is cancelled.",
     "chance_of_success": 50,
@@ -1869,7 +1869,7 @@
     "min_max_status": {
         "apprentice": [1, 1]
     },
-    "weight": 20,
+    "weight": 1,
     "intro_text": "app1 nervously creeps out towards c_n's dirtplace, profile low to the ground as {PRONOUN/app1/subject} {VERB/app1/sneak/sneaks} out of camp. Let's see what a night hunt feels like.",
     "decline_text": "app1 thinks better of the plan, and returns to {PRONOUN/app1/poss} nest.",
     "chance_of_success": 50,
@@ -1939,7 +1939,7 @@
     "min_max_status": {
         "normal adult": [1, 6]
     },
-    "weight": 20,
+    "weight": 1,
     "intro_text": "As they head out into c_n's territory, p_l suggests a high cover hunting ground, perfect for ambushing.",
     "decline_text": "The cats encounter a border patrol that needs more paws, and volunteer their time for that instead.",
     "chance_of_success": 50,
@@ -2019,7 +2019,7 @@
     "min_max_status": {
         "normal adult": [1, 6]
     },
-    "weight": 20,
+    "weight": 1,
     "intro_text": "The small hunting patrol heads out together.",
     "decline_text": "The cats encounter a border patrol that needs more paws, and volunteer their time for that instead.",
     "chance_of_success": 50,
@@ -2142,7 +2142,7 @@
     "min_max_status": {
         "normal adult": [1, 6]
     },
-    "weight": 20,
+    "weight": 1,
     "intro_text": "This hunting patrol might be small, but p_l thinks {PRONOUN/p_l/subject} {VERB/p_l/know/knows} the perfect spot to take advantage of that.",
     "decline_text": "The cats encounter a border patrol that needs more paws, and volunteer their time for that instead.",
     "chance_of_success": 50,
@@ -2274,7 +2274,7 @@
     "min_max_status": {
         "normal adult": [1, 6]
     },
-    "weight": 20,
+    "weight": 1,
     "intro_text": "With a smaller hunting party, the cats are going to need to coordinate together well to succeed.",
     "decline_text": "The cats encounter a border patrol that needs more paws, and volunteer their time for that instead.",
     "chance_of_success": 50,
@@ -2420,7 +2420,7 @@
     "min_max_status": {
         "normal adult": [1, 6]
     },
-    "weight": 20,
+    "weight": 1,
     "intro_text": "Eyes glowing with the last rays of the sunset, the small hunting party heads out into the gathering dusk.",
     "decline_text": "The cats encounter a border patrol that needs more paws, and volunteer their time for that instead.",
     "chance_of_success": 50,
@@ -2559,7 +2559,7 @@
     "min_max_status": {
         "normal adult": [1, 6]
     },
-    "weight": 20,
+    "weight": 1,
     "intro_text": "A large hunting patrol is formed and sent out to see what they can find.",
     "decline_text": "The patrol can't agree on a hunting ground, and breaks up into smaller groups instead.",
     "chance_of_success": 50,
@@ -2631,7 +2631,7 @@
     "min_max_status": {
         "normal adult": [1, 6]
     },
-    "weight": 20,
+    "weight": 1,
     "intro_text": "Honestly, it looks like a scat day to try to hunt, so the cats team up into a bigger hunting patrol, hoping that will help.",
     "decline_text": "The patrol can't agree on a hunting ground, and breaks up into smaller groups instead.",
     "chance_of_success": 50,
@@ -2721,7 +2721,7 @@
     "min_max_status": {
         "normal adult": [1, 6]
     },
-    "weight": 20,
+    "weight": 1,
     "intro_text": "The cats chat as they head out to hunt.",
     "decline_text": "The patrol can't agree on a hunting ground, and breaks up into smaller groups instead.",
     "chance_of_success": 50,
@@ -2811,7 +2811,7 @@
     "min_max_status": {
         "normal adult": [1, 6]
     },
-    "weight": 20,
+    "weight": 1,
     "intro_text": "The bigger the hunting party, the bigger the expectations for what they'll bring home to the fresh-kill pile.",
     "decline_text": "The patrol can't agree on a hunting ground, and breaks up into smaller groups instead.",
     "chance_of_success": 50,
@@ -2901,7 +2901,7 @@
     "min_max_status": {
         "normal adult": [1, 6]
     },
-    "weight": 20,
+    "weight": 1,
     "intro_text": "There's a spring in their steps as the cats head out - today looks like a good day for hunting.",
     "decline_text": "The patrol can't agree on a hunting ground, and breaks up into smaller groups instead.",
     "chance_of_success": 50,
@@ -2999,7 +2999,7 @@
         "apprentice": [2, 6],
         "normal adult": [-1, -1]
     },
-    "weight": 20,
+    "weight": 1,
     "intro_text": "A hunting patrol of just apprentices! This is going to go great!",
     "decline_text": "It's not a great day for hunting, p_l decides, and calls it off before {PRONOUN/p_l/subject} even {VERB/p_l/start/starts}.",
     "chance_of_success": 50,
@@ -3106,7 +3106,7 @@
         "apprentice": [2, 6],
         "normal adult": [-1, -1]
     },
-    "weight": 20,
+    "weight": 1,
     "intro_text": "Maybe they <i>should</i> bring along one of their mentors, but they don't <i>want</i> to. There's no reason to always need an adult around, they aren't <i>kits</i>.",
     "decline_text": "dep_name spots the group of apprentices definitely-not-sneaking-out and orders them back to camp.",
     "chance_of_success": 50,
@@ -3222,7 +3222,7 @@
         "apprentice": [2, 6],
         "normal adult": [-1, -1]
     },
-    "weight": 20,
+    "weight": 1,
     "intro_text": "On a dare, the apprentices sneak out in the middle of the night. They're going to prove who's the best hunter!",
     "decline_text": "dep_name spots the group of apprentices definitely-not-sneaking-out and orders them back to camp.",
     "chance_of_success": 50,
@@ -3345,7 +3345,7 @@
         "apprentice": [2, 6],
         "normal adult": [-1, -1]
     },
-    "weight": 20,
+    "weight": 1,
     "intro_text": "Sometimes, it's a lot easier to work on their hunting techniques without a warrior around. Not that there's anything wrong with the warriors! Just... sometimes there less pressure, hunting as an apprentice-only patrol.",
     "decline_text": "dep_name spots the group of apprentices definitely-not-sneaking-out and orders them back to camp.",
     "chance_of_success": 50,
@@ -3459,7 +3459,7 @@
         "apprentice": [2, 6],
         "normal adult": [-1, -1]
     },
-    "weight": 20,
+    "weight": 1,
     "intro_text": "A hunting patrol of just apprentices! This is going to go great!",
     "decline_text": "dep_name spots the group of apprentices definitely-not-sneaking-out and orders them back to camp.",
     "chance_of_success": 50,

--- a/resources/dicts/patrols/general/training.json
+++ b/resources/dicts/patrols/general/training.json
@@ -2744,7 +2744,7 @@
         "min_max_status": {
             "all apprentices":[-1, -1]
         },
-        "weight": 20,
+        "weight": 10,
         "intro_text": "p_l suggests this might be a good chance for the cats to practice teamwork.",
         "decline_text": "They decide to focus on working on a different skill instead.",
         "chance_of_success": 25,
@@ -3035,7 +3035,7 @@
         "min_max_status": {
             "all apprentices": [-1, -1]
         },
-        "weight": 20,
+        "weight": 10,
         "intro_text": "p_l suggests this might be a good chance to practice teamwork with r_c.",
         "decline_text": "They decide to focus on working on a different skill instead.",
         "chance_of_success": 60,
@@ -3308,7 +3308,7 @@
             "apprentice": [1, 6],
             "normal adult": [1, 6]
         },
-        "weight": 20,
+        "weight": 10,
         "intro_text": "p_l suggests this might be a good chance for the cats to practice teamwork, particularly with app1.",
         "decline_text": "They decide to focus on working on a different skill instead.",
         "chance_of_success": 40,
@@ -3497,7 +3497,7 @@
             "apprentice": [1, 6],
             "normal adult": [1, 6]
         },
-        "weight": 20,
+        "weight": 10,
         "intro_text": "p_l suggests this might be a good chance to practice teamwork with app1.",
         "decline_text": "They decide to focus on working on a different skill instead.",
         "chance_of_success": 60,

--- a/resources/dicts/relationship_events/become_mates.json
+++ b/resources/dicts/relationship_events/become_mates.json
@@ -1,14 +1,55 @@
 {
 	"high_romantic": [
-		"m_c confessed {PRONOUN/m_c/poss} feelings to r_c and they have become mates."
+		"m_c confessed {PRONOUN/m_c/poss} feelings to r_c and they have become mates.",
+		"This has been a long time coming - m_c and r_c have become mates.",
+		"m_c and r_c really think the Clan hasn't noticed how they feel about each other? Everyone carefully hides their smiles as they announce becoming mates.",
+		"m_c and r_c have been practically floating on air since announcing their commitment as mates before c_n.",
+		"Some of the less sympathetic cats of c_n try and hack up a hairball, rather than watch m_c and r_c melt in each others' direction. New mates can be insufferable.",
+		"The more romantic members of the Clan sigh, watching the new mates m_c and r_c, who're too caught up in each other to notice.",
+		"In a bright spot this moon, m_c and r_c have finally announced their commitment as mates.",
+		"Their love has been a slow basking warmth, not a wildfire, and m_c wouldn't change it for the world. {PRONOUN/m_c/subject/CAP}{VERB/m_c/'re/'s} so excited to commit to padding at r_c's side forever.",
+		"It's neither a mystery nor a surprise, but c_n are happy to celebrate m_c and r_c becoming mates regardless.",
+		"m_c and r_c announce they've become mates in the least showy way possible, by combining their nests into one.",
+		"There's such happiness in the promises they make to each other. m_c and r_c leap into their new life as mates without question or hesitation.",
+		"For just this one perfect moment, heads pressed together and speaking their commitment in front of the Clan, there's nothing in m_c and r_c's worlds but love.",
+		"m_c and r_c are very proud to announce their new status as mates - it's quite cute."
 	],
 	"low_romantic":[
-		"m_c and r_c have become mates."
+		"m_c and r_c have become mates.",
+		"It's funny how quickly love takes flight - m_c and r_c have become mates.",
+		"The Clan gathers to celebrate a new pair of mates, m_c and r_c.",
+		"In a bright spot this moon, m_c and r_c have announced their commitment as mates.",
+		"m_c puts their paw over r_c's, as they announce they've become mates.",
+		"m_c bunts {PRONOUN/m_c/poss} against r_c's as c_n celebrates the new mates.",
+		"It's funny how love has worked for m_c and r_c. Slowly at first, like a little trip or tumble, and then suddenly falling all at once.",
+		"Maybe it's surprising to some cats. It doesn't feel like it should be, m_c is so sure {PRONOUN/m_c/subject} {VERB/m_c/want/wants} r_c as {PRONOUN/m_c/poss} mate, and r_c loves {PRONOUN/m_c/object} just as much in return.",
+		"This moom marks the beginning of the rest of their lives together for m_c and r_c.",
+		"Tails twined together, m_c and r_c announce that love has blossomed between them. They've become mates.",
+		"It's endearing how embarassed m_c is, with {PRONOUN/m_c/object} and r_c briefly becoming the center of attention as new mates.",
+		"No one is going to blame m_c for the pride {PRONOUN/m_c/subject} display in succcessfully asking r_c to become {PRONOUN/m_c/poss} mate. It's a wonderful life event to celebrate, and something to rightfully congratulate the couple on."
 	],
 	"platonic_to_romantic":[
-		"m_c and r_c see each other in a different light and have become mates."
+		"m_c and r_c see each other in a different light and have become mates.",
+		"It's like- like shedding fur to find a new colour underneath, m_c explains. r_c has been such an important friend, is it so surprising that both their feelings have evolved in this new direction to become mates?",
+		"It surprised them, too. But m_c and r_c are sure of this. So sure. The new mates celebrate with c_n.",
+		"Closeness can bring new aspects to any relationship. m_c glows with contentment, flushed the thrill of {PRONOUN/m_c/poss} new romance with r_c.",
+		"Tails twined together, m_c and r_c announce that love has blossomed between them. They've become mates.",
+		"In a bright spot this moon, m_c and r_c announce that their friendship has had romance added to the mix - they're now mates.",
+		"Sometimes one form of love can grow into another - m_c and r_c no longer only think of each other platonically.",
+		"Love blooms from platonic to romantic, and m_c is now mates with r_c.",
+		"m_c and r_c don't make any big announcements. But when they combine their nests, the clan realises that their relationship isn't so platonic anymore."
 	],
 	"rejected":[
-		"m_c confessed {PRONOUN/m_c/poss} feelings to r_c but {PRONOUN/m_c/subject} got rejected."
+		"m_c confessed {PRONOUN/m_c/poss} feelings to r_c but {PRONOUN/m_c/subject} got rejected.",
+		"m_c confessed to r_c. Everyone tiptoes around {PRONOUN/m_c/object}, not wanting to disturb {PRONOUN/m_c/object} as m_c processes the rejection.",
+		"This, them, together? It wouldn't work out. r_c rejects m_c.",
+		"It stings. m_c is going to be nursing the hurt from r_c rejecting {PRONOUN/m_c/object} for a while.",
+		"m_c was so confident r_c felt the same. But {PRONOUN/r_c/subject} {VERB/r_c/don't/doesn't}. m_c <i>really</i> doesn't want to talk about it.",
+		"r_c's rejection of m_c was very... public. Everyone's still feeling awkward about it.",
+		"m_c's dreams of romance and love have been crushed by r_c's rejection.",
+		"After being rejected by r_c, m_c's barely been visible round camp. {PRONOUN/m_c/subject/CAP}{VERB/m_c/'re/'s} good a hiding when {PRONOUN/m_c/subject} want to be.",
+		"m_c confesses {PRONOUN/m_c/poss} feelings to r_c, asking to be mates. And the answer, well, it's not yes.",
+		"Look, r_c is sorry, but {PRONOUN/r_c/subject} just don't see m_c that way. m_c slinks off, rejected.",
+		"m_c's confession of love to r_c could've gone better. Actually, anything would've been better than the rejection {PRONOUN/m_c/subject} got."
 	]
 }


### PR DESCRIPTION
Modify patrol weights for hunting balance patrols to 1 - balance patrols should be easily overridden by more biome or season specific hunting patrols if they exist.

Modify some general training.json patrol weights from 20 to 10. These are currently being triggered to commonly, the weight change should help with this

Add mate announcement and birth announcement text options for variety.