### PR TITLE
Add missing module list to missing requirement message

### DIFF
--- a/main.py
+++ b/main.py
@@ -53,7 +53,6 @@ Please look at the "README.md" file for instructions on how to install them.\n""
 
     del required_modules
     del is_missing
-    del new_line
 del find_spec
 
 from scripts.housekeeping.log_cleanup import prune_logs

--- a/main.py
+++ b/main.py
@@ -24,7 +24,7 @@ import threading
 from importlib.util import find_spec
 
 if not getattr(sys, 'frozen', False):
-    requiredModules = [
+    required_modules = [
         "ujson",
         "pygame",
         "pygame_gui",
@@ -34,24 +34,26 @@ if not getattr(sys, 'frozen', False):
         "strenum"
     ]
 
-    isMissing = False
+    is_missing = False
+    failed_modules = []
 
-    for module in requiredModules:
+    for module in required_modules:
         if find_spec(module) is None:
-            isMissing = True
-            break
+            is_missing = True
+            failed_modules.append(module)
 
-    if isMissing:
-        print("""You are missing some requirements to run clangen!
-                
-                Please look at the "README.md" file for instructions on how to install them.
-                """)
-        
+    if is_missing:
+        # prior to 3.12, you can't use \n in f-strings
+        new_line = "\n"
+        print(f"""You are missing some requirements to run clangen!
+{new_line.join([" -{}".format(module) for module in failed_modules])}
+Please look at the "README.md" file for instructions on how to install them.\n""")
         print("If you are still having issues, please ask for help in the clangen discord server: https://discord.gg/clangen")
         sys.exit(1)
 
-    del requiredModules
-    del isMissing
+    del required_modules
+    del is_missing
+    del new_line
 del find_spec
 
 from scripts.housekeeping.log_cleanup import prune_logs


### PR DESCRIPTION
Created to move the discussion from discord#dev-game-talk to Github so more people can talk on the topic, if desired. Tested on 3.11[.8], 3.12[.2]
This simply adds a couple extra lines to show which modules specifically are missing, as well as renames variables relating to the check to follow PEP 8 standards
![image](https://github.com/ClanGenOfficial/clangen/assets/24992550/bdf41e9e-04bf-49f3-a49f-05086f0748f8)
[start of original thread](https://canary.discord.com/channels/1003759225522110524/1005586496142704800/1217329065086947411)