### PR TITLE
Fixing the wetlands, and a little bit of Mountainous clean up

### DIFF
--- a/resources/dicts/patrols/mountainous/border/greenleaf.json
+++ b/resources/dicts/patrols/mountainous/border/greenleaf.json
@@ -920,7 +920,7 @@
     },
     {
         "patrol_id": "mtn_bord_shortswim1",
-        "biome": ["mountain"],
+        "biome": ["mountainous"],
         "season": ["greenleaf"],
         "types": ["border"],
         "tags": [],

--- a/resources/dicts/patrols/mountainous/border/leaf-fall.json
+++ b/resources/dicts/patrols/mountainous/border/leaf-fall.json
@@ -1,7 +1,7 @@
 [
     {
     "patrol_id": "mtn_bord_leaf-fall_goatfight1",
-    "biome": "mountainous",
+    "biome": ["mountainous"],
     "season": ["leaf-fall"],
     "types": ["border"],
     "tags": [],

--- a/resources/dicts/patrols/wetlands/hunting/any.json
+++ b/resources/dicts/patrols/wetlands/hunting/any.json
@@ -83,7 +83,7 @@
     },
     {
         "patrol_id": "wtlnd_gen_hunt_twolegplace2",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["any"],
         "types": ["hunting"],
         "tags": [],
@@ -2184,7 +2184,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_redfox_scavenge5",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["any"],
         "types": ["hunting"],
         "tags": [],
@@ -2320,7 +2320,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_redfox_scavenge6",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["any"],
         "types": ["hunting"],
         "tags": [],
@@ -2456,7 +2456,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_redfox_scavenge8",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["any"],
         "types": ["hunting"],
         "tags": [],
@@ -2621,7 +2621,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_foxgray_scavenge4",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["any"],
         "types": ["hunting"],
         "tags": [],
@@ -2765,7 +2765,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_foxgray_scavenge2",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["any"],
         "types": ["hunting"],
         "tags": [],
@@ -2885,7 +2885,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_foxgray_scavenge3",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["any"],
         "types": ["hunting"],
         "tags": [],
@@ -3052,7 +3052,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_redfox_steal1",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["any"],
         "types": ["hunting"],
         "tags": [],
@@ -3279,7 +3279,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_redfox_steal2",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["any"],
         "types": ["hunting"],
         "tags": [],
@@ -3457,7 +3457,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_redfox_steal6",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["any"],
         "types": ["hunting"],
         "tags": [],
@@ -3635,7 +3635,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_foxgray_steal1",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["any"],
         "types": ["hunting"],
         "tags": [],
@@ -3828,7 +3828,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_foxgray_steal5",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["any"],
         "types": ["hunting"],
         "tags": [],
@@ -4019,7 +4019,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_foxgray_steal6",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["any"],
         "types": ["hunting"],
         "tags": [],
@@ -4134,7 +4134,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_redfox_scavenge9",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["any"],
         "types": ["hunting"],
         "tags": [],
@@ -4270,7 +4270,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_redfox_scavenge7",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["any"],
         "types": ["hunting"],
         "tags": [],
@@ -4406,7 +4406,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_redfox_scavenge10",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["any"],
         "types": ["hunting"],
         "tags": [],
@@ -4571,7 +4571,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_foxgray_scavenge1",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["any"],
         "types": ["hunting"],
         "tags": [],
@@ -4715,7 +4715,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_foxgray_scavenge5",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["any"],
         "types": ["hunting"],
         "tags": [],
@@ -4835,7 +4835,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_foxgray_scavenge6",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["any"],
         "types": ["hunting"],
         "tags": [],
@@ -5002,7 +5002,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_redfox_steal4",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["any"],
         "types": ["hunting"],
         "tags": [],
@@ -5229,7 +5229,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_redfox_steal5",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["any"],
         "types": ["hunting"],
         "tags": [],
@@ -5407,7 +5407,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_redfox_steal3",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["any"],
         "types": ["hunting"],
         "tags": [],
@@ -5581,7 +5581,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_foxgray_steal4",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["any"],
         "types": ["hunting"],
         "tags": [],
@@ -5774,7 +5774,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_foxgray_steal2",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["any"],
         "types": ["hunting"],
         "tags": [],
@@ -5965,7 +5965,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_foxgray_steal3",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["any"],
         "types": ["hunting"],
         "tags": [],

--- a/resources/dicts/patrols/wetlands/hunting/greenleaf.json
+++ b/resources/dicts/patrols/wetlands/hunting/greenleaf.json
@@ -2209,7 +2209,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_redvixen13",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["greenleaf"],
         "types": [],
         "tags": [],
@@ -2400,7 +2400,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_redvixen14",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["greenleaf"],
         "types": [],
         "tags": [],
@@ -2563,7 +2563,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_redvixen6",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["greenleaf"],
         "types": [],
         "tags": [],
@@ -2711,7 +2711,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_grayvixen4",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["greenleaf"],
         "types": [],
         "tags": [],
@@ -2874,7 +2874,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_grayvixen5",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["greenleaf"],
         "types": [],
         "tags": [],
@@ -3037,7 +3037,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_grayvixen15",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["greenleaf"],
         "types": [],
         "tags": [],
@@ -3186,7 +3186,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_swiftfox_greenleafscavenge3",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["greenleaf"],
         "types": ["hunting"],
         "tags": [],
@@ -3300,7 +3300,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_swiftfox_greenleafscavenge2",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["greenleaf"],
         "types": ["hunting"],
         "tags": [],
@@ -3420,7 +3420,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_redvixen4",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["greenleaf"],
         "types": [],
         "tags": [],
@@ -3611,7 +3611,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_redvixen5",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["greenleaf"],
         "types": [],
         "tags": [],
@@ -3774,7 +3774,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_redvixen15",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["greenleaf"],
         "types": [],
         "tags": [],
@@ -3922,7 +3922,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_grayvixen13",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["greenleaf"],
         "types": [],
         "tags": [],
@@ -4085,7 +4085,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_grayvixen14",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["greenleaf"],
         "types": [],
         "tags": [],
@@ -4248,7 +4248,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_grayvixen6",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["greenleaf"],
         "types": [],
         "tags": [],
@@ -4397,7 +4397,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_swiftfox_greenleafscavenge1",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["greenleaf"],
         "types": ["hunting"],
         "tags": [],
@@ -4511,7 +4511,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_swiftfox_greenleafscavenge4",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["greenleaf"],
         "types": ["hunting"],
         "tags": [],

--- a/resources/dicts/patrols/wetlands/hunting/leaf-bare.json
+++ b/resources/dicts/patrols/wetlands/hunting/leaf-bare.json
@@ -2430,7 +2430,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_swiftfox_leaf-barescavenge3",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["leaf-bare"],
         "types": ["hunting"],
         "tags": [],
@@ -2544,7 +2544,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_swiftfox_leaf-barescavenge2",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["leaf-bare"],
         "types": ["hunting"],
         "tags": [],
@@ -2664,7 +2664,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_kitfox_scavenge1",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["leaf-bare"],
         "types": ["hunting"],
         "tags": [],
@@ -2770,7 +2770,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_kitfox_scavenge2",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["leaf-bare"],
         "types": ["hunting"],
         "tags": [],
@@ -2831,7 +2831,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_swiftfox_leaf-barescavenge1",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["leaf-bare"],
         "types": ["hunting"],
         "tags": [],
@@ -2945,7 +2945,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_swiftfox_leaf-barescavenge4",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["leaf-bare"],
         "types": ["hunting"],
         "tags": [],
@@ -3065,7 +3065,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_kitfox_scavenge3",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["leaf-bare"],
         "types": ["hunting"],
         "tags": [],
@@ -3171,7 +3171,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_kitfox_scavenge4",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["leaf-bare"],
         "types": ["hunting"],
         "tags": [],
@@ -3232,7 +3232,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_leafbare_kingfisher_storylorehunterclimberteacherlocked1",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["leaf-bare"],
         "types": ["hunting"],
         "tags": [],

--- a/resources/dicts/patrols/wetlands/hunting/leaf-fall.json
+++ b/resources/dicts/patrols/wetlands/hunting/leaf-fall.json
@@ -2209,7 +2209,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_redvixen7",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["leaf-fall"],
         "types": [],
         "tags": [],
@@ -2400,7 +2400,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_redvixen8",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["leaf-fall"],
         "types": [],
         "tags": [],
@@ -2540,7 +2540,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_redvixen9",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["leaf-fall"],
         "types": [],
         "tags": [],
@@ -2688,7 +2688,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_grayvixen16",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["leaf-fall"],
         "types": [],
         "tags": [],
@@ -2851,7 +2851,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_grayvixen17",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["leaf-fall"],
         "types": [],
         "tags": [],
@@ -3014,7 +3014,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_grayvixen9",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["leaf-fall"],
         "types": [],
         "tags": [],
@@ -3177,7 +3177,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_swiftfox_leaf-fallscavenge1",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["leaf-fall"],
         "types": ["hunting"],
         "tags": [],
@@ -3291,7 +3291,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_swiftfox_leaf-fallscavenge2",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["leaf-fall"],
         "types": ["hunting"],
         "tags": [],
@@ -3411,7 +3411,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_redvixen16",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["leaf-fall"],
         "types": [],
         "tags": [],
@@ -3602,7 +3602,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_redvixen17",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["leaf-fall"],
         "types": [],
         "tags": [],
@@ -3742,7 +3742,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_redvixen18",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["leaf-fall"],
         "types": [],
         "tags": [],
@@ -3890,7 +3890,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_grayvixen7",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["leaf-fall"],
         "types": [],
         "tags": [],
@@ -4053,7 +4053,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_grayvixen8",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["leaf-fall"],
         "types": [],
         "tags": [],
@@ -4216,7 +4216,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_grayvixen18",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["leaf-fall"],
         "types": [],
         "tags": [],
@@ -4379,7 +4379,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_swiftfox_leaf-fallscavenge3",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["leaf-fall"],
         "types": ["hunting"],
         "tags": [],
@@ -4493,7 +4493,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_swiftfox_leaf-fallscavenge4",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["leaf-fall"],
         "types": ["hunting"],
         "tags": [],

--- a/resources/dicts/patrols/wetlands/hunting/newleaf.json
+++ b/resources/dicts/patrols/wetlands/hunting/newleaf.json
@@ -2209,7 +2209,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_redvixen1",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["newleaf"],
         "types": [],
         "tags": [],
@@ -2400,7 +2400,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_redvixen2",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["newleaf"],
         "types": [],
         "tags": [],
@@ -2563,7 +2563,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_redvixen12",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["newleaf"],
         "types": [],
         "tags": [],
@@ -2711,7 +2711,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_grayvixen1",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["newleaf"],
         "types": [],
         "tags": [],
@@ -2874,7 +2874,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_grayvixen2",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["newleaf"],
         "types": [],
         "tags": [],
@@ -3037,7 +3037,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_grayvixen3",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["newleaf"],
         "types": [],
         "tags": [],
@@ -3186,7 +3186,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_swiftfox_newleafscavenge3",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["newleaf"],
         "types": ["hunting"],
         "tags": [],
@@ -3300,7 +3300,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_swiftfox_newleafscavenge2",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["newleaf"],
         "types": ["hunting"],
         "tags": [],
@@ -3420,7 +3420,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_redvixen10",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["newleaf"],
         "types": [],
         "tags": [],
@@ -3611,7 +3611,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_redvixen11",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["newleaf"],
         "types": [],
         "tags": [],
@@ -3774,7 +3774,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_redvixen3",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["newleaf"],
         "types": [],
         "tags": [],
@@ -3922,7 +3922,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_grayvixen10",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["newleaf"],
         "types": [],
         "tags": [],
@@ -4085,7 +4085,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_grayvixen11",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["newleaf"],
         "types": [],
         "tags": [],
@@ -4248,7 +4248,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_grayvixen12",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["newleaf"],
         "types": [],
         "tags": [],
@@ -4397,7 +4397,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_swiftfox_newleafscavenge1",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["newleaf"],
         "types": ["hunting"],
         "tags": [],
@@ -4511,7 +4511,7 @@
     },
     {
         "patrol_id": "wtlnd_hunt_swiftfox_newleafscavenge4",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["newleaf"],
         "types": ["hunting"],
         "tags": [],

--- a/resources/dicts/patrols/wetlands/med/greenleaf.json
+++ b/resources/dicts/patrols/wetlands/med/greenleaf.json
@@ -1,7 +1,7 @@
 [
     {
         "patrol_id": "wtlnd_med_greenleaf_daisy_lorestoryhealinglocked1",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["greenleaf"],
         "types": ["herb_gathering"],
         "tags": [],
@@ -66,7 +66,7 @@
     },
     {
         "patrol_id": "wtlnd_med_greenleaf_gatheringelder_lorehealingstorylocked1",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["greenleaf"],
         "types": ["herb_gathering"],
         "tags": [],
@@ -176,7 +176,7 @@
     },
     {
         "patrol_id": "wtlnd_med_greenleaf_juniper_lorestoryhealerlocked1",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["greenleaf"],
         "types": ["herb_gathering"],
         "tags": [],
@@ -241,7 +241,7 @@
     },
     {
         "patrol_id": "wtlnd_med_greenleaf_lungwort_storylorehealerlocked1",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["greenleaf"],
         "types": ["herb_gathering"],
         "tags": [],
@@ -314,7 +314,7 @@
     },
     {
         "patrol_id": "wtlnd_med_greenleaf_mallow_storylorehealerlocked1",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["greenleaf"],
         "types": ["herb_gathering"],
         "tags": [],
@@ -384,7 +384,7 @@
     },
     {
         "patrol_id": "wtlnd_med_greenleaf_marigold_storylorehealerlocked1",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["greenleaf"],
         "types": ["herb_gathering"],
         "tags": [],
@@ -449,7 +449,7 @@
     },
     {
         "patrol_id": "wtlnd_med_greenleaf_oakleaves_storylorehealerlocked1",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["greenleaf"],
         "types": ["herb_gathering"],
         "tags": [],
@@ -514,7 +514,7 @@
     },
     {
         "patrol_id": "wtlnd_med_greenleaf_ragwort_storylorehealerlocked1",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["greenleaf"],
         "types": ["herb_gathering"],
         "tags": [],
@@ -608,7 +608,7 @@
     },
     {
         "patrol_id": "wtlnd_med_greenleaf_raspberry_storylorehealerlocked1",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["greenleaf"],
         "types": ["herb_gathering"],
         "tags": [],
@@ -679,7 +679,7 @@
     },
     {
         "patrol_id": "wtlnd_med_greenleaf_tansy_storylorehealerlocked1",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["greenleaf"],
         "types": ["herb_gathering"],
         "tags": [],
@@ -799,7 +799,7 @@
     },
     {
         "patrol_id": "wtlnd_med_greenleaf_thyme_risingclanref_storylorehealerlocked1",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["greenleaf"],
         "types": ["herb_gathering"],
         "tags": [],

--- a/resources/dicts/patrols/wetlands/med/leaf-fall.json
+++ b/resources/dicts/patrols/wetlands/med/leaf-fall.json
@@ -1,7 +1,7 @@
 [
     {
         "patrol_id": "wtlnd_med_leaffall_daisy_lorestoryhealinglocked1",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["leaf-fall"],
         "types": ["herb_gathering"],
         "tags": [],
@@ -66,7 +66,7 @@
     },
     {
         "patrol_id": "wtlnd_med_leaffall_gatheringelder_lorehealingstorylocked1",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["leaf-fall"],
         "types": ["herb_gathering"],
         "tags": [],
@@ -176,7 +176,7 @@
     },
     {
         "patrol_id": "wtlnd_med_leaffall_juniper_lorestoryhealerlocked1",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["leaf-fall"],
         "types": ["herb_gathering"],
         "tags": [],
@@ -241,7 +241,7 @@
     },
     {
         "patrol_id": "wtlnd_med_leaffall_lungwort_storylorehealerlocked1",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["leaf-fall"],
         "types": ["herb_gathering"],
         "tags": [],
@@ -314,7 +314,7 @@
     },
     {
         "patrol_id": "wtlnd_med_leaffall_mallow_storylorehealerlocked1",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["leaf-fall"],
         "types": ["herb_gathering"],
         "tags": [],
@@ -384,7 +384,7 @@
     },
     {
         "patrol_id": "wtlnd_med_leaffall_marigold_storylorehealerlocked1",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["leaf-fall"],
         "types": ["herb_gathering"],
         "tags": [],
@@ -449,7 +449,7 @@
     },
     {
         "patrol_id": "wtlnd_med_leaffall_oakleaves_storylorehealerlocked1",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["leaf-fall"],
         "types": ["herb_gathering"],
         "tags": [],
@@ -514,7 +514,7 @@
     },
     {
         "patrol_id": "wtlnd_med_leaffall_ragwort_storylorehealerlocked1",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["leaf-fall"],
         "types": ["herb_gathering"],
         "tags": [],
@@ -608,7 +608,7 @@
     },
     {
         "patrol_id": "wtlnd_med_leaffall_raspberry_storylorehealerlocked1",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["leaf-fall"],
         "types": ["herb_gathering"],
         "tags": [],
@@ -679,7 +679,7 @@
     },
     {
         "patrol_id": "wtlnd_med_leaffall_tansy_storylorehealerlocked1",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["leaf-fall"],
         "types": ["herb_gathering"],
         "tags": [],
@@ -799,7 +799,7 @@
     },
     {
         "patrol_id": "wtlnd_med_leaffall_thyme_risingclanref_storylorehealerlocked1",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["leaf-fall"],
         "types": ["herb_gathering"],
         "tags": [],

--- a/resources/dicts/patrols/wetlands/med/newleaf.json
+++ b/resources/dicts/patrols/wetlands/med/newleaf.json
@@ -1,7 +1,7 @@
 [
     {
         "patrol_id": "wtlnd_med_newleaf_daisy_lorestoryhealinglocked1",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["newleaf"],
         "types": ["herb_gathering"],
         "tags": [],
@@ -66,7 +66,7 @@
     },
     {
         "patrol_id": "wtlnd_med_newleaf_gatheringelder_lorehealingstorylocked1",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["newleaf"],
         "types": ["herb_gathering"],
         "tags": [],
@@ -176,7 +176,7 @@
     },
     {
         "patrol_id": "wtlnd_med_newleaf_juniper_lorestoryhealerlocked1",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["newleaf"],
         "types": ["herb_gathering"],
         "tags": [],
@@ -241,7 +241,7 @@
     },
     {
         "patrol_id": "wtlnd_med_newleaf_lungwort_storylorehealerlocked1",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["newleaf"],
         "types": ["herb_gathering"],
         "tags": [],
@@ -314,7 +314,7 @@
     },
     {
         "patrol_id": "wtlnd_med_newleaf_mallow_storylorehealerlocked1",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["newleaf"],
         "types": ["herb_gathering"],
         "tags": [],
@@ -384,7 +384,7 @@
     },
     {
         "patrol_id": "wtlnd_med_newleaf_marigold_storylorehealerlocked1",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["newleaf"],
         "types": ["herb_gathering"],
         "tags": [],
@@ -449,7 +449,7 @@
     },
     {
         "patrol_id": "wtlnd_med_newleaf_oakleaves_storylorehealerlocked1",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["newleaf"],
         "types": ["herb_gathering"],
         "tags": [],
@@ -514,7 +514,7 @@
     },
     {
         "patrol_id": "wtlnd_med_newleaf_ragwort_storylorehealerlocked1",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["newleaf"],
         "types": ["herb_gathering"],
         "tags": [],
@@ -608,7 +608,7 @@
     },
     {
         "patrol_id": "wtlnd_med_newleaf_raspberry_storylorehealerlocked1",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["newleaf"],
         "types": ["herb_gathering"],
         "tags": [],
@@ -679,7 +679,7 @@
     },
     {
         "patrol_id": "wtlnd_med_newleaf_tansy_storylorehealerlocked1",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["newleaf"],
         "types": ["herb_gathering"],
         "tags": [],
@@ -799,7 +799,7 @@
     },
     {
         "patrol_id": "wtlnd_med_newleaf_thyme_risingclanref_storylorehealerlocked1",
-        "biome": ["wetland"],
+        "biome": ["wetlands"],
         "season": ["newleaf"],
         "types": ["herb_gathering"],
         "tags": [],


### PR DESCRIPTION
## About The Pull Request
fixes biome tag wetland to be wetlands.
Fixes a couple mtn patrols with incorrect biome tag

## Why This Is Good For ClanGen
Makes the patrols work properly

## Linked Issues
fixes #2500 

## Proof of Testing

@j-gynn my friend, Ill be asking for you to run your handy test here as well to make sure I didn't miss anything.

