### PR TITLE
Remove non functional alias for "age" debug command

### DIFF
--- a/scripts/debug_commands/cat.py
+++ b/scripts/debug_commands/cat.py
@@ -46,7 +46,6 @@ class listCatsCommand(Command):
 class ageCatsCommand(Command):
     name = "age"
     description = "Age a cat"
-    aliases = ["a"]
     usage = "<cat name|id> [number]"
 
     def callback(self, args: List[str]):


### PR DESCRIPTION
The "age" command for cats had the same alias as the "add" command ("a"). Executing the command with the alias would always run the "add" command regardless of if the right arguments for the "age" command would be given, so I removed the alias as it was non functional even if it didn't cause problems.