### PR TITLE
[BUGFIX] fixed r_c showing instead of name after death during patrol #2680

### DIFF
--- a/resources/dicts/patrols/beach/hunting/any.json
+++ b/resources/dicts/patrols/beach/hunting/any.json
@@ -5400,8 +5400,8 @@
                         }
                     ],
                     "history_text": {
-                        "scar": "r_c was permantly marked by the barb of a stingray as an apprentice - but {PRONOUN/r_c/subject} survived.",
-                        "reg_death": "r_c died from the strike of a stingray encountered on a hunt as a foolish apprentice."
+                        "scar": "m_c was permantly marked by the barb of a stingray as an apprentice - but {PRONOUN/m_c/subject} survived.",
+                        "reg_death": "m_c died from the strike of a stingray encountered on a hunt as a foolish apprentice."
                         }
                 }
             ]

--- a/resources/dicts/patrols/beach/hunting/leaf-bare.json
+++ b/resources/dicts/patrols/beach/hunting/leaf-bare.json
@@ -2044,8 +2044,8 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "r_c still shows where cold sunk its fangs into {PRONOUN/r_c/subject} after an unplanned leaf-bare swim.",
-                    "reg_death": "r_c was killed by cold water - not that the swim was planned.",
+                    "scar": "m_c still shows where cold sunk its fangs into {PRONOUN/m_c/subject} after an unplanned leaf-bare swim.",
+                    "reg_death": "m_c was killed by cold water - not that the swim was planned.",
                     "lead_death": "were taken by an unexpected cold-water dunking"
                 },
                 "prey": ["very_small"]
@@ -2231,8 +2231,8 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "r_c bears the scars from an unexpected cold dunking on a hunting patrol.",
-                    "reg_death": "r_c was killed by the cold ocean dunking they received when a wave swamped them unexpectedly.",
+                    "scar": "m_c bears the scars from an unexpected cold dunking on a hunting patrol.",
+                    "reg_death": "m_c was killed by the cold ocean dunking they received when a wave swamped them unexpectedly.",
                     "lead_death": "were taken by an unexpected cold-water dunking"
                 },
                 "prey": ["very_small"]
@@ -2483,8 +2483,8 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "r_c still shows where cold sunk its fangs into {PRONOUN/r_c/subject} after an unplanned leaf-bare swim.",
-                    "reg_death": "r_c was killed by cold water - not that the swim was planned.",
+                    "scar": "m_c still shows where cold sunk its fangs into {PRONOUN/m_c/subject} after an unplanned leaf-bare swim.",
+                    "reg_death": "m_c was killed by cold water - not that the swim was planned.",
                     "lead_death": "were taken by an unexpected cold-water dunking"
                 },
                 "prey": ["very_small"]
@@ -2670,8 +2670,8 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "r_c bears the scars from an unexpected cold dunking on a hunting patrol.",
-                    "reg_death": "r_c was killed by the cold ocean dunking they received when a wave swamped them unexpectedly.",
+                    "scar": "m_c bears the scars from an unexpected cold dunking on a hunting patrol.",
+                    "reg_death": "m_c was killed by the cold ocean dunking they received when a wave swamped them unexpectedly.",
                     "lead_death": "were taken by an unexpected cold-water dunking"
                 },
                 "prey": ["very_small"]

--- a/resources/dicts/patrols/desert/hunting/any.json
+++ b/resources/dicts/patrols/desert/hunting/any.json
@@ -2764,8 +2764,8 @@
                         }
                     ],
                     "history_text": {
-                        "scar": "r_c was permantly marked by the bite of a gila monster as an apprentice - but {PRONOUN/r_c/subject} survived.",
-                        "reg_death": "r_c died from the bite of a gila monster encountered on a hunt as a foolish apprentice.",
+                        "scar": "m_c was permantly marked by the bite of a gila monster as an apprentice - but {PRONOUN/m_c/subject} survived.",
+                        "reg_death": "m_c died from the bite of a gila monster encountered on a hunt as a foolish apprentice.",
                         "lead_death": "from the bite of a gila monster encountered on a hunt as a foolish apprentice"
                         }
                 }

