### PR TITLE
More disability thoughts: constantly dizzy and lasting grief

### DIFF
--- a/resources/dicts/thoughts/alive/general.json
+++ b/resources/dicts/thoughts/alive/general.json
@@ -2372,5 +2372,39 @@
             "newborn",
             "kitten"
         ]
+    },
+    
+    {
+        "id": "constantly_dizzy_gen_to_alive_gen",
+        "thoughts": [
+            "Stood up too fast again",
+            "Assures r_c {PRONOUN/m_c/poss} dizzy spell will end in a moment",
+            "Ignores the fuzzy spots on the edge of {PRONOUN/m_c/poss} vision",
+            "Feels like the world is moving a little too fast"
+        ],
+        "perm_conditions": {
+            "m_c": [
+                "constantly dizzy"
+            ]
+        },
+        "random_age_constraint": [
+            "any"
+        ]
+    },
+    {
+        "id": "lasting_grief_gen_to_alive_gen",
+        "thoughts": [
+            "Worries about losing r_c too",
+            "Puts on a smile for r_c",
+            "Struggles to voice how {PRONOUN/m_c/subject} feel"
+        ],
+        "perm_conditions": {
+            "m_c": [
+                "lasting grief"
+            ]
+        },
+        "random_age_constraint": [
+            "any"
+        ]
     }
 ]

--- a/resources/dicts/thoughts/alive/general.json
+++ b/resources/dicts/thoughts/alive/general.json
@@ -2380,7 +2380,8 @@
             "Stood up too fast again",
             "Assures r_c {PRONOUN/m_c/poss} dizzy spell will end in a moment",
             "Ignores the fuzzy spots on the edge of {PRONOUN/m_c/poss} vision",
-            "Feels like the world is moving a little too fast"
+            "Feels like the world is moving a little too fast",
+            "Tells r_c that {PRONOUN/m_c/subject} need to sit down for a second"
         ],
         "perm_conditions": {
             "m_c": [

--- a/resources/dicts/thoughts/alive/general.json
+++ b/resources/dicts/thoughts/alive/general.json
@@ -2381,7 +2381,7 @@
             "Assures r_c {PRONOUN/m_c/poss} dizzy spell will end in a moment",
             "Ignores the fuzzy spots on the edge of {PRONOUN/m_c/poss} vision",
             "Feels like the world is moving a little too fast",
-            "Tells r_c that {PRONOUN/m_c/subject} need to sit down for a second",
+            "Tells r_c that {PRONOUN/m_c/subject} {VERB/m_c/need/needs} to sit down for a second",
             "Finds the sun to be too bright today"
         ],
         "perm_conditions": {
@@ -2389,8 +2389,8 @@
                 "constantly dizzy"
             ]
         },
-        "random_age_constraint": [
-            "any"
+        "random_living_constraint": [
+            "living"
         ]
     },
     {
@@ -2398,15 +2398,15 @@
         "thoughts": [
             "Worries about losing r_c too",
             "Puts on a smile for r_c",
-            "Struggles to voice how {PRONOUN/m_c/subject} feel"
+            "Struggles to voice how {PRONOUN/m_c/subject} {VERB/m_c/feel/feels}"
         ],
         "perm_conditions": {
             "m_c": [
                 "lasting grief"
             ]
         },
-        "random_age_constraint": [
-            "any"
+        "random_living_constraint": [
+            "living"
         ]
     }
 ]

--- a/resources/dicts/thoughts/alive/general.json
+++ b/resources/dicts/thoughts/alive/general.json
@@ -2381,7 +2381,8 @@
             "Assures r_c {PRONOUN/m_c/poss} dizzy spell will end in a moment",
             "Ignores the fuzzy spots on the edge of {PRONOUN/m_c/poss} vision",
             "Feels like the world is moving a little too fast",
-            "Tells r_c that {PRONOUN/m_c/subject} need to sit down for a second"
+            "Tells r_c that {PRONOUN/m_c/subject} need to sit down for a second",
+            "Finds the sun to be too bright today"
         ],
         "perm_conditions": {
             "m_c": [


### PR DESCRIPTION


## About The Pull Request

Added 9 new general thoughts (6 for constantly dizzy and 3 for lasting grief) based on my personal experiences with both conditions.

## Why This Is Good For ClanGen

Currently, we have a large gap in disability thoughts (sel made a chart in the dev chat and some have no thoughts at all). I think as a game with a large team with disabled people, it would be nice to have more rep!


## Proof of Testing

![Screenshot 2024-08-23 185623](https://github.com/user-attachments/assets/ab58a8c7-0114-4259-8a57-e09e06bf21d8)
![Screenshot 2024-08-23 185601](https://github.com/user-attachments/assets/2afa45b0-5a32-4da5-bb5a-3aafa66870e8)
![Screenshot 2024-08-23 185524](https://github.com/user-attachments/assets/dba99485-2167-4b77-a2df-70c2ed44c2a5)
(ignore how lasting grief is born with i just copy pasted my default perm condition into the condition files and forgot its not congenital)

## Changelog/Credits

changed files: general.json (in alive thoughts), credits: dinofelisDruid
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
