### PR TITLE
New relationship events in all categories- plus 5 cat negative interaction

### DIFF
--- a/resources/dicts/relationship_events/group_interactions/5/negative.json
+++ b/resources/dicts/relationship_events/group_interactions/5/negative.json
@@ -1,1 +1,34 @@
-[]
+[
+    {
+	"id": "morning_stretches",
+	"biome": ["any"],
+	"season": ["any"],
+	"intensity": "medium",
+	"cat_amount": 5,
+	"interactions": [
+		"m_c, wanting to help keep {PRONOUN/m_c/poss} Clanmates in shape and ready for anything, woke r_c1, r_c2, r_c3, and r_c4 up early for morning stretches."
+	],
+	"status_constraint": {
+		"m_c": ["deputy", "leader", "warrior", "elder", "medicine cat", "mediator"]
+	},
+	"specific_reaction": {
+		"r_c1_to_m_c": {
+			"romantic": "increase",
+			"dislike": "decrease",
+			"comfortable": "increase",
+			"trust": "increase"
+		},
+        	"r_c2_to_m_c": {
+			"dislike": "increase"
+		},
+        "r_c3_to_m_c": {
+			"comfortable": "increase",
+			"trust": "increase"
+		},
+        "r_c4_to_m_c": {
+			"comfortable": "increase",
+			"trust": "increase"
+		}   
+	}
+}
+]

