### PR TITLE
[BUGFIX] Death History Text No Longer Misleading

### DIFF
--- a/resources/dicts/patrols/beach/border/any.json
+++ b/resources/dicts/patrols/beach/border/any.json
@@ -67,7 +67,7 @@
                 "dead_cats": ["multi"],
                 "history_text": {
                     "scar": "m_c was badly scarred when rogues ambushed {PRONOUN/m_c/poss} patrol.",
-                    "reg_death": "This cat was killed when rogues ambushed {PRONOUN/m_c/poss} patrol.",
+                    "reg_death": "m_c was killed when rogues ambushed {PRONOUN/m_c/poss} patrol.",
                     "lead_death": "killed in a rogue ambush"
                 }
             },
@@ -84,8 +84,8 @@
                 ],
                 "history_text": {
                     "scar": "m_c was badly scarred when rogues ambushed {PRONOUN/m_c/poss} patrol.",
-                    "reg_death": "This cat was killed when rogues ambushed {PRONOUN/m_c/poss} patrol.",
-                    "lead_death": "killed in a rogue ambush"
+                    "reg_death": "m_c died of injuries sustained in a rogue ambush.",
+                    "lead_death": "died of injuries sustained in a rogue ambush"
                 }
             }
         ]
@@ -157,7 +157,7 @@
                 "weight": 10,
                 "dead_cats": ["r_c"],
                 "history_text": {
-                    "reg_death": "This cat was killed when rogues ambushed {PRONOUN/m_c/object} while on a solo patrol.",
+                    "reg_death": "m_c was killed when rogues ambushed {PRONOUN/m_c/object} while on a solo patrol.",
                     "lead_death": "{VERB/m_c/were/was} killed in a rogue ambush"
                 },
                 "relationships": [
@@ -254,8 +254,8 @@
                 "dead_cats": ["multi"],
                 "history_text": {
                     "scar": "m_c was badly scarred when rogues attacked {PRONOUN/m_c/poss} patrol.",
-                    "reg_death": "This cat was killed when rogues attacked {PRONOUN/m_c/poss} patrol.",
-                    "lead_death": "killed in a rogue ambush"
+                    "reg_death": "m_c died of injuries sustained in a rogue ambush.",
+                    "lead_death": "died of injuries sustained in a rogue ambush"
                 },
                 "relationships": [
                     {
@@ -280,8 +280,8 @@
                 ],
                 "history_text": {
                     "scar": "m_c was badly scarred when rogues attacked {PRONOUN/m_c/poss} patrol.",
-                    "reg_death": "This cat was killed when rogues attacked {PRONOUN/m_c/poss} patrol.",
-                    "lead_death": "killed in a rogue ambush"
+                    "reg_death": "m_c died of injuries sustained in a rogue ambush.",
+                    "lead_death": "died of injuries sustained in a rogue ambush"
                 },
                 "relationships": [
                     {
@@ -762,8 +762,8 @@
                 ],
                 "history_text": {
                     "scar": "m_c was scarred by an invading rogue.",
-                    "reg_death": "m_c was killed by an invading rogue.",
-                    "lead_death": "{VERB/m_c/were/was} killed by an invading rogue"
+                    "reg_death": "m_c died of an injury inflicted by an invading rogue.",
+                    "lead_death": "died of an injury inflicted by an invading rogue"
                 },
                 "relationships": [
                     {
@@ -938,8 +938,8 @@
                 ],
                 "history_text": {
                     "scar": "m_c was scarred by an invading rogue.",
-                    "reg_death": "m_c was killed by an invading rogue.",
-                    "lead_death": "{VERB/m_c/were/was} killed by an invading rogue"
+                    "reg_death": "m_c died of an injury inflicted by an invading rogue.",
+                    "lead_death": "died of an injury inflicted by an invading rogue"
                 },
                 "relationships": [
                     {
@@ -1035,8 +1035,8 @@
                 ],
                 "history_text": {
                     "scar": "m_c was scarred by an invading rogue.",
-                    "reg_death": "m_c was killed by an invading rogue.",
-                    "lead_death": "{VERB/m_c/were/was} killed by an invading rogue"
+                    "reg_death": "m_c died of an injury inflicted by an invading rogue.",
+                    "lead_death": "died of an injury inflicted by an invading rogue"
                 }
             }
         ]
@@ -1173,7 +1173,11 @@
                         "scars": ["BRIDGE"]
                     }
                 ],
-                "history_text": { "scar": "m_c was scarred by an invading rogue." },
+                "history_text": { 
+                    "scar": "m_c was scarred by an invading rogue.",
+                    "reg_death": "m_c died of an injury inflicted by an invading rogue.",
+                    "lead_death": "died of an injury inflicted by an invading rogue"
+                 },
                 "relationships": [
                     {
                         "cats_to": ["patrol"],
@@ -1318,7 +1322,11 @@
                         "scars": ["BRIDGE"]
                     }
                 ],
-                "history_text": { "scar": "m_c was scarred by an invading rogue." },
+                "history_text": {
+                    "scar": "m_c was scarred by an invading rogue.",
+                    "reg_death": "m_c died of an injury inflicted by an invading rogue.",
+                    "lead_death": "died of an injury inflicted by an invading rogue"
+                },
                 "relationships": [
                     {
                         "cats_to": ["patrol"],
@@ -1400,7 +1408,11 @@
                         "scars": ["BRIDGE"]
                     }
                 ],
-                "history_text": { "scar": "m_c was scarred by an invading rogue." }
+                "history_text": {
+                    "scar": "m_c was scarred by an invading rogue.",
+                    "reg_death": "m_c died of an injury inflicted by an invading rogue.",
+                    "lead_death": "died of an injury inflicted by an invading rogue"
+                }
             }
         ]
     },

