### PR TITLE
Add support for 'not_working' thoughts (#2233)

### DIFF
--- a/resources/dicts/thoughts/alive/general.json
+++ b/resources/dicts/thoughts/alive/general.json
@@ -82,6 +82,59 @@
         ]
     },
     {
+        "id": "gen_alive_not_working_insteadinthemedden",
+        "thoughts": [
+            "Misses {PRONOUN/m_c/poss} own nest, despite the ones in the medicine den being... fine",
+            "Can't get the sharp smell of the herb stores out of {PRONOUN/m_c/poss} nose",
+            "Feeling confined and cooped up",
+            "Just wants to sleep",
+            "Why is recovering so exhausting!",
+            "Basking in the sun at the medicine den entrance",
+            "Feeling frustrated at {PRONOUN/m_c/poss} own exhaustion",
+            "Doesn't think {PRONOUN/m_c/subject} should have to sleep in the medicine den",
+            "Eats some prey because {PRONOUN/m_c/suject} know {PRONOUN/m_c/subject} should, not because of hunger",
+            "Stands up for a second and feels lightheaded",
+            "Isn't having a fun time"
+        ],
+        "main_status_constraint": [
+            "not_working"
+        ]
+    },
+    {
+        "id": "gen_alive_not_working_insteadinthemedden_withmedcat",
+        "thoughts": [
+            "Watches r_c fuss around the herb stores, half-asleep",
+            "Isn't goign to argue with r_c about {PRONOUN/m_c/poss} medical care",
+            "Is going to argue with r_c about {PRONOUN/m_c/poss} medical care",
+            "Dutifully stretching out {PRONOUN/m_c/poss} limbs like r_c told {PRONOUN/m_c/object} to",
+            "Asks r_c for pain relief",
+            "Wishes {PRONOUN/m_c/subject} understood what r_c is doing"
+        ],
+        "main_status_constraint": [
+            "not_working"
+        ],
+        "random_status_constraint": [
+            "medicine cat"
+        ]
+    },
+    {
+        "id": "gen_alive_not_working_insteadinthemedden_withmedcatapp",
+        "thoughts": [
+            "Laps up water r_c has brought {PRONOUN/m_c/object}",
+            "Grunts in pain as r_c changes {PRONOUN/m_c/poss} nest bedding",
+            "Wishes r_c would be a bit more quiet as {PRONOUN/r_c/subject} {VERB/r_c/work/works}",
+            "Tells r_c {PRONOUN/r_c/subject}{VERB/r_c/'re/'s} doing a good job",
+            "Asks r_c for pain relief",
+            "Wishes {PRONOUN/m_c/subject} understood what r_c is doing"
+        ],
+        "main_status_constraint": [
+            "not_working"
+        ],
+        "random_status_constraint": [
+            "medicine cat apprentice"
+        ]
+    },
+    {
         "id": "gen_not_kittypet",
         "thoughts": [
             "Is thinking about how awful kittypet food must taste",

--- a/resources/dicts/thoughts/alive/general.json
+++ b/resources/dicts/thoughts/alive/general.json
@@ -93,7 +93,7 @@
             "Basking in the sun at the medicine den entrance",
             "Feeling frustrated at {PRONOUN/m_c/poss} own exhaustion",
             "Doesn't think {PRONOUN/m_c/subject} should have to sleep in the medicine den",
-            "Eats some prey because {PRONOUN/m_c/suject} know {PRONOUN/m_c/subject} should, not because of hunger",
+            "Eats some prey because {PRONOUN/m_c/subject} know {PRONOUN/m_c/subject} should, not because of hunger",
             "Stands up for a second and feels lightheaded",
             "Isn't having a fun time"
         ]

--- a/resources/dicts/thoughts/alive/general.json
+++ b/resources/dicts/thoughts/alive/general.json
@@ -83,6 +83,7 @@
     },
     {
         "id": "gen_alive_not_working_insteadinthemedden",
+        "not_working": true,
         "thoughts": [
             "Misses {PRONOUN/m_c/poss} own nest, despite the ones in the medicine den being... fine",
             "Can't get the sharp smell of the herb stores out of {PRONOUN/m_c/poss} nose",
@@ -95,13 +96,11 @@
             "Eats some prey because {PRONOUN/m_c/suject} know {PRONOUN/m_c/subject} should, not because of hunger",
             "Stands up for a second and feels lightheaded",
             "Isn't having a fun time"
-        ],
-        "main_status_constraint": [
-            "not_working"
         ]
     },
     {
         "id": "gen_alive_not_working_insteadinthemedden_withmedcat",
+        "not_working": true,
         "thoughts": [
             "Watches r_c fuss around the herb stores, half-asleep",
             "Isn't goign to argue with r_c about {PRONOUN/m_c/poss} medical care",
@@ -110,15 +109,13 @@
             "Asks r_c for pain relief",
             "Wishes {PRONOUN/m_c/subject} understood what r_c is doing"
         ],
-        "main_status_constraint": [
-            "not_working"
-        ],
         "random_status_constraint": [
             "medicine cat"
         ]
     },
     {
         "id": "gen_alive_not_working_insteadinthemedden_withmedcatapp",
+        "not_working": true,
         "thoughts": [
             "Laps up water r_c has brought {PRONOUN/m_c/object}",
             "Grunts in pain as r_c changes {PRONOUN/m_c/poss} nest bedding",
@@ -126,9 +123,6 @@
             "Tells r_c {PRONOUN/r_c/subject}{VERB/r_c/'re/'s} doing a good job",
             "Asks r_c for pain relief",
             "Wishes {PRONOUN/m_c/subject} understood what r_c is doing"
-        ],
-        "main_status_constraint": [
-            "not_working"
         ],
         "random_status_constraint": [
             "medicine cat apprentice"

--- a/scripts/cat/thoughts.py
+++ b/scripts/cat/thoughts.py
@@ -67,6 +67,11 @@ class Thoughts():
             if camp not in thought["camp"]:
                 return False
 
+        # This is for checking the 'not_working' status
+        if "not_working" in thought:
+            if thought["not_working"] != main_cat.not_working():
+                return False
+
         # This is for checking if another cat is needed and there is a other cat
         r_c_in = [thought_str for thought_str in thought["thoughts"] if "r_c" in thought_str]
         if len(r_c_in) > 0 and not random_cat:

--- a/tests/test_thoughts.py
+++ b/tests/test_thoughts.py
@@ -10,6 +10,67 @@ import ujson
 
 from scripts.cat.cats import Cat
 
+class TestNotWorkingThoughts(unittest.TestCase):
+    def setUp(self):
+        self.main = Cat(status="warrior")
+        self.other = Cat(status="warrior")
+        self.biome = "Forest"
+        self.season = "Newleaf"
+        self.camp = "camp2"
+
+        self.thoughts = [
+            {"id": "test_not_working_true", "thoughts": [], "not_working": True},
+            {"id": "test_not_working_false", "thoughts": [], "not_working": False},
+            {"id": "test_not_working_any", "thoughts": []},
+        ]
+
+    def available_thought_ids(self):
+        """Return a list of id's for available thoughts"""
+        possible = [thought for thought in self.thoughts if
+                    Thoughts.cats_fulfill_thought_constraints(
+                        self.main,
+                        self.other,
+                        thought,
+                        "expanded",
+                        self.biome,
+                        self.season,
+                        self.camp)]
+
+        return {thought["id"] for thought in possible}
+
+    def test_not_working_thought_null(self):
+        self.assertEqual({"test_not_working_false", "test_not_working_any"}, self.available_thought_ids())
+
+    def test_not_working_thought_injury_minor(self):
+        # given
+        self.main.injuries["test-injury-1"] = {"severity": "minor"}
+
+        # then
+        self.assertEqual({"test_not_working_false", "test_not_working_any"}, self.available_thought_ids())
+
+    def test_not_working_thought_injury_major(self):
+        # given
+        self.main.injuries["test-injury-1"] = {"severity": "major"}
+
+        # then
+        self.assertEqual({"test_not_working_any", "test_not_working_true"}, self.available_thought_ids())
+
+    def test_not_working_thought_illness_minor(self):
+        # given
+        self.main.illnesses["test-illness-1"] = {"severity": "minor"}
+
+        # then
+        self.assertEqual({"test_not_working_false", "test_not_working_any"}, self.available_thought_ids())
+
+    def test_not_working_thought_illness_major(self):
+        # given
+        self.main.illnesses["test-illness-1"] = {"severity": "major"}
+
+        # then
+        self.assertEqual({"test_not_working_any", "test_not_working_true"}, self.available_thought_ids())
+
+
+
 class TestsGetStatusThought(unittest.TestCase):
 
     def test_medicine_thought(self):


### PR DESCRIPTION
This change allows thoughts to be selected based upon a boolean attribute in the thought format called 'not_working'. The 'not_working' status of a cat is an existing feature that returns `true` if the cat has anything more than a minor illness/injury and `false` otherwise.