### PR TITLE
[CONTENT] Two versus One Fight Training Patrol

### DIFF
--- a/resources/dicts/patrols/general/training.json
+++ b/resources/dicts/patrols/general/training.json
@@ -12069,5 +12069,384 @@
          "weight": 10
      }
        ]
-   }
+   },
+   {
+	"patrol_id": "gen_train_two_on_one",
+	"biome": [ "any" ],
+	"season": [ "any" ],
+	"types": [ "training" ],
+	"tags": [],
+	"patrol_art": "train_general_intro",
+	"min_cats": 3,
+	"max_cats": 3,
+	"min_max_status": {
+		"normal adult": [3, 3]
+	},
+	"weight": 20,
+	"chance_of_success": 30,
+	"intro_text": "Since they have three cats, p_l suggests they practice two-on-one fighting.",
+	"decline_text": "r_c announces {PRONOUN/r_c/subject} {VERB/r_c/want/wants} to practice stalking instead.",
+	"success_outcomes": [
+		{
+            "text": "p_l waggles {PRONOUN/p_l/poss} haunches and dares r_c and s_c to come at {PRONOUN/p_l/object}. The three cats tussle until r_c distracts p_l with a sheathed strike to {PRONOUN/p_l/poss} ear, and s_c pins {PRONOUN/p_l/object} down. They congratulate each other as they head back to camp.",
+            "exp": 5,
+        "weight": 20,
+        "stat_trait": ["troublesome", "lonesome", "fierce", "bloodthirsty", "cold", "childish", "playful", "charismatic", "bold", "daring", "nervous", "righteous", "insecure", "strict", "compassionate", "thoughtful", "ambitious", "confident", "adventurous", "calm", "careful", "faithful", "loving", "loyal", "responsible", "shameless", "sneaky", "strange", "vengeful", "wise", "arrogant", "competitive", "grumpy", "cunning", "oblivious", "gloomy", "sincere", "flamboyant", "rebellious"],
+            "relationships": [
+        {
+                    "cats_to": ["patrol"],
+                    "cats_from": ["patrol"],
+                    "mutual": false,
+                    "values": ["comfort", "respect", "platonic"],
+                    "amount": 7
+        }
+        ],
+        "art": "patrol_outcome_art"
+},
+{
+    "text": "p_l suggests that {PRONOUN/p_l/subject} and r_c team up against s_c. Though s_c does {PRONOUN/s_c/poss} best, {PRONOUN/s_c/subject} {VERB/s_c/do/does}n't stand much of a chance against two of {PRONOUN/s_c/poss} Clanmates.",
+    "exp": 5,
+"weight": 20,
+"stat_trait": ["troublesome", "lonesome", "fierce", "bloodthirsty", "cold", "childish", "playful", "charismatic", "bold", "daring", "nervous", "righteous", "insecure", "strict", "compassionate", "thoughtful", "ambitious", "confident", "adventurous", "calm", "careful", "faithful", "loving", "loyal", "responsible", "shameless", "sneaky", "strange", "vengeful", "wise", "arrogant", "competitive", "grumpy", "cunning", "oblivious", "gloomy", "sincere", "flamboyant", "rebellious"],
+    "relationships": [
+{
+            "cats_to": ["patrol"],
+            "cats_from": ["patrol"],
+            "mutual": false,
+            "values": ["comfort", "respect", "platonic"],
+            "amount": 7
+}
+],
+"art": "train_general_intro"
+},
+{
+    "text": "p_l suggests that {PRONOUN/p_l/subject} and r_c team up against s_c. s_c tries to keep {PRONOUN/s_c/poss} eyes on both {PRONOUN/s_c/poss} Clanmates at once, but p_l and r_c find a rhythm together, and s_c can't keep up. After the match, p_l and r_c agree they'll have to try some of these moves in a future skirmish.",
+    "exp": 5,
+"weight": 20,
+"stat_trait": ["troublesome", "lonesome", "fierce", "bloodthirsty", "cold", "childish", "playful", "charismatic", "bold", "daring", "nervous", "righteous", "insecure", "strict", "compassionate", "thoughtful", "ambitious", "confident", "adventurous", "calm", "careful", "faithful", "loving", "loyal", "responsible", "shameless", "sneaky", "strange", "vengeful", "wise", "arrogant", "competitive", "grumpy", "cunning", "oblivious", "gloomy", "sincere", "flamboyant", "rebellious"],
+    "relationships": [
+{
+            "cats_to": ["patrol"],
+            "cats_from": ["patrol"],
+            "mutual": false,
+            "values": ["comfort", "respect", "platonic"],
+            "amount": 5
+},
+{
+           "cats_to": ["p_l"],
+            "cats_from": ["r_c"],
+            "mutual": true,
+           "values": ["trust"],
+           "amount": 10
+}
+],
+"art": "train_general_intro"
+},
+{  
+	"text": "p_l suggests that {PRONOUN/p_l/subject} and r_c team up against s_c. s_c agrees, puffing out {PRONOUN/s_c/poss} chest and crouching low. When p_l and r_c pounce, s_c dodges aside as quick as a rabbit and swipes at p_l, then leaps out of the way of r_c's strike. p_l and r_c best {PRONOUN/s_c/object} eventually, but s_c makes them work for it.",
+	"exp": 10,
+    "weight": 40,
+    "stat_trait": [ "bloodthirsty", "arrogant", "ambitious", "confident", "sneaky", "cunning", "fierce", "competitive" ],
+	"relationships": [
+{
+			"cats_to": [ "patrol" ],
+			"cats_from": [ "patrol" ],
+			"mutual": false,
+			"values": [ "comfort", "platonic"],
+			"amount": 5
+},	
+{
+			"cats_to": [ "s_c" ],
+			"cats_from": [ "p_l", "r_c" ],
+			"mutual": false,
+			"values": [ "respect" ],
+			"amount": 10
+		}
+],
+"art": "train_general_intro"
+		},
+        {
+            "text": "p_l suggests that {PRONOUN/p_l/subject} and r_c team up against s_c. When p_l and r_c pounce, s_c shocks them by springing forward and knocking p_l off {PRONOUN/p_l/poss} paws. Before {PRONOUN/p_l/subject} can scramble to {PRONOUN/p_l/poss} feet, s_c whirls around, shoulders r_c off balance, and pins {PRONOUN/r_c/object} down. p_l and r_c exchange shocked and impressed glances from their backs on the ground.",
+            "exp": 10,
+            "weight": 40,
+            "stat_trait": [ "bloodthirsty", "adventurous", "arrogant", "ambitious", "confident", "fierce", "competitive" ],
+            "stat_skill": [ "FIGHTER,2"],
+            "relationships": [
+        {
+                    "cats_to": [ "patrol" ],
+                    "cats_from": [ "patrol" ],
+                    "mutual": false,
+                    "values": [ "comfort", "platonic"],
+                    "amount": 5
+        },	
+        {
+                    "cats_to": [ "s_c" ],
+                    "cats_from": [ "p_l", "r_c" ],
+                    "mutual": false,
+                    "values": [ "respect" ],
+                    "amount": 10
+                }
+        ],
+        "art": "train_general_intro"        
+        },
+        {
+            "text": "p_l suggests that {PRONOUN/p_l/subject} and r_c team up against s_c. No matter how hard r_c and p_l try to flank s_c, {PRONOUN/s_c/subject} {VERB/s_c/move/moves} fast and fluid like moving water. {PRONOUN/s_c/subject/CAP} {VERB/s_c/seem/seems} to know where they'll strike before they do, wearing them down until r_c and p_l admit defeat, panting and impressed.",
+            "exp": 10,
+            "weight": 40,
+            "stat_trait": [ "wise", "thoughtful", "calm", "careful", "lonesome" ],
+            "stat_skill": [ "FIGHTER,2"],
+            "relationships": [
+        {
+                    "cats_to": [ "patrol" ],
+                    "cats_from": [ "patrol" ],
+                    "mutual": false,
+                    "values": [ "comfort", "platonic"],
+                    "amount": 5
+        },	
+        {
+                    "cats_to": [ "s_c" ],
+                    "cats_from": [ "p_l", "r_c" ],
+                    "mutual": false,
+                    "values": [ "respect" ],
+                    "amount": 10
+                }
+        ],
+        "art": "train_general_intro"    
+        },
+        {
+            "text": "p_l suggests that {PRONOUN/p_l/subject} and r_c team up against s_c. Just as r_c gathers {PRONOUN/r_c/poss} haunches to pounce on s_c, s_c exclaims that a fox is right behind r_c! As p_l and r_c scramble out of the way, s_c swipes at their fleeing tails. After all, p_l didn't specify {PRONOUN/s_c/subject} had to fight fair.",
+            "exp": 10,
+            "weight": 40,
+            "stat_trait": [ "cunning", "sneaky", "shameless", "flamboyant", "charismatic", "daring", "bold" ],
+            "stat_skill": [ "FIGHTER,1"],
+            "relationships": [
+        {
+                    "cats_to": [ "patrol" ],
+                    "cats_from": [ "patrol" ],
+                    "mutual": false,
+                    "values": [ "comfort", "platonic"],
+                    "amount": 5
+        },	
+        {
+                    "cats_to": [ "s_c" ],
+                    "cats_from": [ "p_l", "r_c" ],
+                    "mutual": false,
+                    "values": [ "respect" ],
+                    "amount": -3
+                }
+        ],
+        "art": "gen_train_playbite_2warriors"        
+        },
+        {
+            "text": "p_l suggests that {PRONOUN/p_l/subject} and r_c team up against s_c. As the three of them tussle, p_l and r_c discover that s_c knows them better than either of them realized - {PRONOUN/s_c/subject} {VERB/s_c/anticipate/anticipates} their every move, knocking away their strikes easily.",
+            "exp": 10,
+            "weight": 40,
+            "stat_trait": [ "charismatic", "loving", "compassionate", "loyal", "faithful", "cunning", "thoughtful", "sincere" ],
+            "stat_skill": [ "FIGHTER,2"],
+            "relationships": [
+        {
+                    "cats_to": [ "patrol" ],
+                    "cats_from": [ "patrol" ],
+                    "mutual": false,
+                    "values": [ "comfort", "platonic"],
+                    "amount": 5
+        },	
+        {
+                    "cats_to": [ "s_c" ],
+                    "cats_from": [ "p_l", "r_c" ],
+                    "mutual": false,
+                    "values": [ "respect" ],
+                    "amount": 10
+                }
+        ],
+        "art": "train_general_intro"        
+        },
+        {
+            "text": "p_l suggests that {PRONOUN/p_l/subject} and r_c team up against s_c. They rarely see their Clanmate come alive the way {PRONOUN/s_c/subject} {VERB/s_c/do/does} in a fight. r_c and p_l circle s_c, but they can't catch {PRONOUN/s_c/object} off-guard. Eventually, r_c makes a hasty move, and s_c pins {PRONOUN/r_c/object}.",
+            "exp": 10,
+            "weight": 40,
+            "stat_trait": [ "cunning", "sneaky", "cold", "lonesome", "grumpy", "gloomy", "strict", "strange", "insecure", "nervous" ],
+            "stat_skill": [ "FIGHTER,2"],
+            "relationships": [
+        {
+                    "cats_to": [ "patrol" ],
+                    "cats_from": [ "patrol" ],
+                    "mutual": false,
+                    "values": [ "comfort", "platonic"],
+                    "amount": 5 
+        },	
+        {
+                    "cats_to": [ "s_c" ],
+                    "cats_from": [ "p_l", "r_c" ],
+                    "mutual": false,
+                    "values": [ "respect" ],
+                    "amount": 10
+                }
+        ],
+        "art": "train_general_intro"       
+        },
+        {
+            "text": "p_l suggests that {PRONOUN/p_l/subject} and r_c team up against s_c. s_c warily agrees, but {PRONOUN/s_c/subject} {VERB/s_c/have/has} nothing to worry about. Even outnumbered, s_c proves {PRONOUN/s_c/poss} talent in battle, and r_c and p_l heap praise on {PRONOUN/s_c/object} after the bout.",
+            "exp": 10,
+            "weight": 40,
+            "stat_trait": [ "gloomy", "lonsome", "insecure", "nervous" ],
+            "stat_skill": [ "FIGHTER,2"],
+            "relationships": [
+        {
+                    "cats_to": [ "patrol" ],
+                    "cats_from": [ "patrol" ],
+                    "mutual": false,
+                    "values": [ "comfort", "platonic"],
+                    "amount": 10
+        },	
+        {
+                    "cats_to": [ "s_c" ],
+                    "cats_from": [ "p_l", "r_c" ],
+                    "mutual": false,
+                    "values": [ "respect" ],
+                    "amount": 10
+                }
+        ],
+        "art": "train_general_intro"        
+        },
+        {
+            "text": "p_l suggests that {PRONOUN/p_l/subject} and r_c team up against s_c. No matter how hard r_c and p_l try to flank s_c, {PRONOUN/s_c/subject} always {VERB/s_c/seem/seems} to know where they'll strike before they do, wearing them down until r_c and p_l admit defeat, panting and impressed. s_c smiles secretively.",
+            "exp": 10,
+            "weight": 40,
+            "stat_skill": [ "CLAIRVOYANT,1"],
+            "relationships": [
+        {
+                    "cats_to": [ "patrol" ],
+                    "cats_from": [ "patrol" ],
+                    "mutual": false,
+                    "values": [ "comfort", "platonic"],
+                    "amount": 5 
+        },	
+        {
+                    "cats_to": [ "s_c" ],
+                    "cats_from": [ "p_l", "r_c" ],
+                    "mutual": false,
+                    "values": [ "respect" ],
+                    "amount": 10
+                }
+        ],
+        "art": "train_general_intro"        
+        }
+	],
+	"fail_outcomes": [
+        {
+            "text": "p_l suggests that {PRONOUN/p_l/subject} and r_c team up against s_c. s_c immediately begins whining that it's unfair, so p_l groans and calls off the whole idea. They can all find hunting patrols to join instead.",
+            "exp": 0,
+            "weight": 40,
+            "stat_trait": [ "childish"],
+            "relationships": [
+        {
+                    "cats_to": [ "s_c" ],
+                    "cats_from": [ "p_l", "r_c" ],
+                    "mutual": false,
+                    "values": [ "respect" ],
+                    "amount": -10
+                },
+                {
+                            "cats_to": [ "s_c" ],
+                            "cats_from": [ "p_l", "r_c" ],
+                            "mutual": false,
+                            "values": [ "dislike" ],
+                            "amount": 5
+                }
+        ],
+        "art": "gen_train_argue"        
+        },
+    {
+        "text": "p_l suggests that {PRONOUN/p_l/subject} and r_c team up against s_c. As soon as they attack, s_c turns tail and sprints off. When p_l calls {PRONOUN/s_c/object} back, confused, {PRONOUn/s_c/subject} {VERB/s_c/explain/explains} that's what {PRONOUN/s_c/subject}'d do if {PRONOUN/s_c/subject} were outnumbered in a fight. p_l sighs.",
+        "exp": 0,
+        "weight": 40,
+        "stat_trait": [ 
+        "troublesome", "lonesome", "cold", "childish", "playful", "charismatic", "bold", "daring", "nervous", "righteous", "insecure", "strict", "compassionate", "thoughtful", "confident", "calm", "careful", "faithful", "loving", "loyal", "responsible", "shameless", "sneaky", "strange", "vengeful", "wise", "arrogant", "competitive", "grumpy", "cunning", "oblivious", "gloomy", "sincere", "flamboyant", "rebellious"
+    ],
+        "relationships": [
+    {
+                "cats_to": [ "s_c" ],
+                "cats_from": [ "p_l", "r_c" ],
+                "mutual": false,
+                "values": [ "platonic" ],
+                "amount": -5
+            }
+    ],
+    "art": "running_two_warriors"        
+		},
+        {
+            "text": "p_l and r_c team up against s_c and thrash {PRONOUN/s_c/object} easily. While p_l and r_c congratulate each other, s_c silently stews over this unfair, unbalanced training exercise. {PRONOUN/s_c/poss/CAP} Clanmates don't notice {PRONOUN/s_c/poss} bad mood, which only makes {PRONOUN/s_c/object} more irritable.",
+            "exp": 0,
+            "weight": 20,
+            "stat_trait": [ 
+            "troublesome", "lonesome", "fierce", "bloodthirsty", "cold", "childish", "playful", "charismatic", "bold", "daring", "nervous", "righteous", "insecure", "strict", "compassionate", "thoughtful", "ambitious", "confident", "adventurous", "calm", "careful", "faithful", "loving", "loyal", "responsible", "shameless", "sneaky", "strange", "vengeful", "wise", "arrogant", "competitive", "grumpy", "cunning", "oblivious", "gloomy", "sincere", "flamboyant", "rebellious"
+        ],
+            "relationships": [
+        {
+                    "cats_to": [ "p_l", "r_c" ],
+                    "cats_from": [ "s_c" ],
+                    "mutual": false,
+                    "values": [ "platonic", "comfort", "respect" ],
+                    "amount": -5
+                },
+                {
+                    "cats_to": [ "p_l", "r_c" ],
+                    "cats_from": [ "s_c" ],
+                    "mutual": false,
+                    "values": [ "dislike" ],
+                    "amount": 5
+                }
+        ],
+        "art": "gen_train_argue"        
+            },
+            {
+                "text": "p_l and r_c team up against s_c and, despite s_c's best efforts, the fight is over extremely quickly. While p_l and r_c compliment each other's fighting styles, s_c's temper boils over, and {PRONOUN/s_c/subject} {VERB/s_c/snap/snaps} that it was an unfair fight - {PRONOUN/s_c/subject} could totally beat either of them one-on-one!",
+                "exp": 0,
+                "weight": 10,
+                "stat_trait": [ 
+                "troublesome", "lonesome", "fierce", "bloodthirsty", "cold", "childish", "bold", "daring", "righteous", "insecure", "strict", "ambitious", "confident", "adventurous", "faithful", "loyal", "shameless", "sneaky", "strange", "vengeful", "arrogant", "competitive", "grumpy", "gloomy", "sincere", "flamboyant", "rebellious"
+            ],
+                "relationships": [
+            {
+                        "cats_to": [ "p_l", "r_c" ],
+                        "cats_from": [ "s_c" ],
+                        "mutual": false,
+                        "values": [ "platonic", "comfort", "respect" ],
+                        "amount": -10
+                    },
+                    {
+                        "cats_to": [ "p_l", "r_c" ],
+                        "cats_from": [ "s_c" ],
+                        "mutual": false,
+                        "values": [ "dislike" ],
+                        "amount": 10
+                    }
+            ],
+            "art": "gen_train_argue"        
+                },
+                {
+                    "text": "p_l uses {PRONOUN/p_l/poss} position as patrol leader to boss the other two around. They can't get organized enough to do a proper scrum because neither wants to listen to p_l.",
+                    "exp": 0,
+                    "weight": 20,
+                    "relationships": [
+                {
+                            "cats_to": [ "p_l" ],
+                            "cats_from": [ "patrol" ],
+                            "mutual": false,
+                            "values": [ "platonic", "comfort", "respect" ],
+                            "amount": 5
+                        },
+                        {
+                            "cats_to": [ "p_l" ],
+                            "cats_from": [ "patrol" ],
+                            "mutual": false,
+                            "values": [ "dislike" ],
+                            "amount": 5
+                        }
+                ],
+                "art": "gen_train_argue"        
+                    }
+	]
+}
 ]

