### PR TITLE
[BUGFIX] Audio: Exiting settings without saving results in desynced volume on return #2675

### DIFF
--- a/scripts/screens/SettingsScreen.py
+++ b/scripts/screens/SettingsScreen.py
@@ -13,7 +13,11 @@ from scripts.game_structure.discord_rpc import _DiscordRPC
 from scripts.game_structure.game_essentials import game, screen_x, screen_y, MANAGER
 from scripts.game_structure.ui_elements import UIImageButton, UIImageHorizontalSlider
 from scripts.game_structure.windows import SaveError
-from scripts.utility import get_text_box_theme, scale, quit  # pylint: disable=redefined-builtin
+from scripts.utility import (
+    get_text_box_theme,
+    scale,
+    quit,
+)  # pylint: disable=redefined-builtin
 from .Screens import Screens
 from ..game_structure.audio import music_manager, sound_manager
 from ..housekeeping.datadir import get_data_dir
@@ -21,7 +25,7 @@ from ..housekeeping.version import get_version_info
 
 logger = logging.getLogger(__name__)
 
-with open('resources/gamesettings.json', 'r', encoding='utf-8') as f:
+with open("resources/gamesettings.json", "r", encoding="utf-8") as f:
     settings_dict = ujson.load(f)
 
 
@@ -29,13 +33,14 @@ class SettingsScreen(Screens):
     """
     TODO: DOCS
     """
+
     text_size = {
-        '0': 'small',
-        '1': 'medium',
-        '2': 'big'
+        "0": "small",
+        "1": "medium",
+        "2": "big",
     }  # How text sizes will show up on the screen
-    bool = {True: 'Yes', False: 'No', None: 'None'}
-    sub_menu = 'general'
+    bool = {True: "Yes", False: "No", None: "None"}
+    sub_menu = "general"
 
     # This is set to the current settings when the screen is opened.
     # All edits are made directly to game.settings, however, when you
@@ -59,7 +64,7 @@ class SettingsScreen(Screens):
 
     info_text = ""
     tooltip_text = []
-    with open('resources/credits_text.json', 'r', encoding='utf-8') as f:
+    with open("resources/credits_text.json", "r", encoding="utf-8") as f:
         credits_text = ujson.load(f)
     for string in credits_text["text"]:
         if string == "{contrib}":
@@ -87,29 +92,29 @@ class SettingsScreen(Screens):
                 self.update_save_button()
 
         if event.type == pygame_gui.UI_TEXT_BOX_LINK_CLICKED:
-            if platform.system() == 'Darwin':
+            if platform.system() == "Darwin":
                 subprocess.Popen(["open", "-u", event.link_target])
-            elif platform.system() == 'Windows':
-                os.system(f"start \"\" {event.link_target}")
-            elif platform.system() == 'Linux':
-                subprocess.Popen(['xdg-open', event.link_target])
+            elif platform.system() == "Windows":
+                os.system(f'start "" {event.link_target}')
+            elif platform.system() == "Linux":
+                subprocess.Popen(["xdg-open", event.link_target])
         if event.type == pygame_gui.UI_BUTTON_START_PRESS:
             self.mute_button_pressed(event)
 
             if event.ui_element == self.main_menu_button:
-                self.change_screen('start screen')
+                self.change_screen("start screen")
                 return
             if event.ui_element == self.fullscreen_toggle:
-                game.switch_setting('fullscreen')
+                game.switch_setting("fullscreen")
                 quit(savesettings=True, clearevents=False)
             elif event.ui_element == self.open_data_directory_button:
-                if platform.system() == 'Darwin':
+                if platform.system() == "Darwin":
                     subprocess.Popen(["open", "-R", get_data_dir()])
-                elif platform.system() == 'Windows':
+                elif platform.system() == "Windows":
                     os.startfile(get_data_dir())  # pylint: disable=no-member
-                elif platform.system() == 'Linux':
+                elif platform.system() == "Linux":
                     try:
-                        subprocess.Popen(['xdg-open', get_data_dir()])
+                        subprocess.Popen(["xdg-open", get_data_dir()])
                     except OSError:
                         logger.exception("Failed to call to xdg-open.")
                 return
