### PR TITLE
[ENHANCEMENT] tag newborns in moon birth event

### DIFF
--- a/resources/credits_text.json
+++ b/resources/credits_text.json
@@ -104,6 +104,7 @@
         "Tybaxel": "Patrol sprites, Clan creation screen art",
         "wood pank": "Art",
         "ZtheCorgi (Zabe)": "Nylon & indigo collars, various small bugfixes and proofreading",
-        "PoppyBlossom (Poppy)": "Code, Bugfixes & More!"
+        "PoppyBlossom (Poppy)": "Code, Bugfixes & More!",
+        "Rusty": "Bugfixes and enhancements"
     }
 }

--- a/scripts/events_module/relationship/pregnancy_events.py
+++ b/scripts/events_module/relationship/pregnancy_events.py
@@ -425,6 +425,8 @@ class Pregnancy_Events:
         else:
             event_list.append(choice(events["birth"]["unmated_parent"]))
 
+        involved_cats += kits
+
         if clan.game_mode != "classic":
             try:
                 death_chance = cat.injuries["pregnant"]["mortality"]

--- a/scripts/events_module/relationship/pregnancy_events.py
+++ b/scripts/events_module/relationship/pregnancy_events.py
@@ -425,7 +425,7 @@ class Pregnancy_Events:
         else:
             event_list.append(choice(events["birth"]["unmated_parent"]))
 
-        involved_cats += kits
+        involved_cats += [k.ID for k in kits]
 
         if clan.game_mode != "classic":
             try:


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->

## About The Pull Request
When a litter of kits is born, the kits are now listed as involved cats on the events screen and not just the parents. 
To be specific, the known parents (hasn't changed from before) are listed first, then the kits.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Why This Is Good For ClanGen
According to discussion in #2548, kits were previously not displayed as involved cats in birth events because of possibility for overflowing the box. However, with the event screen refactor (#2545), it is now possible to scroll across involved cats.
<!-- If this is a bug fix, you can remove this section. -->
<!-- Please add a short description of why you think these changes would benefit the game. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->
<!-- If you have multiple features that can stand on their own, or unrelated bugfixes, please create separate PRs for them. -->

## Linked Issues

<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->
Resolves #2548

## Proof of Testing
<img width="1680" alt="image" src="https://github.com/user-attachments/assets/c25a81ab-7d71-4a77-b641-468ea529938f">
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
I added myself to the `credits_text.json`.

<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
