### PR TITLE
Fix outlines of patrol art being ugly when scaled

### DIFF
--- a/scripts/screens/PatrolScreen.py
+++ b/scripts/screens/PatrolScreen.py
@@ -211,8 +211,8 @@ class PatrolScreen(Screens):
             self.elements["patrol_start"].disable()
             self.selected_cat = None
             if (
-                    self.start_patrol_thread is not None
-                    and self.start_patrol_thread.is_alive()
+                self.start_patrol_thread is not None
+                and self.start_patrol_thread.is_alive()
             ):
                 return
             self.start_patrol_thread = self.loading_screen_start_work(

--- a/scripts/screens/PatrolScreen.py
+++ b/scripts/screens/PatrolScreen.py
@@ -760,11 +760,13 @@ class PatrolScreen(Screens):
         self.elements["intro_image"] = pygame_gui.elements.UIImage(
             ui_scale(pygame.Rect((75, 150), (300, 300))),
             pygame.transform.scale(
-                self.patrol_obj.get_patrol_art(), ui_scale_dimensions((300, 300))
+                self.patrol_obj.get_patrol_art().premul_alpha(),
+                ui_scale_dimensions((300, 300)),
             )
             if game.settings["no sprite antialiasing"]
             else pygame.transform.smoothscale(
-                self.patrol_obj.get_patrol_art(), ui_scale_dimensions((300, 300))
+                self.patrol_obj.get_patrol_art().premul_alpha(),
+                ui_scale_dimensions((300, 300)),
             ),
         )
 


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->

## About The Pull Request
Just a quick fix I noticed I hadn't implemented for patrol art. This gets rid of the white/black outline that could be seen when scaling up!

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
No specific reported issue but I have sulked about it in the past
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
Tracking down a patrol that demonstrates this well is turning out to be a pain in the butt. Source: trust me?? 🥺 Why is it that when I'm trying to demonstrate this I can't freaking get one...

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits

<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