--- a/resources/dicts/patrols/disaster.json
+++ b/resources/dicts/patrols/disaster.json
@@ -571,7 +571,7 @@
                 "weight": 10,
                 "dead_cats": ["r_c", "some_lives"],
                 "history_text": {
-                    "reg_death": "This cat died from being ambushed by rogues while on a solo patrol.",
+                    "reg_death": "m_c died in a rogue ambush while on a solo patrol.",
                     "lead_death": "{VERB/m_c/were/was} ambushed by rogues while on a solo patrol"
                 }
             }
@@ -1575,7 +1575,7 @@
                 "weight": 10,
                 "dead_cats": ["r_c", "some_lives"],
                 "history_text": {
-                    "reg_death": "This cat died from being ambushed by rogues while on a solo patrol.",
+                    "reg_death": "m_c died in a rogue ambush while on a solo patrol.",
                     "lead_death": "{VERB/m_c/were/was} ambushed by rogues while on a solo patrol"
                 }
             }
@@ -2149,8 +2149,8 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "This cat was badly scarred when rogues ambushed their patrol.",
-                    "reg_death": "This cat was killed when rogues ambushed {PRONOUN/m_c/poss} patrol.",
+                    "scar": "m_c was badly scarred when rogues ambushed their patrol.",
+                    "reg_death": "m_c was killed when rogues ambushed {PRONOUN/m_c/poss} patrol.",
                     "lead_death": "{VERB/m_c/were/was} killed in a rogue ambush"
                 }
             }
@@ -2390,7 +2390,7 @@
                 ],
                 "history_text": {
                     "scar": "m_c was badly scarred when rogues ambushed {PRONOUN/m_c/poss} patrol.",
-                    "reg_death": "This cat was killed when rogues ambushed {PRONOUN/m_c/poss} patrol.",
+                    "reg_death": "m_c was killed when rogues ambushed {PRONOUN/m_c/poss} patrol.",
                     "lead_death": "{VERB/m_c/were/was} killed in a rogue ambush"
                 }
             }
