### PR TITLE
[CONTENT] add default patrol outcomes

### DIFF
--- a/resources/dicts/patrols/general/medcat.json
+++ b/resources/dicts/patrols/general/medcat.json
@@ -3639,7 +3639,7 @@
                 ]
             },
 			{
-				"text": "It's completely okay to feel unsure in the path you've chosen. Being a medicine cat comes with so many ups and downs, it can be hard not to doubt yourself. Whatever choice app1 makes, p_l will support {PRONOUN/app1/object}. With glistening eyes, app1 huddles against {PRONOUN/app1/poss} mentor, thanking {PRONOUN/p_l/object} profusely for the support.",
+				"text": "p_l reassures app1 that it's completely okay to feel unsure in the path {PRONOUN/app1/subject} chose. Being a medicine cat comes with so many ups and downs, it can be hard not to doubt yourself. Whatever choice app1 makes, p_l will support {PRONOUN/app1/object}. With glistening eyes, app1 huddles against {PRONOUN/app1/poss} mentor, thanking {PRONOUN/p_l/object} profusely for the support.",
 				"exp": 20,
 				"weight": 20,
 				"herbs": ["random_herbs"],

--- a/resources/dicts/patrols/general/medcat.json
+++ b/resources/dicts/patrols/general/medcat.json
@@ -3869,7 +3869,7 @@
                 ]
             },
 			{
-                "text": "Even as {PRONOUN/p_l/poss} kit grows, p_l will always see {PRONOUN/r_c/object} as a mewling kit, always hungry for milk. p_l gazes fondly at r_c as {PRONOUN/r_c/subject} {VERB/r_c/sniff/sniffs} around, looking for herbs. It's just so wonderful seeing your kit grow up. Of course, it can be sad, but that's why p_l cherishes every moment {PRONOUN/p_l/subject} {VERB/p_l/spend/spends} with r_c.",
+                "text": "Even as {PRONOUN/r_c/poss} kit grows, r_c will always see p_l as a mewling kit, always hungry for milk. r_c gazes fondly at p_l as {PRONOUN/p_l/subject} {VERB/p_l/sniff/sniffs} around, looking for herbs. It's just so wonderful seeing your kit grow up. Of course, it can be sad, but that's why r_c cherishes every moment {PRONOUN/r_c/subject} {VERB/r_c/spend/spends} with p_l.",
                 "exp": 20,
                 "weight": 20,
                 "herbs": ["random_herbs"],

--- a/resources/dicts/patrols/general/medcat.json
+++ b/resources/dicts/patrols/general/medcat.json
@@ -3591,7 +3591,7 @@
         "chance_of_success": 60,
         "success_outcomes": [
             {
-                "text": "Smiling softly, s_c reasures app1 that {PRONOUN/s_c/subject} didn't feel ready to be a medicine cat, either, when {PRONOUN/s_c/subject} {VERB/s_c/were/was} an apprentice. s_c tells app1 a story from {PRONOUN/s_c/poss} own apprenticeship, when {PRONOUN/s_c/subject} accidentally swapped all the thyme for yarrow. Great StarClan was {PRONOUN/s_c/poss} mentor unhappy when all their patients started throwing up! Before long, app1 is laughing at s_c's own mishaps, {PRONOUN/app1/poss} own troubles forgotten.",
+                "text": "Smiling softly, s_c reassures app1 that {PRONOUN/s_c/subject} didn't feel ready to be a medicine cat, either, when {PRONOUN/s_c/subject} {VERB/s_c/were/was} an apprentice. s_c tells app1 a story from {PRONOUN/s_c/poss} own apprenticeship, when {PRONOUN/s_c/subject} accidentally swapped all the thyme for yarrow. Great StarClan was {PRONOUN/s_c/poss} mentor unhappy when all their patients started throwing up! Before long, app1 is laughing at s_c's own mishaps, {PRONOUN/app1/poss} own troubles forgotten.",
                 "exp": 20,
                 "weight": 20,
 		"stat_trait": ["childish", "bold", "oblivious", "playful", "shameless", "troublesome", "adventurous", "rebellious"],

--- a/resources/dicts/patrols/general/medcat.json
+++ b/resources/dicts/patrols/general/medcat.json
@@ -3638,6 +3638,29 @@
                     }
                 ]
             },