--- a/resources/dicts/patrols/general/training.json
+++ b/resources/dicts/patrols/general/training.json
@@ -12446,7 +12446,22 @@
                         }
                 ],
                 "art": "gen_train_argue"        
-                    }
+                    },
+            {
+                "text": "p_l and r_c team up against s_c, and everything goes well until s_c shoves p_l off {PRONOUN/s_c/object} a little too vigorously and p_l yelps in pain as {PRONOUN/p_l/subject} {VERB/p_l/hit/hits} the ground. Then r_c and s_c team up - to help p_l limp back to camp.",
+                "exp": 0,
+                "weight": 20,
+                "stat_trait": [ 
+                "troublesome", "lonesome", "fierce", "bloodthirsty", "cold", "childish", "bold", "daring", "righteous", "insecure", "strict", "ambitious", "confident", "adventurous", "faithful", "loyal", "shameless", "sneaky", "strange", "vengeful", "arrogant", "competitive", "grumpy", "gloomy", "sincere", "flamboyant", "rebellious"
+            ],
+            "injury": [
+                {
+                    "cats": [ "p_l" ],
+                    "injuries": [ "sprain" ]
+                }
+            ],
+            "art": "train_general_intro"        
+                }
 	]
 }
 ]

--- a/resources/dicts/patrols/general/training.json
+++ b/resources/dicts/patrols/general/training.json
@@ -12116,7 +12116,7 @@
                     "amount": 7
         }
         ],
