### PR TITLE
Bugfix: Crashes, Event IDs, and Event filters

### DIFF
--- a/resources/dicts/events/death/general.json
+++ b/resources/dicts/events/death/general.json
@@ -928,7 +928,7 @@
         }]
     },
     {
-        "event_id": "gen_death_badprey_any1",
+        "event_id": "gen_death_badprey_anydoubledeath1",
         "location": ["any"],
         "season": [
             "any"
@@ -997,7 +997,7 @@
         }]
     },
     {
-        "event_id": "gen_death_rogue_any1",
+        "event_id": "gen_death_rogue_anydoubledeath1",
         "location": ["any"],
         "season": [
             "any"
@@ -1357,7 +1357,7 @@
         }
     },
     {
-        "event_id": "gen_death_war_any5",
+        "event_id": "gen_death_war_sacrifice1",
         "location": ["any"],
         "season": [
             "any"
@@ -2626,7 +2626,7 @@
         ]
     },
     {
-        "event_id": "gen_death_war_any3",
+        "event_id": "gen_death_war_any5",
         "location": ["mountainous", "forest", "beach"],
         "season": [
             "any"
@@ -3259,7 +3259,7 @@
         ]
     },
     {
-        "event_id": "gen_death_ockill_anymed1",
+        "event_id": "gen_death_ockill_anymed2",
         "location": ["any"],
         "season": [
             "any"
@@ -3302,7 +3302,7 @@
         ]
     },
     {
-        "event_id": "gen_death_ockill_anymed2",
+        "event_id": "gen_death_ockill_anymed3",
         "location": ["any"],
         "season": ["any"],
         "tags": [],

--- a/resources/dicts/events/death/mountainous.json
+++ b/resources/dicts/events/death/mountainous.json
@@ -1,6 +1,6 @@
 [
   {
-        "event_id": "gen_death_bury_multi1",
+        "event_id": "mtn_death_bury_multicamp1",
         "location": ["mountainous:camp1"],
         "season": [
             "leaf-fall",

--- a/resources/dicts/events/injury/general.json
+++ b/resources/dicts/events/injury/general.json
@@ -1017,7 +1017,7 @@
         ]
     },
     {
-        "event_id": "multi_injury_anykit1",
+        "event_id": "multi_injury_anykiteagle1",
         "location": [
             "plains",
             "forest",
@@ -1070,7 +1070,7 @@
         ]
     },
     {
-        "event_id": "multi_injury_anykit1",
+        "event_id": "multi_injury_anykithawk1",
         "location": [
             "plains",
             "forest",
@@ -1278,7 +1278,7 @@
         ]
     },
     {
-        "event_id": "multi_injury_anybruises1",
+        "event_id": "multi_injury_anybruisestree1",
         "location": [
             "beach",
             "mountainous",
@@ -1300,7 +1300,7 @@
         ]
     },
     {
-        "event_id": "multi_injury_anybruises1",
+        "event_id": "multi_injury_anybruisesshowoff1",
         "location": [
             "beach",
             "forest",
@@ -3657,7 +3657,7 @@
         ]
     },
     {
-        "event_id": "gen_injury_clawwoundcatbite_anyapprenticemultitraitappmentorothercat1",
+        "event_id": "gen_injury_clawwoundcatbite_anydefensepunish1",
         "location": ["any"],
         "season": ["any"],
         "weight": 10,
@@ -3990,7 +3990,7 @@
         ]
     },
     {
-        "event_id": "gen_injury_clawwoundcatbite_anyapprenticemultitraitappmentorothercat1",
+        "event_id": "gen_injury_clawwoundcatbite_anydisobeypunish1",
         "location": ["any"],
         "season": ["any"],
         "weight": 10,
@@ -4074,7 +4074,7 @@
         ]
     },
     {
-        "event_id": "gen_injury_clawwoundcatbite_anyapprenticemultitraitappmentorothercat1",
+        "event_id": "gen_injury_clawwoundcatbite_anymentorfight1",
         "location": ["any"],
         "season": ["any"],
         "weight": 10,

--- a/resources/dicts/events/misc/general.json
+++ b/resources/dicts/events/misc/general.json
@@ -492,7 +492,7 @@
   {
     "event_id": "gen_misc_leafbare_misc1",
     "location": ["any"],
-    "season": ["leafbare"],
+    "season": ["leaf-bare"],
     "weight": 20,
     "event_text": "m_c and r_c begin a small camp snowball fight while on guard duty, eventually getting the whole Clan to join in.",
     "m_c": {

--- a/resources/dicts/events/misc/general.json
+++ b/resources/dicts/events/misc/general.json
@@ -2932,7 +2932,7 @@
     ]
   },
   {
-    "event_id": "gen_misc_freshkill_anystolen1",
+    "event_id": "gen_misc_freshkill_anystolen2",
     "location": ["any"],
     "season": ["any"],
     "tags": ["clan_wide"],
@@ -3118,7 +3118,7 @@
     }
   },
   {
-    "event_id": "gen_misc_herb_anyallyrequeslungwort2",
+    "event_id": "gen_misc_herb_anyallyrequeslungwort4",
     "location": ["any"],
     "season": ["any"],
     "tags": ["clan_wide"],

--- a/resources/dicts/events/misc/general.json
+++ b/resources/dicts/events/misc/general.json
@@ -2558,11 +2558,15 @@
       "age":["any"],
       "status": ["medicine cat apprentice", "medicine cat"]
     },
