### PR TITLE
BUGFIX: Patrol debug_ensure not working properly

### DIFF
--- a/scripts/patrol/patrol.py
+++ b/scripts/patrol/patrol.py
@@ -379,7 +379,7 @@ class Patrol:
         # This is a debug option. If the patrol_id set isn "debug_ensure_patrol" is possible,
         # make it the *only* possible patrol
         if isinstance(game.config["patrol_generation"]["debug_ensure_patrol_id"], str):
-            for _pat in possible_patrols:
+            for _pat in final_patrols:
                 if (
                     _pat.patrol_id
                     == game.config["patrol_generation"]["debug_ensure_patrol_id"]


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->

## About The Pull Request
The debug_ensure was incorrectly pulling the ensured patrol from the unfiltered list of patrols instead of the filter list, leading to confusing results.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Proof of Testing
![image](https://github.com/user-attachments/assets/17a90fac-efec-4ee0-b380-182111dd1c39)
Print message showing that an ensured patrol is now being properly constrained.  This is the patrol I was trying to debug when I discovered the debug_ensure wasn't working correctly.  Prior to my fix, all cats seemed to be able to access this deputy-specific patrol, even though the filters were working correctly.
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->
