### PR TITLE
Fix for cat list breaking bug

### DIFF
--- a/scripts/screens/ListScreen.py
+++ b/scripts/screens/ListScreen.py
@@ -555,11 +555,33 @@ class ListScreen(Screens):
                 manager=MANAGER
             )
         else:
-            self.cat_display.text_theme = (
-                get_text_box_theme("#text_box_30_horizcenter")
-                if self.death_status == "living"
-                else "#text_box_30_horizcenter_light")
-            self.cat_display.update_display(current_page=self.current_page, cat_list=self.current_listed_cats)
+            if self.cat_display.relative_rect != "Rect(0, 0, 710, 480)":
+                self.cat_display.kill()
+                self.cat_display = UINamedCatListDisplay(
+                    scale(pygame.Rect((0, 0), (0, 0))),
+                    container=self.cat_display_container,
+                    object_id="#cat_list_display",
+                    starting_height=1,
+                    cat_list=self.current_listed_cats,
+                    cats_displayed=20,
+                    x_px_between=240,
+                    y_px_between=200,
+                    columns=5,
+                    prev_button=self.display_container_elements["previous_page_button"],
+                    next_button=self.display_container_elements["next_page_button"],
+                    first_button=self.display_container_elements["first_page_button"],
+                    last_button=self.display_container_elements["last_page_button"],
+                    current_page=self.current_page,
+                    text_theme=get_text_box_theme("#text_box_30_horizcenter") if self.death_status == "living"
+                    else "#text_box_30_horizcenter_light",
+                    manager=MANAGER
+                )
+            else:
+                self.cat_display.text_theme = (
+                    get_text_box_theme("#text_box_30_horizcenter")
+                    if self.death_status == "living"
+                    else "#text_box_30_horizcenter_light")
+                self.cat_display.update_display(current_page=self.current_page, cat_list=self.current_listed_cats)
 
         self.set_bg_and_heading()
 


### PR DESCRIPTION
## About The Pull Request

Fixes a game-breaking bug with the Clan list that could permanently disable a large chunk of the cat list buttons until the game is restarted. When using "back_button" to return to a list view with 15 or less cats, the cat_display container would be created with dimensions appropriate for the *smaller* number of cat buttons, meaning that if COTC had one row and your Clan had 4, all but the first row of your Clan will be cut off. Switching group views would not actually fix the cat_display dimensions because it would be modifying the preexisting cat_display. Now if it's less than 20 cats, the cat_display is deleted and a new, properly sized, one is generated. This might be inefficient but it's the only solution I could find that works reliably for now as trying to directly set things like self.cat_display.relative_rect didn't work.

## Linked Issues

Fixes: #2480

The issue would happen like this:

1. Open Clan list

2. Switch the view to another group (StarClan, COTC, etc) that has at least 1, but no more than 15, cat(s)

3. Click on one of these cats' sprites to open the profile view

4. Click the back button

Now all lists of cats that contain more cats than the smaller group will be broken. This will happen 100% of the time you follow these steps given that the conditions (more rows/cats in the first page of your living Clan than the first page of the other view) are met.

## Proof of Testing

Before:
https://github.com/ClanGenOfficial/clangen/assets/104292791/7ba3ba37-22fc-4c52-8622-73ee54b5fd41

After:
https://github.com/ClanGenOfficial/clangen/assets/104292791/e9244063-4928-448d-9ca8-fd1f3100ff10


## Changelog/Credits

- Fixes a bug that would disable and hide cat sprites and buttons in the list view until game restart
