### PR TITLE
Grandkits Inheritance Issue fix

### DIFF
--- a/scripts/cat_relations/inheritance.py
+++ b/scripts/cat_relations/inheritance.py
@@ -534,7 +534,7 @@ class Inheritance():
                         "type": rel_type,
                         "additional": [add_info]
                     }
-                    self.all_but_cousins.append(inter_cat)
+                    self.all_but_cousins.append(inter_id)
                     self.all_involved.append(inter_id)
                 
 


### PR DESCRIPTION
Cat object was added to all_but_cousins rather than ID. Python and her lists...

Fixes #2053 