### PR TITLE
Bugfix: Add missing claw-wound permanent condition mapping

### DIFF
--- a/resources/dicts/conditions/condition_got_strings/gain_permanent_condition_strings.json
+++ b/resources/dicts/conditions/condition_got_strings/gain_permanent_condition_strings.json
@@ -182,6 +182,13 @@
             "m_c jumps when another cat comes up on {PRONOUN/m_c/poss} bad side. {PRONOUN/m_c/subject/CAP} {VERB/m_c/remind/reminds} {PRONOUN/m_c/self} that {PRONOUN/m_c/subject} {VERB/m_c/have/has} to get used to this. {PRONOUN/m_c/subject/CAP} {VERB/m_c/know/knows} {PRONOUN/m_c/poss} eye is permanently damaged."
         ]
     },
+    "claw-wound": {
+        "weak leg": [
+            "r_c informs m_c that {PRONOUN/m_c/poss} healed claw-wound has left {PRONOUN/m_c/poss} leg permanently weakened.",
+            "m_c finds that {PRONOUN/m_c/subject} {VERB/m_c/have/has} a new limp, despite having healed from {PRONOUN/m_c/poss} claw-wound. r_c tells {PRONOUN/m_c/object} it's likely permanent.",
+            "m_c limps around camp, fully healed from {PRONOUN/m_c/poss} claw-wound but still marked by it for the rest of {PRONOUN/m_c/poss} life."
+        ]
+    },
     "broken back": {
         "paralyzed": [
             "r_c is gentle when {PRONOUN/r_c/subject} {VERB/r_c/break/breaks} the news, but m_c had already expected it. {PRONOUN/m_c/subject/CAP} will never walk again.",


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->

## About The Pull Request

Adds specific onemoon event message for claw-wound injuries resulting in a weak leg permanent condition

(I just copied the bite wound ones) 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues

Fixes #3069

<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing

![image](https://github.com/user-attachments/assets/8563505d-ce33-49f0-80f3-952d0325dd7a)
![image](https://github.com/user-attachments/assets/05d1df31-58fd-4c83-b5ec-3ed00f7434ef)
![image](https://github.com/user-attachments/assets/d0f18877-f2d4-4d74-9690-23c0d324af6c)

## Changelog/Credits

<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