-    "supplies": {
-      "type": "any_herb",
-      "trigger": ["low"],
-      "amount": "increase_5"
-    }
+    "supplies": [
+      {
+        "type": "any_herb",
+        "trigger": [
+          "low"
+        ],
+        "amount": "increase_5"
+      }
+    ]
   },
   {
     "event_id": "gen_misc_any_medicinecatmedcatapp1",

--- a/resources/dicts/events/misc/general.json
+++ b/resources/dicts/events/misc/general.json
@@ -2564,7 +2564,7 @@
         "trigger": [
           "low"
         ],
-        "amount": "increase_5"
+        "adjust": "increase_5"
       }
     ]
   },

--- a/resources/dicts/events/new_cat/general.json
+++ b/resources/dicts/events/new_cat/general.json
@@ -648,7 +648,7 @@
         }
     },
     {
-        "event_id": "gen_new_cat_war_any2",
+        "event_id": "gen_new_cat_war_anydefect1",
         "location": ["any"],
         "season": ["any"],
         "sub_type": ["war"],
@@ -672,7 +672,7 @@
         }
     },
     {
-        "event_id": "gen_new_cat_war_any2",
+        "event_id": "gen_new_cat_war_anydefect2",
         "location": ["any"],
         "season": ["any"],
         "sub_type": ["war"],

--- a/resources/game_config.json
+++ b/resources/game_config.json
@@ -257,7 +257,7 @@
 		]
 	},
 	"event_generation": {
-		"debug_ensure_event_id": "gen_death_border_any1"
+		"debug_ensure_event_id": null
 	},
 	"death_related": {
 		"leader_death_chance": 50,

--- a/scripts/cat/history.py
+++ b/scripts/cat/history.py
@@ -677,7 +677,8 @@ class History:
                 else:
                     victim_history["revelation_text"] = "The truth of {PRONOUN/m_c/poss} murder was discovered by [discoverer]."
 
-                discoverer = str(other_cat.name)
+                if other_cat:
+                    discoverer = str(other_cat.name)
                 if "clan_discovery" in murder_history:
                     discoverer = game.clan.name + "Clan"
 

--- a/scripts/events_module/generate_events.py
+++ b/scripts/events_module/generate_events.py
@@ -214,8 +214,6 @@ class GenerateEvents:
         final_events = []
         incorrect_format = []
 
-        event_id_requirement_not_met = None
-
         # Chance to bypass the skill or trait requirements. 
         trait_skill_bypass = 15
 

--- a/scripts/events_module/generate_events.py
+++ b/scripts/events_module/generate_events.py
@@ -214,6 +214,8 @@ class GenerateEvents:
         final_events = []
         incorrect_format = []
 
+        event_id_requirement_not_met = None
+
         # Chance to bypass the skill or trait requirements. 
         trait_skill_bypass = 15
 
@@ -236,6 +238,7 @@ class GenerateEvents:
             for sub in sub_types:
                 if sub not in event.sub_type:
                     wrong_type = True
+
                     continue
             for sub in event.sub_type:
                 if sub not in sub_types:
@@ -287,27 +290,28 @@ class GenerateEvents:
             if game.clan.game_mode in ["classic", "expanded"] and "cruel_season" in event.tags:
                 continue
 
-            # make complete leader death less likely until the leader is over 150 moons
-            if "all_lives" in event.tags:
-                if int(cat.moons) < 150 and int(random.random() * 5):
+            # make complete leader death less likely until the leader is over 150 moons (or unless it's a murder)
+            if cat.status == "leader":
+                if "all_lives" in event.tags and "murder" not in event.sub_type:
+                    if int(cat.moons) < 150 and int(random.random() * 5):
+                        continue
+
+                leader_lives = game.clan.leader_lives
+
+                # make sure that 'some lives' and "lives_remain" events don't show up if the leader doesn't have
+                # multiple lives to spare
+                if "some_lives" in event.tags and leader_lives <= 3:
+                    continue
+                if "lives_remain" in event.tags and leader_lives < 2:
                     continue
 
-            leader_lives = game.clan.leader_lives
-
-            # make sure that 'some lives' and "lives_remain" events don't show up if the leader doesn't have multiple
-            # lives to spare
-            if "some_lives" in event.tags and leader_lives <= 3:
-                continue
-            if "lives_remain" in event.tags and leader_lives < 2:
-                continue
-
-            # check leader life count
-            if "high_lives" in event.tags and leader_lives not in [7, 8, 9]:
-                continue
-            elif "mid_lives" in event.tags and leader_lives not in [4, 5, 6]:
-                continue
-            elif "low_lives" in event.tags and leader_lives not in [1, 2, 3]:
-                continue
+                # check leader life count
+                if "high_lives" in event.tags and leader_lives not in [7, 8, 9]:
+                    continue
+                elif "mid_lives" in event.tags and leader_lives not in [4, 5, 6]:
+                    continue
+                elif "low_lives" in event.tags and leader_lives not in [1, 2, 3]:
+                    continue
 
             discard = False
             for rank in Cat_class.rank_sort_order:
@@ -357,56 +361,56 @@ class GenerateEvents:
                         continue
 
                 # check cat trait and skill
-                has_trait = False
-                if event.m_c["trait"]:
-                    if cat.personality.trait in event.m_c["trait"]:
-                        has_trait = True
+                if int(random.random() * trait_skill_bypass) or prevent_bypass:  # small chance to bypass
+                    has_trait = False
+                    if event.m_c["trait"]:
+                        if cat.personality.trait in event.m_c["trait"]:
+                            has_trait = True
 
-                has_skill = False
-                if event.m_c["skill"]:
-                    for _skill in event.m_c["skill"]:
-                        split = _skill.split(",")
+                    has_skill = False
+                    if event.m_c["skill"]:
+                        for _skill in event.m_c["skill"]:
+                            split = _skill.split(",")
 
-                        if len(split) < 2:
-                            print("Cat skill incorrectly formatted", _skill)
+                            if len(split) < 2:
+                                print("Cat skill incorrectly formatted", _skill)
+                                continue
+
+                            if cat.skills.meets_skill_requirement(split[0], int(split[1])):
+                                has_skill = True
+                                break
+
+                    if event.m_c["trait"] and event.m_c["skill"]:
+                        if not has_trait or has_skill:
+                            continue
+                    elif event.m_c["trait"]:
+                        if not has_trait:
+                            continue
+                    elif event.m_c["skill"]:
+                        if not has_skill:
                             continue
 
-                        if cat.skills.meets_skill_requirement(split[0], int(split[1])):
-                            has_skill = True
-                            break
+                    # check cat negate trait and skill
+                    has_trait = False
+                    if event.m_c["not_trait"]:
+                        if cat.personality.trait in event.m_c["not_trait"]:
+                            has_trait = True
 
-                if event.m_c["trait"] and event.m_c["skill"]:
-                    if not (has_trait or has_skill) and (prevent_bypass or int(random.random() * trait_skill_bypass)):
+                    has_skill = False
+                    if event.m_c["not_skill"]:
+                        for _skill in event.m_c["not_skill"]:
+                            split = _skill.split(",")
+
+                            if len(split) < 2:
+                                print("Cat skill incorrectly formatted", _skill)
+                                continue
+
+                            if cat.skills.meets_skill_requirement(split[0], int(split[1])):
+                                has_skill = True
+                                break
+
+                    if has_trait or has_skill:
                         continue
-                elif event.m_c["trait"]:
-                    if not has_trait and (prevent_bypass or int(random.random() * trait_skill_bypass)):
-                        continue
-                elif event.m_c["skill"]:
-                    if not has_skill and (prevent_bypass or int(random.random() * trait_skill_bypass)):
-                        continue
-
-                # check cat negate trait and skill
-                has_trait = False
-                if event.m_c["not_trait"]:
-                    if cat.personality.trait in event.m_c["not_trait"]:
-                        has_trait = True
-
-                has_skill = False
-                if event.m_c["not_skill"]:
-                    for _skill in event.m_c["not_skill"]:
-                        split = _skill.split(",")
-
-                        if len(split) < 2:
-                            print("Cat skill incorrectly formatted", _skill)
-                            continue
-
-                        if cat.skills.meets_skill_requirement(split[0], int(split[1])):
-                            has_skill = True
-                            break
-
-                # There is a small chance to bypass the skill or trait requirements.
-                if (has_trait or has_skill) and (prevent_bypass or int(random.random() * trait_skill_bypass)):
-                    continue
 
                 # check backstory
                 if event.m_c["backstory"]:
@@ -425,57 +429,57 @@ class GenerateEvents:
                                                     event_id=event.event_id):
                         continue
 
