### PR TITLE
[BUG] fixed switch focus button re-enabling after closing relationship log

### DIFF
--- a/scripts/game_structure/windows.py
+++ b/scripts/game_structure/windows.py
@@ -1605,9 +1605,11 @@ class RelationshipLog(UIWindow):
         )
         self.closing_buttons = [self.exit_button, self.back_button, self.log_icon]
 
-        self.disable_button_list = disable_button_list
-        for button in self.disable_button_list:
-            button.disable()
+        self.disable_button_list = []
+        for button in disable_button_list:
+            if button.is_enabled:
+                self.disable_button_list.append(button)
+                button.disable()
 
         opposite_log_string = None
         if not relationship.opposite_relationship:


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->

## About The Pull Request
When closing the relationship log, it now doesn't reenable the "switch focus" button if it was originally disabled.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues

<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->
Fixes #2923

## Proof of Testing

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

https://github.com/user-attachments/assets/47e9ac83-a990-486e-a529-21d4b1843259

## Changelog/Credits

<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
Add "bugfixes" to changelog if not already present