@@ -133,21 +138,21 @@ class SettingsScreen(Screens):
                 return
             elif event.ui_element == self.language_button:
                 self.open_lang_settings()
-            if self.sub_menu in ['general', 'relation', 'language']:
+            if self.sub_menu in ["general", "relation", "language"]:
                 self.handle_checkbox_events(event)
 
-        elif event.type == pygame.KEYDOWN and game.settings['keybinds']:
+        elif event.type == pygame.KEYDOWN and game.settings["keybinds"]:
             if event.key == pygame.K_ESCAPE:
-                self.change_screen('start screen')
+                self.change_screen("start screen")
             elif event.key == pygame.K_RIGHT:
-                if self.sub_menu == 'general':
+                if self.sub_menu == "general":
                     self.open_info_screen()
-                elif self.sub_menu == 'info':
+                elif self.sub_menu == "info":
                     self.open_lang_settings()
             elif event.key == pygame.K_LEFT:
-                if self.sub_menu == 'info':
+                if self.sub_menu == "info":
                     self.open_general_settings()
-                elif self.sub_menu == 'language':
+                elif self.sub_menu == "language":
                     self.open_info_screen()
 
     def handle_checkbox_events(self, event):
@@ -157,17 +162,19 @@ class SettingsScreen(Screens):
         if event.ui_element in self.checkboxes.values():
             for key, value in self.checkboxes.items():
                 if value == event.ui_element:
-                    if self.sub_menu == 'language':
-                        game.settings['language'] = key
+                    if self.sub_menu == "language":
+                        game.settings["language"] = key
                     else:
                         game.switch_setting(key)
                     self.settings_changed = True
                     self.update_save_button()
-                    if self.sub_menu == 'general' and event.ui_element is self.checkboxes['discord']:
-                        if game.settings['discord']:
+                    if (
+                        self.sub_menu == "general"
+                        and event.ui_element is self.checkboxes["discord"]
+                    ):
+                        if game.settings["discord"]:
                             print("Starting Discord RPC")
-                            game.rpc = _DiscordRPC("1076277970060185701",
-                                                   daemon=True)
+                            game.rpc = _DiscordRPC("1076277970060185701", daemon=True)
                             game.rpc.start()
                             game.rpc.start_rpc.set()
                         else:
@@ -176,20 +183,25 @@ class SettingsScreen(Screens):
 
                     opens = {
                         "general": self.open_general_settings,
-                        "language": self.open_lang_settings
+                        "language": self.open_lang_settings,
                     }
 
                     scroll_pos = None
-                    if "container_general" in self.checkboxes_text and \
-                            self.checkboxes_text["container_general"].vert_scroll_bar:
-                        scroll_pos = self.checkboxes_text["container_general"].vert_scroll_bar.start_percentage
+                    if (
+                        "container_general" in self.checkboxes_text
+                        and self.checkboxes_text["container_general"].vert_scroll_bar
+                    ):
+                        scroll_pos = self.checkboxes_text[
+                            "container_general"
+                        ].vert_scroll_bar.start_percentage
 
                     if self.sub_menu in opens:
                         opens[self.sub_menu]()
 
                     if scroll_pos is not None:
-                        self.checkboxes_text["container_general"].vert_scroll_bar.set_scroll_from_start_percentage(
-                            scroll_pos)
+                        self.checkboxes_text[
+                            "container_general"
+                        ].vert_scroll_bar.set_scroll_from_start_percentage(scroll_pos)
 
                     break
 
@@ -204,37 +216,43 @@ class SettingsScreen(Screens):
             scale(pygame.Rect((200, 200), (300, 60))),
             "",
             object_id="#general_settings_button",
