### PR TITLE
[BUGFIX] Various Patrols Format Fixing

### DIFF
--- a/resources/dicts/patrols/beach/hunting/any.json
+++ b/resources/dicts/patrols/beach/hunting/any.json
@@ -5301,7 +5301,7 @@
         "patrol_id": "bch_hunt_frogman1",
         "biome": ["beach"],
         "season": ["any"],
-        "types": ["hunt"],
+        "types": ["hunting"],
         "tags": ["halloween"],
         "patrol_art": "loveland_frog_INTRO",
         "min_cats": 2,

--- a/resources/dicts/patrols/beach/hunting/any.json
+++ b/resources/dicts/patrols/beach/hunting/any.json
@@ -5034,8 +5034,8 @@
                 "weight": 20,
                 "relationships": [
                     {
-                        "cats_to": "patrol",
-                        "cats_from": "clan",
+                        "cats_to": ["patrol"],
+                        "cats_from": ["clan"],
                         "mutual": false,
                         "values": ["respect"],
                         "amount": -5
@@ -5062,8 +5062,8 @@
                 ],
                 "relationships": [
                     {
-                        "cats_to": "patrol",
-                        "cats_from": "clan",
+                        "cats_to": ["patrol"],
+                        "cats_from": ["clan"],
                         "mutual": false,
                         "values": ["respect"],
                         "amount": -5
@@ -5090,8 +5090,8 @@
                 },
                 "relationships": [
                     {
-                        "cats_to": "patrol",
-                        "cats_from": "clan",
+                        "cats_to": ["patrol"],
+                        "cats_from": ["clan"],
                         "mutual": false,
                         "values": ["respect"],
                         "amount": -5
@@ -5130,8 +5130,8 @@
                 },
                 "relationships": [
                     {
-                        "cats_to": "patrol",
-                        "cats_from": "clan",
+                        "cats_to": ["patrol"],
+                        "cats_from": ["clan"],
                         "mutual": false,
                         "values": ["respect"],
                         "amount": -5

--- a/resources/dicts/patrols/general/border.json
+++ b/resources/dicts/patrols/general/border.json
@@ -2686,7 +2686,7 @@
                 {
                     "cats_from": ["n_c:0", "n_c:1"],
                     "cats_to": ["patrol"],
-                    "mutual": "true",
+                    "mutual": true,
                     "values": ["platonic", "trust", "comfort"],
                     "amount": 10
                 }
@@ -2860,7 +2860,7 @@
                 {
                     "cats_from": ["n_c:0", "n_c:1"],
                     "cats_to": ["patrol"],
-                    "mutual": "true",
+                    "mutual": true,
                     "values": ["platonic", "trust", "comfort"],
                     "amount": 10
                 }

--- a/resources/dicts/patrols/general/border.json
+++ b/resources/dicts/patrols/general/border.json
@@ -1683,10 +1683,12 @@
                 "text": "p_l and r_c had been bickering the entire morning. But when {PRONOUN/p_l/subject} {VERB/p_l/spot/spots} the shadow of a rouge falling on r_c, {PRONOUN/p_l/subject} {VERB/p_l/react/reacts} without thought, leaping forward, claws ripping into the enemy's back and flipping them off r_c with a ferocious snarl. r_c is badly injured, but will live thanks to p_l dragging {PRONOUN/r_c/object} back to camp.",
                 "exp": 10,
                 "weight": 5,
-                "injury": {
-                    "cats": ["r_c"],
-                    "injuries": ["battle_injury", "battle_injury"]
-                },
+                "injury": [
+                    {
+                        "cats": ["r_c"],
+                        "injuries": ["battle_injury", "battle_injury"]
+                    }
+                ],
                 "relationships": [
                     {
                         "cats_to": ["p_l"],
@@ -1740,10 +1742,12 @@
                 "text": "While they are bickering, r_c trips, and p_l snickers, earning r_c's ire.",
                 "exp": 0,
                 "weight": 20,
-                "injury": {
-                    "cats": ["r_c"],
-                    "injuries": ["minor_injury"]
-                },
+                "injury": [
+                    {
+                        "cats": ["r_c"],
+                        "injuries": ["minor_injury"]
+                    }
+                ],
                 "relationships": [
                     {
                         "cats_to": ["p_l"],
@@ -1864,10 +1868,12 @@
                 "text": "p_l and r_c had been arguing the entire morning. But when {PRONOUN/p_l/subject} {VERB/p_l/spot/spots} the shadow of a rouge falling on r_c, {PRONOUN/p_l/subject} {VERB/p_l/react/reacts} without thought, leaping forward, claws ripping into the enemy's back and flipping them off r_c with a ferocious snarl. r_c is badly injured, but will live thanks to p_l dragging {PRONOUN/r_c/object} back to camp.",
                 "exp": 10,
                 "weight": 15,
-                "injury": {
-                    "cats": ["r_c"],
-                    "injuries": ["battle_injury", "battle_injury"]
-                },
+                "injury": [
+                    {
+                        "cats": ["r_c"],
+                        "injuries": ["battle_injury", "battle_injury"]
+                    }
+                ],
                 "relationships": [
                     {
                         "cats_to": ["p_l"],
@@ -1921,10 +1927,12 @@
                 "text": "In the midst of another argument, p_l swiftly swipes at r_c to shut {PRONOUN/r_c/object} up. r_c hisses, and slashes back. Fur flies as both cats trade blows. The chaotic brawl ends with both of them wounded and a tense silence in the air. When they return to camp, many eyes stare in judgement. The Clan is disappointed in their actions.",
                 "exp": 0,
                 "weight": 10,
-                "injury": {
-                    "cats": ["r_c", "p_l"],
-                    "injuries": ["minor_injury","minor_injury","battle_injury"]
-                },
+                "injury": [
+                    {
+                        "cats": ["r_c", "p_l"],
+                        "injuries": ["minor_injury","minor_injury","battle_injury"]
+                    }
+                ],
                 "relationships": [
                     {
                         "cats_to": ["p_l"],

--- a/resources/dicts/patrols/general/border.json
+++ b/resources/dicts/patrols/general/border.json
@@ -2767,8 +2767,8 @@
                 }
             ],
             "new_cat": [
-                ["kittypet", "meeting", "existing"],
-                ["kittypet", "meeting", "existing"]
+                ["kittypet", "meeting", "exists"],
+                ["kittypet", "meeting", "exists"]
             ],
             "art": "gen_angry_cat_warrior",
             "outsider_rep": -1
@@ -2794,7 +2794,7 @@
                 }
             ],
             "new_cat": [
-                ["dead", "meeting", "existing", "kittypet"],
+                ["dead", "meeting", "exists", "kittypet"],
                 ["kittypet", "meeting"]
             ],
             "art": "gen_gen_newcat_hostile",
@@ -2941,8 +2941,8 @@
                 }
             ],
             "new_cat": [
-                ["kittypet", "meeting", "existing"],
-                ["kittypet", "meeting", "existing"]
+                ["kittypet", "meeting", "exists"],
+                ["kittypet", "meeting", "exists"]
             ],
             "art": "gen_angry_cat_warrior",
             "outsider_rep": -1
@@ -2968,7 +2968,7 @@
                 }
             ],
             "new_cat": [
-                ["dead", "meeting", "existing", "kittypet"],
+                ["dead", "meeting", "exists", "kittypet"],
                 ["kittypet", "meeting"]
             ],
             "art": "gen_gen_newcat_hostile",

--- a/resources/dicts/patrols/general/hunting.json
+++ b/resources/dicts/patrols/general/hunting.json
@@ -3711,7 +3711,7 @@
             "exp": 20,
             "weight": 20,
             "prey": ["small"],
-            "art": ["kittylion_OUTCOME"]
+            "art": "kittylion_OUTCOME"
         },
         {
             "text": "Boldly, s_c steps forward to interrogate the small lion, who explains that it is a kittypet that must put up with its Twolegs' insistence on something called \"costumes\". It even offers to let s_c try its accessory!",
@@ -3725,7 +3725,7 @@
                 "shameless", 
                 "playful"
             ],
-            "art": ["kittylion_OUTCOME"]
+            "art": "kittylion_OUTCOME"
         }
     ],
     "fail_outcomes": [

--- a/resources/dicts/patrols/general/hunting.json
+++ b/resources/dicts/patrols/general/hunting.json
@@ -4030,7 +4030,7 @@
 		{
             	"cats_to": ["s_c"],
             	"cats_from": ["r_c"],
-            	"values": ["dislike", "jealousy"],
+            	"values": ["dislike", "jealous"],
             	"amount": -5
 		}
 	    ],

--- a/resources/dicts/patrols/general/medcat.json
+++ b/resources/dicts/patrols/general/medcat.json
@@ -415,7 +415,7 @@
                         "cats_to": ["p_l"],
                         "cats_from": ["patrol"],
                         "mutual": true,
-                        "values": ["jealousy"],
+                        "values": ["jealous"],
                         "amount": -5
                     }
                 ]
