### PR TITLE
fix patrol s_c and error2

### DIFF
--- a/resources/dicts/patrols/general/training.json
+++ b/resources/dicts/patrols/general/training.json
@@ -9659,7 +9659,7 @@
         ],
         "fail_outcomes": [
             {
-                "text": "s_c tries to think of something to say or do, anything, but {PRONOUN/s_c/subject} {VERB/s_c/fumble/fumbles} as app1 becomes more and more unconsolable. Finally, s_c gives up, leaving app1 alone with {PRONOUN/app1/poss} thoughts.",
+                "text": "p_l tries to think of something to say or do, anything, but {PRONOUN/p_l/subject} {VERB/p_l/fumble/fumbles} as app1 becomes more and more unconsolable. Finally, p_l gives up, leaving app1 alone with {PRONOUN/app1/poss} thoughts.",
                 "exp": 0,
                 "can_have_stat": ["p_l"],
                 "relationships": [


### PR DESCRIPTION
fix a patrol in which p_l was mistakenly tagged as s_c

reported here: https://github.com/ClanGenOfficial/clangen/issues/2050
and here: https://github.com/ClanGenOfficial/clangen/issues/2062