-                # check random_cat trait and skill
-                has_trait = False
-                if event.r_c["trait"]:
-                    if random_cat.personality.trait in event.r_c["trait"]:
-                        has_trait = True
+                # check cat trait and skill
+                if int(random.random() * trait_skill_bypass) or prevent_bypass:  # small chance to bypass
+                    has_trait = False
+                    if event.r_c["trait"]:
+                        if random_cat.personality.trait in event.r_c["trait"]:
+                            has_trait = True
 
-                has_skill = False
-                if event.r_c["skill"]:
-                    for _skill in event.r_c["skill"]:
-                        split = _skill.split(",")
+                    has_skill = False
+                    if event.r_c["skill"]:
+                        for _skill in event.r_c["skill"]:
+                            split = _skill.split(",")
 
-                        if len(split) < 2:
-                            print("random_cat skill incorrectly formatted", _skill)
+                            if len(split) < 2:
+                                print("random_cat skill incorrectly formatted", _skill)
+                                continue
+
+                            if random_cat.skills.meets_skill_requirement(split[0], int(split[1])):
+                                has_skill = True
+                                break
+
+                    if event.r_c["trait"] and event.r_c["skill"]:
+                        if not has_trait or has_skill:
+                            continue
+                    elif event.r_c["trait"]:
+                        if not has_trait:
+                            continue
+                    elif event.r_c["skill"]:
+                        if not has_skill:
                             continue
 