@@ -2510,7 +2510,7 @@
                 ],
                 "history_text": {
                     "scar": "m_c was badly scarred when rogues ambushed {PRONOUN/m_c/poss} patrol.",
-                    "reg_death": "This cat was killed when rogues ambushed {PRONOUN/m_c/poss} patrol.",
+                    "reg_death": "m_c was killed when rogues ambushed {PRONOUN/m_c/poss} patrol.",
                     "lead_death": "{VERB/m_c/were/was} killed in a rogue ambush"
                 }
             }

--- a/resources/dicts/patrols/forest/border/any.json
+++ b/resources/dicts/patrols/forest/border/any.json
@@ -92,9 +92,9 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "This cat was badly scarred when rogues ambushed {PRONOUN/m_c/poss} patrol.",
-                    "reg_death": "This cat was killed when rogues ambushed {PRONOUN/m_c/poss} patrol.",
-                    "lead_death": "rogues ambushed {PRONOUN/m_c/poss} patrol"
+                    "scar": "m_c was badly scarred when rogues ambushed {PRONOUN/m_c/poss} patrol.",
+                    "reg_death": "m_c died of an injury sustained in a rogue ambush.",
+                    "lead_death": "died of an injury sustained in a rogue ambush"
                 },
                 "relationships": [
                     {
@@ -272,7 +272,7 @@
                 "dead_cats": ["multi"],
                 "history_text": {
                     "scar": "m_c was badly scarred when rogues attacked {PRONOUN/m_c/poss} patrol.",
-                    "reg_death": "This cat was killed when rogues attacked {PRONOUN/m_c/poss} patrol.",
+                    "reg_death": "m_c was killed when rogues attacked {PRONOUN/m_c/poss} patrol.",
                     "lead_death": "{VERB/m_c/were/was} killed when rogues attacked {PRONOUN/m_c/poss} patrol"
                 },
                 "relationships": [
@@ -298,8 +298,8 @@
                 ],
                 "history_text": {
                     "scar": "m_c was badly scarred when rogues attacked {PRONOUN/m_c/poss} patrol.",
-                    "reg_death": "This cat was killed when rogues attacked {PRONOUN/m_c/poss} patrol.",
-                    "lead_death": "{VERB/m_c/were/was} killed when rogues attacked {PRONOUN/m_c/poss} patrol"
+                    "reg_death": "m_c died of an injury sustained in a rogue ambush.",
+                    "lead_death": "died of an injury sustained in a rogue ambush"
                 },
                 "relationships": [
                     {

--- a/resources/dicts/patrols/general/border.json
+++ b/resources/dicts/patrols/general/border.json
@@ -97,8 +97,8 @@
                 "art": "gen_coyote_danger2_w1",
                 "dead_cats": ["r_c"],
                 "history_text": {
-                    "scar": "This cat is scarred from bravely defending the Clan against a dog.",
-                    "reg_death": "This cat died to keep c_n safe from a large dog.",
+                    "scar": "m_c was scarred from bravely defending the Clan against a dog.",
+                    "reg_death": "m_c died to keep c_n safe from a large dog.",
                     "lead_death": "died to keep c_n safe from a large dog"
                 },
                 "relationships": [
@@ -124,8 +124,8 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "This cat is scarred from bravely defending the Clan against a dog.",
-                    "reg_death": "This cat died to keep c_n safe from a large dog.",
+                    "scar": "m_c was scarred from bravely defending the Clan against a dog.",
+                    "reg_death": "m_c died to keep c_n safe from a large dog.",
                     "lead_death": "died to keep c_n safe from a large dog"
                 },
                 "relationships": [
@@ -290,8 +290,8 @@
                 "art": "gen_coyote_danger2_w1",
                 "dead_cats": ["r_c"],
                 "history_text": {
-                    "scar": "This cat is scarred from bravely defending the Clan against a dog.",
-                    "reg_death": "This cat died to keep the Clan safe from a large dog.",
+                    "scar": "m_c was scarred from bravely defending the Clan against a dog.",
+                    "reg_death": "m_c died to keep the Clan safe from a large dog.",
                     "lead_death": "died to keep c_n safe from a large dog"
                 },
                 "relationships": [
@@ -580,8 +580,8 @@
                 "weight": 10,
                 "dead_cats": ["r_c"],
                 "history_text": {
-                    "scar": "This cat got a scar from a fight with a small dog, but {PRONOUN/m_c/subject} always {VERB/m_c/say/says} it was a huge dog.",
-                    "reg_death": "This cat was killed in a fight with a small dog, but {PRONOUN/m_c/subject} took the dog out with {PRONOUN/m_c/object}.",
+                    "scar": "m_c got a scar from a fight with a small dog, but {PRONOUN/m_c/subject} always {VERB/m_c/say/says} it was a huge dog.",
+                    "reg_death": "m_c was killed in a fight with a small dog, but {PRONOUN/m_c/subject} took the dog out with {PRONOUN/m_c/object}.",
                     "lead_death": "killed in a fight with a small dog"
                 }
             },
@@ -597,8 +597,8 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "This cat got a scar from a fight with a small dog, but {PRONOUN/m_c/subject} always {VERB/m_c/say/says} it was a huge dog.",
-                    "reg_death": "This cat was killed in a fight with a small dog, but {PRONOUN/m_c/subject} took the dog out with {PRONOUN/m_c/object}.",
+                    "scar": "m_c got a scar from a fight with a small dog, but {PRONOUN/m_c/subject} always {VERB/m_c/say/says} it was a huge dog.",
+                    "reg_death": "m_c was killed in a fight with a small dog, but {PRONOUN/m_c/subject} took the dog out with {PRONOUN/m_c/object}.",
                     "lead_death": "killed in a fight with a small dog"
                 }
             }
@@ -684,7 +684,9 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "This cat got a scar from a fight with a small dog, but {PRONOUN/m_c/subject} always {VERB/m_c/say/says} it was a huge dog."
+                    "scar": "m_c got a scar from a fight with a small dog, but {PRONOUN/m_c/subject} always {VERB/m_c/say/says} it was a huge dog.",
+                    "reg_death": "m_c was died from injuries sustained in a fight with a small dog.",
+                    "lead_death": "died from {PRONOUN/m_c/poss} injuries"
                 }
             }
         ]
