### PR TITLE
[BUGFIX] Default string, this should never appear #2703

### DIFF
--- a/resources/credits_text.json
+++ b/resources/credits_text.json
@@ -103,6 +103,7 @@
         "transfoxes": "Code, pronoun tagging",
         "Tybaxel": "Patrol sprites, Clan creation screen art",
         "wood pank": "Art",
-        "ZtheCorgi (Zabe)": "Nylon & indigo collars, various small bugfixes and proofreading"
+        "ZtheCorgi (Zabe)": "Nylon & indigo collars, various small bugfixes and proofreading",
+        "PoppyBlossom (Poppy)": "Code, Bugfixes & More!"
     }
 }

--- a/resources/dicts/relationship_events/normal_interactions/platonic/decrease.json
+++ b/resources/dicts/relationship_events/normal_interactions/platonic/decrease.json
@@ -5,10 +5,10 @@
 		"interactions": [
 			"m_c thinks r_c isn't very considerate of others.",
 			"m_c avoids r_c.",
-            "m_c noticed something r_c does that annoyed {PRONOUN/m_c/object}.",
-            "r_c splashes m_c as they pass a puddle.",
-            "m_c wasn't paying attention when r_c was talking to {PRONOUN/m_c/object}.",
-            "m_c settled to eat on the opposite side of camp from r_c."
+			"m_c noticed something r_c does that annoyed {PRONOUN/m_c/object}.",
+			"r_c splashes m_c as they pass a puddle.",
+			"m_c wasn't paying attention when r_c was talking to {PRONOUN/m_c/object}.",
+			"m_c settled to eat on the opposite side of camp from r_c."
 		]
 	},
 	{
@@ -17,8 +17,8 @@
 		"interactions": [
 			"m_c and r_c have an argument about who should get a pretty feather, and end up destroying it in their fight.",
 			"m_c has drawn the ire of r_c by deliberately taking the last of {PRONOUN/r_c/poss} favorite nesting materials for {PRONOUN/m_c/self}.",
-			 "m_c rolls {PRONOUN/m_c/poss} eyes at r_c.",
-            "m_c sneered at r_c."
+			"m_c rolls {PRONOUN/m_c/poss} eyes at r_c.",
+			"m_c sneered at r_c."
 		],
 		"reaction_random_cat": {
 			"platonic": "decrease"
@@ -28,18 +28,15 @@
 		"id": "platonic_de_med1",
 		"intensity": "medium",
 		"interactions": [
-			"m_c caught r_c complaining about {PRONOUN/m_c/object} behind {PRONOUN/m_c/poss} back.",
-			"m_c interrupted r_c when {PRONOUN/r_c/subject} {VERB/r_c/was/were} very busy with an important task, ruining {PRONOUN/r_c/poss} focus.",
-            "m_c realized r_c was only pretending to pay attention to {PRONOUN/m_c/object} when {PRONOUN/m_c/subject} {VERB/m_c/was/were} talking.",
-            "m_c tried to talk to r_c but gave up, seeing how clearly {PRONOUN/r_c/subject} wanted to be doing anything else.",
-            "m_c overheard r_c talking about {PRONOUN/m_c/object}, but when pressed for details, r_c denied mentioning {PRONOUN/m_c/object} at all.",
-            "m_c got up and walked away when m_c sat nearby.",
-            "m_c blatantly ignored r_c.",
-            "Lately, m_c's had some choice words for r_c about how {PRONOUN/m_c/subject}{VERB/m_c/'ve/'s} been acting.",
-            "m_c asked another cat to pass a message to r_c rather doing it {PRONOUN/m_c/self}.",
-            "m_c was passive aggressive towards r_c for taking something {PRONOUN/r_c/subject} knew m_c had {PRONOUN/m_c/poss} eye on all day.",
-            "r_c is caught tossing out a gift m_c <i>just</i> gave {PRONOUN/m_c/object}.",
-            "m_c actively avoids r_c any chance {PRONOUN/m_c/subject} get."
+			"m_c realized r_c was only pretending to pay attention to {PRONOUN/m_c/object} when {PRONOUN/m_c/subject} {VERB/m_c/was/were} talking.",
+			"m_c tried to talk to r_c but gave up, seeing how clearly {PRONOUN/r_c/subject} wanted to be doing anything else.",
+			"m_c overheard r_c talking about {PRONOUN/m_c/object}, but when pressed for details, r_c denied mentioning {PRONOUN/m_c/object} at all.",
+			"m_c got up and walked away when m_c sat nearby.",
+			"m_c blatantly ignored r_c.",
+			"Lately, m_c's had some choice words for r_c about how {PRONOUN/m_c/subject}{VERB/m_c/'ve/'s} been acting.",
+			"m_c asked another cat to pass a message to r_c rather doing it {PRONOUN/m_c/self}.",
+			"m_c was passive aggressive towards r_c for taking something {PRONOUN/r_c/subject} knew m_c had {PRONOUN/m_c/poss} eye on all day.",
+			"m_c actively avoids r_c any chance {PRONOUN/m_c/subject} get."
 		]
 	},
 	{
@@ -47,13 +44,13 @@
 		"interactions": [
 			"m_c is annoyed that {PRONOUN/m_c/subject} {VERB/m_c/have/has} to pull ticks off of r_c today.",
 			"m_c refreshes r_c's bedding last out of all the elders.",
-            "r_c wanted to thank m_c for doing a good job but m_c seemed irritated the entire time {PRONOUN/m_c/subject} had to be around {PRONOUN/r_c/object}.",
-            "m_c was supposed to pull ticks off r_c but {PRONOUN/m_c/subject} never came to do it, leaving {PRONOUN/m_c/object} to itch and itch all day.",
-            "m_c is stuck listening to r_c's complaints.",
-            "r_c swears m_c has been adding less and less bedding to {PRONOUN/r_c/poss} nest recently...",
-            "m_c added r_c's least favorite nesting material to {PRONOUN/r_c/poss} nest.",
-            "m_c hid thorns in r_c's bedding.",
-            "m_c is stuck listening to a boring story r_c is telling."
+			"r_c wanted to thank m_c for doing a good job but m_c seemed irritated the entire time {PRONOUN/m_c/subject} had to be around {PRONOUN/r_c/object}.",
+			"m_c was supposed to pull ticks off r_c but {PRONOUN/m_c/subject} never came to do it, leaving {PRONOUN/m_c/object} to itch and itch all day.",
+			"m_c is stuck listening to r_c's complaints.",
+			"r_c swears m_c has been adding less and less bedding to {PRONOUN/r_c/poss} nest recently...",
+			"m_c added r_c's least favorite nesting material to {PRONOUN/r_c/poss} nest.",
+			"m_c hid thorns in r_c's bedding.",
+			"m_c is stuck listening to a boring story r_c is telling."
 		],
 		"main_status_constraint": [
 			"apprentice"
@@ -76,7 +73,7 @@
 		"id": "platonic_de_med4",
 		"interactions": [
 			"r_c is not backing down in an argument with m_c.",
-            "m_c is picking a fight over something r_c thought was already resolved."
+			"m_c is picking a fight over something r_c thought was already resolved."
 		],
 		"random_trait_constraint": [
 			"fierce"
@@ -87,9 +84,9 @@
 		"interactions": [
 			"m_c scorns r_c for not catching enough prey.",
 			"r_c criticized m_c's skills.",
-            "m_c can't stand r_c's constant nagging.",
-            "According to r_c, m_c just can't do anything right.",
-            "r_c criticized every single error m_c makes."
+			"m_c can't stand r_c's constant nagging.",
+			"According to r_c, m_c just can't do anything right.",
+			"r_c criticized every single error m_c makes."
 		],
 		"random_trait_constraint": [
 			"strict"
@@ -179,5 +176,20 @@
 		"reaction_random_cat": {
 			"platonic": "decrease"
 		}
+	},
+	{
+		"id": "platonic_de_high4",
+		"intensity": "high",
+		"interactions": [
+			"r_c is caught tossing out a gift m_c <i>just</i> gave {PRONOUN/m_c/object}.",
+			"m_c caught r_c complaining about {PRONOUN/m_c/object} behind {PRONOUN/m_c/poss} back.",
+			"m_c interrupted r_c when {PRONOUN/r_c/subject} {VERB/r_c/was/were} very busy with an important task, ruining {PRONOUN/r_c/poss} focus.",
+			"r_c purposefully pick the smallest prey for m_c when {PRONOUN/m_c/subject} asked for help.",
+			"r_c was find spreading rumors about m_c stealing stuff from {PRONOUN/r_c/object}.",
+			"r_c was caught hiding m_c belongings.",
+			"r_c publicly mocked m_c during a gathering.",
+			"m_c discovered r_c was sabotaging {PRONOUN/m_c/object} efforts at work.",
+			"m_c walked in on r_c destroying a memento {PRONOUN/m_c/object} cherished."
+		]
 	}
 ]

--- a/resources/dicts/relationship_events/normal_interactions/platonic/decrease.json
+++ b/resources/dicts/relationship_events/normal_interactions/platonic/decrease.json
@@ -185,8 +185,8 @@
 			"m_c caught r_c complaining about {PRONOUN/m_c/object} behind {PRONOUN/m_c/poss} back.",
 			"m_c interrupted r_c when {PRONOUN/r_c/subject} {VERB/r_c/was/were} very busy with an important task, ruining {PRONOUN/r_c/poss} focus.",
 			"r_c purposefully pick the smallest prey for m_c when {PRONOUN/m_c/subject} asked for help.",
-			"r_c was find spreading rumors about m_c stealing stuff from {PRONOUN/r_c/object}.",
-			"r_c was caught hiding m_c belongings.",
+			"r_c was found spreading rumors about m_c stealing stuff from {PRONOUN/r_c/object}.",
+			"r_c was caught hiding m_c's belongings.",
 			"r_c publicly mocked m_c during a gathering.",
 			"m_c discovered r_c was sabotaging {PRONOUN/m_c/object} efforts at work.",
 			"m_c walked in on r_c destroying a memento {PRONOUN/m_c/object} cherished."

--- a/scripts/cat_relations/relationship.py
+++ b/scripts/cat_relations/relationship.py
@@ -124,22 +124,15 @@ class Relationship:
                 all_interactions, intensity, biome, season, game_mode
             )
 
+        # return if there are no possible interactions.
         if len(possible_interactions) <= 0:
             print(
-                "ERROR: No interaction with this conditions. ",
+                "WARNING: No interaction with this conditions.",
                 rel_type,
                 in_de_crease,
                 intensity,
             )
-            possible_interactions = [
-                SingleInteraction(
-                    "fall_back",
-                    "Any",
-                    "Any",
-                    "medium",
-                    ["Default string, this should never appear."],
-                )
-            ]
+            return
 
         # check if the current interaction id is already used and us another if so
         chosen_interaction = choice(possible_interactions)


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->

## About The Pull Request
This pull request addresses an issue where the game lacked an unrestricted "dislike high" interaction after the only nonrestrictive "dislike high" was demoted to medium in #2690. So I added a few more interactions to compensate for this. The error message for no interaction was changed from an error to a warning, and the default string interaction was removed since this issue doesn't significantly impact gameplay.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
fixes: #2703
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
The issue no longer occurs and I ran for an additional 200 moons just to make sure.
<!-- Include screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
Fixed default string.
_Can I be added to the credits list by the way_
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
