### PR TITLE
[BUGFIX] correct injuries for fst_hunt_leaffall_vanish1

### DIFF
--- a/resources/dicts/patrols/forest/hunting/leaf-fall.json
+++ b/resources/dicts/patrols/forest/hunting/leaf-fall.json
@@ -440,12 +440,12 @@
                 "injury": [
                     {
                         "cats": ["r_c"],
-                        "injuries": ["sprain", "sore", "shivering"],
+                        "injuries": ["shivering"],
                         "scars": []
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c was scarred after disappearing on patrol and being discovered injured."
+                    "scar": "m_c was scarred after disappearing on patrol and being found soaked and freezing."
                 },
                 "relationships": [
                     {


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->

## About The Pull Request
fixes a patrol where a cat gets too cold, but could be given the 'sore' or 'sprain' injuries. also changed the history text to reflect this.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
fixes #2947 
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Changelog/Credits
- fixes a bug where the cat is given the wrong injury on patrol
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