@@ -437,7 +437,7 @@
                         "cats_to": ["p_l"],
                         "cats_from": ["patrol"],
                         "mutual": true,
-                        "values": ["jealousy"],
+                        "values": ["jealous"],
                         "amount": -5
                     }
                 ]
@@ -459,7 +459,7 @@
                         "cats_to": ["p_l"],
                         "cats_from": ["patrol"],
                         "mutual": true,
-                        "values": ["jealousy"],
+                        "values": ["jealous"],
                         "amount": -5
                     }
                 ]
@@ -483,7 +483,7 @@
                         "cats_to": ["r_c"],
                         "cats_from": ["patrol"],
                         "mutual": true,
-                        "values": ["jealousy"],
+                        "values": ["jealous"],
                         "amount": -5
                     }
                 ]
@@ -549,7 +549,7 @@
                         "cats_to": ["p_l"],
                         "cats_from": ["patrol"],
                         "mutual": true,
-                        "values": ["jealousy"],
+                        "values": ["jealous"],
                         "amount": 5
                     }
                 ]
@@ -627,7 +627,7 @@
                         "cats_to": ["r_c"],
                         "cats_from": ["s_c"],
                         "mutual": false,
-                        "values": ["jealousy"],
+                        "values": ["jealous"],
                         "amount": 15
                     }
                 ]
