### PR TITLE
CONTENT: Skill-specific outcomes for Leader's Den

### DIFF
--- a/resources/dicts/events/leader_den/fail/outsider.json
+++ b/resources/dicts/events/leader_den/fail/outsider.json
@@ -185,5 +185,35 @@
         }
       ]
     }
+  },
+  {
+    "interaction_type": "drive",
+    "event_text": "Some of c_n's best hunters challenge m_c to a hunt-off. The stakes are simple: if c_n wins, m_c leaves the territory; if m_c wins, then {PRONOUN/m_c/subject} will be allowed to hunt within the Clan's borders undisturbed. m_c wins by a landslide and, though they grumble about it, the c_n cats honor the agreement and leave {PRONOUN/m_c/object} alone.",
+    "reputation": ["any"],
+    "rep_change": -1,
+    "m_c": {
+      "status": ["loner", "rogue", "kittypet"],
+      "age": ["adolescent", "young adult", "adult", "senior adult"],
+      "skill": [
+        "HUNTER,3"
+      ],
+      "new_thought": "Is feeling rather proud of {PRONOUN/m_c/self}",
+      "relationships": [
+        {
+          "cats_from": ["m_c"],
+          "cats_to": ["clan"],
+          "mutual": false,
+          "values": ["dislike"],
+          "amount": 5
+        },
+        {
+          "cats_from": ["clan"],
+          "cats_to": ["m_c"],
+          "mutual": false,
+          "values": ["respect"],
+          "amount": 5
+        }
+      ]
+    }
   }
 ]

--- a/resources/dicts/events/leader_den/success/outsider.json
+++ b/resources/dicts/events/leader_den/success/outsider.json
@@ -100,5 +100,146 @@
         }
       ]
     }
+  },
+  {
+    "interaction_type": "invite",
+    "event_text": "There's one specific cat, m_c, that keeps regularly upstaging c_n's hunting patrols. However, instead of trying to drive {PRONOUN/m_c/object} out, c_n welcomes m_c with open paws.",
+    "reputation": ["any"],
+    "rep_change": 1,
+    "m_c": {
+      "status": ["loner", "rogue", "kittypet"],
+      "age": ["adolescent", "young adult", "adult", "senior adult"],
+      "skill": [
+        "HUNTER,3",
+        "HUNTER,4"
+      ],
+      "new_thought": "Can't wait to help provide for {PRONOUN/m_c/poss} new Clan",
+      "kit_thought": "Is curious about the new place {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} in",
+      "relationships": [
+        {
+          "cats_from": ["m_c"],
+          "cats_to": ["clan"],
+          "mutual": false,
+          "values": ["dislike"],
+          "amount": -5
+        },
+        {
+          "cats_from": ["m_c"],
+          "cats_to": ["some_clan"],
+          "mutual": false,
+          "values": ["trust"],
+          "amount": 5
+        },
+        {
+          "cats_from": ["clan"],
+          "cats_to": ["m_c"],
+          "mutual": false,
+          "values": ["respect"],
+          "amount": 5
+        }
+      ]
+    }
+  },
+  {
+    "interaction_type": "drive",
+    "event_text": "m_c keeps regularly upstaging c_n's hunting patrols. Obviously, c_n doesn't take too kindly to some outsider stealing what they consider to be <b><i>their</i></b> prey...especially when said outsider is doing it as successfully as m_c is. The yowls that chase m_c to the c_n border and beyond are a clear warning: do not return.",
+    "reputation": ["any"],
+    "rep_change": -2,
+    "m_c": {
+      "status": ["loner", "rogue", "kittypet"],
+      "age": ["adolescent", "young adult", "adult", "senior adult"],
+      "skill": [
+        "HUNTER,3",
+        "HUNTER,4"
+      ],
+      "kit_thought": "Is unsure why {PRONOUN/m_c/poss} parent hasn't come back."
+    }
+  },
+  {
+    "interaction_type": "invite",
+    "event_text": "Some of c_n's best hunters challenge m_c to a hunt-off. The stakes are simple: if c_n wins, m_c leaves the territory; if m_c wins, then {PRONOUN/m_c/subject} will be allowed to hunt within the Clan's borders undisturbed. m_c wins by a landslide but, in a surprising twist, requests that {PRONOUN/m_c/poss} prize be the chance to join c_n.",
+    "reputation": ["any"],
+    "rep_change": 1,
+    "m_c": {
+      "status": ["loner", "rogue", "kittypet"],
+      "age": ["adolescent", "young adult", "adult", "senior adult"],
+      "skill": [
+        "HUNTER,3",
+        "HUNTER,4"
+      ],
+      "new_thought": "Can't wait to help provide for {PRONOUN/m_c/poss} new Clan",
+      "kit_thought": "Is curious about the new place {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} in",
+      "relationships": [
+        {
+          "cats_from": ["m_c"],
+          "cats_to": ["clan"],
+          "mutual": false,
+          "values": ["dislike"],
+          "amount": -5
+        },
+        {
+          "cats_from": ["clan"],
+          "cats_to": ["m_c"],
+          "mutual": false,
+          "values": ["respect"],
+          "amount": 5
+        }
+      ]
+    }
+  },
+  {
+    "interaction_type": "hunt",
+    "event_text": "m_c keeps regularly upstaging c_n's hunting patrols. Obviously, c_n doesn't take too kindly to some outsider stealing what they consider to be <b><i>their</i></b> prey, so they decide to...get rid of the issue. It may be brutal, but c_n needs to put c_n first.",
+    "reputation": ["any"],
+    "rep_change": -10,
+    "m_c": {
+      "status": ["loner", "rogue", "kittypet"],
+      "age": ["adolescent", "young adult", "adult", "senior adult"],
+      "skill": [
+        "HUNTER,3",
+        "HUNTER,4"
+      ],
+      "new_thought": "Is shocked that {PRONOUN/m_c/subject} {VERB/m_c/were/was} killed",
+      "kit_thought": "Is unsure why {PRONOUN/m_c/poss} parent hasn't come back."
+    }
+  },
+  {
+    "interaction_type": "invite",
+    "event_text": "While {PRONOUN/m_c/subject} may have been cast out for a reason, there's no denying that m_c is a skilled hunter. The Clan could definitely learn a thing or two from {PRONOUN/m_c/object} so, after much deliberation, a decision is made to welcome m_c back to c_n.",
+    "reputation": ["any"],
+    "rep_change": 1,
+    "m_c": {
+      "status": ["exiled"],
+      "age": ["adolescent", "young adult", "adult", "senior adult"],
+      "skill": [
+        "HUNTER,3",
+        "HUNTER,4"
+      ],
+      "new_thought": "Is happy to be back with c_n",
+      "kit_thought": "Is curious why {PRONOUN/m_c/subject}{VERB/m_c/'ve/'s} been brought here",
+      "relationships": [
+        {
+          "cats_from": ["m_c"],
+          "cats_to": ["clan"],
+          "mutual": false,
+          "values": ["dislike"],
+          "amount": -5
+        },
+        {
+          "cats_from": ["m_c"],
+          "cats_to": ["some_clan"],
+          "mutual": false,
+          "values": ["trust"],
+          "amount": 5
+        },
+        {
+          "cats_from": ["clan"],
+          "cats_to": ["m_c"],
+          "mutual": false,
+          "values": ["respect"],
+          "amount": 5
+        }
+      ]
+    }
   }
 ]