--- a/resources/dicts/patrols/desert/hunting/leaf-fall.json
+++ b/resources/dicts/patrols/desert/hunting/leaf-fall.json
@@ -1571,9 +1571,9 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "r_c carries the scars of escaping a wildfire, brought on by lightning strikes in leaf-fall.",
-                    "reg_death": "r_c was killed by the damage {PRONOUN/r_c/subject} took escaping a wildfire out in the territory with {PRONOUN/r_c/poss} sibling.",
-                    "lead_death": "was killed by the damage {PRONOUN/r_c/subject} took escaping a wildfire out in the territory with {PRONOUN/r_c/poss} sibling"
+                    "scar": "m_c carries the scars of escaping a wildfire, brought on by lightning strikes in leaf-fall.",
+                    "reg_death": "m_c was killed by the damage {PRONOUN/m_c/subject} took escaping a wildfire out in the territory with {PRONOUN/m_c/poss} sibling.",
+                    "lead_death": "was killed by the damage {PRONOUN/m_c/subject} took escaping a wildfire out in the territory with {PRONOUN/m_c/poss} sibling"
                 },
                 "prey": ["very_small"]
             }
@@ -2005,9 +2005,9 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "r_c carries the scars of escaping a wildfire, brought on by lightning strikes in leaf-fall.",
-                    "reg_death": "r_c was killed by the damage {PRONOUN/r_c/subject} took escaping a wildfire out in the territory with {PRONOUN/r_c/poss} siblings.",
-                    "lead_death": "was killed by the damage {PRONOUN/r_c/subject} took escaping a wildfire out in the territory with {PRONOUN/r_c/poss} siblings"
+                    "scar": "m_c carries the scars of escaping a wildfire, brought on by lightning strikes in leaf-fall.",
+                    "reg_death": "m_c was killed by the damage {PRONOUN/m_c/subject} took escaping a wildfire out in the territory with {PRONOUN/m_c/poss} siblings.",
+                    "lead_death": "was killed by the damage {PRONOUN/m_c/subject} took escaping a wildfire out in the territory with {PRONOUN/m_c/poss} siblings"
                 },
                 "prey": ["very_small"]
             }

--- a/resources/dicts/patrols/general/training.json
+++ b/resources/dicts/patrols/general/training.json
@@ -11126,7 +11126,7 @@
                 "weight": 10,
                 "dead_cats": ["app1"],
                 "history_text": {
-                    "death": "r_c was killed by another cat while doing {PRONOUN/r_c/poss} assessment as an apprentice."
+                    "death": "m_c was killed by another cat while doing {PRONOUN/m_c/poss} assessment as an apprentice."
                 },
                 "relationships": [
                     {

--- a/resources/dicts/patrols/mountainous/hunting/any.json
+++ b/resources/dicts/patrols/mountainous/hunting/any.json
@@ -1253,8 +1253,8 @@
                         }
                     ],
                     "history_text": {
-                        "scar": "r_c was permantly marked by the barb of a stingray as an apprentice - but {PRONOUN/r_c/subject} survived.",
-                        "reg_death": "r_c died from the strike of a stingray encountered on a hunt as a foolish apprentice.",
+                        "scar": "m_c was permantly marked by the barb of a stingray as an apprentice - but {PRONOUN/m_c/subject} survived.",
+                        "reg_death": "m_c died from the strike of a stingray encountered on a hunt as a foolish apprentice.",
                         "lead_death": "from the strike of a stingray encountered on a hunt as a foolish apprentice"
                         }
                 }

