### PR TITLE
[CLEANUP] Align stat_trait outcomes

### DIFF
--- a/resources/dicts/patrols/beach/border/any.json
+++ b/resources/dicts/patrols/beach/border/any.json
@@ -234,7 +234,7 @@
                 "text": "s_c takes the lead, confronting the gang with confidence. Eventually, the rogues admit that they've been struggling to find enough prey and were looking to steal richer territory from the Clan. Tensions are eased when s_c informs the rogues of a prey-rich forest outside of c_n territory.",
                 "exp": 30,
                 "weight": 20,
-                "stat_trait": ["bold", "confident", "charming"],
+                "stat_trait": ["bold", "confident"],
                 "relationships": [
                     {
                         "cats_to": ["patrol"],

--- a/resources/dicts/patrols/beach/hunting/leaf-bare.json
+++ b/resources/dicts/patrols/beach/hunting/leaf-bare.json
@@ -382,7 +382,7 @@
                 "text": "s_c really keeps the patrol on task and motivated through the sharp cold of the leaf-bare morning, not through authority or commands, but with a gentle voice and compassionate understanding that encourages every cat to do their best for c_n.",
                 "exp": 10,
                 "weight": 20,
-                "stat_trait": ["altruistic", "compassionate", "empathetic", "faithful", "loving"],
+                "stat_trait": ["altruistic", "compassionate", "faithful", "loving"],
                 "prey": ["large"],
                 "relationships": [
                     {
@@ -531,7 +531,7 @@
                 "text": "A storm descends, sudden and violent, putting an end to any other thoughts but survival. As the cats hide from the wind, s_c keeps an eye out for everyone. It's a long couple of hours, but with gentle understanding and compassion, the cats make it through safely, closer than ever afterwards.",
                 "exp": 10,
                 "weight": 20,
-                "stat_trait": ["altruistic", "compassionate", "empathetic", "faithful", "loving"],
+                "stat_trait": ["altruistic", "compassionate", "faithful", "loving"],
                 "prey": ["small"],
                 "relationships": [
                     {

--- a/resources/dicts/patrols/beach/hunting/leaf-bare.json
+++ b/resources/dicts/patrols/beach/hunting/leaf-bare.json
@@ -382,7 +382,7 @@
                 "text": "s_c really keeps the patrol on task and motivated through the sharp cold of the leaf-bare morning, not through authority or commands, but with a gentle voice and compassionate understanding that encourages every cat to do their best for c_n.",
                 "exp": 10,
                 "weight": 20,
-                "stat_trait": ["altruistic", "compassionate", "faithful", "loving"],
+                "stat_trait": ["compassionate", "faithful", "loving"],
                 "prey": ["large"],
                 "relationships": [
                     {
@@ -531,7 +531,7 @@
                 "text": "A storm descends, sudden and violent, putting an end to any other thoughts but survival. As the cats hide from the wind, s_c keeps an eye out for everyone. It's a long couple of hours, but with gentle understanding and compassion, the cats make it through safely, closer than ever afterwards.",
                 "exp": 10,
                 "weight": 20,
-                "stat_trait": ["altruistic", "compassionate", "faithful", "loving"],
+                "stat_trait": ["compassionate", "faithful", "loving"],
                 "prey": ["small"],
                 "relationships": [
                     {

--- a/resources/dicts/patrols/beach/med/greenleaf.json
+++ b/resources/dicts/patrols/beach/med/greenleaf.json
@@ -3052,7 +3052,7 @@
                 "text": "Night falls, and still s_c insists they keep going. Lungwort is the only reliable cure for yellowcough, and {PRONOUN/s_c/subject} just can't let c_n go without. Exhausted but determined, the medicine cats persevere until they finally find the precious speckled leaves.",
                 "exp": 20,
                 "weight": 20,
-                "stat_trait": ["patient"],
+                "stat_trait": ["thoughtful", "confident", "loyal", "responsible", "arrogant"],
                 "can_have_stat": ["adult"],
                 "herbs": ["lungwort"],
                 "relationships": [
@@ -3165,7 +3165,7 @@
                 "text": "Night falls, but still s_c insistently keeps going - {PRONOUN/s_c/subject} just can't let c_n go without. Exhausted but determined, the medicine cat perseveres until {PRONOUN/s_c/subject} {VERB/s_c/find/finds} the precious speckled leaves.",
                 "exp": 20,
                 "weight": 20,
-                "stat_trait": ["patient"],
+                "stat_trait": ["thoughtful", "confident", "loyal", "responsible", "arrogant"],
                 "herbs": ["lungwort"],
                 "relationships": [
                     {
@@ -3286,7 +3286,7 @@
                 "text": "Night falls, but still s_c insistently keeps going - {PRONOUN/s_c/subject} just can't let c_n go without. Exhausted but determined, the medicine cat perseveres until {PRONOUN/s_c/subject} {VERB/s_c/find/finds} the precious speckled leaves.",
                 "exp": 20,
                 "weight": 20,
-                "stat_trait": ["patient"],
+                "stat_trait": ["thoughtful", "confident", "loyal", "responsible", "arrogant"],
                 "can_have_stat": ["r_c"],
                 "herbs": ["lungwort"],
                 "relationships": [

--- a/resources/dicts/patrols/beach/med/leaf-fall.json
+++ b/resources/dicts/patrols/beach/med/leaf-fall.json
@@ -3125,7 +3125,7 @@
                 "text": "Night falls, and still s_c insists {PRONOUN/s_c/subject} {VERB/s_c/keep/keeps} going. Lungwort is the only reliable cure for yellowcough, and {PRONOUN/s_c/subject} just can't let c_n go without. Exhausted but determined, the medicine cats persist patiently until {PRONOUN/s_c/subject} finally find the precious speckled leaves.",
                 "exp": 20,
                 "weight": 20,
-                "stat_trait": ["patient"],
+                "stat_trait": ["thoughtful", "confident", "loyal", "responsible", "arrogant"],
                 "can_have_stat": ["adult"],
                 "herbs": ["lungwort"],
                 "relationships": [
@@ -3238,7 +3238,7 @@
                 "text": "Night falls, but still s_c insistently keeps going - {PRONOUN/s_c/subject} just can't let c_n go without. Exhausted but determined, the medicine cat persists patiently until {PRONOUN/s_c/subject} {VERB/s_c/find/finds} the precious speckled leaves.",
                 "exp": 20,
                 "weight": 20,
-                "stat_trait": ["patient"],
+                "stat_trait": ["thoughtful", "confident", "loyal", "responsible", "arrogant"],
                 "herbs": ["lungwort"],
                 "relationships": [
                     {
@@ -3372,7 +3372,7 @@
                 "text": "Night falls, but still s_c insistently keeps going - {PRONOUN/s_c/subject} just can't let c_n go without. Exhausted but determined, the medicine cat persists patiently until {PRONOUN/s_c/subject} {VERB/s_c/find/finds} the precious speckled leaves.",
                 "exp": 20,
                 "weight": 20,
-                "stat_trait": ["patient"],
+                "stat_trait": ["thoughtful", "confident", "loyal", "responsible", "arrogant"],
                 "can_have_stat": ["r_c"],
                 "herbs": ["lungwort"],
                 "relationships": [

--- a/resources/dicts/patrols/beach/med/newleaf.json
+++ b/resources/dicts/patrols/beach/med/newleaf.json
@@ -3003,7 +3003,7 @@
                 "text": "Night falls, and still s_c insists they keep going. Lungwort is the only reliable cure for yellowcough, and {PRONOUN/s_c/subject} just can't let c_n go without. Exhausted but determined, the medicine cats persist patiently until they finally find the precious speckled leaves.",
                 "exp": 20,
                 "weight": 20,
-                "stat_trait": ["patient"],
+                "stat_trait": ["thoughtful", "confident", "loyal", "responsible", "arrogant"],
                 "can_have_stat": ["adult"],
                 "herbs": ["lungwort"],
                 "relationships": [
@@ -3116,7 +3116,7 @@
                 "text": "Night falls, but still s_c insistently keeps going - {PRONOUN/s_c/subject} just can't let c_n go without. Exhausted, but determined, the medicine cat persists patiently until {PRONOUN/s_c/subject} {VERB/s_c/find/finds} the precious speckled leaves.",
                 "exp": 20,
                 "weight": 20,
-                "stat_trait": ["patient"],
+                "stat_trait": ["thoughtful", "confident", "loyal", "responsible", "arrogant"],
                 "herbs": ["lungwort"],
                 "relationships": [
                     {
@@ -3237,7 +3237,7 @@
                 "text": "Night falls, but still s_c insistently keeps going - {PRONOUN/s_c/subject} just can't let c_n go without. Exhausted but determined, the medicine cat persists patiently until {PRONOUN/s_c/subject} {VERB/s_c/find/finds} the precious speckled leaves.",
                 "exp": 20,
                 "weight": 20,
-                "stat_trait": ["patient"],
+                "stat_trait": ["thoughtful", "confident", "loyal", "responsible", "arrogant"],
                 "can_have_stat": ["r_c"],
                 "herbs": ["lungwort"],
                 "relationships": [

--- a/resources/dicts/patrols/beach/training/any.json
+++ b/resources/dicts/patrols/beach/training/any.json
@@ -129,7 +129,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -306,7 +305,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -479,7 +477,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -1577,7 +1574,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "lonesome",

--- a/resources/dicts/patrols/beach/training/any.json
+++ b/resources/dicts/patrols/beach/training/any.json
@@ -131,7 +131,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -306,7 +305,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -477,7 +475,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1873,7 +1870,6 @@
                     "lonesome",
                     "loyal",
                     "nervous",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"

--- a/resources/dicts/patrols/beach/training/any.json
+++ b/resources/dicts/patrols/beach/training/any.json
@@ -347,8 +347,7 @@
                     "shameless",
                     "strict",
                     "troublesome",
-                    "vengeful",
-                    "bossy"
+                    "vengeful"
                 ],
                 "relationships": [
                     {
@@ -518,8 +517,7 @@
                     "shameless",
                     "strict",
                     "troublesome",
-                    "vengeful",
-                    "bossy"
+                    "vengeful"
                 ],
                 "can_have_stat": ["p_l"],
                 "relationships": [

--- a/resources/dicts/patrols/beach/training/any.json
+++ b/resources/dicts/patrols/beach/training/any.json
@@ -134,8 +134,7 @@
                     "patient",
                     "responsible",
                     "thoughtful",
-                    "wise",
-                    "inquisitive"
+                    "wise"
                 ],
                 "relationships": [
                     {
@@ -310,8 +309,7 @@
                     "patient",
                     "responsible",
                     "thoughtful",
-                    "wise",
-                    "inquisitive"
+                    "wise"
                 ],
                 "relationships": [
                     {
@@ -482,8 +480,7 @@
                     "patient",
                     "responsible",
                     "thoughtful",
-                    "wise",
-                    "inquisitive"
+                    "wise"
                 ],
                 "can_have_stat": ["p_l"],
                 "relationships": [

--- a/resources/dicts/patrols/beach/training/newleaf.json
+++ b/resources/dicts/patrols/beach/training/newleaf.json
@@ -68,7 +68,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",

--- a/resources/dicts/patrols/beach/training/newleaf.json
+++ b/resources/dicts/patrols/beach/training/newleaf.json
@@ -70,7 +70,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"

--- a/resources/dicts/patrols/desert/border/any.json
+++ b/resources/dicts/patrols/desert/border/any.json
@@ -51,7 +51,6 @@
                     "ambitious",
                     "compassionate",
                     "confident",
-                    "empathetic",
                     "faithful",
                     "fierce",
                     "loving",
@@ -184,7 +183,6 @@
                 "stat_trait": [
                     "compassionate",
                     "confident",
-                    "empathetic",
                     "faithful",
                     "fierce",
                     "loving",
@@ -346,7 +344,6 @@
                 "stat_trait": [
                     "compassionate",
                     "confident",
-                    "empathetic",
                     "faithful",
                     "fierce",
                     "loving",

--- a/resources/dicts/patrols/desert/hunting/any.json
+++ b/resources/dicts/patrols/desert/hunting/any.json
@@ -247,7 +247,6 @@
                     "nervous",
                     "sneaky",
                     "strange",
-                    "patient",
                     "thoughtful",
                     "wise"
                 ],
@@ -326,7 +325,6 @@
                     "nervous",
                     "sneaky",
                     "strange",
-                    "patient",
                     "thoughtful",
                     "wise"
                 ],
@@ -396,7 +394,6 @@
                     "nervous",
                     "sneaky",
                     "strange",
-                    "patient",
                     "thoughtful",
                     "wise"
                 ],
@@ -466,7 +463,6 @@
                     "nervous",
                     "sneaky",
                     "strange",
-                    "patient",
                     "thoughtful",
                     "wise"
                 ],
@@ -547,7 +543,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -621,7 +616,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -695,7 +689,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -754,7 +747,6 @@
                     "nervous",
                     "sneaky",
                     "strange",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -826,7 +818,6 @@
                     "nervous",
                     "sneaky",
                     "strange",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"

--- a/resources/dicts/patrols/desert/hunting/any.json
+++ b/resources/dicts/patrols/desert/hunting/any.json
@@ -545,7 +545,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -620,7 +619,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -695,7 +693,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",

--- a/resources/dicts/patrols/desert/hunting/greenleaf.json
+++ b/resources/dicts/patrols/desert/hunting/greenleaf.json
@@ -2266,7 +2266,6 @@
                 "exp": 15,
                 "weight": 20,
                 "stat_trait": [
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise",
@@ -2325,7 +2324,6 @@
                 "exp": 15,
                 "weight": 20,
                 "stat_trait": [
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise",

--- a/resources/dicts/patrols/desert/hunting/leaf-bare.json
+++ b/resources/dicts/patrols/desert/hunting/leaf-bare.json
@@ -2345,7 +2345,7 @@
                 "text": "The cats slip and slide in a world suddenly damp and wet in the growing rainstorm, but s_c commiserates with those who fall and encourages every cat on, the patrol not only having fun with each other, but also managing to catch a good haul of desert creatures as confused by the slippery ground as they are.",
                 "exp": 20,
                 "weight": 20,
-                "stat_trait": ["altruistic", "compassionate", "empathetic", "faithful", "loving"],
+                "stat_trait": ["altruistic", "compassionate", "faithful", "loving"],
                 "prey": ["large"],
                 "relationships": [
                     {
@@ -2464,7 +2464,7 @@
                 "text": "A storm descends, sudden and violent enough to drive the c_n cats to shelter. As the cats hide from the wind, s_c keeps an eye out for everyone. There's a lot of restless energy in the shelter as the cats watch leaf-bare bless c_n, but it's easily redirected to games and friendly debates, perhaps even a little flirting.",
                 "exp": 10,
                 "weight": 20,
-                "stat_trait": ["altruistic", "compassionate", "empathetic", "faithful", "loving"],
+                "stat_trait": ["altruistic", "compassionate", "faithful", "loving"],
                 "relationships": [
                     {
                         "cats_to": ["p_l"],

--- a/resources/dicts/patrols/desert/hunting/leaf-bare.json
+++ b/resources/dicts/patrols/desert/hunting/leaf-bare.json
@@ -2345,7 +2345,7 @@
                 "text": "The cats slip and slide in a world suddenly damp and wet in the growing rainstorm, but s_c commiserates with those who fall and encourages every cat on, the patrol not only having fun with each other, but also managing to catch a good haul of desert creatures as confused by the slippery ground as they are.",
                 "exp": 20,
                 "weight": 20,
-                "stat_trait": ["altruistic", "compassionate", "faithful", "loving"],
+                "stat_trait": ["compassionate", "faithful", "loving"],
                 "prey": ["large"],
                 "relationships": [
                     {
@@ -2464,7 +2464,7 @@
                 "text": "A storm descends, sudden and violent enough to drive the c_n cats to shelter. As the cats hide from the wind, s_c keeps an eye out for everyone. There's a lot of restless energy in the shelter as the cats watch leaf-bare bless c_n, but it's easily redirected to games and friendly debates, perhaps even a little flirting.",
                 "exp": 10,
                 "weight": 20,
-                "stat_trait": ["altruistic", "compassionate", "faithful", "loving"],
+                "stat_trait": ["compassionate", "faithful", "loving"],
                 "relationships": [
                     {
                         "cats_to": ["p_l"],

--- a/resources/dicts/patrols/desert/hunting/leaf-fall.json
+++ b/resources/dicts/patrols/desert/hunting/leaf-fall.json
@@ -2296,7 +2296,6 @@
                 "exp": 15,
                 "weight": 20,
                 "stat_trait": [
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise",
@@ -2344,7 +2343,6 @@
                 "exp": 15,
                 "weight": 20,
                 "stat_trait": [
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise",

--- a/resources/dicts/patrols/desert/hunting/newleaf.json
+++ b/resources/dicts/patrols/desert/hunting/newleaf.json
@@ -2368,7 +2368,6 @@
                 "exp": 15,
                 "weight": 20,
                 "stat_trait": [
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise",
@@ -2416,7 +2415,6 @@
                 "exp": 15,
                 "weight": 20,
                 "stat_trait": [
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise",

--- a/resources/dicts/patrols/desert/med/any.json
+++ b/resources/dicts/patrols/desert/med/any.json
@@ -367,7 +367,7 @@
                 "text": "Night falls, and still s_c insists they keep going - lungwort is the only reliable cure for yellowcough, they can't let c_n go without. Exhausted but determined, the medicine cats persist patiently until they find those precious speckled leaves.",
                 "exp": 20,
                 "weight": 20,
-                "stat_trait": ["patient"],
+                "stat_trait": ["thoughtful", "confident", "loyal", "responsible", "arrogant"],
                 "relationships": [
                     {
                         "cats_to": ["patrol"],
@@ -476,7 +476,7 @@
                 "text": "Night falls, and still s_c insists to {PRONOUN/s_c/self} that {PRONOUN/s_c/subject} {VERB/s_c/need/needs} to keep going - {PRONOUN/s_c/subject} just can't let c_n go without. Exhausted but determined, the medicine cat persists patiently until {PRONOUN/s_c/subject} {VERB/s_c/find/finds} those precious speckled leaves.",
                 "exp": 20,
                 "weight": 20,
-                "stat_trait": ["patient"],
+                "stat_trait": ["thoughtful", "confident", "loyal", "responsible", "arrogant"],
                 "relationships": [
                     {
                         "cats_to": ["patrol"],
@@ -582,7 +582,7 @@
                 "exp": 20,
                 "weight": 20,
                 "herbs": ["many_herbs", "lungwort"],
-                "stat_trait": ["patient"],
+                "stat_trait": ["thoughtful", "confident", "loyal", "responsible", "arrogant"],
                 "relationships": [
                     {
                         "cats_to": ["patrol"],
@@ -722,7 +722,7 @@
                 "text": "Night falls, and still s_c insists they keep going - lungwort is the only reliable cure for yellowcough, they can't let c_n go without. Exhausted but determined, the medicine cats persist patiently until they find those precious speckled leaves.",
                 "exp": 20,
                 "weight": 20,
-                "stat_trait": ["patient"],
+                "stat_trait": ["thoughtful", "confident", "loyal", "responsible", "arrogant"],
                 "relationships": [
                     {
                         "cats_to": ["patrol"],
@@ -831,7 +831,7 @@
                 "text": "Night falls, and still s_c insists to {PRONOUN/s_c/self} that {PRONOUN/s_c/subject} {VERB/s_c/need/needs} to keep going - {PRONOUN/s_c/subject} just can't let c_n go without. Exhausted but determined, the medicine cat persists patiently until {PRONOUN/s_c/subject} {VERB/s_c/find/finds} those precious speckled leaves.",
                 "exp": 20,
                 "weight": 20,
-                "stat_trait": ["patient"],
+                "stat_trait": ["thoughtful", "confident", "loyal", "responsible", "arrogant"],
                 "relationships": [
                     {
                         "cats_to": ["patrol"],
@@ -937,7 +937,7 @@
                 "exp": 20,
                 "weight": 20,
                 "herbs": ["many_herbs", "lungwort"],
-                "stat_trait": ["patient"],
+                "stat_trait": ["thoughtful", "confident", "loyal", "responsible", "arrogant"],
                 "relationships": [
                     {
                         "cats_to": ["patrol"],
@@ -1077,7 +1077,7 @@
                 "text": "Night falls, and still s_c insists they keep going - lungwort is the only reliable cure for yellowcough, they can't let c_n go without. Exhausted but determined, the medicine cats persist patiently until they find those precious speckled leaves.",
                 "exp": 20,
                 "weight": 20,
-                "stat_trait": ["patient"],
+                "stat_trait": ["thoughtful", "confident", "loyal", "responsible", "arrogant"],
                 "relationships": [
                     {
                         "cats_to": ["patrol"],
@@ -1186,7 +1186,7 @@
                 "text": "Night falls, and still s_c insists to {PRONOUN/s_c/self} that {PRONOUN/s_c/subject} {VERB/s_c/need/needs} to keep going - {PRONOUN/s_c/subject} just can't let c_n go without. Exhausted but determined, the medicine cat persists patiently until {PRONOUN/s_c/subject} {VERB/s_c/find/finds} those precious speckled leaves.",
                 "exp": 20,
                 "weight": 20,
-                "stat_trait": ["patient"],
+                "stat_trait": ["thoughtful", "confident", "loyal", "responsible", "arrogant"],
                 "relationships": [
                     {
                         "cats_to": ["patrol"],
@@ -1292,7 +1292,7 @@
                 "exp": 20,
                 "weight": 20,
                 "herbs": ["many_herbs", "lungwort"],
-                "stat_trait": ["patient"],
+                "stat_trait": ["thoughtful", "confident", "loyal", "responsible", "arrogant"],
                 "relationships": [
                     {
                         "cats_to": ["patrol"],

--- a/resources/dicts/patrols/desert/med/greenleaf.json
+++ b/resources/dicts/patrols/desert/med/greenleaf.json
@@ -157,7 +157,6 @@
                 "text": "Even though there should be many herbs they fail to find anything. p_l blames r_c for distracting them and they get into a huge argument.",
                 "exp": 0,
                 "weight": 20,
-                "stat_trait": ["None"],
                 "relationships": [
                     {
                         "cats_to": ["patrol"],

--- a/resources/dicts/patrols/desert/med/leaf-bare.json
+++ b/resources/dicts/patrols/desert/med/leaf-bare.json
@@ -157,7 +157,6 @@
                 "text": "Even though there should be many herbs they fail to find anything. p_l blames r_c for distracting them and they get into a huge argument.",
                 "exp": 0,
                 "weight": 20,
-                "stat_trait": ["None"],
                 "relationships": [
                     {
                         "cats_to": ["patrol"],

--- a/resources/dicts/patrols/desert/med/leaf-fall.json
+++ b/resources/dicts/patrols/desert/med/leaf-fall.json
@@ -157,7 +157,6 @@
                 "text": "Even though there should be many herbs they fail to find anything. p_l blames r_c for distracting them and they get into a huge argument.",
                 "exp": 0,
                 "weight": 20,
-                "stat_trait": ["None"],
                 "relationships": [
                     {
                         "cats_to": ["patrol"],

--- a/resources/dicts/patrols/desert/med/newleaf.json
+++ b/resources/dicts/patrols/desert/med/newleaf.json
@@ -157,7 +157,6 @@
                 "text": "Even though there should be many herbs they fail to find anything. p_l blames r_c for distracting them and they get into a huge argument.",
                 "exp": 0,
                 "weight": 20,
-                "stat_trait": ["None"],
                 "relationships": [
                     {
                         "cats_to": ["patrol"],

--- a/resources/dicts/patrols/desert/training/any.json
+++ b/resources/dicts/patrols/desert/training/any.json
@@ -30,7 +30,7 @@
                 "text": "By the end of the patrol s_c is able to move steadily with the wind and sand, their movements sure and confident",
                 "exp": 10,
                 "weight": 20,
-                "stat_trait": ["calm", "careful", "sneak", "quiet"]
+                "stat_trait": ["calm", "careful", "sneak"]
             }
         ],
         "fail_outcomes": [

--- a/resources/dicts/patrols/desert/training/any.json
+++ b/resources/dicts/patrols/desert/training/any.json
@@ -30,7 +30,7 @@
                 "text": "By the end of the patrol s_c is able to move steadily with the wind and sand, their movements sure and confident",
                 "exp": 10,
                 "weight": 20,
-                "stat_trait": ["calm", "careful", "sneak"]
+                "stat_trait": ["calm", "careful", "sneaky"]
             }
         ],
         "fail_outcomes": [

--- a/resources/dicts/patrols/desert/training/any.json
+++ b/resources/dicts/patrols/desert/training/any.json
@@ -30,7 +30,7 @@
                 "text": "By the end of the patrol s_c is able to move steadily with the wind and sand, their movements sure and confident",
                 "exp": 10,
                 "weight": 20,
-                "stat_trait": ["calm", "careful", "sneak", "quiet", "patient"]
+                "stat_trait": ["calm", "careful", "sneak", "quiet"]
             }
         ],
         "fail_outcomes": [
@@ -83,7 +83,6 @@
                 "exp": 30,
                 "weight": 20,
                 "stat_trait": [
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise",
@@ -163,7 +162,6 @@
                 "exp": 30,
                 "weight": 20,
                 "stat_trait": [
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise",
@@ -268,7 +266,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -411,7 +408,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"

--- a/resources/dicts/patrols/desert/training/any.json
+++ b/resources/dicts/patrols/desert/training/any.json
@@ -271,8 +271,7 @@
                     "patient",
                     "responsible",
                     "thoughtful",
-                    "wise",
-                    "inquisitive"
+                    "wise"
                 ],
                 "relationships": [
                     {
@@ -415,8 +414,7 @@
                     "patient",
                     "responsible",
                     "thoughtful",
-                    "wise",
-                    "inquisitive"
+                    "wise"
                 ],
                 "relationships": [
                     {

--- a/resources/dicts/patrols/desert/training/any.json
+++ b/resources/dicts/patrols/desert/training/any.json
@@ -308,8 +308,7 @@
                     "shameless",
                     "strict",
                     "troublesome",
-                    "vengeful",
-                    "bossy"
+                    "vengeful"
                 ],
                 "relationships": [
                     {
@@ -450,8 +449,7 @@
                     "shameless",
                     "strict",
                     "troublesome",
-                    "vengeful",
-                    "bossy"
+                    "vengeful"
                 ],
                 "relationships": [
                     {

--- a/resources/dicts/patrols/desert/training/any.json
+++ b/resources/dicts/patrols/desert/training/any.json
@@ -43,7 +43,7 @@
                 "text": "s_c struggles to take the lesson seriously, and eventually the training session ends early with no real progress made.",
                 "exp": 0,
                 "weight": 20,
-                "stat_trait": ["troublesome", "playful", "noisy"]
+                "stat_trait": ["troublesome", "playful"]
             }
         ]
     },

--- a/resources/dicts/patrols/desert/training/any.json
+++ b/resources/dicts/patrols/desert/training/any.json
@@ -266,7 +266,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -411,7 +410,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",

--- a/resources/dicts/patrols/forest/hunting/any.json
+++ b/resources/dicts/patrols/forest/hunting/any.json
@@ -510,7 +510,6 @@
                 "stat_trait": [
                     "careful",
                     "calm",
-                    "patient",
                     "responsible",
                     "sneaky",
                     "thoughtful",
@@ -610,7 +609,6 @@
                 "stat_trait": [
                     "careful",
                     "calm",
-                    "patient",
                     "responsible",
                     "sneaky",
                     "thoughtful",
@@ -703,7 +701,6 @@
                 "stat_trait": [
                     "careful",
                     "calm",
-                    "patient",
                     "responsible",
                     "sneaky",
                     "thoughtful",
@@ -778,7 +775,6 @@
                 "stat_trait": [
                     "careful",
                     "calm",
-                    "patient",
                     "responsible",
                     "sneaky",
                     "thoughtful",
@@ -871,7 +867,6 @@
                 "stat_trait": [
                     "careful",
                     "calm",
-                    "patient",
                     "responsible",
                     "sneaky",
                     "thoughtful",
@@ -946,7 +941,6 @@
                 "stat_trait": [
                     "careful",
                     "calm",
-                    "patient",
                     "responsible",
                     "sneaky",
                     "thoughtful",
@@ -1125,7 +1119,6 @@
                     "nervous",
                     "sneaky",
                     "strange",
-                    "patient",
                     "thoughtful",
                     "wise"
                 ],
@@ -1221,7 +1214,6 @@
                     "nervous",
                     "sneaky",
                     "strange",
-                    "patient",
                     "thoughtful",
                     "wise"
                 ],
@@ -1291,7 +1283,6 @@
                     "nervous",
                     "sneaky",
                     "strange",
-                    "patient",
                     "thoughtful",
                     "wise"
                 ],
@@ -1361,7 +1352,6 @@
                     "nervous",
                     "sneaky",
                     "strange",
-                    "patient",
                     "thoughtful",
                     "wise"
                 ],
@@ -1583,7 +1573,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1656,7 +1645,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1725,7 +1713,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1809,7 +1796,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise",
@@ -1937,7 +1923,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -2069,7 +2054,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -2269,7 +2253,6 @@
                     "nervous",
                     "sneaky",
                     "strange",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -2358,7 +2341,6 @@
                     "nervous",
                     "sneaky",
                     "strange",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -2447,7 +2429,6 @@
                     "nervous",
                     "sneaky",
                     "strange",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -2531,7 +2512,6 @@
                     "nervous",
                     "sneaky",
                     "strange",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"

--- a/resources/dicts/patrols/forest/hunting/any.json
+++ b/resources/dicts/patrols/forest/hunting/any.json
@@ -1723,7 +1723,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -1808,7 +1807,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -1937,7 +1935,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -2070,7 +2067,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",

--- a/resources/dicts/patrols/forest/hunting/any.json
+++ b/resources/dicts/patrols/forest/hunting/any.json
@@ -393,7 +393,7 @@
                 "text": "s_c sticks {PRONOUN/s_c/poss} nose into the hole only to come face-to-face with a skunk! The whole patrol is sprayed!",
                 "exp": 0,
                 "weight": 20,
-                "stat_trait": ["bold", "ambitious", "childish", "impulsive"],
+                "stat_trait": ["bold", "ambitious", "childish"],
                 "prey": ["very_small"]
             },
             {
@@ -454,7 +454,7 @@
                 "text": "s_c sticks {PRONOUN/s_c/poss} nose into the hole, only to come face-to-face with a skunk! {PRONOUN/s_c/subject/CAP} is sprayed!",
                 "exp": 0,
                 "weight": 20,
-                "stat_trait": ["bold", "ambitious", "childish", "impulsive"]
+                "stat_trait": ["bold", "ambitious", "childish"]
             },
             {
                 "text": "Oh no! The burrow was home to a wolverine, now angry at the disturbance. r_c bolts away to escape its wrath, but doesn't quite move fast enough and is caught in its claws. With no other cats around to help, r_c is quickly killed by the predator.",

--- a/resources/dicts/patrols/forest/hunting/leaf-bare.json
+++ b/resources/dicts/patrols/forest/hunting/leaf-bare.json
@@ -49,7 +49,7 @@
                 "text": "s_c really keeps the patrol on task and motivated through the sharp cold of the leaf-bare morning, not through authority or commands, but with a gentle voice and compassionate understanding that encourages every cat to do their best for c_n.",
                 "exp": 10,
                 "weight": 20,
-                "stat_trait": ["altruistic", "compassionate", "faithful", "loving"],
+                "stat_trait": ["compassionate", "faithful", "loving"],
                 "prey": ["medium"],
                 "relationships": [
                     {
@@ -1793,7 +1793,7 @@
                 "text": "s_c really keeps the patrol on task and motivated through the sharp cold of the leaf-bare morning, not through authority or commands, but with a gentle voice and compassionate understanding that encourages every cat to do their best for c_n.",
                 "exp": 10,
                 "weight": 20,
-                "stat_trait": ["altruistic", "compassionate", "faithful", "loving"],
+                "stat_trait": ["compassionate", "faithful", "loving"],
                 "prey": ["medium"],
                 "relationships": [
                     {

--- a/resources/dicts/patrols/forest/hunting/leaf-bare.json
+++ b/resources/dicts/patrols/forest/hunting/leaf-bare.json
@@ -49,7 +49,7 @@
                 "text": "s_c really keeps the patrol on task and motivated through the sharp cold of the leaf-bare morning, not through authority or commands, but with a gentle voice and compassionate understanding that encourages every cat to do their best for c_n.",
                 "exp": 10,
                 "weight": 20,
-                "stat_trait": ["altruistic", "compassionate", "empathetic", "faithful", "loving"],
+                "stat_trait": ["altruistic", "compassionate", "faithful", "loving"],
                 "prey": ["medium"],
                 "relationships": [
                     {
@@ -206,7 +206,7 @@
                 "text": "A storm descends, sudden and violent, putting an end to any other thoughts but survival. As the cats hide under the low-hanging branches of a pine, s_c keeps an eye out for everyone. It's a long couple of hours, but with gentle understanding and compassion the cats make it through safely, closer than ever afterwards.",
                 "exp": 10,
                 "weight": 20,
-                "stat_trait": ["compassionate", "empathetic", "faithful", "loving"],
+                "stat_trait": ["compassionate", "faithful", "loving"],
                 "prey": ["small"],
                 "relationships": [
                     {
@@ -1793,7 +1793,7 @@
                 "text": "s_c really keeps the patrol on task and motivated through the sharp cold of the leaf-bare morning, not through authority or commands, but with a gentle voice and compassionate understanding that encourages every cat to do their best for c_n.",
                 "exp": 10,
                 "weight": 20,
-                "stat_trait": ["altruistic", "compassionate", "empathetic", "faithful", "loving"],
+                "stat_trait": ["altruistic", "compassionate", "faithful", "loving"],
                 "prey": ["medium"],
                 "relationships": [
                     {
@@ -1993,7 +1993,7 @@
                 "text": "A storm descends, sudden and violent, putting an end to any other thoughts but survival. As the cats hide under the low-hanging branches of a pine, s_c keeps an eye out for everyone. It's a long couple of hours, but with gentle understanding and compassion the cats make it through safely, closer than ever afterwards.",
                 "exp": 10,
                 "weight": 20,
-                "stat_trait": ["compassionate", "empathetic", "faithful", "loving"],
+                "stat_trait": ["compassionate", "faithful", "loving"],
                 "prey": ["small"],
                 "relationships": [
                     {

--- a/resources/dicts/patrols/forest/med/greenleaf.json
+++ b/resources/dicts/patrols/forest/med/greenleaf.json
@@ -3871,7 +3871,7 @@
                 "text": "Night falls, and still s_c insists they keep going. Lungwort is the only reliable cure for yellowcough, and they just can't let c_n go without. Exhausted, but determined, the medicine cats persist patiently until they finally find the precious, speckled leaves.",
                 "exp": 20,
                 "weight": 20,
-                "stat_trait": ["patient"],
+                "stat_trait": ["thoughtful", "confident", "loyal", "responsible", "arrogant"],
                 "can_have_stat": ["adult"],
                 "herbs": ["lungwort"],
                 "relationships": [
@@ -3985,7 +3985,7 @@
                 "text": "Night falls, but still s_c keeps going - {PRONOUN/s_c/subject} just can't let c_n go without. Exhausted, but determined, the medicine cat persists until {PRONOUN/s_c/subject} {VERB/s_c/find/finds} the precious, speckled leaves.",
                 "exp": 20,
                 "weight": 20,
-                "stat_trait": ["patient"],
+                "stat_trait": ["thoughtful", "confident", "loyal", "responsible", "arrogant"],
                 "herbs": ["lungwort"],
                 "relationships": [
                     {
@@ -4092,7 +4092,7 @@
                 "text": "Night falls, but still s_c keeps going - {PRONOUN/s_c/subject} just can't let c_n go without. Exhausted, but determined, the medicine cat persists until {PRONOUN/s_c/subject} {VERB/s_c/find/finds} the precious, speckled leaves.",
                 "exp": 20,
                 "weight": 20,
-                "stat_trait": ["patient"],
+                "stat_trait": ["thoughtful", "confident", "loyal", "responsible", "arrogant"],
                 "can_have_stat": ["r_c"],
                 "herbs": ["lungwort"],
                 "relationships": [

--- a/resources/dicts/patrols/forest/med/leaf-fall.json
+++ b/resources/dicts/patrols/forest/med/leaf-fall.json
@@ -2884,7 +2884,7 @@
                 "text": "Night falls, but still s_c keeps going - {PRONOUN/s_c/subject} just can't let c_n go without. Exhausted, but determined, the medicine cat persists until {PRONOUN/s_c/subject} {VERB/s_c/find/finds} the precious, speckled leaves.",
                 "exp": 20,
                 "weight": 20,
-                "stat_trait": ["patient", "ambitious"],
+                "stat_trait": ["ambitious"],
                 "herbs": ["lungwort"],
                 "relationships": [
                     {

--- a/resources/dicts/patrols/forest/med/leaf-fall.json
+++ b/resources/dicts/patrols/forest/med/leaf-fall.json
@@ -2771,7 +2771,7 @@
                 "text": "Night falls, and still s_c insists they keep going. Lungwort is the only reliable cure for yellowcough, and they just can't let c_n go without. Exhausted, but determined, the medicine cats persist patiently until they finally find the precious, speckled leaves.",
                 "exp": 20,
                 "weight": 20,
-                "stat_trait": ["patient"],
+                "stat_trait": ["thoughtful", "confident", "loyal", "responsible", "arrogant"],
                 "can_have_stat": ["adult"],
                 "herbs": ["lungwort"],
                 "relationships": [
@@ -2990,7 +2990,7 @@
                 "text": "Night falls, but still s_c keeps going - {PRONOUN/s_c/subject} just can't let c_n go without. Exhausted, but determined, the medicine cat persists until {PRONOUN/s_c/subject} {VERB/s_c/find/finds} the precious, speckled leaves.",
                 "exp": 20,
                 "weight": 20,
-                "stat_trait": ["patient"],
+                "stat_trait": ["thoughtful", "confident", "loyal", "responsible", "arrogant"],
                 "can_have_stat": ["r_c"],
                 "herbs": ["lungwort"],
                 "relationships": [

--- a/resources/dicts/patrols/forest/med/newleaf.json
+++ b/resources/dicts/patrols/forest/med/newleaf.json
@@ -2773,7 +2773,7 @@
                 "text": "Night falls, and still s_c insists they keep going. Lungwort is the only reliable cure for yellowcough, and {PRONOUN/p_l/subject} just can't let c_n go without. Exhausted, but determined, the medicine cats persist patiently until they finally find the precious, speckled leaves.",
                 "exp": 20,
                 "weight": 20,
-                "stat_trait": ["patient"],
+                "stat_trait": ["thoughtful", "confident", "loyal", "responsible", "arrogant"],
                 "can_have_stat": ["adult"],
                 "herbs": ["lungwort"],
                 "relationships": [
@@ -2886,7 +2886,7 @@
                 "text": "Night falls, but still s_c insistently keeps going - {PRONOUN/s_c/subject} just can't let c_n go without. Exhausted, but determined, the medicine cat persists patiently until {PRONOUN/s_c/subject} {VERB/s_c/find/finds} the precious, speckled leaves.",
                 "exp": 20,
                 "weight": 20,
-                "stat_trait": ["patient"],
+                "stat_trait": ["thoughtful", "confident", "loyal", "responsible", "arrogant"],
                 "herbs": ["lungwort"],
                 "relationships": [
                     {
@@ -2992,7 +2992,7 @@
                 "text": "Night falls, but still s_c insistently keeps going - {PRONOUN/s_c/subject} just can't let c_n go without. Exhausted, but determined, the medicine cat persists patiently until {PRONOUN/s_c/subject} {VERB/s_c/find/finds} the precious, speckled leaves.",
                 "exp": 20,
                 "weight": 20,
-                "stat_trait": ["patient"],
+                "stat_trait": ["thoughtful", "confident", "loyal", "responsible", "arrogant"],
                 "can_have_stat": ["healer"],
                 "herbs": ["lungwort"],
                 "relationships": [

--- a/resources/dicts/patrols/forest/training/any.json
+++ b/resources/dicts/patrols/forest/training/any.json
@@ -289,7 +289,6 @@
                 "exp": 40,
                 "weight": 20,
                 "stat_trait": [
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise",

--- a/resources/dicts/patrols/general/border.json
+++ b/resources/dicts/patrols/general/border.json
@@ -1702,7 +1702,7 @@
                 "exp": 10,
                 "weight": 10,
                 "can_have_stat": ["p_l"],
-                "stat_trait": ["troublesome", "fierce", "bloodthirsty", "cold", "childish", "shameless", "vengeful", "arrogant", "competitive", "grumpy", "cunning", "oblivous", "rebellious"],
+                "stat_trait": ["troublesome", "fierce", "bloodthirsty", "cold", "childish", "shameless", "vengeful", "arrogant", "competitive", "grumpy", "cunning", "oblivious", "rebellious"],
                 "relationships": [
                     {
                         "cats_to": ["s_c"],
@@ -1765,7 +1765,7 @@
                 "exp": 0,
                 "weight": 10,
                 "can_have_stat": ["p_l"],
-                "stat_trait": ["troublesome", "fierce", "bloodthirsty", "cold", "childish", "shameless", "vengeful", "arrogant", "competitive", "grumpy", "cunning", "oblivous", "rebellious"],
+                "stat_trait": ["troublesome", "fierce", "bloodthirsty", "cold", "childish", "shameless", "vengeful", "arrogant", "competitive", "grumpy", "cunning", "oblivious", "rebellious"],
                 "relationships": [
                     {
                         "cats_to": ["s_c"],
@@ -1883,7 +1883,7 @@
                 "exp": 10,
                 "weight": 10,
                 "can_have_stat": ["p_l"],
-                "stat_trait": ["troublesome", "fierce", "bloodthirsty", "cold", "childish", "shameless", "vengeful", "arrogant", "competitive", "grumpy", "cunning", "oblivous", "rebellious"],
+                "stat_trait": ["troublesome", "fierce", "bloodthirsty", "cold", "childish", "shameless", "vengeful", "arrogant", "competitive", "grumpy", "cunning", "oblivious", "rebellious"],
                 "relationships": [
                     {
                         "cats_to": ["s_c"],
@@ -1967,7 +1967,7 @@
                 "exp": 0,
                 "weight": 10,
                 "can_have_stat": ["p_l"],
-                "stat_trait": ["troublesome", "fierce", "bloodthirsty", "cold", "childish", "shameless", "vengeful", "arrogant", "competitive", "grumpy", "cunning", "oblivous", "rebellious"],
+                "stat_trait": ["troublesome", "fierce", "bloodthirsty", "cold", "childish", "shameless", "vengeful", "arrogant", "competitive", "grumpy", "cunning", "oblivious", "rebellious"],
                 "relationships": [
                     {
                         "cats_to": ["s_c"],

--- a/resources/dicts/patrols/general/medcat.json
+++ b/resources/dicts/patrols/general/medcat.json
@@ -246,7 +246,7 @@
                     "shameless",
                     "arrogant",
                     "grumpy",
-                    "oblivous"
+                    "oblivious"
                 ],
                 "relationships": [
                     {
@@ -367,7 +367,7 @@
                     "sneaky",
                     "grumpy",
                     "cunning",
-                    "oblivous"
+                    "oblivious"
                 ]
             }
         ]
@@ -783,7 +783,7 @@
                     "nervous",
                     "insecure",
                     "gloomy",
-                    "oblivous"
+                    "oblivious"
                 ]
             },
             {

--- a/resources/dicts/patrols/general/medcat.json
+++ b/resources/dicts/patrols/general/medcat.json
@@ -75,7 +75,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -2268,7 +2267,7 @@
                 "text": "s_c sits down and motions for app1 to join {PRONOUN/s_c/object}, looking at {PRONOUN/app1/object} inquisitively. app1 tentatively explains that {PRONOUN/app1/subject}{VERB/app1/'re/'s} curious about herbs but {VERB/app1/are/is} worried that desire to learn is detrimental to {PRONOUN/app1/poss} progress as a warrior. s_c reassures {PRONOUN/app1/object} that nobody would think less of {PRONOUN/app1/object} for that, and it's good to know the basics. s_c promises to teach {PRONOUN/app1/object} when they get back to camp.",
                 "exp": 20,
                 "weight": 20,
-                "stat_trait": ["compassionate", "patient", "wise"],
+                "stat_trait": ["compassionate", "wise"],
                 "herbs": ["random_herbs"],
                 "relationships": [
                     {
@@ -3356,7 +3355,6 @@
                 "stat_trait": [
                     "compassionate",
                     "loving",
-                    "patient",
                     "thoughtful"
                 ],
                 "can_have_stat": ["r_c"],
@@ -3462,7 +3460,6 @@
                 "stat_trait": [
                     "compassionate",
                     "loving",
-                    "patient",
                     "thoughtful"
                 ],
                 "can_have_stat": ["r_c"],
@@ -3570,7 +3567,6 @@
                 "stat_trait": [
                     "compassionate",
                     "loving",
-                    "patient",
                     "thoughtful"
                 ],
                 "can_have_stat": ["p_l"],

--- a/resources/dicts/patrols/general/training.json
+++ b/resources/dicts/patrols/general/training.json
@@ -494,7 +494,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -661,7 +660,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -874,7 +872,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -971,7 +968,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -1060,7 +1056,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -1164,7 +1159,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -2360,7 +2354,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -2447,7 +2440,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -2543,7 +2535,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -2634,7 +2625,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -2944,7 +2934,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -3308,7 +3297,7 @@
                 "text": "s_c cannot relate to the frankly nightmarish scenes app1 has been tormented by, but {PRONOUN/s_c/subject} can't believe {PRONOUN/s_c/poss} Clanmate has been going through so much without anybody noticing. Wrapping {PRONOUN/s_c/poss} tail around app1's shoulders, {PRONOUN/s_c/subject} tell app1 this will all be alright - {PRONOUN/s_c/subject}{VERB/s_c/'re/'s} going to make sure that app1 doesn't have to shoulder this burden alone.",
                 "exp": 20,
                 "weight": 20,
-                "stat_trait": ["calm", "compassionate", "empathetic", "faithful", "strange"],
+                "stat_trait": ["calm", "compassionate", "faithful", "strange"],
                 "can_have_stat": ["adult"],
                 "relationships": [
                     {
@@ -3683,7 +3672,6 @@
                 "prey": ["small"],
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -3738,7 +3726,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",

--- a/resources/dicts/patrols/general/training.json
+++ b/resources/dicts/patrols/general/training.json
@@ -496,7 +496,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise",
@@ -662,7 +661,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -874,7 +872,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -970,7 +967,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1058,7 +1054,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1161,7 +1156,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -2356,7 +2350,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -2442,7 +2435,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -2537,7 +2529,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -2627,7 +2618,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -2936,7 +2926,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -3674,7 +3663,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -3728,7 +3716,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -6117,7 +6104,6 @@
                 "weight": 30,
                 "stat_trait": [
                     "loyal",
-                    "patient",
                     "responsible",
                     "righteous",
                     "sincere",

--- a/resources/dicts/patrols/mountainous/border/any.json
+++ b/resources/dicts/patrols/mountainous/border/any.json
@@ -171,7 +171,7 @@
                 "text": "s_c takes the lead, confronting the gang with confidence. Eventually the rogues admit that they've been struggling to find enough prey and were looking to steal richer territory from the Clan. Tensions are eased when s_c informs the rogues of a prey-rich meadow outside of c_n territory.",
                 "exp": 30,
                 "weight": 20,
-                "stat_trait": ["bold", "confident", "charming"],
+                "stat_trait": ["bold", "confident"],
                 "relationships": [
                     {
                         "cats_to": ["patrol"],

--- a/resources/dicts/patrols/mountainous/border/any.json
+++ b/resources/dicts/patrols/mountainous/border/any.json
@@ -298,7 +298,6 @@
                     "charismatic",
                     "childish",
                     "playful",
-                    "empathetic",
                     "loving",
                     "patient"
                 ],

--- a/resources/dicts/patrols/mountainous/border/any.json
+++ b/resources/dicts/patrols/mountainous/border/any.json
@@ -298,8 +298,7 @@
                     "charismatic",
                     "childish",
                     "playful",
-                    "loving",
-                    "patient"
+                    "loving"
                 ],
                 "relationships": [
                     {

--- a/resources/dicts/patrols/mountainous/hunting/any.json
+++ b/resources/dicts/patrols/mountainous/hunting/any.json
@@ -189,7 +189,6 @@
                     "nervous",
                     "sneaky",
                     "strange",
-                    "patient",
                     "thoughtful",
                     "wise"
                 ],
@@ -283,7 +282,6 @@
                     "nervous",
                     "sneaky",
                     "strange",
-                    "patient",
                     "thoughtful",
                     "wise"
                 ],
@@ -353,7 +351,6 @@
                     "nervous",
                     "sneaky",
                     "strange",
-                    "patient",
                     "thoughtful",
                     "wise"
                 ],
@@ -423,7 +420,6 @@
                     "nervous",
                     "sneaky",
                     "strange",
-                    "patient",
                     "thoughtful",
                     "wise"
                 ],
@@ -711,7 +707,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -788,7 +783,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -865,7 +859,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -919,7 +912,6 @@
                     "nervous",
                     "sneaky",
                     "strange",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1008,7 +1000,6 @@
                     "nervous",
                     "sneaky",
                     "strange",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"

--- a/resources/dicts/patrols/mountainous/hunting/any.json
+++ b/resources/dicts/patrols/mountainous/hunting/any.json
@@ -709,7 +709,6 @@
                 "weight": 10,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -787,7 +786,6 @@
                 "weight": 10,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -865,7 +863,6 @@
                 "weight": 10,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",

--- a/resources/dicts/patrols/mountainous/hunting/leaf-bare.json
+++ b/resources/dicts/patrols/mountainous/hunting/leaf-bare.json
@@ -1734,7 +1734,6 @@
                     "responsible",
                     "confident",
                     "wise",
-                    "patient",
                     "sneaky",
                     "careful"
                 ],
@@ -1921,7 +1920,6 @@
                     "careful",
                     "righteous",
                     "responsible",
-                    "patient",
                     "strange",
                     "shameless"
                 ],

--- a/resources/dicts/patrols/mountainous/hunting/leaf-bare.json
+++ b/resources/dicts/patrols/mountainous/hunting/leaf-bare.json
@@ -657,7 +657,7 @@
                 "text": "s_c really keeps the patrol on task and motivated through the sharp cold of the leaf-bare morning, not through authority or commands, but with a gentle voice and compassionate understanding that encourages every cat to do their best for c_n.",
                 "exp": 10,
                 "weight": 20,
-                "stat_trait": [ "compassionate", "empathetic", "faithful", "loving", "thoughtful" ],
+                "stat_trait": [ "compassionate", "faithful", "loving", "thoughtful" ],
                 "prey": ["medium"],
                 "relationships": [
                     {
@@ -819,7 +819,7 @@
                 "text": "A storm descends, sudden and violent, putting an end to any other thoughts but survival. As the cats hide under shrubbery of a sheltered valley, s_c keeps an eye out for everyone. It's a long couple of hours, but with gentle understanding and compassion the cats make it through safely, closer than ever afterwards.",
                 "exp": 10,
                 "weight": 20,
-                "stat_trait": [ "compassionate", "empathetic", "faithful", "loving", "thoughtful" ],
+                "stat_trait": [ "compassionate", "faithful", "loving", "thoughtful" ],
                 "relationships": [
                     {
                         "cats_to": ["p_l"],

--- a/resources/dicts/patrols/mountainous/hunting/leaf-fall.json
+++ b/resources/dicts/patrols/mountainous/hunting/leaf-fall.json
@@ -521,7 +521,7 @@
                 "text": "s_c really keeps the patrol on task and motivated through the sharp chill of the leaf-fall morning, not through authority or commands, but with a gentle voice and compassionate understanding that encourages every cat to do their best for c_n.",
                 "exp": 20,
                 "weight": 20,
-                "stat_trait": ["altruistic", "compassionate", "faithful", "loving"],
+                "stat_trait": ["compassionate", "faithful", "loving"],
                 "prey": ["medium"],
                 "relationships": [
                     {
@@ -674,7 +674,7 @@
                 "text": "A storm descends, sudden and violent, putting an end to any other thoughts but survival. As the cats hide under shrubbery of a sheltered valley, s_c keeps an eye out for everyone. It's a long couple of hours, but with gentle understanding and compassion the cats make it through safely, closer than ever afterwards.",
                 "exp": 10,
                 "weight": 20,
-                "stat_trait": ["altruistic", "compassionate", "faithful", "loving"],
+                "stat_trait": ["compassionate", "faithful", "loving"],
                 "relationships": [
                     {
                         "cats_to": ["p_l"],

--- a/resources/dicts/patrols/mountainous/hunting/leaf-fall.json
+++ b/resources/dicts/patrols/mountainous/hunting/leaf-fall.json
@@ -521,7 +521,7 @@
                 "text": "s_c really keeps the patrol on task and motivated through the sharp chill of the leaf-fall morning, not through authority or commands, but with a gentle voice and compassionate understanding that encourages every cat to do their best for c_n.",
                 "exp": 20,
                 "weight": 20,
-                "stat_trait": ["altruistic", "compassionate", "empathetic", "faithful", "loving"],
+                "stat_trait": ["altruistic", "compassionate", "faithful", "loving"],
                 "prey": ["medium"],
                 "relationships": [
                     {
@@ -674,7 +674,7 @@
                 "text": "A storm descends, sudden and violent, putting an end to any other thoughts but survival. As the cats hide under shrubbery of a sheltered valley, s_c keeps an eye out for everyone. It's a long couple of hours, but with gentle understanding and compassion the cats make it through safely, closer than ever afterwards.",
                 "exp": 10,
                 "weight": 20,
-                "stat_trait": ["altruistic", "compassionate", "empathetic", "faithful", "loving"],
+                "stat_trait": ["altruistic", "compassionate", "faithful", "loving"],
                 "relationships": [
                     {
                         "cats_to": ["p_l"],

--- a/resources/dicts/patrols/mountainous/hunting/newleaf.json
+++ b/resources/dicts/patrols/mountainous/hunting/newleaf.json
@@ -619,7 +619,7 @@
                 "text": "s_c really keeps the patrol on task and motivated through the sharp chill of the newleaf morning, not through authority or commands, but with a gentle voice and compassionate understanding that encourages every cat to do their best for c_n.",
                 "exp": 20,
                 "weight": 20,
-                "stat_trait": ["altruistic", "compassionate", "empathetic", "faithful", "loving"],
+                "stat_trait": ["altruistic", "compassionate", "faithful", "loving"],
                 "prey": ["medium"],
                 "relationships": [
                     {
@@ -771,7 +771,7 @@
                 "text": "A storm descends, sudden and violent, putting an end to any other thoughts but survival. As the cats hide under shrubbery of a sheltered valley, s_c keeps an eye out for everyone. It's a long couple of hours, but with gentle understanding and compassion the cats make it through safely, closer than ever afterwards.",
                 "exp": 10,
                 "weight": 20,
-                "stat_trait": ["altruistic", "compassionate", "empathetic", "faithful", "loving"],
+                "stat_trait": ["altruistic", "compassionate", "faithful", "loving"],
                 "relationships": [
                     {
                         "cats_to": ["p_l"],

--- a/resources/dicts/patrols/mountainous/hunting/newleaf.json
+++ b/resources/dicts/patrols/mountainous/hunting/newleaf.json
@@ -619,7 +619,7 @@
                 "text": "s_c really keeps the patrol on task and motivated through the sharp chill of the newleaf morning, not through authority or commands, but with a gentle voice and compassionate understanding that encourages every cat to do their best for c_n.",
                 "exp": 20,
                 "weight": 20,
-                "stat_trait": ["altruistic", "compassionate", "faithful", "loving"],
+                "stat_trait": ["compassionate", "faithful", "loving"],
                 "prey": ["medium"],
                 "relationships": [
                     {
@@ -771,7 +771,7 @@
                 "text": "A storm descends, sudden and violent, putting an end to any other thoughts but survival. As the cats hide under shrubbery of a sheltered valley, s_c keeps an eye out for everyone. It's a long couple of hours, but with gentle understanding and compassion the cats make it through safely, closer than ever afterwards.",
                 "exp": 10,
                 "weight": 20,
-                "stat_trait": ["altruistic", "compassionate", "faithful", "loving"],
+                "stat_trait": ["compassionate", "faithful", "loving"],
                 "relationships": [
                     {
                         "cats_to": ["p_l"],

--- a/resources/dicts/patrols/mountainous/med/any.json
+++ b/resources/dicts/patrols/mountainous/med/any.json
@@ -2019,7 +2019,6 @@
                 "text": "Even though there should be many herbs they fail to find anything. p_l blames r_c for distracting {PRONOUN/p_l/object} and they get into a huge argument.",
                 "exp": 0,
                 "weight": 20,
-                "stat_trait": ["None"],
                 "relationships": [
                     {
                         "cats_to": ["patrol"],

--- a/resources/dicts/patrols/mountainous/med/greenleaf.json
+++ b/resources/dicts/patrols/mountainous/med/greenleaf.json
@@ -2757,7 +2757,7 @@
                 "text": "Night falls, and still s_c insists they keep going. Lungwort is the only reliable cure for yellowcough, and they just can't let c_n go without. Exhausted, but determined, the medicine cats persist patiently until they finally find the precious, speckled leaves.",
                 "exp": 20,
                 "weight": 20,
-                "stat_trait": ["patient"],
+                "stat_trait": ["thoughtful", "confident", "loyal", "responsible", "arrogant"],
                 "can_have_stat": ["adult"],
                 "herbs": ["lungwort"],
                 "relationships": [
@@ -2870,7 +2870,7 @@
                 "text": "Night falls, but still s_c keeps going - {PRONOUN/s_c/subject} just can't let c_n go without. Exhausted, but determined, the medicine cat persists until {PRONOUN/s_c/subject} {VERB/s_c/find/finds} the precious, speckled leaves.",
                 "exp": 20,
                 "weight": 20,
-                "stat_trait": ["patient"],
+                "stat_trait": ["thoughtful", "confident", "loyal", "responsible", "arrogant"],
                 "herbs": ["lungwort"],
                 "relationships": [
                     {
@@ -2977,7 +2977,7 @@
                 "text": "Night falls, but still s_c keeps going - {PRONOUN/s_c/subject} just can't let c_n go without. Exhausted, but determined, the medicine cat persists until {PRONOUN/s_c/subject} {VERB/s_c/find/finds} the precious, speckled leaves.",
                 "exp": 20,
                 "weight": 20,
-                "stat_trait": ["patient"],
+                "stat_trait": ["thoughtful", "confident", "loyal", "responsible", "arrogant"],
                 "can_have_stat": ["r_c"],
                 "herbs": ["lungwort"],
                 "relationships": [

--- a/resources/dicts/patrols/mountainous/med/leaf-fall.json
+++ b/resources/dicts/patrols/mountainous/med/leaf-fall.json
@@ -2767,7 +2767,7 @@
                 "text": "Night falls, and still s_c insists they keep going. Lungwort is the only reliable cure for yellowcough, and they just can't let c_n go without. Exhausted, but determined, the medicine cats persist patiently until they finally find the precious, speckled leaves.",
                 "exp": 20,
                 "weight": 20,
-                "stat_trait": ["patient"],
+                "stat_trait": ["thoughtful", "confident", "loyal", "responsible", "arrogant"],
                 "can_have_stat": ["adult"],
                 "herbs": ["lungwort"],
                 "relationships": [
@@ -2880,7 +2880,7 @@
                 "text": "Night falls, but still s_c keeps going - {PRONOUN/s_c/subject} just can't let c_n go without. Exhausted, but determined, the medicine cat persists until {PRONOUN/s_c/subject} {VERB/s_c/find/finds} the precious, speckled leaves.",
                 "exp": 20,
                 "weight": 20,
-                "stat_trait": ["patient"],
+                "stat_trait": ["thoughtful", "confident", "loyal", "responsible", "arrogant"],
                 "herbs": ["lungwort"],
                 "relationships": [
                     {
@@ -2986,7 +2986,7 @@
                 "text": "Night falls, but still s_c keeps going - {PRONOUN/s_c/subject} just can't let c_n go without. Exhausted, but determined, the medicine cat persists until {PRONOUN/s_c/subject} {VERB/s_c/find/finds} the precious, speckled leaves.",
                 "exp": 20,
                 "weight": 20,
-                "stat_trait": ["patient"],
+                "stat_trait": ["thoughtful", "confident", "loyal", "responsible", "arrogant"],
                 "can_have_stat": ["r_c"],
                 "herbs": ["lungwort"],
                 "relationships": [

--- a/resources/dicts/patrols/mountainous/med/newleaf.json
+++ b/resources/dicts/patrols/mountainous/med/newleaf.json
@@ -2755,7 +2755,7 @@
                 "text": "Night falls, and still s_c insists they keep going. Lungwort is the only reliable cure for yellowcough, and they just can't let c_n go without. Exhausted, but determined, the medicine cats persist patiently until they finally find the precious, speckled leaves.",
                 "exp": 20,
                 "weight": 20,
-                "stat_trait": ["patient"],
+                "stat_trait": ["thoughtful", "confident", "loyal", "responsible", "arrogant"],
                 "herbs": ["lungwort"],
                 "relationships": [
                     {
@@ -2867,7 +2867,7 @@
                 "text": "Night falls, but still s_c insistently keeps going - {PRONOUN/s_c/subject} just can't let c_n go without. Exhausted, but determined, the medicine cat persists patiently until {PRONOUN/s_c/subject} {VERB/s_c/find/finds} the precious, speckled leaves.",
                 "exp": 20,
                 "weight": 20,
-                "stat_trait": ["patient"],
+                "stat_trait": ["thoughtful", "confident", "loyal", "responsible", "arrogant"],
                 "herbs": ["lungwort"],
                 "relationships": [
                     {
@@ -2974,7 +2974,7 @@
                 "text": "Night falls, but still s_c keeps going - {PRONOUN/s_c/subject} just can't let c_n go without. Exhausted, but determined, the medicine cat persists until {PRONOUN/s_c/subject} {VERB/s_c/find/finds} the precious, speckled leaves.",
                 "exp": 20,
                 "weight": 20,
-                "stat_trait": ["patient"],
+                "stat_trait": ["thoughtful", "confident", "loyal", "responsible", "arrogant"],
                 "can_have_stat": ["r_c"],
                 "herbs": ["lungwort"],
                 "relationships": [

--- a/resources/dicts/patrols/mountainous/training/any.json
+++ b/resources/dicts/patrols/mountainous/training/any.json
@@ -127,7 +127,6 @@
                 "exp": 30,
                 "weight": 20,
                 "stat_trait": [
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise",
@@ -288,7 +287,6 @@
                 "exp": 30,
                 "weight": 20,
                 "stat_trait": [
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise",
@@ -415,7 +413,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -650,7 +647,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -821,7 +817,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"

--- a/resources/dicts/patrols/mountainous/training/any.json
+++ b/resources/dicts/patrols/mountainous/training/any.json
@@ -413,7 +413,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -649,7 +648,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -822,7 +820,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",

--- a/resources/dicts/patrols/mountainous/training/any.json
+++ b/resources/dicts/patrols/mountainous/training/any.json
@@ -653,8 +653,7 @@
                     "patient",
                     "responsible",
                     "thoughtful",
-                    "wise",
-                    "inquisitive"
+                    "wise"
                 ],
                 "relationships": [
                     {
@@ -825,8 +824,7 @@
                     "patient",
                     "responsible",
                     "thoughtful",
-                    "wise",
-                    "inquisitive"
+                    "wise"
                 ],
                 "relationships": [
                     {

--- a/resources/dicts/patrols/mountainous/training/any.json
+++ b/resources/dicts/patrols/mountainous/training/any.json
@@ -690,8 +690,7 @@
                     "shameless",
                     "strict",
                     "troublesome",
-                    "vengeful",
-                    "bossy"
+                    "vengeful"
                 ],
                 "relationships": [
                     {
@@ -860,8 +859,7 @@
                     "shameless",
                     "strict",
                     "troublesome",
-                    "vengeful",
-                    "bossy"
+                    "vengeful"
                 ],
                 "relationships": [
                     {

--- a/resources/dicts/patrols/mountainous/training/leaf-bare.json
+++ b/resources/dicts/patrols/mountainous/training/leaf-bare.json
@@ -53,7 +53,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"

--- a/resources/dicts/patrols/mountainous/training/leaf-bare.json
+++ b/resources/dicts/patrols/mountainous/training/leaf-bare.json
@@ -51,7 +51,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",

--- a/resources/dicts/patrols/mountainous/training/leaf-fall.json
+++ b/resources/dicts/patrols/mountainous/training/leaf-fall.json
@@ -53,7 +53,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"

--- a/resources/dicts/patrols/mountainous/training/leaf-fall.json
+++ b/resources/dicts/patrols/mountainous/training/leaf-fall.json
@@ -51,7 +51,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",

--- a/resources/dicts/patrols/mountainous/training/newleaf.json
+++ b/resources/dicts/patrols/mountainous/training/newleaf.json
@@ -569,7 +569,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",

--- a/resources/dicts/patrols/mountainous/training/newleaf.json
+++ b/resources/dicts/patrols/mountainous/training/newleaf.json
@@ -571,7 +571,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"

--- a/resources/dicts/patrols/new_cat_welcoming.json
+++ b/resources/dicts/patrols/new_cat_welcoming.json
@@ -1346,7 +1346,7 @@
                 "text": "s_c takes the lead in checking the noise and finds that the bush is hiding a loner and {PRONOUN/n_c:0/poss} litter! The kits are freshly born, new to the world, and s_c is quick to sit and talk quietly with the new parent. After some coaxing, s_c convinces {PRONOUN/n_c:0/object} to come stay with the Clan for a while, maybe even to join permanently.",
                 "exp": 10,
                 "weight": 20,
-                "stat_trait": ["compassionate", "empathetic", "loving", "calm"],
+                "stat_trait": ["compassionate", "loving", "calm"],
                 "new_cat": [
                     ["age:has_kits", "loner", "can_birth"],
                     ["litter", "parent:0", "status:newborn", "backstory:outsider_roots2"]

--- a/resources/dicts/patrols/other_clan.json
+++ b/resources/dicts/patrols/other_clan.json
@@ -533,7 +533,7 @@
                 "text": "The patrol follows the scent and finds a wounded o_c_n warrior. It seems the cat had been caught by a dog and chased into c_n territory. The dog is gone now, but the warrior can't make it back across the border on their own. s_c insists that the patrol at least escort the wounded warrior to the border.",
                 "exp": 10,
                 "weight": 20,
-                "stat_trait": ["altruistic", "compassionate", "empathetic", "calm"],
+                "stat_trait": ["altruistic", "compassionate", "calm"],
                 "other_clan_rep": 2
             }
         ],
@@ -632,7 +632,7 @@
                 "text": "s_c follows the scent and finds a wounded o_c_n warrior. It seems the cat had been caught by a dog and chased into c_n territory. The dog is gone now, but the warrior can't make it back across the border on their own. s_c insists on helping the warrior back to the border.",
                 "exp": 10,
                 "weight": 20,
-                "stat_trait": ["altruistic", "compassionate", "empathetic", "calm"],
+                "stat_trait": ["altruistic", "compassionate", "calm"],
                 "other_clan_rep": 2
             }
         ],
@@ -741,7 +741,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -833,7 +832,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -941,7 +939,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -1049,7 +1046,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -1125,7 +1121,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -1199,7 +1194,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -1277,7 +1271,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -1369,7 +1362,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -1461,7 +1453,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -1523,7 +1514,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -1586,7 +1576,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -1679,7 +1668,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -1787,7 +1775,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -1895,7 +1882,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -1971,7 +1957,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -2047,7 +2032,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -2145,7 +2129,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -2237,7 +2220,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -2329,7 +2311,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -2391,7 +2372,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -2450,7 +2430,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -2542,7 +2521,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -2650,7 +2628,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -2758,7 +2735,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -2834,7 +2810,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",

--- a/resources/dicts/patrols/other_clan.json
+++ b/resources/dicts/patrols/other_clan.json
@@ -200,7 +200,6 @@
                 "stat_trait": [
                     "careful",
                     "calm",
-                    "patient",
                     "wise",
                     "sneaky",
                     "responsible"
@@ -743,7 +742,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -834,7 +832,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -941,7 +938,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1048,7 +1044,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1123,7 +1118,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1196,7 +1190,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1273,7 +1266,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1364,7 +1356,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1455,7 +1446,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1516,7 +1506,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1578,7 +1567,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1670,7 +1658,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1777,7 +1764,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1884,7 +1870,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1959,7 +1944,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -2034,7 +2018,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -2131,7 +2114,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -2222,7 +2204,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -2313,7 +2294,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -2374,7 +2354,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -2432,7 +2411,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -2523,7 +2501,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -2630,7 +2607,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -2737,7 +2713,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -2812,7 +2787,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"

--- a/resources/dicts/patrols/other_clan.json
+++ b/resources/dicts/patrols/other_clan.json
@@ -39,7 +39,7 @@
                 "text": "Once the patrols cross paths, s_c is quick to break the awkward atmosphere with a friendly greeting and easy conversation. The two patrols eventually return to their tasks, feeling confident in their good relations with the opposite Clan.",
                 "exp": 10,
                 "weight": 20,
-                "stat_trait": ["altruistic", "calm", "charismatic", "confident", "wise"],
+                "stat_trait": ["calm", "charismatic", "confident", "wise"],
                 "other_clan_rep": 2
             }
         ],
@@ -303,7 +303,7 @@
                 "text": "Once the patrols cross paths, s_c is quick to break the awkward atmosphere with a friendly greeting and easy conversation. The two patrols eventually return to their tasks, feeling confident in their good relations with the opposite Clan.",
                 "exp": 10,
                 "weight": 20,
-                "stat_trait": ["altruistic", "calm", "charismatic", "confident", "wise"],
+                "stat_trait": ["calm", "charismatic", "confident", "wise"],
                 "other_clan_rep": 2
             }
         ],
@@ -532,7 +532,7 @@
                 "text": "The patrol follows the scent and finds a wounded o_c_n warrior. It seems the cat had been caught by a dog and chased into c_n territory. The dog is gone now, but the warrior can't make it back across the border on their own. s_c insists that the patrol at least escort the wounded warrior to the border.",
                 "exp": 10,
                 "weight": 20,
-                "stat_trait": ["altruistic", "compassionate", "calm"],
+                "stat_trait": ["compassionate", "calm"],
                 "other_clan_rep": 2
             }
         ],
@@ -631,7 +631,7 @@
                 "text": "s_c follows the scent and finds a wounded o_c_n warrior. It seems the cat had been caught by a dog and chased into c_n territory. The dog is gone now, but the warrior can't make it back across the border on their own. s_c insists on helping the warrior back to the border.",
                 "exp": 10,
                 "weight": 20,
-                "stat_trait": ["altruistic", "compassionate", "calm"],
+                "stat_trait": ["compassionate", "calm"],
                 "other_clan_rep": 2
             }
         ],

--- a/resources/dicts/patrols/other_clan_allies.json
+++ b/resources/dicts/patrols/other_clan_allies.json
@@ -117,8 +117,7 @@
                     "bold",
                     "righteous",
                     "bloodthirsty",
-                    "compassionate",
-                    "empathetic"
+                    "compassionate"
                 ],
                 "other_clan_rep": 2
             }
@@ -335,7 +334,7 @@
                 "text": "The patrol follows the scent and finds a wounded o_c_n warrior. It seems the cat had been caught by a dog and chased into c_n territory. The dog is gone now, but the warrior can't make it back across the border on their own. s_c insists that the patrol escort the warrior back to the o_c_n camp and the o_c_n leader is grateful for the service.",
                 "exp": 10,
                 "weight": 20,
-                "stat_trait": ["altruistic", "compassionate", "empathetic", "calm"],
+                "stat_trait": ["altruistic", "compassionate", "calm"],
                 "other_clan_rep": 2
             }
         ],
@@ -432,7 +431,7 @@
                 "text": "p_l follows the scent and finds a wounded o_c_n warrior. It seems the cat had been caught by a dog and chased into c_n territory.  The dog is gone now, but the warrior can't make it back across the border on their own. s_c insists on escorting the warrior back to the o_c_n camp - the o_c_n leader is grateful for the service.",
                 "exp": 10,
                 "weight": 20,
-                "stat_trait": ["altruistic", "compassionate", "empathetic", "calm"],
+                "stat_trait": ["altruistic", "compassionate", "calm"],
                 "other_clan_rep": 2
             }
         ],
@@ -540,7 +539,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -618,7 +616,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -710,7 +707,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -809,7 +805,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -877,7 +872,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -952,7 +946,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -1030,7 +1023,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -1122,7 +1114,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -1221,7 +1212,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -1289,7 +1279,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -1364,7 +1353,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -1442,7 +1430,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -1534,7 +1521,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -1633,7 +1619,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -1701,7 +1686,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -1776,7 +1760,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -1854,7 +1837,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -1946,7 +1928,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -2045,7 +2026,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -2113,7 +2093,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",

--- a/resources/dicts/patrols/other_clan_allies.json
+++ b/resources/dicts/patrols/other_clan_allies.json
@@ -37,7 +37,7 @@
                 "text": "s_c excitedly trots up to the other patrol, greeting them pleasantly. They seem to be on good terms with the other cats on this patrol and strike up conversation about specific happenings in their Clan, asking if so-and-so had kits or if a certain apprentice had been made a warrior yet.",
                 "exp": 10,
                 "weight": 20,
-                "stat_trait": ["charismatic", "altruistic", "thoughtful", "wise", "confident"],
+                "stat_trait": ["charismatic", "thoughtful", "wise", "confident"],
                 "other_clan_rep": 2
             }
         ],
@@ -333,7 +333,7 @@
                 "text": "The patrol follows the scent and finds a wounded o_c_n warrior. It seems the cat had been caught by a dog and chased into c_n territory. The dog is gone now, but the warrior can't make it back across the border on their own. s_c insists that the patrol escort the warrior back to the o_c_n camp and the o_c_n leader is grateful for the service.",
                 "exp": 10,
                 "weight": 20,
-                "stat_trait": ["altruistic", "compassionate", "calm"],
+                "stat_trait": ["compassionate", "calm"],
                 "other_clan_rep": 2
             }
         ],
@@ -430,7 +430,7 @@
                 "text": "p_l follows the scent and finds a wounded o_c_n warrior. It seems the cat had been caught by a dog and chased into c_n territory.  The dog is gone now, but the warrior can't make it back across the border on their own. s_c insists on escorting the warrior back to the o_c_n camp - the o_c_n leader is grateful for the service.",
                 "exp": 10,
                 "weight": 20,
-                "stat_trait": ["altruistic", "compassionate", "calm"],
+                "stat_trait": ["compassionate", "calm"],
                 "other_clan_rep": 2
             }
         ],

--- a/resources/dicts/patrols/other_clan_allies.json
+++ b/resources/dicts/patrols/other_clan_allies.json
@@ -195,7 +195,6 @@
                 "stat_trait": [
                     "careful",
                     "calm",
-                    "patient",
                     "wise",
                     "sneaky",
                     "responsible"
@@ -541,7 +540,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -618,7 +616,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -709,7 +706,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -807,7 +803,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -874,7 +869,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -948,7 +942,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1025,7 +1018,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1116,7 +1108,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1214,7 +1205,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1281,7 +1271,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1355,7 +1344,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1432,7 +1420,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1523,7 +1510,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1621,7 +1607,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1688,7 +1673,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1762,7 +1746,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1839,7 +1822,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1930,7 +1912,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -2028,7 +2009,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -2095,7 +2075,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"

--- a/resources/dicts/patrols/other_clan_hostile.json
+++ b/resources/dicts/patrols/other_clan_hostile.json
@@ -437,7 +437,7 @@
                 "text": "The patrol follows the scent and finds a wounded o_c_n warrior. It seems the cat had been caught by a dog and chased into c_n territory. The dog is gone now, but the warrior can't make it back across the border on their own. s_c is hesitant, but insists that the patrol at least escort the wounded warrior to the border.",
                 "exp": 10,
                 "weight": 20,
-                "stat_trait": ["altruistic", "compassionate", "empathetic", "calm"],
+                "stat_trait": ["altruistic", "compassionate", "calm"],
                 "other_clan_rep": 2
             }
         ],
@@ -536,7 +536,7 @@
                 "text": "s_c follows the scent and finds a wounded o_c_n warrior. It seems the cat had been caught by a dog and chased into c_n territory. The dog is gone now, but the warrior can't make it back across the border on their own. s_c is hesitant, but insists that {PRONOUN/s_c/subject} at least escort the wounded warrior to the border.",
                 "exp": 10,
                 "weight": 20,
-                "stat_trait": ["altruistic", "compassionate", "empathetic", "calm"],
+                "stat_trait": ["altruistic", "compassionate", "calm"],
                 "other_clan_rep": 2
             }
         ],
@@ -644,7 +644,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -790,7 +789,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -948,7 +946,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -1112,7 +1109,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -1242,7 +1238,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -1379,7 +1374,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -1525,7 +1519,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -1683,7 +1676,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -1848,7 +1840,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -1977,7 +1968,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -2114,7 +2104,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -2260,7 +2249,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -2418,7 +2406,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -2583,7 +2570,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -2713,7 +2699,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -2850,7 +2835,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -2996,7 +2980,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -3154,7 +3137,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -3319,7 +3301,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -3449,7 +3430,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",

--- a/resources/dicts/patrols/other_clan_hostile.json
+++ b/resources/dicts/patrols/other_clan_hostile.json
@@ -31,7 +31,7 @@
                 "text": "s_c is quick to strike up conversation with the other patrol, trying to get to the root of their rudeness. Eventually the problem is smoothed over, nothing but a misunderstanding and unfounded assumptions.",
                 "exp": 10,
                 "weight": 20,
-                "stat_trait": ["charismatic", "altruistic", "thoughtful", "wise", "confident"],
+                "stat_trait": ["charismatic", "thoughtful", "wise", "confident"],
                 "other_clan_rep": 2
             }
         ],
@@ -436,7 +436,7 @@
                 "text": "The patrol follows the scent and finds a wounded o_c_n warrior. It seems the cat had been caught by a dog and chased into c_n territory. The dog is gone now, but the warrior can't make it back across the border on their own. s_c is hesitant, but insists that the patrol at least escort the wounded warrior to the border.",
                 "exp": 10,
                 "weight": 20,
-                "stat_trait": ["altruistic", "compassionate", "calm"],
+                "stat_trait": ["compassionate", "calm"],
                 "other_clan_rep": 2
             }
         ],
@@ -535,7 +535,7 @@
                 "text": "s_c follows the scent and finds a wounded o_c_n warrior. It seems the cat had been caught by a dog and chased into c_n territory. The dog is gone now, but the warrior can't make it back across the border on their own. s_c is hesitant, but insists that {PRONOUN/s_c/subject} at least escort the wounded warrior to the border.",
                 "exp": 10,
                 "weight": 20,
-                "stat_trait": ["altruistic", "compassionate", "calm"],
+                "stat_trait": ["compassionate", "calm"],
                 "other_clan_rep": 2
             }
         ],

--- a/resources/dicts/patrols/other_clan_hostile.json
+++ b/resources/dicts/patrols/other_clan_hostile.json
@@ -262,7 +262,6 @@
                 "stat_trait": [
                     "careful",
                     "calm",
-                    "patient",
                     "wise",
                     "sneaky",
                     "responsible"
@@ -646,7 +645,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -791,7 +789,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -948,7 +945,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1111,7 +1107,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1240,7 +1235,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1376,7 +1370,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1521,7 +1514,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1678,7 +1670,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1842,7 +1833,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1970,7 +1960,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -2106,7 +2095,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -2251,7 +2239,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -2408,7 +2395,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -2572,7 +2558,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -2701,7 +2686,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -2837,7 +2821,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -2982,7 +2965,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -3139,7 +3121,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -3303,7 +3284,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -3432,7 +3412,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"

--- a/resources/dicts/patrols/plains/border/any.json
+++ b/resources/dicts/patrols/plains/border/any.json
@@ -92,7 +92,7 @@
                 "text": "s_c rushes into the tunnels with a gleeful meow! A new place to explore and discover! {PRONOUN/s_c/subject/CAP}{VERB/s_c/'re/'s} brought up short when the tunnel abruptly ends. It seems this tunnel leads to a dead end only a few fox-lengths from the entrance.",
                 "exp": 0,
                 "weight": 20,
-                "stat_trait": ["childish", "impulsive", "playful", "adventurous"],
+                "stat_trait": ["childish", "playful", "adventurous"],
                 "relationships": [
                     {
                         "cats_to": ["patrol"],
@@ -199,7 +199,7 @@
                 "text": "s_c rushes into the tunnels with a gleeful meow! A new place to explore and discover! {PRONOUN/s_c/subject/CAP}{VERB/s_c/'re/'s} brought up short when the tunnel abruptly ends. It seems this tunnel leads to nothing but a dead end only a few fox-lengths from the entrance.",
                 "exp": 0,
                 "weight": 20,
-                "stat_trait": ["childish", "impulsive", "playful", "adventurous"]
+                "stat_trait": ["childish", "playful", "adventurous"]
             },
             {
                 "text": "It seems this hole is home to a cranky wolverine, a fact that the patrol learns very quickly when r_c is snagged by the jaws of the predator. r_c won't make it back to camp...",

--- a/resources/dicts/patrols/plains/border/any.json
+++ b/resources/dicts/patrols/plains/border/any.json
@@ -448,7 +448,7 @@
                 "text": "s_c takes the lead, confronting the gang with confidence. Eventually the rogues admit that they've been struggling to find enough prey and were looking to steal richer territory from the Clan. Tensions are eased when s_c informs the rogues of a prey-rich forest outside of c_n territory.",
                 "exp": 30,
                 "weight": 20,
-                "stat_trait": ["bold", "confident", "charming"],
+                "stat_trait": ["bold", "confident"],
                 "relationships": [
                     {
                         "cats_to": ["patrol"],

--- a/resources/dicts/patrols/plains/border/any.json
+++ b/resources/dicts/patrols/plains/border/any.json
@@ -1552,7 +1552,6 @@
                     "charismatic",
                     "childish",
                     "playful",
-                    "empathetic",
                     "loving",
                     "patient"
                 ],

--- a/resources/dicts/patrols/plains/border/any.json
+++ b/resources/dicts/patrols/plains/border/any.json
@@ -61,7 +61,7 @@
                 "text": "s_c stops the patrol before they can move to enter the tunnels. After a careful inspection of the entrance, s_c concludes that a wolverine has claimed this as its home. The predator seems to be away for the moment but could return soon. The patrol quickly moves on.",
                 "exp": 20,
                 "weight": 20,
-                "stat_trait": ["careful", "wise", "patient", "responsible"],
+                "stat_trait": ["careful", "wise", "responsible"],
                 "relationships": [
                     {
                         "cats_to": ["patrol"],
@@ -186,7 +186,7 @@
                 "text": "s_c pauses before entering the tunnels. After a careful inspection of the entrance, s_c concludes that a wolverine has claimed this as its home. The predator seems to be away for the moment but could return soon. The patrol quickly moves on.",
                 "exp": 20,
                 "weight": 20,
-                "stat_trait": ["careful", "wise", "patient", "responsible"]
+                "stat_trait": ["careful", "wise", "responsible"]
             }
         ],
         "fail_outcomes": [
@@ -1552,8 +1552,7 @@
                     "charismatic",
                     "childish",
                     "playful",
-                    "loving",
-                    "patient"
+                    "loving"
                 ],
                 "relationships": [
                     {

--- a/resources/dicts/patrols/plains/hunting/any.json
+++ b/resources/dicts/patrols/plains/hunting/any.json
@@ -448,7 +448,6 @@
                     "nervous",
                     "sneaky",
                     "strange",
-                    "patient",
                     "thoughtful",
                     "wise"
                 ],
@@ -542,7 +541,6 @@
                     "nervous",
                     "sneaky",
                     "strange",
-                    "patient",
                     "thoughtful",
                     "wise"
                 ],
@@ -612,7 +610,6 @@
                     "nervous",
                     "sneaky",
                     "strange",
-                    "patient",
                     "thoughtful",
                     "wise"
                 ],
@@ -682,7 +679,6 @@
                     "nervous",
                     "sneaky",
                     "strange",
-                    "patient",
                     "thoughtful",
                     "wise"
                 ],
@@ -970,7 +966,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1043,7 +1038,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1118,7 +1112,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1187,7 +1180,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1270,7 +1262,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1395,7 +1386,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1525,7 +1515,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1726,7 +1715,6 @@
                     "nervous",
                     "sneaky",
                     "strange",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1816,7 +1804,6 @@
                     "nervous",
                     "sneaky",
                     "strange",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1905,7 +1892,6 @@
                     "nervous",
                     "sneaky",
                     "strange",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1989,7 +1975,6 @@
                     "nervous",
                     "sneaky",
                     "strange",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -2260,7 +2245,6 @@
                 "exp": 25,
                 "weight": 20,
                 "stat_trait": [
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise",

--- a/resources/dicts/patrols/plains/hunting/any.json
+++ b/resources/dicts/patrols/plains/hunting/any.json
@@ -229,7 +229,7 @@
                 "text": "s_c sticks {PRONOUN/s_c/poss} nose into the hole only to come face-to-face with a skunk! The whole patrol is sprayed!",
                 "exp": 0,
                 "weight": 20,
-                "stat_trait": ["bold", "ambitious", "childish", "impulsive"],
+                "stat_trait": ["bold", "ambitious", "childish"],
                 "prey": ["very_small"]
             },
             {
@@ -288,7 +288,7 @@
                 "text": "s_c sticks {PRONOUN/s_c/poss} nose into the hole only to come face-to-face with a skunk! The whole patrol is sprayed!",
                 "exp": 0,
                 "weight": 20,
-                "stat_trait": ["bold", "ambitious", "childish", "impulsive"]
+                "stat_trait": ["bold", "ambitious", "childish"]
             },
             {
                 "text": "Oh no! The burrow was home to a wolverine, now angry at the disturbance. r_c bolts away to escape its wrath, but doesn't quite move fast enough and is caught in its claws. With no other cats around to help, {PRONOUN/r_c/subject} is quickly killed by the predator.",
@@ -448,6 +448,7 @@
                     "nervous",
                     "sneaky",
                     "strange",
+                    "patient",
                     "thoughtful",
                     "wise"
                 ],
@@ -541,6 +542,7 @@
                     "nervous",
                     "sneaky",
                     "strange",
+                    "patient",
                     "thoughtful",
                     "wise"
                 ],
@@ -610,6 +612,7 @@
                     "nervous",
                     "sneaky",
                     "strange",
+                    "patient",
                     "thoughtful",
                     "wise"
                 ],
@@ -679,6 +682,7 @@
                     "nervous",
                     "sneaky",
                     "strange",
+                    "patient",
                     "thoughtful",
                     "wise"
                 ],
@@ -966,6 +970,7 @@
                     "compassionate",
                     "faithful",
                     "loving",
+                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1038,6 +1043,7 @@
                     "compassionate",
                     "faithful",
                     "loving",
+                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1112,6 +1118,7 @@
                     "compassionate",
                     "faithful",
                     "loving",
+                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1180,6 +1187,7 @@
                     "compassionate",
                     "faithful",
                     "loving",
+                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1262,6 +1270,7 @@
                     "compassionate",
                     "faithful",
                     "loving",
+                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1386,6 +1395,7 @@
                     "compassionate",
                     "faithful",
                     "loving",
+                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1515,6 +1525,7 @@
                     "compassionate",
                     "faithful",
                     "loving",
+                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1715,6 +1726,7 @@
                     "nervous",
                     "sneaky",
                     "strange",
+                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1804,6 +1816,7 @@
                     "nervous",
                     "sneaky",
                     "strange",
+                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1892,6 +1905,7 @@
                     "nervous",
                     "sneaky",
                     "strange",
+                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1975,6 +1989,7 @@
                     "nervous",
                     "sneaky",
                     "strange",
+                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -2245,6 +2260,7 @@
                 "exp": 25,
                 "weight": 20,
                 "stat_trait": [
+                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise",

--- a/resources/dicts/patrols/plains/hunting/any.json
+++ b/resources/dicts/patrols/plains/hunting/any.json
@@ -968,7 +968,6 @@
                 "weight": 10,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -1042,7 +1041,6 @@
                 "weight": 10,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -1118,7 +1116,6 @@
                 "weight": 10,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -1188,7 +1185,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -1272,7 +1268,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -1398,7 +1393,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -1529,7 +1523,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",

--- a/resources/dicts/patrols/plains/hunting/greenleaf.json
+++ b/resources/dicts/patrols/plains/hunting/greenleaf.json
@@ -1287,7 +1287,6 @@
                 "exp": 20,
                 "weight": 20,
                 "stat_trait": [
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise",
@@ -1383,7 +1382,6 @@
                 "exp": 10,
                 "weight": 20,
                 "stat_trait": [
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise",

--- a/resources/dicts/patrols/plains/hunting/leaf-bare.json
+++ b/resources/dicts/patrols/plains/hunting/leaf-bare.json
@@ -745,7 +745,6 @@
                 "exp": 20,
                 "weight": 20,
                 "stat_trait": [
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise",
@@ -841,7 +840,6 @@
                 "exp": 10,
                 "weight": 20,
                 "stat_trait": [
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise",

--- a/resources/dicts/patrols/plains/hunting/leaf-bare.json
+++ b/resources/dicts/patrols/plains/hunting/leaf-bare.json
@@ -49,7 +49,7 @@
                 "text": "s_c really keeps the patrol on task and motivated through the sharp cold of the leaf-bare morning, not through authority or commands, but with a gentle voice and compassionate understanding that encourages every cat to do their best for c_n.",
                 "exp": 10,
                 "weight": 20,
-                "stat_trait": ["altruistic", "compassionate", "empathetic", "faithful", "loving"],
+                "stat_trait": ["altruistic", "compassionate", "faithful", "loving"],
                 "prey": ["medium"],
                 "relationships": [
                     {
@@ -196,7 +196,7 @@
                 "text": "A storm descends, sudden and violent, putting an end to any other thoughts but survival. As the cats hide from the wind in a stream gully, s_c keeps an eye out for everyone. It's a long couple of hours, but with gentle understanding and compassion the cats make it through safely, closer than ever afterwards.",
                 "exp": 10,
                 "weight": 20,
-                "stat_trait": ["altruistic", "compassionate", "empathetic", "faithful", "loving"],
+                "stat_trait": ["altruistic", "compassionate", "faithful", "loving"],
                 "relationships": [
                     {
                         "cats_to": ["p_l"],

--- a/resources/dicts/patrols/plains/hunting/leaf-bare.json
+++ b/resources/dicts/patrols/plains/hunting/leaf-bare.json
@@ -49,7 +49,7 @@
                 "text": "s_c really keeps the patrol on task and motivated through the sharp cold of the leaf-bare morning, not through authority or commands, but with a gentle voice and compassionate understanding that encourages every cat to do their best for c_n.",
                 "exp": 10,
                 "weight": 20,
-                "stat_trait": ["altruistic", "compassionate", "faithful", "loving"],
+                "stat_trait": ["compassionate", "faithful", "loving"],
                 "prey": ["medium"],
                 "relationships": [
                     {
@@ -196,7 +196,7 @@
                 "text": "A storm descends, sudden and violent, putting an end to any other thoughts but survival. As the cats hide from the wind in a stream gully, s_c keeps an eye out for everyone. It's a long couple of hours, but with gentle understanding and compassion the cats make it through safely, closer than ever afterwards.",
                 "exp": 10,
                 "weight": 20,
-                "stat_trait": ["altruistic", "compassionate", "faithful", "loving"],
+                "stat_trait": ["compassionate", "faithful", "loving"],
                 "relationships": [
                     {
                         "cats_to": ["p_l"],

--- a/resources/dicts/patrols/plains/hunting/leaf-fall.json
+++ b/resources/dicts/patrols/plains/hunting/leaf-fall.json
@@ -1178,7 +1178,6 @@
                 "exp": 20,
                 "weight": 20,
                 "stat_trait": [
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise",
@@ -1274,7 +1273,6 @@
                 "exp": 10,
                 "weight": 20,
                 "stat_trait": [
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise",

--- a/resources/dicts/patrols/plains/hunting/newleaf.json
+++ b/resources/dicts/patrols/plains/hunting/newleaf.json
@@ -1133,7 +1133,6 @@
                 "exp": 20,
                 "weight": 20,
                 "stat_trait": [
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise",
@@ -1229,7 +1228,6 @@
                 "exp": 10,
                 "weight": 20,
                 "stat_trait": [
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise",

--- a/resources/dicts/patrols/plains/med/greenleaf.json
+++ b/resources/dicts/patrols/plains/med/greenleaf.json
@@ -2943,7 +2943,7 @@
                 "text": "Night falls, and still s_c insists they keep going. Lungwort is the only reliable cure for yellowcough, and they just can't let c_n go without. Exhausted, but determined, the medicine cats persist patiently until they finally find the precious, speckled leaves.",
                 "exp": 20,
                 "weight": 20,
-                "stat_trait": ["patient"],
+                "stat_trait": ["thoughtful", "confident", "loyal", "responsible", "arrogant"],
                 "can_have_stat": ["adult"],
                 "herbs": ["lungwort"],
                 "relationships": [
@@ -3056,7 +3056,7 @@
                 "text": "Night falls, but still s_c keeps going - {PRONOUN/s_c/subject} just can't let c_n go without. Exhausted, but determined, the medicine cat persists until {PRONOUN/s_c/subject} {VERB/s_c/find/finds} the precious, speckled leaves.",
                 "exp": 20,
                 "weight": 20,
-                "stat_trait": ["patient"],
+                "stat_trait": ["thoughtful", "confident", "loyal", "responsible", "arrogant"],
                 "herbs": ["lungwort"],
                 "relationships": [
                     {
@@ -3163,7 +3163,7 @@
                 "text": "Night falls, but still s_c keeps going - {PRONOUN/s_c/subject} just can't let c_n go without. Exhausted, but determined, the medicine cat persists until {PRONOUN/s_c/subject} {VERB/s_c/find/finds} the precious, speckled leaves.",
                 "exp": 20,
                 "weight": 20,
-                "stat_trait": ["patient"],
+                "stat_trait": ["thoughtful", "confident", "loyal", "responsible", "arrogant"],
                 "can_have_stat": ["r_c"],
                 "herbs": ["lungwort"],
                 "relationships": [

--- a/resources/dicts/patrols/plains/med/leaf-fall.json
+++ b/resources/dicts/patrols/plains/med/leaf-fall.json
@@ -2763,7 +2763,7 @@
                 "text": "Night falls, and still s_c insists they keep going. Lungwort is the only reliable cure for yellowcough, and they just can't let c_n go without. Exhausted, but determined, the medicine cats persist patiently until they finally find the precious, speckled leaves.",
                 "exp": 20,
                 "weight": 20,
-                "stat_trait": ["patient"],
+                "stat_trait": ["thoughtful", "confident", "loyal", "responsible", "arrogant"],
                 "can_have_stat": ["adult"],
                 "herbs": ["lungwort"],
                 "relationships": [
@@ -2876,7 +2876,7 @@
                 "text": "Night falls, but still s_c keeps going - {PRONOUN/s_c/subject} just can't let c_n go without. Exhausted, but determined, the medicine cat persists until {PRONOUN/s_c/subject} {VERB/s_c/find/finds} the precious, speckled leaves.",
                 "exp": 20,
                 "weight": 20,
-                "stat_trait": ["patient"],
+                "stat_trait": ["thoughtful", "confident", "loyal", "responsible", "arrogant"],
                 "herbs": ["lungwort"],
                 "relationships": [
                     {
@@ -2982,7 +2982,7 @@
                 "text": "Night falls, but still s_c keeps going - {PRONOUN/s_c/subject} just can't let c_n go without. Exhausted, but determined, the medicine cat persists until {PRONOUN/s_c/subject} {VERB/s_c/find/finds} the precious, speckled leaves.",
                 "exp": 20,
                 "weight": 20,
-                "stat_trait": ["patient"],
+                "stat_trait": ["thoughtful", "confident", "loyal", "responsible", "arrogant"],
                 "can_have_stat": ["r_c"],
                 "herbs": ["lungwort"],
                 "relationships": [

--- a/resources/dicts/patrols/plains/med/newleaf.json
+++ b/resources/dicts/patrols/plains/med/newleaf.json
@@ -1886,7 +1886,7 @@
                 "text": "Night falls, and still s_c insists they keep going. Lungwort is the only reliable cure for yellowcough, and they just can't let c_n go without. Exhausted, but determined, the medicine cats persist patiently until they finally find the precious, speckled leaves.",
                 "exp": 20,
                 "weight": 20,
-                "stat_trait": ["patient"],
+                "stat_trait": ["thoughtful", "confident", "loyal", "responsible", "arrogant"],
                 "herbs": ["lungwort"],
                 "relationships": [
                     {
@@ -1999,7 +1999,7 @@
                 "text": "Night falls, and still s_c insists on continuing - {PRONOUN/s_c/subject} just can't let c_n go without. Exhausted, but determined, the medicine cat persists patiently until {PRONOUN/s_c/subject} {VERB/s_c/find/finds} the precious, speckled leaves.",
                 "exp": 20,
                 "weight": 20,
-                "stat_trait": ["patient"],
+                "stat_trait": ["thoughtful", "confident", "loyal", "responsible", "arrogant"],
                 "herbs": ["lungwort"],
                 "relationships": [
                     {
@@ -2106,7 +2106,7 @@
                 "text": "Night falls, but still s_c continues - {PRONOUN/s_c/subject} just can't let c_n go without. Exhausted, but determined, the medicine cat persists until {PRONOUN/s_c/subject} {VERB/s_c/find/finds} the precious, speckled leaves.",
                 "exp": 20,
                 "weight": 20,
-                "stat_trait": ["patient"],
+                "stat_trait": ["thoughtful", "confident", "loyal", "responsible", "arrogant"],
                 "can_have_stat": ["r_c"],
                 "herbs": ["lungwort"],
                 "relationships": [

--- a/resources/dicts/patrols/plains/training/any.json
+++ b/resources/dicts/patrols/plains/training/any.json
@@ -180,7 +180,6 @@
                 "exp": 30,
                 "weight": 20,
                 "stat_trait": [
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise",
@@ -341,7 +340,6 @@
                 "exp": 30,
                 "weight": 20,
                 "stat_trait": [
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise",
@@ -482,7 +480,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -740,7 +737,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -909,7 +905,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"

--- a/resources/dicts/patrols/wetlands/border/any.json
+++ b/resources/dicts/patrols/wetlands/border/any.json
@@ -43,7 +43,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -120,7 +119,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -208,7 +206,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -296,7 +293,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -357,7 +353,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -418,7 +413,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -495,7 +489,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -572,7 +565,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -649,7 +641,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -716,7 +707,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -784,7 +774,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -882,7 +871,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -991,7 +979,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1100,7 +1087,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1172,7 +1158,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -2268,8 +2253,7 @@
                     "charismatic",
                     "childish",
                     "playful",
-                    "loving",
-                    "patient"
+                    "loving"
                 ],
                 "relationships": [
                     {

--- a/resources/dicts/patrols/wetlands/border/any.json
+++ b/resources/dicts/patrols/wetlands/border/any.json
@@ -41,7 +41,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -119,7 +118,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -208,7 +206,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -297,7 +294,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -359,7 +355,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -421,7 +416,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -499,7 +493,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -577,7 +570,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -655,7 +647,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -723,7 +714,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -792,7 +782,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -891,7 +880,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -1001,7 +989,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -1111,7 +1098,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -1184,7 +1170,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -2283,7 +2268,6 @@
                     "charismatic",
                     "childish",
                     "playful",
-                    "empathetic",
                     "loving",
                     "patient"
                 ],

--- a/resources/dicts/patrols/wetlands/hunting/any.json
+++ b/resources/dicts/patrols/wetlands/hunting/any.json
@@ -571,7 +571,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -644,7 +643,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -717,7 +715,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -790,7 +787,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -865,7 +861,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -936,7 +931,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -1062,7 +1056,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -1193,7 +1186,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",

--- a/resources/dicts/patrols/wetlands/hunting/any.json
+++ b/resources/dicts/patrols/wetlands/hunting/any.json
@@ -275,7 +275,6 @@
                     "nervous",
                     "sneaky",
                     "strange",
-                    "patient",
                     "thoughtful",
                     "wise"
                 ],
@@ -354,7 +353,6 @@
                     "nervous",
                     "sneaky",
                     "strange",
-                    "patient",
                     "thoughtful",
                     "wise"
                 ],
@@ -424,7 +422,6 @@
                     "nervous",
                     "sneaky",
                     "strange",
-                    "patient",
                     "thoughtful",
                     "wise"
                 ],
@@ -494,7 +491,6 @@
                     "nervous",
                     "sneaky",
                     "strange",
-                    "patient",
                     "thoughtful",
                     "wise"
                 ],
@@ -573,7 +569,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -645,7 +640,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -717,7 +711,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -789,7 +782,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -863,7 +855,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -933,7 +924,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1058,7 +1048,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1188,7 +1177,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1389,7 +1377,6 @@
                     "nervous",
                     "sneaky",
                     "strange",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1461,7 +1448,6 @@
                     "nervous",
                     "sneaky",
                     "strange",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1533,7 +1519,6 @@
                     "nervous",
                     "sneaky",
                     "strange",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -1599,7 +1584,6 @@
                     "nervous",
                     "sneaky",
                     "strange",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -3114,7 +3098,6 @@
                     "insecure",
                     "loyal",
                     "nervous",
-                    "patient",
                     "responsible",
                     "righteous",
                     "thoughtful",
@@ -3327,7 +3310,6 @@
                     "insecure",
                     "loyal",
                     "nervous",
-                    "patient",
                     "responsible",
                     "righteous",
                     "thoughtful",
@@ -3505,7 +3487,6 @@
                     "insecure",
                     "loyal",
                     "nervous",
-                    "patient",
                     "responsible",
                     "righteous",
                     "thoughtful",
@@ -3698,7 +3679,6 @@
                     "insecure",
                     "loyal",
                     "nervous",
-                    "patient",
                     "responsible",
                     "righteous",
                     "thoughtful",
@@ -3891,7 +3871,6 @@
                     "insecure",
                     "loyal",
                     "nervous",
-                    "patient",
                     "responsible",
                     "righteous",
                     "thoughtful",
@@ -4049,7 +4028,6 @@
                     "insecure",
                     "loyal",
                     "nervous",
-                    "patient",
                     "responsible",
                     "righteous",
                     "thoughtful",
@@ -5064,7 +5042,6 @@
                     "insecure",
                     "loyal",
                     "nervous",
-                    "patient",
                     "responsible",
                     "righteous",
                     "thoughtful",
@@ -5277,7 +5254,6 @@
                     "insecure",
                     "loyal",
                     "nervous",
-                    "patient",
                     "responsible",
                     "righteous",
                     "thoughtful",
@@ -5455,7 +5431,6 @@
                     "insecure",
                     "loyal",
                     "nervous",
-                    "patient",
                     "responsible",
                     "righteous",
                     "thoughtful",
@@ -5644,7 +5619,6 @@
                     "insecure",
                     "loyal",
                     "nervous",
-                    "patient",
                     "responsible",
                     "righteous",
                     "thoughtful",
@@ -5837,7 +5811,6 @@
                     "insecure",
                     "loyal",
                     "nervous",
-                    "patient",
                     "responsible",
                     "righteous",
                     "thoughtful",
@@ -5995,7 +5968,6 @@
                     "insecure",
                     "loyal",
                     "nervous",
-                    "patient",
                     "responsible",
                     "righteous",
                     "thoughtful",

--- a/resources/dicts/patrols/wetlands/hunting/greenleaf.json
+++ b/resources/dicts/patrols/wetlands/hunting/greenleaf.json
@@ -3235,7 +3235,6 @@
                 "exp": 20,
                 "weight": 20,
                 "stat_trait": [
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise",
@@ -3332,7 +3331,6 @@
                 "exp": 10,
                 "weight": 20,
                 "stat_trait": [
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise",
@@ -4447,7 +4445,6 @@
                 "exp": 20,
                 "weight": 20,
                 "stat_trait": [
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise",
@@ -4544,7 +4541,6 @@
                 "exp": 10,
                 "weight": 20,
                 "stat_trait": [
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise",

--- a/resources/dicts/patrols/wetlands/hunting/leaf-bare.json
+++ b/resources/dicts/patrols/wetlands/hunting/leaf-bare.json
@@ -2303,7 +2303,7 @@
                 "text": "s_c really keeps the patrol on task and motivated through the sharp cold of the leaf-bare morning, not through authority or commands, but with a gentle voice and compassionate understanding that encourages every cat to do their best for c_n.",
                 "exp": 10,
                 "weight": 20,
-                "stat_trait": ["altruistic", "compassionate", "faithful", "loving"],
+                "stat_trait": ["compassionate", "faithful", "loving"],
                 "prey": ["medium"],
                 "relationships": [
                     {
@@ -2414,7 +2414,7 @@
                 "text": "A storm descends, sudden and violent, putting an end to any other thoughts but survival. As the cats hide from the wind, s_c keeps an eye out for everyone. It's a long couple of hours, but with gentle understanding and compassion the cats make it through safely, closer than ever afterwards.",
                 "exp": 10,
                 "weight": 20,
-                "stat_trait": ["altruistic", "compassionate", "faithful", "loving"],
+                "stat_trait": ["compassionate", "faithful", "loving"],
                 "relationships": [
                     {
                         "cats_to": ["p_l"],

--- a/resources/dicts/patrols/wetlands/hunting/leaf-bare.json
+++ b/resources/dicts/patrols/wetlands/hunting/leaf-bare.json
@@ -2479,7 +2479,6 @@
                 "exp": 20,
                 "weight": 20,
                 "stat_trait": [
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise",
@@ -2576,7 +2575,6 @@
                 "exp": 10,
                 "weight": 20,
                 "stat_trait": [
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise",
@@ -2729,7 +2727,6 @@
                 "exp": 10,
                 "weight": 20,
                 "stat_trait": [
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise",
@@ -2809,7 +2806,6 @@
                 "exp": 10,
                 "weight": 20,
                 "stat_trait": [
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise",
@@ -2882,7 +2878,6 @@
                 "exp": 20,
                 "weight": 20,
                 "stat_trait": [
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise",
@@ -2979,7 +2974,6 @@
                 "exp": 10,
                 "weight": 20,
                 "stat_trait": [
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise",
@@ -3132,7 +3126,6 @@
                 "exp": 10,
                 "weight": 20,
                 "stat_trait": [
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise",
@@ -3212,7 +3205,6 @@
                 "exp": 10,
                 "weight": 20,
                 "stat_trait": [
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise",

--- a/resources/dicts/patrols/wetlands/hunting/leaf-bare.json
+++ b/resources/dicts/patrols/wetlands/hunting/leaf-bare.json
@@ -2303,7 +2303,7 @@
                 "text": "s_c really keeps the patrol on task and motivated through the sharp cold of the leaf-bare morning, not through authority or commands, but with a gentle voice and compassionate understanding that encourages every cat to do their best for c_n.",
                 "exp": 10,
                 "weight": 20,
-                "stat_trait": ["altruistic", "compassionate", "empathetic", "faithful", "loving"],
+                "stat_trait": ["altruistic", "compassionate", "faithful", "loving"],
                 "prey": ["medium"],
                 "relationships": [
                     {
@@ -2414,7 +2414,7 @@
                 "text": "A storm descends, sudden and violent, putting an end to any other thoughts but survival. As the cats hide from the wind, s_c keeps an eye out for everyone. It's a long couple of hours, but with gentle understanding and compassion the cats make it through safely, closer than ever afterwards.",
                 "exp": 10,
                 "weight": 20,
-                "stat_trait": ["altruistic", "compassionate", "empathetic", "faithful", "loving"],
+                "stat_trait": ["altruistic", "compassionate", "faithful", "loving"],
                 "relationships": [
                     {
                         "cats_to": ["p_l"],

--- a/resources/dicts/patrols/wetlands/hunting/leaf-fall.json
+++ b/resources/dicts/patrols/wetlands/hunting/leaf-fall.json
@@ -3226,7 +3226,6 @@
                 "exp": 20,
                 "weight": 20,
                 "stat_trait": [
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise",
@@ -3323,7 +3322,6 @@
                 "exp": 10,
                 "weight": 20,
                 "stat_trait": [
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise",
@@ -4429,7 +4427,6 @@
                 "exp": 20,
                 "weight": 20,
                 "stat_trait": [
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise",
@@ -4526,7 +4523,6 @@
                 "exp": 10,
                 "weight": 20,
                 "stat_trait": [
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise",

--- a/resources/dicts/patrols/wetlands/hunting/newleaf.json
+++ b/resources/dicts/patrols/wetlands/hunting/newleaf.json
@@ -3235,7 +3235,6 @@
                 "exp": 20,
                 "weight": 20,
                 "stat_trait": [
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise",
@@ -3331,7 +3330,6 @@
                 "exp": 10,
                 "weight": 20,
                 "stat_trait": [
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise",
@@ -4446,7 +4444,6 @@
                 "exp": 20,
                 "weight": 20,
                 "stat_trait": [
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise",
@@ -4542,7 +4539,6 @@
                 "exp": 10,
                 "weight": 20,
                 "stat_trait": [
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise",

--- a/resources/dicts/patrols/wetlands/med/any.json
+++ b/resources/dicts/patrols/wetlands/med/any.json
@@ -416,7 +416,6 @@
                 "text": "Even though there should be many herbs they fail to find anything. p_l blames r_c for distracting them and they get into a huge argument.",
                 "exp": 0,
                 "weight": 20,
-                "stat_trait": ["None"],
                 "relationships": [
                     {
                         "cats_to": ["patrol"],

--- a/resources/dicts/patrols/wetlands/med/greenleaf.json
+++ b/resources/dicts/patrols/wetlands/med/greenleaf.json
@@ -1013,7 +1013,11 @@
                 "exp": 20,
                 "weight": 20,
                 "stat_trait": [
-                    "patient"
+                    "thoughtful",
+                    "confident",
+                    "loyal",
+                    "responsible",
+                    "arrogant"
                 ],
                 "relationships": [
                     {
@@ -1188,7 +1192,11 @@
                 "exp": 20,
                 "weight": 20,
                 "stat_trait": [
-                    "patient"
+                    "thoughtful",
+                    "confident",
+                    "loyal",
+                    "responsible",
+                    "arrogant"
                 ],
                 "relationships": [
                     {
@@ -1360,7 +1368,11 @@
                     "lungwort"
                 ],
                 "stat_trait": [
-                    "patient"
+                    "thoughtful",
+                    "confident",
+                    "loyal",
+                    "responsible",
+                    "arrogant"
                 ],
                 "relationships": [
                     {

--- a/resources/dicts/patrols/wetlands/med/leaf-bare.json
+++ b/resources/dicts/patrols/wetlands/med/leaf-bare.json
@@ -155,7 +155,11 @@
                 "exp": 20,
                 "weight": 20,
                 "stat_trait": [
-                    "patient"
+                    "thoughtful",
+                    "confident",
+                    "loyal",
+                    "responsible",
+                    "arrogant"
                 ],
                 "relationships": [
                     {
@@ -330,7 +334,11 @@
                 "exp": 20,
                 "weight": 20,
                 "stat_trait": [
-                    "patient"
+                    "thoughtful",
+                    "confident",
+                    "loyal",
+                    "responsible",
+                    "arrogant"
                 ],
                 "relationships": [
                     {
@@ -498,7 +506,11 @@
                 "exp": 20,
                 "weight": 20,
                 "stat_trait": [
-                    "patient"
+                    "thoughtful",
+                    "confident",
+                    "loyal",
+                    "responsible",
+                    "arrogant"
                 ],
                 "herbs": [
                     "many_herbs",

--- a/resources/dicts/patrols/wetlands/med/leaf-fall.json
+++ b/resources/dicts/patrols/wetlands/med/leaf-fall.json
@@ -1013,7 +1013,11 @@
                 "exp": 20,
                 "weight": 20,
                 "stat_trait": [
-                    "patient"
+                    "thoughtful",
+                    "confident",
+                    "loyal",
+                    "responsible",
+                    "arrogant"
                 ],
                 "relationships": [
                     {
@@ -1188,7 +1192,11 @@
                 "exp": 20,
                 "weight": 20,
                 "stat_trait": [
-                    "patient"
+                    "thoughtful",
+                    "confident",
+                    "loyal",
+                    "responsible",
+                    "arrogant"
                 ],
                 "relationships": [
                     {
@@ -1360,7 +1368,11 @@
                     "lungwort"
                 ],
                 "stat_trait": [
-                    "patient"
+                    "thoughtful",
+                    "confident",
+                    "loyal",
+                    "responsible",
+                    "arrogant"
                 ],
                 "relationships": [
                     {

--- a/resources/dicts/patrols/wetlands/med/newleaf.json
+++ b/resources/dicts/patrols/wetlands/med/newleaf.json
@@ -1013,7 +1013,11 @@
                 "exp": 20,
                 "weight": 20,
                 "stat_trait": [
-                    "patient"
+                    "thoughtful",
+                    "confident",
+                    "loyal",
+                    "responsible",
+                    "arrogant"
                 ],
                 "relationships": [
                     {
@@ -1188,7 +1192,11 @@
                 "exp": 20,
                 "weight": 20,
                 "stat_trait": [
-                    "patient"
+                    "thoughtful",
+                    "confident",
+                    "loyal",
+                    "responsible",
+                    "arrogant"
                 ],
                 "relationships": [
                     {
@@ -1360,7 +1368,11 @@
                     "lungwort"
                 ],
                 "stat_trait": [
-                    "patient"
+                    "thoughtful",
+                    "confident",
+                    "loyal",
+                    "responsible",
+                    "arrogant"
                 ],
                 "relationships": [
                     {

--- a/resources/dicts/patrols/wetlands/training/any.json
+++ b/resources/dicts/patrols/wetlands/training/any.json
@@ -43,7 +43,7 @@
                 "text": "s_c struggles to take the lesson seriously, and the training session ends early with no real progress made.",
                 "exp": 0,
                 "weight": 20,
-                "stat_trait": ["troublesome", "playful", "noisy"]
+                "stat_trait": ["troublesome", "playful"]
             }
         ]
     },

--- a/resources/dicts/patrols/wetlands/training/any.json
+++ b/resources/dicts/patrols/wetlands/training/any.json
@@ -116,8 +116,7 @@
                     "patient",
                     "responsible",
                     "thoughtful",
-                    "wise",
-                    "inquisitive"
+                    "wise"
                 ],
                 "relationships": [
                     {
@@ -260,8 +259,7 @@
                     "patient",
                     "responsible",
                     "thoughtful",
-                    "wise",
-                    "inquisitive"
+                    "wise"
                 ],
                 "relationships": [
                     {

--- a/resources/dicts/patrols/wetlands/training/any.json
+++ b/resources/dicts/patrols/wetlands/training/any.json
@@ -111,7 +111,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",
@@ -256,7 +255,6 @@
                 "weight": 20,
                 "stat_trait": [
                     "compassionate",
-                    "empathetic",
                     "faithful",
                     "loving",
                     "patient",

--- a/resources/dicts/patrols/wetlands/training/any.json
+++ b/resources/dicts/patrols/wetlands/training/any.json
@@ -30,7 +30,7 @@
                 "text": "By the end of the patrol, s_c is able to hide in the water, {PRONOUN/s_c/poss} movements barely creating ripples.",
                 "exp": 20,
                 "weight": 20,
-                "stat_trait": ["calm", "careful", "sneaky", "quiet", "patient"]
+                "stat_trait": ["calm", "careful", "sneaky", "quiet"]
             }
         ],
         "fail_outcomes": [
@@ -113,7 +113,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"
@@ -256,7 +255,6 @@
                     "compassionate",
                     "faithful",
                     "loving",
-                    "patient",
                     "responsible",
                     "thoughtful",
                     "wise"

--- a/resources/dicts/patrols/wetlands/training/any.json
+++ b/resources/dicts/patrols/wetlands/training/any.json
@@ -30,7 +30,7 @@
                 "text": "By the end of the patrol, s_c is able to hide in the water, {PRONOUN/s_c/poss} movements barely creating ripples.",
                 "exp": 20,
                 "weight": 20,
-                "stat_trait": ["calm", "careful", "sneaky", "quiet"]
+                "stat_trait": ["calm", "careful", "sneaky"]
             }
         ],
         "fail_outcomes": [

--- a/resources/dicts/patrols/wetlands/training/any.json
+++ b/resources/dicts/patrols/wetlands/training/any.json
@@ -155,8 +155,7 @@
                     "shameless",
                     "strict",
                     "troublesome",
-                    "vengeful",
-                    "bossy"
+                    "vengeful"
                 ],
                 "relationships": [
                     {
@@ -297,8 +296,7 @@
                     "shameless",
                     "strict",
                     "troublesome",
-                    "vengeful",
-                    "bossy"
+                    "vengeful"
                 ],
                 "relationships": [
                     {


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->

## About The Pull Request

A while ago, several traits were removed from the game. However, some data related to these traits still exists in the code. 

For patrols, this:
* Removes removed traits from stat_trait outcomes ("empathetic", "inquisitive", "patient", "altruistic")
* Removes "None" stat_trait since it's the same as not having a stat_trait at all
* Removes kit traits from stat_trait outcomes because kits can't go on patrol ("quiet", "noisy", "bossy", "charming", "impulsive")
* Corrects a few stat_trait typos 

## Why This Is Good For ClanGen
Makes it easier to validate against actual issues (like trait name typos) in the future. Also may prevent devs from seeing deleted traits in old patrols and thinking they're still used.
