### PR TITLE
fix leader_name issues

### DIFF
--- a/resources/dicts/events/ceremonies/ceremony-master.json
+++ b/resources/dicts/events/ceremonies/ceremony-master.json
@@ -2831,7 +2831,7 @@
       "prepared",
       "general_mentor",
       "general_parents",
-      "general_leader",
+      "yes_leader",
       "general_backstory",
       "all_traits"
     ],
@@ -2843,7 +2843,7 @@
       "prepared",
       "general_mentor",
       "general_parents",
-      "general_leader",
+      "yes_leader",
       "general_backstory",
       "all_traits"
     ],
@@ -2854,7 +2854,7 @@
       "mediator",
       "alive_mentor",
       "general_parents",
-      "general_leader",
+      "yes_leader",
       "general_backstory",
       "all_traits"
     ],


### PR DESCRIPTION
some mediator ceremonies were referencing l_n while having general_leader. changed it to yes_leader so this doesnt occur

example below of issue:
![image](https://github.com/ClanGenOfficial/clangen/assets/126827015/1b52554e-c827-4bf1-82d7-dc876202aa3c)
