### PR TITLE
[CI] Action for people to self-assign issues

### DIFF
--- a/.github/workflows/self-assign.yml
+++ b/.github/workflows/self-assign.yml
@@ -1,0 +1,17 @@
+name: Assign Issue
+
+on:
+  # for automatic unassigning for inactivity
+  schedule:
+    - cron: 0 0 * * *
+  issue_comment:
+    types: [created]
+
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign user or unassign inactive self-assigned issue
+        uses: takanome-dev/assign-issue-action@v2.1.1
+        with:
+          github_token: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
## About The Pull Request
Allows people to self-assign on the GitHub repository by commenting `/assign-me` using [Assign Me Action](https://github.com/marketplace/actions/assign-me-action).

## Why This Is Good For ClanGen
In order to be assigned an issue, people have to ping a senior developer on Discord or on GitHub to be manually assigned. This automates this process.

## Proof of Testing
[Example of it working on my fork](https://github.com/larkgz/clangen/issues/1)