### PR TITLE
fix: ensure that the changelog is read as UTF-8

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+<strong>TBD</strong>
+- Fix: ensure that the changelog is read as UTF-8
+
 <strong>v0.11.1</strong>
 - Fix: The changelog. Yep, just the changelog. Yes, it happened again-
 

--- a/scripts/game_structure/windows.py
+++ b/scripts/game_structure/windows.py
@@ -925,7 +925,7 @@ class ChangelogPopup(UIWindow):
                 ["git", "log", r"--pretty=format:%H|||%cd|||%b|||%s", "-15", "--no-decorate", "--merges", "--grep=Merge pull request", "--date=short"]).decode("utf-8")
             dynamic_changelog = True
         else:
-            with open("changelog.txt", "r") as read_file:
+            with open("changelog.txt", "r", encoding='utf-8') as read_file:
                 file_cont = read_file.read()
 
         if get_version_info().is_dev() and not get_version_info().is_source_build:


### PR DESCRIPTION
So fancy quotation marks don't bork games anymore, eh?- @Ryos00 