### PR TITLE
Fix: Prevent duplicate prefixes in the same litter

### DIFF
--- a/scripts/events_module/relationship/pregnancy_events.py
+++ b/scripts/events_module/relationship/pregnancy_events.py
@@ -714,6 +714,10 @@ class Pregnancy_Events():
                 kit = Cat(parent1=cat.ID, moons=0, backstory=backstory, status='newborn')
                 kit.thought = f"Snuggles up to the belly of {cat.name}"
 
+            # Prevent duplicate prefixes in the same litter
+            while kit.name.prefix in [kitty.name.prefix for kitty in all_kitten]:
+                kit.name = Name("newborn")
+
             all_kitten.append(kit)
             # adoptive parents are set at the end, when everything else is decided
 


### PR DESCRIPTION
Prevent kits in the same litter from being born with the same name.