### PR TITLE
fix: bump up age minimum for generating with kits

### DIFF
--- a/scripts/patrol/patrol_outcome.py
+++ b/scripts/patrol/patrol_outcome.py
@@ -984,7 +984,7 @@ class PatrolOutcome():
                 break
                 
             if match.group(1) == "has_kits":
-                age = randint(14, 120)
+                age = randint(19, 120)
                 break
                 
         


### PR DESCRIPTION
- changed the minimum from 14 to 19 to account for the possibility of 5 moon old kits