### PR TITLE
Pregnancy Text Edits

### DIFF
--- a/resources/dicts/conditions/pregnancy.json
+++ b/resources/dicts/conditions/pregnancy.json
@@ -36,7 +36,7 @@
         " It's time to settle into the nursery and make sure everything is perfectly prepared.",
         " {PRONOUN/m_c/subject/CAP}{VERB/m_c/'re/'s} scolded into taking up a nest in the nursery, despite {PRONOUN/m_c/poss} best protests.",
         " {PRONOUN/m_c/subject/CAP}{VERB/m_c/'re/'s} keen to move into the nursery quickly, as though by doing so {PRONOUN/m_c/poss} litter will get the message and appear sooner.",
-        " Despite {PRONOUN/m_c/poss} protests, {PRONOUN/m_c/subject} begrudgingly {VERB/m_c/agree/agrees} to settle in the nursery. {PRONOUN/m_c/poss/CAP} Clanmates make it clear they can spare {PRONOUN/m_c/object} til the kits arrive.",
+        " Despite {PRONOUN/m_c/poss} protests, m_c begrudgingly agrees to settle in the nursery. {PRONOUN/m_c/poss/CAP} Clanmates make it clear they can spare {PRONOUN/m_c/object} til the kits arrive.",
         " {PRONOUN/m_c/subject/CAP} couldn't settle into the nursery fast enough.",
         " So many things could happen to m_c and {PRONOUN/m_c/poss} kits if {PRONOUN/m_c/subject} kept working. Worried by the consequences of continuing {PRONOUN/m_c/poss} duties too long, {PRONOUN/m_c/subject} {VERB/m_c/settle/settles} into the nursery."
     ],

--- a/resources/dicts/conditions/pregnancy.json
+++ b/resources/dicts/conditions/pregnancy.json
@@ -31,19 +31,19 @@
         " {PRONOUN/m_c/subject/CAP} {VERB/m_c/don't/doesn't} believe {PRONOUN/m_c/subject} can efficiently perform {PRONOUN/m_c/poss} duties while expecting kits and {VERB/m_c/decide/decides} to move into the nursery.",
         " Time to move to the nursery and relax before the new arrivals make their appearance.",
         " Though, when one waddles more than pads around camp, one has to accept that {PRONOUN/m_c/subject} should move into the nursery.",
-        " {PRONOUN/m_c/subject/CAP}{VERB/m_c/'ve/'s} been moved into the nursery, despite {PRONOUN/m_c/poss} grumbling protest.",
+        " {PRONOUN/m_c/subject/CAP} moves into the nursery, grumbling {PRONOUN/m_c/poss} protest all the way.",
         " Pregnancy sucks. m_c gives in and moves into the nursery.",
         " It's time to settle into the nursery and make sure everything is perfectly prepared.",
         " {PRONOUN/m_c/subject/CAP}{VERB/m_c/'re/'s} scolded into taking up a nest in the nursery, despite {PRONOUN/m_c/poss} best protests.",
         " {PRONOUN/m_c/subject/CAP}{VERB/m_c/'re/'s} keen to move into the nursery quickly, as though by doing so {PRONOUN/m_c/poss} litter will get the message and appear sooner.",
-        " Despite {PRONOUN/m_c/poss} protests, {PRONOUN/m_c/subject} {VERB/m_c/have/has} no choice but to settle in the nursery, nobody wants to let {PRONOUN/m_c/object} work til the kits arrive.",
+        " Despite {PRONOUN/m_c/poss} protests, {PRONOUN/m_c/subject} begrudgingly {VERB/m_c/agree/agrees} to settle in the nursery. {PRONOUN/m_c/poss/CAP} Clanmates make it clear they can spare {PRONOUN/m_c/object} til the kits arrive.",
         " {PRONOUN/m_c/subject/CAP} couldn't settle into the nursery fast enough.",
-        " So many things could happen to m_c and {PRONOUN/m_c/poss} kits if {PRONOUN/m_c/subject} kept working, no way did {PRONOUN/m_c/subject} want anything to happen to them, so into the nursery {PRONOUN/m_c/subject} go."
+        " So many things could happen to m_c and {PRONOUN/m_c/poss} kits if {PRONOUN/m_c/subject} kept working. Worried by the consequences of continuing {PRONOUN/m_c/poss} duties too long, {PRONOUN/m_c/subject} {VERB/m_c/settle/settles} into the nursery."
     ],
     "minor_severity": [
         " {PRONOUN/m_c/subject/CAP} won't be moving into the nursery just yet.",
         " {PRONOUN/m_c/subject/CAP} {VERB/m_c/choose/chooses} to continue {PRONOUN/m_c/poss} duties as usual for now.",
-        " c_n wants to congratulate m_c - but the rising celebration is interrupted by m_c snapping, completely unprovoked, that this pregnancy doesn't make {PRONOUN/m_c/object} a wilting flower and {PRONOUN/m_c/subject} will not be moving {PRONOUN/m_c/poss} nest. Pregnancy hormones are terrifying.",
+        " c_n wants to congratulate m_c - but the rising celebration is interrupted by m_c snapping, completely unprovoked, that this pregnancy doesn't make {PRONOUN/m_c/object} a wilting flower and {PRONOUN/m_c/subject} will not be moving {PRONOUN/m_c/poss} nest.",
         " {PRONOUN/m_c/subject/CAP} {VERB/m_c/aren't/isn't} keen on being confined to the nursery just yet.",
         " Life goes on for now - {PRONOUN/m_c/subject}'ll move into the nursery, but not this moon.",
         " {PRONOUN/m_c/subject/CAP}{VERB/m_c/'re/'s} still full of energy and moving to the nursery would feel stifling - maybe next moon.",


### PR DESCRIPTION
## About The Pull Request

I edited a few of the texts that describe pregnant cats moving to the nursery after one writing dev raised concerns on the discord. There are a few that I feel are too emphatic about how the pregnant cat is being moved against their will, so I edited them to keep with the spirit of the text while being a bit more sensitive.

## Why This Is Good For ClanGen

It'll just make some of the text a bit more appropriate and reduce the potential for players taking offence.