### PR TITLE
Bugfix: Pygui Update Fixes

### DIFF
--- a/scripts/game_structure/windows.py
+++ b/scripts/game_structure/windows.py
@@ -21,7 +21,6 @@ from pygame_gui.elements import UIWindow
 
 from scripts.housekeeping.datadir import get_save_dir, get_cache_dir, get_saved_images_dir, get_data_dir
 from scripts.game_structure import image_cache
-from scripts.game_structure.game_essentials import game, screen_x, screen_y
 from scripts.game_structure.image_button import UIImageButton, UITextBoxTweaked
 from scripts.housekeeping.progress_bar_updater import UIUpdateProgressBar
 from scripts.housekeeping.update import self_update, UpdateChannel, get_latest_version_number
@@ -39,7 +38,8 @@ class SaveCheck(UIWindow):
         super().__init__(scale(pygame.Rect((500, 400), (600, 400))),
                          window_display_title='Save Check',
                          object_id='#save_check_window',
-                         resizable=False)
+                         resizable=False,
+                         always_on_top=True)
 
         self.clan_name = "UndefinedClan"
         if game.clan:
@@ -88,6 +88,7 @@ class SaveCheck(UIWindow):
             pygame.transform.scale(
                 image_cache.load_image('resources/images/save_clan_saved.png'),
                 (228, 60)),
+            starting_height=top_stack_menu_layer_height + 2,
             container=self)
         self.save_button_saved_state.hide()
         self.save_button_saving_state = pygame_gui.elements.UIImage(
@@ -96,6 +97,7 @@ class SaveCheck(UIWindow):
                 image_cache.load_image(
                     'resources/images/save_clan_saving.png'),
                 (228, 60)),
+            starting_height=top_stack_menu_layer_height + 1,
             container=self)
         self.save_button_saving_state.hide()
 

--- a/scripts/screens/MedDenScreen.py
+++ b/scripts/screens/MedDenScreen.py
@@ -471,7 +471,7 @@ class MedDenScreen(Screens):
             short_name = shorten_text_to_fit(name, 185, 30)
             self.cat_names.append(pygame_gui.elements.UITextBox(short_name,
                                                                 scale(
-                                                                    pygame.Rect((pos_x - 60, pos_y + 100), (220, 60))),
+                                                                    pygame.Rect((pos_x - 60, pos_y + 100), (220, -1))),
                                                                 object_id="#text_box_30_horizcenter", manager=MANAGER))
 
             pos_x += 200

--- a/scripts/screens/ProfileScreen.py
+++ b/scripts/screens/ProfileScreen.py
@@ -514,10 +514,10 @@ class ProfileScreen(Screens):
 
         # Write cat thought
         self.profile_elements["cat_thought"] = pygame_gui.elements.UITextBox(self.the_cat.thought,
-                                                                             scale(pygame.Rect((200, 340), (1200, 80))),
+                                                                             scale(pygame.Rect((200, 340), (1200, -1))),
                                                                              wrap_to_height=True,
                                                                              object_id=get_text_box_theme(
-                                                                                 "#text_box_30_horizcenter_spacing_95")
+                                                                                 "#text_box_30_horizcenter")
                                                                              , manager=MANAGER)
 
         self.profile_elements["cat_info_column1"] = UITextBoxTweaked(self.generate_column1(self.the_cat),

--- a/scripts/screens/ProfileScreen.py
+++ b/scripts/screens/ProfileScreen.py
@@ -491,7 +491,6 @@ class ProfileScreen(Screens):
                                                                               "#text_box_40_horizcenter"),
                                                                           manager=MANAGER)
         name_text_size = self.profile_elements["cat_name"].get_relative_rect()
-        print(name_text_size)
         self.profile_elements["cat_name"].kill()
 
         # don't like having to do this, but for some reason the usual scaling is not working here