--- a/resources/dicts/events/leader_den/success/outsider.json
+++ b/resources/dicts/events/leader_den/success/outsider.json
@@ -110,8 +110,7 @@
       "status": ["loner", "rogue", "kittypet"],
       "age": ["adolescent", "young adult", "adult", "senior adult"],
       "skill": [
-        "HUNTER,3",
-        "HUNTER,4"
+        "HUNTER,3"
       ],
       "new_thought": "Can't wait to help provide for {PRONOUN/m_c/poss} new Clan",
       "kit_thought": "Is curious about the new place {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} in",

--- a/resources/dicts/events/leader_den/success/outsider.json
+++ b/resources/dicts/events/leader_den/success/outsider.json
@@ -148,8 +148,7 @@
       "status": ["loner", "rogue", "kittypet"],
       "age": ["adolescent", "young adult", "adult", "senior adult"],
       "skill": [
-        "HUNTER,3",
-        "HUNTER,4"
+        "HUNTER,3"
       ],
       "kit_thought": "Is unsure why {PRONOUN/m_c/poss} parent hasn't come back."
     }
@@ -163,8 +162,7 @@
       "status": ["loner", "rogue", "kittypet"],
       "age": ["adolescent", "young adult", "adult", "senior adult"],
       "skill": [
-        "HUNTER,3",
-        "HUNTER,4"
+        "HUNTER,3"
       ],
       "new_thought": "Can't wait to help provide for {PRONOUN/m_c/poss} new Clan",
       "kit_thought": "Is curious about the new place {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} in",
