### PR TITLE
Bugfix: Adds default relationship log text

### DIFF
--- a/scripts/utility.py
+++ b/scripts/utility.py
@@ -1311,8 +1311,8 @@ def unpack_rel_block(
     possible_values = ("romantic", "platonic", "dislike", "comfort", "jealous", "trust", "respect")
 
     for block in relationship_effects:
-        cats_from = block.get("cats_from", ())
-        cats_to = block.get("cats_to", ())
+        cats_from = block.get("cats_from", [])
+        cats_to = block.get("cats_to", [])
         amount = block.get("amount")
         values = [x for x in block.get("values", ()) if x in possible_values]
 
@@ -1392,15 +1392,21 @@ def unpack_rel_block(
                 print(f"something is wrong with relationship log: {log}")
 
         if not log1:
-            try:
-                log1 = event.text + effect
-            except AttributeError:
-                print(f"WARNING: event changed relationships but did not create a relationship log")
+            if hasattr(event, "text"):
+                try:
+                    log1 = event.text + effect
+                except AttributeError:
+                    print(f"WARNING: event changed relationships but did not create a relationship log")
+            else:
+                log1 = "These cats recently interacted." + effect
         if not log2:
-            try:
-                log2 = event.text + effect
-            except AttributeError:
-                print(f"WARNING: event changed relationships but did not create a relationship log")
+            if hasattr(event, "text"):
+                try:
+                    log2 = event.text + effect
+                except AttributeError:
+                    print(f"WARNING: event changed relationships but did not create a relationship log")
+            else:
+                log2 = f"These cats recently interacted." + effect
 
         change_relationship_values(
             cats_to_ob,


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix:, Feature:, Enhancement: or Content: in the title to describe what type of PR it is. -->

## About The Pull Request

Adds a simple, deeply generic sentence for a cat's relationship log. I can't go into any more detail (e.g. "these cats recently patrolled together") because it lives in `utility.py` which can't import Patrol to use for isinstance. If anyone has any ideas of how to bodge it, I'm all ears. If a different sentence is preferred, I can change that too.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
Fixes #2440 
<!-- If this is not related to an issue, you can remove this section. -->
<!-- If this was in response to a github issue, please write it here with the format Fixes: #1234 so that github knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
![image](https://github.com/ClanGenOfficial/clangen/assets/48025294/c7a556fc-2e1c-48e5-83b5-a2463ec9c89b)
![image](https://github.com/ClanGenOfficial/clangen/assets/48025294/134f2dd0-35bd-43bc-93c1-48d324c288db)



<!-- Include any screenshots, debugging steps or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
Bugfix: add default relationship log text

<!-- Include any changes that should be made to the changelog of the game here, or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
