### PR TITLE
Further UICatListDisplay and ListScreen optimisations

### DIFF
--- a/scripts/game_structure/game_essentials.py
+++ b/scripts/game_structure/game_essentials.py
@@ -152,7 +152,7 @@ class Game:
         "showcoords": False,
         "showbounds": False,
         "visualdebugmode": False,
-        "showfps": True,
+        "showfps": False,
     }
 
     # Init Settings

--- a/scripts/game_structure/game_essentials.py
+++ b/scripts/game_structure/game_essentials.py
@@ -152,7 +152,7 @@ class Game:
         "showcoords": False,
         "showbounds": False,
         "visualdebugmode": False,
-        "showfps": False,
+        "showfps": True,
     }
 
     # Init Settings
@@ -674,7 +674,9 @@ def load_manager(res: tuple):
         manager.get_theme().load_theme("resources/theme/text_boxes_small.json")
         manager.get_theme().load_theme("resources/theme/text_boxes_dark_small.json")
         manager.get_theme().load_theme("resources/theme/vertical_scroll_bar_small.json")
-        manager.get_theme().load_theme("resources/theme/horizontal_scroll_bar_small.json")
+        manager.get_theme().load_theme(
+            "resources/theme/horizontal_scroll_bar_small.json"
+        )
         manager.get_theme().load_theme("resources/theme/window_base_small.json")
         manager.get_theme().load_theme("resources/theme/tool_tips_small.json")
 

--- a/scripts/game_structure/ui_elements.py
+++ b/scripts/game_structure/ui_elements.py
@@ -1,6 +1,7 @@
-from math import floor, ceil
-from typing import Union, Tuple, Optional
 import html
+from functools import lru_cache
+from math import ceil
+from typing import Tuple, Optional, List
 
 import pygame
 import pygame_gui
@@ -10,11 +11,10 @@ from pygame_gui.core.interfaces import IUIManagerInterface
 from pygame_gui.core.text.html_parser import HTMLParser
 from pygame_gui.core.text.text_box_layout import TextBoxLayout
 from pygame_gui.core.utility import translate
-from pygame_gui.elements import UIAutoResizingContainer, UIHorizontalScrollBar
+from pygame_gui.elements import UIAutoResizingContainer
 
 from scripts.game_structure import image_cache
 from scripts.game_structure.game_essentials import game
-
 from scripts.utility import scale, shorten_text_to_fit
 
 
@@ -92,15 +92,16 @@ class UIImageButton(pygame_gui.elements.UIButton):
 
 class UIModifiedScrollingContainer(pygame_gui.elements.UIScrollingContainer):
     def __init__(
-            self,
-            relative_rect: pygame.Rect,
-            manager=None,
-            starting_height: int = 1,
-            container=None,
-            object_id=None,
-            visible: int = 1,
-            allow_scroll_x: bool = False,
-            allow_scroll_y: bool = False):
+        self,
+        relative_rect: pygame.Rect,
+        manager=None,
+        starting_height: int = 1,
+        container=None,
+        object_id=None,
+        visible: int = 1,
+        allow_scroll_x: bool = False,
+        allow_scroll_y: bool = False,
+    ):
 
         super().__init__(
             relative_rect=relative_rect,
@@ -111,32 +112,41 @@ class UIModifiedScrollingContainer(pygame_gui.elements.UIScrollingContainer):
             visible=visible,
             allow_scroll_x=allow_scroll_x,
             allow_scroll_y=allow_scroll_y,
-            should_grow_automatically=True)
+            should_grow_automatically=True,
+        )
 
         if self.allow_scroll_y:
             self.vert_scroll_bar.kill()
             self.vert_scroll_bar = None
 
             self.scroll_bar_width = self._get_scroll_bar_width()
-            scroll_bar_rect = pygame.Rect(-self.scroll_bar_width,
-                                          0,
-                                          self.scroll_bar_width,
-                                          self.relative_rect.height)
+            scroll_bar_rect = pygame.Rect(
+                -self.scroll_bar_width,
+                0,
+                self.scroll_bar_width,
+                self.relative_rect.height,
+            )
 
