### PR TITLE
[BUGFIX] added check for empty sequence when selecting random patrol cat

### DIFF
--- a/scripts/screens/PatrolScreen.py
+++ b/scripts/screens/PatrolScreen.py
@@ -92,7 +92,10 @@ class PatrolScreen(Screens):
 
     def handle_choose_cats_events(self, event):
         if event.ui_element == self.elements["random"]:
-            self.selected_cat = choice(self.able_cats)
+            if self.able_cats:
+                self.selected_cat = choice(self.able_cats)
+            else:
+                print('WARNING: attempted to select random cat for patrol from empty list of able cats')
             self.update_selected_cat()
             self.update_button()
         # Check is a cat is clicked
@@ -128,7 +131,10 @@ class PatrolScreen(Screens):
                         able_no_med = self.able_cats
                     self.selected_cat = choice(able_no_med)
                 else:
-                    self.selected_cat = choice(self.able_cats)
+                    if self.able_cats:
+                        self.selected_cat = choice(self.able_cats)
+                    else:
+                        print('WARNING: attempted to select random cat for patrol from empty list of able cats')
                 self.update_selected_cat()
                 self.current_patrol.append(self.selected_cat)
             self.update_cat_images_buttons()


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->

## About The Pull Request
This PR adds a check for an empty list before adding/choosing a random cat on the patrol screen, in order to alleviate what I believe is a race condition causing a crash.

In the original bug report, only choosing a random cat was mentioned ("dice" icon), but I have fixed the "plus one" icon as well because the crash also happens with it. The crash does not happen with the +3 or +5 icons as the code for those is different. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->


## Linked Issues
Resolves #2809
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
https://youtu.be/0p1Nr94Wttk
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
N/A
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
