### PR TITLE
[BUGFIX] Outsider romance

### DIFF
--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -2435,8 +2435,8 @@ class Cat:
         if self.is_related(other_cat, first_cousin_mates):
             return False
 
-        # check exiled, outside, and dead cats
-        if (self.dead != other_cat.dead) or self.outside or other_cat.outside:
+        # check dead cats
+        if self.dead != other_cat.dead:
             return False
 
         # check for age

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -2439,10 +2439,6 @@ class Cat:
         if self.dead != other_cat.dead:
             return False
 
-        # check that outside status matches
-        # if self.outside != other_cat.outside:
-        #     return False
-
         # check for age
         if age_restriction:
             if (self.moons < 14 or other_cat.moons < 14) and not for_love_interest:

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -2440,8 +2440,8 @@ class Cat:
             return False
 
         # check that outside status matches
-        if self.outside != other_cat.outside:
-            return False
+        # if self.outside != other_cat.outside:
+        #     return False
 
         # check for age
         if age_restriction:

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -2439,6 +2439,10 @@ class Cat:
         if self.dead != other_cat.dead:
             return False
 
+        # check that outside status matches
+        if self.outside != other_cat.outside:
+            return False
+
         # check for age
         if age_restriction:
             if (self.moons < 14 or other_cat.moons < 14) and not for_love_interest:

--- a/scripts/events_module/relation_events.py
+++ b/scripts/events_module/relation_events.py
@@ -91,6 +91,10 @@ class Relation_Events:
         # only adding cats which already have SOME relationship with each other
         cat_to_choose_from = []
         for inter_cat in possible_cats:
+            # toss out cats who are outside
+            if inter_cat.outside:
+                continue
+
             if inter_cat.ID not in cat.relationships:
                 cat.create_one_relationship(inter_cat)
             if cat.ID not in inter_cat.relationships:

--- a/scripts/events_module/relationship/romantic_events.py
+++ b/scripts/events_module/relationship/romantic_events.py
@@ -448,6 +448,7 @@ class Romantic_Events:
 
         return: bool if event is triggered or not
         """
+
         # get the highest romantic love relationships and
         rel_list = cat_from.relationships.values()
         highest_romantic_relation = get_highest_romantic_relation(
@@ -463,6 +464,10 @@ class Romantic_Events:
             return False
 
         cat_to = highest_romantic_relation.cat_to
+
+        if cat_to.outside != cat_from.outside:
+            return False
+
         if not cat_to.is_potential_mate(cat_from) or not cat_from.is_potential_mate(
             cat_to
         ):
@@ -572,6 +577,9 @@ class Romantic_Events:
         """Checks if the two cats can become mates, or not. Returns: boolean and event_string"""
         become_mates = False
         young_age = ["newborn", "kitten", "adolescent"]
+        if cat_to.outside != cat_from.outside:
+            return False, None
+
         if not cat_from.is_potential_mate(cat_to):
             return False, None
 

--- a/scripts/events_module/relationship/romantic_events.py
+++ b/scripts/events_module/relationship/romantic_events.py
@@ -299,9 +299,6 @@ class Romantic_Events:
     @staticmethod
     def handle_new_mate_events(cat):
         """Triggers and handles any events that result in a new mate"""
-        # outsiders don't get to have mate events for now
-        if cat.outside:
-            return
 
         # First, check high love confession
         flag = Romantic_Events.handle_confession(cat)

--- a/scripts/events_module/relationship/romantic_events.py
+++ b/scripts/events_module/relationship/romantic_events.py
@@ -299,6 +299,9 @@ class Romantic_Events:
     @staticmethod
     def handle_new_mate_events(cat):
         """Triggers and handles any events that result in a new mate"""
+        # outsiders don't get to have mate events for now
+        if cat.outside:
+            return
 
         # First, check high love confession
         flag = Romantic_Events.handle_confession(cat)

--- a/scripts/screens/ChooseMateScreen.py
+++ b/scripts/screens/ChooseMateScreen.py
@@ -1189,6 +1189,7 @@ class ChooseMateScreen(Screens):
             and self.the_cat.is_potential_mate(
                 i, for_love_interest=False, age_restriction=False, ignore_no_mates=True
             )
+            and i.outside == self.the_cat.outside
             and i.ID not in self.the_cat.mate
             and (not self.single_only or not i.mate)
             and (


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->

## About The Pull Request
It was impossible for cats on patrol to gain romantic like with an outsider who does not join the Clan, due to `is_potential_mate` checking for matching outside status.  This was causing issues for writers attempting to create new clan/outsider events.  

This PR removes that check, but also adds checks to confession, mating, and romantic increase rel events to prevent outsiders from having *those* events.  This means that outsiders can now gain romantic like toward a clan cat via ShortEvents and PatrolEvents, but cannot confess, mate, or increase that romantic like via moon relationship events while they remain outside the clan.

I hope that in the future we can expand this side of the game to allow for clan/outsider specific relationship events, confessions, and mateship.  For now, this solution serves a good stop gap to allow further patrol/shortevent variety.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Proof of Testing
![image](https://github.com/user-attachments/assets/60a189c6-6ae2-493d-8921-41d314425dc4)
![image](https://github.com/user-attachments/assets/6ee5075d-8826-47c6-ae67-1e5900b70e1c)
Sotast and Mousehope gain romantic like via gen_bord_welcomingbinglegift1 patrol.  The only moon event they ever had past that was a "moving on" event to break their mateship, which is an allowed event in this case.  I went through a few moons and never saw any relationship events between them.

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- PatrolEvents and ShortEvents that create a romantic relationship between a clancat and an outsider are now able to assign the given romantic like.
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