-                        if random_cat.skills.meets_skill_requirement(split[0], int(split[1])):
-                            has_skill = True
-                            break
+                    # check cat negate trait and skill
+                    has_trait = False
+                    if event.r_c["not_trait"]:
+                        if random_cat.personality.trait in event.r_c["not_trait"]:
+                            has_trait = True
 
-                if event.r_c["trait"] and event.r_c["skill"]:
-                    if not (has_trait or has_skill) and (prevent_bypass or int(random.random() * trait_skill_bypass)):
+                    has_skill = False
+                    if event.r_c["not_skill"]:
+                        for _skill in event.r_c["not_skill"]:
+                            split = _skill.split(",")
+
+                            if len(split) < 2:
+                                print("random_cat skill incorrectly formatted", _skill)
+                                continue
+
+                            if random_cat.skills.meets_skill_requirement(split[0], int(split[1])):
+                                has_skill = True
+                                break
+
+                    if has_trait or has_skill:
                         continue
-                elif event.r_c["trait"]:
-                    if not has_trait and (prevent_bypass or int(random.random() * trait_skill_bypass)):
-                        continue
-                elif event.r_c["skill"]:
-                    if not has_skill and (prevent_bypass or int(random.random() * trait_skill_bypass)):
-                        continue
-
-                # check random_cat negate trait and skill
-                has_trait = False
-                if event.r_c["not_trait"]:
-                    if random_cat.personality.trait in event.r_c["not_trait"]:
-                        has_trait = True
-
-                has_skill = False
-                if event.r_c["not_skill"]:
-                    for _skill in event.r_c["not_skill"]:
-                        split = _skill.split(",")
-
-                        if len(split) < 2:
-                            print("random_cat skill incorrectly formatted", _skill)
-                            continue
-
-                        if random_cat.skills.meets_skill_requirement(split[0], int(split[1])):
-                            has_skill = True
-                            break
-
-                # There is a small chance to bypass the skill or trait requirements.
-                if (has_trait or has_skill) and (prevent_bypass or int(random.random() * trait_skill_bypass)):
-                    continue
 
                 # check backstory
                 if event.r_c["backstory"]:

--- a/scripts/events_module/handle_short_events.py
+++ b/scripts/events_module/handle_short_events.py
@@ -682,7 +682,7 @@ class HandleShortEvents():
             elif adjustment == "reduce_eighth":
                 herbs[self.chosen_herb] = int(game.clan.herbs[self.chosen_herb] / 8)
             elif "increase" in adjustment:
-                herbs[self.chosen_herb] += adjustment.split("_")[1]
+                herbs[self.chosen_herb] += int(adjustment.split("_")[1])
 
         if not self.chosen_herb:
             self.chosen_herb = random.choice(list(herbs.keys()))


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix:, Feature:, Enhancement: or Content: in the title to describe what type of PR it is. -->

## About The Pull Request
Fixes #2422 
Fixes #2443 
Fixes #2442

Made some fixes + adjustments to the ShortEvent filter code.  
- Some events were prevented from triggered due to the "all_lives" tag, despite the chosen event cat not being a leader
- Skill and Trait constraints likely worked fine, but I've refined the code to make it more understandable, as I frankly couldn't really decipher it before.  Additionally, we no longer check the trait/status constraints at all if we've already hit the random chance to bypass the skill/trait constraints.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
Fixes #2422 
Fixes #2443 
Fixes #2442
<!-- If this is not related to an issue, you can remove this section. -->
<!-- If this was in response to a github issue, please write it here with the format Fixes: #1234 so that github knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
![image](https://github.com/ClanGenOfficial/clangen/assets/115410010/693892b0-d7e7-4d1c-8d00-152afcea93dc)
^^ event that caused the crash triggered successfully without crashing

![image](https://github.com/ClanGenOfficial/clangen/assets/115410010/d2df0736-69c3-42b3-8087-40841bdba88e)
A trait specific event that includes the "all_lives" tag triggered successfully for allowed cats.

<!-- Include any screenshots, debugging steps or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Game no longer crashes when the moon event gen_misc_leafbaremedicinecatwar1 is triggered
- Fixed typo in season tagging of gen_misc_leafbare_misc1
- Fixed various duplicate event IDs
- Made some fixes + adjustments to the ShortEvent filter code.  
- Some events were prevented from triggered due to the "all_lives" tag, despite the chosen event cat not being a leader
- Skill and Trait constraints likely worked fine, but I've refined the code to make it more understandable, as I frankly couldn't really decipher it before.  Additionally, we no longer check the trait/status constraints at all if we've already hit the random chance to bypass the skill/trait constraints.
<!-- Include any changes that should be made to the changelog of the game here, or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