--- a/resources/dicts/patrols/mountainous/hunting/leaf-bare.json
+++ b/resources/dicts/patrols/mountainous/hunting/leaf-bare.json
@@ -2321,8 +2321,8 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "r_c is scarred from a leaf-bare they endured as a young cat.",
-                    "reg_death": "r_c was killed by the cold of the mountain leaf-bare.",
+                    "scar": "m_c is scarred from a leaf-bare they endured as a young cat.",
+                    "reg_death": "m_c was killed by the cold of the mountain leaf-bare.",
                     "lead_death": "was killed by the cold of the mountain leaf-bare"
                 },
                 "prey": ["very_small"]
@@ -2563,8 +2563,8 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "r_c is scarred from a leaf-bare they endured as a young cat.",
-                    "reg_death": "r_c was killed by the cold of the mountain leaf-bare.",
+                    "scar": "m_c is scarred from a leaf-bare they endured as a young cat.",
+                    "reg_death": "m_c was killed by the cold of the mountain leaf-bare.",
                     "lead_death": "was killed by the cold of the mountain leaf-bare"
                 },
                 "prey": ["very_small"]
@@ -2805,8 +2805,8 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "r_c is scarred from a leaf-bare they endured as a young cat.",
-                    "reg_death": "r_c was killed by the cold of the mountain leaf-bare.",
+                    "scar": "m_c is scarred from a leaf-bare they endured as a young cat.",
+                    "reg_death": "m_c was killed by the cold of the mountain leaf-bare.",
                     "lead_death": "was killed by the cold of the mountain leaf-bare"
                 },
                 "prey": ["very_small"]
@@ -3047,8 +3047,8 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "r_c is scarred from a leaf-bare they endured as a young cat.",
-                    "reg_death": "r_c was killed by the cold of the mountain leaf-bare.",
+                    "scar": "m_c is scarred from a leaf-bare they endured as a young cat.",
+                    "reg_death": "m_c was killed by the cold of the mountain leaf-bare.",
                     "lead_death": "was killed by the cold of the mountain leaf-bare"
                 },
                 "prey": ["very_small"]
@@ -3286,8 +3286,8 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "r_c is scarred from a leaf-bare they endured as a young cat.",
-                    "reg_death": "r_c was killed by the cold of the mountain leaf-bare.",
+                    "scar": "m_c is scarred from a leaf-bare they endured as a young cat.",
+                    "reg_death": "m_c was killed by the cold of the mountain leaf-bare.",
                     "lead_death": "was killed by the cold of the mountain leaf-bare"
                 },
                 "prey": ["very_small"]
@@ -3823,9 +3823,9 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "r_c was scarred by the cold of a harsh leaf-bare.",
-                    "reg_death": "r_c was killed by the cold of a harsh leaf-bare.",
-                    "lead_death": "were killed by cold that sunk its fangs in while r_c hunted to provide for c_n"
+                    "scar": "m_c was scarred by the cold of a harsh leaf-bare.",
+                    "reg_death": "m_c was killed by the cold of a harsh leaf-bare.",
+                    "lead_death": "were killed by cold that sunk its fangs in while m_c hunted to provide for c_n"
                 },
                 "prey": ["very_small"]
             }
@@ -4270,9 +4270,9 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "r_c was scarred by the cold of a harsh leaf-bare.",
-                    "reg_death": "r_c was killed by the cold of a harsh leaf-bare.",
-                    "lead_death": "were killed by cold that sunk its fangs in while r_c hunted to provide for c_n"
+                    "scar": "m_c was scarred by the cold of a harsh leaf-bare.",
+                    "reg_death": "m_c was killed by the cold of a harsh leaf-bare.",
+                    "lead_death": "were killed by cold that sunk its fangs in while m_c hunted to provide for c_n"
                 },
                 "prey": ["very_small"]
             }

