### PR TITLE
[BUGFIX] Half-clan litter compatibility with ignore-biology setting

### DIFF
--- a/scripts/events_module/relationship/pregnancy_events.py
+++ b/scripts/events_module/relationship/pregnancy_events.py
@@ -726,7 +726,7 @@ class Pregnancy_Events:
         blood_parent = None
 
         ##### SELECT BACKSTORY #####
-        if cat and cat.gender == "female":
+        if cat and "pregnant" in cat.injuries:
             backstory = choice(["halfclan1", "outsider_roots1"])
         elif cat:
             backstory = choice(["halfclan2", "outsider_roots2"])
@@ -756,7 +756,6 @@ class Pregnancy_Events:
 
         #### GENERATE THE KITS ######
         for kit in range(kits_amount):
-            kit = None
             if not cat:
                 # No parents provided, give a blood parent - this is an adoption.
                 if not blood_parent:


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->

## About The Pull Request
Previously, the generation of a half-clan litter always presumed the birthing parent was the female.  If the ignore-biology setting was on and a male became pregnant with a half-clan litter, the kits would always be given the wrong backstory (cat was born *outside* the clan).  My change checks for the "pregnant" condition in the parent and bases backstory assignation on that.

(the second line change is just a removal of an unused variable that i noticed while digging for a solution lol)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

<!-- If this is a bug fix, you can remove this section. -->
<!-- Please add a short description of why you think these changes would benefit the game. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->
<!-- If you have multiple features that can stand on their own, or unrelated bugfixes, please create separate PRs for them. -->

## Linked Issues
Fixes #2586
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
![image](https://github.com/user-attachments/assets/7dcbdd2d-6c3a-435e-aae4-efcb5154808d)
![image](https://github.com/user-attachments/assets/593884e1-6836-4822-8196-4ca5921022bb)
Pythonglare is male, Nectarkit shows the correct backstory for this event.

![image](https://github.com/user-attachments/assets/17fd0038-d98a-4405-90b4-dd17c87f8a1e)
![image](https://github.com/user-attachments/assets/20410da8-e652-43b1-a649-faddcd34fee0)
Fallenkit is his kit and has the correct backstory for Saffron being the birthing parent.

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