@@ -808,7 +808,7 @@
         "biome": ["any"],
         "season": ["any"],
         "types": ["herb_gathering"],
-        "tags": ["jealousy"],
+        "tags": ["jealous"],
         "patrol_art": "gen_med_vision",
         "min_cats": 2,
         "max_cats": 2,
@@ -848,7 +848,7 @@
                         "cats_to": ["p_l"],
                         "cats_from": ["r_c"],
                         "mutual": true,
-                        "values": ["jealousy"],
+                        "values": ["jealous"],
                         "amount": -5
                     }
                 ]
@@ -871,7 +871,7 @@
                         "cats_to": ["p_l"],
                         "cats_from": ["app1"],
                         "mutual": true,
-                        "values": ["jealousy"],
+                        "values": ["jealous"],
                         "amount": -5
                     }
                 ]
@@ -973,7 +973,7 @@
                         "cats_to": ["p_l"],
                         "cats_from": ["app1"],
                         "mutual": true,
-                        "values": ["jealousy"],
+                        "values": ["jealous"],
                         "amount": -5
                     }
                 ]
@@ -1081,7 +1081,7 @@
                         "cats_to": ["app1"],
                         "cats_from": ["s_c"],
                         "mutual": true,
-                        "values": ["jealousy"],
+                        "values": ["jealous"],
                         "amount": 5
                     }
                 ]
@@ -2729,7 +2729,7 @@
                         "cats_to": ["patrol"],
                         "cats_from": ["patrol"],
                         "mutual": false,
-                        "values": ["dislike", "jealousy"],
+                        "values": ["dislike", "jealous"],
                         "amount": -5
                     }
                 ]
@@ -2751,7 +2751,7 @@
                         "cats_to": ["patrol"],
                         "cats_from": ["patrol"],
                         "mutual": false,
-                        "values": ["dislike", "jealousy"],
+                        "values": ["dislike", "jealous"],
                         "amount": -5
                     }
                 ]