@@ -768,7 +770,9 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "This cat got a scar from a fight with a small dog, though {PRONOUN/m_c/subject} {VERB/m_c/insist/insists} it was huge."
+                    "scar": "m_c got a scar from a fight with a small dog, though {PRONOUN/m_c/subject} {VERB/m_c/insist/insists} it was huge.",
+                    "reg_death": "m_c was died from injuries sustained in a fight with a small dog.",
+                    "lead_death": "died from {PRONOUN/m_c/poss} injuries"
                 }
             }
         ]
@@ -1401,7 +1405,9 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c was scarred when {PRONOUN/m_c/subject} tried to sneak across the o_c_n border."
+                    "scar": "m_c was scarred when {PRONOUN/m_c/subject} tried to sneak across the o_c_n border.",
+                    "reg_death": "m_c died from injuries after trying to sneak across the o_c_n border.",
+                    "lead_death": "died of injuries after trying to sneak over the border"
                 },
                 "relationships": [
                     {
@@ -1435,7 +1441,9 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c was scarred when {PRONOUN/m_c/subject} tried to sneak across the o_c_n border."
+                    "scar": "m_c was scarred when {PRONOUN/m_c/subject} tried to sneak across the o_c_n border.",
+                    "reg_death": "m_c died from injuries after trying to sneak across the o_c_n border.",
+                    "lead_death": "died of injuries after trying to sneak over the border"
                 },
                 "relationships": [
                     {
@@ -1749,6 +1757,10 @@
                     "cats": ["r_c"],
                     "injuries": ["battle_injury", "battle_injury"]
                 },
+                "history_text": {
+                    "reg_death": "m_c died from {PRONOUN/r_c/poss} injuries after a fight with a rogue.",
+                    "scar": "m_c was scarred in a fight with a rogue."
+                },
                 "relationships": [
                     {
                         "cats_to": ["p_l"],
@@ -1818,11 +1830,15 @@
                 ]
             },
             {
-                "text": "As the duo are patroling, they are ambushed by a rogue! r_c is badly injured, and succumbs to the wounds when p_l flees, leaving {PRONOUN/r_c/object} behind.",
+                "text": "As the duo are patroling, they are ambushed by a rogue! r_c is badly injured and succumbs to the wounds when p_l flees, leaving {PRONOUN/r_c/object} behind.",
                 "exp": 0,
                 "weight": 5,
                 "art": "gen_dead_cat",
-                "dead_cats": ["r_c"]
+                "dead_cats": ["r_c"],
+                "history_text": {
+                    "reg_death": "m_c succumbed to injury after being ambushed by a rogue and abandoned on patrol.",
+                    "lead_death": "succumbed to injury after being ambushed and abandoned"
+                }
             },
             {
                 "text": "s_c can't resist the temptation to make pointed remarks {PRONOUN/s_c/subject} {VERB/s_c/know/knows} are hurtful to r_c. But when a verbal barb sinks too deep and r_c starts crying, s_c lashes their tail, snapping at r_c to focus on patrolling. r_c runs off, leaving s_c to finish the patrol alone.",
@@ -1935,6 +1951,11 @@
                     "cats": ["r_c"],
                     "injuries": ["battle_injury", "battle_injury"]
                 },
+                "history_text": {
+                    "scar": "m_c was scarred after being ambushed on patrol.",
+                    "reg_death": "m_c died of injuries sustained in an ambush.",
+                    "lead_death": "died of injuries sustained in an ambush"
+                },
                 "relationships": [
                     {
                         "cats_to": ["p_l"],
@@ -1994,6 +2015,11 @@
                     "cats": ["r_c", "p_l"],
                     "injuries": ["minor_injury","minor_injury","battle_injury"]
                 },
+                "history_text": {
+                    "scar": "m_c was scarred after brawling with a Clanmate.",
+                    "reg_death": "m_c died from injuries sustained in a brawl with a Clanmate.",
+                    "lead_death": "died from injuries sustained in a brawl with a Clanmate"
+                },
                 "relationships": [
                     {
                         "cats_to": ["p_l"],
@@ -2019,18 +2045,28 @@
                 ]
             },
             {
-                "text": "As the duo are patroling, too distracted by their argument, they didn't notice the shadow desending on them as they are ambushed by a rogue. r_c is badly injured, and succumbs to the wounds when p_l flees, leaving {PRONOUN/r_c/object} behind.",
+                "text": "As the duo are patroling, too distracted by their argument, they didn't notice the shadow desending on them as they are ambushed by a rogue. r_c is badly injured and succumbs to the wounds when p_l flees, leaving {PRONOUN/r_c/object} behind.",
                 "exp": 0,
                 "weight": 5,
                 "art": "gen_dead_cat",
-                "dead_cats": ["r_c"]
+                "dead_cats": ["r_c"],
+                "history_text": {
+                    "scar": "m_c was scarred after being ambushed on patrol.",
+                    "reg_death": "m_c died after {PRONOUN/m_c/poss} Clanmate abandoned {PRONOUN/m_c/object} to a rogue ambush.",
+                    "lead_death": "died after being abandoned and ambushed on patrol"
+                }
             },
             {
-                "text": "As the duo are patroling, they are ambushed by an o_c_n patrol! p_l is fighting for {PRONOUN/p_l/poss} life, when out of the corner of {PRONOUN/p_l/poss} eye {PRONOUN/p_l/subject} {VERB/p_l/see/sees} r_c fleeing. Outnumbered and overwhelmed, p_l is killed.",
+                "text": "As the duo are patroling, they are ambushed by a o_c_n patrol! p_l is fighting for {PRONOUN/p_l/poss} life, when out of the corner of {PRONOUN/p_l/poss} eye {PRONOUN/p_l/subject} {VERB/p_l/see/sees} r_c fleeing. Outnumbered and overwhelmed, p_l is killed.",
                 "exp": 0,
                 "weight": 5,
                 "art": "gen_big_fight_warriors_other_clan",
                 "dead_cats": ["p_l"],
+                "history_text": {
+                    "scar": "m_c was scarred in a o_c_n ambush.",
+                    "reg_death": "m_c died after {PRONOUN/m_c/poss} Clanmate abandoned them to a o_c_n ambush.",
+                    "lead_death": "died after being abandoned and ambushed on patrol"
+                },
                 "other_clan_rep": -2
             },
             {
@@ -2306,9 +2342,8 @@
                 ],
                 "history_text":
                 {
-                    "cats": [ "app1" ],
-                    "reg_death": "app1 died after picking a fight with a o_c_n apprentice on patrol.",
-                    "scar": "app1 was scarred by a o_c_n apprentice after a border scrum."
+                    "scar": "m_c was scarred by a o_c_n apprentice after a border scrum.",
+                    "reg_death": "m_c died after picking a fight with a o_c_n apprentice on patrol."
                 },
                 "relationships":[
                     {
@@ -2341,9 +2376,9 @@
                 ],
                 "history_text":
                 {
-                    "cats": [ "r_c" ],
-                    "reg_death": "r_c died from injuries sustained in a border skirmish.",
-                    "scar": "r_c was scarred in a border skirmish."
+                    "scar": "m_c was scarred in a border skirmish.",
+                    "reg_death": "m_c died from injuries sustained in a border skirmish.",
+                    "lead_death": "died from injuries sustained in a border skirmish"
                 },
                 "relationships":[
                     {
@@ -2366,7 +2401,12 @@
                         "injuries": [ "battle_injury" ],
                         "scar": [ "NECKBITE", "SNOUT" ]
                     }
-                ]
+                ],
+                "history_text": {
+                    "scar": "m_c was scarred in a border skirmish.",
+                    "reg_death": "m_c died of injuries sustained in a border skirmish.",
+                    "lead_death": "died of injuries sustained in a border skirmish"
+                }
             }
         ]
 
@@ -3107,9 +3147,8 @@
         "injuries": [ "grief stricken" ]
     }
 ],