-            manager=MANAGER)
-        self.audio_settings_button = UIImageButton(scale(
-            pygame.Rect((500, 200), (300, 60))),
+            manager=MANAGER,
+        )
+        self.audio_settings_button = UIImageButton(
+            scale(pygame.Rect((500, 200), (300, 60))),
             "",
             object_id="#audio_settings_button",
-            manager=MANAGER)
-        self.info_button = UIImageButton(scale(
-            pygame.Rect((800, 200), (300, 60))),
+            manager=MANAGER,
+        )
+        self.info_button = UIImageButton(
+            scale(pygame.Rect((800, 200), (300, 60))),
             "",
             object_id="#info_settings_button",
-            manager=MANAGER)
-        self.language_button = UIImageButton(scale(
-            pygame.Rect((1100, 200), (300, 60))),
+            manager=MANAGER,
+        )
+        self.language_button = UIImageButton(
+            scale(pygame.Rect((1100, 200), (300, 60))),
             "",
             object_id="#lang_settings_button",
-            manager=MANAGER)
+            manager=MANAGER,
+        )
         self.save_settings_button = UIImageButton(
             scale(pygame.Rect((654, 1100), (292, 60))),
             "",
             object_id="#save_settings_button",
-            manager=MANAGER)
+            manager=MANAGER,
+        )
 
-        if game.settings['fullscreen']:
+        if game.settings["fullscreen"]:
             self.fullscreen_toggle = UIImageButton(
                 scale(pygame.Rect((1234, 50), (316, 72))),
                 "",
                 object_id="#toggle_fullscreen_button",
                 manager=MANAGER,
                 tool_tip_text="This will close the game. "
-                              "When you reopen, the game"
-                              " will be windowed. ")
+                "When you reopen, the game"
+                " will be windowed. ",
+            )
         else:
             self.fullscreen_toggle = UIImageButton(
                 scale(pygame.Rect((1234, 50), (316, 72))),
@@ -242,8 +260,9 @@ class SettingsScreen(Screens):
                 object_id="#toggle_fullscreen_button",
                 manager=MANAGER,
                 tool_tip_text="This will close the game. "
-                              "When you reopen, the game"
-                              " will be fullscreen. ")
+                "When you reopen, the game"
+                " will be fullscreen. ",
+            )
 
         self.open_data_directory_button = UIImageButton(
             scale(pygame.Rect((50, 1290), (356, 60))),
@@ -251,19 +270,21 @@ class SettingsScreen(Screens):
             object_id="#open_data_directory_button",
             manager=MANAGER,
             tool_tip_text="Opens the data directory. "
-                          "This is where save files "
-                          "and logs are stored.")
+            "This is where save files "
+            "and logs are stored.",
+        )
 
         if get_version_info().is_sandboxed:
             self.open_data_directory_button.hide()
 
         self.update_save_button()
-        self.main_menu_button = UIImageButton(scale(
-            pygame.Rect((50, 50), (305, 60))),
+        self.main_menu_button = UIImageButton(
+            scale(pygame.Rect((50, 50), (305, 60))),
             "",
             object_id="#main_menu_button",
-            manager=MANAGER)
-        self.sub_menu = 'general'
+            manager=MANAGER,
+        )
+        self.sub_menu = "general"
         self.open_general_settings()
 
         self.settings_at_open = game.settings.copy()
@@ -312,36 +333,40 @@ class SettingsScreen(Screens):
         self.enable_all_menu_buttons()
         self.general_settings_button.disable()
         self.clear_sub_settings_buttons_and_text()
-        self.sub_menu = 'general'
+        self.sub_menu = "general"
         self.save_settings_button.show()
 
-        self.checkboxes_text[
-            "container_general"] = pygame_gui.elements.UIScrollingContainer(
-            scale(pygame.Rect((0, 440), (1400, 600))),
-            allow_scroll_x=False,
-            manager=MANAGER)
+        self.checkboxes_text["container_general"] = (
+            pygame_gui.elements.UIScrollingContainer(
+                scale(pygame.Rect((0, 440), (1400, 600))),
+                allow_scroll_x=False,
+                manager=MANAGER,
+            )
+        )
 
         n = 0
-        for code, desc in settings_dict['general'].items():
+        for code, desc in settings_dict["general"].items():
             self.checkboxes_text[code] = pygame_gui.elements.UITextBox(
                 desc[0],
                 scale(pygame.Rect((450, n * 78), (1000, 78))),
                 container=self.checkboxes_text["container_general"],
                 object_id=get_text_box_theme("#text_box_30_horizleft_pad_0_8"),
-                manager=MANAGER)
+                manager=MANAGER,
+            )
             self.checkboxes_text[code].disable()
             n += 1
 
