### PR TITLE
Minor fix and change

### DIFF
--- a/resources/dicts/patrols/forest/hunting/leaf-fall.json
+++ b/resources/dicts/patrols/forest/hunting/leaf-fall.json
@@ -399,6 +399,7 @@
                     "playful",
                     "righteous"
                 ],
+                "can_have_stat": ["r_c"],
                 "relationships": [
                     {
                         "cats_to": ["s_c"],

--- a/scripts/patrol/patrol_outcome.py
+++ b/scripts/patrol/patrol_outcome.py
@@ -365,6 +365,9 @@ class PatrolOutcome():
                     out_set.add(patrol.patrol_apprentices[1])
                 elif _cat == "patrol":
                     out_set.update(patrol.patrol_cats)
+                elif _cat == "some_clan":
+                    clan_dying = [x for x in Cat.all_cats_list if not (x.dead or x.outside)]
+                    out_set.update(random.sample(clan_dying, k=min(len(clan_dying), choice([2, 3, 4]))))
                 elif _cat == "multi":
                     cats_dying = random.randint(1, max(1, len(patrol.patrol_cats) - 1))
                     out_set.update(random.sample(patrol.patrol_cats, cats_dying))


### PR DESCRIPTION
 - Modifies the forest patrol fst_hunt_leaffal_vanish1 to prevent the patrol leader from becoming the stat cat, which if the patrol leader was the stat cat, would allow them to search for themselves.
   - #2223 
 - Adds the some_clan option to a patrol outcome's dead_cats list.
   - #2271