### PR TITLE
Balancing: Herbs

### DIFF
--- a/resources/dicts/events/misc/beach.json
+++ b/resources/dicts/events/misc/beach.json
@@ -53,12 +53,12 @@
     "season": ["leaf-bare"],
     "tags": ["clan_wide"],
     "weight": 1,
-    "event_text": "A huge wave crashes into camp, leaving everyone soaked and the herb stores irreparably damaged.",
+    "event_text": "A huge wave crashes into camp, leaving everyone soaked and the herb stores quite damaged.",
     "supplies": [
       {
           "type": "all_herb",
-          "trigger": ["always"],
-          "adjust": "reduce_full"
+          "trigger": ["excess"],
+          "adjust": "reduce_half"
       }
     ]
   },

--- a/resources/dicts/events/misc/general.json
+++ b/resources/dicts/events/misc/general.json
@@ -3403,7 +3403,7 @@
     "location": ["any"],
     "season": ["greenleaf"],
     "tags": ["clan_wide"],
-    "weight": 10,
+    "weight": 15,
     "event_text": "As the herb stores are being inspected, it's noticed that some of the given_herb went bad. They'll need to be replaced.",
     "supplies": [
       {
@@ -3418,7 +3418,7 @@
     "location": ["any"],
     "season": ["any"],
     "tags": ["clan_wide"],
-    "weight": 15,
+    "weight": 20,
     "event_text": "The Clan has gathered plenty of moss recently, time to refresh the dens!",
     "supplies": [
       {

--- a/resources/dicts/events/misc/general.json
+++ b/resources/dicts/events/misc/general.json
@@ -2550,7 +2550,7 @@
     "season": ["leaf-bare"],
     "sub_type": ["war"],
     "weight": 10,
-    "event_text": "m_c hopes to find the herbs that c_n needs in the war, and goes to look for them even in this Leaf-bare's harsh weather.",
+    "event_text": "m_c hopes to find the herbs that c_n needs in the war, and goes to look for them even in this leaf-bare's harsh weather.",
     "m_c": {
       "age":["any"],
       "status": ["medicine cat apprentice", "medicine cat"]
@@ -3134,18 +3134,62 @@
     }
   },
   {
+    "event_id": "gen_misc_herb_anyallyaid1",
+    "location": ["any"],
+    "season": ["any"],
+    "tags": ["clan_wide"],
+    "weight": 10,
+    "event_text": "The herb stores are low, m_c decides to ask o_c_n for aid in these hard times. Thankfully, the allied Clan is happy to share their excess herbs.",
+    "m_c": {
+      "status": ["medicine cat", "medicine cat apprentice"]
+    },
+    "supplies": [
+      {
+          "type": "any_herb",
+          "trigger": ["low"],
+          "adjust": "increase_10"
+      }
+    ],
+    "other_clan": {
+      "current_rep": ["ally"],
+      "changed": 1
+    }
+  },
+  {
+    "event_id": "gen_misc_herb_anyallyaid2",
+    "location": ["any"],
+    "season": ["any"],
+    "tags": ["clan_wide", "clan:leader", "clan:medicine cat"],
+    "weight": 10,
+    "event_text": "lead_name hears from med_name that the Clan is low on herbs. m_c is sent to bargain with o_c_n for whatever herbs they can spare.",
+    "m_c": {
+      "status": ["mediator", "mediator apprentice"]
+    },
+    "supplies": [
+      {
+          "type": "any_herb",
+          "trigger": ["low"],
+          "adjust": "increase_10"
+      }
+    ],
+    "other_clan": {
+      "current_rep": ["neutral"],
+      "changed": 1
+    }
+  },
+  {
     "event_id": "gen_misc_herb_anywarsteal1",
     "location": ["any"],
     "season": ["any"],
     "subtype": ["war"],
     "tags": ["clan_wide"],
     "weight": 5,
-    "event_text": "o_c_n breaks into the camp and ravages the herb stores, taking some for themselves and destroying the rest.",
+    "event_text": "o_c_n breaks into the camp and ravages the herb stores, taking some for themselves and attempting to destroy. The Clan manages to recover some of the herbs, but the store was still badly damaged.",
     "supplies": [
       {
           "type": "all_herb",
-          "trigger": ["always"],
-          "adjust": "reduce_full"
+          "trigger": ["adequate", "full", "excess"],
+          "adjust": "reduce_half"
       }
     ],
     "other_clan": {
@@ -3159,12 +3203,12 @@
     "season": ["any"],
     "tags": ["clan_wide"],
     "weight": 1,
-    "event_text": "Some sort of pest got into the herb stores and completely destroyed them. c_n will have to clean it out and start over anew.",
+    "event_text": "Some sort of pest got into the herb stores and ruined much of the supplies.. c_n will have to clean it out and start over anew.",
     "supplies": [
       {
           "type": "all_herb",
-          "trigger": ["always"],
-          "adjust": "reduce_full"
+          "trigger": ["adequate", "full", "excess"],
+          "adjust": "reduce_half"
       }
     ]
   },
@@ -3174,12 +3218,12 @@
     "season": ["any"],
     "tags": ["clan_wide"],
     "weight": 1,
-    "event_text": "Abnormally strong winds blew through the camp last night and scattered the herb store into a useless state.",
+    "event_text": "Abnormally strong winds blew through the camp last night and scattered the herb store into a useless state. The Clan manages to recover some of the herbs, but the resulting supply is much smaller than before.",
     "supplies": [
       {
           "type": "all_herb",
-          "trigger": ["always"],
-          "adjust": "reduce_full"
+          "trigger": ["adequate", "full", "excess"],
+          "adjust": "reduce_half"
       }
     ]
   },
@@ -3193,8 +3237,8 @@
     "supplies": [
       {
           "type": "all_herb",
-          "trigger": ["always"],
-          "adjust": "reduce_full"
+          "trigger": ["adequate", "full", "excess"],
+          "adjust": "reduce_half"
       }
     ]
   },
@@ -3204,12 +3248,12 @@
     "season": ["leaf-bare"],
     "tags": ["clan_wide"],
     "weight": 1,
-    "event_text": "Freezing temperatures have not just affected the cats. It's also frostbitten the stored herbs. They're useless now and will have to be replaced.",
+    "event_text": "Freezing temperatures have not just affected the cats. It's also frostbitten the stored herbs. Many of them are useless now and will have to be replaced.",
     "supplies": [
       {
           "type": "all_herb",
-          "trigger": ["always"],
-          "adjust": "reduce_full"
+          "trigger": ["adequate", "full", "excess"],
+          "adjust": "reduce_half"
       }
     ]
   },
@@ -3234,12 +3278,12 @@
     "season": ["greenleaf"],
     "tags": ["clan_wide"],
     "weight": 1,
-    "event_text": "The persistent, dry heat managed to cause a small fire in the herb stores. While no one was injured, the herbs are little more than ashes now.",
+    "event_text": "The persistent, dry heat managed to cause a small fire in the herb stores. While no one was injured, many of the herbs are little more than ashes now.",
     "supplies": [
       {
           "type": "all_herb",
-          "trigger": ["always"],
-          "adjust": "reduce_full"
+          "trigger": ["adequate", "full", "excess"],
+          "adjust": "reduce_half"
       }
     ]
   },