+			{
+				"text": "It's completely okay to feel unsure in the path you've chosen. Being a medicine cat comes with so many ups and downs, it can be hard not to doubt yourself. Whatever choice app1 makes, p_l will support {PRONOUN/app1/object}. With glistening eyes, app1 huddles against {PRONOUN/app1/poss} mentor, thanking {PRONOUN/p_l/object} profusely for the support.",
+				"exp": 20,
+				"weight": 20,
+				"herbs": ["random_herbs"],
+				"relationships": [
+				{
+					"cats_to": ["patrol"],
+					"cats_from": ["patrol"],
+					"mutual": false,
+					"values": ["platonic",
+					"comfort", "trust"],
+					"amount": 10
+					},
+				{
+					"cats_to": ["patrol"],
+					"cats_from": ["patrol"],
+					"mutual": true,
+					"values": ["dislike", "jealousy"],
+					"amount": -10
+					}
+				]
+			},
             {
                 "text": "Turning to face app1, s_c reminds {PRONOUN/app1/object} that {PRONOUN/app1/subject} {VERB/app1/were/was} chosen by <i>StarClan</i> - their ancestors know that app1 is good enough, so {PRONOUN/app1/subject} should, too. Smiling, app1 nods, raising {PRONOUN/app1/poss} tail with a new-found confidence.",
                 "exp": 20,
@@ -3837,6 +3860,28 @@
                         "amount": 5
                     },
 		    {
+                        "cats_to": ["patrol"],
+                        "cats_from": ["patrol"],
+                        "mutual": false,
+                        "values": ["dislike"],
+                        "amount": -5
+                    }
+                ]
+            },
+			{
+                "text": "Even as {PRONOUN/p_l/poss} kit grows, p_l will always see {PRONOUN/r_c/object} as a mewling kit, always hungry for milk. p_l gazes fondly at r_c as {PRONOUN/r_c/subject} {VERB/r_c/sniff/sniffs} around, looking for herbs. It's just so wonderful seeing your kit grow up. Of course, it can be sad, but that's why p_l cherishes every moment {PRONOUN/p_l/subject} {VERB/p_l/spend/spends} with r_c.",
+                "exp": 20,
+                "weight": 20,
+                "herbs": ["random_herbs"],
+                "relationships": [
+                    {
+                        "cats_to": ["patrol"],
+                        "cats_from": ["patrol"],
+                        "mutual": false,
+                        "values": ["platonic", "comfort", "trust"],
+                        "amount": 5
+                    },
+					{
                         "cats_to": ["patrol"],
                         "cats_from": ["patrol"],
                         "mutual": false,

--- a/resources/dicts/patrols/general/training.json
+++ b/resources/dicts/patrols/general/training.json
@@ -11281,7 +11281,7 @@
                 "weight": 20
             },
 			{
-                "text": "p_l can empathize- it may seem impossible to find your place in c_n, especially as an apprentice with your whole future ahead. But it's important to breath. In, out, in, out. It's hard for app1 to calm down, and p_l knows this, but once app1 is calm enough, the two can begin to talk and figure out the best way for app1 to thrive and learn.",
+                "text": "p_l can empathize- it may seem impossible for app1 to find {PRONOUN/app1/poss} place in c_n, especially as an apprentice with {PRONOUN/app1/poss} whole future ahead. But it's important to breath. In, out, in, out. It's hard for app1 to calm down, and p_l knows this, but once app1 is calm enough, the two can begin to talk and figure out the best way for app1 to thrive and learn.",
                 "exp": 10,
                 "relationships": [
                     {

--- a/resources/dicts/patrols/general/training.json
+++ b/resources/dicts/patrols/general/training.json
@@ -11261,7 +11261,8 @@
                         "cats_from": ["app1"],
                         "values": ["platonic", "comfort", "respect", "trust"],
                         "amount": 10
-                    } ],
+                    }
+					],
                 "weight": 20
             },
             {
@@ -11275,7 +11276,8 @@
                         "cats_from": ["app1"],
                         "values": ["platonic", "comfort", "respect", "trust"],
                         "amount": 10
-                    } ],
+                    }
+					],
                 "weight": 20
             },
 			{

--- a/resources/dicts/patrols/general/training.json
+++ b/resources/dicts/patrols/general/training.json
@@ -11277,6 +11277,18 @@
                         "amount": 10
                     } ],
                 "weight": 20
+            },
+			{
+                "text": "p_l can empathize- it may seem impossible to find your place in c_n, especially as an apprentice with your whole future ahead. But it's important to breath. In, out, in, out. It's hard for app1 to calm down, and p_l knows this, but once app1 is calm enough, the two can begin to talk and figure out the best way for app1 to thrive and learn.",
+                "exp": 10,
+                "relationships": [
+                    {
+                        "cats_to": ["p_l"],
+                        "cats_from": ["app1"],
+                        "values": ["platonic", "comfort", "respect", "trust"],
+                        "amount": 10
+                    } ],
+                "weight": 20
             }
         ],
         "fail_outcomes": [


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->

## About The Pull Request

three patrols ("gen_train_amentorswisdom", "gen_med_with_parent", and "gen_med_app_mentor_advice") lack default patrol outcomes. all outcomes are trait-locked or stat-locked. this ensures that if clangen were to ever add a new trait, these patrols will not break (also benefits modders a lot)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Why This Is Good For ClanGen

as stated before, this protects clangen in the future for if they decide to add new traits. if new traits are added and a cat with a new trait goes on one of the listed patrols, the game will spit out an error because the trait is not defined in any outcome. this also helps modders a bunch

## Proof of Testing
![image](https://github.com/user-attachments/assets/7bec7272-a8ff-474f-b3f2-55385964d85e)
![image](https://github.com/user-attachments/assets/ff122f2c-1aa8-4bfc-bb8c-ad30b710aff2)
![image](https://github.com/user-attachments/assets/af35d451-e11b-4b9e-88a5-809a3df861b5)

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
add default patrol outcomes
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
