### PR TITLE
Remove reference to requirements.txt from main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -44,7 +44,7 @@ if not getattr(sys, 'frozen', False):
     if isMissing:
         print("""You are missing some requirements to run clangen!
                 
-                Please look at the "readme.md" file for instructions on how to install them.
+                Please look at the "README.md" file for instructions on how to install them.
                 """)
         
         print("If you are still having issues, please ask for help in the clangen discord server: https://discord.gg/clangen")

--- a/main.py
+++ b/main.py
@@ -42,18 +42,10 @@ if not getattr(sys, 'frozen', False):
             break
 
     if isMissing:
-        if find_spec("thonny") is not None:
-            print("""You are missing some requirements to run clangen!
-                  Please press "Tools" -> "Manage Packages"
-                  Once the menu opens, click the link below "Install from requirements file".
-                  Then, select the file "requirements.txt" in the clangen folder.
-                  """)
-        else:
-            print("""You are missing some requirements to run clangen!
-                  Please run the following command in your terminal to install them:
-                  
-                  python3 -m pip install -r requirements.txt
-                  """)
+        print("""You are missing some requirements to run clangen!
+                
+                Please look at the "readme.md" file for instructions on how to install them.
+                """)
         
         print("If you are still having issues, please ask for help in the clangen discord server: https://discord.gg/clangen")
         sys.exit(1)


### PR DESCRIPTION
Reinstalling all my dependencies on a new computer, tried to run it without and got this error message that gives outdated instructions for installing using requirements.txt.