### PR TITLE
[BUGFIX] Add "affair_mated" category of events

### DIFF
--- a/resources/dicts/conditions/pregnancy.json
+++ b/resources/dicts/conditions/pregnancy.json
@@ -105,9 +105,11 @@
             "r_c goes to visit m_c in the nursery with {PRONOUN/m_c/poss} new {insert}, on a completely innocent mission to deliver food to the new parent.",
             "The newly arrived {insert} that m_c has just given birth to looks suspiciously like r_c. ",
             "No one wants to ruin such a happy occasion, but... it doesn't take a genius to notice how m_c's {insert} looks suspiciously like r_c...",
-            "m_c can see it, m_c's mate can see it, r_c can see it, everyone in c_n can see how the new {insert} looks a bit too much like r_c for it to be coincidence...",
-            "Ever since the birth, rumor's gone around that m_c's {insert} belongs to r_c and, while no one wants to confirm anything, no one really has to when the evidence is mewling right there...",
-            "m_c's mate is such a wonderful cat, deserving of being a parent... so why does m_c's {insert} look more like r_c instead?"
+            "Ever since the birth, rumor's gone around that m_c's {insert} belongs to r_c and, while no one wants to confirm anything, no one really has to when the evidence is mewling right there..."
+        ],
+        "affair_mated": [
+            "m_c's mate is such a wonderful cat, deserving of being a parent... so why does m_c's {insert} look more like r_c instead?",
+            "m_c can see it, m_c's mate can see it, r_c can see it, everyone in c_n can see how the new {insert} looks a bit too much like r_c for it to be coincidence..."
         ],
         "death": [
             "Later, as the medicine cat wails with m_c's blood streaked through their pelt and a warrior comes to move the body for the vigil, no one knows what to do with the {insert}.",

--- a/scripts/events_module/relationship/pregnancy_events.py
+++ b/scripts/events_module/relationship/pregnancy_events.py
@@ -422,6 +422,8 @@ class Pregnancy_Events:
         ):
             involved_cats.append(other_cat.ID)
             event_list.append(choice(events["birth"]["affair"]))
+            if len(cat.mate) > 0:
+                event_list.append(choice(events["birth"]["affair_mated"]))
         else:
             event_list.append(choice(events["birth"]["unmated_parent"]))
 


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->

## About The Pull Request
Adds a new category of birth events for events that mention the birthing cat's mate not being the parent of the new litter.  This previously caused issues as there was no delineation between the birthing cat being unfaithful or the other parent being unfaithful.  Thus it was possible for a birthing cat without a mate to receive affair birth text that mentioned a mate (in this case, the cat who had been unfaithful to their mate/s would have been the other parent).
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
Fixes #2845 
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
![image](https://github.com/user-attachments/assets/ae5b5150-ca55-4f09-91dc-5ee130c1942f)
![image](https://github.com/user-attachments/assets/0d3af36e-b9fd-40d3-a231-2477b14ed5ac)
![image](https://github.com/user-attachments/assets/44a53b00-192b-4e7a-985d-2291d90fe2a6)
I did also test the other way around and received appropriate events.
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Adds a new category of birth events for events that specifically mention the birthing cat's mate not being the parent of the new litter.
- Affair birth events will no longer mention nonexistent mates.
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
