### PR TITLE
[CONTENT] Very Specific Leader's Den Gathering Outcomes

### DIFF
--- a/resources/dicts/events/leader_den/fail/other_clan.json
+++ b/resources/dicts/events/leader_den/fail/other_clan.json
@@ -181,6 +181,17 @@
   },
   {
     "interaction_type": "praise",
+    "event_text": "Before the Gathering, m_c takes o_c_n's leader aside and warns them that their mate will be caught in a flood in the next moon. o_c_n's leader cuts {PRONOUN/m_c/object} off in disbelief, finding it too terrible to imagine. m_c watches o_c_n's leader leave after the Gathering, {PRONOUN/m_c/poss} heart sinking.",
+    "rel_change": -3,
+    "m_c": {
+      "trait": ["sincere"],
+      "skill": ["CLAIRVOYANT,4"]
+    },
+    "player_clan_temper": ["any"],
+    "other_clan_temper": ["any"]
+  },
+  {
+    "interaction_type": "praise",
     "event_text": "m_c attempts to use {PRONOUN/m_c/poss} honeyed words to get onto o_c_n's good side, only for the other leader to give {PRONOUN/m_c/object} a pointed and <i>very</i> knowing look.",
     "rel_change": -3,
     "m_c": {
@@ -589,7 +600,7 @@
   {
     "interaction_type": "befriend",
     "event_text": "At the Gathering, m_c remarks on how a fighting technique developed by o_c_n warriors is something m_c hopes to teach to c_n's apprentices for moons to come. o_c_n's leader scowls and seems unhappy m_c even knows about this special technique.",
-    "rel_change": 5,
+    "rel_change": -5,
     "m_c": {
       "trait": ["thoughtful" ],
       "skill": ["FIGHTER,2"]

--- a/resources/dicts/events/leader_den/fail/other_clan.json
+++ b/resources/dicts/events/leader_den/fail/other_clan.json
@@ -163,6 +163,17 @@
   },
   {
     "interaction_type": "praise",
+    "event_text": "While trying to scramble up onto the leader's perch at the Gathering, o_c_n's new young leader slips and scrabbles with their hindlegs for purchase. Thinking fast, m_c grabs their scruff and lifts them onto the perch easily. o_c_n's leader screeches that they're not a kit and need <i>no</i> help!",
+    "rel_change": -5,
+    "m_c": {
+      "skill": ["CLIMBER,3", "KIT,3"],
+      "trait": ["calm", "thoughtful", "wise", "careful", "sincere" ]
+    },
+    "player_clan_temper": ["any"],
+    "other_clan_temper": ["any"]
+  },
+  {
+    "interaction_type": "praise",
     "event_text": "m_c praises the beauty of o_c_n's territory at length during the Gathering. o_c_n's leader questions whether m_c is hinting that {PRONOUN/m_c/subject}'d like to steal some of it for c_n.",
     "rel_change": -1,
     "m_c": {},
@@ -487,6 +498,17 @@
   },
   {
     "interaction_type": "befriend",
+    "event_text": "As o_c_n's leader announces new apprentices at the Gathering, m_c interrupts to offer plenty of unsolicited advice about how best to train an apprentice. o_c_n's leader seems less than grateful.",
+    "rel_change": -5,
+    "m_c": {
+      "skill": ["TEACHER,2"],
+      "trait": [ "shameless", "arrogant" ]
+    },
+    "player_clan_temper": ["any"],
+    "other_clan_temper": ["any"]
+  },
+  {
+    "interaction_type": "befriend",
     "event_text": "At the Gathering, m_c pulls o_c_n's leader aside and suggests they form an alliance; with their combined strength, they can crush all that would oppose them. o_c_n's leader declines this offer.",
     "rel_change": 0,
     "m_c": {
@@ -511,6 +533,17 @@
     "rel_change": 0,
     "m_c": {
       "trait": [ "insecure", "nervous", "careful", "gloomy", "lonesome", "grumpy" ]
+    },
+    "player_clan_temper": ["any"],
+    "other_clan_temper": ["any"]
+  },
+  {
+    "interaction_type": "befriend",
+    "event_text": "At the Gathering, o_c_n's leader struggles through a report that an entire litter of o_c_n kits were wiped out by kitten-cough. m_c draws them aside after and reassures them that the kittens are playing moss-ball together in StarClan. o_c_n's leader hisses that this means nothing to the grieving parents.",
+    "rel_change": -5,
+    "m_c": {
+      "skill": [ "KIT,3", "STAR,2"],
+      "trait": [ "playful", "compassionate", "thoughtful", "loving" ]
     },
     "player_clan_temper": ["any"],
     "other_clan_temper": ["any"]
@@ -1013,6 +1046,16 @@
     },
     "player_clan_temper": ["any"],
     "other_clan_temper": ["wary"]
+  },
+  {
+    "interaction_type": "appease",
+    "event_text": "At the Gathering, m_c reveals to o_c_n's leader that one of the o_c_n warriors who died in a recent conflict came to m_c and spoke to {PRONOUN/m_c/object} about peace. o_c_n's leader is furious m_c would presume to speak for one of their dead Clanmates.",
+    "rel_change": -5,
+    "m_c": {
+      "skill": ["GHOST,3"]
+    },
+    "player_clan_temper": ["any"],
+    "other_clan_temper": ["any"]
   },
   {
     "interaction_type": "appease",

--- a/resources/dicts/events/leader_den/fail/other_clan.json
+++ b/resources/dicts/events/leader_den/fail/other_clan.json
@@ -486,6 +486,16 @@
   },
   {
     "interaction_type": "befriend",
+    "event_text": "At the Gathering, m_c pulls o_c_n's leader aside to warn them that fire may be a problem for o_c_n in the coming moons. o_c_n's leader stiffens, staring at m_c with intense mistrust and skepticism.",
+    "rel_change": -2,
+    "m_c": {
+      "skill": ["CLAIRVOYANT,2"]
+    },
+    "player_clan_temper": ["any"],
+    "other_clan_temper": ["any"]
+  },
+  {
+    "interaction_type": "befriend",
     "event_text": "m_c has never been good at making friends, and in a high-pressure situation like a Gathering? {PRONOUN/m_c/subject/CAP} barely {VERB/m_c/manage/manages} more than two or three words to o_c_n's leader.",
     "rel_change": 0,
     "m_c": {
@@ -572,6 +582,17 @@
     "rel_change": 0,
     "m_c": {
       "trait": [ "adventurous" ]
+    },
+    "player_clan_temper": ["any"],
+    "other_clan_temper": ["any"]
+  },
+  {
+    "interaction_type": "befriend",
+    "event_text": "At the Gathering, m_c remarks on how a fighting technique developed by o_c_n warriors is something m_c hopes to teach to c_n's apprentices for moons to come. o_c_n's leader scowls and seems unhappy m_c even knows about this special technique.",
+    "rel_change": 5,
+    "m_c": {
+      "trait": ["thoughtful" ],
+      "skill": ["FIGHTER,2"]
     },
     "player_clan_temper": ["any"],
     "other_clan_temper": ["any"]
@@ -940,6 +961,17 @@
     },
     "player_clan_temper": ["any"],
     "other_clan_temper": ["stoic", "logical"]
+  },
+  {
+    "interaction_type": "appease",
+    "event_text": "On the way to the Gathering, m_c spots a patch of greenish-yellow mushrooms and assumes this must be a sign of StarClan favoring c_n. {PRONOUN/m_c/subject/CAP} {VERB/m_c/greet/greets} o_c_n's leader by confidently accepting their surrender in the ongoing hostilities; o_c_n's leader snarls in {PRONOUN/m_c/poss} face. Maybe they were just normal mushrooms, then.",
+    "rel_change": -5,
+    "m_c": {
+      "trait": ["arrogant"],
+      "skill": [ "OMEN,2" ]
+    },
+    "player_clan_temper": ["any"],
+    "other_clan_temper": ["any"]
   },
   {
     "interaction_type": "appease",

--- a/resources/dicts/events/leader_den/success/other_clan.json
+++ b/resources/dicts/events/leader_den/success/other_clan.json
@@ -261,6 +261,28 @@
   },
   {
     "interaction_type": "praise",
+    "event_text": "Before the Gathering, m_c takes o_c_n's leader aside and warns them that their mate will be caught in a flood in the next moon, unless o_c_n's leader moves their camp to high ground. o_c_n's leader is shocked and grateful for m_c's clairvoyance.",
+    "rel_change": 10,
+    "m_c": {
+      "trait": ["sincere"],
+      "skill": ["CLAIRVOYANT,4"]
+    },
+    "player_clan_temper": ["any"],
+    "other_clan_temper": ["any"]
+  },
+  {
+    "interaction_type": "praise",
+    "event_text": "Before the Gathering, m_c murmurs to o_c_n's leader that in the next moon, another Clan will suffer a greencough outbreak. This could make a great opportunity for o_c_n and c_n to seize some more territory and split it between them.",
+    "rel_change": 10,
+    "m_c": {
+      "trait": ["ambitious"],
+      "skill": ["CLAIRVOYANT,2"]
+    },
+    "player_clan_temper": ["any"],
+    "other_clan_temper": ["logical", "proud", "cunning", "bloodthirsty", "stoic"]
+  },
+  {
+    "interaction_type": "praise",
     "event_text": "At the Gathering, m_c praises o_c_n's leader for how sharp o_c_n warriors' claws are, be it for hunting or fighting. o_c_n's leader is all the more pleased to hear that from a leader like m_c.",
     "rel_change": 3,
     "m_c": {
@@ -330,6 +352,28 @@
     "m_c": {
       "trait": ["confident", "compassionate", "bold", "righteous", "loyal", "sincere"],
       "skill": ["SPEAKER,3", "MEDIATOR,3"]
+    },
+    "player_clan_temper": [],
+    "other_clan_temper": []
+  },
+  {
+    "interaction_type": "praise",
+    "event_text": "At the Gathering, m_c tells the story of a Clan that supported another through the darkest time in their shared history - even to great personal cost. {PRONOUN/m_c/subject/CAP} {VERB/m_c/announce/announces} that just like the mythical Clan, c_n will never abandon their ally.",
+    "rel_change": 10,
+    "m_c": {
+      "trait": ["loyal"],
+      "skill": ["STORY,2"]
+    },
+    "player_clan_temper": [],
+    "other_clan_temper": []
+  },
+  {
+    "interaction_type": "praise",
+    "event_text": "At the Gathering, m_c announces that {PRONOUN/m_c/subject} {VERB/m_c/believe/believes} StarClan intends for o_c_n and c_n warriors to go on a quest together. o_c_n's leader is surprised, but agrees to send out a joint patrol to explore this possibility.",
+    "rel_change": 10,
+    "m_c": {
+      "trait": ["adventurous"],
+      "skill": ["STAR,2", "PROPHET,2"]
     },
     "player_clan_temper": [],
     "other_clan_temper": []
@@ -427,6 +471,17 @@
     "event_text": "When o_c_n's leader announces new warriors at the Gathering, m_c is pointedly silent while the others cheer and welcome the new warriors.",
     "rel_change": -2,
     "m_c": {},
+    "player_clan_temper": ["any"],
+    "other_clan_temper": ["any"]
+  },
+  {
+    "interaction_type": "provoke",
+    "event_text": "During the Gathering, o_c_n's leader delivers their news of a border skirmish. m_c grumbles under {PRONOUN/m_c/poss} breath about lazy, undisciplined fighting styles, and how o_c_n's warriors can hardly be called warriors at all.",
+    "rel_change": -5,
+    "m_c": {
+      "skill": ["FIGHTER,2"],
+      "trait": ["grumpy"]
+    },
     "player_clan_temper": ["any"],
     "other_clan_temper": ["any"]
   },
@@ -636,7 +691,17 @@
   },
   {
     "interaction_type": "befriend",
-    "event_text": "At the Gathering, m_c pulls o_c_n's leader aside to warn them that fire may be a problem for o_c_n in the coming moons. o_c_n's leader agrees to be careful, thanking m_c for the heads-up.",
+    "event_text": "At the Gathering, m_c pulls o_c_n's leader aside to warn them that fire may be a problem for o_c_n in the coming moons. o_c_n's leader seems skeptical as to how m_c could possibly know that, but nevertheless thanks {PRONOUN/m_c/object} for the heads-up.",
+    "rel_change": 3,
+    "m_c": {
+      "skill": ["CLAIRVOYANT,2"]
+    },
+    "player_clan_temper": ["any"],
+    "other_clan_temper": ["any"]
+  },
+  {
+    "interaction_type": "befriend",
+    "event_text": "At the Gathering, m_c pulls o_c_n's leader aside to warn them that a large dog may be a problem for o_c_n in the coming moons. o_c_n's leader agrees to be careful, thanking m_c for the heads-up.",
     "rel_change": 3,
     "m_c": {
       "skill": ["CLAIRVOYANT,2"]
@@ -720,6 +785,28 @@
     "rel_change": 5,
     "m_c": {
       "trait": ["charismatic", "compassionate", "playful"]
+    },
+    "player_clan_temper": ["any"],
+    "other_clan_temper": ["any"]
+  },
+  {
+    "interaction_type": "befriend",
+    "event_text": "At the Gathering, m_c goes out on a limb and admits to o_c_n's leader that their deceased parent is still hovering by them in spirit. o_c_n's leader bows their head, too overcome to speak.",
+    "rel_change": 5,
+    "m_c": {
+      "trait": ["daring", "bold" ],
+      "skill": ["GHOST,2"]
+    },
+    "player_clan_temper": ["any"],
+    "other_clan_temper": ["any"]
+  },
+  {
+    "interaction_type": "befriend",
+    "event_text": "At the Gathering, m_c remarks on how a fighting technique developed by o_c_n warriors is something m_c hopes to teach to c_n's apprentices for moons to come. o_c_n's leader is impressed and flattered.",
+    "rel_change": 5,
+    "m_c": {
+      "trait": ["thoughtful" ],
+      "skill": ["FIGHTER,2"]
     },
     "player_clan_temper": ["any"],
     "other_clan_temper": ["any"]
@@ -1222,9 +1309,20 @@
   {
     "interaction_type": "appease",
     "event_text": "m_c is quick to assert {PRONOUN/m_c/self} at the Gathering, announcing that {PRONOUN/m_c/subject} received an omen: omen_list_smell_emotional/m_c. After a long debate, it's decided that the omen insists o_c_n and c_n cease hostilities.",
-    "rel_change": 10,
+    "rel_change": 8,
     "m_c": {
       "skill": ["OMEN,1"]
+    },
+    "player_clan_temper": ["any"],
+    "other_clan_temper": ["any"]
+  },
+  {
+    "interaction_type": "appease",
+    "event_text": "At the Gathering, m_c speaks passionately of the omen {PRONOUN/m_c/subject} received the previous night - omen_list_sound/m_c. o_c_n's leader is cowed by the echo of flames and scent of sulfur in m_c's speech, and quickly agrees to de-escalate tensions.",
+    "rel_change": 10,
+    "m_c": {
+      "skill": ["OMEN,1"],
+      "trait": ["fierce"]
     },
     "player_clan_temper": ["any"],
     "other_clan_temper": ["any"]

--- a/resources/dicts/events/leader_den/success/other_clan.json
+++ b/resources/dicts/events/leader_den/success/other_clan.json
@@ -151,6 +151,28 @@
   },
   {
     "interaction_type": "offend",
+    "event_text": "Another Clan's leader accuses o_c_n at the Gathering of refusing to share herbs in the case of a sick kitten. m_c turns on o_c_n's leader immediately, hissing that {PRONOUN/m_c/subject} cannot ally {PRONOUN/m_c/self} with fox-hearts.",
+    "rel_change": -6,
+    "m_c": {
+      "trait": ["strict", "faithful", "righteous"],
+      "skill": ["HEALER,2"]
+    },
+    "player_clan_temper": ["any"],
+    "other_clan_temper": ["any"]
+  },
+  {
+    "interaction_type": "offend",
+    "event_text": "At the Gathering, o_c_n's leader vents to m_c about how o_c_n apprentices don't help out enough around camp. m_c scoffs, saying {PRONOUN/m_c/subject} would never permit such unruly behavior, because camp-keeping is a fundamental part of c_n apprenticeship.",
+    "rel_change": -4,
+    "m_c": {
+      "trait": [ "cold", "strict" ],
+      "skill": ["CAMP,2"]
+    },
+    "player_clan_temper": ["any"],
+    "other_clan_temper": ["any"]
+  },
+  {
+    "interaction_type": "offend",
     "event_text": "m_c grins as {PRONOUN/m_c/subject} {VERB/m_c/spout/spouts} insults at o_c_n's leader during the Gathering.",
     "rel_change": -5,
     "m_c": {
@@ -198,6 +220,39 @@
     "event_text": "At the Gathering, o_c_n's leader discusses a problem with a dog near their border. m_c is quick to volunteer c_n's warriors as reinforcement, should the need arise.",
     "rel_change": 1,
     "m_c": {},
+    "player_clan_temper": ["any"],
+    "other_clan_temper": ["any"]
+  },
+  {
+    "interaction_type": "praise",
+    "event_text": "At the Gathering, m_c shares a dream {PRONOUN/m_c/subject} had the previous night about o_c_n and c_n thriving and strengthening each other. o_c_n's leader amazedly reports they had the exact same dream.",
+    "rel_change": 5,
+    "m_c": {
+      "skill": ["DREAM,2"],
+      "trait": ["loyal", "bold", "daring"]
+    },
+    "player_clan_temper": ["any"],
+    "other_clan_temper": ["any"]
+  },
+  {
+    "interaction_type": "praise",
+    "event_text": "At the Gathering, m_c fills the ears of o_c_n's leader with flattering rhetoric about how c_n could enable o_c_n to dominate the territories. o_c_n's leader listens attentively, but never notices the shadow flickering behind m_c, too dark to be cast by the moon's light.",
+    "rel_change": 7,
+    "m_c": {
+      "skill": ["DARK,3"],
+      "trait": ["bold", "daring", "ambitious", "cunning"]
+    },
+    "player_clan_temper": ["any"],
+    "other_clan_temper": ["proud", "logical", "stoic", "wary", "bloodthirsty"]
+  },
+  {
+    "interaction_type": "praise",
+    "event_text": "While trying to scramble up onto the leader's perch at the Gathering, o_c_n's new young leader slips and scrabbles with their hindlegs for purchase. Thinking fast, m_c grabs their scruff and lifts them onto the perch easily. o_c_n's leader breathlessly thanks {PRONOUN/m_c/object}.",
+    "rel_change": 5,
+    "m_c": {
+      "skill": ["CLIMBER,3", "KIT,3"],
+      "trait": ["calm", "thoughtful", "wise", "careful", "sincere" ]
+    },
     "player_clan_temper": ["any"],
     "other_clan_temper": ["any"]
   },
@@ -290,6 +345,17 @@
     },
     "player_clan_temper": ["any"],
     "other_clan_temper": ["any"]
+  },
+  {
+    "interaction_type": "praise",
+    "event_text": "m_c realizes the full moon has risen and {PRONOUN/m_c/poss} Gathering patrol is still in camp. m_c leads c_n in a wild sprint to the meeting place, where o_c_n's leader has convinced the others to wait. m_c thanks them profusely, {PRONOUN/m_c/poss} fur sticking up in all directions.",
+    "rel_change": 3,
+    "m_c": {
+      "skill": ["RUNNER,2"],
+      "trait": ["childish", "oblivious"]
+    },
+    "player_clan_temper": ["any"],
+    "other_clan_temper": ["mellow", "gracious", "stoic", "wary", "logical", "amiable"]
   },
   {
     "interaction_type": "praise",
@@ -428,6 +494,28 @@
   },
   {
     "interaction_type": "provoke",
+    "event_text": "Every cat always told m_c {PRONOUN/m_c/subject} would get in trouble for {PRONOUN/m_c/poss} smart mouth... but no cat could've predicted how useful it would be in this situation. By the end of the Gathering, o_c_n's leader seems ready to claw {PRONOUN/m_c/poss} face off.",
+    "rel_change": -10,
+    "m_c": {
+      "skill": ["SPEAKER,3"],
+      "trait": [ "troublesome" ]
+    },
+    "player_clan_temper": ["any"],
+    "other_clan_temper": ["any"]
+  },
+  {
+    "interaction_type": "provoke",
+    "event_text": "As o_c_n's leader announces new apprentices at the Gathering, m_c interrupts to offer plenty of unsolicited advice about how best to train an apprentice.",
+    "rel_change": -5,
+    "m_c": {
+      "skill": ["TEACHER,2"],
+      "trait": [ "shameless", "arrogant" ]
+    },
+    "player_clan_temper": ["any"],
+    "other_clan_temper": ["any"]
+  },
+  {
+    "interaction_type": "provoke",
     "event_text": "At the Gathering, m_c accuses o_c_n's leader of using loners and rogues to spy on c_n.",
     "rel_change": -2,
     "m_c": {},
@@ -487,6 +575,17 @@
   },
   {
     "interaction_type": "provoke",
+    "event_text": "During the Gathering, m_c makes a surprise outburst about how o_c_n has had the other Clans under their paw for far too long, and it's time for c_n and their allies to rise up against o_c_n.",
+    "rel_change": -7,
+    "m_c": {
+      "skill": ["SPEAKER,2"],
+      "trait": ["rebellious"]
+    },
+    "player_clan_temper": ["any"],
+    "other_clan_temper": ["any"]
+  },
+  {
+    "interaction_type": "provoke",
     "event_text": "During the Gathering, m_c spits accusations at o_c_n's leader.",
     "rel_change": -2,
     "m_c": {
@@ -500,16 +599,7 @@
     "event_text": "During the Gathering, m_c comments unprompted that {PRONOUN/m_c/subject} could easily take on two o_c_n warriors at once in a fight.",
     "rel_change": -2,
     "m_c": {
-      "skill": [ "FIGHTER,1" ]
-    },
-    "player_clan_temper": ["any"],
-    "other_clan_temper": ["any"]
-  },
-  {
-    "interaction_type": "provoke",
-    "event_text": "During the Gathering, m_c comments unprompted that {PRONOUN/m_c/subject} could easily take on two o_c_n warriors at once in a fight.",
-    "rel_change": -2,
-    "m_c": {
+      "skill": [ "FIGHTER,1" ],
       "trait": [ "confident", "competitive", "arrogant", "ambitious", "shameless", "flamboyant" ]
     },
     "player_clan_temper": ["any"],
@@ -520,17 +610,8 @@
     "event_text": "During the Gathering, m_c 'jokes' that {PRONOUN/m_c/subject} probably caught more prey this moon than all of o_c_n combined.",
     "rel_change": -2,
     "m_c": {
+      "skill": [ "HUNTER,1" ],
       "trait": [ "confident", "competitive", "arrogant", "ambitious", "shameless", "flamboyant" ]
-    },
-    "player_clan_temper": ["any"],
-    "other_clan_temper": ["any"]
-  },
-  {
-    "interaction_type": "provoke",
-    "event_text": "During the Gathering, m_c 'jokes' that {PRONOUN/m_c/subject} probably caught more prey this moon than all of o_c_n combined.",
-    "rel_change": -2,
-    "m_c": {
-      "skill": [ "HUNTER,1" ]
     },
     "player_clan_temper": ["any"],
     "other_clan_temper": ["any"]
@@ -551,6 +632,17 @@
     "rel_change": -3,
     "m_c": {
       "skill": [ "KIT,2"]
+    },
+    "player_clan_temper": ["any"],
+    "other_clan_temper": ["any"]
+  },
+  {
+    "interaction_type": "provoke",
+    "event_text": "During the Gathering, m_c asks o_c_n's leader earnestly if they really think they're living up to o_c_n's legacy. o_c_n's leader frowns at the implication.",
+    "rel_change": -5,
+    "m_c": {
+      "skill": [ "LORE,2"],
+      "trait": ["sincere"]
     },
     "player_clan_temper": ["any"],
     "other_clan_temper": ["any"]
@@ -711,6 +803,17 @@
   },
   {
     "interaction_type": "befriend",
+    "event_text": "At the Gathering, o_c_n's leader struggles through a report that an entire litter of o_c_n kits were wiped out by kitten-cough. m_c draws them aside after and reassures them that the kittens are playing moss-ball together in StarClan. o_c_n's leader thanks {PRONOUN/m_c/object}, their mew thick with emotion.",
+    "rel_change": 5,
+    "m_c": {
+      "skill": [ "KIT,3", "STAR,2"],
+      "trait": [ "playful", "compassionate", "thoughtful", "loving" ]
+    },
+    "player_clan_temper": ["any"],
+    "other_clan_temper": ["any"]
+  },
+  {
+    "interaction_type": "befriend",
     "event_text": "During the Gathering, m_c flatters o_c_n's leader with {PRONOUN/m_c/poss} attention. After all, m_c knows exactly how to handle short tempers and immature behavior.",
     "rel_change": 1,
     "m_c": {
@@ -718,6 +821,28 @@
     },
     "player_clan_temper": ["any"],
     "other_clan_temper": ["proud"]
+  },
+  {
+    "interaction_type": "befriend",
+    "event_text": "During the Gathering, o_c_n's leader wearily reports how o_c_n kits keep sneaking out of camp. m_c pulls them aside after and suggests that bringing the kits onto the territory in supervised groups might help regulate all that kithood energy. o_c_n's leader is impressed and thanks m_c for the suggestion.",
+    "rel_change": 5,
+    "m_c": {
+      "skill": [ "KIT,2" ],
+      "trait": ["adventurous"]
+    },
+    "player_clan_temper": ["any"],
+    "other_clan_temper": ["any"]
+  },
+  {
+    "interaction_type": "befriend",
+    "event_text": "During the Gathering, o_c_n's leader comments to the other leaders that their apprentices are struggling to learn to swim. m_c snorts that most mentors forget to teach apprentices to blow bubbles first. Embarrassed, o_c_n's leader admits they had forgotten and thanks m_c for the reminder.",
+    "rel_change": 5,
+    "m_c": {
+      "skill": [ "TEACHER,2", "SWIMMER,2" ],
+      "trait": ["grumpy"]
+    },
+    "player_clan_temper": ["any"],
+    "other_clan_temper": ["any"]
   },
   {
     "interaction_type": "befriend",
@@ -807,6 +932,17 @@
     "m_c": {
       "trait": ["thoughtful" ],
       "skill": ["FIGHTER,2"]
+    },
+    "player_clan_temper": ["any"],
+    "other_clan_temper": ["any"]
+  },
+  {
+    "interaction_type": "befriend",
+    "event_text": "At the Gathering, m_c thinks about how making friends is a lot like hunting - it's all a matter of approaching at the best angle, timing it right, and then pouncing. By the end of the night, o_c_n's leader is on c_n's fresh-kill pile... metaphorically.",
+    "rel_change": 5,
+    "m_c": {
+      "trait": ["charismatic" ],
+      "skill": ["HUNTER,2"]
     },
     "player_clan_temper": ["any"],
     "other_clan_temper": ["any"]
@@ -921,6 +1057,17 @@
   },
   {
     "interaction_type": "antagonize",
+    "event_text": "At the Gathering, o_c_n's leader takes up all the air in the meeting place snarling insults and threats. m_c waits for {PRONOUN/m_c/poss} moment before coolly delivering a single devastating verbal blow.",
+    "rel_change": -5,
+    "m_c": {
+      "trait": [ "CLEVER,2", "SPEAKER,2"],
+      "skill": [ "cold", "calm", "cunning" ]
+    },
+    "player_clan_temper": ["any"],
+    "other_clan_temper": ["any"]
+  },
+  {
+    "interaction_type": "antagonize",
     "event_text": "m_c spends the Gathering making thinly veiled comments about o_c_n's hunting abilities. By the end of it, the proud o_c_n leader is visibly annoyed.",
     "rel_change": -2,
     "m_c": {
@@ -939,6 +1086,17 @@
     },
     "player_clan_temper": ["any"],
     "other_clan_temper": ["any"]
+  },
+  {
+    "interaction_type": "antagonize",
+    "event_text": "o_c_n's leader reports at the Gathering that some of their warriors led an uprising and had to be put down. m_c scoffs, unsheathes {PRONOUN/m_c/poss} claws, and announces {PRONOUN/m_c/subject}'d rebel against o_c_n's leader too, if {PRONOUN/m_c/subject} were one of o_c_n's warriors.",
+    "rel_change": -8,
+    "m_c": {
+      "skill": ["FIGHTER,2"],
+      "trait": [ "rebellious" ]
+    },
+    "player_clan_temper": ["any"],
+    "other_clan_temper": ["stoic", "bloodthirsty", "logical", "wary", "cunning", "proud"]
   },
   {
     "interaction_type": "antagonize",
@@ -976,6 +1134,17 @@
     "rel_change": -3,
     "m_c": {
       "skill": [ "STORY,2", "LORE,2", "SPEAKER,4" ]
+    },
+    "player_clan_temper": ["any"],
+    "other_clan_temper": ["any"]
+  },
+  {
+    "interaction_type": "antagonize",
+    "event_text": "Before entering the Gathering meeting place, m_c signals for {PRONOUN/m_c/poss} Clanmates to hang back. m_c eavesdrops on o_c_n, picking up all the Clan secrets that boastful warriors and indiscreet apprentices share, then strolls into the Gathering to use this information in {PRONOUN/m_c/poss} speech.",
+    "rel_change": -6,
+    "m_c": {
+      "skill": [ "SENSE,3" ],
+      "trait": ["sneaky", "cunning"]
     },
     "player_clan_temper": ["any"],
     "other_clan_temper": ["any"]
@@ -1175,7 +1344,7 @@
     "event_text": "At the Gathering, o_c_n's leader gets in m_c's face. m_c squares {PRONOUN/m_c/poss} shoulders and lets {PRONOUN/m_c/poss} muscular physique speak for itself; o_c_n's leader suddenly acquires an appetite for peace. m_c's Clanmates giddily report the next morning that the leader looked like a kit next to {PRONOUN/m_c/object}.",
     "rel_change": 3,
     "m_c": {
-      "skill": [ "SWIMMER,3", "CLIMBING,3", "RUNNER,3", "FIGHTER,4" ],
+      "skill": [ "SWIMMER,3", "CLIMBER,3", "RUNNER,3", "FIGHTER,4" ],
       "trait": [ "bold", "shameless", "daring", "cold", "vengeful", "fierce", "arrogant", "competitive", "cunning", "troublesome", "confident", "adventurous", "loyal", "responsible" ]
     },
     "player_clan_temper": ["any"],
@@ -1210,6 +1379,39 @@
       "skill": ["SPEAKER,1"]
     },
     "player_clan_temper": ["gracious", "mellow", "logical", "amiable", "cunning", "stoic"],
+    "other_clan_temper": ["any"]
+  },
+  {
+    "interaction_type": "antagonize",
+    "event_text": "Before o_c_n's leader says a word at the Gathering, m_c speaks in a low, commanding voice... reciting something that sounds awfully like a prophecy foretelling o_c_n's doom. m_c isn't the sort of cat to waste {PRONOUN/m_c/poss} breath on empty words; o_c_n's leader stiffens, bone-deep fear flashing over their face.",
+    "rel_change": -10,
+    "m_c": {
+      "trait": ["lonesome"],
+      "skill": ["PROPHET,4"]
+    },
+    "player_clan_temper": ["any"],
+    "other_clan_temper": ["any"]
+  },
+  {
+    "interaction_type": "antagonize",
+    "event_text": "At the Gathering, o_c_n's leader repeatedly provokes and challenges c_n. m_c remains composed, not a whisker out of place, and asks o_c_n's leader to name a place and time for them to settle the score. {PRONOUN/m_c/poss/CAP} self-possession riles o_c_n's leader even more",
+    "rel_change": -10,
+    "m_c": {
+      "trait": ["calm"],
+      "skill": ["FIGHTER,2"]
+    },
+    "player_clan_temper": ["any"],
+    "other_clan_temper": ["any"]
+  },
+  {
+    "interaction_type": "antagonize",
+    "event_text": "At the Gathering, m_c forgoes a traditional speech in favor of retelling the tale of a legendary o_c_n leader... but with {PRONOUN/m_c/poss} own special graphically violent twist. o_c_n warriors cover their apprentices' ears, and even o_c_n's leader looks like they'll have nightmares",
+    "rel_change": -10,
+    "m_c": {
+      "trait": ["bloodthirsty"],
+      "skill": ["STORY,2", "LORE,3"]
+    },
+    "player_clan_temper": ["any"],
     "other_clan_temper": ["any"]
   },
   {
@@ -1308,6 +1510,17 @@
   },
   {
     "interaction_type": "appease",
+    "event_text": "o_c_n's leader threatens c_n throughout the Gathering. m_c remains silent until {PRONOUN/m_c/poss} turn to speak, then remarks that no cat in o_c_n really wants war. o_c_n warriors shuffle their paws and avoid their leader's gaze, not wanting to admit that m_c is right",
+    "rel_change": 6,
+    "m_c": {
+      "trait": ["strange", "thoughtful", "calm"],
+      "skill": [ "INSIGHT,2", "CLEVER,3" ]
+    },
+    "player_clan_temper": ["any"],
+    "other_clan_temper": ["stoic", "logical"]
+  },
+  {
+    "interaction_type": "appease",
     "event_text": "m_c is quick to assert {PRONOUN/m_c/self} at the Gathering, announcing that {PRONOUN/m_c/subject} received an omen: omen_list_smell_emotional/m_c. After a long debate, it's decided that the omen insists o_c_n and c_n cease hostilities.",
     "rel_change": 8,
     "m_c": {
@@ -1329,6 +1542,16 @@
   },
   {
     "interaction_type": "appease",
+    "event_text": "At the Gathering, m_c reveals to o_c_n's leader that one of the o_c_n warriors who died in a recent conflict came to m_c and spoke to {PRONOUN/m_c/object} about peace. o_c_n's leader admits the same warrior appeared in their dreams.",
+    "rel_change": 10,
+    "m_c": {
+      "skill": ["GHOST,3"]
+    },
+    "player_clan_temper": ["any"],
+    "other_clan_temper": ["any"]
+  },
+  {
+    "interaction_type": "appease",
     "event_text": "m_c is quick to assert {PRONOUN/m_c/self} at the Gathering, announcing that {PRONOUN/m_c/subject} received an omen: omen_list_smell_emotional/m_c. After a long debate, it's decided that the omen insists o_c_n and c_n cease hostilities.",
     "rel_change": 10,
     "m_c": {
@@ -1336,6 +1559,17 @@
     },
     "player_clan_temper": ["any"],
     "other_clan_temper": ["any"]
+  },
+  {
+    "interaction_type": "appease",
+    "event_text": "At the Gathering, o_c_n's leader launches the usual threats, and m_c challenges them to a meanie-off. A... what? A meanie-off, m_c explains, involves going back and forth with insults until a winner is declared. o_c_n's leader purrs despite themself at how ridiculous the suggestion is.",
+    "rel_change": 5,
+    "m_c": {
+      "skill": ["MEDIATOR,2"],
+      "trait": [ "childish", "playful" ]
+    },
+    "player_clan_temper": ["any"],
+    "other_clan_temper": ["wary"]
   },
   {
     "interaction_type": "appease",
@@ -1376,5 +1610,16 @@
     },
     "player_clan_temper": ["any"],
     "other_clan_temper": ["bloodthirsty"]
+  },
+  {
+    "interaction_type": "appease",
+    "event_text": "While o_c_n's leader spits threats at m_c, {PRONOUN/m_c/subject} {VERB/m_c/react/reacts} exactly as much as will satisfy o_c_n's leader, without revealing weakness. By the end of the Gathering, o_c_n's leader seems to have worn themself out.",
+    "rel_change": 5,
+    "m_c": {
+      "skill": ["CLEVER,2"],
+      "trait": [ "calm", "wise" ]
+    },
+    "player_clan_temper": ["any"],
+    "other_clan_temper": ["any"]
   }
 ]

--- a/resources/dicts/events/leader_den/success/other_clan.json
+++ b/resources/dicts/events/leader_den/success/other_clan.json
@@ -331,7 +331,7 @@
     "rel_change": 10,
     "m_c": {
       "trait": ["ambitious"],
-      "skill": ["CLAIRVOYANT,2"]
+      "skill": ["CLAIRVOYANT,1"]
     },
     "player_clan_temper": ["any"],
     "other_clan_temper": ["logical", "proud", "cunning", "bloodthirsty", "stoic"]
@@ -341,7 +341,7 @@
     "event_text": "At the Gathering, m_c praises o_c_n's leader for how sharp o_c_n warriors' claws are, be it for hunting or fighting. o_c_n's leader is all the more pleased to hear that from a leader like m_c.",
     "rel_change": 3,
     "m_c": {
-      "skill": ["FIGHTER,2", "HUNTER,2"]
+      "skill": ["FIGHTER,1", "HUNTER,1"]
     },
     "player_clan_temper": ["any"],
     "other_clan_temper": ["any"]
@@ -351,7 +351,7 @@
     "event_text": "m_c realizes the full moon has risen and {PRONOUN/m_c/poss} Gathering patrol is still in camp. m_c leads c_n in a wild sprint to the meeting place, where o_c_n's leader has convinced the others to wait. m_c thanks them profusely, {PRONOUN/m_c/poss} fur sticking up in all directions.",
     "rel_change": 3,
     "m_c": {
-      "skill": ["RUNNER,2"],
+      "skill": ["RUNNER,1"],
       "trait": ["childish", "oblivious"]
     },
     "player_clan_temper": ["any"],
@@ -428,7 +428,7 @@
     "rel_change": 10,
     "m_c": {
       "trait": ["loyal"],
-      "skill": ["STORY,2"]
+      "skill": ["STORY,1"]
     },
     "player_clan_temper": [],
     "other_clan_temper": []
@@ -439,7 +439,7 @@
     "rel_change": 10,
     "m_c": {
       "trait": ["adventurous"],
-      "skill": ["STAR,2", "PROPHET,2"]
+      "skill": ["STAR,1", "PROPHET,1"]
     },
     "player_clan_temper": [],
     "other_clan_temper": []
@@ -508,7 +508,7 @@
     "event_text": "As o_c_n's leader announces new apprentices at the Gathering, m_c interrupts to offer plenty of unsolicited advice about how best to train an apprentice.",
     "rel_change": -5,
     "m_c": {
-      "skill": ["TEACHER,2"],
+      "skill": ["TEACHER,1"],
       "trait": [ "shameless", "arrogant" ]
     },
     "player_clan_temper": ["any"],
@@ -567,7 +567,7 @@
     "event_text": "During the Gathering, o_c_n's leader delivers their news of a border skirmish. m_c grumbles under {PRONOUN/m_c/poss} breath about lazy, undisciplined fighting styles, and how o_c_n's warriors can hardly be called warriors at all.",
     "rel_change": -5,
     "m_c": {
-      "skill": ["FIGHTER,2"],
+      "skill": ["FIGHTER,1"],
       "trait": ["grumpy"]
     },
     "player_clan_temper": ["any"],
@@ -578,7 +578,7 @@
     "event_text": "During the Gathering, m_c makes a surprise outburst about how o_c_n has had the other Clans under their paw for far too long, and it's time for c_n and their allies to rise up against o_c_n.",
     "rel_change": -7,
     "m_c": {
-      "skill": ["SPEAKER,2"],
+      "skill": ["SPEAKER,1"],
       "trait": ["rebellious"]
     },
     "player_clan_temper": ["any"],
@@ -641,7 +641,7 @@
     "event_text": "During the Gathering, m_c asks o_c_n's leader earnestly if they really think they're living up to o_c_n's legacy. o_c_n's leader frowns at the implication.",
     "rel_change": -5,
     "m_c": {
-      "skill": [ "LORE,2"],
+      "skill": [ "LORE,1"],
       "trait": ["sincere"]
     },
     "player_clan_temper": ["any"],
@@ -652,7 +652,7 @@
     "event_text": "During the Gathering, o_c_n's leader brags about recent successes in border skirmishes. m_c remarks that they're obfuscating how badly wounded some warriors are and how overworked their medicine cats seem.",
     "rel_change": -3,
     "m_c": {
-      "skill": [ "INSIGHTFUL,2", "SENSE,2"]
+      "skill": [ "INSIGHTFUL,1", "SENSE,1"]
     },
     "player_clan_temper": ["any"],
     "other_clan_temper": ["any"]
@@ -776,7 +776,7 @@
     "event_text": "During the Gathering, m_c brings up an old legend about two Clans that put aside their differences and formed an alliance, bringing strength to both of them. o_c_n's leader listens with interest.",
     "rel_change": 3,
     "m_c": {
-      "skill": ["STORY,2"]
+      "skill": ["STORY,1"]
     },
     "player_clan_temper": ["any"],
     "other_clan_temper": ["any"]
@@ -806,7 +806,7 @@
     "event_text": "At the Gathering, o_c_n's leader struggles through a report that an entire litter of o_c_n kits were wiped out by kitten-cough. m_c draws them aside after and reassures them that the kittens are playing moss-ball together in StarClan. o_c_n's leader thanks {PRONOUN/m_c/object}, their mew thick with emotion.",
     "rel_change": 5,
     "m_c": {
-      "skill": [ "KIT,3", "STAR,2"],
+      "skill": [ "KIT,2", "STAR,1"],
       "trait": [ "playful", "compassionate", "thoughtful", "loving" ]
     },
     "player_clan_temper": ["any"],
@@ -817,7 +817,7 @@
     "event_text": "During the Gathering, m_c flatters o_c_n's leader with {PRONOUN/m_c/poss} attention. After all, m_c knows exactly how to handle short tempers and immature behavior.",
     "rel_change": 1,
     "m_c": {
-      "skill": [ "KIT,2" ]
+      "skill": [ "KIT,1" ]
     },
     "player_clan_temper": ["any"],
     "other_clan_temper": ["proud"]
@@ -827,7 +827,7 @@
     "event_text": "During the Gathering, o_c_n's leader wearily reports how o_c_n kits keep sneaking out of camp. m_c pulls them aside after and suggests that bringing the kits onto the territory in supervised groups might help regulate all that kithood energy. o_c_n's leader is impressed and thanks m_c for the suggestion.",
     "rel_change": 5,
     "m_c": {
-      "skill": [ "KIT,2" ],
+      "skill": [ "KIT,1" ],
       "trait": ["adventurous"]
     },
     "player_clan_temper": ["any"],
@@ -838,7 +838,7 @@
     "event_text": "During the Gathering, o_c_n's leader comments to the other leaders that their apprentices are struggling to learn to swim. m_c snorts that most mentors forget to teach apprentices to blow bubbles first. Embarrassed, o_c_n's leader admits they had forgotten and thanks m_c for the reminder.",
     "rel_change": 5,
     "m_c": {
-      "skill": [ "TEACHER,2", "SWIMMER,2" ],
+      "skill": [ "TEACHER,1", "SWIMMER,1" ],
       "trait": ["grumpy"]
     },
     "player_clan_temper": ["any"],
@@ -859,7 +859,7 @@
     "event_text": "At the Gathering, m_c points out a constellation of stars to o_c_n's leader that almost form the very thing that o_c_n was named for. o_c_n's leader agrees with a purr, remarking that they had never noticed it.",
     "rel_change": 3,
     "m_c": {
-      "skill": ["STAR,2", "CLEVER,4", "SENSE,2", "OMEN,2"]
+      "skill": ["STAR,1", "CLEVER,3", "SENSE,1", "OMEN,2"]
     },
     "player_clan_temper": ["any"],
     "other_clan_temper": ["any"]
@@ -931,7 +931,7 @@
     "rel_change": 5,
     "m_c": {
       "trait": ["thoughtful" ],
-      "skill": ["FIGHTER,2"]
+      "skill": ["FIGHTER,1"]
     },
     "player_clan_temper": ["any"],
     "other_clan_temper": ["any"]
@@ -942,7 +942,7 @@
     "rel_change": 5,
     "m_c": {
       "trait": ["charismatic" ],
-      "skill": ["HUNTER,2"]
+      "skill": ["HUNTER,1"]
     },
     "player_clan_temper": ["any"],
     "other_clan_temper": ["any"]
@@ -986,7 +986,7 @@
     "event_text": "When o_c_n's leader insults m_c at the Gathering, m_c replies that {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} used to handling immature, childish behavior - but this is a lot, even for {PRONOUN/m_c/object}.",
     "rel_change": -3,
     "m_c": {
-      "skill": [ "KIT,2"]
+      "skill": [ "KIT,1"]
     },
     "player_clan_temper": ["any"],
     "other_clan_temper": ["any"]
@@ -1060,8 +1060,8 @@
     "event_text": "At the Gathering, o_c_n's leader takes up all the air in the meeting place snarling insults and threats. m_c waits for {PRONOUN/m_c/poss} moment before coolly delivering a single devastating verbal blow.",
     "rel_change": -5,
     "m_c": {
-      "trait": [ "CLEVER,2", "SPEAKER,2"],
-      "skill": [ "cold", "calm", "cunning" ]
+      "skill": [ "CLEVER,1", "SPEAKER,1"],
+      "trait": [ "cold", "calm", "cunning" ]
     },
     "player_clan_temper": ["any"],
     "other_clan_temper": ["any"]
@@ -1081,7 +1081,7 @@
     "event_text": "m_c flexes {PRONOUN/m_c/poss} claws in front of o_c_n's leader at the Gathering and asks if they ever wish o_c_n had a fighter as talented as {PRONOUN/m_c/object}. {PRONOUN/m_c/subject/CAP}{VERB/m_c/'re/'s} rewarded for {PRONOUN/m_c/poss} insolence with a hiss of outrage from o_c_n's leader.",
     "rel_change": -2,
     "m_c": {
-      "skill": ["FIGHTER,2"],
+      "skill": ["FIGHTER,1"],
       "trait": [ "arrogant", "confident", "ambitious", "shameless", "fierce", "bloodthirsty", "cold", "competitive", "childish", "flamboyant", "adventurous", "troublesome" ]
     },
     "player_clan_temper": ["any"],
@@ -1092,7 +1092,7 @@
     "event_text": "o_c_n's leader reports at the Gathering that some of their warriors led an uprising and had to be put down. m_c scoffs, unsheathes {PRONOUN/m_c/poss} claws, and announces {PRONOUN/m_c/subject}'d rebel against o_c_n's leader too, if {PRONOUN/m_c/subject} were one of o_c_n's warriors.",
     "rel_change": -8,
     "m_c": {
-      "skill": ["FIGHTER,2"],
+      "skill": ["FIGHTER,1"],
       "trait": [ "rebellious" ]
     },
     "player_clan_temper": ["any"],
@@ -1133,7 +1133,7 @@
     "event_text": "At the Gathering, m_c brings up an old tale of a tyrannical mouse-brain that nearly destroyed their own Clan with warmongering. o_c_n's leader is snarling by the end of the story.",
     "rel_change": -3,
     "m_c": {
-      "skill": [ "STORY,2", "LORE,2", "SPEAKER,4" ]
+      "skill": [ "STORY,1", "LORE,2", "SPEAKER,4" ]
     },
     "player_clan_temper": ["any"],
     "other_clan_temper": ["any"]
@@ -1398,7 +1398,7 @@
     "rel_change": -10,
     "m_c": {
       "trait": ["calm"],
-      "skill": ["FIGHTER,2"]
+      "skill": ["FIGHTER,1"]
     },
     "player_clan_temper": ["any"],
     "other_clan_temper": ["any"]
@@ -1409,7 +1409,7 @@
     "rel_change": -10,
     "m_c": {
       "trait": ["bloodthirsty"],
-      "skill": ["STORY,2", "LORE,3"]
+      "skill": ["STORY,1", "LORE,3"]
     },
     "player_clan_temper": ["any"],
     "other_clan_temper": ["any"]
@@ -1514,7 +1514,7 @@
     "rel_change": 6,
     "m_c": {
       "trait": ["strange", "thoughtful", "calm"],
-      "skill": [ "INSIGHT,2", "CLEVER,3" ]
+      "skill": [ "INSIGHT,1", "CLEVER,3" ]
     },
     "player_clan_temper": ["any"],
     "other_clan_temper": ["stoic", "logical"]
@@ -1565,7 +1565,7 @@
     "event_text": "At the Gathering, o_c_n's leader launches the usual threats, and m_c challenges them to a meanie-off. A... what? A meanie-off, m_c explains, involves going back and forth with insults until a winner is declared. o_c_n's leader purrs despite themself at how ridiculous the suggestion is.",
     "rel_change": 5,
     "m_c": {
-      "skill": ["MEDIATOR,2"],
+      "skill": ["MEDIATOR,1"],
       "trait": [ "childish", "playful" ]
     },
     "player_clan_temper": ["any"],

--- a/resources/dicts/events/leader_den/success/other_clan.json
+++ b/resources/dicts/events/leader_den/success/other_clan.json
@@ -1394,7 +1394,7 @@
   },
   {
     "interaction_type": "antagonize",
-    "event_text": "At the Gathering, o_c_n's leader repeatedly provokes and challenges c_n. m_c remains composed, not a whisker out of place, and asks o_c_n's leader to name a place and time for them to settle the score. {PRONOUN/m_c/poss/CAP} self-possession riles o_c_n's leader even more",
+    "event_text": "At the Gathering, o_c_n's leader repeatedly provokes and challenges c_n. m_c remains composed, not a whisker out of place, and asks o_c_n's leader to name a place and time for them to settle the score. {PRONOUN/m_c/poss/CAP} self-possession riles o_c_n's leader even more.",
     "rel_change": -10,
     "m_c": {
       "trait": ["calm"],
@@ -1405,7 +1405,7 @@
   },
   {
     "interaction_type": "antagonize",
-    "event_text": "At the Gathering, m_c forgoes a traditional speech in favor of retelling the tale of a legendary o_c_n leader... but with {PRONOUN/m_c/poss} own special graphically violent twist. o_c_n warriors cover their apprentices' ears, and even o_c_n's leader looks like they'll have nightmares",
+    "event_text": "At the Gathering, m_c forgoes a traditional speech in favor of retelling the tale of a legendary o_c_n leader... but with {PRONOUN/m_c/poss} own special graphically violent twist. o_c_n warriors cover their apprentices' ears, and even o_c_n's leader looks like they'll have nightmares.",
     "rel_change": -10,
     "m_c": {
       "trait": ["bloodthirsty"],
@@ -1510,7 +1510,7 @@
   },
   {
     "interaction_type": "appease",
-    "event_text": "o_c_n's leader threatens c_n throughout the Gathering. m_c remains silent until {PRONOUN/m_c/poss} turn to speak, then remarks that no cat in o_c_n really wants war. o_c_n warriors shuffle their paws and avoid their leader's gaze, not wanting to admit that m_c is right",
+    "event_text": "o_c_n's leader threatens c_n throughout the Gathering. m_c remains silent until {PRONOUN/m_c/poss} turn to speak, then remarks that no cat in o_c_n really wants war. o_c_n warriors shuffle their paws and avoid their leader's gaze, not wanting to admit that m_c is right.",
     "rel_change": 6,
     "m_c": {
       "trait": ["strange", "thoughtful", "calm"],


### PR DESCRIPTION
## About The Pull Request

Some extra specific leader's den outcomes (mostly successes, but some fails) for trait/skill combos.

## Why This Is Good For ClanGen

Help traits and skills feel like they really interact with each other to determine how a character acts.

## Proof of Testing
