### PR TITLE
CONTENT: More Leader's Den Events

### DIFF
--- a/resources/dicts/events/leader_den/fail/outsider.json
+++ b/resources/dicts/events/leader_den/fail/outsider.json
@@ -215,5 +215,155 @@
         }
       ]
     }
+  },
+  {
+    "interaction_type": "drive",
+    "event_text": "The cats of c_n have been scouring the territory for m_c, but {PRONOUN/m_c/poss} strong senses have helped {PRONOUN/m_c/object} to stay two pawsteps ahead of {PRONOUN/m_c/poss} pursuers.",
+    "reputation": ["any"],
+    "rep_change": -1,
+    "m_c": {
+      "status": ["loner", "rogue", "kittypet", "exiled"],
+      "age": ["adolescent", "young adult", "adult", "senior adult"],
+      "skill": [
+        "SENSE,1"
+      ],
+      "new_thought": "Is thankful {PRONOUN/m_c/subject} {VERB/m_c/weren't/wasn't} caught by c_n",
+      "relationships": [
+        {
+          "cats_from": ["m_c"],
+          "cats_to": ["clan"],
+          "mutual": true,
+          "values": ["dislike"],
+          "amount": 5
+        },
+        {
+          "cats_from": ["clan"],
+          "cats_to": ["m_c"],
+          "mutual": false,
+          "values": ["respect"],
+          "amount": 5
+        }
+      ]
+    }
+  },
+  {
+    "interaction_type": "hunt",
+    "event_text": "The cats of c_n have set up an ambush, hoping to get rid of m_c once and for all. However, despite the Clancats' best efforts, m_c's strong senses have helped {PRONOUN/m_c/object} to evade the trap.",
+    "reputation": ["any"],
+    "rep_change": -2,
+    "m_c": {
+      "status": ["loner", "rogue", "kittypet", "exiled"],
+      "age": ["adolescent", "young adult", "adult", "senior adult"],
+      "skill": [
+        "SENSE,1"
+      ],
+      "new_thought": "Is thankful {PRONOUN/m_c/subject} {VERB/m_c/weren't/wasn't} caught by c_n",
+      "relationships": [
+        {
+          "cats_from": ["m_c"],
+          "cats_to": ["clan"],
+          "mutual": true,
+          "values": ["dislike"],
+          "amount": 15
+        },
+        {
+          "cats_from": ["clan"],
+          "cats_to": ["m_c"],
+          "mutual": false,
+          "values": ["respect"],
+          "amount": 5
+        }
+      ]
+    }
+  },
+  {
+    "interaction_type": "drive",
+    "event_text": "Some of c_n's best hunters challenge m_c to a hunt-off. The stakes are simple: if c_n wins, then m_c leaves the territory. Well, m_c soon proves that with age comes experience, easily winning the contest before continuing on {PRONOUN/m_c/poss} merry way.",
+    "reputation": ["any"],
+    "rep_change": -1,
+    "m_c": {
+      "status": ["loner", "rogue", "kittypet"],
+      "age": ["senior"],
+      "skill": [
+        "HUNTER,3"
+      ],
+      "new_thought": "Is feeling rather pleased after showing those whippersnappers a thing or two",
+      "relationships": [
+        {
+          "cats_from": ["m_c"],
+          "cats_to": ["clan"],
+          "mutual": false,
+          "values": ["dislike"],
+          "amount": 5
+        },
+        {
+          "cats_from": ["clan"],
+          "cats_to": ["m_c"],
+          "mutual": false,
+          "values": ["respect"],
+          "amount": 10
+        }
+      ]
+    }
+  },
+  {
+    "interaction_type": "drive",
+    "event_text": "The cats of c_n have been scouring the territory for m_c but, even in {PRONOUN/m_c/poss} advanced age, m_c's senses have remained sharp enough for {PRONOUN/m_c/object} to stay two pawsteps ahead of {PRONOUN/m_c/poss} pursuers.",
+    "reputation": ["any"],
+    "rep_change": -1,
+    "m_c": {
+      "status": ["loner", "rogue", "kittypet", "exiled"],
+      "age": ["senior"],
+      "skill": [
+        "SENSE,1"
+      ],
+      "new_thought": "Is thankful {PRONOUN/m_c/subject} {VERB/m_c/weren't/wasn't} caught by c_n",
+      "relationships": [
+        {
+          "cats_from": ["m_c"],
+          "cats_to": ["clan"],
+          "mutual": true,
+          "values": ["dislike"],
+          "amount": 5
+        },
+        {
+          "cats_from": ["clan"],
+          "cats_to": ["m_c"],
+          "mutual": false,
+          "values": ["respect"],
+          "amount": 5
+        }
+      ]
+    }
+  },
+  {
+    "interaction_type": "hunt",
+    "event_text": "The cats of c_n have set up an ambush, hoping to get rid of m_c once and for all. However, even in {PRONOUN/m_c/poss} advanced age, m_c's senses are more than sharp enough to help {PRONOUN/m_c/object} evade the trap.",
+    "reputation": ["any"],
+    "rep_change": -2,
+    "m_c": {
+      "status": ["loner", "rogue", "kittypet", "exiled"],
+      "age": ["senior"],
+      "skill": [
+        "SENSE,1"
+      ],
+      "new_thought": "Isn't ready to join StarClan just yet",
+      "relationships": [
+        {
+          "cats_from": ["m_c"],
+          "cats_to": ["clan"],
+          "mutual": true,
+          "values": ["dislike"],
+          "amount": 15
+        },
+        {
+          "cats_from": ["clan"],
+          "cats_to": ["m_c"],
+          "mutual": false,
+          "values": ["respect"],
+          "amount": 10
+        }
+      ]
+    }
   }
 ]

