### PR TITLE
Kit Trait Changes

### DIFF
--- a/resources/dicts/thoughts/alive/kitten.json
+++ b/resources/dicts/thoughts/alive/kitten.json
@@ -64,17 +64,13 @@
         ],
         "relationship_constraint": [
             "child/parent"
-        ],
-        "random_living_status": [
-            "living"
         ]
     },
     {
         "id": "guarding_kit",
         "thoughts": [
             "Has taken up the role of guarding the fresh-kill pile from cats wanting an extra piece and is taking {PRONOUN/m_c/poss} job very seriously",
-            "Is trying to force {PRONOUN/m_c/poss} way into being allowed to guard camp",
-            "Wants to guard the nursery"
+            "Is trying to force {PRONOUN/m_c/poss} way into being allowed to guard camp"
 	],
         "main_trait_constraint": [
             "bossy",
@@ -88,7 +84,7 @@
     {
         "id": "gen_kit",
         "thoughts": [
-            "Plays mossball by {PRONOUN/m_c/self}",
+            "Plays moss ball by {PRONOUN/m_c/self}",
             "Wonders who {PRONOUN/m_c/poss} mentor will be",
             "Wants to take a nap",
             "Tries to sneak out of camp",
@@ -124,7 +120,7 @@
             "Wants to be big someday",
             "Wants to have fun",
             "Is playing pretend",
-            "Is going through an angsty phase, much to {PRONOUN/m_c/poss} Clanmates chagrin",
+            "Is going through an angsty phase much to {PRONOUN/m_c/poss} Clanmates chagrin",
             "Is fighting sleep... and failing",
             "Knocked {PRONOUN/m_c/self} over with a sneeze",
             "Wants a badger ride",
@@ -138,9 +134,6 @@
             "Can't wait to be a warrior",
             "Pricked {PRONOUN/m_c/self} on the brambles protecting camp",
             "Pounces on a shred of moss"
-        ],
-        "random_living_status": [
-            "living"
         ]
     },
     {
@@ -181,9 +174,6 @@
             "adult",
             "senior adult",
             "senior"
-        ],
-        "random_living_status": [
-            "living"
         ]
     },
     {
@@ -302,7 +292,7 @@
     {
         "id": "fearless_kit",
         "thoughts": [
-            "Is attempting to pounce on r_c's tail",
+            "Is attempting to pounce on the tail of r_c",
             "Tries to sneak out of camp with a patrol",
             "Is boldly walking out of camp",
             "Is demanding others spar with {PRONOUN/m_c/object}",
@@ -313,6 +303,7 @@
             "Is telling other cats that {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} the deputy now",
             "Wants to taste a toad",
             "Thinks {PRONOUN/m_c/subject} can outsmart a fox",
+            "Wants to guard the nursery",
             "Is sure {PRONOUN/m_c/subject} could fight a badger",
             "Sticks {PRONOUN/m_c/poss} paw into an old snake hole",
             "Is playing with a dead snake",
@@ -335,9 +326,6 @@
         ],
         "random_status_constraint": [
         	"apprentice"
-        ],
-        "random_living_status": [
-            "living"
         ]
     },
     {
@@ -351,9 +339,6 @@
         ],
         "random_status_constraint": [
             "leader"
-        ],
-        "random_living_status": [
-            "living"
         ]
     },
     {
@@ -392,7 +377,7 @@
         "thoughts": [
             "Is streaking across the clearing",
             "Is stuck in a tree... again",
-            "Is complaining of a tummyache after eating too much",
+            "Is complaining of a tummy ache after eating too much",
             "Is awfully close to getting a nip on the rump for misbehaving",
             "Is waiting for an opportunity to sprint out of sight",
             "Is tired of waiting to be an apprentice",
@@ -416,9 +401,6 @@
         ],
         "main_trait_constraint": [
             "impulsive"
-        ],
-        "random_living_status": [
-            "living"
         ]
     },
     {
@@ -488,7 +470,7 @@
             "Finds somewhere comfy to nap",
             "Was forgotten about...",
             "Is feeling at peace sitting alone watching the other kits play",
-            "Doesn't want to play",
+            "Dosen't want to play",
             "Is saying sorry for being loud when they barely even spoke up"
         ],
         "main_trait_constraint": [
@@ -610,9 +592,6 @@
         ],
         "main_trait_constraint": [
             "attention-seeker"
-        ],
-        "random_living_status": [
-            "living"
         ]
     },
     {
@@ -640,7 +619,7 @@
         ]
     },
     {
-        "id": "noisy_kit_to_elder",
+        "id": "noisy_kit",
         "thoughts": [
             "Asked r_c for a story but keeps interrupting {PRONOUN/r_c/object}"
         ],
@@ -649,9 +628,6 @@
         ],
         "random_status_constraint": [
             "elder"
-        ],
-        "random_living_status": [
-            "living"
         ]
     },
     {
@@ -765,9 +741,6 @@
             "deputy",
             "leader",
             "elder"
-        ],
-        "random_living_status": [
-            "living"
         ]
     }
 ]

