### PR TITLE
Condensing Patrol Text to Remove Scroll Bar

### DIFF
--- a/resources/dicts/patrols/general/border.json
+++ b/resources/dicts/patrols/general/border.json
@@ -792,7 +792,7 @@
                 ]
             },
             {
-                "text": "The patrol follows the sound of the cries to a kittypet, curled up by the side of the road with the scent of sickness rising from {PRONOUN/n_c:0/poss} pelt. As p_l comforts {PRONOUN/n_c:0/object} and asks if {PRONOUN/n_c:0/subject} {VERB/n_c:0/need/needs} attention from a medicine cat, s_c quizzes {PRONOUN/n_c:0/object}. {VERB/n_c:0/Are/Is} {PRONOUN/n_c:0/subject} a spy for Twolegs? {VERB/n_c:0/Have/Has} {PRONOUN/n_c:0/subject} been sent to collect information on c_n in order to facilitate a Twolegs takeover? Once the kittypet answers no to both, s_c nods seriously. {PRONOUN/n_c:0/subject/CAP} can be welcomed into the Clan.",
+                "text": "The patrol follows the sound of the cries to a kittypet, curled up by the side of the road with the scent of sickness rising from {PRONOUN/n_c:0/poss} pelt. As p_l comforts {PRONOUN/n_c:0/object} and asks if {PRONOUN/n_c:0/subject} {VERB/n_c:0/need/needs} attention from a medicine cat, s_c quizzes {PRONOUN/n_c:0/object}. {VERB/n_c:0/Are/Is} {PRONOUN/n_c:0/subject} a spy for Twolegs? {VERB/n_c:0/Were/Was} {PRONOUN/n_c:0/subject} sent to collect information on c_n to facilitate a Twolegs takeover? Once the kittypet answers no to both, s_c nods seriously. {PRONOUN/n_c:0/subject/CAP} can be welcomed into the Clan.",
                 "exp": 15,
                 "weight": 5,
                 "stat_trait": [ "childish", "playful", "strange" ],

--- a/resources/dicts/patrols/general/hunting.json
+++ b/resources/dicts/patrols/general/hunting.json
@@ -1248,7 +1248,7 @@
         "stat_trait": ["wise", "thoughtful", "careful"]
       },
       {
-        "text": "r_c kills the rat easily in its distracted state, but then notices the scent of sickness on its body. Best not to bring this one back, p_l decides; even in leaf-bare, it isn't safe to risk sickness. s_c cocks {PRONOUN/s_c/poss} head. If they aren't going to eat it, can they at least name it? Before p_l can figure out how to reply to that, s_c touches {PRONOUN/s_c/poss} nose to the body of the rat. Henceforth, this rat will be known as Stinkyrat, honored for its stinkiness. Stinkyrat! Stinkyrat!",
+        "text": "r_c kills the distracted rat easily, but p_l points out the putrid scent. c_n could use the prey, but it isn't safe to risk sickness. s_c cocks {PRONOUN/s_c/poss} head. If they aren't going to eat it, can they at least name it? Before p_l can figure out how to reply to that, s_c touches {PRONOUN/s_c/poss} nose to the body of the rat. Henceforth, this rat will be known as Stinkyrat, honored for its stinkiness. Stinkyrat! Stinkyrat!",
         "exp": 30,
         "weight": 10,
         "stat_trait": ["childish", "playful" ]


### PR DESCRIPTION

## About The Pull Request

Condensed some text from my own recently written and merged patrol outcomes in order to avoid generating the scroll bar.

## Why This Is Good For ClanGen

Brevity is king. And also scroll bar yucky.

## Proof of Testing

![image](https://github.com/user-attachments/assets/fd28f117-a119-4ca3-ba9e-9bbf4d74b4a2)
![image](https://github.com/user-attachments/assets/94ed719d-82ef-492b-89c9-c30a79dca3fc)