--- a/resources/dicts/events/leader_den/success/outsider.json
+++ b/resources/dicts/events/leader_den/success/outsider.json
@@ -279,5 +279,36 @@
       ],
       "kit_thought": "Is unsure why {PRONOUN/m_c/poss} parent hasn't come back."
     }
+  },
+  {
+    "interaction_type": "search",
+    "event_text": "Patrol after patrol has been sent out in search of m_c, always returning without their lost Clanmate. Then, just as the Clan is about to give up all hope, m_c manages to track them down, resulting in a joyful reunion.",
+    "reputation": ["any"],
+    "rep_change": 1,
+    "m_c": {
+      "status": ["lost"],
+      "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+      "skill": [
+        "SENSE,1"
+      ],
+      "new_thought": "Is glad to have returned",
+      "kit_thought": "Is curious about the new place {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} in",
+      "relationships": [
+        {
+          "cats_from": ["m_c"],
+          "cats_to": ["clan"],
+          "mutual": false,
+          "values": ["dislike"],
+          "amount": -5
+        },
+        {
+          "cats_from": ["m_c"],
+          "cats_to": ["some_clan"],
+          "mutual": false,
+          "values": ["trust"],
+          "amount": 5
+        }
+      ]
+    }
   }
 ]


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->

## About The Pull Request
**Adds multiple new Leader's Den events, with most involving the Sense skill.**
3x Drive fails
2x Hunt fails
1x Search success
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Why This Is Good For ClanGen
More variety when it comes to the Leader's Den events means that players will be less likely to roll the same result multiple times
<!-- If this is a bug fix, you can remove this section. -->
<!-- Please add a short description of why you think these changes would benefit the game. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->
<!-- If you have multiple features that can stand on their own, or unrelated bugfixes, please create separate PRs for them. -->

## Proof of Testing
![Outsider_DriveOff_Elder_Fail1](https://github.com/user-attachments/assets/01a21d62-d97c-4328-b2b5-5211aa15d23d)
![Outsider_DriveOff_Elder_Fail1](https://github.com/user-attachments/assets/1f6c7c10-ed36-41ed-b31b-f7e65decee1b)
![Outsider_HuntDown_Fail1](https://github.com/user-attachments/assets/0c7a86e6-6ebb-49fe-9aab-66bafe9231d0)

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
Added Leader's Den events
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