-    "history": [
+    "history_text": [
                 {
-                    "cats": [ "p_l" ],
                     "scar": "m_c was scarred by {PRONOUN/m_c/poss} mate's Clanmates.",
                     "reg_death": "m_c died from injuries inflicted by {PRONOUN/m_c/poss} mate's Clanmates."
                 }

--- a/resources/dicts/patrols/mountainous/border/any.json
+++ b/resources/dicts/patrols/mountainous/border/any.json
@@ -57,7 +57,7 @@
                 ],
                 "history_text": {
                     "scar": "m_c was badly scarred when rogues ambushed {PRONOUN/m_c/poss} patrol.",
-                    "reg_death": "This cat was killed when rogues ambushed {PRONOUN/m_c/poss} patrol.",
+                    "reg_death": "m_c was killed when rogues ambushed {PRONOUN/m_c/poss} patrol.",
                     "lead_death": "{VERB/m_c/were/was} killed in a rogue ambush"
                 }
             }

--- a/resources/dicts/patrols/new_cat.json
+++ b/resources/dicts/patrols/new_cat.json
@@ -1911,7 +1911,7 @@
                 "weight": 10,
                 "dead_cats": ["r_c", "some_lives"],
                 "history_text": {
-                    "reg_death": "This cat died in an ambush set by rogues.",
+                    "reg_death": "m_c died in an ambush set by rogues.",
                     "lead_death": "{VERB/m_c/were/was} killed in a rogue ambush"
                 },
                 "outsider_rep": -1