@@ -2774,7 +2774,7 @@
                         "cats_to": ["patrol"],
                         "cats_from": ["patrol"],
                         "mutual": false,
-                        "values": ["dislike", "jealousy"],
+                        "values": ["dislike", "jealous"],
                         "amount": -5
                     }
                 ]
@@ -2798,7 +2798,7 @@
                         "cats_to": ["patrol"],
                         "cats_from": ["patrol"],
                         "mutual": false,
-                        "values": ["dislike", "jealousy"],
+                        "values": ["dislike", "jealous"],
                         "amount": 5
                     }
                 ]
@@ -2821,7 +2821,7 @@
                         "cats_to": ["patrol"],
                         "cats_from": ["patrol"],
                         "mutual": false,
-                        "values": ["dislike", "jealousy"],
+                        "values": ["dislike", "jealous"],
                         "amount": 5
                     }
                 ]
@@ -3649,7 +3649,7 @@
                         "cats_to": ["patrol"],
                         "cats_from": ["patrol"],
                         "mutual": true,
-                        "values": ["dislike", "jealousy"],
+                        "values": ["dislike", "jealous"],
                         "amount": -10
                     }
                 ]
@@ -3686,7 +3686,7 @@
                         "cats_to": ["patrol"],
                         "cats_from": ["patrol"],
                         "mutual": true,
-                        "values": ["dislike", "jealousy"],
+                        "values": ["dislike", "jealous"],
                         "amount": -10
                     }
                 ]
@@ -3709,7 +3709,7 @@
 					"cats_to": ["patrol"],
 					"cats_from": ["patrol"],
 					"mutual": true,
-					"values": ["dislike", "jealousy"],
+					"values": ["dislike", "jealous"],
 					"amount": -10
 					}
 				]
@@ -3733,7 +3733,7 @@
                         "cats_to": ["patrol"],
                         "cats_from": ["patrol"],
                         "mutual": true,
-                        "values": ["dislike", "jealousy"],
+                        "values": ["dislike", "jealous"],
                         "amount": -10
                     }
                 ]
@@ -3757,7 +3757,7 @@
                         "cats_to": ["patrol"],
                         "cats_from": ["patrol"],
                         "mutual": true,
-                        "values": ["dislike", "jealousy"],
+                        "values": ["dislike", "jealous"],
                         "amount": -10
                     }
                 ]
@@ -3781,7 +3781,7 @@
                         "cats_to": ["patrol"],
                         "cats_from": ["patrol"],
                         "mutual": true,
-                        "values": ["dislike", "jealousy"],
+                        "values": ["dislike", "jealous"],
                         "amount": -10
                     }
                 ]
@@ -3805,7 +3805,7 @@
                         "cats_to": ["patrol"],
                         "cats_from": ["patrol"],
                         "mutual": true,
-                        "values": ["dislike", "jealousy"],
+                        "values": ["dislike", "jealous"],
                         "amount": -10
                     }
                 ]
@@ -4065,7 +4065,7 @@
                     {
                         "cat_to": [ "s_c" ],
                         "cat_from": [ "app2" ],
-                        "values": [ "dislike", "jealousy" ],
+                        "values": [ "dislike", "jealous" ],
                         "amount": 10
                     }
                 ],

--- a/resources/dicts/patrols/general/medcat.json
+++ b/resources/dicts/patrols/general/medcat.json
@@ -4052,8 +4052,8 @@
                 "text": "s_c rolls {PRONOUN/s_c/poss} eyes. That kind of information is only for very <i>important</i> cats - which doesn't include app2, s_c is quick to inform {PRONOUN/app2/object}. Now run along and help gather herbs like a good little apprentice.",
                 "exp": 10,
                 "weight": 40,