-            self.vert_scroll_bar = UIImageVerticalScrollBar(relative_rect=scroll_bar_rect,
-                                                            visible_percentage=1.0,
-                                                            manager=self.ui_manager,
-                                                            container=self._root_container,
-                                                            parent_element=self,
-                                                            starting_height=10,
-                                                            anchors={'left': 'right',
-                                                                     'right': 'right',
-                                                                     'top': 'top',
-                                                                     'bottom': 'bottom'},
-                                                            visible=False)
+            self.vert_scroll_bar = UIImageVerticalScrollBar(
+                relative_rect=scroll_bar_rect,
+                visible_percentage=1.0,
+                manager=self.ui_manager,
+                container=self._root_container,
+                parent_element=self,
+                starting_height=10,
+                anchors={
+                    "left": "right",
+                    "right": "right",
+                    "top": "top",
+                    "bottom": "bottom",
+                },
+                visible=False,
+            )
             self.join_focus_sets(self.vert_scroll_bar)
 
-            self.vert_scroll_bar.set_container_this_will_scroll(self.scrollable_container)
+            self.vert_scroll_bar.set_container_this_will_scroll(
+                self.scrollable_container
+            )
 
         if self.allow_scroll_x:
             self.horiz_scroll_bar.kill()
@@ -145,20 +155,32 @@ class UIModifiedScrollingContainer(pygame_gui.elements.UIScrollingContainer):
             self.scroll_bar_height = self._get_scroll_bar_height()
 
             scroll_bar_rect = scale(
-                pygame.Rect(0, -self.scroll_bar_height, self.relative_rect.width, self.scroll_bar_height))
-            self.horiz_scroll_bar = UIModifiedHorizScrollBar(relative_rect=scroll_bar_rect,
-                                                             visible_percentage=1.0,
-                                                             manager=self.ui_manager,
-                                                             container=self._root_container,
-                                                             parent_element=self,
-                                                             anchors={'left': 'left',
-                                                                      'right': 'right',
-                                                                      'top': 'bottom',
-                                                                      'bottom': 'bottom'},
-                                                             visible=False)
+                pygame.Rect(
+                    0,
+                    -self.scroll_bar_height,
+                    self.relative_rect.width,
+                    self.scroll_bar_height,
+                )
+            )
+            self.horiz_scroll_bar = UIModifiedHorizScrollBar(
+                relative_rect=scroll_bar_rect,
+                visible_percentage=1.0,
+                manager=self.ui_manager,
+                container=self._root_container,
+                parent_element=self,
+                anchors={
+                    "left": "left",
+                    "right": "right",
+                    "top": "bottom",
+                    "bottom": "bottom",
+                },
+                visible=False,
+            )
             self.horiz_scroll_bar.set_dimensions((self.relative_rect.width, 0))
             self.horiz_scroll_bar.set_relative_position((0, 0))
-            self.horiz_scroll_bar.set_container_this_will_scroll(self.scrollable_container)
+            self.horiz_scroll_bar.set_container_this_will_scroll(
+                self.scrollable_container
+            )
 
     def set_view_container_dimensions(self, dimensions: Coordinate):
         self._view_container.set_dimensions(dimensions)
@@ -192,21 +214,29 @@ class UIModifiedScrollingContainer(pygame_gui.elements.UIScrollingContainer):
         need_horiz_scroll_bar = False
         need_vert_scroll_bar = False
 
-        if (self.scrolling_height > self._view_container.rect.height or
-            self.scrollable_container.relative_rect.top != 0) and self.allow_scroll_y:
+        if (
+            self.scrolling_height > self._view_container.rect.height
+            or self.scrollable_container.relative_rect.top != 0
+        ) and self.allow_scroll_y:
             need_vert_scroll_bar = True
             self.scroll_bar_width = self._get_scroll_bar_width()
 
         # Need to subtract scrollbar width here to account for when the above statement evaluated to True