@@ -195,8 +193,7 @@
       "status": ["loner", "rogue", "kittypet"],
       "age": ["adolescent", "young adult", "adult", "senior adult"],
       "skill": [
-        "HUNTER,3",
-        "HUNTER,4"
+        "HUNTER,3"
       ],
       "new_thought": "Is shocked that {PRONOUN/m_c/subject} {VERB/m_c/were/was} killed",
       "kit_thought": "Is unsure why {PRONOUN/m_c/poss} parent hasn't come back."
@@ -211,8 +208,7 @@
       "status": ["exiled"],
       "age": ["adolescent", "young adult", "adult", "senior adult"],
       "skill": [
-        "HUNTER,3",
-        "HUNTER,4"
+        "HUNTER,3"
       ],
       "new_thought": "Is happy to be back with c_n",
       "kit_thought": "Is curious why {PRONOUN/m_c/subject}{VERB/m_c/'ve/'s} been brought here",
@@ -239,6 +235,49 @@
           "amount": 5
         }
       ]
+    }
+  },
+  {
+    "interaction_type": "drive",
+    "event_text": "Some of c_n's best hunters challenge m_c to a hunt-off. The stakes are simple: if c_n wins, m_c leaves the territory; if m_c wins, then {PRONOUN/m_c/subject} will be allowed to hunt within the Clan's borders undisturbed. It's a close contest but, in the end, the Clan cats claim victory, and m_c has no choice but to find somewhere else to call home.",
+    "reputation": ["any"],
+    "rep_change": -2,
+    "m_c": {
+      "status": ["loner", "rogue", "kittypet"],
+      "age": ["adolescent", "young adult", "adult", "senior adult"],
+      "skill": [
+        "HUNTER,3"
+      ],
+      "kit_thought": "Is unsure why {PRONOUN/m_c/poss} parent hasn't come back."
+    }
+  },
+  {
+    "interaction_type": "hunt",
+    "event_text": "m_c may have been exiled from c_n, but that hasn't stopped {PRONOUN/m_c/object} from sneaking back into the territory to hunt. However, m_c's luck runs out when {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} caught by a patrol, {PRONOUN/m_c/poss} former Clanmates not even giving {PRONOUN/m_c/object} a chance to run.",
+    "reputation": ["any"],
+    "rep_change": -10,
+    "m_c": {
+      "status": ["exiled"],
+      "age": ["adolescent", "young adult", "adult", "senior adult"],
+      "skill": [
+        "HUNTER,3"
+      ],
+      "new_thought": "Just wanted some fresh-kill",
+      "kit_thought": "Is unsure why {PRONOUN/m_c/poss} parent hasn't come back."
+    }
+  },
+  {
+    "interaction_type": "drive",
+    "event_text": "m_c may have been exiled from c_n, but that hasn't stopped {PRONOUN/m_c/object} from sneaking back into the territory to hunt. However, m_c's luck runs out when {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} caught by a patrol, with {PRONOUN/m_c/poss} former Clanmates chasing {PRONOUN/m_c/object} right back over the border.",
+    "reputation": ["any"],
+    "rep_change": -2,
+    "m_c": {
+      "status": ["exiled"],
+      "age": ["adolescent", "young adult", "adult", "senior adult"],
+      "skill": [
+        "HUNTER,3"
+      ],
+      "kit_thought": "Is unsure why {PRONOUN/m_c/poss} parent hasn't come back."
     }
   }
 ]


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->

## About The Pull Request
**Adds five new Leader's Den outcomes involving the Hunting skill.**
2x Outsider invites
1x Exile invite
1x Outsider drive-off
1x Outsider hunt down
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Why This Is Good For ClanGen
As mentioned in the Discord, Leader's Den events are fairly basic. These new outcomes should hopefully add a bit more flavour to the feature
Discord Conversation Link: https://discord.com/channels/1003759225522110524/1101276997751164948/1283142501162684487
<!-- If this is a bug fix, you can remove this section. -->
<!-- Please add a short description of why you think these changes would benefit the game. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->
<!-- If you have multiple features that can stand on their own, or unrelated bugfixes, please create separate PRs for them. -->

## Proof of Testing
![Exile_Invite1](https://github.com/user-attachments/assets/b010da3c-3196-4020-a05f-8601b2bf857d)
![Outsider_DriveOff1](https://github.com/user-attachments/assets/13127359-6142-472c-a050-3b8af6363b56)
![Outsider_HuntDown1](https://github.com/user-attachments/assets/7cc11a81-a49a-43cd-980c-8bcd55f0599f)
![Outsider_Invite1](https://github.com/user-attachments/assets/57f179b0-61df-4b7c-a365-cdaa1ec5f57c)
![Outsider_Invite2](https://github.com/user-attachments/assets/1c5af840-d3bd-49a7-bbfd-669271bea2fb)

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
Added new Leader's Den outcomes
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
