### PR TITLE
bugfix/cleanup: newborn thought

### DIFF
--- a/resources/dicts/names/names.json
+++ b/resources/dicts/names/names.json
@@ -431,6 +431,6 @@
     "Wren"
 	],
 	"inappropriate_names": [
-		"wetback", "yellowface", "redface", "blackface", "brownface", "pancakeface", "yellowbone"
+		"wetback", "yellowface", "redface", "blackface", "brownface", "pancakeface", "yellowbone", "molesting"
 	]
 }

--- a/scripts/events_module/relationship/pregnancy_events.py
+++ b/scripts/events_module/relationship/pregnancy_events.py
@@ -704,14 +704,9 @@ class Pregnancy_Events():
                 kit = Cat(parent1=blood_parent.ID ,moons=0, backstory=backstory, status='newborn')
             elif cat and other_cat:
                 # Two parents provided
+                # The cat that gave birth is always parent1 so there is no need to check gender
                 kit = Cat(parent1=cat.ID, parent2=other_cat.ID, moons=0, status='newborn')
-                
-                if cat.gender == 'female':
-                    kit.thought = f"Snuggles up to the belly of {cat.name}"
-                elif cat.gender == 'male' and other_cat.gender == 'male':
-                    kit.thought = f"Snuggles up to the belly of {cat.name}"
-                else:
-                    kit.thought = f"Snuggles up to the belly of {other_cat.name}"
+                kit.thought = f"Snuggles up to the belly of {cat.name}"
             else:
                 # A one blood parent litter is the only option left. 
                 kit = Cat(parent1=cat.ID, moons=0, backstory=backstory, status='newborn')


### PR DESCRIPTION
this really just reverts to an earlier behavior, which is to always have the newborn be snuggled to the belly of parent1

there is never a need to check gender, because parent1 is always the parent that gave birth.

it also fixes kits incorrectly having thoughts of snuggling up to the belly of the female parent in m/f couples when the male was the one that gave birth.