--- a/resources/dicts/patrols/mountainous/training/leaf-bare.json
+++ b/resources/dicts/patrols/mountainous/training/leaf-bare.json
@@ -540,8 +540,8 @@
                                 }
                             ],
                         "history_text": {
-                        "reg_death": "r_c died from lack of sleep, {PRONOUN/r_c/poss} vision haunted by dark shadows.",
-                        "lead_death": "from lack of sleep, {PRONOUN/r_c/poss} vision haunted by dark shadows"
+                        "reg_death": "m_c died from lack of sleep, {PRONOUN/m_c/poss} vision haunted by dark shadows.",
+                        "lead_death": "from lack of sleep, {PRONOUN/m_c/poss} vision haunted by dark shadows"
                        }
                 },
                 {
@@ -655,7 +655,7 @@
                                 }
                             ],
                     "history_text": {
-                        "reg_death": "r_c died as a consequence of poor den construction, getting too cold in leaf-bare.",
+                        "reg_death": "m_c died as a consequence of poor den construction, getting too cold in leaf-bare.",
                         "lead_death": "as a consequence of poor den construction, getting too cold in leaf-bare"
                        }
                 },

--- a/resources/dicts/patrols/mountainous/training/leaf-fall.json
+++ b/resources/dicts/patrols/mountainous/training/leaf-fall.json
@@ -734,8 +734,8 @@
                                 }
                             ],
                         "history_text": {
-                        "reg_death": "r_c died from lack of sleep, {PRONOUN/r_c/poss} vision haunted by dark shadows.",
-                        "lead_death": "from lack of sleep, {PRONOUN/r_c/poss} vision haunted by dark shadows"
+                        "reg_death": "m_c died from lack of sleep, {PRONOUN/m_c/poss} vision haunted by dark shadows.",
+                        "lead_death": "from lack of sleep, {PRONOUN/m_c/poss} vision haunted by dark shadows"
                        }
                 },
                 {

--- a/resources/dicts/patrols/other_clan_hostile.json
+++ b/resources/dicts/patrols/other_clan_hostile.json
@@ -3610,9 +3610,9 @@
                 "weight": 10,
                 "dead_cats": ["r_c"],
                 "history_text": {
-                    "scar": "r_c carries a scar, and lingering resentment, from when a Clanmate failed to watch {PRONOUN/r_c/poss} back during a border altercation.",
-                    "reg_death": "r_c was killed in a border altercation when a Clanmate failed to watch {PRONOUN/r_c/poss} back.",
-                    "lead_death": "were killed when a Clanmate failed to support {PRONOUN/r_c/object} during a border altercation"
+                    "scar": "m_c carries a scar, and lingering resentment, from when a Clanmate failed to watch {PRONOUN/m_c/poss} back during a border altercation.",
+                    "reg_death": "m_c was killed in a border altercation when a Clanmate failed to watch {PRONOUN/m_c/poss} back.",
+                    "lead_death": "were killed when a Clanmate failed to support {PRONOUN/m_c/object} during a border altercation"
                 },
                 "relationships": [
                     {
@@ -3644,9 +3644,9 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "r_c carries a scar, and lingering resentment, from when a Clanmate failed to watch {PRONOUN/r_c/poss} back during a border altercation.",
-                    "reg_death": "r_c was killed in a border altercation when a Clanmate failed to watch {PRONOUN/r_c/poss} back.",
-                    "lead_death": "were killed when a Clanmate failed to support {PRONOUN/r_c/object} during a border altercation"
+                    "scar": "m_c carries a scar, and lingering resentment, from when a Clanmate failed to watch {PRONOUN/m_c/poss} back during a border altercation.",
+                    "reg_death": "m_c was killed in a border altercation when a Clanmate failed to watch {PRONOUN/m_c/poss} back.",
+                    "lead_death": "were killed when a Clanmate failed to support {PRONOUN/m_c/object} during a border altercation"
                 },
                 "relationships": [
                     {
@@ -3724,7 +3724,7 @@
                 "weight": 10,
                 "dead_cats": ["patrol", "some_lives"],
                 "history_text": {
-                    "reg_death": "r_c was killed in a border ambush by a hostile Clan.",
+                    "reg_death": "m_c was killed in a border ambush by a hostile Clan.",
                     "lead_death": "were killed by o_c_n in a border ambush"
                 },
                 "other_clan_rep": -1
@@ -3747,7 +3747,7 @@
                 ],
                 "dead_cats": ["patrol", "some_lives"],
                 "history_text": {
-                    "reg_death": "r_c was killed in a border ambush by a hostile Clan.",
+                    "reg_death": "m_c was killed in a border ambush by a hostile Clan.",
                     "lead_death": "were killed by o_c_n in a border ambush"
                 },
                 "other_clan_rep": -1
@@ -3810,8 +3810,8 @@
                 "weight": 10,
                 "dead_cats": ["patrol", "some_lives"],
                 "history_text": {
-                    "scar": "r_c carries the scars o_c_n gave them, a permanent reminder of the Clan's hositilities.",
-                    "reg_death": "r_c was killed in a border ambush by a hostile Clan.",
+                    "scar": "m_c carries the scars o_c_n gave them, a permanent reminder of the Clan's hositilities.",
+                    "reg_death": "m_c was killed in a border ambush by a hostile Clan.",
                     "lead_death": "were killed by o_c_n in a border ambush"
                 },
                 "other_clan_rep": -1
@@ -3834,8 +3834,8 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "r_c carries the scars o_c_n gave them, a permanent reminder of the Clan's hositilities.",
-                    "reg_death": "r_c was killed in a border ambush by a hostile Clan.",
+                    "scar": "m_c carries the scars o_c_n gave them, a permanent reminder of the Clan's hositilities.",
+                    "reg_death": "m_c was killed in a border ambush by a hostile Clan.",
                     "lead_death": "were killed by o_c_n in a border ambush"
                 },
                 "other_clan_rep": -1
@@ -3858,8 +3858,8 @@
                 ],
                 "dead_cats": ["patrol", "some_lives"],
                 "history_text": {
-                    "scar": "r_c carries the scars o_c_n gave them, a permanent reminder of the Clan's hositilities.",
-                    "reg_death": "r_c was killed in a border ambush by a hostile Clan.",
+                    "scar": "m_c carries the scars o_c_n gave them, a permanent reminder of the Clan's hositilities.",
+                    "reg_death": "m_c was killed in a border ambush by a hostile Clan.",
                     "lead_death": "were killed by o_c_n in a border ambush"
                 },
                 "other_clan_rep": -1
@@ -3922,8 +3922,8 @@
                 "weight": 10,
                 "dead_cats": ["multi", "some_lives"],
                 "history_text": {
-                    "scar": "r_c carries the scars o_c_n gave them, a permanent reminder of the Clan's hositilities.",
-                    "reg_death": "r_c was killed in a border ambush by a hostile Clan.",
+                    "scar": "m_c carries the scars o_c_n gave them, a permanent reminder of the Clan's hositilities.",
+                    "reg_death": "m_c was killed in a border ambush by a hostile Clan.",
                     "lead_death": "were killed by o_c_n in a border ambush"
                 },
                 "other_clan_rep": -1
@@ -3946,8 +3946,8 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "r_c carries the scars o_c_n gave them, a permanent reminder of the Clan's hositilities.",
-                    "reg_death": "r_c was killed in a border ambush by a hostile Clan.",
+                    "scar": "m_c carries the scars o_c_n gave them, a permanent reminder of the Clan's hositilities.",
+                    "reg_death": "m_c was killed in a border ambush by a hostile Clan.",
                     "lead_death": "were killed by o_c_n in a border ambush"
                 },
                 "other_clan_rep": -1
