### PR TITLE
BUGFIX: crash on clan creation screen

### DIFF
--- a/scripts/screens/MakeClanScreen.py
+++ b/scripts/screens/MakeClanScreen.py
@@ -791,7 +791,7 @@ class MakeClanScreen(Screens):
                         sprites.sprites[self.symbol_selected], (200, 200)
                     ).convert_alpha()
                 )
-                symbol_name = self.symbol_selected.removeprefix("symbol")
+                symbol_name = self.symbol_selected.replace("symbol", "")
                 self.text["selected"].set_text(f"Selected Symbol: {symbol_name}")
                 self.elements["selected_symbol"].show()
                 self.elements["done_button"].enable()
@@ -1864,7 +1864,7 @@ class MakeClanScreen(Screens):
                 )
 
         if self.symbol_selected:
-            symbol_name = self.symbol_selected.removeprefix("symbol")
+            symbol_name = self.symbol_selected.replace("symbol", "")
             self.text["selected"].set_text(f"Selected Symbol: {symbol_name}")
 
             self.elements["selected_symbol"] = pygame_gui.elements.UIImage(


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix:, Feature:, Enhancement: or Content: in the title to describe what type of PR it is. -->

## About The Pull Request

This is a fix for the crash that occurs when trying to load the Clan symbol selection part of Clan creation for those using versions of python <3.9 (this also affects some build users for some reason). removeprefix was introduced in python 3.9 and using replace instead essentially accomplishes the same thing for us and is more compatible. 

## Proof of Testing

I was not affected by this because I use 3.10, so I had Anju test to see if it was still causing a crash for them. Seems it has been cleared up! Screen works as intended for both me and them

## Changelog/Credits

Symbol selection crash fix