--- a/resources/dicts/thoughts/alive/kitten.json
+++ b/resources/dicts/thoughts/alive/kitten.json
@@ -64,19 +64,23 @@
         ],
         "relationship_constraint": [
             "child/parent"
+        ],
+        "random_living_status": [
+            "living"
         ]
     },
     {
         "id": "guarding_kit",
         "thoughts": [
             "Has taken up the role of guarding the fresh-kill pile from cats wanting an extra piece and is taking {PRONOUN/m_c/poss} job very seriously",
-            "Is trying to force {PRONOUN/m_c/poss} way into being allowed to guard camp"
-        ],
+            "Is trying to force {PRONOUN/m_c/poss} way into being allowed to guard camp",
+            "Wants to guard the nursery"
+		],
         "main_trait_constraint": [
             "bossy",
             "attention-seeker",
             "bullying",
-            "daring",
+            "fearless",
             "noisy",
             "troublesome"
         ]
@@ -84,7 +88,7 @@
     {
         "id": "gen_kit",
         "thoughts": [
-            "Plays moss ball by {PRONOUN/m_c/self}",
+            "Plays mossball by {PRONOUN/m_c/self}",
             "Wonders who {PRONOUN/m_c/poss} mentor will be",
             "Wants to take a nap",
             "Tries to sneak out of camp",
@@ -120,7 +124,7 @@
             "Wants to be big someday",
             "Wants to have fun",
             "Is playing pretend",
-            "Is going through an angsty phase much to {PRONOUN/m_c/poss} Clanmates chagrin",
+            "Is going through an angsty phase, much to {PRONOUN/m_c/poss} Clanmates chagrin",
             "Is fighting sleep... and failing",
             "Knocked {PRONOUN/m_c/self} over with a sneeze",
             "Wants a badger ride",
@@ -134,6 +138,9 @@
             "Can't wait to be a warrior",
             "Pricked {PRONOUN/m_c/self} on the brambles protecting camp",
             "Pounces on a shred of moss"
+        ],
+        "random_living_status": [
+            "living"
         ]
     },
     {
@@ -174,6 +181,9 @@
             "adult",
             "senior adult",
             "senior"
+        ],
+        "random_living_status": [
+            "living"
         ]
     },
     {
@@ -290,11 +300,10 @@
         ]
     },
     {
-        "id": "daring_kit",
+        "id": "fearless_kit",
         "thoughts": [
-            "Is attempting to pounce on the tail of r_c",
+            "Is attempting to pounce on r_c's tail",
             "Tries to sneak out of camp with a patrol",
-            "Pounced on r_c",
             "Is boldly walking out of camp",
             "Is demanding others spar with {PRONOUN/m_c/object}",
             "Is taking the biggest piece of fresh-kill",
@@ -304,66 +313,44 @@
             "Is telling other cats that {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} the deputy now",
             "Wants to taste a toad",
             "Thinks {PRONOUN/m_c/subject} can outsmart a fox",
-            "Wants to guard the nursery",
             "Is sure {PRONOUN/m_c/subject} could fight a badger",
-            "Picks a fight with an apprentice so {PRONOUN/m_c/subject} can show {PRONOUN/m_c/poss} skills",
             "Sticks {PRONOUN/m_c/poss} paw into an old snake hole",
             "Is playing with a dead snake",
-            "Isn't afraid of the dark at all"
-
-        ],
-        "main_trait_constraint": [
-            "daring"
-        ]
-    },
-    {
-        "id": "daring_kit",
-        "thoughts": [
-            "Picks a fight with an apprentice so {PRONOUN/m_c/subject} can show {PRONOUN/m_c/poss} skills"
-
-        ],
-        "main_trait_constraint": [
-            "daring"
-        ],
-        "random_status_constraint": [
-        "apprentice"
-        ]
-    },
-    {
-        "id": "daring_kit",
-        "thoughts": [
-            "Is trying to challenge the leader but isn't being taken very seriously",
-            "Is sneaking into the leader's nest"
-
-        ],
-        "main_trait_constraint": [
-            "daring"
-        ],
-        "random_status_constraint": [
-            "leader"
-        ]
-    },
-    {
-        "id": "fearless_kit",
-        "thoughts": [
-            "Is attempting to pounce on the tail of r_c",
-            "Tries to sneak out of camp with a patrol",
-            "Is boldly walking out of camp",
-            "Is taking the biggest piece of fresh-kill",
-            "Demands to be on the next border patrol",
-            "Isn't scared of anything",
-            "Is climbing way too high",
-            "Is telling other cats that {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} the deputy now",
-            "Wants to taste a toad",
-            "Thinks {PRONOUN/m_c/subject} can outsmart a fox",
-            "Wants to guard the nursery",
-            "Is sure {PRONOUN/m_c/subject} could fight a badger",
-            "Is sneaking into the leader's nest",
-            "Sticks {PRONOUN/m_c/poss} paw into an old snake hole",
             "Isn't afraid of the dark at all"
         ],
         "main_trait_constraint": [
             "fearless"
+        ],
+        "random_living_status": [
+            "living"
+        ]
+    },
+    {
+        "id": "fearless_kit_to_apprentice",
+        "thoughts": [
+            "Picks a fight with an apprentice so {PRONOUN/m_c/subject} can show {PRONOUN/m_c/poss} skills"
+        ],
+        "main_trait_constraint": [
+            "fearless"
+        ],
+        "random_status_constraint": [
+        	"apprentice"
+        ],
+        "random_living_status": [
+            "living"
+        ]
+    },
+    {
+        "id": "fearless_kit_to_leader",
+        "thoughts": [
+            "Is trying to challenge the leader but isn't being taken very seriously",
+            "Is sneaking into the leader's nest"
+        ],
+        "main_trait_constraint": [
+            "fearless"
+        ],
+        "random_status_constraint": [
+            "leader"
         ],
         "random_living_status": [
             "living"
@@ -405,7 +392,7 @@
         "thoughts": [
             "Is streaking across the clearing",
             "Is stuck in a tree... again",
-            "Is complaining of a tummy ache after eating too much",
+            "Is complaining of a tummyache after eating too much",
             "Is awfully close to getting a nip on the rump for misbehaving",
             "Is waiting for an opportunity to sprint out of sight",
             "Is tired of waiting to be an apprentice",
@@ -429,6 +416,9 @@
         ],
         "main_trait_constraint": [
             "impulsive"
+        ],
+        "random_living_status": [
+            "living"
         ]
     },
     {
@@ -498,7 +488,7 @@
             "Finds somewhere comfy to nap",
             "Was forgotten about...",
             "Is feeling at peace sitting alone watching the other kits play",
-            "Dosen't want to play",
+            "Doesn't want to play",
             "Is saying sorry for being loud when they barely even spoke up"
         ],
         "main_trait_constraint": [
@@ -620,6 +610,9 @@
         ],
         "main_trait_constraint": [
             "attention-seeker"
+        ],
+        "random_living_status": [
+            "living"
         ]
     },
     {
@@ -647,7 +640,7 @@
         ]
     },
     {
-        "id": "noisy_kit",
+        "id": "noisy_kit_to_elder",
         "thoughts": [
             "Asked r_c for a story but keeps interrupting {PRONOUN/r_c/object}"
         ],
@@ -656,6 +649,9 @@
         ],
         "random_status_constraint": [
             "elder"
+        ],
+        "random_living_status": [
+            "living"
         ]
     },
     {
@@ -769,6 +765,9 @@
             "deputy",
             "leader",
             "elder"
+        ],
+        "random_living_status": [
+            "living"
         ]
     }
 ]