@@ -3970,8 +3970,8 @@
                 ],
                 "dead_cats": ["multi", "some_lives"],
                 "history_text": {
-                    "scar": "r_c carries the scars o_c_n gave them, a permanent reminder of the Clan's hositilities.",
-                    "reg_death": "r_c was killed in a border ambush by a hostile Clan.",
+                    "scar": "m_c carries the scars o_c_n gave them, a permanent reminder of the Clan's hositilities.",
+                    "reg_death": "m_c was killed in a border ambush by a hostile Clan.",
                     "lead_death": "were killed by o_c_n in a border ambush"
                 },
                 "other_clan_rep": -1

--- a/resources/dicts/patrols/plains/hunting/any.json
+++ b/resources/dicts/patrols/plains/hunting/any.json
@@ -2843,8 +2843,8 @@
                         }
                     ],
                     "history_text": {
-                        "scar": "r_c was permantly marked by the claws of a hare as an apprentice - but {PRONOUN/r_c/subject} survived.",
-                        "reg_death": "r_c died from the claws of a hare encountered on a hunt as a foolish apprentice.",
+                        "scar": "m_c was permantly marked by the claws of a hare as an apprentice - but {PRONOUN/m_c/subject} survived.",
+                        "reg_death": "m_c died from the claws of a hare encountered on a hunt as a foolish apprentice.",
                         "lead_death": "from the claws of a hare encountered on a hunt as a foolish apprentice"
                         }
                 }

