### PR TITLE
[Bugfix] Fix file path for Linux

### DIFF
--- a/scripts/screens/screens_core/screens_core.py
+++ b/scripts/screens/screens_core/screens_core.py
@@ -424,7 +424,7 @@ def get_camp_bgs():
 
     try:
         camp_nr = game.clan.camp_bg
-        biome = game.clan.biome
+        biome = game.clan.biome.lower()
     except AttributeError:
         camp_nr = "camp1"
         biome = available_biome[0]


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->

## About The Pull Request

changes the biome name in the file path to be all lowercase because 'Forest' and 'forest' indicate different folders on Linux (case sensitive)

## Linked Issues

issue found on Discord. game was crashing after selecting a symbol or continuing a Clan because it could not find the specific biome folder

## Proof of Testing

opens without crashing now
