### PR TITLE
Bugfix: existing kit in clan is not considered new when parent reinvited

### DIFF
--- a/scripts/events.py
+++ b/scripts/events.py
@@ -8,7 +8,6 @@ TODO: Docs
 
 import random
 # pylint: enable=line-too-long
-import re
 import traceback
 from collections import Counter
 
@@ -374,6 +373,7 @@ class Events:
             # ADJUST REP
             game.clan.reputation += chosen_event["rep_change"]
 
+            additional_kits = None
             # SUCCESS/FAIL
             if info_dict["success"]:
                 if info_dict["interaction_type"] == "hunt":
@@ -476,7 +476,8 @@ class Events:
                     clan=game.clan)
 
             if "kit_thought" in cat_dict:
-                additional_kits = outsider_cat.get_children()
+                if additional_kits is None:
+                    additional_kits = outsider_cat.get_children()
                 if additional_kits:
                     for kit_ID in additional_kits:
                         kit = Cat.fetch_cat(kit_ID)


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix:, Feature:, Enhancement: or Content: in the title to describe what type of PR it is. -->

## About The Pull Request

Adds a check that lets `events.py` "remember" which cats should come along for the ride when a parent is invited.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
Fixes #2504 
<!-- If this is not related to an issue, you can remove this section. -->
<!-- If this was in response to a github issue, please write it here with the format Fixes: #1234 so that github knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing

https://github.com/ClanGenOfficial/clangen/assets/48025294/9a6f6591-c694-4185-ba61-b81739ed28a0

(featuring the cat list ui bug as well but y'know that's not what's being tested so 😄 )

<!-- Include any screenshots, debugging steps or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
Bugfix: existing kit in clan is not considered new when parent reinvited

<!-- Include any changes that should be made to the changelog of the game here, or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