-        self.checkboxes_text[
-            "container_general"].set_scrollable_area_dimensions(
-            (1360 / 1600 * screen_x, (n * 78 + 80) / 1400 * screen_y))
+        self.checkboxes_text["container_general"].set_scrollable_area_dimensions(
+            (1360 / 1600 * screen_x, (n * 78 + 80) / 1400 * screen_y)
+        )
 
-        self.checkboxes_text['instr'] = pygame_gui.elements.UITextBox(
+        self.checkboxes_text["instr"] = pygame_gui.elements.UITextBox(
             """Change the general settings of your game here.\n"""
             """More settings are available in the settings page of your Clan.""",
             scale(pygame.Rect((200, 320), (1200, 200))),
             object_id=get_text_box_theme("#text_box_30_horizcenter"),
-            manager=MANAGER)
+            manager=MANAGER,
+        )
 
         # This is where the actual checkboxes are created. I don't like
         #   how this is separated from the text boxes, but I've spent too much time to rewrite it.
@@ -354,14 +379,15 @@ class SettingsScreen(Screens):
         self.enable_all_menu_buttons()
         self.audio_settings_button.disable()
         self.clear_sub_settings_buttons_and_text()
-        self.sub_menu = 'audio'
+        self.sub_menu = "audio"
         self.save_settings_button.show()
 
         self.volume_elements["audio_settings_info"] = pygame_gui.elements.UITextBox(
             "Change the settings for the game audio here.",
             scale(pygame.Rect((200, 320), (1200, 200))),
             object_id=get_text_box_theme("#text_box_30_horizcenter"),
-            manager=MANAGER)
+            manager=MANAGER,
+        )
 
         # music volume elements
         x_pos = 350
@@ -371,7 +397,8 @@ class SettingsScreen(Screens):
             "Music Volume:",
             scale(pygame.Rect((x_pos, y_pos), (300, 60))),
             object_id=get_text_box_theme("#text_box_30_horizcenter"),
-            manager=MANAGER)
+            manager=MANAGER,
+        )
 
         x_pos += 390
 
@@ -380,15 +407,17 @@ class SettingsScreen(Screens):
             start_value=int(music_manager.volume * 100),
             value_range=(0, 100),
             click_increment=1,
-            object_id='horizontal_slider',
-            manager=MANAGER)
+            object_id="horizontal_slider",
+            manager=MANAGER,
+        )
         x_pos += 385
 
         self.volume_elements["music_volume_indicator"] = pygame_gui.elements.UITextBox(
             f"{self.volume_elements['music_volume_slider'].get_current_value()}",
             scale(pygame.Rect((x_pos, y_pos), (100, 60))),
             object_id=get_text_box_theme("#text_box_30_horizcenter"),
-            manager=MANAGER)
+            manager=MANAGER,
+        )
 
         # sound volume elements
         x_pos = 350
@@ -398,7 +427,8 @@ class SettingsScreen(Screens):
             "Sound Effect Volume:",
             scale(pygame.Rect((x_pos, y_pos), (400, 60))),
             object_id=get_text_box_theme("#text_box_30_horizcenter"),
-            manager=MANAGER)
+            manager=MANAGER,
+        )
 
         x_pos += 390
 
@@ -407,15 +437,17 @@ class SettingsScreen(Screens):
             start_value=int(sound_manager.volume * 100),
             value_range=(0, 100),
             click_increment=1,
-            object_id='horizontal_slider',
-            manager=MANAGER)
+            object_id="horizontal_slider",
+            manager=MANAGER,
+        )
         x_pos += 385
 
         self.volume_elements["sound_volume_indicator"] = pygame_gui.elements.UITextBox(
             f"{self.volume_elements['sound_volume_slider'].get_current_value()}",
             scale(pygame.Rect((x_pos, y_pos), (100, 60))),
             object_id=get_text_box_theme("#text_box_30_horizcenter"),
-            manager=MANAGER)
+            manager=MANAGER,
+        )
 
     def update_music_volume_indicator(self):
         self.volume_elements["music_volume_indicator"].kill()
@@ -424,7 +456,8 @@ class SettingsScreen(Screens):
             f"{self.volume_elements['music_volume_slider'].get_current_value()}",
             scale(pygame.Rect((1115, 500), (100, 60))),
             object_id=get_text_box_theme("#text_box_30_horizcenter"),
