### PR TITLE
[BUGFIX] Moon adoption events

### DIFF
--- a/resources/dicts/events/new_cat/general.json
+++ b/resources/dicts/events/new_cat/general.json
@@ -15,6 +15,7 @@
             [
                 "new_name",
                 "parent:0",
+                "adoptive:m_c",
                 "backstory:abandoned2, outsider1",
                 "litter"
             ]
@@ -40,6 +41,7 @@
             [
                 "new_name",
                 "parent:0",
+                "adoptive:m_c",
                 "backstory:abandoned2, outsider1",
                 "litter"
             ]
@@ -61,8 +63,11 @@
             "status": ["any"]
         },
         "new_cat": [
+            ["age:has_kits", "meeting", "clancat", "can_birth"],
             [
                 "new_name",
+                "parent:0",
+                "adoptive:m_c",
                 "backstory:abandoned2, outsider1",
                 "litter"
             ]
@@ -88,6 +93,7 @@
             [
                 "new_name",
                 "parent:0",
+                "adoptive:m_c",
                 "backstory:abandoned2, outsider1",
                 "litter"
             ]
@@ -109,8 +115,11 @@
             "status": ["any"]
         },
         "new_cat": [
+            ["age:has_kits", "meeting", "unknown", "can_birth"],
             [
                 "new_name",
+                "parent:0",
+                "adoptive:m_c",
                 "backstory:abandoned2, outsider1",
                 "litter"
             ]

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -142,6 +142,7 @@ class Cat:
         backstory="clanborn",
         parent1=None,
         parent2=None,
+        adoptive_parents=None,
         suffix=None,
         specsuffix_hidden=False,
         ID=None,
@@ -199,7 +200,7 @@ class Cat:
         )
         self.parent1 = parent1
         self.parent2 = parent2
-        self.adoptive_parents = []
+        self.adoptive_parents = adoptive_parents if adoptive_parents else []
         self.pelt = pelt if pelt else Pelt()
         self.former_mentor = []
         self.patrol_with_mentor = 0

--- a/scripts/events_module/handle_short_events.py
+++ b/scripts/events_module/handle_short_events.py
@@ -314,6 +314,7 @@ class HandleShortEvents:
         extra_text = None
 
         in_event_cats = {"m_c": self.main_cat}
+
         if self.random_cat:
             in_event_cats["r_c"] = self.random_cat
         for i, attribute_list in enumerate(self.chosen_event.new_cat):
@@ -328,7 +329,10 @@ class HandleShortEvents:
                 if cat.dead:
                     extra_text = f"{cat.name}'s ghost now wanders."
                 elif cat.outside:
-                    extra_text = f"The Clan has encountered {cat.name}."
+                    if "unknown" in attribute_list:
+                        extra_text = ""
+                    else:
+                        extra_text = f"The Clan has encountered {cat.name}."
                 else:
                     Relation_Events.welcome_new_cats([cat])
                 self.involved_cats.append(cat.ID)