--- a/scripts/screens/RelationshipScreen.py
+++ b/scripts/screens/RelationshipScreen.py
@@ -122,7 +122,7 @@ class RelationshipScreen(Screens):
                 else:
                     RelationshipLog(
                         self.the_cat.relationships[self.inspect_cat.ID],
-                        [self.view_profile_button, self.switch_focus_button, self.next_page_button, self.next_cat_button, self.previous_cat_button, 
+                        [self.view_profile_button, self.switch_focus_button, self.next_page_button, self.next_cat_button, self.previous_cat_button,
                          self.next_page_button],
                         [self.back_button, self.log_icon, self.checkboxes["show_dead"],
                          self.checkboxes["show_empty"], self.show_dead_text, self.show_empty_text]
@@ -132,7 +132,7 @@ class RelationshipScreen(Screens):
                 self.update_checkboxes()
                 self.apply_cat_filter()
             elif event.ui_element == self.checkboxes["show_empty"]:
-                game.clan.clan_settings['show empty relation'] = not game.clan.clan_settings['show empty relation'] 
+                game.clan.clan_settings['show empty relation'] = not game.clan.clan_settings['show empty relation']
                 self.update_checkboxes()
                 self.apply_cat_filter()
                 self.update_cat_page()
@@ -616,8 +616,6 @@ class RelationshipScreen(Screens):
         # ------------------------------------------------------------------------------------------------------------ #
         # RELATION BARS
 
-        barbar = 44
-        bar_count = 0
 
         # ROMANTIC LOVE
         # CHECK AGE DIFFERENCE
@@ -642,16 +640,33 @@ class RelationshipScreen(Screens):
         else:
             text = "romantic like:"
 
+        # determine placing on screen
+        barbar = 44
+        bar_count = 0
+
+        # fix text positioning on fullscreen
+        if game.settings["fullscreen"]:
+            f_add = 5
+        else:
+            f_add = 0
+
+        rel_pos_x = pos_x + 6
+        text_pos_y = pos_y + f_add + 87
+        bar_pos_y = pos_y + 130
+
+        text_size_x = -1
+        text_size_y = 60
+
+        bar_size_x = 188
+        bar_size_y = 20
+
         self.relation_list_elements[f'romantic_text{i}'] = pygame_gui.elements.UITextBox(text,
                                                                                          scale(pygame.Rect(
-                                                                                             (pos_x + 6, pos_y + 87 + (
-                                                                                                     barbar * bar_count)),
-                                                                                             (170, 60))),
+                                                                                             (rel_pos_x, text_pos_y + (barbar * bar_count)),
+                                                                                             (text_size_x, text_size_y))),
                                                                                          object_id="#text_box_22_horizleft")
