### PR TITLE
Fix: Add clan_discovery tag for when the entire clan discovers a murder.

### DIFF
--- a/resources/dicts/events/misc_events/general/general.json
+++ b/resources/dicts/events/misc_events/general/general.json
@@ -652,6 +652,7 @@
             "Leaf-bare",
             "Leaf-fall",
             "murder_reveal",
+	    "clan_discovery",
             "other_cat"
         ],
         "event_text": "m_c boldly confesses to the entire Clan that {PRONOUN/m_c/subject} killed mur_c. m_c claims that mur_c deserved to pay for what {PRONOUN/mur_c/subject} did.",

--- a/scripts/cat/history.py
+++ b/scripts/cat/history.py
@@ -662,6 +662,10 @@ class History:
                 victim_history["revealed_by"] = other_cat.ID
                 victim_history["revelation_text"] = "The truth of {PRONOUN/m_c/poss} murder was discovered by [discoverer]."
 
+                discoverer = str(other_cat.name)
+                if "clan_discovery" in murder_history:
+                    discoverer = game.clan.name + "Clan"       
+
                 murder_history["revelation_text"] = murder_history["revelation_text"].replace('[victim]', str(victim.name))
-                murder_history["revelation_text"] = murder_history["revelation_text"].replace('[discoverer]', str(other_cat.name))
-                victim_history["revelation_text"] = victim_history["revelation_text"].replace('[discoverer]', str(other_cat.name))
+                murder_history["revelation_text"] = murder_history["revelation_text"].replace('[discoverer]', discoverer)
+                victim_history["revelation_text"] = victim_history["revelation_text"].replace('[discoverer]', discoverer)

--- a/scripts/events_module/misc_events.py
+++ b/scripts/events_module/misc_events.py
@@ -133,8 +133,12 @@ class MiscEvents():
         game.cur_events_list.append(Single_Event(event_text, types, involved_cats))
 
         if reveal:
+            # Check if whole clan should replace murder witness
+            if "clan_discovery" in misc_event.tags:
+                History.get_murders(cat)["is_murderer"][murder_index]["clan_discovery"] = True
+            # Reveal murder
             History.reveal_murder(cat, other_cat, Cat, victim, murder_index)
-
+            
     @staticmethod
     def handle_relationship_changes(cat, misc_event, other_cat):
 


### PR DESCRIPTION
This fixes the issue where other_cat is shown to be the witness to a murder in the dead cat's history (For murders revealed to the entire clan). In those cases, the witness will now be reported as the whole clan. E.g. "The truth of their crime was discovered by ThunderClan."

Fixes #1850, fixes #2236 