### PR TITLE
Fix for misc events with missing relationship tags

### DIFF
--- a/resources/dicts/events/misc_events/general/apprentice.json
+++ b/resources/dicts/events/misc_events/general/apprentice.json
@@ -14,6 +14,7 @@
         "tags": [
             "other_cat",
             "other_cat_adult",
+            "mc_to_rc",
             "platonic",
             "comfort",
             "respect",
@@ -73,6 +74,7 @@
             "Leaf-fall",
             "other_cat",
             "other_cat_kit",
+            "to_both",
             "comfort",
             "platonic"
         ],
@@ -90,6 +92,7 @@
             "Leaf-bare",
             "other_cat",
             "other_cat_app",
+            "rc_to_mc",
             "dislike",
             "jealousy"
         ],
@@ -233,7 +236,9 @@
         "tags": [
             "Leaf-bare",
             "other_cat",
-            "other_cat_app"
+            "other_cat_app",
+            "to_both",
+            "comfort"
         ],
         "event_text": "m_c encourages r_c to play in the snow with {PRONOUN/m_c/object} during a patrol.",
         "cat_trait": "playful"
@@ -247,6 +252,7 @@
             "Leaf-fall",
             "other_cat",
             "other_cat_app",
+            "to_both",
             "romantic",
             "comfort",
             "trust"

--- a/resources/dicts/events/misc_events/general/general.json
+++ b/resources/dicts/events/misc_events/general/general.json
@@ -455,6 +455,7 @@
             "Greenleaf",
             "Leaf-fall",
             "Leaf-bare",
+            "rc_to_mc",
             "comfort",
             "respect",
             "clan_kits"

--- a/resources/dicts/events/misc_events/general/kitten.json
+++ b/resources/dicts/events/misc_events/general/kitten.json
@@ -18,6 +18,7 @@
         "tags": [
             "other_cat",
             "other_cat_adult",
+            "mc_to_rc",
             "platonic",
             "comfort",
             "respect",

--- a/resources/dicts/events/misc_events/general/mediator.json
+++ b/resources/dicts/events/misc_events/general/mediator.json
@@ -62,6 +62,7 @@
             "Leaf-bare",
             "other_cat",
             "other_cat_kit",
+            "rc_to_mc",
             "platonic",
             "comfort",
             "neg_dislike"

--- a/resources/dicts/events/misc_events/general/warrior.json
+++ b/resources/dicts/events/misc_events/general/warrior.json
@@ -45,6 +45,7 @@
             "Leaf-bare",
             "other_cat",
             "other_cat_warrior",
+            "to_both",
             "comfort"
         ],
         "event_text": "m_c encourages r_c to play in the snow with {PRONOUN/m_c/object} during a patrol.",
@@ -62,6 +63,7 @@
             "Leaf-fall",
             "other_cat",
             "other_cat_mate",
+            "to_both",
             "romantic",
             "comfort",
             "trust"
@@ -85,6 +87,7 @@
             "Leaf-fall",
             "other_cat",
             "other_cat_mate",
+            "to_both",
             "romantic",
             "comfort",
             "trust"


### PR DESCRIPTION
Fixed all events that had relationship tags (i.e., "romantic") but no subject (like "mc_to_rc"), resulting in them not actually affecting relationship values