-                "can_have_stat": "healer",
-                "stat_trait": "arrogant",
+                "can_have_stat": ["healer"],
+                "stat_trait": ["arrogant"],
                 "herbs": ["random_herbs"],
                 "relationship": [
                     {
@@ -4075,7 +4075,7 @@
                 "text": "No way, does app2 want to get them both in trouble? They're looking for <i>herbs</i>, not poison. s_c flatly refuses and the apprentices get on with their assignment.",
                 "exp": 10,
                 "weight": 40,
-                "can_have_stat": "healer",
+                "can_have_stat": ["healer"],
                 "stat_trait": [ "loyal", "strict", "responsible", "righteous" ],
                 "herbs": ["random_herbs"],
                 "relationship": [

--- a/resources/dicts/patrols/general/medcat.json
+++ b/resources/dicts/patrols/general/medcat.json
@@ -4280,10 +4280,12 @@
                     }
                 ],
                 "injury":
-                    {
-                                "cats": [ "app2" ],
-                                "injuries": [ "poisoned" ]
-                    },
+                    [
+                        {
+                            "cats": [ "app2" ],
+                            "injuries": [ "poisoned" ]
+                        }
+                    ],
                 "history_text": {
                         "reg_death": "m_c died after tasting deathberries out of curiosity.",
                         "lead_death": "died after tasting deathberries"

--- a/resources/dicts/patrols/general/training.json
+++ b/resources/dicts/patrols/general/training.json
@@ -11508,7 +11508,7 @@
     {
                 "text": "Mistiming {PRONOUN/app1/poss} jump, app1 ends up sprawled on the ground after his failed battle move. Even worse, {PRONOUN/app1/subject} {VERB/app1/catch/catches} sight of s_c rolling {PRONOUN/app2/poss} eyes on the sidelines.",
                 "exp": 0,
-		"stat_skill": ["arrogant", "bloodthirsty", "cold", "competitive", "cunning", "fierce", "gloomy", "grumpy", "vengeful"],
+		        "stat_trait": ["arrogant", "bloodthirsty", "cold", "competitive", "cunning", "fierce", "gloomy", "grumpy", "vengeful"],
                 "can_have_stat": ["app2"],
                 "relationships": [
                     {
@@ -11529,7 +11529,7 @@
      {
                 "text": "Though s_c reassures app1 {PRONOUN/app1/poss} battle move was great, app1 can tell {PRONOUN/s_c/subject}{VERB/s_c/'re/'s} just being kind. Honestly, app1 wished {PRONOUN/s_c/subject}'d just call {PRONOUN/app1/object} a mousebrain.",
                 "exp": 0,
-		"stat_skill": ["calm", "careful", "compassionate", "loving", "insecure", "nervous", "thoughtful"],
+		        "stat_trait": ["calm", "careful", "compassionate", "loving", "insecure", "nervous", "thoughtful"],
                 "can_have_stat": ["app2"],
                 "relationships": [
                     {

--- a/resources/dicts/patrols/general/training.json
+++ b/resources/dicts/patrols/general/training.json
@@ -11503,10 +11503,8 @@
                     }
 		],
                 "weight": 10
-            }
+            },
 
-        ]
-    },
     {
                 "text": "Mistiming {PRONOUN/app1/poss} jump, app1 ends up sprawled on the ground after his failed battle move. Even worse, {PRONOUN/app1/subject} {VERB/app1/catch/catches} sight of s_c rolling {PRONOUN/app2/poss} eyes on the sidelines.",
                 "exp": 0,
@@ -11561,7 +11559,9 @@
                     }
 		],
                 "weight": 5
-     },
+     }
+    ]
+    },
      {
         "patrol_id": "gen_train_kittypets_lesson",
         "biome": ["any"],

--- a/resources/dicts/patrols/mountainous/border/any.json
+++ b/resources/dicts/patrols/mountainous/border/any.json
@@ -535,7 +535,7 @@
    		 "injury": [
    			 {
    				 "cats": ["r_c"],
-   				 "injuries": ["persistent headache"]
+   				 "injuries": ["persistent headaches"]
    			 }
    		 ],
          "art": "mothman_OUTCOME"

--- a/resources/dicts/patrols/mountainous/border/greenleaf.json
+++ b/resources/dicts/patrols/mountainous/border/greenleaf.json
@@ -399,20 +399,6 @@
                 ]
             },
             {
-                "text": "The strange scent leads to a stinky dogwood tree, newly in bloom... app1 huffs with embarrassment, suddenly grateful that {PRONOUN/app1/poss} patrol is so small. Fewer eyes watching that embarrassing moment. {PRONOUN/app1/subject/CAP} {VERB/app1/don't/doesn't} want to look dumb in front of other cats.",
-                "exp": 0,
-                "weight": 20,
-                "relationships": [
-                    {
-                        "cats_to": ["patrol"],
-                        "cats_from": ["patrol"],
-                        "mutual": false,
-                        "values": ["respect", "comfort", "trust"],
-                        "amount": -5
-                    }
-                ]
-            },
-            {
                 "text": "Following the trail with {PRONOUN/app1/poss} nose to the ground, app1 doesn't see the blow coming. {PRONOUN/app1/subject/CAP} {VERB/app1/haul/hauls} {PRONOUN/app1/self} to {PRONOUN/app1/poss} feet, squealing with pain, and {VERB/app1/run/runs} for home.",
                 "exp": 0,
                 "weight": 10,
@@ -623,20 +609,6 @@
                         "mutual": false,
                         "values": ["respect", "comfort", "trust"],
                         "amount": 5
-                    }
-                ]
-            },
-            {
-                "text": "The strange scent leads to a stinky dogwood tree, newly in bloom... app1 huffs with embarrassment and can't meet the eyes of the rest of the patrol. {PRONOUN/app1/subject/CAP} {VERB/app1/don't/doesn't} want to look dumb in front of other cats.",
-                "exp": 0,
-                "weight": 20,
-                "relationships": [
-                    {
-                        "cats_to": ["patrol"],
-                        "cats_from": ["patrol"],
-                        "mutual": false,
-                        "values": ["respect", "comfort", "trust"],
-                        "amount": -5
                     }
                 ]
             }

