### PR TITLE
[BUGFIX] History crash

### DIFF
--- a/resources/dicts/events/death/general.json
+++ b/resources/dicts/events/death/general.json
@@ -2714,7 +2714,7 @@
         },
         "history": [{
             "cats": ["m_c"],
-            "reg_death": ["m_c died defending r_c from a hawk"],
+            "reg_death": "m_c died defending r_c from a hawk",
             "lead_death": "defended r_c from a hawk"
         }],
         "relationships": [

--- a/scripts/utility.py
+++ b/scripts/utility.py
@@ -2058,6 +2058,11 @@ def event_text_adjust(
         text = "This should not appear, report as a bug please! Tried to adjust the text, but no text was provided."
         print("WARNING: Tried to adjust text, but no text was provided.")
 
+    # this check is really just here to catch odd bug edge-cases from old saves, specifically in death history
+    # otherwise we should really *never* have lists being passed as the text
+    if isinstance(text, list):
+        text = text[0]
+
     replace_dict = {}
 
     # special lists - this needs to happen first for pronoun tag reasons


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->

## About The Pull Request
A death events history block was formatted incorrectly, causing death history to be saved as a list instead of a string.  This meant that attempts to adjust the text failed due to passing a list as the text arg.  I've fixed the guilty event and added a catch for lists being passed as the text in the event_text_adjust function, really just to catch saved instances of this specific issue.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
Fixes #3100
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
![image](https://github.com/user-attachments/assets/fa499021-b412-4057-ae99-028eb91b971c)
I'm using the save file from the affected user who created the issue.  Wolverineclaw is the cat that caused the crash when opening their history, this screenshot is from after my fix and demonstrates that the history is now accessible and readable.
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->