@@ -1940,7 +1940,7 @@
         ],
         "antag_success_outcomes": [
             {
-                "text": "p_l can sense it's a trap and waits just outside, setting {PRONOUN/p_l/poss} own trap. {PRONOUN/p_l/subject/CAP} {VERB/p_l/manage/manages} to set up such a yowl that it sends the rogues running as if LionClan were after them.",
+                "text": "p_l can sense it's a trap and waits just outside, setting {PRONOUN/p_l/poss} own trap. {PRONOUN/p_l/subject/CAP} {VERB/p_l/fill/fills} {PRONOUN/p_l/poss} lungs deeply and {VERB/p_l/let/lets} out a yowl that sends the rogues running as if LionClan were after them.",
                 "exp": 30,
                 "weight": 20,
                 "outsider_rep": -2,
@@ -2044,7 +2044,7 @@
                 "weight": 10,
                 "dead_cats": ["multi"],
                 "history_text": {
-                    "reg_death": "This cat died in an ambush set by rogues.",
+                    "reg_death": "m_c died in an ambush set by rogues.",
                     "lead_death": "{VERB/m_c/were/was} killed in a rogue ambush"
                 },
                 "outsider_rep": -1,
@@ -2212,7 +2212,11 @@
                         "scars": ["BRIDGE"]
                     }
                 ],