--- a/resources/dicts/patrols/mountainous/border/greenleaf.json
+++ b/resources/dicts/patrols/mountainous/border/greenleaf.json
@@ -397,9 +397,7 @@
                         "amount": 5
                     }
                 ]
-            }
-        ],
-        "fail_outcomes": [
+            },
             {
                 "text": "The strange scent leads to a stinky dogwood tree, newly in bloom... app1 huffs with embarrassment, suddenly grateful that {PRONOUN/app1/poss} patrol is so small. Fewer eyes watching that embarrassing moment. {PRONOUN/app1/subject/CAP} {VERB/app1/don't/doesn't} want to look dumb in front of other cats.",
                 "exp": 0,
@@ -627,9 +625,7 @@
                         "amount": 5
                     }
                 ]
-            }
-        ],
-        "fail_outcomes": [
+            },
             {
                 "text": "The strange scent leads to a stinky dogwood tree, newly in bloom... app1 huffs with embarrassment and can't meet the eyes of the rest of the patrol. {PRONOUN/app1/subject/CAP} {VERB/app1/don't/doesn't} want to look dumb in front of other cats.",
                 "exp": 0,

--- a/resources/dicts/patrols/new_cat.json
+++ b/resources/dicts/patrols/new_cat.json
@@ -1267,7 +1267,7 @@
                 "weight": 20,
                 "outsider_rep": -1,
                 "new_cat": [
-                    "meeting", "loner"
+                    ["meeting", "loner"]
                 ],
                 "relationships": [
                     {
@@ -1287,7 +1287,7 @@
                 "weight": 20,
                 "outsider_rep": -2,
                 "new_cat": [
-                    "meeting", "loner"
+                    ["meeting", "loner"]
                 ]
             }
         ]

--- a/resources/dicts/patrols/other_clan_hostile.json
+++ b/resources/dicts/patrols/other_clan_hostile.json
@@ -161,7 +161,12 @@
                 "exp": 0,
                 "weight": 20,
                 "stat_trait": ["bloodthirsty", "vengeful", "loyal", "fierce"],
-                "injury":["minor_injury", "minor_injury", "minor_injury"],
+                "injury": [
+                    {
+                        "cats": ["s_c"],
+                        "injuries": ["minor_injury"]
+                    }
+                ],
                 "relationships": [
                     {
                         "cats_to": ["patrol"],

--- a/resources/dicts/patrols/plains/border/any.json
+++ b/resources/dicts/patrols/plains/border/any.json
@@ -1670,10 +1670,10 @@
                 "weight": 20,
                 "relationships": [
                     {
-                        "cat_to": ["patrol"],
-                        "cat_from": ["patrol"],
+                        "cats_to": ["patrol"],
+                        "cats_from": ["patrol"],
                         "mutual": true,
-                        "values": ["platonic, comfort"],
+                        "values": ["platonic", "comfort"],
                         "amount": 5
                     }
                     

--- a/resources/dicts/patrols/plains/hunting/any.json
+++ b/resources/dicts/patrols/plains/hunting/any.json
@@ -2730,10 +2730,10 @@
                 "weight": 20,
                 "relationships": [
                     {
-                        "cat_to": ["patrol"],
-                        "cat_from": ["patrol"],
+                        "cats_to": ["patrol"],
+                        "cats_from": ["patrol"],
                         "mutual": true,
-                        "values": ["platonic, comfort"],
+                        "values": ["platonic", "comfort"],
                         "amount": 5
                     }
                     

--- a/resources/dicts/patrols/plains/hunting/greenleaf.json
+++ b/resources/dicts/patrols/plains/hunting/greenleaf.json
@@ -2087,7 +2087,7 @@
         "text": "r_c finds {PRONOUN/r_c/self} face to fang with a rattling snake. {PRONOUN/r_c/subject/CAP} {VERB/r_c/flinch/flinches} away just as the snake snaps its dripping fangs shut a whisker-length from {PRONOUN/r_c/poss} nose. r_c bolts back to the patrol. They'll need to alter their hunting path - that was too close!",
                 "exp": 5,
                 "weight": 20, 
-                "prey": ["very small"],
+                "prey": ["very_small"],
                 "relationships": [
                     {
                         "cats_to": ["r_c"],

--- a/resources/dicts/patrols/plains/hunting/greenleaf.json
+++ b/resources/dicts/patrols/plains/hunting/greenleaf.json
@@ -2112,8 +2112,8 @@
                         "amount": -5
                     }
                 ],
-                "injury": 
-    {
+                "injury": [
+                    {
                         "cats": ["r_c"],
                         "injuries": ["snake bite","poisoned"],
                         "scars": ["SNAKE"],
@@ -2123,6 +2123,7 @@
                             "lead_death": "a rattlesnake while hunting."
                         }
                     }
+                ]
                 
             },
             {
@@ -2138,8 +2139,8 @@
                         "amount": -5
                     }
                 ],
-                "injury": 
-    {
+                "injury": [
+                    {
                         "cats": ["r_c"],
                         "injuries": ["snake bite","poisoned","damaged eyes"],
                         "scars": ["RIGHTBLIND","LEFTBLIND","BOTHBLIND"],
@@ -2150,6 +2151,7 @@
                         "lead_death": "a rattlesnake while hunting."}
                         
                     }
+                ]
     
             },
             {

--- a/resources/dicts/patrols/plains/hunting/greenleaf.json
+++ b/resources/dicts/patrols/plains/hunting/greenleaf.json
@@ -2093,7 +2093,7 @@
                         "cats_to": ["r_c"],
                         "cats_from": ["patrol"],
                         "mutual": false,
-                        "values": ["respect,trust"],
+                        "values": ["respect", "trust"],
                         "amount": 5
                     }
         ]

--- a/resources/dicts/patrols/plains/hunting/greenleaf.json
+++ b/resources/dicts/patrols/plains/hunting/greenleaf.json
@@ -2062,8 +2062,6 @@
         }, 
         "weight": 15,
         "chance_of_success": 30,
