### PR TITLE
Content: Relationship Boost when Setting Adoptive Parents

### DIFF
--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -2568,7 +2568,7 @@ class Cat:
             if self.ID not in other_cat.relationships:
                 other_cat.create_one_relationship(self)
             other_relationship = other_cat.relationships[self.ID]
-            other_relationship.platonic_like -= randint(10, 30)
+            other_relationship.platonic_like -= 20
             other_relationship.comfortable -= 20
             other_relationship.trust -= 10
             

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -2549,6 +2549,49 @@ class Cat:
             other_relationship.comfortable += 20
             other_relationship.trust += 10
             other_relationship.mate = True
+            
+    def unset_adoptive_parent(self, other_cat: Cat):
+        """Unset the adoptive parent from self"""
+        self.adoptive_parents.remove(other_cat.ID)
+        self.create_inheritance_new_cat()
+        other_cat.create_inheritance_new_cat()
+        if not self.dead:
+            if other_cat.ID not in self.relationships:
+                self.create_one_relationship(other_cat)
+            self_relationship = self.relationships[other_cat.ID]
+            self_relationship.comfortable -= randint(10, 30)
+            self_relationship.trust -= randint(5, 15)
+
+
+        if not other_cat.dead:
+            if self.ID not in other_cat.relationships:
+                other_cat.create_one_relationship(self)
+            other_relationship = other_cat.relationships[self.ID]
+            other_relationship.comfortable -= 20
+            other_relationship.trust -= 10
+            
+    def set_adoptive_parent(self, other_cat: Cat):
+        """Sets up a parent-child relationship between self and other_cat."""
+        self.adoptive_parents.append(other_cat.ID)
+        self.create_inheritance_new_cat()
+
+        # Set starting relationship values
+        if not self.dead:
+            if other_cat.ID not in self.relationships:
+                self.create_one_relationship(other_cat)
+            self_relationship = self.relationships[other_cat.ID]
+            self_relationship.platonic_like += 20
+            self_relationship.comfortable += 20
+            self_relationship.trust += 10
+
+
+        if not other_cat.dead:
+            if self.ID not in other_cat.relationships:
+                other_cat.create_one_relationship(self)               
+            other_relationship = other_cat.relationships[self.ID]
+            other_relationship.platonic_like += 20
+            other_relationship.comfortable += 20
+            other_relationship.trust += 10
 
     def create_inheritance_new_cat(self):
         """Creates the inheritance class for a new cat."""

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -2559,6 +2559,7 @@ class Cat:
             if other_cat.ID not in self.relationships:
                 self.create_one_relationship(other_cat)
             self_relationship = self.relationships[other_cat.ID]
+            self_relationship.platonic_like -= randint(10, 30)
             self_relationship.comfortable -= randint(10, 30)
             self_relationship.trust -= randint(5, 15)
 
@@ -2567,6 +2568,7 @@ class Cat:
             if self.ID not in other_cat.relationships:
                 other_cat.create_one_relationship(self)
             other_relationship = other_cat.relationships[self.ID]
+            other_relationship.platonic_like -= randint(10, 30)
             other_relationship.comfortable -= 20
             other_relationship.trust -= 10
             

--- a/scripts/screens/ChooseAdoptiveParentScreen.py
+++ b/scripts/screens/ChooseAdoptiveParentScreen.py
@@ -351,18 +351,14 @@ class ChooseAdoptiveParentScreen(Screens):
 
     def change_adoptive_parent(self):
         """Make adoptive parent changes"""
-
         if not self.selected_cat:
             return
 
         if self.selected_cat.ID not in self.the_cat.adoptive_parents:
-            self.the_cat.adoptive_parents.append(self.selected_cat.ID)
-            self.the_cat.create_inheritance_new_cat()
+            self.the_cat.set_adoptive_parent(self.selected_cat)
 
         else:
-            self.the_cat.adoptive_parents.remove(self.selected_cat.ID)
-            self.the_cat.create_inheritance_new_cat()
-            self.selected_cat.create_inheritance_new_cat()
+            self.the_cat.unset_adoptive_parent(self.selected_cat)
 
     def update_after_change(self):
         """Updates that need to be run after setting an adoptive parent"""


### PR DESCRIPTION
## About The Pull Request
Similarly to the 'choose mate' screen, the 'choose adoptive parents' screen now provides a boost to platonic like, comfort, and trust when setting an adoptive parent, and detracts from these relationships when removing an adoptive parent.

## Why This Is Good For ClanGen
Biological families get relationship boosts upon creation, so this provides a similar boost for adoptive families. Also ensures that there aren't any issues with parents seemingly not knowing who their adoptive kits are or vice versa, because a relationship file will now be built if one does not exist already.

## Proof of Testing
Setting Blueleaf as Wrenstar's adoptive parent increases their relationship, and then decreases it when he's removed as her adoptive parent.
Before:
![Screenshot 2024-11-13 234020](https://github.com/user-attachments/assets/7fe0144e-d5c2-478a-8f9d-9b8b3673ae73)

After setting as adoptive parent:
![Screenshot 2024-11-13 234038](https://github.com/user-attachments/assets/9c5eb6bb-430b-4a5e-967a-e19bf1032dfa)

After removing as adoptive parent:
![Screenshot 2024-11-13 234058](https://github.com/user-attachments/assets/5f227b3d-c92e-4938-b5f5-3320c0a2a45d)


## Changelog
Setting a cat as an adoptive parent now provides a platonic relationship boost between parent and child.
