### PR TITLE
BUGFIX: Various Event Bugs

### DIFF
--- a/resources/dicts/events/new_cat/general.json
+++ b/resources/dicts/events/new_cat/general.json
@@ -587,7 +587,8 @@
             [
                 "old_name",
                 "clancat",
-                "status:warrior"
+                "status:warrior",
+                "backstory:former_clancat_backstories"
             ]
         ],
         "other_clan": {
@@ -608,7 +609,8 @@
             [
                 "old_name",
                 "clancat",
-                "status:warrior"
+                "status:warrior",
+                "backstory:former_clancat_backstories"
             ]
         ],
         "injury": [

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -121,6 +121,10 @@ class Events:
             # get the moonskip freshkill
             self.get_moon_freshkill()
 
+        # Adding in any potential lead den events that have been saved
+        if "lead_den_interaction" in game.clan.clan_settings:
+            if game.clan.clan_settings["lead_den_interaction"]:
+                self.handle_lead_den_event()
 
         # checking if a lost cat returns on their own
         rejoin_upperbound = game.config["lost_cat"]["rejoin_chance"]
@@ -133,11 +137,6 @@ class Events:
                 self.one_moon_cat(cat)
             else:
                 self.one_moon_outside_cat(cat)
-
-        # Adding in any potential lead den events that have been saved
-        if "lead_den_interaction" in game.clan.clan_settings:
-            if game.clan.clan_settings["lead_den_interaction"]:
-                self.handle_lead_den_event()
 
         # keeping this commented out till disasters are more polished
         # self.disaster_events.handle_disasters()

--- a/scripts/events_module/generate_events.py
+++ b/scripts/events_module/generate_events.py
@@ -854,7 +854,7 @@ class GenerateEvents:
                 if discard:
                     continue
 
-            final_events.append(event)
+            final_events.extend([event] * event.weight)
 
         for notice in incorrect_format:
             print(notice)


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->

## About The Pull Request
Add backstory constraints to some new cat events.

Makes shortevent weighting actually... work...
turns out I didn't hook this up when I made the new shortevent system??? wild that I didn't notice that.  oh well, works now!

Prevents lost cats from returning twice, once due to leader event and a second time due to natural lost cat return.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
Fixes #2858 
Fixes #2751
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
![image](https://github.com/user-attachments/assets/17412175-53d1-4c20-9285-39e4700b0d88)
![image](https://github.com/user-attachments/assets/24b2608e-f1d4-41c7-9369-b16de20f1d33)
Wispspeckle now joins with an appropriate backstory

![image](https://github.com/user-attachments/assets/01350359-4396-4216-adfa-1c74de334194)
Bit hard to test, but at the very least I did get a lost cat to return without a repetitive event.

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Adds missing backstory constraints to some events
- Actually makes the shortevent weighting work...
- Lost cats can no longer return twice in one moon
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