-        "relationship_constraint": null,
-        "pl_skill_constraint": null,
         "intro_text": "The patrol hears a strange sound coming from the grass. What is that? It's like... a hiss and rustle at once?",
         "decline_text": "p_l knows <i>exactly</i> what that sound is. Get away! Now! lead_name will have to be informed of this venomous threat on their hunting path.",
         "success_outcomes": [

--- a/resources/dicts/patrols/plains/hunting/leaf-bare.json
+++ b/resources/dicts/patrols/plains/hunting/leaf-bare.json
@@ -3815,8 +3815,6 @@
         },
         "weight": 20,
         "chance_of_success": 30,
-        "relationship_constraint": null,
-        "pl_skill_constraint": null,
         "intro_text": "Leaf-bare is taking its toll. The patrol is cold, frustrated, and most of all, hungry. p_l notices something odd. Is that a fox in the distance? Why is it jumping into the snow like that?",
         "decline_text": "First the cold, and the snow, and now a fox? This is too much for one day, p_l decides. Back to camp, another patrol can try again later.",
         "success_outcomes": [

--- a/resources/dicts/patrols/plains/hunting/leaf-bare.json
+++ b/resources/dicts/patrols/plains/hunting/leaf-bare.json
@@ -3853,7 +3853,7 @@
             {"text": "r_c snarls. {PRONOUN/r_c/subject/CAP} {VERB/r_c/are/is} too cold and too hungry to watch a stupid fox. This will be a hard hunt, r_c snaps, and if the others can't focus, then they should go huddle with the kits at camp.",
             "exp": 0,
             "weight": 15, 
-            "prey": ["very small"],
+            "prey": ["very_small"],
             "relationships": [
                 {
                     "cats_to": ["r_c"],

--- a/resources/dicts/patrols/plains/hunting/leaf-bare.json
+++ b/resources/dicts/patrols/plains/hunting/leaf-bare.json
@@ -1343,11 +1343,11 @@
                         "scars": []
                     }
                 ],
-                "history_text": [
-                    {"reg_death": "m_c perished after being frostbitten on patrol."},
-                    {"lead_death": "couldn't recover after freezing on patrol"},
-                    {"scar": "m_c was frostbitten as an apprentice while hunting."}
-                ]
+                "history_text": {
+                    "reg_death": "m_c perished after being frostbitten on patrol.",
+                    "lead_death": "couldn't recover after freezing on patrol",
+                    "scar": "m_c was frostbitten as an apprentice while hunting."
+                }
             }
         ]
     },

