### PR TITLE
Fix "Change Focus" button in SelectFocusClans.

### DIFF
--- a/scripts/game_structure/windows.py
+++ b/scripts/game_structure/windows.py
@@ -2069,10 +2069,11 @@ class SelectFocusClans(UIWindow):
             object_id="#exit_window_button",
             container=self,
         )
-        self.save_button = UIImageButton(
+        self.save_button = UISurfaceImageButton(
             ui_scale(pygame.Rect((80, 180), (139, 30))),
-            "",
-            object_id="#change_focus_button",
+            "Change Focus",
+            get_button_dict(ButtonStyles.SQUOVAL, (139, 30)),
+            object_id="@buttonstyles_squoval",
             container=self,
         )
         self.save_button.disable()


### PR DESCRIPTION
## About The Pull Request

Fixed "Change Focus" button in the SelectFocusClans class so now it shows up again.

## Linked Issues
fixes #2884 

## Proof of Testing

![evidence](https://github.com/user-attachments/assets/b90d8d8e-cd37-4393-b411-3642808f17a8)

## Changelog/Credits
