### PR TITLE
Patrol Any Fix

### DIFF
--- a/scripts/patrol/patrol.py
+++ b/scripts/patrol/patrol.py
@@ -589,11 +589,11 @@ class Patrol():
             if flag:
                 continue
             
-            if biome not in patrol.biome and "Any" not in patrol.biome:
+            if biome not in patrol.biome and "any" not in patrol.biome:
                 continue
-            if camp not in patrol.camp and "Any" not in patrol.camp:
+            if camp not in patrol.camp and "any" not in patrol.camp:
                 continue
-            if current_season not in patrol.season and "Any" not in patrol.season:
+            if current_season not in patrol.season and "any" not in patrol.season:
                 continue
 
             if 'hunting' not in patrol.types and patrol_type == 'hunting':

--- a/scripts/patrol/patrol_event.py
+++ b/scripts/patrol/patrol_event.py
@@ -36,9 +36,9 @@ class PatrolEvent:
         
         self.patrol_art = patrol_art
         self.patrol_art_clean = patrol_art_clean
-        self.biome = biome if biome is not None else ["Any"]
-        self.camp = camp if camp is not None else ["Any"]
-        self.season = season if season is not None else ["Any"]
+        self.biome = biome if biome is not None else ["any"]
+        self.camp = camp if camp is not None else ["any"]
+        self.season = season if season is not None else ["any"]
         self.tags = tags if tags is not None else []
         self.intro_text = intro_text
         


### PR DESCRIPTION
Makes it so patrols read any instead of Any.

Fixes Patrols that couldn't activate because they were expecting "Any".

Fixes #2346