### PR TITLE
Bugfix: Typo in rejection event

### DIFF
--- a/resources/dicts/relationship_events/become_mates.json
+++ b/resources/dicts/relationship_events/become_mates.json
@@ -49,7 +49,7 @@
 		"m_c's dreams of romance and love have been crushed by r_c's rejection.",
 		"After being rejected by r_c, m_c's barely been visible round camp. {PRONOUN/m_c/subject/CAP}{VERB/m_c/'re/'s} good a hiding when {PRONOUN/m_c/subject} want to be.",
 		"m_c confesses {PRONOUN/m_c/poss} feelings to r_c, asking to be mates. And the answer, well, it's not yes.",
-		"Look, r_c is sorry, but {PRONOUN/r_c/subject} just don't see m_c that way. m_c slinks off, rejected.",
+		"Look, r_c is sorry, but {PRONOUN/r_c/subject} just {VERB/r_c/don't/doesn't} see m_c that way. m_c slinks off, rejected.",
 		"m_c's confession of love to r_c could've gone better. Actually, anything would've been better than the rejection {PRONOUN/m_c/subject} got."
 	]
 }


### PR DESCRIPTION
Missed pronoun tagging, brought up in the typo issue master thread