### PR TITLE
[BUGFIX] Remove period in history text when leader dies to condition

### DIFF
--- a/scripts/events_module/condition_events.py
+++ b/scripts/events_module/condition_events.py
@@ -181,7 +181,7 @@ class Condition_Events:
             event = event_text_adjust(Cat, event.strip(), main_cat=cat)
 
             if cat.status == "leader":
-                history_event = history_event.replace("m_c ", "")
+                history_event = history_event.replace("m_c ", "").replace(".", "")
                 History.add_death(
                     cat, condition="starving", death_text=history_event.strip()
                 )
@@ -569,7 +569,7 @@ class Condition_Events:
 
                 if cat.status == "leader":
                     event = event + " " + get_leader_life_notice()
-                    history_event = history_event.replace("m_c ", "")
+                    history_event = history_event.replace("m_c ", "").replace(".", "")
                     History.add_death(
                         cat, condition=illness, death_text=history_event.strip()
                     )
@@ -674,7 +674,7 @@ class Condition_Events:
 
                 if cat.status == "leader":
                     event = event + " " + get_leader_life_notice()
-                    history_text = history_text.replace("m_c", " ")
+                    history_text = history_text.replace("m_c", " ").replace(".", "")
                     History.add_death(
                         cat, condition=injury, death_text=history_text.strip()
                     )


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->

## About The Pull Request
Pretty self explanatory
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->


## Linked Issues
Fixes #2493
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
![image](https://github.com/user-attachments/assets/f386568a-6d2e-45fc-ab25-5484d6713e7a)

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Adjust history text formatting when leader dies to condition so that doubled punctuation does not occur.
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
