### PR TITLE
Fix: Negative page numbers

### DIFF
--- a/scripts/screens/AllegiancesScreen.py
+++ b/scripts/screens/AllegiancesScreen.py
@@ -638,6 +638,8 @@ class MedDenScreen(Screens):
                 self.current_page = 1
             else:
                 self.current_page = len(all_pages)
+        elif self.current_page < 1:
+            self.current_page = 1
 
         # Check for empty list (no cats)
         if all_pages:

--- a/scripts/screens/AllegiancesScreen.py
+++ b/scripts/screens/AllegiancesScreen.py
@@ -633,13 +633,7 @@ class MedDenScreen(Screens):
         else:
             all_pages = self.chunks(tab_list, 10)
 
-        if self.current_page > len(all_pages):
-            if len(all_pages) == 0:
-                self.current_page = 1
-            else:
-                self.current_page = len(all_pages)
-        elif self.current_page < 1:
-            self.current_page = 1
+        self.current_page = max(1, min(self.current_page, len(all_pages)))
 
         # Check for empty list (no cats)
         if all_pages:

--- a/scripts/screens/ChooseMentorScreen.py
+++ b/scripts/screens/ChooseMentorScreen.py
@@ -372,7 +372,9 @@ class ChooseMentorScreen(Screens):
         # If the number of pages becomes smaller than the number of our current page, set
         #   the current page to the last page
         if self.current_page > len(valid_mentors):
-            self.list_page = len(valid_mentors)
+            self.current_page = len(valid_mentors)
+        elif self.current_page < 1:
+            self.current_page = 1
 
         # Handle which next buttons are clickable.
         if len(valid_mentors) <= 1:

--- a/scripts/screens/ChooseMentorScreen.py
+++ b/scripts/screens/ChooseMentorScreen.py
@@ -369,12 +369,8 @@ class ChooseMentorScreen(Screens):
         """Updates the cat sprite buttons. """
         valid_mentors = self.chunks(self.get_valid_mentors(), 30)
 
-        # If the number of pages becomes smaller than the number of our current page, set
-        #   the current page to the last page
-        if self.current_page > len(valid_mentors):
-            self.current_page = len(valid_mentors)
-        elif self.current_page < 1:
-            self.current_page = 1
+        # clamp current page to a valid page number
+        self.current_page = max(1, min(self.current_page, len(valid_mentors)))
 
         # Handle which next buttons are clickable.
         if len(valid_mentors) <= 1:

--- a/scripts/screens/ClearingScreen.py
+++ b/scripts/screens/ClearingScreen.py
@@ -417,6 +417,8 @@ class ClearingScreen(Screens):
                 self.current_page = 1
             else:
                 self.current_page = len(all_pages)
+        elif self.current_page < 1:
+            self.current_page = 1
 
         # Check for empty list (no cats)
         if all_pages:

--- a/scripts/screens/ClearingScreen.py
+++ b/scripts/screens/ClearingScreen.py
@@ -412,13 +412,7 @@ class ClearingScreen(Screens):
         else:
             all_pages = self.chunks(tab_list, 10)
 
-        if self.current_page > len(all_pages):
-            if len(all_pages) == 0:
-                self.current_page = 1
-            else:
-                self.current_page = len(all_pages)
-        elif self.current_page < 1:
-            self.current_page = 1
+        self.current_page = max(1, min(self.current_page, len(all_pages)))
 
         # Check for empty list (no cats)
         if all_pages:

--- a/scripts/screens/ListScreen.py
+++ b/scripts/screens/ListScreen.py
@@ -579,6 +579,8 @@ class ListScreen(Screens):
         #   the current page to the last page
         if self.list_page > self.all_pages:
             self.list_page = self.all_pages
+        elif self.list_page < 1:
+            self.list_page = 1
 
         # Handle which next buttons are clickable.
         if self.all_pages <= 1:

--- a/scripts/screens/ListScreen.py
+++ b/scripts/screens/ListScreen.py
@@ -575,12 +575,8 @@ class ListScreen(Screens):
         elif self.current_group == 'df':
             self.update_heading_text(f'Dark Forest')
 
-        # If the number of pages becomes smaller than the number of our current page, set
-        #   the current page to the last page
-        if self.list_page > self.all_pages:
-            self.list_page = self.all_pages
-        elif self.list_page < 1:
-            self.list_page = 1
+        # clamp current page to a valid page number
+        self.list_page = max(1, min(self.list_page, self.all_pages))
 
         # Handle which next buttons are clickable.
         if self.all_pages <= 1:

--- a/scripts/screens/MedDenScreen.py
+++ b/scripts/screens/MedDenScreen.py
@@ -420,13 +420,7 @@ class MedDenScreen(Screens):
         else:
             all_pages = self.chunks(tab_list, 10)
 
-        if self.current_page > len(all_pages):
-            if len(all_pages) == 0:
-                self.current_page = 1
-            else:
-                self.current_page = len(all_pages)
-        elif self.current_page < 1:
-            self.current_page = 1
+        self.current_page = max(1, min(self.current_page, len(all_pages)))
 
         # Check for empty list (no cats)
         if all_pages:

--- a/scripts/screens/MedDenScreen.py
+++ b/scripts/screens/MedDenScreen.py
@@ -425,6 +425,8 @@ class MedDenScreen(Screens):
                 self.current_page = 1
             else:
                 self.current_page = len(all_pages)
+        elif self.current_page < 1:
+            self.current_page = 1
 
         # Check for empty list (no cats)
         if all_pages:

--- a/scripts/screens/PatrolScreen.py
+++ b/scripts/screens/PatrolScreen.py
@@ -648,13 +648,7 @@ class PatrolScreen(Screens):
         else:
             all_pages = self.chunks(self.able_cats, 15)
 
-        if self.current_page > len(all_pages):
-            if len(all_pages) == 0:
-                self.current_page = 1
-            else:
-                self.current_page = len(all_pages)
-        elif self.current_page < 1:
-            self.current_page = 1
+        self.current_page = max(1, min(self.current_page, len(all_pages)))
 
         # Check for empty list (no able cats)
         if all_pages:

--- a/scripts/screens/PatrolScreen.py
+++ b/scripts/screens/PatrolScreen.py
@@ -653,6 +653,8 @@ class PatrolScreen(Screens):
                 self.current_page = 1
             else:
                 self.current_page = len(all_pages)
+        elif self.current_page < 1:
+            self.current_page = 1
 
         # Check for empty list (no able cats)
         if all_pages:

--- a/scripts/screens/RelationshipScreen.py
+++ b/scripts/screens/RelationshipScreen.py
@@ -485,13 +485,7 @@ class RelationshipScreen(Screens):
 
         all_pages = self.chunks(self.filtered_cats, 8)
 
-        if self.current_page > len(all_pages):
-            self.current_page = len(all_pages)
-        elif self.current_page < 1:
-            self.current_page = 1
-
-        if self.current_page == 0:
-            self.current_page = 1
+        self.current_page = max(1, min(self.current_page, len(all_pages)))
 
         if all_pages:
             display_rel = all_pages[self.current_page - 1]

--- a/scripts/screens/RelationshipScreen.py
+++ b/scripts/screens/RelationshipScreen.py
@@ -487,6 +487,8 @@ class RelationshipScreen(Screens):
 
         if self.current_page > len(all_pages):
             self.current_page = len(all_pages)
+        elif self.current_page < 1:
+            self.current_page = 1
 
         if self.current_page == 0:
             self.current_page = 1


### PR DESCRIPTION
Rarely, if someone pressed the previous page button quickly enough, they could go into "negative" page values. Fixes that issue by making sure the current page is always at least 1.

The variable in `ChooseMentorScreen.py` is changed because `self.list_page` does not seem to be used anywhere in that file.

Should fix #2239.