### PR TITLE
Mate death reactions organization

### DIFF
--- a/resources/dicts/events/death/death_reactions/general/general_romantic.json
+++ b/resources/dicts/events/death/death_reactions/general/general_romantic.json
@@ -1,34 +1,18 @@
 {
   "general": {
     "body": [
-      "r_c bends over the body of {PRONOUN/r_c/poss} love, wailing {PRONOUN/r_c/poss} despair into m_c's fur. {PRONOUN/r_c/subject/CAP} {VERB/r_c/sit/sits} vigil next to the body, wishing {PRONOUN/r_c/subject} could wake from this nightmare.",
+      "r_c bends over the body of {PRONOUN/r_c/poss} crush, wailing {PRONOUN/r_c/poss} despair into m_c's fur. {PRONOUN/r_c/subject/CAP} {VERB/r_c/sit/sits} vigil next to the body, wishing {PRONOUN/r_c/subject} could wake from this nightmare.",
       "r_c stares dully at m_c, the world fading from awareness as {PRONOUN/r_c/subject} {VERB/r_c/try/tries} to comprehend {PRONOUN/m_c/poss} death. All the things they'll never do together, the places r_c wanted to show {PRONOUN/r_c/object}, the life they could have lived by each other's sides, all wiped away in an instant.",
-      "As the Clan sits vigil for m_c, r_c refuses to even move from {PRONOUN/r_c/poss} nest, refuses to eat or drink or talk, as though refusing to face the world will bring {PRONOUN/m_c/object} back.",
-      "Surely, surely the world can't go on, surely the sun won't rise and the seasons won't turn, not now that m_c is dead. r_c doesn't know how to go on without {PRONOUN/m_c/object}.",
-      "r_c lies next to m_c as the Clan sits vigil for {PRONOUN/m_c/object}. {PRONOUN/r_c/poss/CAP} world has ended with m_c.",
-      "So many happy memories, gone in an instant. r_c buries {PRONOUN/r_c/poss} nose in m_c's cold pelt, promising {PRONOUN/r_c/self} that {PRONOUN/r_c/subject} will never forget the warmth of m_c's scent.",
-      "r_c can't believe that the stiff body before {PRONOUN/r_c/object} was once {PRONOUN/r_c/poss} love, m_c. At any moment, {PRONOUN/r_c/subject} {VERB/r_c/expect/expects} m_c to open {PRONOUN/m_c/poss} eyes and laugh; but it never happens. The world seems so much darker now."
+      "r_c wishes that {PRONOUN/r_c/subject} could have had the courage to ask m_c to be {PRONOUN/r_c/poss} mate, but now, with m_c's cold body before {PRONOUN/r_c/object}, r_c would never get the chance again. All those missed oppurtunities flashed before {PRONOUN/r_c/poss} eyes, and {PRONOUN/r_c/subject} bowed {PRONOUN/r_c/poss} head in the vigil."
 
     ],
     "no_body": [
-      "Surely, surely the world can't go on, surely the sun won't rise and the seasons won't turn, not now that m_c is dead. r_c doesn't know how to go on without {PRONOUN/m_c/object}.",
-      "As the Clan sits vigil for m_c, r_c refuses to even move from {PRONOUN/r_c/poss} nest, refuses to eat or drink or talk, as though refusing to face the world will bring {PRONOUN/m_c/object} back.",
-      "Though {PRONOUN/r_c/subject} {VERB/r_c/know/knows} it's unrealistic, deep down, r_c is praying to StarClan that m_c isn't truly gone.",
-      "r_c feels lost without m_c's body to sit vigil over. {PRONOUN/r_c/subject/CAP} {VERB/r_c/stare/stares} up at Silverpelt all night, straining to see if a new star has joined the sky and refusing to move until daybreak.",
-      "r_c's nest feels so big and empty without m_c's body next to {PRONOUN/r_c/inposs}. {PRONOUN/r_c/subject/CAP} can barely sleep, surrounded by m_c's scent and cold night air."
+     "Though {PRONOUN/r_c/subject} {VERB/r_c/know/knows} it's unrealistic, deep down, r_c is praying to StarClan that m_c isn't truly gone."
     ]
   },
   "adventurous": {
     "body": [
 
-
-    ],
-    "no_body": [
-
-    ]
-  },
-  "altruistic": {
-    "body": [
 
     ],
     "no_body": [
@@ -61,8 +45,6 @@
   },
   "calm": {
     "body": [
-      "r_c doesn't show {PRONOUN/r_c/poss} emotions often, but when m_c's body is returned to camp, {PRONOUN/r_c/subject} can't suppress a shriek of grief. The cats around {PRONOUN/r_c/object} give {PRONOUN/r_c/object} space as {PRONOUN/r_c/subject} {VERB/r_c/collapse/collapses} next to {PRONOUN/r_c/poss} former love."
-
     ],
     "no_body": [
 
@@ -94,8 +76,6 @@
   },
   "cold": {
     "body": [
-      "r_c doesn't show {PRONOUN/r_c/poss} emotions often, but when m_c's body is returned to camp, {PRONOUN/r_c/subject} can't suppress a shriek of grief. The cats around {PRONOUN/r_c/object} give {PRONOUN/r_c/object} space as {PRONOUN/r_c/subject} {VERB/r_c/collapse/collapses} next to {PRONOUN/r_c/poss} former love."
-
     ],
     "no_body": [
 
@@ -103,8 +83,7 @@
   },
   "compassionate": {
     "body": [
-      "Although r_c's grief at the loss of m_c is overwhelming, {PRONOUN/r_c/subject} {VERB/r_c/make/makes} sure to tend to {PRONOUN/r_c/poss} Clanmates before indulging in {PRONOUN/r_c/poss} own mourning. It's all {PRONOUN/r_c/subject} can do not to collapse, but caring for the cats around {PRONOUN/r_c/object} has always brought {PRONOUN/r_c/object} comfort in times of need."
-
+      "r_c helps {PRONOUN/r_c/poss} clanmates in their mourning. It's all {PRONOUN/r_c/subject} can do not dwell on the possibilities, but caring for the cats around {PRONOUN/r_c/object} has always brought {PRONOUN/r_c/object} comfort in times of need. Perhaps in another life, r_c and m_c could have been mates, but it wouldn't do to dwell on such a fantasy, it only made the ache in {PRONOUN/r_c/poss} heart grow."
     ],
     "no_body": [
 
@@ -156,37 +135,25 @@
     ],
     "no_body": [
       "Maybe m_c didn't really die. Maybe {PRONOUN/m_c/subject} {VERB/m_c/were/was} just finally fed up with r_c and decided to leave. r_c stays in {PRONOUN/r_c/poss} nest, numb and terrified."
-
     ]
   },
   "lonesome": {
     "body": [
-      "r_c had thought that {PRONOUN/r_c/subject} would never feel alone again after m_c entered {PRONOUN/r_c/poss} life. Now, staring at m_c's lifeless body, r_c doesn't know what {PRONOUN/r_c/subject}'ll do, how {PRONOUN/r_c/subject}'ll ever go on from here.",
-      "r_c's Clanmates make sure to spend extra time with {PRONOUN/r_c/object} in the days following m_c's death, sharing their fresh-kill and tongues. One night, r_c even finds extra moss lining {PRONOUN/r_c/poss} bed. Maybe {PRONOUN/r_c/subject}{VERB/r_c/'re/'s} not as alone as {PRONOUN/r_c/subject} always thought {PRONOUN/r_c/subject} {VERB/r_c/were/was}."
-
     ],
     "no_body": [
-      "If only r_c had proof that m_c was really dead... with no body, the void left by m_c's absence is so much harder to bear. r_c sits motionless in {PRONOUN/r_c/poss} nest, staring at the camp entrance and waiting, hoping, for a familiar face to appear."
-
     ]
   },
   "loving": {
     "body": [
-      "When m_c's body is returned to camp, r_c can't help but break down in caterwauls. {PRONOUN/r_c/subject/CAP} {VERB/r_c/press/presses} {PRONOUN/r_c/poss} muzzle into m_c's icy pelt, shivering with grief.",
-      "Despite feeling like {PRONOUN/r_c/poss} heart has been torn in two, r_c gently places m_c's favorite nest decorations next to {PRONOUN/m_c/poss} still body, so that it looks like {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} not dead, but simply in a deep and peaceful sleep."
 
     ],
     "no_body": [
-      "Even with no body, r_c is determined to never fall in love with another cat again. m_c was {PRONOUN/r_c/poss} one true love, and maybe, just maybe, {PRONOUN/m_c/subject} will return someday."
-
     ]
   },
   "loyal": {
     "body": [
     ],
     "no_body": [
-      "Even with no body, r_c is determined to never fall in love with another cat again. Maybe, just maybe, m_c will return someday."
-
     ]
   },
   "nervous": {
@@ -279,11 +246,9 @@
   },
   "vengeful": {
     "body": [
-      "r_c wants to tear the world apart. Looking down at m_c's lifeless body, r_c digs {PRONOUN/r_c/poss} claws into the ground and grits {PRONOUN/r_c/poss} teeth, vowing to {PRONOUN/r_c/self} to avenge {PRONOUN/r_c/poss} lost love in any way possible."
 
     ],
     "no_body": [
-      "The world is so much colder now without m_c in it. r_c stares up at the sky, yowling {PRONOUN/r_c/poss} fury at StarClan for taking away {PRONOUN/r_c/poss} love. No matter what, and wherever {PRONOUN/r_c/subject} {VERB/r_c/go/goes}, {PRONOUN/r_c/subject} will never stop searching for m_c."
 
     ]
   },
@@ -369,9 +334,7 @@
   },
   "polite": {
     "body": [
-      "r_c doesn't want to trouble {PRONOUN/r_c/poss} Clanmates with {PRONOUN/r_c/poss} grief. Everyone is hurting after m_c's death. r_c waits until {PRONOUN/r_c/subject} {VERB/r_c/are/is} alone, then sits a silent vigil under Silverpelt, holding back {PRONOUN/r_c/poss} wails."
-
-
+      "r_c can't believe m_c is dead. r_c though they had their whole lives ahead of them, to grow up, become mates. But instead, m_c was taken away. r_c waits until everyone else has gone ahead of {PRONOUN/r_c/object}, before approaching m_c's body. r_c wails, why did StarClan have to take m_c now?"
     ],
     "no_body": [
 
@@ -379,7 +342,7 @@
   },
   "quiet": {
     "body": [
-      "r_c doesn't want to trouble {PRONOUN/r_c/poss} Clanmates with {PRONOUN/r_c/poss} grief. Everyone is hurting after m_c's death. r_c waits until {PRONOUN/r_c/subject} {VERB/r_c/are/is} alone, then sits a silent vigil under Silverpelt, holding back {PRONOUN/r_c/poss} wails."
+ 
 
     ],
     "no_body": [

--- a/resources/dicts/events/death/death_reactions/general/general_romantic.json
+++ b/resources/dicts/events/death/death_reactions/general/general_romantic.json
@@ -1,9 +1,8 @@
 {
   "general": {
     "body": [
-      "r_c bends over the body of {PRONOUN/r_c/poss} crush, wailing {PRONOUN/r_c/poss} despair into m_c's fur. {PRONOUN/r_c/subject/CAP} {VERB/r_c/sit/sits} vigil next to the body, wishing {PRONOUN/r_c/subject} could wake from this nightmare.",
-      "r_c stares dully at m_c, the world fading from awareness as {PRONOUN/r_c/subject} {VERB/r_c/try/tries} to comprehend {PRONOUN/m_c/poss} death. All the things they'll never do together, the places r_c wanted to show {PRONOUN/r_c/object}, the life they could have lived by each other's sides, all wiped away in an instant.",
-      "r_c wishes that {PRONOUN/r_c/subject} could have had the courage to ask m_c to be {PRONOUN/r_c/poss} mate, but now, with m_c's cold body before {PRONOUN/r_c/object}, r_c would never get the chance again. All those missed oppurtunities flashed before {PRONOUN/r_c/poss} eyes, and {PRONOUN/r_c/subject} bowed {PRONOUN/r_c/poss} head in the vigil."
+      "r_c bends over the body of {PRONOUN/r_c/poss}, wailing {PRONOUN/r_c/poss} despair into m_c's fur. {PRONOUN/r_c/subject/CAP} {VERB/r_c/sit/sits} vigil next to the body, wishing {PRONOUN/r_c/subject} could wake from this nightmare.",
+      "r_c stares dully at m_c, the world fading from awareness as {PRONOUN/r_c/subject} {VERB/r_c/try/tries} to comprehend {PRONOUN/m_c/poss} death. All the things they'll never do together, the places r_c wanted to show {PRONOUN/r_c/object}, the life they could have lived by each other's sides, all wiped away in an instant."
 
     ],
     "no_body": [
@@ -83,7 +82,6 @@
   },
   "compassionate": {
     "body": [
-      "r_c helps {PRONOUN/r_c/poss} clanmates in their mourning. It's all {PRONOUN/r_c/subject} can do not dwell on the possibilities, but caring for the cats around {PRONOUN/r_c/object} has always brought {PRONOUN/r_c/object} comfort in times of need. Perhaps in another life, r_c and m_c could have been mates, but it wouldn't do to dwell on such a fantasy, it only made the ache in {PRONOUN/r_c/poss} heart grow."
     ],
     "no_body": [
 

--- a/resources/dicts/events/death/death_reactions/mate/mate_dislike.json
+++ b/resources/dicts/events/death/death_reactions/mate/mate_dislike.json
@@ -1,6 +1,7 @@
 {
   "general": {
     "body": [
+      "Perhaps people expected r_c to be more mournful over m_c's passing, however r_c couldn't help but feel a bitter sense of relief to be free from m_c."
 
    ],
    "no_body": [

--- a/resources/dicts/events/death/death_reactions/mate/mate_romantic.json
+++ b/resources/dicts/events/death/death_reactions/mate/mate_romantic.json
@@ -1,24 +1,25 @@
 {
   "general": {
     "body": [
+      "r_c bends over the body of {PRONOUN/r_c/poss} mate, wailing {PRONOUN/r_c/poss} despair into m_c's fur. {PRONOUN/r_c/subject/CAP} {VERB/r_c/sit/sits} vigil next to the body, wishing {PRONOUN/r_c/subject} could wake from this nightmare.",
+      "As the Clan sits vigil for m_c, r_c refuses to even move from {PRONOUN/r_c/poss} nest, refuses to eat or drink or talk, as though refusing to face the world will bring {PRONOUN/m_c/object} back.",
+      "Surely, surely the world can't go on, surely the sun won't rise and the seasons won't turn, not now that m_c is dead. r_c doesn't know how to go on without {PRONOUN/m_c/object}.",
+      "r_c lies next to m_c as the Clan sits vigil for {PRONOUN/m_c/object}. {PRONOUN/r_c/poss/CAP} world has ended with m_c.",      
+      "So many happy memories, gone in an instant. r_c buries {PRONOUN/r_c/poss} nose in m_c's cold pelt, promising {PRONOUN/r_c/self} that {PRONOUN/r_c/subject} will never forget the warmth of m_c's scent.",
+      "r_c can't believe that the stiff body before {PRONOUN/r_c/object} was once {PRONOUN/r_c/poss} mate, m_c. At any moment, {PRONOUN/r_c/subject} {VERB/r_c/expect/expects} m_c to open {PRONOUN/m_c/poss} eyes and laugh; but it never happens. The world seems so much darker now."
 
     ],
     "no_body": [
-
-
+      "Surely, surely the world can't go on, surely the sun won't rise and the seasons won't turn, not now that m_c is gone. r_c doesn't know how to go on without {PRONOUN/m_c/object}. r_c didn't want to believe that {PRONOUN/r_c/poss} mate is truly dead.",
+      "As the Clan sits vigil for m_c, r_c refuses to even move from {PRONOUN/r_c/poss} nest, refuses to eat or drink or talk, as though refusing to face the world will bring {PRONOUN/m_c/object} back.",
+      "Though {PRONOUN/r_c/subject} {VERB/r_c/know/knows} it's unrealistic, deep down, r_c is praying to StarClan that m_c isn't truly gone. How could {PRONOUN/r_c/subject} live on if {PRONOUN/r_c/poss} mate was dead?",
+      "r_c feels lost without m_c's body to sit vigil over. {PRONOUN/r_c/subject/CAP} {VERB/r_c/stare/stares} up at Silverpelt all night, straining to see if a new star has joined the sky and refusing to move until daybreak.",
+      "r_c's nest feels so big and empty without m_c's body next to {PRONOUN/r_c/inposs}. {PRONOUN/r_c/subject/CAP} can barely sleep, surrounded by m_c's scent and cold night air."
     ]
   },
   "adventurous": {
     "body": [
 
-
-    ],
-    "no_body": [
-
-    ]
-  },
-  "altruistic": {
-    "body": [
 
     ],
     "no_body": [
@@ -51,7 +52,7 @@
   },
   "calm": {
     "body": [
-
+      "r_c made not a single noise, but refused to leave m_c's body the entire vigil. With one last lick over the fur, r_c walks away, leaving camp for the day. Nobody bothers r_c as {PRONOUN/r_c/subject} {VERB/r_c/grieve/grieves} for {PRONOUN/r_c/poss} mate."
     ],
     "no_body": [
 
@@ -82,8 +83,9 @@
     ]
   },
   "cold": {
-    "body": [
-
+    "body": [      
+      "Nobody in the clan could doubt r_c's love for m_c when {PRONOUN/r_c/poss} wails echo throughout the camp as PRONOUN/r_c/subject} {VERB/r_c/collapse/collapses} next to {PRONOUN/r_c/poss} former love.",
+      "r_c doesn't show {PRONOUN/r_c/poss} emotions often, but when m_c's body is returned to camp, {PRONOUN/r_c/subject} can't suppress a shriek of grief. The cats around {PRONOUN/r_c/object} give {PRONOUN/r_c/object} space as {PRONOUN/r_c/subject} {VERB/r_c/collapse/collapses} next to {PRONOUN/r_c/poss} former love."
     ],
     "no_body": [
 
@@ -91,7 +93,7 @@
   },
   "compassionate": {
     "body": [
-
+      "Although r_c's grief at the loss of {PRONOUN/r_c/poss} mate is overwhelming, {PRONOUN/r_c/subject} {VERB/r_c/make/makes} sure to tend to {PRONOUN/r_c/poss} Clanmates before indulging in {PRONOUN/r_c/poss} own mourning. Seeing m_c's body, it's all {PRONOUN/r_c/subject} can do not to collapse, but caring for the cats around {PRONOUN/r_c/object} has always brought {PRONOUN/r_c/object} comfort in times of need."
     ],
     "no_body": [
 
@@ -106,14 +108,6 @@
     ]
   },
   "daring": {
-    "body": [
-
-    ],
-    "no_body": [
-
-    ]
-  },
-  "empathetic": {
     "body": [
 
     ],
@@ -142,43 +136,39 @@
 
     ],
     "no_body": [
-
+      "m_c had always promised to stay by r_c's side when they became mates. But with no body, it was hard to keep out the doubts. Maybe m_c didn't really die. Maybe {PRONOUN/m_c/subject} {VERB/m_c/were/was} just finally fed up with r_c and decided to leave. r_c stays in {PRONOUN/r_c/poss} nest, numb and terrified."
     ]
   },
   "lonesome": {
     "body": [
-
+      "r_c doesn't want to trouble {PRONOUN/r_c/poss} Clanmates with {PRONOUN/r_c/poss} grief. Everyone is hurting after m_c's death. r_c waits until {PRONOUN/r_c/subject} {VERB/r_c/are/is} alone, then sits a silent vigil under Silverpelt, holding back {PRONOUN/r_c/poss} wails.",
+      "r_c had thought that {PRONOUN/r_c/subject} would never feel alone again after m_c entered {PRONOUN/r_c/poss} life. Now, staring at m_c's lifeless body, r_c doesn't know what {PRONOUN/r_c/subject}'ll do, how {PRONOUN/r_c/subject}'ll ever go on from here.",
+      "r_c's Clanmates make sure to spend extra time with {PRONOUN/r_c/object} in the days following m_c's death, sharing their fresh-kill and tongues. One night, r_c even finds extra moss lining {PRONOUN/r_c/poss} bed. Maybe {PRONOUN/r_c/subject}{VERB/r_c/'re/'s} not as alone as {PRONOUN/r_c/subject} always thought {PRONOUN/r_c/subject} {VERB/r_c/were/was}."
     ],
     "no_body": [
-
+      "If only r_c had proof that m_c was really dead... with no body, the void left by m_c's absence is so much harder to bear. r_c sits motionless in {PRONOUN/r_c/poss} nest, staring at the camp entrance and waiting, hoping, for a familiar face to appear."
     ]
-  },
+  },  
   "loving": {
     "body": [
+      "When m_c's body is returned to camp, r_c can't help but break down in caterwauls. {PRONOUN/r_c/subject/CAP} {VERB/r_c/press/presses} {PRONOUN/r_c/poss} muzzle into m_c's icy pelt, shivering with grief.",
+      "Despite feeling like {PRONOUN/r_c/poss} heart has been torn in two, r_c gently places m_c's favorite nest decorations next to {PRONOUN/m_c/poss} still body, so that it looks like {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} not dead, but simply in a deep and peaceful sleep."
 
     ],
     "no_body": [
+      "Even with no body, r_c is determined to never fall in love with another cat again. m_c was {PRONOUN/r_c/poss} one true love, and maybe, just maybe, {PRONOUN/m_c/subject} will return someday."
 
     ]
   },
   "loyal": {
     "body": [
-    
-
+      "Even with the body before them, r_c can't accept that m_c is gone. {PRONOUN/r_c/subject/CAP} {VERB/r_c/vow/vows} to never fall in love with anyone else until {PRONOUN/r_c/subject} can reunite with m_c in StarClan."
     ],
-    "no_body": [
-
+    "no_body": [      
+      "Even with no body, r_c is determined to never fall in love with another cat again. Maybe, just maybe, m_c will return someday."
     ]
   },
   "nervous": {
-    "body": [
-
-    ],
-    "no_body": [
-
-    ]
-  },
-  "patient": {
     "body": [
 
     ],
@@ -244,7 +234,7 @@
   },
   "thoughtful": {
     "body": [
-
+      "r_c doesn't want to trouble {PRONOUN/r_c/poss} Clanmates with {PRONOUN/r_c/poss} grief. Everyone is hurting after m_c's death. r_c waits until {PRONOUN/r_c/subject} {VERB/r_c/are/is} alone, then sits a silent vigil under Silverpelt, holding back {PRONOUN/r_c/poss} wails."
     ],
     "no_body": [
 
@@ -260,9 +250,11 @@
   },
   "vengeful": {
     "body": [
+      "r_c wants to tear the world apart. Looking down at m_c's lifeless body, r_c digs {PRONOUN/r_c/poss} claws into the ground and grits {PRONOUN/r_c/poss} teeth, vowing to {PRONOUN/r_c/self} to avenge {PRONOUN/r_c/poss} lost love in any way possible."
 
     ],
     "no_body": [
+      "The world is so much colder now without m_c in it. r_c stares up at the sky, yowling {PRONOUN/r_c/poss} fury at StarClan for taking away {PRONOUN/r_c/poss} love. No matter what, and wherever {PRONOUN/r_c/subject} {VERB/r_c/go/goes}, {PRONOUN/r_c/subject} will never stop searching for m_c."
 
     ]
   },


### PR DESCRIPTION
## About The Pull Request

Reorganizes death reactions so most of the general romantic are now in mate romantic, plus adds a couple.

## Why This Is Good For ClanGen

Allows for clean organization, and a couple new reactions.

## Proof of Testing
https://discord.com/channels/1003759225522110524/1101276997751164948
Part of the project, I focused more on reorganizing then adding new content, and would like to have the organization done first, before really focusing on adding new reactions.