--- a/resources/dicts/patrols/plains/hunting/greenleaf.json
+++ b/resources/dicts/patrols/plains/hunting/greenleaf.json
@@ -1421,8 +1421,8 @@
                 "weight": 10,
                 "dead_cats": ["r_c"],
                 "history_text": {
-                    "scar": "r_c carries a scar from fighting with a swift fox.",
-                    "reg_death": "While scavenging alone, r_c was killed by a predator {PRONOUN/r_c/subject} didn't see.",
+                    "scar": "m_c carries a scar from fighting with a swift fox.",
+                    "reg_death": "While scavenging alone, m_c was killed by a predator {PRONOUN/m_c/subject} didn't see.",
                     "lead_death": "{VERB/m_c/were/was} killed by a predator"
                 }
             },
@@ -1438,8 +1438,8 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "r_c carries a scar from fighting with a swift fox.",
-                    "reg_death": "While scavenging alone, r_c was killed by a predator {PRONOUN/r_c/subject} didn't see.",
+                    "scar": "m_c carries a scar from fighting with a swift fox.",
+                    "reg_death": "While scavenging alone, m_c was killed by a predator {PRONOUN/m_c/subject} didn't see.",
                     "lead_death": "{VERB/m_c/were/was} killed by a predator"
                 }
             },
@@ -1463,8 +1463,8 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "r_c carries a scar from fighting with a swift fox.",
-                    "reg_death": "While scavenging alone, r_c was killed by a predator {PRONOUN/r_c/subject} didn't see.",
+                    "scar": "m_c carries a scar from fighting with a swift fox.",
+                    "reg_death": "While scavenging alone, m_c was killed by a predator {PRONOUN/m_c/subject} didn't see.",
                     "lead_death": "{VERB/m_c/were/was} killed by a predator"
                 }
             }

--- a/resources/dicts/patrols/plains/med/greenleaf.json
+++ b/resources/dicts/patrols/plains/med/greenleaf.json
@@ -6090,8 +6090,8 @@
                         }
                     ],
                     "history_text": {
-                        "scar": "r_c was permantly marked by raspberry bramble thorns.",
-                        "reg_death": "r_c died from complications from a small cut, proof that even tiny wounds can progress to dangerous levels.",
+                        "scar": "m_c was permantly marked by raspberry bramble thorns.",
+                        "reg_death": "m_c died from complications from a small cut, proof that even tiny wounds can progress to dangerous levels.",
                         "lead_death": "from complications from a small cut, proof that even tiny wounds can progress to dangerous levels"
                         }
                 }