--- a/resources/dicts/thoughts/alive/kitten.json
+++ b/resources/dicts/thoughts/alive/kitten.json
@@ -75,7 +75,7 @@
             "Has taken up the role of guarding the fresh-kill pile from cats wanting an extra piece and is taking {PRONOUN/m_c/poss} job very seriously",
             "Is trying to force {PRONOUN/m_c/poss} way into being allowed to guard camp",
             "Wants to guard the nursery"
-		],
+	],
         "main_trait_constraint": [
             "bossy",
             "attention-seeker",

--- a/resources/dicts/traits/trait_ranges.json
+++ b/resources/dicts/traits/trait_ranges.json
@@ -266,19 +266,19 @@
             "aggression": [0, 8],
             "stability": [0, 8]
         },
-        "charming": {
+        "daydreamer": {
             "lawfulness": [0, 8],
             "sociability": [8, 16],
             "aggression": [0, 8],
             "stability": [8, 16]
         },
-        "fearless": {
+        "charming": {
             "lawfulness": [0, 8],
             "sociability": [8, 16],
             "aggression": [8, 16],
             "stability": [0, 8]
         },
-        "noisy": {
+        "fearless": {
             "lawfulness": [0, 8],
             "sociability": [8, 16],
             "aggression": [8, 16],
@@ -302,7 +302,7 @@
             "aggression": [8, 16],
             "stability": [0, 8]
         },
-        "daydreamer": {
+        "know-it-all": {
             "lawfulness": [8, 16],
             "sociability": [0, 8],
             "aggression": [8, 16],
@@ -320,13 +320,13 @@
             "aggression": [0, 8],
             "stability": [8, 16]
         },
-        "know-it-all": {
+        "bossy": {
             "lawfulness": [8, 16],
             "sociability": [8, 16],
             "aggression": [8, 16],
             "stability": [0, 8]
         },
-        "bossy": {
+        "noisy": {
             "lawfulness": [8, 16],
             "sociability": [8, 16],
             "aggression": [8, 16],


### PR DESCRIPTION
## About The Pull Request

moved around kit traits to make more sense with the equivalent range normal traits:
- daydreamer lines up with playful's sillier, more kit-like/wondering, but still stable nature; and barely seems to line up with strict at all
- charming does work with playful, but it lines up very well with charismatic since the two words are synonyms and the thoughts of both traits involve very similar ideas (other cats liking the charming/charismatic cat a lot)
- fearless is the kit trait that was named daring before kit traits were disambiguated from normal traits, and that shows in the related thoughts. fearless is synonyms with bold/daring, and the trait (and the thoughts related to it) lines up very well with them
- know-it-all is an okay match for ambitious, but it lines up with strict very well, particularly with thoughts involving correcting another cat on something trivial, telling another cat that they should know more about types of moss, having memorized the warrior code already, etc. know-it-all and strict share a "things need to be correct" vibe 
- bossy does somewhat align with confident, but it's not too hard to argue that it lines up with ambitious better, with thoughts about wanting to be deputy/leader, and a lot of telling other cats what to do. bossy and ambitious both are traits that want to be in charge
- noisy is perhaps the edit i was least sure about, but it does match pretty well with confident. noisy kits seem to be unabashed (particularly in the use of their voice), and confident can be seen as a more mature version of that, doing things like boasting about their ability to catch prey and feeling secure in the space they take up.

also made some edits to thoughts/alive/kitten.json, particularly merging the "daring" kit thoughts into "fearless" since "daring" is not in the kit traits dict of trait-ranges.json and "fearless" is what it was renamed to. all other changes in kitten.json are minor fixes (one typo, some small edits to sentence flow, adding random_living_status: living where r_c is mentioned)

## Why This Is Good For ClanGen

these changes make the development of a cat's personality as they grow from a kit to an apprentice more intuitive and natural. particularly with the daydreamer kit trait and the strict normal trait, it is now much less likely that a kit suddenly becomes significantly different in personality and behavior as they become an adolescent.

## Proof of Testing

![trait - daydreamer to playful](https://github.com/user-attachments/assets/da3106ad-a782-4a55-a48f-980126d0d1aa)
![trait - fearless to daring](https://github.com/user-attachments/assets/0ddf2300-ed12-488b-b29e-d68f40efae40)
![trait - bossy to ambitious](https://github.com/user-attachments/assets/b31f13b9-94a8-4635-a7cf-c5e0e96c5b24)
![trait - charming to charismatic](https://github.com/user-attachments/assets/cb2e6a54-8e78-4c26-8e01-13b80817757f)

## Changelog/Credits

trait ranges adjusted for the following kit traits: daydreamer, charming, fearless, know-it-all, bossy, noisy
"daring" kit thoughts merged with "fearless" to go along with "daring" kit trait being renamed to "fearless" in the past disambiguation of kit traits and normal traits