-            manager=MANAGER)
+            manager=MANAGER,
+        )
 
     def update_sound_volume_indicator(self):
         self.volume_elements["sound_volume_indicator"].kill()
@@ -433,71 +466,81 @@ class SettingsScreen(Screens):
             f"{self.volume_elements['sound_volume_slider'].get_current_value()}",
             scale(pygame.Rect((1115, 600), (100, 60))),
             object_id=get_text_box_theme("#text_box_30_horizcenter"),
-            manager=MANAGER)
+            manager=MANAGER,
+        )
 
     def open_info_screen(self):
         """Open's info screen"""
         self.enable_all_menu_buttons()
         self.info_button.disable()
         self.clear_sub_settings_buttons_and_text()
-        self.sub_menu = 'info'
+        self.sub_menu = "info"
         self.save_settings_button.hide()
 
-        self.checkboxes_text["info_container"] = pygame_gui.elements.UIScrollingContainer(
-            scale(pygame.Rect((200, 300), (1200, 1000))),
-            allow_scroll_x=False,
-            manager=MANAGER
+        self.checkboxes_text["info_container"] = (
+            pygame_gui.elements.UIScrollingContainer(
+                scale(pygame.Rect((200, 300), (1200, 1000))),
+                allow_scroll_x=False,
+                manager=MANAGER,
+            )
         )
 
-        self.checkboxes_text['info_text_box'] = pygame_gui.elements.UITextBox(
+        self.checkboxes_text["info_text_box"] = pygame_gui.elements.UITextBox(
             self.info_text,
             scale(pygame.Rect((0, 0), (1150, -1))),
             object_id=get_text_box_theme("#text_box_30_horizcenter"),
             container=self.checkboxes_text["info_container"],
-            manager=MANAGER)
+            manager=MANAGER,
+        )
 
-        self.checkboxes_text['info_text_box'].disable()
+        self.checkboxes_text["info_text_box"].disable()
 
         i = 0
         y_pos = 690
         for tooltip in self.tooltip_text:
             if not tooltip:
-                self.tooltip[f'tip{i}'] = UIImageButton(
-                    scale(pygame.Rect((400, i * 52 + y_pos), (400, 52))),
-                    "",
-                    object_id="#blank_button",
-                    container=self.checkboxes_text["info_container"],
-                    manager=MANAGER,
-                    starting_height=2
-                ),
+                self.tooltip[f"tip{i}"] = (
+                    UIImageButton(
+                        scale(pygame.Rect((400, i * 52 + y_pos), (400, 52))),
+                        "",
+                        object_id="#blank_button",
+                        container=self.checkboxes_text["info_container"],
+                        manager=MANAGER,
+                        starting_height=2,
+                    ),
+                )
             else:
-                self.tooltip[f'tip{i}'] = UIImageButton(
-                    scale(pygame.Rect((400, i * 52 + y_pos), (400, 52))),
-                    "",
-                    object_id="#blank_button",
-                    container=self.checkboxes_text["info_container"],
-                    manager=MANAGER,
-                    tool_tip_text=tooltip,
-                    starting_height=2
-                ),
+                self.tooltip[f"tip{i}"] = (
+                    UIImageButton(
+                        scale(pygame.Rect((400, i * 52 + y_pos), (400, 52))),
+                        "",
+                        object_id="#blank_button",
+                        container=self.checkboxes_text["info_container"],
+                        manager=MANAGER,
+                        tool_tip_text=tooltip,
+                        starting_height=2,
+                    ),
+                )
 
             i += 1
         self.checkboxes_text["info_container"].set_scrollable_area_dimensions(
-            (1150 / 1600 * screen_x, (i * 56 + y_pos + 550) / 1300 * screen_y))
+            (1150 / 1600 * screen_x, (i * 56 + y_pos + 550) / 1300 * screen_y)
+        )
 
     def open_lang_settings(self):
         """Open Language Settings"""
         self.enable_all_menu_buttons()
         self.language_button.disable()
         self.clear_sub_settings_buttons_and_text()
-        self.sub_menu = 'language'
+        self.sub_menu = "language"
         self.save_settings_button.show()
 
