### PR TITLE
[BUGFIX] cats can get accessories again

### DIFF
--- a/scripts/events.py
+++ b/scripts/events.py
@@ -1208,7 +1208,7 @@ class Events:
 
         self.invite_new_cats(cat)
         self.other_interactions(cat)
-        # self.gain_accessories(cat)
+        self.gain_accessories(cat)
 
         # switches between the two death handles
         if random.getrandbits(1):


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix:, Feature:, Enhancement: or Content: in the title to describe what type of PR it is. -->

## About The Pull Request

huge thanks to blackkat for pointing this out: the line that allowed cats to randomly get accessories on moon skip (aside from ceremony accessories) was commented out. this fixes it

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Proof of Testing

here is very sad, fashionless acctestclan with the code commented out. the only accessories were pregenerated or given as ceremony gifts.

https://github.com/ClanGenOfficial/clangen/assets/126827015/5a7b2fa0-1d79-423a-a2ee-e7ac1a2daec1

here is fashionable acctest2clan who has the code. so many fashionistas

https://github.com/ClanGenOfficial/clangen/assets/126827015/99b85d9f-4d03-4c44-8f64-b4c364f30919

<!-- Include any screenshots, debugging steps or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->