--- a/resources/dicts/patrols/plains/hunting/leaf-bare.json
+++ b/resources/dicts/patrols/plains/hunting/leaf-bare.json
@@ -3831,7 +3831,7 @@
                 "cats_to": ["s_c"],
                 "cats_from": ["patrol"],
                 "mutual": false,
-                "values": ["respect, trust, platonic"],
+                "values": ["respect", "trust", "platonic"],
                 "amount": 5
             } ] }, 
         {
@@ -3859,7 +3859,7 @@
                     "cats_to": ["r_c"],
                     "cats_from": ["patrol"],
                     "mutual": true,
-                    "values": ["platonic, respect, trust"],
+                    "values": ["platonic", "respect", "trust"],
                     "amount": -5
                 }
             ]

--- a/resources/dicts/patrols/plains/training/any.json
+++ b/resources/dicts/patrols/plains/training/any.json
@@ -2475,10 +2475,10 @@
                 "weight": 20,
                 "relationships": [
                     {
-                        "cat_to": ["patrol"],
-                        "cat_from": ["patrol"],
+                        "cats_to": ["patrol"],
+                        "cats_from": ["patrol"],
                         "mutual": true,
-                        "values": ["platonic, comfort"],
+                        "values": ["platonic", "comfort"],
                         "amount": 5
                     }
                     


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

Several patrols have slightly wrong formatting, causing them to not work as expected. This corrects them to have the correct formatting.  

More specifically:
* Relationship outcomes use "cats_to" and "cats_from", which are arrays
* Relationship outcomes (somewhat confusingly) use "jealous" instead of "jealousy"
* Relationship outcomes values are a list of strings, not a single comma separated string 
* Hunting patrols are "hunting" patrols, not "hunt" patrols
* Injury outcomes are arrays of objects that specify the injury
* To use existing cat for new_cat, should use "exists", not "existing"
* new_cat is specified by an array of arrays
* Very small prey is specified as "very_small", not "very small"
* Patrol art is a string, not a list of strings
* "can_have_stat" and "stat_trait" are arrays of strings. "stat_trait" refers to traits.
* Removes some `null` values since it's the same as if the property was not specified
* Fixes some improper JSON formatting that caused a patrol to be skipped over, or parse outcomes strangely