--- a/resources/dicts/patrols/plains/med/leaf-fall.json
+++ b/resources/dicts/patrols/plains/med/leaf-fall.json
@@ -5639,8 +5639,8 @@
                         }
                     ],
                     "history_text": {
-                        "scar": "r_c was permantly marked by raspberry bramble thorns.",
-                        "reg_death": "r_c died from complications from a small cut, proof that even tiny wounds can progress to dangerous levels.",
+                        "scar": "m_c was permantly marked by raspberry bramble thorns.",
+                        "reg_death": "m_c died from complications from a small cut, proof that even tiny wounds can progress to dangerous levels.",
                         "lead_death": "from complications from a small cut, proof that even tiny wounds can progress to dangerous levels"
                         }
                 }

--- a/resources/dicts/patrols/wetlands/hunting/any.json
+++ b/resources/dicts/patrols/wetlands/hunting/any.json
@@ -6142,8 +6142,8 @@
                         }
                     ],
                     "history_text": {
-                        "reg_death": "r_c died from the water {PRONOUN/r_c/subject} inhaled on a hunt as a foolish apprentice.",
-                        "lead_death": "from the water {PRONOUN/r_c/subject} inhaled on a hunt as a foolish apprentice"
+                        "reg_death": "m_c died from the water {PRONOUN/m_c/subject} inhaled on a hunt as a foolish apprentice.",
+                        "lead_death": "from the water {PRONOUN/m_c/subject} inhaled on a hunt as a foolish apprentice"
                         }
                 }
             ]

--- a/resources/dicts/patrols/wetlands/hunting/leaf-bare.json
+++ b/resources/dicts/patrols/wetlands/hunting/leaf-bare.json
@@ -1459,8 +1459,8 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "r_c still shows where cold sunk its fangs into {PRONOUN/r_c/subject} after an unplanned leaf-bare swim.",
-                    "reg_death": "r_c was killed by cold water - not that the swim was planned.",
+                    "scar": "m_c still shows where cold sunk its fangs into {PRONOUN/m_c/subject} after an unplanned leaf-bare swim.",
+                    "reg_death": "m_c was killed by cold water - not that the swim was planned.",
                     "lead_death": "were taken by an unexpected cold-water dunking"
                 },
                 "prey": ["very_small"]
@@ -1646,8 +1646,8 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "r_c bears the scars from an unexpected cold dunking on a hunting patrol.",
-                    "reg_death": "r_c was killed by the cold dunking they got from a fall into the water in leaf-bare.",
+                    "scar": "m_c bears the scars from an unexpected cold dunking on a hunting patrol.",
+                    "reg_death": "m_c was killed by the cold dunking they got from a fall into the water in leaf-bare.",
                     "lead_death": "were taken by an unexpected cold-water dunking"
                 },
                 "prey": ["very_small"]
@@ -1898,8 +1898,8 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "r_c still shows where cold sunk its fangs into {PRONOUN/r_c/subject} after an unplanned leaf-bare swim.",
-                    "reg_death": "r_c was killed by cold water - not that the swim was planned.",
+                    "scar": "m_c still shows where cold sunk its fangs into {PRONOUN/m_c/subject} after an unplanned leaf-bare swim.",
+                    "reg_death": "m_c was killed by cold water - not that the swim was planned.",
                     "lead_death": "were taken by an unexpected cold-water dunking"
                 },
                 "prey": ["very_small"]
@@ -2085,8 +2085,8 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "r_c bears the scars from an unexpected cold dunking on a hunting patrol.",
-                    "reg_death": "r_c was killed by the cold dunking they got from a fall into the water in leaf-bare.",
+                    "scar": "m_c bears the scars from an unexpected cold dunking on a hunting patrol.",
+                    "reg_death": "m_c was killed by the cold dunking they got from a fall into the water in leaf-bare.",
                     "lead_death": "were taken by an unexpected cold-water dunking"
                 },
                 "prey": ["very_small"]


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->

## About The Pull Request
This PR fixed some misformatted patrols where r_c was being misused in the death text. The solution was to replace r_c to m_c.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
fixes: #2680
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing

![image](https://github.com/user-attachments/assets/1462439f-9ffe-4da7-b00c-2e1f7f7b3fc4)

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
Fixed some patrols.
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
