### PR TITLE
[BUGFIX] Other Clans can't get clan prefix names

### DIFF
--- a/scripts/clan.py
+++ b/scripts/clan.py
@@ -253,9 +253,9 @@ class Clan:
         number_other_clans = randint(3, 5)
         for _ in range(number_other_clans):
             other_clan_names = [str(i.name) for i in self.all_clans] + [game.clan.name]
-            other_clan_name = choice(names.names_dict["normal_prefixes"])
+            other_clan_name = choice(names.names_dict["normal_prefixes"] + names.names_dict["clan_prefixes"])
             while other_clan_name in other_clan_names:
-                other_clan_name = choice(names.names_dict["normal_prefixes"])
+                other_clan_name = choice(names.names_dict["normal_prefixes"] + names.names_dict["clan_prefixes"])
             other_clan = OtherClan(name=other_clan_name)
             self.all_clans.append(other_clan)
         self.save_clan()


### PR DESCRIPTION
## About The Pull Request

Only player clans could get clan prefixs previously, this fixes it so other clans can now get clan prefixs.


## Proof of Testing
![image](https://github.com/user-attachments/assets/7916ff33-470d-4492-86d7-b2f4aa844ef7)
![image](https://github.com/user-attachments/assets/0cd03e3e-fc80-42aa-95aa-6e621406caf2)


