### PR TITLE
Fixes: #2463 (cats dying in "taken by Twolegs" mass event)

### DIFF
--- a/scripts/events_module/handle_short_events.py
+++ b/scripts/events_module/handle_short_events.py
@@ -406,10 +406,13 @@ class HandleShortEvents:
             if self.main_cat not in self.dead_cats:
                 self.dead_cats.append(self.main_cat)  # got to include the cat that rolled for death in the first place
 
+            taken_cats = []
             for kitty in self.dead_cats:
                 if "lost" in self.chosen_event.tags:
                     kitty.gone()
-                    self.dead_cats.remove(kitty)
+                    taken_cats.append(kitty)
+            for kitty in taken_cats:
+                self.dead_cats.remove(kitty)
                 self.multi_cat.append(kitty)
                 if kitty.ID not in self.involved_cats:
                     self.involved_cats.append(kitty.ID)

--- a/scripts/events_module/handle_short_events.py
+++ b/scripts/events_module/handle_short_events.py
@@ -411,11 +411,12 @@ class HandleShortEvents:
                 if "lost" in self.chosen_event.tags:
                     kitty.gone()
                     taken_cats.append(kitty)
-            for kitty in taken_cats:
-                self.dead_cats.remove(kitty)
                 self.multi_cat.append(kitty)
                 if kitty.ID not in self.involved_cats:
                     self.involved_cats.append(kitty.ID)
+            for kitty in taken_cats:
+                self.dead_cats.remove(kitty)
+
         else:
             return
 


### PR DESCRIPTION
## About The Pull Request
It seems that iterating over dead_cats and removing cats from it at the same time was causing some issues. I tested this and the bug didn't happen after triggering the event. I added the implicated cats into a new variable and then used it to remove them from dead_cats.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
Fixes: #2463

## Proof of Testing
All cats listed in the event appear in the buttons below:
![image](https://github.com/user-attachments/assets/27ee4112-4780-45c8-9e93-01e0556c1c36)
![image](https://github.com/user-attachments/assets/c4150429-798e-4272-a693-acc79727c5ee)
![image](https://github.com/user-attachments/assets/5300d0f0-1e01-45de-a99e-de8c33b6fe5b)

All the implicated cats appear correctly as lost cats:
![image](https://github.com/user-attachments/assets/c622d48a-6c37-4842-952b-3f8c7a72ab77)

No cats have misteriously died after the event (showing the last dead cat, the previous moon, after sorting by death):
![image](https://github.com/user-attachments/assets/72e891fc-8e84-47f2-8635-7d11ded298a0)
![image](https://github.com/user-attachments/assets/d3935784-8b69-4716-9acd-ffb018e1f7a9)


## Changelog/Credits
Changelog: Fixed cats wrongly dying after the taken by Twolegs mass event.
Credits: Kira
<!-- Include any changes that should be made to the changelog of the game here, or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