-        self.checkboxes_text['instr'] = pygame_gui.elements.UITextBox(
+        self.checkboxes_text["instr"] = pygame_gui.elements.UITextBox(
             "Change the language of the game here. This has not been implemented yet.",
             scale(pygame.Rect((200, 320), (1200, 100))),
             object_id=get_text_box_theme("#text_box_30_horizcenter"),
-            manager=MANAGER)
+            manager=MANAGER,
+        )
 
         self.refresh_checkboxes()
 
@@ -511,29 +554,32 @@ class SettingsScreen(Screens):
         self.checkboxes = {}
 
         # CHECKBOXES (ehhh) FOR LANGUAGES
-        if self.sub_menu == 'language':
-            self.checkboxes['english'] = UIImageButton(
+        if self.sub_menu == "language":
+            self.checkboxes["english"] = UIImageButton(
                 scale(pygame.Rect((620, 400), (360, 102))),
                 "",
                 object_id="#english_lang_button",
-                manager=MANAGER)
-            self.checkboxes['spanish'] = UIImageButton(
+                manager=MANAGER,
+            )
+            self.checkboxes["spanish"] = UIImageButton(
                 scale(pygame.Rect((620, 502), (360, 74))),
                 "",
                 object_id="#spanish_lang_button",
-                manager=MANAGER)
-            self.checkboxes['german'] = UIImageButton(
+                manager=MANAGER,
+            )
+            self.checkboxes["german"] = UIImageButton(
                 scale(pygame.Rect((620, 576), (360, 74))),
                 "",
                 object_id="#german_lang_button",
-                manager=MANAGER)
+                manager=MANAGER,
+            )
 
-            if game.settings['language'] == 'english':
-                self.checkboxes['english'].disable()
-            elif game.settings['language'] == 'spanish':
-                self.checkboxes['spanish'].disable()
-            elif game.settings['language'] == 'german':
-                self.checkboxes['german'].disable()
+            if game.settings["language"] == "english":
+                self.checkboxes["english"].disable()
+            elif game.settings["language"] == "spanish":
+                self.checkboxes["spanish"].disable()
+            elif game.settings["language"] == "german":
+                self.checkboxes["german"].disable()
 
         else:
             n = 0
@@ -546,9 +592,9 @@ class SettingsScreen(Screens):
                     scale(pygame.Rect((340, n * 78), (68, 68))),
                     "",
                     object_id=box_type,
-                    container=self.checkboxes_text["container_" +
-                                                   self.sub_menu],
-                    tool_tip_text=desc[1])
+                    container=self.checkboxes_text["container_" + self.sub_menu],
+                    tool_tip_text=desc[1],
+                )
                 n += 1
 
     def clear_sub_settings_buttons_and_text(self):
@@ -560,7 +606,6 @@ class SettingsScreen(Screens):
 
         if "container_general" in self.checkboxes_text:
             self.checkboxes_text["container_general"].kill()
-
 
         for checkbox in self.checkboxes.values():
             checkbox.kill()

--- a/scripts/screens/SettingsScreen.py
+++ b/scripts/screens/SettingsScreen.py
@@ -377,7 +377,7 @@ class SettingsScreen(Screens):
 
         self.volume_elements["music_volume_slider"] = UIImageHorizontalSlider(
             scale(pygame.Rect((x_pos, y_pos), (400, 60))),
-            start_value=game.settings["music_volume"],
+            start_value=int(music_manager.volume * 100),
             value_range=(0, 100),
             click_increment=1,
             object_id='horizontal_slider',
@@ -404,7 +404,7 @@ class SettingsScreen(Screens):
 
         self.volume_elements["sound_volume_slider"] = UIImageHorizontalSlider(
             scale(pygame.Rect((x_pos, y_pos), (400, 60))),
-            start_value=game.settings["sound_volume"],
+            start_value=int(sound_manager.volume * 100),
             value_range=(0, 100),
             click_increment=1,
             object_id='horizontal_slider',


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->

## About The Pull Request
This pull request addresses an issue where the game fails to retain the volume slider settings when exiting the settings screen without saving, despite the audio levels remaining unchanged.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
fixes: #2675
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing

https://github.com/user-attachments/assets/674f7000-d3ed-47b8-b459-f159e3611afe


<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
Addressed some minor audio issues.
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
