### PR TITLE
BUGFIX: Clan Symbol Mislabelling

### DIFF
--- a/resources/dicts/clan_symbols.json
+++ b/resources/dicts/clan_symbols.json
@@ -268,7 +268,7 @@
     "tags0": ["plant"]
   }, 
   "Burrow": {
-    "variants": 0,
+    "variants": 1,
     "tags0": ["location"]
   }, 
   "Bush": {
@@ -1194,7 +1194,7 @@
     "tags0": []
   }, 
   "Lynx": {
-    "variants": 0,
+    "variants": 1,
     "tags0": []
   },
   "Lyre": {


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->

## About The Pull Request
Makes BUTTERFLY0 and LYNX0 symbols accessible in game and fixes misnamed symbols.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
Fixes #2895 
Fixes #2892 
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
![image](https://github.com/user-attachments/assets/2a7126fd-81e4-44f9-a5e2-c36934d3296c)
![image](https://github.com/user-attachments/assets/0d8600f6-7bea-4e05-b094-12e5f20bdab0)

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->
