### PR TITLE
Bugfix: Cat sorting, typos, moonskip crash

### DIFF
--- a/resources/dicts/patrols/wetlands/hunting/any.json
+++ b/resources/dicts/patrols/wetlands/hunting/any.json
@@ -123,7 +123,7 @@
         ],
         "antag_success_outcomes": [
             {
-                "text": "Finding a Twoleg kit wandering alone, the cats harass it until it flees squawking, it's blood on their claws.",
+                "text": "Finding a Twoleg kit wandering alone, the cats harass it until it flees squawking, its blood on their claws.",
                 "exp": 20,
                 "weight": 20
             }

--- a/resources/dicts/thoughts/alive/general.json
+++ b/resources/dicts/thoughts/alive/general.json
@@ -712,7 +712,7 @@
         "id": "gen_former_kittypet_apprentice_to_apprentice",
         "thoughts": [
             "Wishes r_c would stop teasing {PRONOUN/m_c/object} about being a kittypet",
-            "Tells r_c about Twoleg behaviour",
+            "Tells r_c about Twoleg behavior",
             "Is asking r_c about certain Clan customs",
             "Wonders if r_c thinks less of {PRONOUN/m_c/object} because of {PRONOUN/m_c/poss} past",
             "Spends all day trying to outshine r_c and prove former kittypets are just as good as Clanborn apprentices",

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -107,6 +107,7 @@ class Cat():
     id_iter = itertools.count()
 
     all_cats_list: List[Cat] = []
+    ordered_cat_list: List[Cat] = []
 
     grief_strings = {}
 

--- a/scripts/events_module/misc_events.py
+++ b/scripts/events_module/misc_events.py
@@ -3,6 +3,7 @@ import random
 from scripts.cat.cats import Cat
 from scripts.cat.history import History
 from scripts.cat.pelts import Pelt
+from scripts.cat_relations.relationship import Relationship
 from scripts.events_module.generate_events import GenerateEvents
 from scripts.utility import event_text_adjust, change_clan_relations, change_relationship_values
 from scripts.game_structure.game_essentials import game
@@ -105,6 +106,12 @@ class MiscEvents():
                     effect = " (negative effect)"
 
                 log_text = event_text + effect
+
+                if other_cat.ID not in cat.relationships:
+                    cat.relationships[other_cat.ID] = Relationship(cat, other_cat)
+
+                if cat.ID not in other_cat.relationships:
+                    other_cat.relationships[cat.ID] = Relationship(other_cat, cat)
 
                 if cat.moons == 1:
                     cat.relationships[other_cat.ID].log.append(log_text + f" - {cat.name} was {cat.moons} moon old")

--- a/scripts/events_module/relationship/group_events.py
+++ b/scripts/events_module/relationship/group_events.py
@@ -9,7 +9,6 @@ from scripts.cat.cats import Cat
 from scripts.event_class import Single_Event
 from scripts.cat_relations.interaction import create_group_interaction, Group_Interaction, rel_fulfill_rel_constraints
 from scripts.game_structure.game_essentials import game
-from scripts.cat_relations.relationship import Relationship
 
 class Group_Events():
 

--- a/scripts/screens/ListScreen.py
+++ b/scripts/screens/ListScreen.py
@@ -555,6 +555,7 @@ class ListScreen(Screens):
         self.all_pages = int(ceil(len(self.current_listed_cats) /
                                   20.0)) if len(self.current_listed_cats) > 20 else 1
 
+        Cat.ordered_cat_list = self.current_listed_cats
         self.update_page()
 
     def update_page(self):

--- a/scripts/screens/ProfileScreen.py
+++ b/scripts/screens/ProfileScreen.py
@@ -625,7 +625,7 @@ class ProfileScreen(Screens):
         if is_instructor:
             current_cat_found = 1
 
-        for check_cat in Cat.all_cats_list:
+        for check_cat in Cat.ordered_cat_list:
             if check_cat.ID == self.the_cat.ID:
                 current_cat_found = 1
             else:


### PR DESCRIPTION
The following tasks are fixed:
fix #2117
fix #2066 (the ones I could replicate)
fix #2107 