--- a/resources/dicts/relationship_events/normal_interactions/admiration/decrease.json
+++ b/resources/dicts/relationship_events/normal_interactions/admiration/decrease.json
@@ -14,7 +14,10 @@
 		"interactions": [
 			"m_c complains about something r_c did.",
 			"m_c notices that r_c doesn't want to help out.",
-			"m_c doesn't understand why r_c is being so rude."
+			"m_c doesn't understand why r_c is being so rude.",
+			"r_c saw m_c taking extra fresh kill before others had a chance to eat.",
+            		"m_c walks away when r_c asks for help.",
+            		"r_c saw m_c do something kinda selfish."
 		],
 		"reaction_random_cat": {
 			"admiration": "decrease"
@@ -34,7 +37,8 @@
 		"interactions": [
 			"m_c tried to bring r_c's behavior up to them, but it turned into a fight that someone else had to break up.",
 			"m_c confronted r_c about {PRONOUN/r_c/poss} bad attitude but that only makes r_c act out more.",
-			"m_c is disappointed when r_c doesn't uphold a promise."
+			"m_c is disappointed when r_c doesn't uphold a promise.",
+			"r_c saw m_c do something really selfish and while it didn't affect anyone else, m_c's view of {PRONOUN/r_c/object} is definitely warped."
 		],
 		"reaction_random_cat": {
 			"admiration": "decrease"
@@ -100,7 +104,8 @@
 		"interactions": [
 			"m_c has noticed r_c isn't doing a lot of work lately.",
 			"m_c is disappointed in r_c's lack of initiative.",
-			"m_c notices that r_c seems to disappear whenever difficult tasks are being discussed."
+			"m_c notices that r_c seems to disappear whenever difficult tasks are being discussed.",
+			"m_c has noticed r_c's been a lot lazier lately."
 		],
 		"main_status_constraint": [
 			"elder",

--- a/resources/dicts/relationship_events/normal_interactions/admiration/decrease.json
+++ b/resources/dicts/relationship_events/normal_interactions/admiration/decrease.json
@@ -38,7 +38,7 @@
 			"m_c tried to bring r_c's behavior up to them, but it turned into a fight that someone else had to break up.",
 			"m_c confronted r_c about {PRONOUN/r_c/poss} bad attitude but that only makes r_c act out more.",
 			"m_c is disappointed when r_c doesn't uphold a promise.",
-			"r_c saw m_c do something really selfish and while it didn't affect anyone else, m_c's view of {PRONOUN/r_c/object} is definitely warped."
+			"r_c saw m_c do something really selfish and, while it didn't affect anyone else, m_c's view of {PRONOUN/r_c/object} is definitely warped."
 		],
 		"reaction_random_cat": {
 			"admiration": "decrease"

--- a/resources/dicts/relationship_events/normal_interactions/admiration/increase.json
+++ b/resources/dicts/relationship_events/normal_interactions/admiration/increase.json
@@ -14,7 +14,8 @@
 		"interactions": [
 			"m_c mews congratulations to r_c for a job well done.",
 			"m_c thinks r_c is being thoughtful of others.",
-			"m_c approves of r_c's recent efforts."
+			"m_c approves of r_c's recent efforts.",
+			"m_c spreads a positive rumor about r_c."
 		],
 		"reaction_random_cat": {
 			"admiration": "increase"
@@ -28,9 +29,11 @@
 			"m_c really looks up to r_c!",
 			"m_c is awed by how much r_c has done for the Clan.",
 			"m_c is really impressed by all of r_c's accomplishments.",
-			"m_c wants to hold an important position like r_c."
+			"m_c wants to hold an important position like r_c.",
+			"m_c wonders how r_c became the cat {PRONOUN/r_c/subject} are today."
 		],
 		"main_status_constraint": [
+			"kitten",
 			"apprentice",
 			"mediator apprentice",
 			"medicine cat apprentice"
@@ -49,7 +52,8 @@
 			"m_c admires how brave r_c is.",
 			"m_c admires r_c's dedication.",
 			"m_c is impressed with r_c's willingness to help.",
-			"m_c notices that r_c is always one of the first to volunteer for a difficult task."
+			"m_c notices that r_c is always one of the first to volunteer for a difficult task.",
+			"m_c watches and tries to follow what r_c does each day to be more like {PRONOUN/r_c/object}."
 		]
 	},
 	{
@@ -114,7 +118,8 @@
 		"interactions": [
 			"m_c wants to become just like r_c someday!",
 			"m_c is pretending to be r_c.",
-			"m_c always wants to play as r_c in {PRONOUN/m_c/poss} games of pretend."
+			"m_c always wants to play as r_c in {PRONOUN/m_c/poss} games of pretend.",
+			"m_c keeps asking when {PRONOUN/m_c/subject} can be made r_c's apprentice."
 		],
 		"main_status_constraint": [
 			"kitten"
@@ -289,7 +294,9 @@
 		"id": "admire_kit_inc_high1",
 		"intensity": "high",
 		"interactions": [
-			"m_c asks r_c if {PRONOUN/r_c/subject}{VERB/r_c/'re/'s} really going to be the leader someday."
+			"m_c asks r_c if {PRONOUN/r_c/subject}{VERB/r_c/'re/'s} really going to be the leader someday.",
+			"m_c asks if {PRONOUN/m_c/subject} could be r_c's deputy when {PRONOUN/r_c/subject} {VERB/r_c/become/becomes} leader.",
+            		"r_c plays as m_c's deputy."
 		],
 		"main_status_constraint": [
 			"kitten"

--- a/resources/dicts/relationship_events/normal_interactions/comfortable/decrease.json
+++ b/resources/dicts/relationship_events/normal_interactions/comfortable/decrease.json
@@ -14,7 +14,8 @@
 		"interactions": [
 			"m_c said something that rubbed r_c the wrong way.",
 			"m_c was being condescending towards r_c all day long.",
-			"r_c is upset after spending the day with m_c's bad attitude."
+			"r_c is upset after spending the day with m_c's bad attitude.",
+			"r_c encountered m_c at the dirtplace and made awkward eye contact."
 		],
 		"reaction_random_cat": {
 			"comfortable": "decrease"
@@ -32,7 +33,9 @@
 		"interactions": [
 			"m_c feels like r_c was too rough while playing.",
 			"m_c doesn't think r_c was playing fair.",
-			"m_c accuses r_c of cheating during a game of hide-n-seek!"
+			"m_c accuses r_c of cheating during a game of hide-n-seek!",
+			"m_c told r_c {PRONOUN/m_c/subject} didn't want to play but r_c whined until {PRONOUN/m_c/subject} relented.",
+            		"m_c doesn't want to play with r_c."
 		],
 		"main_status_constraint": [
 			"kitten"
@@ -53,8 +56,10 @@
 	{
 		"id": "comfort_de_med3",
 		"interactions": [
-			"r_c is following m_c around.",
-			"r_c tells m_c that {PRONOUN/m_c/poss} pelt looks like a different color today."
+			"r_c is following m_c around a little too closely.",
+			"r_c tells m_c that {PRONOUN/m_c/poss} pelt looks like a different color today.",
+			"m_c woke up to find r_c staring at {PRONOUN/m_c/object}.",
+            		"r_c caught m_c taking some bedding from {PRONOUN/m_c/poss} nest!"
 		],
 		"random_trait_constraint": [
 			"strange"
@@ -87,17 +92,33 @@
 		"interactions": [
 			"r_c crashes into m_c while eager for the new day.",
 			"r_c rejects m_c's advice without letting {PRONOUN/m_c/object} finish.",
-			"r_c interrupts m_c during a conversation."
+			"r_c interrupts m_c during a conversation.",
+			"m_c asked r_c an uncomfortably invasive question."
 		],
 		"random_trait_constraint": [
 			"impulsive"
 		]
 	},
 	{
+		"id": "comfort_de_med7",
+		"interactions": [
+            "m_c told a poorly timed joke while r_c was telling {PRONOUN/m_c/object} some bad news."
+		],
+		"main_trait_constraint": [
+			"charismatic",
+            "playful",
+            "troublesome",
+            "impulsive",
+            "childish",
+            "shameless"
+		]
+	},
+	{
 		"id": "comfort_de_high1",
 		"intensity": "high",
 		"interactions": [
-			"m_c bristles after being scolded by r_c."
+			"m_c bristles after being scolded by r_c.",
+			"m_c shied away from r_c when {PRONOUN/r_c/subject} tried touching noses in greeting."
 		]
 	},
 	{
@@ -134,7 +155,8 @@
 			"m_c doesn't like the way that r_c seems to enjoy {PRONOUN/r_c/poss} influence over the Clan.",
 			"Much to m_c's dismay, r_c has asked {PRONOUN/m_c/object} to do another difficult task.",
 			"m_c thinks that r_c is casting a dark shadow over the whole Clan's reputation.",
-			"m_c is worried that r_c might be sending the Clan down a dark path."
+			"m_c is worried that r_c might be sending the Clan down a dark path.",
+			"m_c has been wondering if StarClan has actually been guiding r_c or if it's really the Dark Forest's influence."
 		],
 		"random_trait_constraint": [
 			"bloodthirsty",
@@ -153,7 +175,9 @@
 			"m_c notices that r_c doesn't seem to care if {PRONOUN/r_c/poss} treatments hurt.",
 			"m_c overhears r_c complaining about giving herbs to cats that don't 'deserve' them.",
 			"m_c is startled at r_c's views on sharing herbs with other Clans.",
-			"m_c bristles after seeing r_c add more deathberries to {PRONOUN/r_c/poss} herb storage."
+			"m_c bristles after seeing r_c add more deathberries to {PRONOUN/r_c/poss} herb storage.",
+			"m_c stopped r_c before {PRONOUN/r_c/subject} gave the wrong herbs to another cat. The look in r_c's eyes as {PRONOUN/r_c/subject} did so scared m_c...",
+            "m_c has been wondering if StarClan has actually been guiding r_c or if it's really the Dark Forest's influence."
 		],
 		"random_trait_constraint": [
 			"bloodthirsty",

--- a/resources/dicts/relationship_events/normal_interactions/comfortable/decrease.json
+++ b/resources/dicts/relationship_events/normal_interactions/comfortable/decrease.json
@@ -102,7 +102,7 @@
 	{
 		"id": "comfort_de_med7",
 		"interactions": [
-            "m_c told a poorly timed joke while r_c was telling {PRONOUN/m_c/object} some bad news."
+            "m_c made a poorly timed joke while r_c was telling {PRONOUN/m_c/object} some bad news."
 		],
 		"main_trait_constraint": [
 			"charismatic",

--- a/resources/dicts/relationship_events/normal_interactions/comfortable/increase.json
+++ b/resources/dicts/relationship_events/normal_interactions/comfortable/increase.json
@@ -4,7 +4,9 @@
 		"intensity": "low",
 		"interactions": [
 			"m_c finds a bit of fluff that smells like r_c and adds it to {PRONOUN/m_c/poss} nest.",
-			"m_c has a friendly chat with r_c that leaves them both feeling happy."
+			"m_c has a friendly chat with r_c that leaves them both feeling happy.",
+			"r_c offered to help m_c.",
+            		"m_c sunbathes with r_c."
 		]
 	},
 	{
@@ -25,7 +27,8 @@
 		"intensity": "low",
 		"interactions": [
 			"m_c is asking r_c to check {PRONOUN/m_c/object} for ticks.",
-			"m_c is happy to see r_c is the cat who is helping {PRONOUN/m_c/object} today."
+			"m_c is happy to see r_c is the cat who is helping {PRONOUN/m_c/object} today.",
+			"m_c didn't even have to ask r_c to check {PRONOUN/m_c/object} for ticks, r_c was on it the moment m_c started to scratch."
 		],
 		"main_status_constraint": [
 			"elder"
@@ -39,7 +42,10 @@
 	{
 		"id": "comfort_inc_med1",
 		"interactions": [
-			"m_c helps r_c pick burrs out of {PRONOUN/r_c/poss} fur."
+			"m_c helps r_c pick burrs out of {PRONOUN/r_c/poss} fur.",
+			"m_c came across r_c napping and left {PRONOUN/r_c/object} be, making sure no one else woke {PRONOUN/r_c/object} either.",
+            "m_c takes {PRONOUN/m_c/poss} time grooming r_c's pelt and making it shine.",
+            "m_c is sharing tongues with r_c."
 		]
 	},
 	{
@@ -50,7 +56,8 @@
 			"m_c basks in the sun with r_c.",
 			"m_c just told r_c a hilarious joke.",
 			"m_c settles near r_c to eat {PRONOUN/m_c/poss} fresh-kill.",
-			"m_c bumps heads with r_c reassuringly."
+			"m_c bumps heads with r_c reassuringly.",
+			"m_c watches the stars with r_c."
 		],
 		"reaction_random_cat": {
 			"comfortable": "increase"
@@ -63,7 +70,8 @@
 			"m_c tells r_c {PRONOUN/m_c/subject}'ll save {PRONOUN/r_c/object} a piece of fresh-kill.",
 			"m_c playfully teases r_c for missing a catch.",
 			"m_c gives r_c some feathers from the bird {PRONOUN/m_c/subject} caught to line {PRONOUN/r_c/poss} nest.",
-			"m_c is delighted to be working with r_c today."
+			"m_c is delighted to be working with r_c today.",
+			"m_c asked r_c to wake {PRONOUN/m_c/object} from {PRONOUN/m_c/poss} nap when the noon patrol starts gathering."
 		],
 		"main_status_constraint": [
 			"apprentice",
@@ -83,7 +91,11 @@
 		"interactions": [
 			"r_c is listening to m_c's woes.",
 			"r_c is listening to m_c's troubles.",
-			"r_c noticed m_c was struggling, and offered to help {PRONOUN/m_c/object}."
+			"r_c noticed m_c was struggling, and offered to help {PRONOUN/m_c/object}.",
+			"r_c offered help to m_c during a hard time.",
+            "m_c offers to help with one of r_c's more tedious tasks.",
+			"m_c helps r_c with a tedious task and it makes the whole day a lot easier.",
+            "m_c had a nightmare and r_c offered to share {PRONOUN/r_c/poss} nest to comfort m_c."
 		],
 		"random_trait_constraint": [
 			"empathetic"
@@ -94,7 +106,8 @@
 		"interactions": [
 			"r_c gave m_c {PRONOUN/m_c/poss} favorite piece of prey.",
 			"r_c is being quite considerate with m_c.",
-			"r_c took the time to help m_c work through a technique {PRONOUN/m_c/subject} {VERB/m_c/are/is} struggling with."
+			"r_c took the time to help m_c work through a technique {PRONOUN/m_c/subject} {VERB/m_c/are/is} struggling with.",
+			"r_c offers {PRONOUN/r_c/poss} fresh kill when m_c realizes all {PRONOUN/m_c/poss} favorites were taken already."
 		],
 		"random_trait_constraint": [
 			"thoughtful"
@@ -136,7 +149,9 @@
 		"id": "comfortable_kit_inc_med2",
 		"interactions": [
 			"m_c wants to snuggle with r_c.",
-			"m_c is hiding under a bush from r_c, but {PRONOUN/m_c/subject} can't stop giggling."
+			"m_c is hiding under a bush from r_c, but {PRONOUN/m_c/subject} can't stop giggling.",
+			"m_c plops down near r_c, sneaking glances at {PRONOUN/r_c/object} expectantly. r_c doesn't understand until m_c wonders aloud to {PRONOUN/m_c/self} if r_c would play with {PRONOUN/m_c/object} if {PRONOUN/m_c/subject} asked.",
+            "r_c woke up from a nap in the clearing to find m_c stuffing bedding scraps under {PRONOUN/r_c/object} to make {PRONOUN/r_c/object} a cozy nest."
 		],
 		"main_status_constraint": [
 			"kitten"
@@ -150,7 +165,8 @@
 		"interactions": [
 			"m_c spent the whole day playing {PRONOUN/m_c/poss} favorite games with r_c.",
 			"m_c had a friendly argument with r_c about which prey tastes the best.",
-			"m_c takes a nap with r_c after a long day playing moss-ball."
+			"m_c takes a nap with r_c after a long day playing moss-ball.",
+			"m_c and r_c had a friendly argument about which beetle would win a fight."
 		],
 		"main_status_constraint": [
 			"kitten"
@@ -200,7 +216,8 @@
 		"id": "comfort_inc_high1",
 		"intensity": "high",
 		"interactions": [
-			"m_c appreciates how r_c always seems to ask how {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} doing."
+			"m_c appreciates how r_c always seems to ask how {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} doing.",
+			"m_c slow blinked at r_c."
 		]
 	},
 	{
@@ -239,5 +256,27 @@
 			"comfortable": "increase",
 			"trust": "increase"
 		}
+	},
+	{
+		"id": "comfort_inc_storm",
+		"interactions": [
+			"m_c comforted r_c through a particularly rough thunderstorm."
+		],
+		"reaction_random_cat": {
+			"comfortable": "increase",
+            "platonic": "increase",
+			"trust": "increase",
+            "admiration": "increase"
+		},
+        "reaction_main_cat": {
+			"comfortable": "increase",
+			"trust": "increase",
+            "platonic": "increase"
+		},
+         "season": [
+            "Newleaf",
+            "Greenleaf",
+            "Leaf-fall"
+        ]
 	}
 ]

--- a/resources/dicts/relationship_events/normal_interactions/comfortable/increase.json
+++ b/resources/dicts/relationship_events/normal_interactions/comfortable/increase.json
@@ -150,7 +150,7 @@
 		"interactions": [
 			"m_c wants to snuggle with r_c.",
 			"m_c is hiding under a bush from r_c, but {PRONOUN/m_c/subject} can't stop giggling.",
-			"m_c plops down near r_c, sneaking glances at {PRONOUN/r_c/object} expectantly. r_c doesn't understand until m_c wonders aloud to {PRONOUN/m_c/self} if r_c would play with {PRONOUN/m_c/object} if {PRONOUN/m_c/subject} asked.",
+			"m_c plops down near r_c, sneaking glances at {PRONOUN/r_c/object} expectantly. r_c doesn't understand until m_c muses aloud to {PRONOUN/m_c/self} about whether or not r_c would play with {PRONOUN/m_c/object} if {PRONOUN/m_c/subject} asked.",
             "r_c woke up from a nap in the clearing to find m_c stuffing bedding scraps under {PRONOUN/r_c/object} to make {PRONOUN/r_c/object} a cozy nest."
 		],
 		"main_status_constraint": [

--- a/resources/dicts/relationship_events/normal_interactions/comfortable/increase.json
+++ b/resources/dicts/relationship_events/normal_interactions/comfortable/increase.json
@@ -166,7 +166,7 @@
 			"m_c spent the whole day playing {PRONOUN/m_c/poss} favorite games with r_c.",
 			"m_c had a friendly argument with r_c about which prey tastes the best.",
 			"m_c takes a nap with r_c after a long day playing moss-ball.",
-			"m_c and r_c had a friendly argument about which beetle would win a fight."
+			"m_c and r_c had a friendly argument about which beetle would win in a fight."
 		],
 		"main_status_constraint": [
 			"kitten"

--- a/resources/dicts/relationship_events/normal_interactions/comfortable/increase.json
+++ b/resources/dicts/relationship_events/normal_interactions/comfortable/increase.json
@@ -266,12 +266,14 @@
 			"comfortable": "increase",
             "platonic": "increase",
 			"trust": "increase",
-            "admiration": "increase"
+            "admiration": "increase",
+			"dislike": "decrease"
 		},
         "reaction_main_cat": {
 			"comfortable": "increase",
 			"trust": "increase",
-            "platonic": "increase"
+            "platonic": "increase",
+		"dislike": "decrease"
 		},
          "season": [
             "Newleaf",

--- a/resources/dicts/relationship_events/normal_interactions/dislike/decrease.json
+++ b/resources/dicts/relationship_events/normal_interactions/dislike/decrease.json
@@ -5,7 +5,9 @@
 		"interactions": [
 			"m_c is surprised by r_c being thoughtful.",
 			"m_c and r_c agree about something trivial.",
-			"m_c is able to work together with r_c."
+			"m_c is able to work together with r_c.",
+			"m_c and r_c actually get along better today.",
+            "m_c and r_c were able to have a debate without it turning into an argument."
 		]
 	},
 	{
@@ -25,25 +27,43 @@
 		"interactions": [
 			"m_c realized that {PRONOUN/m_c/subject} {VERB/m_c/were/was} too harsh in {PRONOUN/m_c/poss} judgment of r_c.",
 			"m_c spends some time with r_c and they both end up understanding each other a little better.",
-			"m_c is rethinking how {PRONOUN/m_c/subject} feel about r_c and gives {PRONOUN/r_c/object} another chance."
+			"m_c is rethinking how {PRONOUN/m_c/subject} feel about r_c and gives {PRONOUN/r_c/object} another chance.",
+			"m_c didn't see r_c at all today and admittedly was a little dissapointed.",
+            "m_c and r_c apologized over something petty they both did to each other."
 		]
 	},
 	{
 		"id": "dislike_de_med2",
 		"interactions": [
 			"m_c covered for r_c on something minor.",
-			"m_c cheers r_c up after a small disagreement."
+			"m_c cheers r_c up after a small disagreement.",
+			"m_c, while grabbing food for {PRONOUN/m_c/self}, saw r_c grabbing a really tasty looking rabbit and asked to share it with {PRONOUN/r_c/object}."
 		],
 		"reaction_random_cat": {
 			"dislike": "decrease"
 		}
 	},
 	{
+		"id": "dislike_de_med3",
+		"interactions": [
+            "m_c recently began looking forward to the little arguments {PRONOUN/m_c/subject} had with r_c.",
+            "m_c and r_c's bickering has gotten more playful as of late.",
+            "m_c was almost sad {PRONOUN/m_c/subject} didn't have a chance to argue with r_c today.",
+            "Even though r_c didn't like m_c, {PRONOUN/r_c/subject} didn't chase {PRONOUN/m_c/object} away when m_c sat down beside {PRONOUN/r_c/object}.",
+            "m_c and r_c, despite never getting along, put aside their differences and worked together surprisingly well during an emergency.",
+            "m_c recently has grown tired of disliking r_c."
+		],
+        "relationship_constraint": [
+			"dislike_20"
+		]
+	},
+	{
 		"id": "dislike_de_high1",
 		"intensity": "high",
 		"interactions": [
 			"m_c is surprised to hear r_c express an ideal {PRONOUN/m_c/subject} can agree with.",
-			"m_c and r_c realize they have more in common than previously thought."
+			"m_c and r_c realize they have more in common than previously thought.",
+			"m_c actually stood up for r_c when {PRONOUN/r_c/subject} were being scolded for something too harshly."
 		]
 	},
 	{
@@ -62,7 +82,7 @@
 		"id": "dislike_de_high3",
 		"intensity": "high",
 		"interactions": [
-			"m_c and r_c heckled another Clan at the gathering together."
+			"m_c and r_c heckled another Clan at the Gathering together."
 		],
 		"reaction_random_cat": {
 			"dislike": "decrease"
@@ -73,8 +93,6 @@
 			"warrior",
 			"mediator apprentice",
 			"mediator",
-			"medicine cat apprentice",
-			"medicine cat",
 			"deputy",
 			"leader"
 		],
@@ -84,8 +102,6 @@
 			"warrior",
 			"mediator apprentice",
 			"mediator",
-			"medicine cat apprentice",
-			"medicine cat",
 			"deputy",
 			"leader"
 		]

--- a/resources/dicts/relationship_events/normal_interactions/dislike/increase.json
+++ b/resources/dicts/relationship_events/normal_interactions/dislike/increase.json
@@ -308,7 +308,24 @@
 		"interactions": [
             "m_c pulls r_c aside and reminds {PRONOUN/r_c/object} {PRONOUN/m_c/subject} could easily exile {PRONOUN/r_c/object}.",
             "m_c scolded r_c for not doing the hard task {PRONOUN/m_c/subject} assigned {PRONOUN/r_c/object} despite knowing it was a job for more then one cat.",
-			"m_c gives r_c a particularly hard task, expecting {PRONOUN/r_c/object} to fail.",
+			"m_c gives r_c a particularly hard task, expecting {PRONOUN/r_c/object} to fail."
+		],
+		"main_status_constraint": [
+			"deputy",
+			"leader"
+		],
+		"random_status_constraint": [
+			"apprentice",
+			"warrior"
+		],
+		"reaction_random_cat": {
+			"dislike": "increase"
+		}
+	},
+	{
+		"id": "dislike_dep_leader_app_inc_high1",
+        "intensity": "high",
+		"interactions": [
 			"m_c threatens r_c with never passing {PRONOUN/r_c/poss} assessment!"
 		],
 		"main_status_constraint": [
@@ -322,6 +339,7 @@
 		"reaction_random_cat": {
 			"dislike": "increase"
 		}
+
 	},
 	{
 		"id": "dislike_med_inc_med1",

--- a/resources/dicts/relationship_events/normal_interactions/dislike/increase.json
+++ b/resources/dicts/relationship_events/normal_interactions/dislike/increase.json
@@ -313,7 +313,18 @@
 		],
 		"main_status_constraint": [
 			"deputy",
-	@@ -159,7 +328,9 @@
+			"leader"
+		],
+		"random_status_constraint": [
+			"apprentice",
+			"warrior"
+		],
+		"reaction_random_cat": {
+			"dislike": "increase"
+		}
+	},
+	{
+		"id": "dislike_med_inc_med1",
 		"interactions": [
 			"m_c gives r_c bitter herbs on purpose.",
 			"m_c accuses r_c of complaining over something trivial and wasting {PRONOUN/m_c/poss} time.",

--- a/resources/dicts/relationship_events/normal_interactions/dislike/increase.json
+++ b/resources/dicts/relationship_events/normal_interactions/dislike/increase.json
@@ -4,7 +4,13 @@
 		"intensity": "low",
 		"interactions": [
 			"m_c had r_c bump into {PRONOUN/m_c/object}, and {PRONOUN/r_c/subject} didn't even apologize!",
-			"r_c stepped on m_c's foot and pretended not to notice."
+			"r_c stepped on m_c's foot and pretended not to notice.",
+			"m_c refuses to look at r_c.",
+            "m_c was in the middle of an important conversation before r_c rudely interrupted {PRONOUN/m_c/object}.",
+            "r_c blocked m_c's way and didn't apologize.",
+            "m_c made plans to share tongues with r_c but never showed up.",
+            "m_c accidentially stepped on r_c's tail.",
+            "m_c teased r_c's for having messy fur right after waking up."
 		]
 	},
 	{
@@ -21,9 +27,63 @@
 		}
 	},
 	{
+		"id": "dislike_inc_kit1",
+        "intensity": "low",
+		"interactions": [
+			"m_c brought r_c back to the nursery despite {PRONOUN/r_c/poss} whining protests.",
+            		"m_c made r_c tidy up a mess {PRONOUN/r_c/subject} made and didn't let {PRONOUN/r_c/object} go until it was all done.",
+			"r_c heard m_c complaining about how {PRONOUN/m_c/subject} {VERB/m_c/aren't/isn't} a kitsitter and shouldn't have to watch m_c.",
+            		"m_c sat r_c down for a boooring lecture on something {PRONOUN/r_c/subject} did wrong."
+		],
+		"main_status_constraint": [
+			"apprentice",
+            "warrior",
+            "elder",
+            "medicine cat",
+            "medicine cat apprentice",
+            "deputy",
+            "leader"
+		],
+		"random_status_constraint": [
+			"kitten"
+		],
+        "reaction_random_cat": {
+			"dislike": "increase"
+		}
+	},
+    {
+		"id": "dislike_inc_kit2",
+        "intensity": "low",
+		"interactions": [
+			"m_c had to clean up a mess r_c made.",
+            "r_c keeps asking m_c why even after being told to stop.",
+            "m_c had to drop everything to look for r_c after {PRONOUN/r_c/subject} went missing. Turns out {PRONOUN/r_c/object} {VERB/r_c/were/was} playing hide and seek by {PRONOUN/r_c/self} without telling anyone."
+		],
+		"main_status_constraint": [
+			"apprentice",
+            "warrior",
+            "elder",
+            "medicine cat",
+            "medicine cat apprentice",
+            "deputy",
+            "leader"
+		],
+		"random_status_constraint": [
+			"kitten"
+		],
+        "reaction_main_cat": {
+			"dislike": "increase"
+		}
+	},
+	{
 		"id": "dislike_inc_med1",
 		"intensity": [
-			"m_c wishes r_c would take things more seriously."
+			"m_c wishes r_c would take things more seriously.",
+			"m_c told r_c to get lost.",
+            "m_c swiped {PRONOUN/m_c/poss} paw at r_c.",
+            "m_c and r_c got into a disagreement earlier and are both still fuming over it.",
+            "m_c and r_c had a fight earlier and are both still fuming over it.",
+            "m_c doesn't like r_c's attitude."
 		]
 	},
 	{
@@ -31,7 +91,10 @@
 		"interactions": [
 			"m_c ignores r_c.",
 			"m_c had a huge argument with r_c.",
-			"m_c had a spat with r_c over a piece of prey on the fresh-kill pile."
+			"m_c had a spat with r_c over a piece of prey on the fresh-kill pile.",
+			"m_c is telling everyone in camp that r_c has greencough.",
+            "m_c took the last of r_c's favorite fresh kill right in front of {PRONOUN/r_c/object}.",
+			"m_c took the fresh kill r_c was eyeing all day."
 		],
 		"reaction_random_cat": {
 			"dislike": "increase"
@@ -43,7 +106,17 @@
 			"m_c had a disagreement with r_c while on patrol earlier.",
 			"m_c stole r_c's catch right out from under {PRONOUN/r_c/poss} claws.",
 			"m_c prays that {PRONOUN/m_c/subject} {VERB/m_c/aren't/isn't} on patrol with r_c tomorrow.",
-			"m_c sighs loudly every time r_c does anything on patrol."
+			"m_c sighs loudly every time r_c does anything on patrol.",
+			"m_c lied about r_c being sick to take {PRONOUN/r_c/poss} spot on a patrol.",
+            "m_c scared away the prey r_c was stalking.",
+            "m_c pulled r_c's tail during training.",
+            "m_c made sure to let all the prey r_c likes get away during {PRONOUN/r_c/poss} patrol.",
+            "m_c keeps upstaging r_c.",
+            "m_c refused to do a task with r_c, opting to do something else instead even while r_c scolded {PRONOUN/m_c/object} for ditching the task.",
+            "m_c tripped r_c during a patrol.",
+            "m_c and r_c were not in sync during training today.",
+            "m_c threatens r_c to use {PRONOUN/m_c/poss} claws next time they train together.",
+            "m_c overheard r_c taking credit for catching the prey {PRONOUN/m_c/subject} caught."
 		],
 		"main_status_constraint": [
 			"apprentice",
@@ -66,7 +139,13 @@
 		"interactions": [
 			"m_c is thinking about how r_c wronged {PRONOUN/m_c/object}.",
 			"m_c is watching r_c scornfully.",
-			"m_c is glaring daggers at r_c."
+			"m_c is glaring daggers at r_c.",
+			"m_c pulls a mean prank on r_c.",
+            "m_c knocked r_c into a puddle with a rough shove before feigning an apology.",
+            "m_c 'accidentally' tripped r_c.",
+            "m_c gave r_c a grimace before walking away without a word.",
+            "m_c smirks when {PRONOUN/m_c/subject} see r_c all by {PRONOUN/r_c/self}.",
+            "m_c enjoys watching things go wrong for r_c."
 		],
 		"main_trait_constraint": [
 			"vengeful"
@@ -78,10 +157,12 @@
 			"r_c is asking m_c to tell {PRONOUN/r_c/object} about how good {PRONOUN/r_c/subject} {VERB/m_c/look/looks}.",
 			"r_c offends m_c with {PRONOUN/r_c/poss} brutal honesty.",
 			"r_c is boasting about {PRONOUN/r_c/poss} accomplishments to m_c, but m_c isn't impressed.",
-			"r_c gets really close to m_c's face while talking and grosses m_c out with {PRONOUN/r_c/poss} bad breath."
+			"r_c gets really close to m_c's face while talking and grosses m_c out with {PRONOUN/r_c/poss} bad breath.",
+			"r_c doesn't understand why m_c lied to save a cats feelings."
 		],
 		"random_trait_constraint": [
-			"shameless"
+			"shameless",
+			"arrogant"
 		]
 	},
 	{
@@ -89,11 +170,39 @@
 		"interactions": [
 			"r_c pulled a prank on m_c.",
 			"r_c blamed m_c for {PRONOUN/r_c/poss} own mistake.",
-			"r_c won't stop bothering m_c."
+			"r_c won't stop bothering m_c.",
+			"r_c was too rough and knocked m_c over.",
+            		"r_c started a rumor about m_c for fun."
 		],
 		"random_trait_constraint": [
 			"troublesome"
 		]
+	},
+	{
+		"id": "dislike_inc_kit_app",
+		"interactions": [
+            "m_c just can't stand r_c's lack of knowledge on things.",
+            "m_c kept talking down to r_c all day, over explaining even the most simple things.",
+            "m_c keeps talking to r_c like {PRONOUN/r_c/subject}{VERB/r_c/'re/'s} younger then {PRONOUN/r_c/subject} {VERB/r_c/are/is}.",
+            "m_c refused to so much as acknowledge r_c simply cause of how young {PRONOUN/r_c/subject} {VERB/r_c/were/was}."
+		],
+        "main_trait_constraint": [
+            "arrogant",
+            "grumpy",
+            "cold"
+            ],
+		"main_status_constraint": [
+			"warrior",
+			"deputy",
+			"leader"
+		],
+		"random_status_constraint": [
+			"apprentice",
+			"kit"
+		],
+		"reaction_random_cat": {
+			"dislike": "increase"
+		}
 	},
 	{
 		"id": "dislike_effect_other1",
@@ -104,7 +213,8 @@
 			"r_c is spreading a rumor about m_c.",
 			"r_c is mocking m_c.",
 			"r_c is telling others about how terrible m_c can really be.",
-			"r_c leaves as soon as m_c arrives and refuses to be nearby."
+			"r_c leaves as soon as m_c arrives and refuses to be nearby.",
+			"m_c gagged at just the thought of being around r_c!"
 		]
 	},
 	{
@@ -113,7 +223,10 @@
 			"m_c trips over r_c.",
 			"m_c had to nip r_c on the rump because {PRONOUN/r_c/subject} {VERB/r_c/were/was} being naughty.",
 			"m_c growls at r_c to get out from under {PRONOUN/m_c/poss} paws.",
-			"m_c snaps at r_c's annoying antics."
+			"m_c snaps at r_c's annoying antics.",
+			"r_c wishes {PRONOUN/r_c/subject} {VERB/r_c/was/were} all grown up so m_c would take {PRONOUN/r_c/object} seriously.",
+            "r_c asked m_c to tell {PRONOUN/r_c/object} a story only to get hissed at instead.",
+            "m_c took the toy r_c was playing with before telling {PRONOUN/m_c/object} to return to the nursery."
 		],
 		"main_status_constraint": [
 			"elder",
@@ -134,13 +247,48 @@
 		}
 	},
 	{
+		"id": "dislike_kit_inc_med2",
+		"interactions": [
+			"m_c purposefully tripped r_c.",
+            "m_c growls at r_c to get out of {PRONOUN/m_c/poss} way.",
+			"m_c snaps at r_c's annoying antics.",
+            "m_c snarls at r_c when asked to play. {PRONOUN/m_c/subject} will not spend {PRONOUN/m_c/poss} time playing stupid games."
+		],
+		"main_status_constraint": [
+			"kitten",
+            "elder",
+			"apprentice",
+			"warrior",
+			"mediator apprentice",
+			"mediator",
+			"medicine cat apprentice",
+			"medicine cat",
+			"deputy",
+			"leader"
+		],
+		"random_status_constraint": [
+			"kitten"
+		],
+        "main_trait_constraint": [
+			"troublesome",
+            "cold",
+            "vengeful",
+            "strange",
+            "grumpy",
+            "bullying",
+            "bossy"
+		],
+		"reaction_random_cat": {
+			"dislike": "increase"
+		}
+	},
+	{
 		"id": "dislike_dep_leader_inc_med1",
 		"interactions": [
 			"m_c punishes r_c with extra work.",
 			"m_c divides r_c into extra patrols.",
-			"m_c gives r_c a particularly hard task, expecting {PRONOUN/r_c/object} to fail.",
-			"m_c threatens r_c with never passing {PRONOUN/r_c/poss} assessment!",
-			"m_c tells other cats that r_c is not doing well in {PRONOUN/r_c/poss} training."
+			"m_c tells other cats that r_c is not doing well in {PRONOUN/r_c/poss} training.",
+			 "m_c gave r_c twice as much work as the other cats {PRONOUN/r_c/poss} age."
 		],
 		"main_status_constraint": [
 			"deputy",
@@ -155,11 +303,23 @@
 		}
 	},
 	{
-		"id": "dislike_med_inc_med1",
+		"id": "dislike_dep_leader_inc_high1",
+        "intensity": "high",
+		"interactions": [
+            "m_c pulls r_c aside and reminds {PRONOUN/r_c/object} {PRONOUN/m_c/subject} could easily exile {PRONOUN/r_c/object}.",
+            "m_c scolded r_c for not doing the hard task {PRONOUN/m_c/subject} assigned {PRONOUN/r_c/object} knowing it was a job for more then one cat.",
+			"m_c gives r_c a particularly hard task, expecting {PRONOUN/r_c/object} to fail.",
+			"m_c threatens r_c with never passing {PRONOUN/r_c/poss} assessment!"
+		],
+		"main_status_constraint": [
+			"deputy",
+	@@ -159,7 +328,9 @@
 		"interactions": [
 			"m_c gives r_c bitter herbs on purpose.",
 			"m_c accuses r_c of complaining over something trivial and wasting {PRONOUN/m_c/poss} time.",
-			"m_c always tends to r_c last."
+			"m_c always tends to r_c last.",
+			"m_c ignores r_c any time {PRONOUN/r_c/subject} come for treatment.",
+            "m_c is extra rough when treating r_c."
 		],
 		"main_status_constraint": [
 			"medicine cat apprentice",
@@ -183,7 +343,8 @@
 		"interactions": [
 			"m_c had a fight with r_c.",
 			"m_c had a heated argument with r_c and said some very hurtful things.",
-			"m_c argues with r_c in front of other cats and reveals something embarrassing."
+			"m_c argues with r_c in front of other cats and reveals something embarrassing.",
+			"m_c and r_c had a spat over a piece of fresh-kill and didn't notice another cat taking it while they were arguing."
 		],
 		"reaction_random_cat": {
 			"dislike": "increase"
@@ -198,7 +359,17 @@
 		"interactions": [
 			"m_c shudders at the sound of r_c's voice.",
 			"m_c will do anything to avoid being anywhere near r_c.",
-			"m_c refuses to do any work with r_c."
+			"m_c refuses to do any work with r_c.",
+			"m_c and r_c got into a loud screaming match with each other and had to be seperated.",
+            "m_c wants to claw r_c's face off.",
+            "m_c wonders if being a loner might just be better then being r_c's Clanmate...",
+            "m_c considers r_c a terrible influence on others.",
+            "m_c finds r_c to be an eyesore.",
+            "m_c daydreams about killing r_c...",
+            "m_c doesn't even pretend to hide how much {PRONOUN/m_c/subject} hate r_c.",
+            "m_c lunged at r_c but was held back by a clanmate.",
+            "m_c hopes r_c ends up in the Dark Forest.",
+            "m_c prayed to StarClan for r_c's downfall to come quick."
 		]
 	},
 	{
@@ -207,7 +378,14 @@
 		"interactions": [
 			"m_c accuses r_c of being a bad leader.",
 			"m_c accuses r_c of not taking care of the Clan.",
-			"m_c accuses r_c of not putting the Clan first."
+			"m_c accuses r_c of not putting the Clan first.",
+			"m_c accused r_c of leading the Clan toward the Dark Forest.",
+            "m_c wonders what stupid decision r_c will make next that'll harm the Clan.",
+            "m_c said aloud how {PRONOUN/m_c/subject} couldn't wait for m_c to just die so someone better could become leader.",
+            "m_c told r_c {PRONOUN/r_c/subject} should just retire already.",
+            "r_c wonders how easy it'd be to convince the rest of the clan to agree exiling r_c is a good move...",
+            "r_c overheard m_c trying to convince the rest of the Clan to ditch r_c and make a new Clan without {PRONOUN/r_c/object}.",
+            "m_c believes r_c isn't doing {PRONOUN/r_c/poss} job good enough."
 		],
 		"relationship_constraint": [
 			"dislike_50"
@@ -222,7 +400,13 @@
 		"interactions": [
 			"m_c accuses r_c of being a bad deputy.",
 			"m_c scoffs at r_c's instructions.",
-			"m_c says that r_c is such a bad deputy {PRONOUN/r_c/subject} should step down."
+			"m_c says that r_c is such a bad deputy {PRONOUN/r_c/subject} should step down.",
+			"m_c dreads the day r_c becomes leader.",
+            "r_c overheard m_c begging the leader to make someone else, ANYONE else deputy, just not r_c.",
+            "m_c claims a kit could do r_c's job better then {PRONOUN/r_c/object}.",
+            "m_c hopes r_c retires soon, StarClan only knows {PRONOUN/r_c/object} becoming leader would be a nightmare.",
+            "m_c hopes r_c never gets to be leader.",
+            "m_c accused r_c of leading the Clan toward the Dark Forest."
 		],
 		"relationship_constraint": [
 			"dislike_50"
@@ -279,10 +463,41 @@
 		}
 	},
 	{
+		"id": "dislike_inc_high8",
+		"intensity": "high",
+		"interactions": [
+            "m_c and r_c nearly got into a serious fight in the middle of camp and had to be seperated by their Clanmates.",
+            "m_c insulted r_c's biggest insecurity directly to {PRONOUN/m_c/poss} face.",
+            "m_c called r_c an embarrassment to the Clan.",
+            "m_c threatens to send r_c directly to the Dark Forest where {PRONOUN/r_c/subject} belong.",
+            "m_c threatened to put r_c in {PRONOUN/r_c/poss} place next time they crossed paths."
+		],
+		"relationship_constraint": [
+			"dislike_40"
+		],
+        "reaction_main_cat": {
+			"trust": "decrease",
+            "platonic": "decrease",
+            "comfort": "decrease"
+		},
+		"reaction_random_cat": {
+			"trust": "decrease",
+            "platonic": "decrease",
+            "comfort": "decrease"
+		}
+	},
+	{
 		"id": "dislike_kit_de_med1",
 		"interactions": [
 			"m_c sticks {PRONOUN/m_c/poss} tongue out at r_c",
-			"m_c makes stinky faces at r_c for seemingly no reason."
+			"m_c makes stinky faces at r_c for seemingly no reason.",
+			"m_c hisses at r_c, wary of {PRONOUN/r_c/object} for reasons nobody knows.",
+            "m_c called r_c an insult {PRONOUN/m_c/subject} just learned and r_c is not amused.",
+            "r_c snapped at m_c for annoying {PRONOUN/r_c/object}.",
+            "m_c cries any time {PRONOUN/m_c/subject} {VERB/m_c/sees/see} r_c.",
+            "m_c is scared of r_c but won't say why.",
+            "m_c thinks r_c is scary.",
+            "m_c blamed r_c for something {PRONOUN/m_c/subject} did to avoid trouble."
 		],
 		"main_status_constraint": [
 			"kitten"
@@ -296,7 +511,9 @@
 		"interactions": [
 			"m_c tried to have a friendly discussion with r_c about what prey tastes best, but it turned into an argument.",
 			"m_c and r_c always end up arguing over what games to play.",
-			"m_c is not playing fairly with r_c!"
+			"m_c is not playing fairly with r_c!",
+			"m_c was too rough with r_c while playing earlier and r_c still hasn't gotten over it.",
+            "m_c refuses to play what r_c wants to play, {PRONOUN/m_c/subject} only wants to play what {PRONOUN/m_c/subject} {VERB/m_c/wants/want}!"
 		],
 		"main_status_constraint": [
 			"kitten"

--- a/resources/dicts/relationship_events/normal_interactions/dislike/increase.json
+++ b/resources/dicts/relationship_events/normal_interactions/dislike/increase.json
@@ -33,7 +33,7 @@
 			"m_c brought r_c back to the nursery despite {PRONOUN/r_c/poss} whining protests.",
             		"m_c made r_c tidy up a mess {PRONOUN/r_c/subject} made and didn't let {PRONOUN/r_c/object} go until it was all done.",
 			"r_c heard m_c complaining about how {PRONOUN/m_c/subject} {VERB/m_c/aren't/isn't} a kitsitter and shouldn't have to watch m_c.",
-            		"m_c sat r_c down for a boooring lecture on something {PRONOUN/r_c/subject} did wrong."
+            		"m_c sat r_c down for a <i>boooring</i> lecture on something {PRONOUN/r_c/subject} did wrong."
 		],
 		"main_status_constraint": [
 			"apprentice",

--- a/resources/dicts/relationship_events/normal_interactions/dislike/increase.json
+++ b/resources/dicts/relationship_events/normal_interactions/dislike/increase.json
@@ -392,7 +392,7 @@
 			"m_c accuses r_c of not putting the Clan first.",
 			"m_c accused r_c of leading the Clan toward the Dark Forest.",
             "m_c wonders what stupid decision r_c will make next that'll harm the Clan.",
-            "m_c said aloud how {PRONOUN/m_c/subject} couldn't wait for m_c to just die so someone better could become leader.",
+            "m_c said aloud how {PRONOUN/m_c/subject} couldn't wait for m_c to die so that someone better could become leader.",
             "m_c told r_c {PRONOUN/r_c/subject} should just retire already.",
             "r_c wonders how easy it'd be to convince the rest of the clan to agree exiling r_c is a good move...",
             "r_c overheard m_c trying to convince the rest of the Clan to ditch r_c and make a new Clan without {PRONOUN/r_c/object}.",

--- a/resources/dicts/relationship_events/normal_interactions/dislike/increase.json
+++ b/resources/dicts/relationship_events/normal_interactions/dislike/increase.json
@@ -158,7 +158,7 @@
 			"r_c offends m_c with {PRONOUN/r_c/poss} brutal honesty.",
 			"r_c is boasting about {PRONOUN/r_c/poss} accomplishments to m_c, but m_c isn't impressed.",
 			"r_c gets really close to m_c's face while talking and grosses m_c out with {PRONOUN/r_c/poss} fox breath.",
-			"r_c doesn't understand why m_c lied to save a cats feelings."
+			"r_c doesn't understand why m_c lied to save a cats' feelings."
 		],
 		"random_trait_constraint": [
 			"shameless",

--- a/resources/dicts/relationship_events/normal_interactions/dislike/increase.json
+++ b/resources/dicts/relationship_events/normal_interactions/dislike/increase.json
@@ -307,7 +307,7 @@
         "intensity": "high",
 		"interactions": [
             "m_c pulls r_c aside and reminds {PRONOUN/r_c/object} {PRONOUN/m_c/subject} could easily exile {PRONOUN/r_c/object}.",
-            "m_c scolded r_c for not doing the hard task {PRONOUN/m_c/subject} assigned {PRONOUN/r_c/object} knowing it was a job for more then one cat.",
+            "m_c scolded r_c for not doing the hard task {PRONOUN/m_c/subject} assigned {PRONOUN/r_c/object} despite knowing it was a job for more then one cat.",
 			"m_c gives r_c a particularly hard task, expecting {PRONOUN/r_c/object} to fail.",
 			"m_c threatens r_c with never passing {PRONOUN/r_c/poss} assessment!"
 		],

--- a/resources/dicts/relationship_events/normal_interactions/dislike/increase.json
+++ b/resources/dicts/relationship_events/normal_interactions/dislike/increase.json
@@ -157,7 +157,7 @@
 			"r_c is asking m_c to tell {PRONOUN/r_c/object} about how good {PRONOUN/r_c/subject} {VERB/m_c/look/looks}.",
 			"r_c offends m_c with {PRONOUN/r_c/poss} brutal honesty.",
 			"r_c is boasting about {PRONOUN/r_c/poss} accomplishments to m_c, but m_c isn't impressed.",
-			"r_c gets really close to m_c's face while talking and grosses m_c out with {PRONOUN/r_c/poss} bad breath.",
+			"r_c gets really close to m_c's face while talking and grosses m_c out with {PRONOUN/r_c/poss} fox breath.",
 			"r_c doesn't understand why m_c lied to save a cats feelings."
 		],
 		"random_trait_constraint": [

--- a/resources/dicts/relationship_events/normal_interactions/jealousy/decrease.json
+++ b/resources/dicts/relationship_events/normal_interactions/jealousy/decrease.json
@@ -3,19 +3,22 @@
 		"id": "jel_de_low1",
 		"intensity": "low",
 		"interactions": [
-			"m_c thinks r_c is very helpful!"
+			"m_c thinks r_c is very helpful!",
+			"m_c offers to help r_c."
 		]
 	},
 	{
 		"id": "jel_de_med1",
 		"interactions": [
-			"m_c surprises r_c with something nice."
+			"m_c surprises r_c with something nice.",
+			"m_c was given a gift but gave it to r_c knowing {PRONOUN/r_c/subject} would like it more."
 		]
 	},
 	{
 		"id": "jel_de_med2",
 		"interactions": [
-			"m_c swaps favorite prey with r_c."
+			"m_c swaps favorite prey with r_c.",
+			"m_c offers r_c a piece of fresh kill they both like."
 		],
 		"reaction_random_cat": {
 			"jealousy": "decrease"
@@ -24,7 +27,8 @@
 	{
 		"id": "jel_de_med3",
 		"interactions": [
-			"m_c always thought r_c had it all figured out, so {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} surprised when r_c asks for help."
+			"m_c always thought r_c had it all figured out, so {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} surprised when r_c asks for help.",
+			"m_c catches r_c in a moment of weakness and offers support."
 		],
 		"main_status_constraint": [
 			"kitten",
@@ -45,7 +49,8 @@
 		"id": "jealousy_app_de_med1",
 		"interactions": [
 			"m_c has been listening to r_c talk about how hard training has been.",
-			"m_c comforts r_c after a hard day's training."
+			"m_c comforts r_c after a hard day's training.",
+			"m_c watches r_c train and acknowledges {PRONOUN/r_c/poss} effort."
 		],
 		"main_status_constraint": [
 			"apprentice",
@@ -69,7 +74,8 @@
 		"id": "jealousy_app_de_med2",
 		"interactions": [
 			"m_c has been listening to r_c talk about how difficult herb memorization is.",
-			"m_c helps r_c wash mouse bile off of {PRONOUN/r_c/poss} paws."
+			"m_c helps r_c wash mouse bile off of {PRONOUN/r_c/poss} paws.",
+			"m_c helps r_c sort ragwort."
 		],
 		"main_status_constraint": [
 			"apprentice",

--- a/resources/dicts/relationship_events/normal_interactions/jealousy/increase.json
+++ b/resources/dicts/relationship_events/normal_interactions/jealousy/increase.json
@@ -59,7 +59,7 @@
 		"id": "jel_inc_med4",
 		"interactions": [
 			"m_c is huffing in annoyance seeing that r_c caught more prey than {PRONOUN/m_c/object}.",
-            "During a border patrol, an o_c patrol stopped them and chatted up a storm with r_c but more or less ignored m_c...",
+            "During a border patrol, an o_c patrol stopped them and chatted up a storm with r_c, but more or less ignored m_c...",
             "m_c feels like r_c is always trying to catch more prey then {PRONOUN/m_c/object}."
 		],
         "main_status_constraint": [

--- a/resources/dicts/relationship_events/normal_interactions/jealousy/increase.json
+++ b/resources/dicts/relationship_events/normal_interactions/jealousy/increase.json
@@ -3,13 +3,15 @@
 		"id": "jel_inc_low1",
 		"intensity": "low",
 		"interactions": [
-			"m_c wishes {PRONOUN/m_c/subject} could get {PRONOUN/m_c/poss} pelt to shine like r_c's."
+			"m_c wishes {PRONOUN/m_c/subject} could get {PRONOUN/m_c/poss} pelt to shine like r_c's.",
+			"m_c wishes {PRONOUN/m_c/poss} claws looked as nice as r_c's."
 		]
 	},
 	{
 		"id": "jel_inc_med1",
 		"interactions": [
-			"m_c thinks the prey r_c is biting into on the other side of camp looks delicious."
+			"m_c thinks the prey r_c is biting into on the other side of camp looks delicious.",
+			 "m_c wishes {PRONOUN/m_c/subject} had it as easy as r_c did."
 		]
 	},
 	{
@@ -54,6 +56,40 @@
 		]
 	},
 	{
+		"id": "jel_inc_med4",
+		"interactions": [
+			"m_c is huffing in annoyance seeing that r_c caught more prey then {PRONOUN/m_c/object}.",
+            "During a border patrol, an o_c patrol stopped them and chatted up a storm with r_c but more or less ignored m_c...",
+            "m_c feels like r_c is always trying to catch more prey then {PRONOUN/m_c/object}."
+		],
+        "main_status_constraint": [
+			"warrior",
+            "apprentice",
+            "deputy",
+            "leader"
+		],
+		"random_status_constraint": [
+			"apprentice",
+			"warrior",
+			"deputy",
+            "leader"
+		]
+	},
+	{
+		"id": "jel_inc_med5",
+		"interactions": [
+			"m_c has been giving r_c the cold shoulder after seeing {PRONOUN/r_c/object} having fun with another cat.",
+            "m_c doesn't like the idea of r_c having a mate that isn't {PRONOUN/m_c/object}.",
+            "m_c has been trying to monopolize r_c's time after seeing {PRONOUN/r_c/object} showing interest in spending time with another cat."
+		],
+        "relationship_constraint": [
+			"romantic_15"
+		],
+        "reaction_main_cat": {
+			"jealousy": "increase"
+		}
+	},
+	{
 		"id": "jealousy_kit_inc_med1",
 		"interactions": [
 			"m_c is jealous that r_c is getting more attention than {PRONOUN/m_c/object}.",
@@ -69,7 +105,9 @@
 	{
 		"id": "jealousy_kit_inc_med2",
 		"interactions": [
-			"m_c hisses at r_c for getting a bigger piece of prey."
+			"m_c hisses at r_c for getting a bigger piece of prey.",
+			"m_c is upset that r_c always wins in their games.",
+            "m_c whines and cries when r_c gets more attention then {PRONOUN/m_c/subject}."
 		],
 		"main_status_constraint": [
 			"kitten"
@@ -85,7 +123,9 @@
 		"id": "jealousy_kit_inc_med3",
 		"interactions": [
 			"m_c looks at r_c and remembers how easy it was to be a kitten.",
-			"m_c is resentful that so much is expected of {PRONOUN/m_c/object}, yet no one expects anything of r_c."
+			"m_c is resentful that so much is expected of {PRONOUN/m_c/object}, yet no one expects anything of r_c.",
+			"m_c watches r_c wondering why {PRONOUN/m_c/subject} wanted to grow up so bad.",
+            "m_c wishes {PRONOUN/m_c/subject} had all the time in the world to play mossball like r_c."
 		],
 		"main_status_constraint": [
 			"apprentice",
@@ -99,12 +139,14 @@
 			"platonic": "decrease"
 		}
 	},
+
 	{
 		"id": "jel_inc_high1",
 		"intensity": "high",
 		"interactions": [
 			"m_c is jealous that r_c gets to do cool super secret medicine cat things.",
-			"m_c thinks it's unfair that r_c always gets to go to Gatherings."
+			"m_c thinks it's unfair that r_c always gets to go to Gatherings.",
+			"m_c is jealous that r_c always smells of beautiful fragrant herbs."
 		],
 		"main_status_constraint": [
 			"apprentice",
@@ -118,7 +160,9 @@
 		"id": "jel_inc_high2",
 		"intensity": "high",
 		"interactions": [
-			"m_c is complaining that r_c never does anything helpful."
+			"m_c is complaining that r_c never does anything helpful.",
+			"m_c keeps comparing {PRONOUN/m_c/self} to r_c.",
+            "m_c hates how r_c has been getting lots of attention as of late."
 		]
 	},
 	{
@@ -130,5 +174,23 @@
 		"random_status_constraint": [
 			"elder"
 		]
+	},
+	{
+		"id": "jel_inc_med4",
+		"intensity": "high",
+		"interactions": [
+            "m_c watches r_c in annoyance wishing {PRONOUN/m_c/subject} were as youthful as {PRONOUN/r_c/object}."
+		],
+		"main_status_constraint": [
+			"elder"
+		],
+        "random_status_constraint": [
+            "kitten",
+            "apprentice",
+            "medicine cat apprentice",
+            "mediator apprentice",
+            "deputy",
+            "warrior"
+            ]
 	}
 ]

--- a/resources/dicts/relationship_events/normal_interactions/jealousy/increase.json
+++ b/resources/dicts/relationship_events/normal_interactions/jealousy/increase.json
@@ -60,7 +60,7 @@
 		"interactions": [
 			"m_c is huffing in annoyance seeing that r_c caught more prey than {PRONOUN/m_c/object}.",
             "During a border patrol, an o_c patrol stopped them and chatted up a storm with r_c, but more or less ignored m_c...",
-            "m_c feels like r_c is always trying to catch more prey then {PRONOUN/m_c/object}."
+            "m_c feels like r_c is always trying to catch more prey than {PRONOUN/m_c/object}."
 		],
         "main_status_constraint": [
 			"warrior",

--- a/resources/dicts/relationship_events/normal_interactions/jealousy/increase.json
+++ b/resources/dicts/relationship_events/normal_interactions/jealousy/increase.json
@@ -107,7 +107,7 @@
 		"interactions": [
 			"m_c hisses at r_c for getting a bigger piece of prey.",
 			"m_c is upset that r_c always wins in their games.",
-            "m_c whines and cries when r_c gets more attention then {PRONOUN/m_c/subject}."
+            "m_c whines and cries when r_c gets more attention than {PRONOUN/m_c/subject}."
 		],
 		"main_status_constraint": [
 			"kitten"

--- a/resources/dicts/relationship_events/normal_interactions/jealousy/increase.json
+++ b/resources/dicts/relationship_events/normal_interactions/jealousy/increase.json
@@ -124,7 +124,7 @@
 		"interactions": [
 			"m_c looks at r_c and remembers how easy it was to be a kitten.",
 			"m_c is resentful that so much is expected of {PRONOUN/m_c/object}, yet no one expects anything of r_c.",
-			"m_c watches r_c wondering why {PRONOUN/m_c/subject} wanted to grow up so bad.",
+			"m_c watches r_c, wondering why {PRONOUN/m_c/subject} wanted to grow up so bad.",
             "m_c wishes {PRONOUN/m_c/subject} had all the time in the world to play mossball like r_c."
 		],
 		"main_status_constraint": [

--- a/resources/dicts/relationship_events/normal_interactions/jealousy/increase.json
+++ b/resources/dicts/relationship_events/normal_interactions/jealousy/increase.json
@@ -58,7 +58,7 @@
 	{
 		"id": "jel_inc_med4",
 		"interactions": [
-			"m_c is huffing in annoyance seeing that r_c caught more prey then {PRONOUN/m_c/object}.",
+			"m_c is huffing in annoyance seeing that r_c caught more prey than {PRONOUN/m_c/object}.",
             "During a border patrol, an o_c patrol stopped them and chatted up a storm with r_c but more or less ignored m_c...",
             "m_c feels like r_c is always trying to catch more prey then {PRONOUN/m_c/object}."
 		],

--- a/resources/dicts/relationship_events/normal_interactions/neutral.json
+++ b/resources/dicts/relationship_events/normal_interactions/neutral.json
@@ -97,8 +97,11 @@
 			"m_c doesn't notice r_c twitching {PRONOUN/r_c/poss} whiskers at {PRONOUN/m_c/object}."
 		],
 		"main_trait_constraint": [
-		"id": "neutral_interaction8"
+			"oblivious"
 		]
+	},
+	{
+		"id": "neutral_interaction8",
 		"interactions": [
 			"r_c notices m_c sulking around camp again.",
             		"r_c sits quietly by m_c.",

--- a/resources/dicts/relationship_events/normal_interactions/neutral.json
+++ b/resources/dicts/relationship_events/normal_interactions/neutral.json
@@ -4,6 +4,11 @@
 		"interactions": [
 			"m_c saw r_c the other day, but didn't get a chance to meow hello.",
 			"m_c bickered about something trivial with r_c.",
+            		"m_c settles down to eat near r_c.",
+            		"m_c offered some fresh-kill to r_c but {PRONOUN/r_c/subject} {VERB/r_c/weren't/wasn't} hungry",
+            		"m_c watches r_c mill about camp.",
+            		"m_c was so busy {PRONOUN/m_c/subject} didn't have a chance to see r_c.",
+            		"m_c wonders what r_c is up to now.",
 			"m_c nods politely as r_c passes by.",
 			"m_c acknowledges r_c with a twitch of {PRONOUN/m_c/poss} whiskers."
 		]
@@ -25,13 +30,15 @@
 			"mediator apprentice",
 			"medicine cat apprentice",
 			"warrior",
-			"mediator"
+			"mediator",
+            		"mediator apprentice"
 		]
 	},
 	{
 		"id": "neutral_interaction3",
 		"interactions": [
 			"m_c is stuttering while speaking to r_c.",
+            		"r_c listens patiently as m_c talks to {PRONOUN/m_c/object}.",
 			"r_c asks m_c to speak up while chatting together.",
 			"m_c avoids facing r_c directly while talking."
 		],
@@ -49,13 +56,25 @@
 			"confident"
 		]
 	},
-	{
+    {
 		"id": "neutral_interaction5",
 		"interactions": [
-			"m_c challenged r_c to spar with {PRONOUN/m_c/object}."
+			"m_c caught a glimpse of r_c during a patrol.",
+            		"m_c saw r_c stalking some prey on a hunting patrol.",
+            		"m_c and r_c's patrols happened to pass by each other.",
+            		"m_c hears a mouse squeak during a patrol and looks around right on time to spot r_c carrying a fat mouse back toward camp."
 		],
-		"main_trait_constraint": [
-			"bold"
+		"main_status_constraint": [
+			"apprentice",
+            		"warrior",
+            		"deputy",
+            		"leader"
+		],
+		"random_status_constraint": [
+			"apprentice",
+            		"warrior",
+            		"deputy",
+            		"leader"
 		]
 	},
 	{
@@ -73,21 +92,23 @@
 		"id": "neutral_interaction7",
 		"interactions": [
 			"m_c doesn't notice r_c leaving camp.",
+            		"m_c doesn't notice r_c nearly bumping into {PRONOUN/m_c/object}.",
+            		"m_c doesn't notice r_c call out to {PRONOUN/m_c/object}.",
 			"m_c doesn't notice r_c twitching {PRONOUN/r_c/poss} whiskers at {PRONOUN/m_c/object}."
 		],
 		"main_trait_constraint": [
-			"oblivious"
+		"id": "neutral_interaction8"
 		]
-	},
-	{
-		"id": "neutral_interaction8",
 		"interactions": [
 			"r_c notices m_c sulking around camp again.",
+            		"r_c sits quietly by m_c.",
+            		"r_c offers to share tongues with m_c but {PRONOUN/m_c/subject} decline.",
 			"r_c meows hello to m_c, but {PRONOUN/m_c/subject} {VERB/m_c/look/looks} pretty glum still."
 		],
 		"main_trait_constraint": [
 			"gloomy",
-			"lonesome"
+			"lonesome",
+            		"quiet"
 		]
 	},
 	{
@@ -95,12 +116,36 @@
 		"interactions": [
 			"m_c always seems to avoid r_c's attempts at small talk.",
 			"r_c is amused at how m_c manages to look so grumpy all the time.",
-			"m_c avoids running into any cat, but r_c interrupts {PRONOUN/m_c/poss} peaceful silence.",
+            		"m_c pretends not to notice r_c.",
+			"m_c avoids running into any cat, but r_c interrupts {PRONOUN/m_c/poss} peaceful silence with something important.",
 			"m_c stares at r_c with an unreadable expression."
 		],
 		"main_trait_constraint": [
 			"grumpy",
 			"cold"
+		]
+	},
+    {
+		"id": "neutral_interaction10",
+		"interactions": [
+            		"m_c asked r_c to spar with {PRONOUN/m_c/object} but r_c had too much work to do to accept.",
+            		"m_c challenged r_c to spar with {PRONOUN/m_c/object}."
+		],
+		"main_trait_constraint": [
+			"bloodthirsty",
+            		"bold"
+		],
+        "main_status_constraint": [
+			"apprentice",
+			"warrior",
+            		"deputy",
+            		"leader"
+		],
+        "random_status_constraint": [
+			"apprentice",
+			"warrior",
+            		"deputy",
+            		"leader"
 		]
 	}
 ]

--- a/resources/dicts/relationship_events/normal_interactions/platonic/decrease.json
+++ b/resources/dicts/relationship_events/normal_interactions/platonic/decrease.json
@@ -3,7 +3,12 @@
 		"id": "platonic_de_low1",
 		"intensity": "low",
 		"interactions": [
-			"m_c thinks r_c isn't very considerate of others."
+			"m_c thinks r_c isn't very considerate of others.",
+			"m_c avoids r_c.",
+            "m_c noticed something r_c does that annoyed {PRONOUN/m_c/object}.",
+            "r_c splashes m_c as they pass a puddle.",
+            "m_c wasn't paying attention when r_c was talking to {PRONOUN/m_c/object}.",
+            "m_c settled to eat on the opposite side of camp from r_c."
 		]
 	},
 	{
@@ -11,7 +16,9 @@
 		"intensity": "medium",
 		"interactions": [
 			"m_c and r_c have an argument about who should get a pretty feather, and end up destroying it in their fight.",
-			"m_c has drawn the ire of r_c by deliberately taking the last of {PRONOUN/r_c/poss} favorite nesting materials for {PRONOUN/m_c/self}."
+			"m_c has drawn the ire of r_c by deliberately taking the last of {PRONOUN/r_c/poss} favorite nesting materials for {PRONOUN/m_c/self}.",
+			 "m_c rolls {PRONOUN/m_c/poss} eyes at r_c.",
+            "m_c sneered at r_c."
 		],
 		"reaction_random_cat": {
 			"platonic": "decrease"
@@ -19,15 +26,34 @@
 	},
 	{
 		"id": "platonic_de_med1",
-		"intensity": "high",
+		"intensity": "medium",
 		"interactions": [
-			"m_c caught r_c complaining about {PRONOUN/m_c/object} behind {PRONOUN/m_c/poss} back."
+			"m_c caught r_c complaining about {PRONOUN/m_c/object} behind {PRONOUN/m_c/poss} back.",
+			"m_c interrupted r_c when {PRONOUN/r_c/subject} {VERB/r_c/was/were} very busy with an important task, ruining {PRONOUN/r_c/poss} focus.",
+            "m_c realized r_c was only pretending to pay attention to {PRONOUN/m_c/object} when {PRONOUN/m_c/subject} {VERB/m_c/was/were} talking.",
+            "m_c tried to talk to r_c but gave up, seeing how clearly {PRONOUN/r_c/subject} wanted to be doing anything else.",
+            "m_c overheard r_c talking about {PRONOUN/m_c/object}, but when pressed for details, r_c denied mentioning {PRONOUN/m_c/object} at all.",
+            "m_c got up and walked away when m_c sat nearby.",
+            "m_c blatantly ignored r_c.",
+            "Lately, m_c's had some choice words for r_c about how {PRONOUN/m_c/subject}{VERB/m_c/'ve/'s} been acting lately...",
+            "m_c asked another cat to pass a message to r_c rather doing it {PRONOUN/m_c/self}.",
+            "m_c was passive aggressive towards r_c for taking something {PRONOUN/r_c/subject} knew m_c had {PRONOUN/m_c/poss} eye on all day.",
+            "r_c is caught tossing out a gift m_c <i>just</i> gave {PRONOUN/m_c/object}.",
+            "m_c actively avoids r_c any chance {PRONOUN/m_c/subject} get."
 		]
 	},
 	{
 		"id": "platonic_de_med2",
 		"interactions": [
-			"m_c is annoyed that {PRONOUN/m_c/subject} {VERB/m_c/have/has} to pull ticks off of r_c today."
+			"m_c is annoyed that {PRONOUN/m_c/subject} {VERB/m_c/have/has} to pull ticks off of r_c today.",
+			"m_c refreshes r_c's bedding last out of all the elders.",
+            "r_c wanted to thank m_c for doing a good job but m_c seemed irritated the entire time {PRONOUN/m_c/subject} had to be around {PRONOUN/r_c/object}.",
+            "m_c was supposed to pull ticks off r_c but {PRONOUN/m_c/subject} never came to do it leaving {PRONOUN/m_c/object} to itch and itch all day.",
+            "m_c is stuck listening to r_c's complaints.",
+            "r_c swears m_c has been adding less and less bedding to {PRONOUN/r_c/poss} nest recently...",
+            "m_c added r_c's least favorite nesting material to {PRONOUN/r_c/poss} nest.",
+            "m_c hid thorns in r_c's bedding.",
+            "m_c is stuck listening to a boring story r_c is telling."
 		],
 		"main_status_constraint": [
 			"apprentice"
@@ -49,7 +75,8 @@
 	{
 		"id": "platonic_de_med4",
 		"interactions": [
-			"r_c is not backing down in an argument with m_c."
+			"r_c is not backing down in an argument with m_c.",
+            "m_c is picking a fight over something r_c thought was already resolved."
 		],
 		"random_trait_constraint": [
 			"fierce"
@@ -58,7 +85,11 @@
 	{
 		"id": "platonic_de_med5",
 		"interactions": [
-			"m_c scorns r_c for not catching enough prey."
+			"m_c scorns r_c for not catching enough prey.",
+			"r_c criticized m_c's skills.",
+            "m_c can't stand r_c's constant nagging.",
+            "According to r_c, m_c just can't do anything right.",
+            "r_c criticized every single error m_c makes."
 		],
 		"random_trait_constraint": [
 			"strict"
@@ -130,7 +161,8 @@
 		"interactions": [
 			"m_c snarls at r_c for coming too close to the herbs.",
 			"m_c shoos r_c away, not having time for curious little kits.",
-			"m_c tells r_c if {PRONOUN/r_c/subject} {VERB/r_c/don't/doesn't} stay away from the medicine den {PRONOUN/m_c/subject} will feed them nasty tasting herbs!"
+			"m_c tells r_c if {PRONOUN/r_c/subject} {VERB/r_c/don't/doesn't} stay away from the medicine den {PRONOUN/m_c/subject} will feed them nasty tasting herbs!",
+			"r_c scrunches {PRONOUN/r_c/poss} nose at m_c and says {PRONOUN/m_c/subject} smell weird."
 		],
 		"main_status_constraint": [
 			"medicine cat",

--- a/resources/dicts/relationship_events/normal_interactions/platonic/decrease.json
+++ b/resources/dicts/relationship_events/normal_interactions/platonic/decrease.json
@@ -48,7 +48,7 @@
 			"m_c is annoyed that {PRONOUN/m_c/subject} {VERB/m_c/have/has} to pull ticks off of r_c today.",
 			"m_c refreshes r_c's bedding last out of all the elders.",
             "r_c wanted to thank m_c for doing a good job but m_c seemed irritated the entire time {PRONOUN/m_c/subject} had to be around {PRONOUN/r_c/object}.",
-            "m_c was supposed to pull ticks off r_c but {PRONOUN/m_c/subject} never came to do it leaving {PRONOUN/m_c/object} to itch and itch all day.",
+            "m_c was supposed to pull ticks off r_c but {PRONOUN/m_c/subject} never came to do it, leaving {PRONOUN/m_c/object} to itch and itch all day.",
             "m_c is stuck listening to r_c's complaints.",
             "r_c swears m_c has been adding less and less bedding to {PRONOUN/r_c/poss} nest recently...",
             "m_c added r_c's least favorite nesting material to {PRONOUN/r_c/poss} nest.",

--- a/resources/dicts/relationship_events/normal_interactions/platonic/decrease.json
+++ b/resources/dicts/relationship_events/normal_interactions/platonic/decrease.json
@@ -35,7 +35,7 @@
             "m_c overheard r_c talking about {PRONOUN/m_c/object}, but when pressed for details, r_c denied mentioning {PRONOUN/m_c/object} at all.",
             "m_c got up and walked away when m_c sat nearby.",
             "m_c blatantly ignored r_c.",
-            "Lately, m_c's had some choice words for r_c about how {PRONOUN/m_c/subject}{VERB/m_c/'ve/'s} been acting lately...",
+            "Lately, m_c's had some choice words for r_c about how {PRONOUN/m_c/subject}{VERB/m_c/'ve/'s} been acting.",
             "m_c asked another cat to pass a message to r_c rather doing it {PRONOUN/m_c/self}.",
             "m_c was passive aggressive towards r_c for taking something {PRONOUN/r_c/subject} knew m_c had {PRONOUN/m_c/poss} eye on all day.",
             "r_c is caught tossing out a gift m_c <i>just</i> gave {PRONOUN/m_c/object}.",

--- a/resources/dicts/relationship_events/normal_interactions/platonic/increase.json
+++ b/resources/dicts/relationship_events/normal_interactions/platonic/increase.json
@@ -29,7 +29,7 @@
 			"m_c saw r_c the other day and did get a chance to meow hello!",
 			"m_c reminds r_c to grab something from the fresh-kill pile if {PRONOUN/r_c/subject} {VERB/r_c/have/has}n't already.",
 			"m_c is watching the shooting stars with r_c.",
-			"m_c panicked when r_c stumbled down a hill during a walk but when {PRONOUN/r_c/subject} sat up perfectly fine, they both had a laugh at r_c's clumsiness"
+			"m_c panicked when r_c stumbled down a hill during a walk, but when {PRONOUN/r_c/subject} sat up perfectly fine they both had a laugh at r_c's clumsiness"
 		]
 	},
 	{

--- a/resources/dicts/relationship_events/normal_interactions/platonic/increase.json
+++ b/resources/dicts/relationship_events/normal_interactions/platonic/increase.json
@@ -284,7 +284,7 @@
 	{
 		"id": "platonic_inc_med15",
 		"interactions": [
-            "m_c and r_c mplayed around during patrol and got in a bit of trouble, but still returned to camp smiling.",
+            "m_c and r_c played around during patrol and got in a bit of trouble, but still returned to camp smiling.",
             "m_c just barely missed a mouse, but r_c caught it right after, handing it off to {PRONOUN/m_c/object}.",
             "m_c and r_c got so into playing around that they got separated from the rest of the patrol, earning themselves an earful back at camp."
 		],
@@ -636,7 +636,7 @@
 			"m_c considers r_c to be one of {PRONOUN/m_c/poss} closest friends.",
 			"m_c couldn't imagine how boring things would be without a friend like r_c.",
 			"m_c and r_c can't get enough of each others company.",
-            "m_c wonders if {PRONOUN/r_c/subject}{VERB/r_c/'re/'s} r_c's friend in every reality...",
+			"m_c wonders if {PRONOUN/r_c/subject}{VERB/r_c/'re/'s} r_c's friends in every reality...",
             "m_c thinks r_c is the best friend a cat could have."
 		],
 		"relationship_constraint": [
@@ -667,6 +667,7 @@
 			"m_c and r_c are inseparable, and can almost always be found with each other.",
 			"m_c goes to r_c any time {PRONOUN/m_c/subject} have any news to share.",
             "m_c knows r_c better then anyone.",
+			"m_c asks r_c if {PRONOUN/r_c/subject} thinks they're best friends in every universe...",
             "m_c tells r_c that {PRONOUN/m_c/subject} consider {PRONOUN/r_c/object} an invaluable member of the Clan."
 		],
 		"relationship_constraint": [

--- a/resources/dicts/relationship_events/normal_interactions/platonic/increase.json
+++ b/resources/dicts/relationship_events/normal_interactions/platonic/increase.json
@@ -285,7 +285,7 @@
 		"id": "platonic_inc_med15",
 		"interactions": [
             "m_c and r_c mplayed around during patrol and got in a bit of trouble, but still returned to camp smiling.",
-            "m_c just barely missed a mouse but r_c caught it right after, handing it off to {PRONOUN/m_c/object}.",
+            "m_c just barely missed a mouse, but r_c caught it right after, handing it off to {PRONOUN/m_c/object}.",
             "m_c and r_c got so into playing around they got seperated from the rest of the patrol earning themselves an earful back at camp."
 		],
 		"main_status_constraint": [

--- a/resources/dicts/relationship_events/normal_interactions/platonic/increase.json
+++ b/resources/dicts/relationship_events/normal_interactions/platonic/increase.json
@@ -307,7 +307,7 @@
     {
 		"id": "platonic_inc_med16",
 		"interactions": [
-			"m_c shows r_c a secret place {PRONOUN/m_c/subject} like to go to be alone offering to let r_c use it too if {PRONOUN/r_c/subject} need to."
+			"m_c shows r_c a secret place {PRONOUN/m_c/subject} like to go to be alone, offering to let r_c use it too if {PRONOUN/r_c/subject} need to."
 		],
         "main_trait_constraint": [
 			"calm",

--- a/resources/dicts/relationship_events/normal_interactions/platonic/increase.json
+++ b/resources/dicts/relationship_events/normal_interactions/platonic/increase.json
@@ -286,7 +286,7 @@
 		"interactions": [
             "m_c and r_c mplayed around during patrol and got in a bit of trouble, but still returned to camp smiling.",
             "m_c just barely missed a mouse, but r_c caught it right after, handing it off to {PRONOUN/m_c/object}.",
-            "m_c and r_c got so into playing around they got seperated from the rest of the patrol earning themselves an earful back at camp."
+            "m_c and r_c got so into playing around that they got separated from the rest of the patrol, earning themselves an earful back at camp."
 		],
 		"main_status_constraint": [
 			"apprentice",

--- a/resources/dicts/relationship_events/normal_interactions/platonic/increase.json
+++ b/resources/dicts/relationship_events/normal_interactions/platonic/increase.json
@@ -422,7 +422,7 @@
 			"m_c whiskers twitch in amusement as r_c tells {PRONOUN/m_c/object} that {PRONOUN/r_c/subject} {VERB/r_c/hope/hopes} {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} {PRONOUN/r_c/poss} mentor when {PRONOUN/r_c/subject} {VERB/r_c/become/becomes} an apprentice.",
 			"m_c tells r_c that {PRONOUN/m_c/subject} caught this prey just for {PRONOUN/r_c/object} as {PRONOUN/m_c/subject} {VERB/m_c/deliver/delivers} it to {PRONOUN/r_c/object}.",
 			"m_c joins a game as r_c runs up to {PRONOUN/m_c/object} yowling that {PRONOUN/r_c/subject}{VERB/r_c/'re/'s} the greatest warrior ever and could never be defeated. The kit squeals in delight as m_c rolls over in surrender.",
-			"m_c tried scolding r_c for sneaking off but couldn't stay mad at {PRONOUN/r_c/object}.",
+			"m_c tried scolding r_c for sneaking off, but couldn't stay mad at {PRONOUN/r_c/object}.",
             "m_c lets r_c play with {PRONOUN/m_c/poss} tail.",
             "m_c helped r_c find a toy {PRONOUN/r_c/subject} lost.",
             "m_c is impressing r_c with a well practiced bird call."

--- a/resources/dicts/relationship_events/normal_interactions/platonic/increase.json
+++ b/resources/dicts/relationship_events/normal_interactions/platonic/increase.json
@@ -3,7 +3,12 @@
 		"id": "platonic_inc_low1",
 		"intensity": "low",
 		"interactions": [
-			"m_c thinks r_c was nice to {PRONOUN/m_c/object} today."
+			"m_c thinks r_c was nice to {PRONOUN/m_c/object} today.",
+			"m_c nods to r_c in acknowledgement as {PRONOUN/m_c/subject} pass {PRONOUN/r_c/object}.",
+            "m_c and r_c sunbathed together.",
+            "m_c stopped r_c to pick a stray leaf out of {PRONOUN/r_c/poss} fur {PRONOUN/r_c/subject} hadn't noticed.",
+            "m_c and r_c had a chat and realized they had the same favorite nesting material.",
+            "r_c splashes m_c as {PRONOUN/m_c/subject} pass a puddle."
 		]
 	},
 	{
@@ -11,7 +16,8 @@
 		"intensity": "low",
 		"interactions": [
 			"m_c is talking with r_c.",
-			"m_c asks r_c how {PRONOUN/r_c/subject}{VERB/r_c/'re/'s} doing."
+			"m_c asks r_c how {PRONOUN/r_c/subject}{VERB/r_c/'re/'s} doing.",
+			"m_c nods to r_c as they eat prey near each other."
 		],
 		"reaction_random_cat": {
 			"platonic": "increase"
@@ -21,7 +27,9 @@
 		"id": "platonic_inc_med1",
 		"interactions": [
 			"m_c saw r_c the other day and did get a chance to meow hello!",
-			"m_c reminds r_c to grab something from the fresh-kill pile if {PRONOUN/r_c/subject} {VERB/r_c/have/has}n't already."
+			"m_c reminds r_c to grab something from the fresh-kill pile if {PRONOUN/r_c/subject} {VERB/r_c/have/has}n't already.",
+			"m_c is watching the shooting stars with r_c.",
+			"m_c panicked when r_c stumbled down a hill during a walk but when {PRONOUN/r_c/subject} sat up perfectly fine, they both had a laugh at r_c's clumsiness"
 		]
 	},
 	{
@@ -29,7 +37,8 @@
 		"interactions": [
 			"m_c is telling a story to r_c.",
 			"m_c is sharing prey with r_c.",
-			"m_c chats with r_c while grabbing something to eat."
+			"m_c chats with r_c while grabbing something to eat.",
+			"m_c snuck some of r_c's favorite nesting material into {PRONOUN/r_c/poss} nest."
 		],
 		"reaction_random_cat": {
 			"platonic": "increase"
@@ -40,7 +49,12 @@
 		"interactions": [
 			"m_c waves to r_c with {PRONOUN/m_c/poss} tail as their patrols cross paths on the territory.",
 			"m_c calls to r_c to catch {PRONOUN/m_c/object} a fat mouse on {PRONOUN/r_c/poss} next hunting patrol.",
-			"m_c hopes {PRONOUN/m_c/subject} {VERB/m_c/are/is} assigned to patrol with r_c tomorrow."
+			"m_c hopes {PRONOUN/m_c/subject} {VERB/m_c/are/is} assigned to patrol with r_c tomorrow.",
+			"m_c and r_c had a great time on patrol together!",
+            "m_c missed a catch during a patrol but r_c cheered {PRONOUN/m_c/object} up.",
+            "m_c surprised r_c with a really cool move during training.",
+            "m_c and r_c were perfectly in sync during training!",
+            "m_c thanks r_c for what {PRONOUN/r_c/subject} {VERB/r_c/do/does} for the Clan."
 		],
 		"main_status_constraint": [
 			"apprentice",
@@ -67,7 +81,9 @@
 			"r_c compliments m_c for {PRONOUN/m_c/poss} good disposition."
 		],
 		"random_trait_constraint": [
-			"charismatic"
+			"charismatic",
+            "flamboyant",
+            "confident"
 		]
 	},
 	{
@@ -78,16 +94,24 @@
 			"r_c is soothing m_c's irrational thoughts."
 		],
 		"random_trait_constraint": [
-			"calm"
+			"calm",
+            "compassionate",
+            "sincere",
+            "quiet"
 		]
 	},
 	{
 		"id": "platonic_inc_med6",
 		"interactions": [
-			"r_c challenges m_c to a race."
+			"r_c challenges m_c to a race.",
+			"m_c dared r_c to eat a strange looking bug."
 		],
 		"random_trait_constraint": [
-			"daring"
+			"daring",
+            "childish",
+            "playful",
+            "troublesome",
+            "bullying"
 		]
 	},
 	{
@@ -98,24 +122,33 @@
 			"r_c is purring loudly to comfort m_c."
 		],
 		"random_trait_constraint": [
-			"loving"
+			"loving",
+            "compassionate",
+            "sincere",
+            "sweet"
 		]
 	},
 	{
 		"id": "platonic_inc_med8",
 		"interactions": [
 			"r_c is playing tag with m_c.",
-			"r_c bats a bit of fluff in front of m_c and gets {PRONOUN/m_c/object} to play a game."
+			"r_c bats a bit of fluff in front of m_c and gets {PRONOUN/m_c/object} to play a game.",
+			"m_c and r_c pull a prank together.",
+			 "m_c and r_c are making faces at each other across camp and laughing."
 		],
 		"random_trait_constraint": [
-			"playful"
+			"playful",
+			"childish",
+            "troublesome"
 		]
 	},
 	{
 		"id": "platonic_inc_med9",
 		"interactions": [
 			"m_c feels bad that {PRONOUN/m_c/subject} caused a problem for r_c.",
-			"m_c convinces r_c to help {PRONOUN/m_c/object} pull a prank on a Clanmate."
+			"m_c convinces r_c to help {PRONOUN/m_c/object} pull a prank on a Clanmate.",
+			 "m_c made sure not to cause any trouble for r_c.",
+            "m_c pulled a prank on r_c {PRONOUN/m_c/subject} knew {PRONOUN/r_c/subject} would like."
 		],
 		"main_trait_constraint": [
 			"troublesome"
@@ -131,23 +164,51 @@
 			"m_c wants to sneak along the border with r_c.",
 			"m_c tells r_c that there's so much to see in the world!"
 		],
+		"main_status_constraint": [
+            "apprentice",
+            "medicine cat apprentice",
+            "mediator apprentice",
+            "warrior",
+            "medicine cat",
+            "mediator",
+            "deputy",
+            "leader",
+            "elder"
+        ],
 		"main_trait_constraint": [
-			"adventurous"
+			"adventurous",
+            "ambitious",
+            "flamboyant",
+            "arrogant",
+            "bold",
+            "confident",
+            "daring",
+            "rebellious",
+            "sneaky"
 		]
 	},
 	{
-		"id": "platonic_inc_med10",
+		"id": "platonic_inc_med11",
 		"interactions": [
-			"m_c is hiding behind a bush ready to pounce on r_c."
+			"m_c is hiding behind a bush ready to pounce on r_c.",
+			"m_c laughed as a childish joke r_c made.",
+            "m_c and r_c are making faces at each other across camp and laughing."
 		],
 		"random_trait_constraint": [
-			"childish"
+			"childish",
+            "playful",
+            "troublesome",
+            "bouncy"
 		]
 	},
 	{
-		"id": "platonic_inc_med4",
+		"id": "platonic_inc_med12",
 		"interactions": [
-			"m_c wants to explore the whole territory with r_c!"
+			"m_c wants to explore the whole territory with r_c!",
+			"m_c is having a wonderful time discussing recent Clan news with r_c.",
+			"m_c is happy to have a chance to chat with r_c.",
+            "m_c playfully teased r_c about {PRONOUN/r_c/poss} love life.",
+            "m_c wants to be an even better friend to r_c."
 		],
 		"relationship_constraint": [
 			"platonic_40"
@@ -176,6 +237,98 @@
 		]
 	},
 	{
+		"id": "platonic_inc_med13",
+		"interactions": [
+			"m_c, after seeing r_c down in the dumps on the other side of camp, bounded over and started messing around trying to cheer {PRONOUN/r_c/object} up."
+		],
+		"main_trait_constraint": [
+			"troublesome",
+            "arrogant",
+            "childish",
+            "competitive",
+            "daring",
+            "fierce",
+            "flamboyant",
+            "playful",
+            "rebellious",
+            "sincere",
+            "attention-seeker",
+            "bouncy",
+            "impulsive",
+            "sweet"
+		]
+	},
+    {
+		"id": "platonic_inc_med14",
+		"interactions": [
+			"m_c, after seeing r_c down in the dumps on the other side of camp, settled beside {PRONOUN/m_c/object} offering a silent comfort that spoke louder than words."
+		],
+		"random_trait_constraint": [
+		    "calm",
+            "cold",
+            "compassionate",
+            "gloomy",
+            "grumpy",
+            "lonesome",
+            "loving",
+            "loyal",
+            "nervous",
+            "sincere",
+            "thoughtful",
+            "wise",
+            "polite",
+            "quiet",
+            "sweet"
+		]
+	},
+	{
+		"id": "platonic_inc_med15",
+		"interactions": [
+            "m_c and r_c mplayed around during patrol and got in a bit of trouble but still returned to camp smiling.",
+            "m_c just barely missed a mouse but r_c caught it right after, handing it off to {PRONOUN/m_c/object}.",
+            "m_c and r_c got so into playing around they got seperated from the rest of the patrol earning themselves an earful back at camp."
+		],
+		"main_status_constraint": [
+			"apprentice",
+			"deputy",
+			"leader",
+			"warrior"
+		],
+		"random_status_constraint": [
+			"apprentice",
+			"deputy",
+			"leader",
+			"warrior"
+		],
+		"also_influences": {
+			"romantic": "increase"
+            }
+	},
+    {
+		"id": "platonic_inc_med16",
+		"interactions": [
+			"m_c shows r_c a secret place {PRONOUN/m_c/subject} like to go to be alone offering to let r_c use it too if {PRONOUN/r_c/subject} need to."
+		],
+        "main_trait_constraint": [
+			"calm",
+            "cold",
+            "grumpy",
+            "thoughtful",
+            "sweet",
+            "lonesome",
+            "quiet",
+            "nervous"
+		],
+		"random_trait_constraint": [
+			"calm",
+            "gloomy",
+            "lonesome",
+            "quiet",
+            "insecure",
+            "nervous"
+		]
+	},
+	{
 		"id": "platonic_to_app_inc_med1",
 		"interactions": [
 			"m_c noticed that r_c is falling behind in training and offered to help {PRONOUN/r_c/object} catch up."
@@ -196,7 +349,10 @@
 	{
 		"id": "platonic_kit_inc_med1",
 		"interactions": [
-			"m_c plays moss-ball with r_c."
+			"m_c plays moss-ball with r_c.",
+			"m_c proudly brought r_c a flower {PRONOUN/m_c/subject} found.",
+			"m_c decorates {PRONOUN/m_c/poss} nest with gifts that r_c brought {PRONOUN/m_c/object}.",
+            "m_c took a nap with r_c."
 		],
 		"reaction_random_cat": {
 			"platonic": "increase"
@@ -206,14 +362,18 @@
 		]
 	},
 	{
-		"id": "platonic_kit_inc_med3",
+		"id": "platonic_kit_inc_med2",
 		"interactions": [
 			"m_c lets r_c play with {PRONOUN/m_c/poss} favorite toy.",
 			"m_c pretends to be a warrior with r_c.",
 			"m_c is pretending to ward off foxes with r_c.",
 			"m_c is pretending to fight off badgers with r_c.",
 			"m_c is racing r_c back and forth across the camp clearing.",
-			"m_c hopes r_c will be {PRONOUN/m_c/poss} friend forever."
+			"m_c hopes r_c will be {PRONOUN/m_c/poss} friend forever.",
+			"m_c let r_c win a game of mossball.",
+            "m_c and r_c are gagging at the idea of having mates when they grow up.",
+            "m_c and r_c are seeing which one of them makes the best bird impression.",
+            "m_c and r_c are trying to master how to croak like a frog together."
 		],
 		"main_status_constraint": [
 			"kitten"
@@ -229,32 +389,10 @@
 		}
 	},
 	{
-		"id": "platonic_kit_inc_med4",
+		"id": "platonic_kit_inc_med3",
 		"interactions": [
-			"m_c decorates {PRONOUN/m_c/poss} nest with gifts that r_c brought {PRONOUN/m_c/object}."
-		],
-		"main_status_constraint": [
-			"kitten"
-		],
-		"random_status_constraint": [
-			"elder",
-			"apprentice",
-			"warrior",
-			"mediator apprentice",
-			"mediator",
-			"medicine cat apprentice",
-			"medicine cat",
-			"deputy",
-			"leader"
-		],
-		"reaction_random_cat": {
-			"platonic": "increase"
-		}
-	},
-	{
-		"id": "platonic_kit_inc_med5",
-		"interactions": [
-			"m_c ask r_c what it's like to be in training."
+			"m_c ask r_c what it's like to be in training.",
+			"m_c begs r_c to show {PRONOUN/m_c/object} {PRONOUN/r_c/poss} moves."
 		],
 		"main_status_constraint": [
 			"kitten"
@@ -269,7 +407,7 @@
 		}
 	},
 	{
-		"id": "platonic_kit_inc_med6",
+		"id": "platonic_kit_inc_med4",
 		"interactions": [
 			"m_c is watching over r_c.",
 			"m_c trains playfully with r_c.",
@@ -283,7 +421,11 @@
 			"m_c purrs as r_c asks {PRONOUN/m_c/object} to show {PRONOUN/r_c/object} how to do a hunter's crouch. {PRONOUN/m_c/subject/CAP} {VERB/m_c/oblige/obliges}, happy to show {PRONOUN/m_c/poss} skills.",
 			"m_c whiskers twitch in amusement as r_c tells {PRONOUN/m_c/object} that {PRONOUN/r_c/subject} {VERB/r_c/hope/hopes} {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} {PRONOUN/r_c/poss} mentor when {PRONOUN/r_c/subject} {VERB/r_c/become/becomes} an apprentice.",
 			"m_c tells r_c that {PRONOUN/m_c/subject} caught this prey just for {PRONOUN/r_c/object} as {PRONOUN/m_c/subject} {VERB/m_c/deliver/delivers} it to {PRONOUN/r_c/object}.",
-			"m_c joins a game as r_c runs up to {PRONOUN/m_c/object} yowling that {PRONOUN/r_c/subject}{VERB/r_c/'re/'s} the greatest warrior ever and could never be defeated. The kit squeals in delight as m_c rolls over in surrender."
+			"m_c joins a game as r_c runs up to {PRONOUN/m_c/object} yowling that {PRONOUN/r_c/subject}{VERB/r_c/'re/'s} the greatest warrior ever and could never be defeated. The kit squeals in delight as m_c rolls over in surrender.",
+			"m_c tried scolding r_c for sneaking off but couldn't stay mad at {PRONOUN/r_c/object}.",
+            "m_c lets r_c play with {PRONOUN/m_c/poss} tail.",
+            "m_c helped r_c find a toy {PRONOUN/r_c/subject} lost.",
+            "m_c is impressing r_c with a well practiced bird call."
 		],
 		"main_status_constraint": [
 			"elder",
@@ -362,7 +504,11 @@
 			"m_c brings r_c a piece of prey to share after a long day of training.",
 			"m_c offers to help r_c clean out the elder's bedding.",
 			"m_c was playing with r_c and learned a fun new battle move from {PRONOUN/r_c/object}!",
-			"m_c is excitedly trying to guess what {PRONOUN/m_c/poss} and r_c's warrior names will be."
+			"m_c is excitedly trying to guess what {PRONOUN/m_c/poss} and r_c's warrior names will be.",
+			"m_c is thinking up new ways to surprise an enemy with r_c hoping to surprise their mentors next time they train together.",
+            "m_c was playing with r_c and made up some super cool special battle moves!",
+            "m_c is practicing battle cries with r_c.",
+            "m_c offered to help r_c with {PRONOUN/r_c/poss} chores."
 		],
 		"main_status_constraint": [
 			"apprentice"
@@ -381,7 +527,9 @@
 			"m_c feels like training goes by much faster when {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} with r_c.",
 			"m_c is playfully making fun of their mentors with r_c.",
 			"m_c stays awake all night whispering secrets to r_c.",
-			"m_c promises not to tell r_c's mentor that {PRONOUN/r_c/subject}{VERB/r_c/'ve/'s} been sneaking out of camp."
+			"m_c promises not to tell r_c's mentor that {PRONOUN/r_c/subject}{VERB/r_c/'ve/'s} been sneaking out of camp.",
+			"m_c and r_c tried sneaking out of camp without their mentors.",
+            "m_c and r_c successfully snuck out of camp without their mentors."
 		],
 		"relationship_constraint": [
 			"platonic_40"
@@ -400,7 +548,8 @@
 			"m_c playfully teases r_c for having herbs stuck in {PRONOUN/r_c/poss} fur.",
 			"m_c offers to teach r_c some fighting stances if r_c will teach {PRONOUN/m_c/object} about more herbs.",
 			"m_c and r_c spend time together despite their different training schedules.",
-			"m_c begs {PRONOUN/m_c/poss} mentor to let r_c come with for some hunting practice."
+			"m_c begs {PRONOUN/m_c/poss} mentor to let r_c come with for some hunting practice.",
+			"m_c excitedly brings an herb {PRONOUN/m_c/subject} recognized to r_c."
 		],
 		"main_status_constraint": [
 			"apprentice"
@@ -484,8 +633,11 @@
 		"intensity": "high",
 		"interactions": [
 			"m_c thinks about how lucky {PRONOUN/m_c/subject} {VERB/m_c/are/is} to have someone like r_c as a friend.",
-			"m_c considers r_c to be one of {PRONOUN/m_c/poss} close friends.",
-			"m_c couldn't imagine how boring things would be without a friend like r_c."
+			"m_c considers r_c to be one of {PRONOUN/m_c/poss} closest friends.",
+			"m_c couldn't imagine how boring things would be without a friend like r_c.",
+			"m_c and r_c can't get enough of each others company.",
+            "m_c wonders if {PRONOUN/r_c/subject}{VERB/r_c/'re/'s} r_c's friend in every reality...",
+            "m_c thinks r_c is the best friend a cat could have."
 		],
 		"relationship_constraint": [
 			"platonic_40"
@@ -512,7 +664,10 @@
 		"interactions": [
 			"m_c can't imagine {PRONOUN/m_c/poss} life if {PRONOUN/m_c/subject} never met r_c.",
 			"m_c thinks of r_c as {PRONOUN/m_c/poss} best friend.",
-			"m_c and r_c are inseparable, and can almost always be found with each other."
+			"m_c and r_c are inseparable, and can almost always be found with each other.",
+			"m_c goes to r_c any time {PRONOUN/m_c/subject} have any news to share.",
+            "m_c knows r_c better then anyone.",
+            "m_c tells r_c that {PRONOUN/m_c/subject} consider {PRONOUN/r_c/object} an invaluable member of the Clan."
 		],
 		"relationship_constraint": [
 			"platonic_60"
@@ -534,6 +689,22 @@
 			"comfortable": "increase",
 			"trust": "increase"
 		}
+	},
+	{
+		"id": "platonic_inc_app",
+		"intensity": "low",
+		"interactions": [
+			"m_c drags r_c out of the medicine cat den saying how looking at herbs all day surely doesn't do good for {PRONOUN/r_c/object}.",
+            "m_c spots r_c gathering herbs during {PRONOUN/m_c/poss} patrol and offers to help since {PRONOUN/m_c/poss} patrol hasn't been very eventful."
+		],
+        "main_status_constraint": [
+            "apprentice",
+            "warrior"
+            ],
+		"random_status_constraint": [
+			"medicine cat apprentice",
+            "medicine cat"
+		]
 	},
 	{
 		"id": "platonic_inc_high_grumpymedcat1",

--- a/resources/dicts/relationship_events/normal_interactions/platonic/increase.json
+++ b/resources/dicts/relationship_events/normal_interactions/platonic/increase.json
@@ -284,7 +284,7 @@
 	{
 		"id": "platonic_inc_med15",
 		"interactions": [
-            "m_c and r_c mplayed around during patrol and got in a bit of trouble but still returned to camp smiling.",
+            "m_c and r_c mplayed around during patrol and got in a bit of trouble, but still returned to camp smiling.",
             "m_c just barely missed a mouse but r_c caught it right after, handing it off to {PRONOUN/m_c/object}.",
             "m_c and r_c got so into playing around they got seperated from the rest of the patrol earning themselves an earful back at camp."
 		],

--- a/resources/dicts/relationship_events/normal_interactions/platonic/increase.json
+++ b/resources/dicts/relationship_events/normal_interactions/platonic/increase.json
@@ -148,7 +148,7 @@
 			"m_c feels bad that {PRONOUN/m_c/subject} caused a problem for r_c.",
 			"m_c convinces r_c to help {PRONOUN/m_c/object} pull a prank on a Clanmate.",
 			 "m_c made sure not to cause any trouble for r_c.",
-            "m_c pulled a prank on r_c {PRONOUN/m_c/subject} knew {PRONOUN/r_c/subject} would like."
+            "m_c pulled a prank on r_c that {PRONOUN/m_c/subject} knew r_c would appreciate."
 		],
 		"main_trait_constraint": [
 			"troublesome"

--- a/resources/dicts/relationship_events/normal_interactions/platonic/increase.json
+++ b/resources/dicts/relationship_events/normal_interactions/platonic/increase.json
@@ -239,7 +239,7 @@
 	{
 		"id": "platonic_inc_med13",
 		"interactions": [
-			"m_c, after seeing r_c down in the dumps on the other side of camp, bounded over and started messing around trying to cheer {PRONOUN/r_c/object} up."
+			"m_c, after seeing r_c down in the dumps on the other side of camp, bounded over and started messing around to try and cheer {PRONOUN/r_c/object} up."
 		],
 		"main_trait_constraint": [
 			"troublesome",

--- a/resources/dicts/relationship_events/normal_interactions/platonic/increase.json
+++ b/resources/dicts/relationship_events/normal_interactions/platonic/increase.json
@@ -694,7 +694,7 @@
 		"id": "platonic_inc_app",
 		"intensity": "low",
 		"interactions": [
-			"m_c drags r_c out of the medicine cat den saying how looking at herbs all day surely doesn't do good for {PRONOUN/r_c/object}.",
+			"m_c drags r_c out of the medicine cat den, saying that looking at herbs all day surely isn't good for {PRONOUN/r_c/object}.",
             "m_c spots r_c gathering herbs during {PRONOUN/m_c/poss} patrol and offers to help since {PRONOUN/m_c/poss} patrol hasn't been very eventful."
 		],
         "main_status_constraint": [

--- a/resources/dicts/relationship_events/normal_interactions/platonic/increase.json
+++ b/resources/dicts/relationship_events/normal_interactions/platonic/increase.json
@@ -505,7 +505,7 @@
 			"m_c offers to help r_c clean out the elder's bedding.",
 			"m_c was playing with r_c and learned a fun new battle move from {PRONOUN/r_c/object}!",
 			"m_c is excitedly trying to guess what {PRONOUN/m_c/poss} and r_c's warrior names will be.",
-			"m_c is thinking up new ways to surprise an enemy with r_c hoping to surprise their mentors next time they train together.",
+			"m_c is thinking up new ways to surprise an enemy with r_c, hoping to surprise their mentors next time they train together.",
             "m_c was playing with r_c and made up some super cool special battle moves!",
             "m_c is practicing battle cries with r_c.",
             "m_c offered to help r_c with {PRONOUN/r_c/poss} chores."

--- a/resources/dicts/relationship_events/normal_interactions/romantic/decrease.json
+++ b/resources/dicts/relationship_events/normal_interactions/romantic/decrease.json
@@ -29,7 +29,8 @@
 		"interactions": [
 			"m_c told r_c to stop padding after {PRONOUN/m_c/object} like a lost kit.",
 			"m_c worries that r_c isn't being honest with their relationship.",
-			"m_c can't stand r_c's snoring in {PRONOUN/r_c/poss} nest."
+			"m_c can't stand r_c's snoring in {PRONOUN/r_c/poss} nest.",
+			"m_c tried flirting with r_c but {PRONOUN/r_c/subject} didn't have time for it and brushed m_c aside."
 		],
 		"relationship_constraint": [
 			"romantic_40",
@@ -45,7 +46,8 @@
 			"m_c worries that r_c will never feel the same way {PRONOUN/m_c/subject} {VERB/m_c/do/does}.",
 			"m_c noticed r_c flirting with someone else.",
 			"m_c heard r_c discussing potential mates but {PRONOUN/m_c/poss} name never came up.",
-			"m_c thinks {PRONOUN/m_c/poss} dreams might not come true with r_c."
+			"m_c thinks {PRONOUN/m_c/poss} dreams might not come true with r_c.",
+			"r_c was seen tossing out a gift m_c gave {PRONOUN/r_c/object}."
 		]
 	},
 	{
@@ -53,14 +55,18 @@
 		"intensity": "low",
 		"interactions": [
 			"m_c feels ignored by r_c.",
-			"m_c didn't get the joke r_c was telling."
+			"m_c didn't get the joke r_c was telling.",
+			"m_c and r_c had a conversation where they realized they didn't have much in common.",
+			"m_c didn't realize r_c was flirting with {PRONOUN/m_c/object}."
 		]
 	},
 	{
 		"id": "rom_dec_medium4",
 		"intensity": "medium",
 		"interactions": [
-			"m_c had a disagreement with r_c over kits."
+			"m_c had a disagreement with r_c over kits.",
+			"m_c and r_c had a disagreement on how to raise kits.",
+            "m_c and r_c had a fight over if they would take a new mate if one of them died or went missing."
 		],
 		"relationship_constraint": [
 			"mates"

--- a/resources/dicts/relationship_events/normal_interactions/romantic/decrease.json
+++ b/resources/dicts/relationship_events/normal_interactions/romantic/decrease.json
@@ -29,7 +29,7 @@
 		"interactions": [
 			"m_c told r_c to stop padding after {PRONOUN/m_c/object} like a lost kit.",
 			"m_c worries that r_c isn't being honest with their relationship.",
-			"m_c can't stand r_c's snoring in {PRONOUN/r_c/poss} nest.",
+			"m_c can't stand listening to r_c's snoring in {PRONOUN/r_c/poss} nest.",
 			"m_c tried flirting with r_c but {PRONOUN/r_c/subject} didn't have time for it and brushed m_c aside."
 		],
 		"relationship_constraint": [

--- a/resources/dicts/relationship_events/normal_interactions/romantic/increase.json
+++ b/resources/dicts/relationship_events/normal_interactions/romantic/increase.json
@@ -133,7 +133,7 @@
             "m_c thinks r_c has a beautiful laugh.",
             "m_c took a nap with r_c, happy to be able to spend this time with {PRONOUN/r_c/object}.",
             "m_c urges r_c to take a break. {PRONOUN/m_c/subject/cap} don't want to see r_c overworking {PRONOUN/r_c/self}.",
-            "m_c saw r_c in pain and was surprised how much it hurt {PRONOUN/m_c/subject} seeing r_c like that.",
+            "m_c saw r_c in pain and was surprised how much it hurt {PRONOUN/m_c/subject} to see r_c like that.",
             "m_c talked generally about the idea of mates with r_c.",
             "m_c realizes {PRONOUN/m_c/poss} chest hurts when {PRONOUN/m_c/subject} see r_c in pain or upset...",
             "m_c realizes {PRONOUN/m_c/subject} {VERB/m_c/have/has} more then just a crush on r_c."

--- a/resources/dicts/relationship_events/normal_interactions/romantic/increase.json
+++ b/resources/dicts/relationship_events/normal_interactions/romantic/increase.json
@@ -321,7 +321,7 @@
 		"interactions": [
 			"m_c purrs for a long time at one of r_c's lame jokes.",
 			"m_c can't stop gushing over r_c.",
-            "m_c came back to camp sulking after failing to catch r_c's favorite prey for {PRONOUN/r_c/object} but {PRONOUN/r_c/subject} didn't seem to care, nuzzling into {PRONOUN/m_c/poss} neck, {PRONOUN/r_c/subject} were just happy m_c was back.",
+            "m_c came back to camp sulking after failing to catch r_c's favorite prey for {PRONOUN/r_c/object} but {PRONOUN/r_c/subject} didn't seem to care, nuzzling into m_c's neck, {PRONOUN/r_c/subject} were just happy m_c was back.",
             "m_c goes out of {PRONOUN/m_c/poss} way to catch r_c {PRONOUN/r_c/poss} favorite prey."
 		],
 		"relationship_constraint": [

--- a/resources/dicts/relationship_events/normal_interactions/romantic/increase.json
+++ b/resources/dicts/relationship_events/normal_interactions/romantic/increase.json
@@ -172,7 +172,7 @@
 			"m_c wants to improve {PRONOUN/m_c/self} for r_c.",
             "m_c and r_c talked about the idea of their ideal mates and noticed each other having a few of those qualities...",
             "m_c can't imagine any cat other then r_c as {PRONOUN/m_c/poss} mate.",
-            "m_c can't stop purring remembering r_c's laugh."
+            "m_c can't stop purring when {PRONOUN/m_c/subject} remember r_c's laugh."
 		],
 		"relationship_constraint": [
 			"romantic_40",

--- a/resources/dicts/relationship_events/normal_interactions/romantic/increase.json
+++ b/resources/dicts/relationship_events/normal_interactions/romantic/increase.json
@@ -136,7 +136,7 @@
             "m_c saw r_c in pain and was surprised how much it hurt {PRONOUN/m_c/subject} to see r_c like that.",
             "m_c talked generally about the idea of mates with r_c.",
             "m_c realizes {PRONOUN/m_c/poss} chest hurts when {PRONOUN/m_c/subject} see r_c in pain or upset...",
-            "m_c realizes {PRONOUN/m_c/subject} {VERB/m_c/have/has} more then just a crush on r_c."
+            "m_c realizes {PRONOUN/m_c/subject} {VERB/m_c/have/has} more than just a crush on r_c."
 		],
 		"relationship_constraint": [
 			"romantic_20",

--- a/resources/dicts/relationship_events/normal_interactions/romantic/increase.json
+++ b/resources/dicts/relationship_events/normal_interactions/romantic/increase.json
@@ -338,7 +338,7 @@
 		"id": "rom_inc_high6",
 		"intensity": "high",
 		"interactions": [
-			"m_c takes r_c out to look at the stars and explaining the constellations to {PRONOUN/r_c/object}.",
+			"m_c takes r_c out to look at the stars and explains the constellations to {PRONOUN/r_c/object}.",
             "m_c tells r_c romantic stories of old."
 		],
 		"main_trait_constraint": [

--- a/resources/dicts/relationship_events/normal_interactions/romantic/increase.json
+++ b/resources/dicts/relationship_events/normal_interactions/romantic/increase.json
@@ -171,7 +171,7 @@
 			"m_c would give it all to make r_c's dreams come true.",
 			"m_c wants to improve {PRONOUN/m_c/self} for r_c.",
             "m_c and r_c talked about the idea of their ideal mates and noticed each other having a few of those qualities...",
-            "m_c can't imagine any cat other then r_c as {PRONOUN/m_c/poss} mate.",
+            "m_c can't imagine any cat other than r_c as {PRONOUN/m_c/poss} mate.",
             "m_c can't stop purring when {PRONOUN/m_c/subject} remember r_c's laugh."
 		],
 		"relationship_constraint": [

--- a/resources/dicts/relationship_events/normal_interactions/romantic/increase.json
+++ b/resources/dicts/relationship_events/normal_interactions/romantic/increase.json
@@ -5,7 +5,8 @@
 		"interactions": [
 			"m_c is developing a crush on r_c.",
 			"m_c might be reading a little too far into r_c's kindness.",
-			"m_c never realized how much {PRONOUN/m_c/subject} {VERB/m_c/love/loves} spending time with r_c."
+			"m_c never realized how much {PRONOUN/m_c/subject} {VERB/m_c/love/loves} spending time with r_c.",
+			"m_c can't help but smile seeing r_c smile."
 		],
 		"relationship_constraint": [
 			"not_mates",
@@ -18,7 +19,11 @@
 		"interactions": [
 			"m_c is admiring r_c from afar...",
 			"m_c stayed up all night thinking of ways to impress r_c.",
-			"m_c thinks r_c is really funny."
+			"m_c thinks r_c is really funny.",
+			"m_c had a dream about r_c.",
+            "m_c thinks r_c has very soft fur.",
+            "m_c and r_c sunbathe together.",
+            "m_c and r_c take a nap together."
 		]
 	},
 	{
@@ -35,7 +40,8 @@
 		"id": "rom_inc_low4",
 		"intensity": "low",
 		"interactions": [
-			"m_c just noticed how beautiful r_c's eyes are."
+			"m_c just noticed how beautiful r_c's eyes are.",
+			"m_c can't help but admire r_c's pelt."
 		],
 		"relationship_constraint": [
 			"not_mates"
@@ -45,10 +51,13 @@
 		"id": "rom_inc_low5",
 		"intensity": "low",
 		"interactions": [
-			"m_c thinks r_c is really charming."
+			"m_c thinks r_c is really charming.",
+			"m_c can't help but smile when around r_c."
 		],
 		"random_trait_constraint": [
-			"charming"
+			"charming",
+            "charismatic",
+            "flamboyant"
 		]
 	},
 	{
@@ -57,7 +66,8 @@
 		"interactions": [
 			"m_c laughs at bad jokes from r_c.",
 			"m_c made r_c laugh again and again.",
-			"m_c goes for a nice long walk with r_c."
+			"m_c goes for a nice long walk with r_c.",
+			"m_c nuzzles against r_c and purrs."
 		],
 		"reaction_random_cat": {
 			"dislike": "decrease",
@@ -69,10 +79,14 @@
 		"id": "rom_inc_medium2",
 		"intensity": "medium",
 		"interactions": [
-			"m_c ensnares r_c with a charming smile."
+			"m_c ensnares r_c with a charming smile.",
+			"m_c knows exactly what to say to make r_c blush.",
+            		"m_c charms r_c with endless compliments."
 		],
 		"main_trait_constraint": [
-			"charming"
+			"charming",
+            "flamboyant",
+            "charismatic"
 		],
 		"reaction_random_cat": {
 			"romantic": "increase",
@@ -85,7 +99,8 @@
 		"intensity": "medium",
 		"interactions": [
 			"m_c is hoping that r_c notices {PRONOUN/m_c/object}.",
-			"m_c wonders what r_c thinks about mates."
+			"m_c wonders what r_c thinks about mates.",
+			"m_c hopes r_c likes {PRONOUN/m_c/object} as much as {PRONOUN/m_c/subject} like r_c."
 		],
 		"relationship_constraint": [
 			"not_mates",
@@ -109,7 +124,19 @@
 			"m_c gets flustered when r_c compliments {PRONOUN/m_c/poss} skill.",
 			"m_c feels {PRONOUN/m_c/poss} jaw drop when the sun catches just right on r_c's pelt.",
 			"m_c immediately thinks of r_c when the topic of mates is brought up.",
-			"m_c is nervous sitting next to r_c at the Clan meeting."
+			"m_c is nervous sitting next to r_c at the Clan meeting.",
+			"m_c and r_c talked about the idea of their ideal mates.",
+            "m_c thinks r_c has a beautiful smile.",
+            "m_c and r_c realized they both had similar values when it came to family.", 
+            "m_c promises to protect r_c.",
+            "Rumor around the Clan was that m_c and r_c are seeing each other and while they did clear things up, neither cat seemed to mind...",
+            "m_c thinks r_c has a beautiful laugh.",
+            "m_c took a nap with r_c, happy to be able to spend this time with {PRONOUN/r_c/object}.",
+            "m_c urges r_c to take a break. {PRONOUN/m_c/subject/cap} don't want to see {PRONOUN/r_c/object} overworking {PRONOUN/r_c/self}.",
+            "m_c saw r_c in pain and was surprised how much it hurt {PRONOUN/m_c/subject} seeing r_c like that.",
+            "m_c talked generally about the idea of mates with r_c.",
+            "m_c realizes {PRONOUN/m_c/poss} chest hurt when {PRONOUN/m_c/subject} see r_c in pain or upset...",
+            "m_c realizes {PRONOUN/m_c/subject} {VERB/m_c/have/has} more then just a crush on r_c."
 		],
 		"relationship_constraint": [
 			"romantic_20",
@@ -123,7 +150,8 @@
 			"m_c brushes against r_c while correcting {PRONOUN/r_c/poss} stance and looks away with a purr.",
 			"m_c left a gift in r_c's nest for {PRONOUN/r_c/object} to find.",
 			"m_c picked out the best piece of prey to share with r_c.",
-			"m_c sees r_c stumble while hunting and thinks it's cute."
+			"m_c sees r_c stumble while hunting and thinks it's cute.",
+			"m_c overhears r_c tell another cat {PRONOUN/r_c/subject} kinda {VERB/r_c/like/likes} m_c."
 		],
 		"reaction_random_cat": {
 			"romantic": "increase",
@@ -132,15 +160,19 @@
 		}
 	},
 	{
-		"id": "rom_inc_medium4",
+		"id": "rom_inc_medium6",
 		"intensity": "medium",
 		"interactions": [
-			"m_c wants to confess {PRONOUN/m_c/poss} love to r_c.",
+			"m_c wants, more then anything, to confess {PRONOUN/m_c/poss} love to r_c.",
 			"m_c is wondering what it would be like to grow old with r_c.",
 			"m_c is the first cat that r_c thinks of when {PRONOUN/m_c/subject} {VERB/m_c/get/gets} good news.",
 			"m_c realizes {PRONOUN/m_c/poss} heart always flutters whenever {PRONOUN/m_c/subject} {VERB/m_c/see/sees} r_c.",
 			"m_c feels like no one understands {PRONOUN/m_c/object} the way r_c does.",
-			"m_c would give it all to make r_c's dreams come true."
+			"m_c would give it all to make r_c's dreams come true.",
+			"m_c wants to improve {PRONOUN/m_c/self} for r_c.",
+            "m_c and r_c talked about the idea of their ideal mates and noticed each other having a few of those qualities...",
+            "m_c can't imagine any cat other then r_c as {PRONOUN/m_c/poss} mate.",
+            "m_c can't stop purring remembering r_c's laugh."
 		],
 		"relationship_constraint": [
 			"romantic_40",
@@ -148,18 +180,52 @@
 		]
 	},
 	{
-		"id": "rom_inc_medium4",
+		"id": "rom_inc_medium7",
 		"intensity": "medium",
 		"interactions": [
 			"m_c thinks r_c is the most beautiful cat in the Clan.",
 			"m_c can't stop thinking about r_c.",
 			"m_c feels giddy about getting on the same patrol as r_c.",
 			"m_c wants r_c to understand how crazy {PRONOUN/m_c/subject} {VERB/m_c/are/is} about {PRONOUN/r_c/object}.",
-			"m_c thinks r_c has a lovely sense of humor."
+			"m_c thinks r_c has a lovely sense of humor.",
+			"If you were to ask m_c, no other cat is anywhere near as fun or interesting as r_c.",
+            "m_c had a lovely dream about r_c."
 		],
 		"relationship_constraint": [
 			"romantic_30"
 		]
+	},
+	{
+		"id": "rom_inc_medium8",
+		"intensity": "medium",
+		"interactions": [
+			"m_c wonders why r_c keeps spending time with {PRONOUN/m_c/object} when others usually don't like {PRONOUN/m_c/poss} attitude but {PRONOUN/m_c/subject} won't object.",
+            "r_c offered to groom m_c and despite {PRONOUN/m_c/poss} grumbling, {PRONOUN/m_c/subject} awkwardly accepted."
+		],
+		"main_trait_constraint": [
+			"grumpy",
+            "strict",
+	    "insecure",
+            "arrogant",
+            "vengeful",
+            "righteous",
+            "rebellious",
+            "cold",
+            "gloomy",
+            "fierce",
+            "righteous",
+            "troublesome"
+		],
+        "reaction_random_cat": {
+			"romantic": "increase",
+			"dislike": "decrease",
+			"comfortable": "increase"
+		},
+		"reaction_main_cat": {
+			"romantic": "increase",
+			"dislike": "decrease",
+			"comfortable": "increase"
+		}
 	},
 	{
 		"id": "rom_inc_high1",
@@ -198,7 +264,8 @@
 			"m_c gave a pretty flower {PRONOUN/m_c/subject} found to r_c.",
 			"m_c picks some fragrant flowers for r_c.",
 			"m_c decorates r_c's nest with flowers to surprise {PRONOUN/r_c/object}!",
-			"m_c rolls around in some herbs after hearing r_c likes their smell."
+			"m_c rolls around in some herbs after hearing r_c likes their smell.",
+			"m_c gave r_c a sprig of catmint {PRONOUN/m_c/subject} found."
 		],
 		"reaction_random_cat": {
 			"romantic": "increase",
@@ -231,7 +298,11 @@
 		"intensity": "high",
 		"interactions": [
 			"m_c was caught enjoying a moonlit stroll with r_c last night...",
-			"m_c sneaks out at night to sleep in r_c's nest."
+			"m_c sneaks out at night to sleep in r_c's nest.",
+			"m_c and r_c were heard discussing kits.",
+            "m_c and r_c have been sickeningly lovey-dovey all day.",
+            "m_c and r_c snuck out of camp together.",
+            "m_c promises r_c to always be there to protect {PRONOUN/r_c/object} with {PRONOUN/m_c/poss} life."
 		],
 		"relationship_constraint": [
 			"romantic_40",
@@ -248,10 +319,30 @@
 		"id": "rom_inc_high5",
 		"intensity": "high",
 		"interactions": [
-			"m_c purrs for a long time at one of r_c's lame jokes."
+			"m_c purrs for a long time at one of r_c's lame jokes.",
+			"m_c can't stop gushing over r_c.",
+            "m_c came back to camp sulking after failing to catch r_c's favorite prey for {PRONOUN/r_c/object} but {PRONOUN/r_c/subject} didn't seem to care, nuzzling into {PRONOUN/m_c/poss} neck, {PRONOUN/r_c/subject} were just happy m_c was back.",
+            "m_c goes out of {PRONOUN/m_c/poss} way to catch r_c {PRONOUN/r_c/poss} favorite prey."
 		],
 		"relationship_constraint": [
 			"mates"
+		],
+		"reaction_random_cat": {
+			"romantic": "increase",
+			"dislike": "decrease",
+			"platonic": "increase",
+			"comfortable": "increase"
+		}
+	},
+	{
+		"id": "rom_inc_high6",
+		"intensity": "high",
+		"interactions": [
+			"m_c takes r_c out to look at the stars and explaining the constellations to {PRONOUN/r_c/object}.",
+            "m_c tells r_c romantic stories of old."
+		],
+		"main_trait_constraint": [
+			"wise"
 		],
 		"reaction_random_cat": {
 			"romantic": "increase",

--- a/resources/dicts/relationship_events/normal_interactions/romantic/increase.json
+++ b/resources/dicts/relationship_events/normal_interactions/romantic/increase.json
@@ -132,7 +132,7 @@
             "Rumor around the Clan was that m_c and r_c are seeing each other and, while they did clear things up, neither cat seemed to mind...",
             "m_c thinks r_c has a beautiful laugh.",
             "m_c took a nap with r_c, happy to be able to spend this time with {PRONOUN/r_c/object}.",
-            "m_c urges r_c to take a break. {PRONOUN/m_c/subject/cap} don't want to see {PRONOUN/r_c/object} overworking {PRONOUN/r_c/self}.",
+            "m_c urges r_c to take a break. {PRONOUN/m_c/subject/cap} don't want to see r_c overworking {PRONOUN/r_c/self}.",
             "m_c saw r_c in pain and was surprised how much it hurt {PRONOUN/m_c/subject} seeing r_c like that.",
             "m_c talked generally about the idea of mates with r_c.",
             "m_c realizes {PRONOUN/m_c/poss} chest hurt when {PRONOUN/m_c/subject} see r_c in pain or upset...",

--- a/resources/dicts/relationship_events/normal_interactions/romantic/increase.json
+++ b/resources/dicts/relationship_events/normal_interactions/romantic/increase.json
@@ -135,7 +135,7 @@
             "m_c urges r_c to take a break. {PRONOUN/m_c/subject/cap} don't want to see r_c overworking {PRONOUN/r_c/self}.",
             "m_c saw r_c in pain and was surprised how much it hurt {PRONOUN/m_c/subject} seeing r_c like that.",
             "m_c talked generally about the idea of mates with r_c.",
-            "m_c realizes {PRONOUN/m_c/poss} chest hurt when {PRONOUN/m_c/subject} see r_c in pain or upset...",
+            "m_c realizes {PRONOUN/m_c/poss} chest hurts when {PRONOUN/m_c/subject} see r_c in pain or upset...",
             "m_c realizes {PRONOUN/m_c/subject} {VERB/m_c/have/has} more then just a crush on r_c."
 		],
 		"relationship_constraint": [

--- a/resources/dicts/relationship_events/normal_interactions/romantic/increase.json
+++ b/resources/dicts/relationship_events/normal_interactions/romantic/increase.json
@@ -129,7 +129,7 @@
             "m_c thinks r_c has a beautiful smile.",
             "m_c and r_c realized they both had similar values when it came to family.", 
             "m_c promises to protect r_c.",
-            "Rumor around the Clan was that m_c and r_c are seeing each other and while they did clear things up, neither cat seemed to mind...",
+            "Rumor around the Clan was that m_c and r_c are seeing each other and, while they did clear things up, neither cat seemed to mind...",
             "m_c thinks r_c has a beautiful laugh.",
             "m_c took a nap with r_c, happy to be able to spend this time with {PRONOUN/r_c/object}.",
             "m_c urges r_c to take a break. {PRONOUN/m_c/subject/cap} don't want to see {PRONOUN/r_c/object} overworking {PRONOUN/r_c/self}.",

--- a/resources/dicts/relationship_events/normal_interactions/romantic/increase.json
+++ b/resources/dicts/relationship_events/normal_interactions/romantic/increase.json
@@ -199,7 +199,7 @@
 		"id": "rom_inc_medium8",
 		"intensity": "medium",
 		"interactions": [
-			"m_c wonders why r_c keeps spending time with {PRONOUN/m_c/object} when others usually don't like {PRONOUN/m_c/poss} attitude but {PRONOUN/m_c/subject} won't object.",
+			"m_c wonders why r_c keeps spending time with {PRONOUN/m_c/object} when others usually don't like {PRONOUN/m_c/poss} attitude, but {PRONOUN/m_c/subject} certainly won't object.",
             "r_c offered to groom m_c and despite {PRONOUN/m_c/poss} grumbling, {PRONOUN/m_c/subject} awkwardly accepted."
 		],
 		"main_trait_constraint": [

--- a/resources/dicts/relationship_events/normal_interactions/romantic/increase.json
+++ b/resources/dicts/relationship_events/normal_interactions/romantic/increase.json
@@ -200,7 +200,7 @@
 		"intensity": "medium",
 		"interactions": [
 			"m_c wonders why r_c keeps spending time with {PRONOUN/m_c/object} when others usually don't like {PRONOUN/m_c/poss} attitude, but {PRONOUN/m_c/subject} certainly won't object.",
-            "r_c offered to groom m_c and despite {PRONOUN/m_c/poss} grumbling, {PRONOUN/m_c/subject} awkwardly accepted."
+            "r_c offered to groom m_c and, despite {PRONOUN/m_c/poss} grumbling, {PRONOUN/m_c/subject} awkwardly accepted."
 		],
 		"main_trait_constraint": [
 			"grumpy",

--- a/resources/dicts/relationship_events/normal_interactions/trust/decrease.json
+++ b/resources/dicts/relationship_events/normal_interactions/trust/decrease.json
@@ -193,7 +193,7 @@
 			"m_c doesn't understand how StarClan could grant a cat as cold and uncaring as r_c nine lives.",
 			"When it comes down to it, m_c doesn't think {PRONOUN/m_c/subject} could follow r_c's every order.",
 			"m_c wonders if {PRONOUN/m_c/subject} could run away if necessary...",
-            "m_c wonders if exile is really so bad given current conditions..."
+            "m_c wonders if exile is really so bad given current Clan leadership..."
 		],
 		"random_status_constraint": [
 			"leader"

--- a/resources/dicts/relationship_events/normal_interactions/trust/decrease.json
+++ b/resources/dicts/relationship_events/normal_interactions/trust/decrease.json
@@ -56,7 +56,7 @@
 			"r_c is gossiping about m_c.",
 			"m_c is spreading a rumor about r_c.",
 			"m_c caught r_c slinking around the camp entrance in the middle of the night.",
-            "m_c catches r_c doing something sneaky and when asked, r_c refused to give a straight answer.",
+            "m_c catches r_c doing something sneaky and, when asked, r_c refused to give a straight answer.",
             "m_c catches r_c sneaking around.",
             "m_c catches r_c sneaking back into camp in the middle of the night."
 		],

--- a/resources/dicts/relationship_events/normal_interactions/trust/decrease.json
+++ b/resources/dicts/relationship_events/normal_interactions/trust/decrease.json
@@ -192,7 +192,7 @@
 			"m_c doesn't believe that r_c has the Clan's best interests in mind.",
 			"m_c doesn't understand how StarClan could grant a cat as cold and uncaring as r_c nine lives.",
 			"When it comes down to it, m_c doesn't think {PRONOUN/m_c/subject} could follow r_c's every order.",
-			"m_c wonders if {PRONOUN/m_c/subject} could run away if necessary...",
+			"m_c wonders if {PRONOUN/m_c/subject} could run away from the Clan if necessary...",
             "m_c wonders if exile is really so bad given current Clan leadership..."
 		],
 		"random_status_constraint": [

--- a/resources/dicts/relationship_events/normal_interactions/trust/decrease.json
+++ b/resources/dicts/relationship_events/normal_interactions/trust/decrease.json
@@ -23,7 +23,7 @@
 		"intensity": "low",
 		"interactions": [
 			"m_c keeps {PRONOUN/m_c/poss} tail tucked around r_c.",
-            "m_c is keeping a close eye on r_c making sure {PRONOUN/r_c/subject} {VERB/r_c/isn't/aren't} causing any trouble."
+            "m_c is keeping a close eye on r_c to make sure {PRONOUN/r_c/subject} {VERB/r_c/isn't/aren't} causing any trouble."
 		],
 		"random_status_constraint": [
 			"kitten"

--- a/resources/dicts/relationship_events/normal_interactions/trust/decrease.json
+++ b/resources/dicts/relationship_events/normal_interactions/trust/decrease.json
@@ -11,8 +11,23 @@
 		"id": "trust_de_low2",
 		"intensity": "low",
 		"interactions": [
-			"m_c shared a embarrassing story about r_c {PRONOUN/m_c/subject} {VERB/m_c/were/was} asked not to share..."
+			"m_c shared a embarrassing story about r_c {PRONOUN/m_c/subject} {VERB/m_c/were/was} asked not to share...",
+			"m_c laughed at r_c when they tripped and didn't even ask if {PRONOUN/m_c/subject} needed help up."
 		],
+		"reaction_random_cat": {
+			"trust": "decrease"
+		}
+	},
+	{
+		"id": "trust_de_low3",
+		"intensity": "low",
+		"interactions": [
+			"m_c keeps {PRONOUN/m_c/poss} tail tucked around r_c.",
+            "m_c is keeping a close eye on r_c making sure {PRONOUN/r_c/subject} {VERB/r_c/isn't/aren't} causing any trouble."
+		],
+		"random_status_constraint": [
+			"kitten"
+        ],
 		"reaction_random_cat": {
 			"trust": "decrease"
 		}
@@ -21,13 +36,15 @@
 		"id": "trust_de_med1",
 		"interactions": [
 			"m_c caught r_c in a lie.",
-			"r_c let m_c down while m_c was counting on {PRONOUN/r_c/object}."
+			"r_c let m_c down while m_c was counting on {PRONOUN/r_c/object}.",
+			"r_c tripped m_c at the gathering in front of all the clans."
 		]
 	},
 	{
 		"id": "trust_de_med2",
 		"interactions": [
-			"m_c said {PRONOUN/m_c/subject}'d cover for r_c, but when it came time, {PRONOUN/m_c/subject} got r_c in trouble."
+			"m_c said {PRONOUN/m_c/subject}'d cover for r_c, but when it came time, {PRONOUN/m_c/subject} got r_c in trouble.",
+			"m_c told r_c {PRONOUN/r_c/subject} could tell {PRONOUN/m_c/object} anything but when r_c took up the offer, m_c got {PRONOUN/r_c/object} in trouble."
 		],
 		"reaction_random_cat": {
 			"trust": "decrease"
@@ -37,7 +54,11 @@
 		"id": "trust_de_med3",
 		"interactions": [
 			"r_c is gossiping about m_c.",
-			"m_c is spreading a rumor about r_c."
+			"m_c is spreading a rumor about r_c.",
+			"m_c caught r_c slinking around the camp entrance in the middle of the night.",
+            "m_c catches r_c doing something sneaky and when asked, r_c refused to give a straight answer.",
+            "m_c catches r_c sneaking around.",
+            "m_c catches r_c sneaking back into camp in the middle of the night."
 		],
 		"random_trait_constraint": [
 			"sneaky"
@@ -47,7 +68,10 @@
 		"id": "trust_kit_de_med1",
 		"interactions": [
 			"m_c constantly pulling pranks on r_c.",
-			"m_c is relentlessly pestering r_c."
+			"m_c is relentlessly pestering r_c.",
+			"m_c keeps pouncing on r_c's tail despite being told to stop.",
+            "r_c hissed at m_c.",
+            "r_c caught m_c misbehaving even though {PRONOUN/m_c/subject} promised to be on {PRONOUN/m_c/poss} best behavior."
 		],
 		"relationship_constraint": [
 			"dislike_40"
@@ -72,7 +96,9 @@
 		"id": "trust_de_high2",
 		"intensity": "high",
 		"interactions": [
-			"m_c tries to scare r_c."
+			"m_c tries to scare r_c.",
+			"m_c dismisses r_c's reasonable concerns and fears and tells them to get over it.",
+            "m_c pulls a mean-spirited prank on r_c."
 		],
 		"relationship_constraint": [
 			"dislike_40"
@@ -90,7 +116,8 @@
 			"m_c accuses r_c of not taking care of cats properly.",
 			"m_c doesn't bother to ask r_c for help with a minor injury, worried that {PRONOUN/r_c/subject} might make it worse.",
 			"m_c complains that r_c doesn't seem to understand signs from StarClan very well.",
-			"m_c feels worse after r_c gave {PRONOUN/m_c/object} the wrong treatment for something minor."
+			"m_c feels worse after r_c gave {PRONOUN/m_c/object} the wrong treatment for something minor.",
+			"m_c doesn't trust r_c to treat {PRONOUN/m_c/object}."
 		],
 		"random_status_constraint": [
 			"medicine cat"
@@ -119,7 +146,13 @@
 			"m_c saw r_c bringing deathberries into the medicine den.",
 			"r_c was rough with m_c during a recent treatment.",
 			"m_c isn't sure why r_c became a medicine cat at all since {PRONOUN/r_c/subject} {VERB/r_c/seem/seems} to not like helping any cats.",
-			"m_c wouldn't be surprised if r_c faked signs from StarClan..."
+			"m_c wouldn't be surprised if r_c faked signs from StarClan...",
+			"m_c makes absolutely sure r_c gave {PRONOUN/m_c/object} the right herbs.",
+            "m_c lashes {PRONOUN/m_c/poss} tail as r_c dismisses {PRONOUN/m_c/poss} health concerns as nothing serious.",
+            "r_c claimed m_c was lying about an injury and refused to even look at it.",
+            "r_c claimed m_c was lying about an illness and refused to even check.",
+            "r_c ignored m_c when {PRONOUN/m_c/subject} needed treatment.",
+            "m_c is doubting whether r_c has any connection to StarClan at all."
 		],
 		"random_status_constraint": [
 			"medicine cat"
@@ -138,7 +171,9 @@
 			"m_c growls frustratingly at r_c when {PRONOUN/r_c/subject} {VERB/r_c/don't/doesn't} pay attention to m_c's health concerns... again.",
 			"m_c looks for r_c for treatment on a minor wound, only to find {PRONOUN/r_c/object} playing with catmint!",
 			"m_c hopes to never have a serious illness with r_c in charge of treatments...",
-			"m_c complains that r_c never takes {PRONOUN/r_c/poss} role of medicine cat seriously."
+			"m_c complains that r_c never takes {PRONOUN/r_c/poss} role of medicine cat seriously.",
+			"m_c can't keep r_c's attention long enough to tell {PRONOUN/r_c/subject} what {PRONOUN/m_c/object} need help with.",
+            "r_c didn't notice m_c when {PRONOUN/m_c/subject} needed treatment."
 		],
 		"random_status_constraint": [
 			"medicine cat"
@@ -156,7 +191,9 @@
 			"After hearing r_c's most recent demands, m_c is concerned about the future of the Clan.",
 			"m_c doesn't believe that r_c has the Clan's best interests in mind.",
 			"m_c doesn't understand how StarClan could grant a cat as cold and uncaring as r_c nine lives.",
-			"When it comes down to it, m_c doesn't think {PRONOUN/m_c/subject} could follow r_c's every order."
+			"When it comes down to it, m_c doesn't think {PRONOUN/m_c/subject} could follow r_c's every order.",
+			"m_c wonders if {PRONOUN/m_c/subject} could run away if necessary...",
+            "m_c wonders if exile is really so bad given current conditions..."
 		],
 		"random_status_constraint": [
 			"leader"

--- a/resources/dicts/relationship_events/normal_interactions/trust/increase.json
+++ b/resources/dicts/relationship_events/normal_interactions/trust/increase.json
@@ -60,7 +60,7 @@
 		"id": "trust_inc_med3",
 		"interactions": [
 			"r_c is telling m_c in great detail how {PRONOUN/r_c/subject} would protect {PRONOUN/m_c/object} from any danger.",
-			 "r_c tells m_c {PRONOUN/r_c/subject} could easily fight off an entire clan of cats to protect {PRONOUN/m_c/object}, {PRONOUN/r_c/subject} swear!",
+			 "r_c tells m_c {PRONOUN/r_c/subject} could easily fight off an entire Clan of cats to protect {PRONOUN/m_c/object}, {PRONOUN/r_c/subject} swear!",
             "r_c protected m_c from a rogue.",
             "r_c protected m_c from a loner.",
             "r_c protected m_c from a dog."

--- a/resources/dicts/relationship_events/normal_interactions/trust/increase.json
+++ b/resources/dicts/relationship_events/normal_interactions/trust/increase.json
@@ -3,7 +3,12 @@
 		"id": "trust_inc_low1",
 		"intensity": "low",
 		"interactions": [
-			"m_c appreciates r_c telling {PRONOUN/m_c/object} that {PRONOUN/m_c/subject} had a feather stuck to {PRONOUN/m_c/poss} face."
+			"m_c appreciates r_c telling {PRONOUN/m_c/object} that {PRONOUN/m_c/subject} had a feather stuck to {PRONOUN/m_c/poss} face.",
+			"m_c offered r_c a paw with something but {PRONOUN/r_c/subject} turned it down thanking {PRONOUN/m_c/object} for the offer.",
+            "m_c offered r_c a paw with something.",
+            "m_c told r_c a hard truth that {PRONOUN/r_c/subject} knew {PRONOUN/m_c/subject} needed to hear.",
+            "r_c warned m_c of a prank.",
+            "m_c gave r_c a helpful suggestion."
 		]
 	},
 	{
@@ -12,7 +17,9 @@
 		"interactions": [
 			"r_c tells m_c to get {PRONOUN/m_c/poss} ailment treated as soon as possible.",
 			"r_c is chiding m_c for being so reckless.",
-			"r_c apologized to m_c for possibly hurting {PRONOUN/m_c/poss} feelings."
+			"r_c apologized to m_c for possibly hurting {PRONOUN/m_c/poss} feelings.",
+			"r_c brought m_c aside and pointed out a messy patch of fur {PRONOUN/m_c/subject} missed grooming that morning.",
+			"m_c recalled some of r_c's careful advice in a tough spot and was greatful when it proved useful!"
 		],
 		"random_trait_constraint": [
 			"careful"
@@ -36,7 +43,8 @@
 		"id": "trust_inc_med1",
 		"interactions": [
 			"m_c thinks about how r_c is always reliable.",
-			"m_c notices how r_c is being helpful around camp."
+			"m_c notices how r_c is being helpful around camp.",
+			"m_c heard an ugly rumor about r_c but {PRONOUN/m_c/subject} {VERB/m_c/stick/sticks} up for {PRONOUN/r_c/object} knowing it's not true."
 		]
 	},
 	{
@@ -51,11 +59,28 @@
 	{
 		"id": "trust_inc_med3",
 		"interactions": [
-			"r_c is telling m_c in great detail how {PRONOUN/r_c/subject} would protect {PRONOUN/m_c/object} from any danger."
+			"r_c is telling m_c in great detail how {PRONOUN/r_c/subject} would protect {PRONOUN/m_c/object} from any danger.",
+			 "r_c tells m_c {PRONOUN/r_c/subject} could easily fight off an entire clan of cats to protect {PRONOUN/m_c/object}, {PRONOUN/r_c/subject} swear!",
+            "r_c protected m_c from a rogue.",
+            "r_c protected m_c from a loner.",
+            "r_c protected m_c from a dog."
 		],
 		"random_trait_constraint": [
-			"fierce"
-		]
+			"bold",
+            "arrogant",
+            "competitive",
+            "bloodthirsty",
+            "daring",
+            "fierce",
+            "responsible"
+		],
+        "random_status_constraint": [
+            "apprentice",
+            "warrior",
+            "deputy",
+            "leader",
+            "elder"
+        ]
 	},
 	{
 		"id": "trust_inc_med4",
@@ -77,32 +102,55 @@
 		]
 	},
 	{
-		"id": "trust_de_med3",
+		"id": "trust_inc_med6",
 		"interactions": [
 			"r_c is teaching m_c how to walk without making a sound.",
 			"r_c is showing m_c how to sneak up on {PRONOUN/m_c/poss} enemies.",
 			"r_c convinces m_c to help {PRONOUN/r_c/object} pull a prank on a Clanmate.",
-			"m_c is whispering quietly with r_c."
+			"m_c is whispering quietly with r_c.",
+			"r_c is teaching m_c to blend in with {PRONOUN/m_c/poss} surroundings seamlessly."
 		],
 		"random_trait_constraint": [
-			"sneaky"
+			"sneaky",
+			"careful"
 		]
 	},
 	{
-		"id": "trust_de_med3",
+		"id": "trust_inc_med7",
 		"interactions": [
 			"r_c is giving m_c advice.",
 			"r_c is teaching m_c something important."
 		],
 		"random_trait_constraint": [
-			"wise"
+			"wise",
+			"responsible",
+            		"thoughtful"
 		]
+	},
+	{
+		"id": "trust_inc_med8",
+		"interactions": [
+            "m_c urges r_c to rest, {PRONOUN/m_c/subject} can handle some of r_c's workload.",
+            "m_c reminded r_c of some work {PRONOUN/m_c/subject} forgot about."
+		],
+        "main_status_constraint": [
+            "apprentice",
+            "medicine cat apprentice",
+            "mediator apprentice",
+            "warrior",
+            "medicine cat",
+            "mediator",
+            "deputy",
+            "leader"
+        ]
 	},
 	{
 		"id": "trust_adult_inc_med1",
 		"interactions": [
 			"m_c is giving advice to r_c.",
-			"m_c is looking out for r_c's well-being."
+			"m_c is looking out for r_c's well-being.",
+			"m_c snuck r_c out of camp for a fun break from {PRONOUN/r_c/poss} duties and covered for {PRONOUN/r_c/object} when they were questioned when they got back.",
+			"r_c reminds m_c of {PRONOUN/m_c/self} in {PRONOUN/m_c/poss} younger years."
 		],
 		"main_status_constraint": [
 			"elder",
@@ -157,7 +205,8 @@
 		"interactions": [
 			"m_c thinks {PRONOUN/m_c/subject} can tell r_c something important.",
 			"m_c feels safe with r_c around.",
-			"m_c knows that the advice r_c gave {PRONOUN/m_c/object} will be helpful."
+			"m_c knows that the advice r_c gave {PRONOUN/m_c/object} will be helpful.",
+			"m_c made a big mistake and knew {PRONOUN/m_c/subject} could trust r_c to help {PRONOUN/m_c/object}."
 		]
 	},
 	{
@@ -166,7 +215,9 @@
 		"interactions": [
 			"m_c is letting r_c share {PRONOUN/r_c/poss} troubles with {PRONOUN/m_c/object}, hoping {PRONOUN/r_c/subject}'ll feel better afterwards.",
 			"m_c promises to always look out for r_c.",
-			"m_c tells r_c to count on {PRONOUN/m_c/object} in a difficult situation."
+			"m_c tells r_c to count on {PRONOUN/m_c/object} in a difficult situation.",
+			"m_c catches r_c in an embarrassing situation and promises not to say anything.",
+			"m_c overheard a big secret about r_c and assured {PRONOUN/r_c/object} {PRONOUN/r_c/poss} it was safe with {PRONOUN/m_c/object}."
 		],
 		"reaction_random_cat": {
 			"trust": "increase"
@@ -192,7 +243,8 @@
 		"intensity": "high",
 		"interactions": [
 			"m_c goes to r_c for advice about some recent troubles.",
-			"m_c asks r_c for help resolving an argument with a friend."
+			"m_c asks r_c for help resolving an argument with a friend.",
+			"r_c gives m_c advice on {PRONOUN/m_c/poss} love life."
 		],
 		"relationship_constraint": [
 			"trust_30"
@@ -273,7 +325,13 @@
 		"id": "trust_med_inc_high2",
 		"interactions": [
 			"m_c observes r_c carefully attending to any cat that needs help.",
-			"m_c feels like {PRONOUN/m_c/subject} can count on r_c to give {PRONOUN/m_c/object} the best treatment possible."
+			"m_c feels like {PRONOUN/m_c/subject} can count on r_c to give {PRONOUN/m_c/object} the best treatment possible.",
+			"m_c is relieved when r_c says {PRONOUN/m_c/poss} injury is nothing to be worried about.",
+            "m_c is relieved when r_c says {PRONOUN/m_c/poss} cough is nothing to be worried about.",
+            "m_c is relieved r_c dosen't judge {PRONOUN/m_c/object} for coming to {PRONOUN/r_c/object} with concerns that end up being nothing at all.",
+            "m_c went to r_c genuinely concerned about a rough looking scratch only to be embarrassed and ashamed when r_c wipes it away. Turns out it was a very convincing smear of dried mud. r_c, amused by it all, promised not to tell anyone.",
+            "r_c is extra careful treating m_c.",
+            "m_c knows if anything goes wrong {PRONOUN/m_c/subject} can depend on r_c always."
 		],
 		"random_status_constraint": [
 			"medicine cat apprentice",

--- a/resources/dicts/relationship_events/normal_interactions/trust/increase.json
+++ b/resources/dicts/relationship_events/normal_interactions/trust/increase.json
@@ -328,7 +328,7 @@
 			"m_c feels like {PRONOUN/m_c/subject} can count on r_c to give {PRONOUN/m_c/object} the best treatment possible.",
 			"m_c is relieved when r_c says {PRONOUN/m_c/poss} injury is nothing to be worried about.",
             "m_c is relieved when r_c says {PRONOUN/m_c/poss} cough is nothing to be worried about.",
-            "m_c is relieved r_c dosen't judge {PRONOUN/m_c/object} for coming to {PRONOUN/r_c/object} with concerns that end up being nothing at all.",
+            "m_c is relieved r_c doesn't judge {PRONOUN/m_c/object} for coming to {PRONOUN/r_c/object} with concerns that end up being nothing at all.",
             "m_c went to r_c genuinely concerned about a rough looking scratch only to be embarrassed and ashamed when r_c wipes it away. Turns out it was a very convincing smear of dried mud. r_c, amused by it all, promised not to tell anyone.",
             "r_c is extra careful treating m_c.",
             "m_c knows if anything goes wrong {PRONOUN/m_c/subject} can depend on r_c always."

--- a/resources/dicts/relationship_events/normal_interactions/trust/increase.json
+++ b/resources/dicts/relationship_events/normal_interactions/trust/increase.json
@@ -60,10 +60,7 @@
 		"id": "trust_inc_med3",
 		"interactions": [
 			"r_c is telling m_c in great detail how {PRONOUN/r_c/subject} would protect {PRONOUN/m_c/object} from any danger.",
-			 "r_c tells m_c {PRONOUN/r_c/subject} could easily fight off an entire Clan of cats to protect {PRONOUN/m_c/object}, {PRONOUN/r_c/subject} swear!",
-            "r_c protected m_c from a rogue.",
-            "r_c protected m_c from a loner.",
-            "r_c protected m_c from a dog."
+			 "r_c tells m_c {PRONOUN/r_c/subject} could easily fight off an entire Clan of cats to protect {PRONOUN/m_c/object}, {PRONOUN/r_c/subject} swear!"
 		],
 		"random_trait_constraint": [
 			"bold",

--- a/resources/dicts/relationship_events/normal_interactions/trust/increase.json
+++ b/resources/dicts/relationship_events/normal_interactions/trust/increase.json
@@ -4,7 +4,7 @@
 		"intensity": "low",
 		"interactions": [
 			"m_c appreciates r_c telling {PRONOUN/m_c/object} that {PRONOUN/m_c/subject} had a feather stuck to {PRONOUN/m_c/poss} face.",
-			"m_c offered r_c a paw with something but {PRONOUN/r_c/subject} turned it down thanking {PRONOUN/m_c/object} for the offer.",
+			"m_c offered r_c a paw with something but {PRONOUN/r_c/subject} turned it down, thanking {PRONOUN/m_c/object} for the offer.",
             "m_c offered r_c a paw with something.",
             "m_c told r_c a hard truth that {PRONOUN/r_c/subject} knew {PRONOUN/m_c/subject} needed to hear.",
             "r_c warned m_c of a prank.",

--- a/resources/dicts/relationship_events/normal_interactions/trust/increase.json
+++ b/resources/dicts/relationship_events/normal_interactions/trust/increase.json
@@ -149,7 +149,7 @@
 		"interactions": [
 			"m_c is giving advice to r_c.",
 			"m_c is looking out for r_c's well-being.",
-			"m_c snuck r_c out of camp for a fun break from {PRONOUN/r_c/poss} duties and covered for {PRONOUN/r_c/object} when they were questioned when they got back.",
+			"m_c snuck r_c out of camp for a fun break from {PRONOUN/r_c/poss} duties and covered for {PRONOUN/r_c/object} when they were later questioned.",
 			"r_c reminds m_c of {PRONOUN/m_c/self} in {PRONOUN/m_c/poss} younger years."
 		],
 		"main_status_constraint": [


### PR DESCRIPTION
## About The Pull Request

added new relationship events in every normal interactions file plus a 5 cat negative interaction

## Why This Is Good For ClanGen

its always nice to have fresh stuff so why not go all the way with it and add to every file?

## Linked Issues

none

## Proof of Testing

![20240913_095743](https://github.com/user-attachments/assets/c8c7aecf-79a5-46f1-bb04-df8959a7c8d1)
![20240913_095649](https://github.com/user-attachments/assets/753d2c10-2761-4639-855d-6170a8f7ee04)
![20240913_095716](https://github.com/user-attachments/assets/9f83b359-a91f-4104-a105-b23e96e28875)
![20240913_095624](https://github.com/user-attachments/assets/d1b4de93-6d0a-46f8-8b68-832ebb3e4dd1)
![20240913_095558](https://github.com/user-attachments/assets/89205912-6843-4cd2-bc21-d1fc5106d9c7)
![20240913_095415](https://github.com/user-attachments/assets/a71f00b0-4bf7-4dac-9f31-7ac62d8be08d)
![20240913_095346](https://github.com/user-attachments/assets/37185638-25f5-40b6-9360-d8d90140119d)


## Changelog/Credits

added relationship events to all normal interactions categories- fuzzy