### PR TITLE
Fix: Add death text for leader dying from birth.

### DIFF
--- a/resources/dicts/conditions/pregnancy.json
+++ b/resources/dicts/conditions/pregnancy.json
@@ -119,6 +119,10 @@
 	"outside_death": [
 		"Some say m_c didn't make it.",
 		"Some say m_c would have needed a medicine cat to survive."
+	],
+	"lead_death": [
+		"m_c lost one of {PRONOUN/m_c/poss} nine lives, but gave birth to a {insert}.",
+		"Although m_c gave birth to a {insert}, it came at the cost of one of {PRONOUN/m_c/poss} nine lives."
 	]
   }
 }

--- a/scripts/events_module/relationship/pregnancy_events.py
+++ b/scripts/events_module/relationship/pregnancy_events.py
@@ -410,6 +410,8 @@ class Pregnancy_Events():
 
             if cat.outside:
                 possible_events = events["birth"]["outside_death"]
+            if game.clan.leader_lives > 1:
+                possible_events = events["birth"]["lead_death"]
             event_list.append(choice(possible_events))
 
             if cat.status == 'leader':


### PR DESCRIPTION
Adds special pregnancy text for when a leader dies from birth but still has lives remaining.