-        if (self.scrolling_width > self._view_container.rect.width - self.scroll_bar_width or
-            self.scrollable_container.relative_rect.left != 0) and self.allow_scroll_x:
+        if (
+            self.scrolling_width
+            > self._view_container.rect.width - self.scroll_bar_width
+            or self.scrollable_container.relative_rect.left != 0
+        ) and self.allow_scroll_x:
             need_horiz_scroll_bar = True
             self.scroll_bar_height = self._get_scroll_bar_height()
 
             # Needs a second check for the case where we didn't need the vertical scroll bar until after creating a
             # horizontal scroll bar
-            if (self.scrolling_height > self._view_container.rect.height - self.scroll_bar_height or
-                self.scrollable_container.relative_rect.top != 0) and self.allow_scroll_y:
+            if (
+                self.scrolling_height
+                > self._view_container.rect.height - self.scroll_bar_height
+                or self.scrollable_container.relative_rect.top != 0
+            ) and self.allow_scroll_y:
                 need_vert_scroll_bar = True
                 self.scroll_bar_width = self._get_scroll_bar_width()
 
@@ -228,16 +258,17 @@ class UIModifiedScrollingContainer(pygame_gui.elements.UIScrollingContainer):
 
 class UIImageVerticalScrollBar(pygame_gui.elements.UIVerticalScrollBar):
     def __init__(
-            self,
-            relative_rect: pygame.Rect,
-            visible_percentage: float,
-            manager=None,
-            container=None,
-            parent_element=None,
-            object_id=None,
-            anchors=None,
-            visible: int = 1,
-            starting_height: int = 1):
+        self,
+        relative_rect: pygame.Rect,
+        visible_percentage: float,
+        manager=None,
+        container=None,
+        parent_element=None,
+        object_id=None,
+        anchors=None,
+        visible: int = 1,
+        starting_height: int = 1,
+    ):
 
         super().__init__(
             relative_rect=relative_rect,
@@ -247,7 +278,8 @@ class UIImageVerticalScrollBar(pygame_gui.elements.UIVerticalScrollBar):
             parent_element=parent_element,
             object_id=object_id,
             anchors=anchors,
-            visible=visible)
+            visible=visible,
+        )
 
         self.scroll_wheel_speed = 100
         self.sliding_button.change_layer(starting_height)
@@ -257,34 +289,33 @@ class UIImageVerticalScrollBar(pygame_gui.elements.UIVerticalScrollBar):
             self.button_height = 16
         self.arrow_button_height = self.button_height
         self.top_button.kill()
-        self.top_button = UIImageButton(scale(pygame.Rect((0, 0),
-                                                          (32, 32))),
-                                        text='',
-                                        manager=self.ui_manager,
-                                        container=self.button_container,
-                                        starting_height=starting_height,
-                                        parent_element=self,
-                                        object_id="#vertical_slider_up_arrow_button",
-                                        anchors={'left': 'left',
-                                                 'right': 'right',
-                                                 'top': 'top',
-                                                 'bottom': 'top'}
-                                        )
+        self.top_button = UIImageButton(
+            scale(pygame.Rect((0, 0), (32, 32))),
+            text="",
+            manager=self.ui_manager,
+            container=self.button_container,
+            starting_height=starting_height,
+            parent_element=self,
+            object_id="#vertical_slider_up_arrow_button",
+            anchors={"left": "left", "right": "right", "top": "top", "bottom": "top"},
+        )
 
         self.bottom_button.kill()
-        self.bottom_button = UIImageButton(scale(pygame.Rect((0, -self.arrow_button_height),
-                                                             (32, 32))),
-                                           text='',
-                                           manager=self.ui_manager,
-                                           container=self.button_container,
-                                           starting_height=starting_height,
-                                           parent_element=self,
-                                           object_id="#vertical_slider_down_arrow_button",
-                                           anchors={'left': 'left',
-                                                    'right': 'right',
-                                                    'top': 'bottom',
-                                                    'bottom': 'bottom'}
-                                           )
+        self.bottom_button = UIImageButton(
+            scale(pygame.Rect((0, -self.arrow_button_height), (32, 32))),
+            text="",
+            manager=self.ui_manager,
+            container=self.button_container,
+            starting_height=starting_height,
+            parent_element=self,
+            object_id="#vertical_slider_down_arrow_button",
+            anchors={
+                "left": "left",
+                "right": "right",
+                "top": "bottom",
+                "bottom": "bottom",
+            },
+        )
 
     def set_visible_percentage(self, percentage: float):
         super().set_visible_percentage(percentage)
