### PR TITLE
Fix: Add missing period to result_text prey success.

### DIFF
--- a/scripts/patrol/patrol_outcome.py
+++ b/scripts/patrol/patrol_outcome.py
@@ -832,7 +832,7 @@ class PatrolOutcome():
             print(f"PREY ADDED: {total_amount}")
             game.freshkill_event_list.append(f"{total_amount} pieces of prey were caught on a patrol.")
             game.clan.freshkill_pile.add_freshkill(total_amount)
-            results = f"A {amount_text} amount of prey is brought to camp"
+            results = f"A {amount_text} amount of prey is brought to camp."
             
         return results
 


### PR DESCRIPTION
Fixes a missing period on result_text from the patrol screen.