### PR TITLE
cleanup (i guess?) & content - med cat and med cat app thoughts

### DIFF
--- a/resources/dicts/thoughts/alive/medicine_cat.json
+++ b/resources/dicts/thoughts/alive/medicine_cat.json
@@ -7,11 +7,6 @@
             "Is exploring unclaimed lands while searching for herbs",
           "Climbs a tree to gather alder bark instead of clawing the trunk",
           "Thinks about visiting StarClan just to explore their hunting grounds",
-            "Asks the deputy to go on patrol",
-            "Begs the leader to give {PRONOUN/m_c/object} the bounciest kit as {PRONOUN/m_c/poss} apprentice",
-            "Is showing the kits herbs by taking them on adventures in the territory",
-            "Helps the leader with their duties while the deputy is on patrol",
-            "Offers to help the queens with badger rides for the kits",
             "Uses extra herbs just to go gather more"
         ],
         "main_trait_constraint": [
@@ -19,11 +14,50 @@
         ]
     },
     {
+        "id": "adventurous_medicine_cat_to_lead",
+        "thoughts": [
+            "Helps the leader with {PRONOUN/r_c/poss} duties",
+	    "Begs the leader to give {PRONOUN/m_c/object} the bounciest kit as {PRONOUN/m_c/poss} apprentice"
+        ],
+        "main_trait_constraint": [
+            "adventurous"
+        ],
+        "random_status_constraint": [
+            "leader"
+        ]
+    },
+    {
+        "id": "adventurous_medicine_cat_kit",
+        "thoughts": [
+	    "Is showing the kits herbs by taking them on adventures in the territory",
+            "Offers to help the queens with badger rides for the kits"
+        ],
+        "main_trait_constraint": [
+            "adventurous"
+        ],
+        "random_status_constraint": [
+            "kitten"
+        ]
+    },
+    {
+        "id": "adventurous_medicine_cat_to_deputy",
+        "thoughts": [
+            "Asks the deputy to go on patrol"
+        ],
+        "main_trait_constraint": [
+            "adventurous"
+        ],
+        "random_status_constraint": [
+            "deputy"
+        ]
+    },
+    {
         "id": "ambitious_medicine_cat",
         "thoughts": [
             "Insists on taking on more tasks",
             "Spends all day gathering herbs",
-            "Can't wait until StarClan sends an omen"
+            "Can't wait until StarClan sends an omen",
+	    "Wants to find a new cure for a disease"
         ],
         "main_trait_constraint": [
             "ambitious"
@@ -48,11 +82,22 @@
             "Is upset that {PRONOUN/m_c/subject} can't fight alongside the warriors",
             "Wishes to fight alongside the warriors",
             "Thinks {PRONOUN/m_c/subject}'d be an amazing leader",
-            "Talks to the leader and deputy about war",
           "Ignores the low herb stocks and practices battle moves instead"
         ],
         "main_trait_constraint": [
             "bloodthirsty"
+        ]
+    },
+    {
+        "id": "bloodthirsty_medicine_cat_to_lead",
+        "thoughts": [
+            "Talks to the leader about war"
+        ],
+        "main_trait_constraint": [
+            "bloodthirsty"
+        ],
+        "random_status_constraint": [
+            "leader"
         ]
     },
     {
@@ -74,6 +119,18 @@
         ]
     },
     {
+        "id": "calm_medicine_cat_apprentice",
+        "thoughts": [
+            "Calms down an apprentice who is panicking other their minor injury"
+        ],
+        "main_trait_constraint": [
+            "calm"
+        ],
+        "random_status_constraint": [
+            "apprentice"
+        ]
+    },
+    {
         "id": "careful_medicine_cat",
         "thoughts": [
           "Counts and re-counts the poppy seeds",
@@ -86,7 +143,8 @@
     {
         "id": "charismatic_medicine_cat",
         "thoughts": [
-            "Is doing {PRONOUN/m_c/poss} daily checkup on the elders"
+            "Is doing {PRONOUN/m_c/poss} daily checkup on the elders",
+	    "Easily persuades another Clan's medicine cat to gift c_n herbs"
         ],
         "main_trait_constraint": [
             "charismatic"
@@ -187,18 +245,28 @@
     {
         "id": "lonesome_medicine_cat",
         "thoughts": [
-          "Wishes {PRONOUN/m_c/subject} could have a mate and kits",
             "Wishes {PRONOUN/m_c/poss} Clanmates could understand {PRONOUN/m_c/poss} struggles",
             "Wishes there were more medicine cats in the Clan",
             "Wonders why the warriors won't share prey with {PRONOUN/m_c/object}",
             "Wishes {PRONOUN/m_c/subject} could make friends with someone",
             "Wishes the warriors shared an interest in herbs",
-            "Wants to talk to the leader about having a new apprentice",
             "Wishes for an apprentice, as {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} a bit lonely",
             "Hasn't talked to any warriors for a few days"
         ],
         "main_trait_constraint": [
             "lonesome"
+        ]
+    },
+    {
+        "id": "lonesome_medicine_cat_to_lead",
+        "thoughts": [
+            "Wants to talk to the leader about having a new apprentice"
+        ],
+        "main_trait_constraint": [
+            "lonesome"
+        ],
+	"random_status_constraint": [
+            "leader"
         ]
     },
     {
@@ -230,6 +298,15 @@
         ],
         "main_trait_constraint": [
             "nervous"
+        ]
+    },
+    {
+      "id": "playful_medicine_cat",
+        "thoughts": [
+            "Keeps {PRONOUN/m_c/poss} patients distracted with silly games while {PRONOUN/m_c/subject} treat them"
+        ],
+        "main_trait_constraint": [
+            "playful"
         ]
     },
     {
@@ -287,7 +364,8 @@
         "thoughts": [
             "Insists everyone eat chamomile leaves at moonhigh",
             "Sleeps in the middle of the clearing",
-          "Looks dazed"
+            "Looks dazed",
+	    "Watches the sky all night without acknowledging any other cat"
         ],
       "main_trait_constraint": [
         "strange"

--- a/resources/dicts/thoughts/alive/medicine_cat.json
+++ b/resources/dicts/thoughts/alive/medicine_cat.json
@@ -121,7 +121,7 @@
     {
         "id": "calm_medicine_cat_apprentice",
         "thoughts": [
-            "Calms down an apprentice who is panicking other their minor injury"
+            "Calms down an apprentice who is panicking over {PRONOUN/r_c/poss} minor injury"
         ],
         "main_trait_constraint": [
             "calm"
@@ -144,7 +144,7 @@
         "id": "charismatic_medicine_cat",
         "thoughts": [
             "Is doing {PRONOUN/m_c/poss} daily checkup on the elders",
-	    "Easily persuades another Clan's medicine cat to gift c_n herbs"
+	    "Is thinking of just the right way to ask another Clan's medicine cat for herbs"
         ],
         "main_trait_constraint": [
             "charismatic"
@@ -303,7 +303,7 @@
     {
       "id": "playful_medicine_cat",
         "thoughts": [
-            "Keeps {PRONOUN/m_c/poss} patients distracted with silly games while {PRONOUN/m_c/subject} treat them"
+            "Keeps {PRONOUN/m_c/poss} patients distracted with silly games while {PRONOUN/m_c/subject} {VERB/m_c/treat/treats} them"
         ],
         "main_trait_constraint": [
             "playful"

--- a/resources/dicts/thoughts/alive/medicine_cat_apprentice.json
+++ b/resources/dicts/thoughts/alive/medicine_cat_apprentice.json
@@ -279,7 +279,7 @@
         "thoughts": [
             "Thinks r_c is far too soft with {PRONOUN/r_c/poss} patients",
 	    "Wishes r_c wasn't so soft",
-	    "Has to promice r_c {PRONOUN/m_c/subject} won't gather deathberries again"
+	    "Has to promise r_c {PRONOUN/m_c/subject} won't gather deathberries again"
         ],
         "random_trait_constraint": [
             "thoughtful",

--- a/resources/dicts/thoughts/alive/medicine_cat_apprentice.json
+++ b/resources/dicts/thoughts/alive/medicine_cat_apprentice.json
@@ -273,5 +273,32 @@
         "random_living_status": [
             "living"
         ]
+    },
+    {
+        "id": "meanie_medicine_cat_apprentice_to_nice_med",
+        "thoughts": [
+            "Thinks r_c is far too soft with {PRONOUN/r_c/poss} patients",
+	    "Wishes r_c wasn't so soft",
+	    "Has to promice r_c {PRONOUN/m_c/subject} won't gather deathberries again"
+        ],
+        "random_trait_constraint": [
+            "thoughtful",
+            "righteous",
+            "loving",
+            "compassionate",
+            "sincere"
+        ],
+        "random_status_constraint": [
+            "medicine cat"
+        ],
+        "main_trait_constraint": [
+            "bloodthirsty",
+            "cold",
+            "vengeful",
+            "fierce"
+        ],
+        "random_living_status": [
+            "living"
+        ]
     }
 ]


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->

## About The Pull Request
was originally just pronoun-ifying, but got carried away and ended up adding loads of random status constraints to the med cat file and new thoughts to both med cat and med cat app... oops
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Why This Is Good For ClanGen
med cats can no longer generate thoughts about kits/leader/deputy when there aren't any in the clan. new thoughts add variety to clangen.

plus scribble seemed like she needed more prs to look through :D /j
<!-- If this is a bug fix, you can remove this section. -->
<!-- Please add a short description of why you think these changes would benefit the game. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->
<!-- If you have multiple features that can stand on their own, or unrelated bugfixes, please create separate PRs for them. -->

## Proof of Testing
<img width="392" alt="charismatic_cat_new_thought" src="https://github.com/user-attachments/assets/cf4ced51-b26d-4941-8a46-cd381b9b957a">

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits

- medicine cats will no longer generate thoughts about kits/leader/deputy when there aren't any in the clan
- added new medicine cat and medicine cat apprentice thoughts