@@ -296,10 +327,25 @@ class UIImageVerticalScrollBar(pygame_gui.elements.UIVerticalScrollBar):
 
 
 class UIModifiedHorizScrollBar(pygame_gui.elements.UIHorizontalScrollBar):
-    def __init__(self, relative_rect: RectLike, visible_percentage: float, manager, container, parent_element, anchors,
-                 visible):
-        super().__init__(relative_rect, visible_percentage, manager=manager, container=container,
-                         parent_element=parent_element, anchors=anchors, visible=visible)
+    def __init__(
+        self,
+        relative_rect: RectLike,
+        visible_percentage: float,
+        manager,
+        container,
+        parent_element,
+        anchors,
+        visible,
+    ):
+        super().__init__(
+            relative_rect,
+            visible_percentage,
+            manager=manager,
+            container=container,
+            parent_element=parent_element,
+            anchors=anchors,
+            visible=visible,
+        )
 
         self.button_width = 15
         self.arrow_button_width = self.button_width
@@ -312,18 +358,18 @@ class UISpriteButton:
     For most functions, this can be used exactly like other pygame_gui elements."""
 
     def __init__(
-            self,
-            relative_rect,
-            sprite,
-            cat_id=None,
-            visible=1,
-            cat_object=None,
-            starting_height=1,
-            manager: IUIManagerInterface = None,
-            container=None,
-            object_id=None,
-            tool_tip_text=None,
-            anchors=None,
+        self,
+        relative_rect,
+        sprite,
+        cat_id=None,
+        visible=1,
+        cat_object=None,
+        starting_height=1,
+        manager: IUIManagerInterface = None,
+        container=None,
+        object_id=None,
+        tool_tip_text=None,
+        anchors=None,
     ):
 
         # We have to scale the image before putting it into the image object. Otherwise, the method of upscaling that
@@ -402,19 +448,19 @@ class CatButton(UIImageButton):
     Can also be used as a general button that holds some data"""
 
     def __init__(
-            self,
-            relative_rect,
-            text,
-            cat_id=None,
-            visible=True,
-            cat_object=None,
-            starting_height=1,
-            parent_element=None,
-            object_id=None,
-            manager=None,
-            tool_tip_text=None,
-            container=None,
-            anchors=None,
+        self,
+        relative_rect,
+        text,
+        cat_id=None,
+        visible=True,
+        cat_object=None,
+        starting_height=1,
+        parent_element=None,
+        object_id=None,
+        manager=None,
+        tool_tip_text=None,
+        container=None,
+        anchors=None,
     ):
         self.cat_id = cat_id
         self.cat_object = cat_object
@@ -447,22 +493,22 @@ class UITextBoxTweaked(pygame_gui.elements.UITextBox):
     only use if you want to have control over the line spacing."""
 
     def __init__(
-            self,
-            html_text: str,
-            relative_rect,
-            manager=None,
-            line_spacing=1,
-            wrap_to_height: bool = False,
-            starting_height: int = 1,
-            container=None,
-            parent_element=None,
-            object_id=None,
-            anchors=None,
-            visible: int = 1,
-            *,
-            pre_parsing_enabled: bool = True,
-            text_kwargs=None,
-            allow_split_dashes: bool = True,
+        self,
+        html_text: str,
+        relative_rect,
+        manager=None,
+        line_spacing=1,
+        wrap_to_height: bool = False,
+        starting_height: int = 1,
+        container=None,
+        parent_element=None,
+        object_id=None,
+        anchors=None,
+        visible: int = 1,
+        *,
+        pre_parsing_enabled: bool = True,
+        text_kwargs=None,
+        allow_split_dashes: bool = True,
     ):
 
         self.line_spaceing = line_spacing
@@ -543,13 +589,13 @@ class UIRelationStatusBar:
     """Wraps together a status bar"""
 
     def __init__(
-            self,
-            relative_rect,
-            percent_full=0,
-            positive_trait=True,
-            dark_mode=False,
-            manager=None,
-            style="bars",
+        self,
+        relative_rect,
+        percent_full=0,
+        positive_trait=True,
+        dark_mode=False,
+        manager=None,
+        style="bars",
     ):
 
         # Change the color of the bar depending on the value and if it's a negative or positive trait
@@ -602,14 +648,14 @@ class IDImageButton(UIImageButton):
     """Class to handle the "involved cats" button on the events page. It stores the IDs of the cat's involved."""
 
     def __init__(
-            self,
-            relative_rect,
-            text="",
-            ids=None,
-            object_id=None,
-            container=None,
-            manager=None,
-            layer_starting_height=1,
+        self,
+        relative_rect,
+        text="",
+        ids=None,
+        object_id=None,
+        container=None,
+        manager=None,
+        layer_starting_height=1,
     ):
 
         if ids:
@@ -647,15 +693,15 @@ class UIDropDownContainer(UIAutoResizingContainer):
                     may override this."""
 
     def __init__(
-            self,
-            relative_rect: RectLike,
-            container: UIContainer,
-            object_id: str,
-            starting_height: int,
-            parent_button: UIImageButton,
-            child_button_container: UIContainer,
-            manager: IUIManagerInterface,
-            visible: bool = False,
+        self,
+        relative_rect: RectLike,
+        container: UIContainer,
+        object_id: str,
+        starting_height: int,
+        parent_button: UIImageButton,
+        child_button_container: UIContainer,
+        manager: IUIManagerInterface,
+        visible: bool = False,
     ):
         super().__init__(
             relative_rect=relative_rect,
@@ -716,14 +762,14 @@ class UICheckbox(UIImageButton):
     """
 
     def __init__(
-            self,
-            position: tuple,
-            container: UIContainer,
-            tool_tip_text: str,
-            starting_height: int,
-            visible: bool,
-            manager,
-            check: bool = False,
+        self,
+        position: tuple,
+        container: UIContainer,
+        tool_tip_text: str,
+        starting_height: int,
+        visible: bool,
+        manager,
+        check: bool = False,
     ):
 
         self.checked = check
@@ -763,28 +809,28 @@ class UICheckbox(UIImageButton):
 
 class UICatListDisplay(UIContainer):
     def __init__(
-            self,
-            relative_rect: RectLike,
-            container: UIContainer,
-            starting_height: int,
-            object_id: str,
-            manager,
-            cat_list: list,
-            cats_displayed: int,
-            x_px_between: int,
-            columns: int,
-            current_page: int,
-            next_button: UIImageButton,
-            prev_button: UIImageButton,
-            first_button: UIImageButton = None,
-            last_button: UIImageButton = None,
-            anchors: Optional[dict] = None,
-            rows: int = None,
-            show_names: bool = False,
-            tool_tip_name: bool = False,
-            visible: bool = True,
-            text_theme="#cat_list_text",
-            y_px_between: int = None,
+        self,
+        relative_rect: RectLike,
+        container: UIContainer,
+        starting_height: int,
+        object_id: str,
+        manager,
+        cat_list: list,
+        cats_displayed: int,
+        x_px_between: int,
+        columns: int,
+        current_page: int,
+        next_button: UIImageButton,
+        prev_button: UIImageButton,
+        first_button: UIImageButton = None,
+        last_button: UIImageButton = None,
+        anchors: Optional[dict] = None,
+        rows: int = None,
+        show_names: bool = False,
+        tool_tip_name: bool = False,
+        visible: bool = True,
+        text_theme="#cat_list_text",
+        y_px_between: int = None,
     ):
         """
         Creates and displays a list of click-able cat sprites.
@@ -849,27 +895,58 @@ class UICatListDisplay(UIContainer):
         if game.settings["dark mode"]:
             self._favor_circle.set_alpha(150)
 
-        cell_width = floor(self.relative_rect.width / self.columns)
-        cell_height = floor(self.relative_rect.height / self.rows)
-
-        for row in range(self.rows):
-            new_row = []
-            for column in range(self.columns):
-                ui_container = UIContainer(
-                    pygame.Rect(
-                        column * cell_width,
-                        row * cell_height,
-                        cell_width,
-                        cell_height,
-                    ),
-                    container=self,
-                    manager=self.ui_manager,
-                )
-                new_row.append(ui_container)
-            self.boxes.append(new_row)
+        self.generate_grid()
 
         self._chunk()
         self._display_cats()
+
+    def generate_grid(self):
+        """
+        A wrapper for the grid generation to speed it up significantly.
+        Must be done like this to avoid memory leak.
+        """
+        self.boxes = self._generate_grid_cached(
+            self.relative_rect.width // self.columns,
+            self.relative_rect.height // self.rows,
+            self.rows,
+            self.columns,
+            self.ui_manager,
+        )
+        for box in self.boxes:
+            box.set_container(self)
+            box.rebuild()
+
+    @staticmethod
+    @lru_cache(maxsize=5)
+    def _generate_grid_cached(cell_width, cell_height, rows, columns, manager):
+        boxes: List[Optional[UIContainer]] = [None] * (rows * columns)
+        for i, box in enumerate(boxes):
+            if i == 0:
+                anchors = {}
+            elif i % columns == 0:
+                # first item in a row excluding first
+                anchors = {"top_target": boxes[i - columns]}
+            elif i < columns:
+                # top row
+                anchors = {"left_target": boxes[i - 1]}
+            else:
+                # all other rows
+                anchors = {
+                    "left_target": boxes[i - 1],
+                    "top_target": boxes[i - columns],
+                }
+
+            boxes[i] = UIContainer(
+                pygame.Rect(
+                    0,
+                    0,
+                    cell_width,
+                    cell_height,
+                ),
+                anchors=anchors,
+                manager=manager,
+            )
+        return boxes
 
     def clear_display(self):
         [sprite.kill() for sprite in self.cat_sprites.values()]
@@ -898,7 +975,7 @@ class UICatListDisplay(UIContainer):
         separates the cat list into smaller chunks to display on each page
         """
         self.cat_chunks = [
-            self.cat_list[x: x + self.cats_displayed]
+            self.cat_list[x : x + self.cats_displayed]
             for x in range(0, len(self.cat_list), self.cats_displayed)
         ]
 