-                "history_text": { "scar": "m_c gained a scar after tussling with a rogue." },
+                "history_text": { 
+                    "scar": "m_c gained a scar after tussling with a rogue.",
+                    "reg_death": "m_c died from injuries sustained in a fight with a rogue.",
+                    "lead_death": "died from injuries sustained in a fight with a rogue"
+                 },
                 "outsider_rep": -1
             }
         ],
@@ -2340,7 +2344,7 @@
                 "weight": 10,
                 "dead_cats": ["patrol"],
                 "history_text": {
-                    "reg_death": "This cat died from being ambushed by rogues.",
+                    "reg_death": "m_c died from being ambushed by rogues.",
                     "lead_death": "{VERB/m_c/were/was} killed in a rogue ambush"
                 },
                 "outsider_rep": -1

--- a/resources/dicts/patrols/new_cat_hostile.json
+++ b/resources/dicts/patrols/new_cat_hostile.json
@@ -1402,8 +1402,8 @@
                 ],
                 "history_text": {
                     "scar": "m_c gained a scar after tussling with a rogue.",
-                    "reg_death": "m_c was killed by a rogue.",
-                    "lead_death": "{VERB/m_c/were/was} killed by a rogue"
+                    "reg_death": "m_c died from injuries sustained in a fight with a rogue.",
+                    "lead_death": "died from injuries sustained in a fight with a rogue"
                 }
             },
             {
@@ -1433,14 +1433,14 @@
                 ],
                 "history_text": {
                     "scar": "m_c gained a scar after tussling with a rogue.",
-                    "reg_death": "m_c was killed by a rogue.",
-                    "lead_death": "{VERB/m_c/were/was} killed by a rogue"
+                    "reg_death": "m_c was died from injuries sustained in a fight with a rogue.",
+                    "lead_death": "died from injuries sustained in a fight with a rogue"
                 }
             }
         ],
         "antag_fail_outcomes": [
             {
-                "text": "p_l finds a gang of rogues in the bush! p_l has to turn tail and run, the sound of gloating the last thing in p_l's ears, hearing how little the rogues think of c_n.",
+                "text": "p_l finds a gang of rogues in the bush! p_l turns tail and runs, the sound of gloating the last thing in p_l's ears, hearing how little the rogues think of c_n.",
                 "exp": 0,
                 "weight": 20,
                 "new_cat": [
@@ -1461,7 +1461,7 @@
         ],
         "antag_success_outcomes": [
             {
-                "text": "p_l goes to check the bush and finds a kittypet cowering inside. p_l scratches its ears off and sends it on its way.",
+                "text": "p_l checks the bush and finds a kittypet cowering inside. p_l scratches its ears off and sends it on its way.",
                 "exp": 10,
                 "weight": 20
             }

--- a/resources/dicts/patrols/new_cat_welcoming.json
+++ b/resources/dicts/patrols/new_cat_welcoming.json
@@ -1399,7 +1399,11 @@
                         "scars": ["BRIDGE"]
                     }
                 ],
-                "history_text": { "scar": "m_c gained a scar after tussling with a loner." },
+                "history_text": { 
+                    "scar": "m_c gained a scar after tussling with a rogue.",
+                    "reg_death": "m_c died from injuries sustained in a fight with a rogue.",
+                    "lead_death": "died from injuries sustained in a fight with a rogue"
+                },
                 "outsider_rep": -1
             }
         ],