--- a/scripts/utility.py
+++ b/scripts/utility.py
@@ -316,16 +316,19 @@ def create_new_cat_block(
     thought = "Is looking around the camp with wonder"
     new_cats = None
 
-    # gather bio parents
+    # gather parents
     parent1 = None
     parent2 = None
+    adoptive_parents = []
     for tag in attribute_list:
-        match = re.match(r"parent:([,0-9]+)", tag)
-        if not match:
+        parent_match = re.match(r"parent:([,0-9]+)", tag)
+        adoptive_match = re.match(r"adoptive:(.+)", tag)
+        if not parent_match and not adoptive_match:
             continue
 
-        parent_indexes = match.group(1).split(",")
-        if not parent_indexes:
+        parent_indexes = parent_match.group(1).split(",") if parent_match else []
+        adoptive_indexes = adoptive_match.group(1).split(",") if adoptive_match else []
+        if not parent_indexes and not adoptive_indexes:
             continue
 
         parent_indexes = [int(index) for index in parent_indexes]
@@ -337,7 +340,14 @@ def create_new_cat_block(
                 parent1 = event.new_cats[index][0]
             else:
                 parent2 = event.new_cats[index][0]
-        break
+
+        adoptive_indexes = [int(index) if index.isdigit() else index for index in adoptive_indexes]
+        for index in adoptive_indexes:
+            if in_event_cats[index].ID not in adoptive_parents:
+                adoptive_parents.append(in_event_cats[index].ID)
+                adoptive_parents.extend(in_event_cats[index].mate)
+
+
 
     # gather mates
     give_mates = []
@@ -593,6 +603,7 @@ def create_new_cat_block(
             outside=outside,
             parent1=parent1.ID if parent1 else None,
             parent2=parent2.ID if parent2 else None,
+            adoptive_parents=adoptive_parents if adoptive_parents else None
         )
 
         # NEXT
@@ -645,6 +656,29 @@ def create_new_cat_block(
                 start_relation.trust = 10 + y
                 n_c.relationships[par.ID] = start_relation
 
+            # ADOPTIVE PARENTS
+            for par in adoptive_parents:
+                if not par:
+                    continue
+
+                par = Cat.fetch_cat(par)
+
+                y = randrange(0, 20)
+                start_relation = Relationship(par, n_c, False, True)
+                start_relation.platonic_like += 30 + y
+                start_relation.comfortable = 10 + y
+                start_relation.admiration = 15 + y
+                start_relation.trust = 10 + y
+                par.relationships[n_c.ID] = start_relation
+
+                y = randrange(0, 20)
+                start_relation = Relationship(n_c, par, False, True)
+                start_relation.platonic_like += 30 + y
+                start_relation.comfortable = 10 + y
+                start_relation.admiration = 15 + y
+                start_relation.trust = 10 + y
+                n_c.relationships[par.ID] = start_relation
+
             # UPDATE INHERITANCE
             n_c.create_inheritance_new_cat()
 
@@ -677,6 +711,7 @@ def create_new_cat(
     outside: bool = False,
     parent1: str = None,
     parent2: str = None,
+    adoptive_parents: list = None
 ) -> list:
     """
     This function creates new cats and then returns a list of those cats
@@ -696,7 +731,8 @@ def create_new_cat(
     :param bool alive: set this as False to generate the cat as already dead - default: True (alive)
     :param bool outside: set this as True to generate the cat as an outsider instead of as part of the Clan - default: False (Clan cat)
     :param str parent1: Cat ID to set as the biological parent1
-    :param str parent2: Cat ID object to set as the biological parert2
+    :param str parent2: Cat ID to set as the biological parent2
+    :param list adoptive_parents: Cat IDs to set as adoptive parents
     """
     # TODO: it would be nice to rewrite this to be less bool-centric
     accessory = None
@@ -762,6 +798,7 @@ def create_new_cat(
                 backstory=backstory,
                 parent1=parent1,
                 parent2=parent2,
+                adoptive_parents=adoptive_parents if adoptive_parents else []
             )
         else:
             # grab starting names and accs for loners/kittypets
@@ -796,6 +833,7 @@ def create_new_cat(
                         backstory=backstory,
                         parent1=parent1,
                         parent2=parent2,
+                        adoptive_parents=adoptive_parents if adoptive_parents else []
                     )
                 else:  # completely new name
                     new_cat = Cat(
@@ -805,6 +843,7 @@ def create_new_cat(
                         backstory=backstory,
                         parent1=parent1,
                         parent2=parent2,
+                        adoptive_parents=adoptive_parents if adoptive_parents else []
                     )
             # these cats keep their old names
             else:
@@ -817,6 +856,7 @@ def create_new_cat(
                     backstory=backstory,
                     parent1=parent1,
                     parent2=parent2,
+                    adoptive_parents=adoptive_parents if adoptive_parents else []
                 )
 
         # give em a collar if they got one


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->

## About The Pull Request
Kits "adopted" during moon events weren't receiving relationship changes or inheritance changes towards their new adoptive parent.  This pull request fixes that issue.  Changelog at end of PR indicates more specific changes. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
#2907  
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
![image](https://github.com/user-attachments/assets/bfa7b382-0134-4b28-bce3-b286317ff68a)
![image](https://github.com/user-attachments/assets/097d7944-db71-41aa-bf01-1eb7e08af61d)
![image](https://github.com/user-attachments/assets/fefa6bf8-ab61-44db-8b51-950a3b76a069)

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Kits adopted during a moon event now receive correct inheritance information and begin with positive relationships towards adoptive parent(s)
- The mates of adoptive parents will also automatically adopt any adopted kits received on moonskip
- Adopted litters now always generate with a biological parent, ensuring their inheritance lists them all as littermates
- New Patrol and ShortEvent new_cat tag: `"adoptive:[index]"`; which allows you to indicate which cat will be the adoptive parent. 
- New ShortEvent new_cat tag: `"unknown"`; which allows you to generate a new cat *without* notifying the player of their existence (i.e. "the clan has encountered" message).  Currently used exclusively for the adoption event that lists no bio parent and only calls the litter "abandoned".  It felt weird for the clan to "encounter" a cat not actually seen in the event, but a bio parent still needed to be generated to allow the kits to be littermates.
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