@@ -923,56 +1000,23 @@ class UICatListDisplay(UIContainer):
 
         # FAVOURITE ICON
         if show_fav:
-            i = -1
-            for row in range(self.rows):
-                for column in range(self.columns):
-                    container = self.boxes[row][column]
-                    i += 1
-                    try:
-                        kitty = display_cats[i]
-                    except IndexError:
-                        break
-                    if kitty.favourite:
-                        self.create_favor_indicator(i, container)
+            fav_indexes = [
+                display_cats.index(cat) for cat in display_cats if cat.favourite
+            ]
+            [self.create_favor_indicator(i, self.boxes[i]) for i in fav_indexes]
 
         # CAT SPRITE
-        i = -1
-        for row in range(self.rows):
-            for column in range(self.columns):
-                container = self.boxes[row][column]
-                i += 1
-                try:
-                    kitty = display_cats[i]
-                except IndexError:
-                    break
-                self.create_cat_button(i, kitty, container)
+        [
+            self.create_cat_button(i, kitty, self.boxes[i])
+            for i, kitty in enumerate(display_cats)
+        ]
 
         # CAT NAME
         if self.show_names:
-            i = -1
-            for row in range(self.rows):
-                for column in range(self.columns):
-                    container = self.boxes[row][column]
-                    i += 1
-                    try:
-                        kitty = display_cats[i]
-                    except IndexError:
-                        break
-                    self.cat_names[f"name{i}"] = pygame_gui.elements.UILabel(
-                        scale(
-                            pygame.Rect(
-                                (0, 10),
-                                (100 + self.x_px_between, 60),
-                            )
-                        ),
-                        shorten_text_to_fit(str(kitty.name), 220, 30),
-                        container=container,
-                        object_id=self.text_theme,
-                        anchors={
-                            "centerx": "centerx",
-                            "top_target": self.cat_sprites[f"sprite{i}"],
-                        },
-                    )
+            [
+                self.create_name(i, kitty, self.boxes[i])
+                for i, kitty in enumerate(display_cats)
+            ]
 
     def create_cat_button(self, i, kitty, container):
         self.cat_sprites[f"sprite{i}"] = UISpriteButton(
@@ -985,6 +1029,23 @@ class UICatListDisplay(UIContainer):
             tool_tip_text=str(kitty.name) if self.tool_tip_name else None,
             starting_height=1,
             anchors={"centerx": "centerx"},
+        )
+
+    def create_name(self, i, kitty, container):
+        self.cat_names[f"name{i}"] = pygame_gui.elements.UILabel(
+            scale(
+                pygame.Rect(
+                    (0, 10),
+                    (100 + self.x_px_between, 60),
+                )
+            ),
+            shorten_text_to_fit(str(kitty.name), 220, 30),
+            container=container,
+            object_id=self.text_theme,
+            anchors={
+                "centerx": "centerx",
+                "top_target": self.cat_sprites[f"sprite{i}"],
+            },
         )
 
     def create_favor_indicator(self, i, container):