--- a/resources/dicts/patrols/plains/border/any.json
+++ b/resources/dicts/patrols/plains/border/any.json
@@ -925,7 +925,11 @@
                         "scars": ["BRIDGE"]
                     }
                 ],
-                "history_text": { "scar": "m_c was scarred by an invading rogue." },
+                "history_text": {
+                    "scar": "m_c was scarred by an invading rogue.",
+                    "reg_death": "m_c died from an injury inflicted by an invading rogue.",
+                    "lead_death": "died from an injury inflicted by an invading rogue"
+                },
                 "relationships": [
                     {
                         "cats_to": ["patrol"],
@@ -1072,7 +1076,11 @@
                         "scars": ["BRIDGE"]
                     }
                 ],
-                "history_text": { "scar": "m_c was scarred by an invading rogue." },
+                "history_text": {
+                    "scar": "m_c was scarred by an invading rogue.",
+                    "reg_death": "m_c died from an injury inflicted by an invading rogue.",
+                    "lead_death": "died from an injury inflicted by an invading rogue"
+                },
                 "relationships": [
                     {
                         "cats_to": ["patrol"],
@@ -1154,7 +1162,11 @@
                         "scars": ["CHEEK"]
                     }
                 ],
-                "history_text": { "scar": "m_c was scarred by an invading rogue." }
+                "history_text": {
+                    "scar": "m_c was scarred by an invading rogue.",
+                    "reg_death": "m_c died from an injury inflicted by an invading rogue.",
+                    "lead_death": "died from an injury inflicted by an invading rogue"
+                }
             }
         ]
     },

--- a/resources/dicts/patrols/plains/border/any.json
+++ b/resources/dicts/patrols/plains/border/any.json
@@ -785,8 +785,8 @@
                 ],
                 "history_text": {
                     "scar": "m_c was scarred by an invading rogue.",
-                    "reg_death": "m_c was killed by an invading rogue.",
-                    "lead_death": "{VERB/m_c/were/was} killed by an invading rogue"
+                    "reg_death": "m_c died from an injury inflicted by an invading rogue.",
+                    "lead_death": "died from an injury inflicted by an invading rogue"
                 }
             }
         ]


### PR DESCRIPTION
## About The Pull Request

Modifying a lot of death histories. Couldn't help editing one or two patrols' text as well. SHOULD fix #2629 because I added death histories to apprentice rogue encounter patrols, but I am not certain of which patrol the bug report was dealing with, so I can't say with absolute certainty that I caught it.

## Linked Issues

Fixes #2629

## Proof of Testing

short event
![image](https://github.com/user-attachments/assets/4d331c6c-6a28-4e94-9ac1-1e356927ef36)

death history
![image](https://github.com/user-attachments/assets/76ca7495-1b01-4fe4-9c73-db287133aa5a)
I edited it more after the fact to be extremely clear that it's from an injury inflicted.