### PR TITLE
Fixes patrol start crashing when clicked rapidly

### DIFF
--- a/scripts/screens/PatrolScreen.py
+++ b/scripts/screens/PatrolScreen.py
@@ -208,6 +208,7 @@ class PatrolScreen(Screens):
                 self.patrol_type = "hunting"
             self.update_button()
         elif event.ui_element == self.elements["patrol_start"]:
+            event.ui_element.disable()
             self.selected_cat = None
             self.start_patrol_thread = self.loading_screen_start_work(
                 self.run_patrol_start, "start"

--- a/scripts/screens/PatrolScreen.py
+++ b/scripts/screens/PatrolScreen.py
@@ -208,8 +208,13 @@ class PatrolScreen(Screens):
                 self.patrol_type = "hunting"
             self.update_button()
         elif event.ui_element == self.elements["patrol_start"]:
-            event.ui_element.disable()
+            self.elements["patrol_start"].disable()
             self.selected_cat = None
+            if (
+                    self.start_patrol_thread is not None
+                    and self.start_patrol_thread.is_alive()
+            ):
+                return
             self.start_patrol_thread = self.loading_screen_start_work(
                 self.run_patrol_start, "start"
             )


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->

## About The Pull Request
Fixes #2958. Simply disables the patrol button once it's clicked so it can't be clicked multiple times and returns if the thread is already running to avoid duplicates.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
Fixes #2962
Fixes #2957 
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
Tested with autoclicker set to 10ms intervals (which consistently triggered the bug before) multiple times - unable to replicate now. Kind of hard to prove that I did this lol
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits

<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