--- a/scripts/screens/ListScreen.py
+++ b/scripts/screens/ListScreen.py
@@ -22,6 +22,16 @@ class ListScreen(Screens):
 
     def __init__(self, name=None):
         super().__init__(name)
+        self.ur_bg_image = pygame.image.load("resources/images/urbg.png").convert()
+        self.sc_bg_image = pygame.image.load(
+            "resources/images/starclanbg.png"
+        ).convert_alpha()
+        self.df_bg_image = pygame.image.load(
+            "resources/images/darkforestbg.png"
+        ).convert_alpha()
+        self.search_bar_image = pygame.image.load(
+            "resources/images/search_bar.png"
+        ).convert_alpha()
         self.all_pages = None
         self.filter_options_visible = True
         self.group_options_visible = False
@@ -297,7 +307,7 @@ class ListScreen(Screens):
         # SEARCH BAR
         self.cat_list_bar_elements["search_bar_image"] = pygame_gui.elements.UIImage(
             scale(pygame.Rect((72, 0), (276, 68))),
-            pygame.image.load("resources/images/search_bar.png").convert_alpha(),
+            self.search_bar_image,
             container=self.cat_list_bar,
             object_id="#search_bar",
             manager=MANAGER,
@@ -469,7 +479,7 @@ class ListScreen(Screens):
         self.sc_bg = pygame_gui.elements.UIImage(
             scale(pygame.Rect((0, 0), (1600, 1400))),
             pygame.transform.scale(
-                pygame.image.load("resources/images/starclanbg.png").convert_alpha(),
+                self.sc_bg_image,
                 (1600, 1400),
             ),
             container=self.list_screen_container,
@@ -481,7 +491,7 @@ class ListScreen(Screens):
         self.ur_bg = pygame_gui.elements.UIImage(
             scale(pygame.Rect((0, 0), (1600, 1400))),
             pygame.transform.scale(
-                pygame.image.load("resources/images/urbg.png").convert(),
+                self.ur_bg_image,
                 (1600, 1400),
             ),
             container=self.list_screen_container,
@@ -493,7 +503,7 @@ class ListScreen(Screens):
         self.df_bg = pygame_gui.elements.UIImage(
             scale(pygame.Rect((0, 0), (1600, 1400))),
             pygame.transform.scale(
-                pygame.image.load("resources/images/darkforestbg.png").convert_alpha(),
+                self.df_bg_image,
                 (1600, 1400),
             ),
             container=self.list_screen_container,

--- a/scripts/screens/ListScreen.py
+++ b/scripts/screens/ListScreen.py
@@ -1,4 +1,5 @@
 from math import ceil
+from typing import Union, Dict, Optional
 
 import pygame
 import pygame_gui
@@ -32,7 +33,22 @@ class ListScreen(Screens):
         self.list_screen_container = None
 
         self.cat_list_bar = None
-        self.cat_list_bar_elements = {}
+        self.cat_list_bar_elements: Dict[
+            str,
+            Union[
+                UIImageButton,
+                pygame_gui.elements.UIImage,
+                pygame_gui.elements.UITextEntryLine,
+                None,
+            ],
+        ] = {
+            "fav_toggle": None,
+            "search_bar_image": None,
+            "search_bar_entry": None,
+            "view_button": None,
+            "choose_group_button": None,
+            "sort_by_button": None,
+        }
 
         self.dead_groups_container = None
         self.choose_dead_dropdown = None
@@ -42,10 +58,31 @@ class ListScreen(Screens):
 
         self.sort_by_button_container = None
         self.sort_by_dropdown = None
-        self.sort_by_buttons = {}
+        self.sort_by_buttons: Dict[str, Optional[UIImageButton]] = {
+            "view_your_clan_button": None,
+            "view_cotc_button": None,
+            "view_starclan_button": None,
+            "view_unknown_residence_button": None,
+            "view_dark_forest_button": None,
+        }
 
         self.cat_display = None
-        self.display_container_elements = {}
+        self.display_container_elements: Dict[
+            str,
+            Union[
+                UIImageButton,
+                pygame_gui.elements.UITextEntryLine,
+                pygame_gui.elements.UITextBox,
+                None,
+            ],
+        ] = {
+            "first_page_button": None,
+            "previous_page_button": None,
+            "last_page_button": None,
+            "next_page_button": None,
+            "page_entry": None,
+            "page_number": None,
+        }
 
         self.df_bg = None
         self.ur_bg = None
@@ -639,6 +676,19 @@ class ListScreen(Screens):
                 },
             )
         else:
+            if self.cat_display.prev_button is None:
+                self.cat_display.prev_button = self.display_container_elements[
+                    "previous_page_button"
+                ]
+                self.cat_display.next_button = self.display_container_elements[
+                    "next_page_button"
+                ]
+                self.cat_display.first_button = self.display_container_elements[
+                    "first_page_button"
+                ]
+                self.cat_display.last_button = self.display_container_elements[
+                    "last_page_button"
+                ]
             self.cat_display.text_theme = (
                 get_text_box_theme("#text_box_30_horizcenter")
                 if self.death_status == "living"


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix:, Feature:, Enhancement: or Content: in the title to describe what type of PR it is. -->

## About The Pull Request

So again, Black (the file watcher style program) makes this look like an absolutely enormous PR. It's four things.

- Fixes the rects I just fixed in UICatListDisplay by unnesting them from that unsettling way and correctly using anchors to place them.
- Further isolate those rectangles into a private static(ish) function that is cached to make it faster to load.
- The loading of images for the DF, SC and UR has been moved into `__init__`.
- Some nice list comprehensions to make some things in the UICatDisplay a little more efficient.

All told, these changes halve the time spent in `screen_switches` for ListScreen, and make it less jarring as compared to other windows. There is still a noticeable delay if transitioning from another heavy screen (the Events screen, for example), but it's improved significantly.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Why This Is Good For ClanGen

I have a grudge against the ListScreen load time, and I want that to be less egregious. This helps!

<!-- If this is a bugfix, you can remove this section. -->
<!-- Please add a short description of why you think these changes would benefit the game. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->
<!-- If you have multiple features that can stand on their own, or unrelated bugfixes, please create separate PRs for them. -->

## Proof of Testing

![image](https://github.com/user-attachments/assets/da3c0f3a-bfe6-47c4-b2eb-115d564d6469)
`screen_switches` time before - 0.371 seconds (observed repeatably at around that range)

![image](https://github.com/user-attachments/assets/aeb31002-beac-414c-bb93-4de1e3acb6f4)
`screen_switches` time after - 0.180 seconds (again, repeatable).

<!-- Include any screenshots, debugging steps or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
Game optimisations
<!-- Include any changes that should be made to the changelog of the game here, or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