-        "art": "patrol_outcome_art"
+        "art": "train_general_intro"
 },
 {
     "text": "p_l suggests that {PRONOUN/p_l/subject} and r_c team up against s_c. Though s_c does {PRONOUN/s_c/poss} best, {PRONOUN/s_c/subject} {VERB/s_c/do/does}n't stand much of a chance against two of {PRONOUN/s_c/poss} Clanmates.",

--- a/resources/dicts/patrols/general/training.json
+++ b/resources/dicts/patrols/general/training.json
@@ -12087,6 +12087,21 @@
 	"intro_text": "Since they have three cats, p_l suggests they practice two-on-one fighting.",
 	"decline_text": "r_c announces {PRONOUN/r_c/subject} {VERB/r_c/want/wants} to practice stalking instead.",
 	"success_outcomes": [
+        {
+            "text": "p_l organizes the patrol into a spar, and the cats congratulate after each other on a good fight.",
+            "exp": 5,
+        "weight": 1,
+            "relationships": [
+        {
+                    "cats_to": ["patrol"],
+                    "cats_from": ["patrol"],
+                    "mutual": false,
+                    "values": ["comfort", "respect", "platonic"],
+                    "amount": 5
+        }
+        ],
+        "art": "train_general_intro"
+        },
 		{
             "text": "p_l waggles {PRONOUN/p_l/poss} haunches and dares r_c and s_c to come at {PRONOUN/p_l/object}. The three cats tussle until r_c distracts p_l with a sheathed strike to {PRONOUN/p_l/poss} ear, and s_c pins {PRONOUN/p_l/object} down. They congratulate each other as they head back to camp.",
             "exp": 5,

--- a/resources/dicts/patrols/general/training.json
+++ b/resources/dicts/patrols/general/training.json
@@ -12088,7 +12088,7 @@
 	"decline_text": "r_c announces {PRONOUN/r_c/subject} {VERB/r_c/want/wants} to practice stalking instead.",
 	"success_outcomes": [
         {
-            "text": "p_l organizes the patrol into a spar, and the cats congratulate after each other on a good fight.",
+            "text": "p_l organizes the patrol into a spar, and the cats congratulate each other on a good fight.",
             "exp": 5,
         "weight": 1,
             "relationships": [

--- a/resources/dicts/patrols/general/training.json
+++ b/resources/dicts/patrols/general/training.json
@@ -12304,7 +12304,7 @@
             "text": "p_l suggests that {PRONOUN/p_l/subject} and r_c team up against s_c. s_c warily agrees, but {PRONOUN/s_c/subject} {VERB/s_c/have/has} nothing to worry about. Even outnumbered, s_c proves {PRONOUN/s_c/poss} talent in battle, and r_c and p_l heap praise on {PRONOUN/s_c/object} after the bout.",
             "exp": 10,
             "weight": 40,
-            "stat_trait": [ "gloomy", "lonsome", "insecure", "nervous" ],
+            "stat_trait": [ "gloomy", "lonesome", "insecure", "nervous" ],
             "stat_skill": [ "FIGHTER,2"],
             "relationships": [
         {


### PR DESCRIPTION
## About The Pull Request

Fun two-on-one fighting patrol for the general training file with plenty of stat-locked outcomes. A few skill locked outcomes, although almost exclusively for fighter cats. I took your idea, scribble, if you're reading this <3, of how cats with different traits and the Fighter skill would still have different fighting styles.

## Why This Is Good For ClanGen

Fun patrol! Particularly to acknowledge that having three cats on a patrol would make things unbalanced in a spar.

## Proof of Testing

![image](https://github.com/user-attachments/assets/9ff5ebfa-3a15-41e4-b94e-982d2ba25b47)
![image](https://github.com/user-attachments/assets/da6ca552-3a2a-4cb0-8f0a-d5dbc6d143cf)
![image](https://github.com/user-attachments/assets/9dcc9019-a61e-4af8-9476-3b0fcfb7eee4)
