### PR TITLE
[BUGFIX] Updates to scar_to_condition dict

### DIFF
--- a/scripts/events_module/condition_events.py
+++ b/scripts/events_module/condition_events.py
@@ -400,23 +400,25 @@ class Condition_Events:
 
         # dict of possible physical conditions that can be acquired from relevant scars
         scar_to_condition = {
-            "LEGBITE": ["weak leg"],
             "THREE": ["one bad eye", "failing eyesight"],
-            "NOPAW": ["lost a leg"],
-            "TOETRAP": ["weak leg"],
-            "NOTAIL": ["lost their tail"],
-            "HALFTAIL": ["lost their tail"],
+            "FOUR": ["weak leg"],
             "LEFTEAR": ["partial hearing loss"],
             "RIGHTEAR": ["partial hearing loss"],
-            "MANLEG": ["weak leg", "twisted leg"],
-            "BRIGHTHEART": ["one bad eye"],
             "NOLEFTEAR": ["partial hearing loss"],
             "NORIGHTEAR": ["partial hearing loss"],
             "NOEAR": ["partial hearing loss", "deaf"],
+            "NOPAW": ["lost a leg"],
+            "NOTAIL": ["lost their tail"],
+            "HALFTAIL": ["lost their tail"],
+            "BRIGHTHEART": ["one bad eye"],
             "LEFTBLIND": ["one bad eye", "failing eyesight"],
             "RIGHTBLIND": ["one bad eye", "failing eyesight"],
-            "BOTHBLIND": ["blind"],
+            "BOTHBLIND": ["failing eyesight", "blind"],
+            "MANLEG": ["weak leg", "twisted leg"],
             "RATBITE": ["weak leg"],
+            "LEGBITE": ["weak leg"],
+            "TOETRAP": ["weak leg"],
+
         }
 
         scarless_conditions = [
@@ -464,12 +466,12 @@ class Condition_Events:
                             return perm_condition
                 except KeyError:
                     print(
-                        f"WARNING: {injury_name} couldn't be found in injury dict! no permanent condition was given"
+                        f"WARNING: {injury_name} couldn't be found in injury dict! no permanent condition is possible."
                     )
                     return perm_condition
             else:
                 print(
-                    f"WARNING: {scar} for {injury_name} is either None or is not in scar_to_condition dict."
+                    f"WARNING: {scar} for {injury_name} is either None or is not in scar_to_condition dict. This is not necessarily a bug.  Only report if you feel the scar should have resulted in a permanent condition."
                 )
 
         elif condition is not None:

--- a/scripts/events_module/condition_events.py
+++ b/scripts/events_module/condition_events.py
@@ -418,6 +418,7 @@ class Condition_Events:
             "RATBITE": ["weak leg"],
             "LEGBITE": ["weak leg"],
             "TOETRAP": ["weak leg"],
+            "HINDLEG": ["weak leg"]
 
         }
 


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->

## About The Pull Request
- Clarifies warning message to remind that it doesn't necessarily mean it's a bug.  
- Adds FOUR and HINDLEG to the scar-to-condition dict
- Reorders dict to match with visual sprite guide (for my own sanity)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
Fixes #2296 
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
![image](https://github.com/user-attachments/assets/0c455ec4-5d8f-44cc-904a-c2f399d4d901)
Moon spammed for a while.  Didn't get any crashes and the new warning showed up fine.  Didn't see any scars being warned for that should receive perm conditions.
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->