@@ -3253,7 +3297,7 @@
     "supplies": [
       {
           "type": "any_herb",
-          "trigger": ["full"],
+          "trigger": ["adequate", "full", "excess"],
           "adjust": "reduce_quarter"
       }
     ]

--- a/resources/dicts/events/misc/general.json
+++ b/resources/dicts/events/misc/general.json
@@ -3137,8 +3137,8 @@
     "event_id": "gen_misc_herb_anyallyaid1",
     "location": ["any"],
     "season": ["any"],
-    "tags": ["clan_wide"],
-    "weight": 10,
+    "tags": [],
+    "weight": 20,
     "event_text": "The herb stores are low, m_c decides to ask o_c_n for aid in these hard times. Thankfully, the allied Clan is happy to share their excess herbs.",
     "m_c": {
       "status": ["medicine cat", "medicine cat apprentice"]
@@ -3159,8 +3159,8 @@
     "event_id": "gen_misc_herb_anyallyaid2",
     "location": ["any"],
     "season": ["any"],
-    "tags": ["clan_wide", "clan:leader", "clan:medicine cat"],
-    "weight": 10,
+    "tags": ["clan:leader", "clan:medicine cat"],
+    "weight": 20,
     "event_text": "lead_name hears from med_name that the Clan is low on herbs. m_c is sent to bargain with o_c_n for whatever herbs they can spare.",
     "m_c": {
       "status": ["mediator", "mediator apprentice"]
@@ -3178,6 +3178,73 @@
     }
   },
   {
+    "event_id": "gen_misc_herb_anyallyaid3",
+    "location": ["any"],
+    "season": ["any"],
+    "tags": ["clan:leader", "clan:medicine cat"],
+    "weight": 20,
+    "event_text": "lead_name hears from med_name that the Clan is low on herbs. m_c is sent to bargain with o_c_n for whatever herbs they can spare.",
+    "m_c": {
+      "status": ["warrior", "deputy"],
+      "skill": ["SPEAKER,2", "MEDIATOR,2"]
+    },
+    "supplies": [
+      {
+          "type": "any_herb",
+          "trigger": ["low"],
+          "adjust": "increase_10"
+      }
+    ],
+    "other_clan": {
+      "current_rep": ["neutral"],
+      "changed": 1
+    }
+  },
+  {
+    "event_id": "gen_misc_herb_anyallyaid4",
+    "location": ["any"],
+    "season": ["any"],
+    "tags": [],
+    "weight": 20,
+    "event_text": "While at the Gathering, m_c pulls the o_c_n leader aside and requests herbs from their Clan. The other leader is happy to help.",
+    "m_c": {
+      "status": ["leader"]
+    },
+    "supplies": [
+      {
+          "type": "any_herb",
+          "trigger": ["low"],
+          "adjust": "increase_10"
+      }
+    ],
+    "other_clan": {
+      "current_rep": ["ally"],
+      "changed": 1
+    }
+  },
+  {
+    "event_id": "gen_misc_herb_anyallyaid5",
+    "location": ["any"],
+    "season": ["any"],
+    "tags": [],
+    "weight": 20,
+    "event_text": "While at the Gathering, m_c speaks to the other medicine cats and expresses worry over {PRONOUN/m_c/poss} herb stores. The medicine cats offer to bring some extra herbs to c_n later, to help bolster {PRONOUN/m_c/poss} supply.",
+    "m_c": {
+      "status": ["medicine cat", "medicine cat apprentice"]
+    },
+    "supplies": [
+      {
+          "type": "any_herb",
+          "trigger": ["low"],
+          "adjust": "increase_20"
+      }
+    ],
+    "other_clan": {
+      "current_rep": ["ally", "neutral"],
+      "changed": 1
+    }
+  },
+  {
     "event_id": "gen_misc_herb_anywarsteal1",
     "location": ["any"],
     "season": ["any"],
@@ -3190,6 +3257,30 @@
           "type": "all_herb",
           "trigger": ["adequate", "full", "excess"],
           "adjust": "reduce_half"
+      }
+    ],
+    "other_clan": {
+      "current_rep": ["hostile"],
+      "changed": -2
+    }
+  },
+  {
+    "event_id": "gen_misc_herb_anywarsteal2",
+    "location": ["any"],
+    "season": ["any"],
+    "subtype": ["war"],
+    "tags": ["clan_wide"],
+    "weight": 5,
+    "event_text": "c_n breaks into the o_c_n camp and steals precious herbs from their medicine cat den.",
+    "m_c": {
+      "status": ["leader"],
+      "trait": ["arrogant", "bloodthirsty", "vengeful", "competitive", "bold", "troublesome", "fierce", "cold", "righteous", "daring", "shameless", "sneaky", "cunning", "rebellious"]
+    },
+    "supplies": [
+      {
+          "type": "all_herb",
+          "trigger": ["low", "adequate"],
+          "adjust": "increase_5"
       }
     ],
     "other_clan": {

--- a/resources/dicts/events/misc/general.json
+++ b/resources/dicts/events/misc/general.json
@@ -3314,7 +3314,7 @@
     "season": ["any"],
     "tags": ["clan_wide"],
     "weight": 1,
-    "event_text": "Some sort of pest got into the herb stores and ruined much of the supplies.. c_n will have to clean it out and start over anew.",
+    "event_text": "Some sort of pest got into the herb stores and ruined much of the supplies. c_n will have to clean it out and start over anew.",
     "supplies": [
       {
           "type": "all_herb",

--- a/resources/dicts/events/misc/general.json
+++ b/resources/dicts/events/misc/general.json
@@ -2986,7 +2986,7 @@
     "location": ["any"],
     "season": ["any"],
     "tags": ["clan_wide"],
-    "weight": 5,
+    "weight": 10,
     "event_text": "The o_c_n medicine cat comes asking if c_n has any given_herb to spare. Graciously, your Clan decides to aid their allies and share the herbs.",
     "supplies": [
       {
@@ -3251,12 +3251,32 @@
     "subtype": ["war"],
     "tags": ["clan_wide"],
     "weight": 5,
-    "event_text": "o_c_n breaks into the camp and ravages the herb stores, taking some for themselves and attempting to destroy. The Clan manages to recover some of the herbs, but the store was still badly damaged.",
+    "event_text": "o_c_n breaks into the camp and ravages the herb stores, taking some for themselves and attempting to destroy the rest. The Clan manages to recover some of the herbs, but the store was still badly damaged.",
     "supplies": [
       {
           "type": "all_herb",
           "trigger": ["adequate", "full", "excess"],
           "adjust": "reduce_half"
+      }
+    ],
+    "other_clan": {
+      "current_rep": ["hostile"],
+      "changed": -2
+    }
+  },
+  {
+    "event_id": "gen_misc_herb_anywarsteal1",
+    "location": ["any"],
+    "season": ["any"],
+    "subtype": ["war"],
+    "tags": ["clan_wide"],
+    "weight": 5,
+    "event_text": "o_c_n breaks into the camp and ravages the herb stores, taking some for themselves and destroying the rest.",
+    "supplies": [
+      {
+          "type": "all_herb",
+          "trigger": ["adequate", "full", "excess"],
+          "adjust": "reduce_full"
       }
     ],
     "other_clan": {

--- a/resources/dicts/events/misc/general.json
+++ b/resources/dicts/events/misc/general.json
@@ -3354,12 +3354,12 @@
     "season": ["newleaf"],
     "tags": ["clan_wide"],
     "weight": 1,
-    "event_text": "The newleaf rain has left the air humid and the whole camp damp. The herb stores are found to be growing mold and have to be thrown out.",
+    "event_text": "The newleaf rain has left the air humid and the whole camp damp. The herb stores are found to be growing mold and many herbs have to be thrown out.",
     "supplies": [
       {
           "type": "all_herb",
-          "trigger": ["always"],
-          "adjust": "reduce_full"
+          "trigger": ["adequate", "full", "excess"],
+          "adjust": "reduce_half"
       }
     ]
   },

--- a/resources/dicts/patrols/forest/med/leaf-bare.json
+++ b/resources/dicts/patrols/forest/med/leaf-bare.json
@@ -2306,6 +2306,7 @@
                     "text": "Two lovers met in leaf-bare at the border between their Clans, under the shelter of a bushy white-berried yew. One night, it was not love that met there, but a great battle between their rival Clans, one neither would stagger from alive. The yew drank of their blood, and in the colder moons, even now, you can see it shining in its deathberries.",
                     "exp": 40,
                     "weight": 20,
+                    "herbs": ["random_herbs"],
                     "relationships": [
                         {
                             "cats_to": ["p_l"],

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -597,7 +597,7 @@ class Events:
                                                    sort=True)
             for med in meds_available:
                 if game.clan.current_season in ["Newleaf", "Greenleaf"]:
-                    amount = random.choices([0, 1, 2, 3], [1, 2, 2, 2], k=1)
+                    amount = random.choices([1, 2, 3, 4], [1, 2, 2, 2], k=1)
                 elif game.clan.current_season == "Leaf-fall":
                     amount = random.choices([0, 1, 2], [3, 2, 1], k=1)
                 else:
@@ -609,9 +609,9 @@ class Events:
                         if herb in ["blackberry"]:
                             continue
                         if game.clan.current_season in ["Newleaf", "Greenleaf"]:
-                            amount = random.choices([1, 2, 3], [3, 3, 1], k=1)
+                            amount = random.choices([2, 5, 8], [3, 3, 1], k=1)
                         else:
-                            amount = random.choices([1, 2], [4, 1], k=1)
+                            amount = random.choices([2, 4], [4, 1], k=1)
                         if herb in game.clan.herbs:
                             game.clan.herbs[herb] += amount[0]
                         else:

--- a/scripts/patrol/patrol_outcome.py
+++ b/scripts/patrol/patrol_outcome.py
@@ -645,9 +645,9 @@ class PatrolOutcome:
         patrol_size_modifier = int(len(patrol.patrol_cats) * 0.5)
         for _herb in specific_herbs:
             if large_bonus:
-                amount_gotten = 4
+                amount_gotten = 6
             else:
-                amount_gotten = choices([1, 2, 3], [2, 3, 1], k=1)[0]
+                amount_gotten = choices([2, 4, 6], [2, 3, 1], k=1)[0]
 
             amount_gotten = int(amount_gotten * patrol_size_modifier)
             amount_gotten = max(1, amount_gotten)


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->

## About The Pull Request
These changes work to balance out the rate of herb gain and loss.  Herb moon events no longer destroy the herb store in it's entirety (with the exception of one war event) and any large destruction events can no longer happen if the herb stores are low.

The number of herbs gained each moonskip and gained during patrols has been buffed slightly.

New moon events added in which allied Clans donate herbs to bolster your stores.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Why This Is Good For ClanGen
Herb balancing has been a struggle for a while, this hopefully helps balance out those issues.
<!-- If this is a bug fix, you can remove this section. -->
<!-- Please add a short description of why you think these changes would benefit the game. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->
<!-- If you have multiple features that can stand on their own, or unrelated bugfixes, please create separate PRs for them. -->

## Proof of Testing
Didn't record because it would have been a rather long video, but I played on a test Clan for around 30 moons.  A single med cat and med cat apprentice took the herb stores from empty to full in a 4-5 moons during Newleaf/Greenleaf.  Herb stores seemed to hold steady around full with cats being regularly treated and herb related moon events popping up occasionally.  Leaf-fall/leaf-bare still saw struggle in finding new herbs, but herb stores from the plentiful seasons seemed to support the Clan well enough.

Overall, feels more satisfying now as the med cats seem to actually have a job to accomplish and aren't held back by constantly destroyed herb stores.  Of course, would be good to hear feedback from players, but I do think this is a much better place than before.

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Herb moon events no longer destroy the herb store in it's entirety (with the exception of one war event) and any large destruction events can no longer happen if the herb stores are low.
- The number of herbs gained each moonskip and gained during patrols has been buffed slightly.
- New moon events added in which allied Clans donate herbs to bolster your stores.

<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
