### PR TITLE
[BUGFIX] Inappropriate Romantic Like

### DIFF
--- a/resources/dicts/relationship_events/normal_interactions/platonic/increase.json
+++ b/resources/dicts/relationship_events/normal_interactions/platonic/increase.json
@@ -281,29 +281,6 @@
             		"sweet"
 		]
 	},
-	{
-		"id": "platonic_inc_med15",
-		"interactions": [
-            		"m_c and r_c played around during patrol and got in a bit of trouble, but still returned to camp smiling.",
-            		"m_c just barely missed a mouse, but r_c caught it right after, handing it off to {PRONOUN/m_c/object}.",
-            		"m_c and r_c got so into playing around that they got separated from the rest of the patrol, earning themselves an earful back at camp."
-		],
-		"main_status_constraint": [
-			"apprentice",
-			"deputy",
-			"leader",
-			"warrior"
-		],
-		"random_status_constraint": [
-			"apprentice",
-			"deputy",
-			"leader",
-			"warrior"
-		],
-		"also_influences": {
-			"romantic": "increase"
-            }
-	},
     {
 		"id": "platonic_inc_med16",
 		"interactions": [

--- a/resources/dicts/relationship_events/normal_interactions/romantic/increase.json
+++ b/resources/dicts/relationship_events/normal_interactions/romantic/increase.json
@@ -229,6 +229,7 @@
 	},
 	{
 		"id": "rom_inc_med9",
+		"intensity": "medium",
 		"interactions": [
             		"m_c and r_c played around during patrol and got in a bit of trouble, but still returned to camp smiling.",
             		"m_c just barely missed a mouse, but r_c caught it right after, handing it off to {PRONOUN/m_c/object}.",

--- a/resources/dicts/relationship_events/normal_interactions/romantic/increase.json
+++ b/resources/dicts/relationship_events/normal_interactions/romantic/increase.json
@@ -236,12 +236,13 @@
             		"m_c and r_c got so into playing around that they got separated from the rest of the patrol, earning themselves an earful back at camp."
 		],
 		"reaction_random_cat": {
-			"romantic": "increase"
+			"romantic": "increase",
 			"platonic": "increase"
             },
 		"reaction_main_cat": {
-			"romantic": "increase"
+			"romantic": "increase",
 			"platonic": "increase"
+		}
 	},
 	{
 		"id": "rom_inc_high1",

--- a/resources/dicts/relationship_events/normal_interactions/romantic/increase.json
+++ b/resources/dicts/relationship_events/normal_interactions/romantic/increase.json
@@ -228,6 +228,21 @@
 		}
 	},
 	{
+		"id": "rom_inc_med9",
+		"interactions": [
+            		"m_c and r_c played around during patrol and got in a bit of trouble, but still returned to camp smiling.",
+            		"m_c just barely missed a mouse, but r_c caught it right after, handing it off to {PRONOUN/m_c/object}.",
+            		"m_c and r_c got so into playing around that they got separated from the rest of the patrol, earning themselves an earful back at camp."
+		],
+		"reaction_random_cat": {
+			"romantic": "increase"
+			"platonic": "increase"
+            },
+		"reaction_main_cat": {
+			"romantic": "increase"
+			"platonic": "increase"
+	},
+	{
 		"id": "rom_inc_high1",
 		"intensity": "high",
 		"interactions": [


### PR DESCRIPTION
## About The Pull Request

I found the issue that's been plaguing me the past week or so. A romantic event was in the platonic increase events file which was resulting in the occasional romantic interest between older cats and much much younger cats, so I moved it to romantic increase where it should be.

## Why This Is Good For ClanGen

No inappropriate relationships!

## Linked Issues

## Proof of Testing

![Event](https://github.com/user-attachments/assets/2497e828-aea1-470c-8300-cf1a84427835)
![Faded](https://github.com/user-attachments/assets/51dc7ae0-ec6b-469f-8899-2c5680d9fb49)
![Red](https://github.com/user-attachments/assets/fcd6a853-9c31-402d-848b-58d457203232)
![romancebar](https://github.com/user-attachments/assets/dd65302e-046a-497c-af41-c758f310cd1e)

## Changelog/Credits

FangoJett