-        self.relation_list_elements[f'romantic_bar{i}'] = UIRelationStatusBar(scale(pygame.Rect((pos_x + 6,
-                                                                                                 pos_y + 130 + (
-                                                                                                         barbar * bar_count)),
-                                                                                                (188, 20))),
+        self.relation_list_elements[f'romantic_bar{i}'] = UIRelationStatusBar(scale(pygame.Rect((rel_pos_x, bar_pos_y + (barbar * bar_count)),
+                                                                                                (bar_size_x, bar_size_y))),
                                                                               display_romantic,
                                                                               positive_trait=True,
                                                                               dark_mode=game.settings['dark mode']
@@ -664,15 +679,11 @@ class RelationshipScreen(Screens):
         else:
             text = "platonic like:"
         self.relation_list_elements[f'plantonic_text{i}'] = pygame_gui.elements.UITextBox(text,
-                                                                                          scale(pygame.Rect((pos_x + 6,
-                                                                                                             pos_y + 87 + (
-                                                                                                                     barbar * bar_count)),
-                                                                                                            (160, 60))),
+                                                                                          scale(pygame.Rect((rel_pos_x, text_pos_y + (barbar * bar_count)),
+                                                                                                            (text_size_x, text_size_y))),
                                                                                           object_id="#text_box_22_horizleft")
-        self.relation_list_elements[f'platonic_bar{i}'] = UIRelationStatusBar(scale(pygame.Rect((pos_x + 6,
-                                                                                                 pos_y + 130 + (
-                                                                                                         barbar * bar_count)),
-                                                                                                (188, 20))),
+        self.relation_list_elements[f'platonic_bar{i}'] = UIRelationStatusBar(scale(pygame.Rect((rel_pos_x, bar_pos_y + (barbar * bar_count)),
+                                                                                                (bar_size_x, bar_size_y))),
                                                                               the_relationship.platonic_like,
                                                                               positive_trait=True,
                                                                               dark_mode=game.settings['dark mode'])
@@ -685,14 +696,10 @@ class RelationshipScreen(Screens):
         else:
             text = "dislike:"
         self.relation_list_elements[f'dislike_text{i}'] = pygame_gui.elements.UITextBox(text,
-                                                                                        scale(pygame.Rect((pos_x + 6,
-                                                                                                           pos_y + 87 + (
-                                                                                                                   barbar * bar_count)),
-                                                                                                          (160, 60))),
+                                                                                        scale(pygame.Rect((rel_pos_x, text_pos_y + (barbar * bar_count)),
+                                                                                                          (text_size_x, text_size_y))),
                                                                                         object_id="#text_box_22_horizleft")
-        self.relation_list_elements[f'dislike_bar{i}'] = UIRelationStatusBar(scale(pygame.Rect((pos_x + 6,
-                                                                                                pos_y + 130 + (
-                                                                                                        barbar * bar_count)),
+        self.relation_list_elements[f'dislike_bar{i}'] = UIRelationStatusBar(scale(pygame.Rect((rel_pos_x, bar_pos_y + (barbar * bar_count)),
                                                                                                (188, 20))),
                                                                              the_relationship.dislike,
                                                                              positive_trait=False,
@@ -706,17 +713,11 @@ class RelationshipScreen(Screens):
         else:
             text = "respect:"
         self.relation_list_elements[f'admiration_text{i}'] = pygame_gui.elements.UITextBox(text,
-                                                                                           scale(pygame.Rect((pos_x + 6,
-                                                                                                              pos_y + 87 + (
-                                                                                                                      barbar * bar_count)),
-                                                                                                             (
-                                                                                                                 160,
-                                                                                                                 60))),
+                                                                                           scale(pygame.Rect((rel_pos_x, text_pos_y + (barbar * bar_count)),
+                                                                                                             (text_size_x, text_size_y))),
                                                                                            object_id="#text_box_22_horizleft")
-        self.relation_list_elements[f'admiration_bar{i}'] = UIRelationStatusBar(scale(pygame.Rect((pos_x + 6,
-                                                                                                   pos_y + 130 + (
-                                                                                                           barbar * bar_count)),
-                                                                                                  (188, 20))),
+        self.relation_list_elements[f'admiration_bar{i}'] = UIRelationStatusBar(scale(pygame.Rect((rel_pos_x, bar_pos_y + (barbar * bar_count)),
+                                                                                                  (bar_size_x, bar_size_y))),
                                                                                 the_relationship.admiration,
                                                                                 positive_trait=True,
                                                                                 dark_mode=game.settings['dark mode'])
@@ -730,15 +731,11 @@ class RelationshipScreen(Screens):
             text = "comfort:"
         self.relation_list_elements[f'comfortable_text{i}'] = pygame_gui.elements.UITextBox(text,
                                                                                             scale(
-                                                                                                pygame.Rect((pos_x + 6,
-                                                                                                             pos_y + 87 + (
-                                                                                                                     barbar * bar_count)),
-                                                                                                            (160, 60))),
+                                                                                                pygame.Rect((rel_pos_x, text_pos_y + (barbar * bar_count)),
+                                                                                                            (text_size_x, text_size_y))),
                                                                                             object_id="#text_box_22_horizleft")
-        self.relation_list_elements[f'comfortable_bar{i}'] = UIRelationStatusBar(scale(pygame.Rect((pos_x + 6,
-                                                                                                    pos_y + 130 + (
-                                                                                                            barbar * bar_count)),
-                                                                                                   (188, 20))),
+        self.relation_list_elements[f'comfortable_bar{i}'] = UIRelationStatusBar(scale(pygame.Rect((rel_pos_x, bar_pos_y + (barbar * bar_count)),
+                                                                                                   (bar_size_x, bar_size_y))),
                                                                                  the_relationship.comfortable,
                                                                                  positive_trait=True,
                                                                                  dark_mode=game.settings['dark mode'])
@@ -751,15 +748,11 @@ class RelationshipScreen(Screens):
         else:
             text = "jealousy:"
         self.relation_list_elements[f'jealous_text{i}'] = pygame_gui.elements.UITextBox(text,
-                                                                                        scale(pygame.Rect((pos_x + 6,
-                                                                                                           pos_y + 87 + (
-                                                                                                                   barbar * bar_count)),
-                                                                                                          (160, 60))),
+                                                                                        scale(pygame.Rect((rel_pos_x, text_pos_y + (barbar * bar_count)),
+                                                                                                          (text_size_x, text_size_y))),
                                                                                         object_id="#text_box_22_horizleft")
-        self.relation_list_elements[f'jealous_bar{i}'] = UIRelationStatusBar(scale(pygame.Rect((pos_x + 6,
-                                                                                                pos_y + 130 + (
-                                                                                                        barbar * bar_count)),
-                                                                                               (188, 20))),
+        self.relation_list_elements[f'jealous_bar{i}'] = UIRelationStatusBar(scale(pygame.Rect((rel_pos_x, bar_pos_y + (barbar * bar_count)),
+                                                                                               (bar_size_x, bar_size_y))),
                                                                              the_relationship.jealousy,
                                                                              positive_trait=False,
                                                                              dark_mode=game.settings['dark mode'])
@@ -772,15 +765,11 @@ class RelationshipScreen(Screens):
         else:
             text = "trust:"
         self.relation_list_elements[f'trust_text{i}'] = pygame_gui.elements.UITextBox(text,
-                                                                                      scale(pygame.Rect((pos_x + 6,
-                                                                                                         pos_y + 87 + (
-                                                                                                                 barbar * bar_count)),
-                                                                                                        (160, 60))),
+                                                                                      scale(pygame.Rect((rel_pos_x, text_pos_y + (barbar * bar_count)),
+                                                                                                        (text_size_x, text_size_y))),
                                                                                       object_id="#text_box_22_horizleft")
-        self.relation_list_elements[f'trust_bar{i}'] = UIRelationStatusBar(scale(pygame.Rect((pos_x + 6,
-                                                                                              pos_y + 130 + (
-                                                                                                      barbar * bar_count)),
-                                                                                             (188, 20))),
+        self.relation_list_elements[f'trust_bar{i}'] = UIRelationStatusBar(scale(pygame.Rect((rel_pos_x, bar_pos_y + (barbar * bar_count)),
+                                                                                             (bar_size_x, bar_size_y))),
                                                                            the_relationship.trust,
                                                                            positive_trait=True,
                                                                            dark_mode=game.settings['dark mode'])

--- a/scripts/screens/Screens.py
+++ b/scripts/screens/Screens.py
@@ -120,7 +120,7 @@ class Screens():
 
         "heading": pygame_gui.elements.UITextBox(
             "",
-            scale(pygame.Rect((610, 54), (380, 70))),
+            scale(pygame.Rect((610, 54), (390, 70))),
             visible=False,
             manager=MANAGER,
             object_id="#text_box_34_horizcenter_light")

--- a/scripts/screens/SpriteInspectScreen.py
+++ b/scripts/screens/SpriteInspectScreen.py
@@ -144,23 +144,28 @@ class SpriteInspectScreen(Screens):
         self.save_image_button = UIImageButton(scale(pygame.Rect((50, 190),(270, 60))), "", object_id="#save_image_button")
         
         # Toggle Text:
-        self.platform_shown_text = pygame_gui.elements.UITextBox("Show Platform", scale(pygame.Rect((310, 1160), (290, 100))),
+        self.platform_shown_text = pygame_gui.elements.UITextBox("Show Platform",
+                                                                 scale(pygame.Rect((300, 1160), (-1, 100))),
                                                                  object_id=get_text_box_theme(
                                                                               "#text_box_34_horizcenter"), 
                                                                  starting_height=2)
-        self.scars_shown_text = pygame_gui.elements.UITextBox("Show Scar(s)", scale(pygame.Rect((710, 1160), (290, 100))),
+        self.scars_shown_text = pygame_gui.elements.UITextBox("Show Scar(s)",
+                                                              scale(pygame.Rect((700, 1160), (-1, 100))),
                                                               object_id=get_text_box_theme(
                                                                               "#text_box_34_horizcenter"), 
                                                                  starting_height=2)
-        self.acc_shown_text = pygame_gui.elements.UITextBox("Show Accessory", scale(pygame.Rect((1100, 1160), (290, 100))),
+        self.acc_shown_text = pygame_gui.elements.UITextBox("Show Accessory",
+                                                            scale(pygame.Rect((1090, 1160), (-1, 100))),
                                                             object_id=get_text_box_theme(
                                                                               "#text_box_34_horizcenter"), 
                                                             starting_height=2)
-        self.override_dead_lineart_text = pygame_gui.elements.UITextBox("Show as Living", scale(pygame.Rect((510, 1260), (290, 100))),
+        self.override_dead_lineart_text = pygame_gui.elements.UITextBox("Show as Living",
+                                                                        scale(pygame.Rect((500, 1260), (-1, 100))),
                                                                         object_id=get_text_box_theme(
                                                                               "#text_box_34_horizcenter"), 
                                                                         starting_height=2)
-        self.override_not_working_text = pygame_gui.elements.UITextBox("Show as Healthy", scale(pygame.Rect((910, 1260), (290, 100))),
+        self.override_not_working_text = pygame_gui.elements.UITextBox("Show as Healthy",
+                                                                       scale(pygame.Rect((900, 1260), (-1, 100))),
                                                                  object_id=get_text_box_theme(
                                                                               "#text_box_34_horizcenter"), 
                                                                  starting_height=2)

--- a/scripts/screens/WarriorDenScreen.py
+++ b/scripts/screens/WarriorDenScreen.py
@@ -21,6 +21,7 @@ class WarriorDenScreen(Screens):
     def __init__(self, name=None):
         super().__init__(name)
         # BG image assets - not interactable
+        self.help_button = None
         self.focus_frame = None
         self.base_image = None
         self.focus_text = None
@@ -117,9 +118,9 @@ class WarriorDenScreen(Screens):
                                                              ((100, 380), (1400, 920))),
                                                        pygame.image.load(
                                                            "resources/images/warrior_den_frame.png").convert_alpha(),
+                                                       object_id="#focus_frame",
+                                                       starting_height=1,
                                                        manager=MANAGER)
-        self.focus_frame.disable()
-
 
         self.save_button = UIImageButton(scale(pygame.Rect((300, 1184), (278, 60))),
                                          "",
@@ -186,6 +187,9 @@ class WarriorDenScreen(Screens):
         for ele in self.focus_information:
             self.focus_information[ele].kill()
         self.focus_information = {}
+        for ele in self.focus:
+            self.focus[ele].kill()
+            self.focus = {}
         # if the focus wasn't changed, reset to the previous focus
         if self.original_focus_code != self.active_code:
             for code in settings_dict["clan_focus"].keys():
@@ -223,6 +227,7 @@ class WarriorDenScreen(Screens):
                 "",
                 object_id=desc[4],
                 container=self.focus["button_container"],
+                starting_height=2,
                 manager=MANAGER)
 
             if game.clan.clan_settings[code]:


### PR DESCRIPTION
- Scrollbars no longer appear in inappropriate places. Fixes #2337 
- Text is no longer displaced when viewing relationship screen in fullscreen. Fixes #2341
- Medicine den names and Thought text no longer cut off the bottom of letters. Fixes some of #2338 
- Entering and leaving the warriors den no longer breaks the hover states of buttons on left side of screen. Fixes some of #2339
- `Saved` state of save button on SaveCheck windows now displays properly. Fixes some of #2339  