### PR TITLE
[BUGFIX] Errors in Patrol Text (Added Constraint) 

### DIFF
--- a/resources/dicts/patrols/general/training.json
+++ b/resources/dicts/patrols/general/training.json
@@ -10797,11 +10797,12 @@
         "min_cats": 2,
         "max_cats": 4,
         "min_max_status": {
-            "apprentice": [1, 6],
-            "normal adult": [-1, -1]
+            "apprentice": [2, 6],
+            "normal adult": [-1, -1],
+            "warrior": [-1, -1]
         },
         "weight": 20,
-        "intro_text": "{PRONOUN/app1/poss/CAP} mentor sends {PRONOUN/app1/object} out with other apprentices from the Clan to assess {PRONOUN/app1/poss} hunting skills. {PRONOUN/app1/poss/CAP} group argues about who should really lead this patrol. app2 wants to be in charge, but {PRONOUN/app2/subject} {VERB/app2/are/is}n't the easiest cat to work with. app1 thinks {PRONOUN/app1/subject} should speak up.",
+        "intro_text": "app1's mentor sends {PRONOUN/app1/object} out with other apprentices from the Clan to assess {PRONOUN/app1/poss} hunting skills. {PRONOUN/app1/poss/CAP} group argues about who should really lead this patrol. app2 wants to be in charge, but {PRONOUN/app2/subject} {VERB/app2/are/is}n't the easiest cat to work with. app1 thinks {PRONOUN/app1/subject} should speak up.",
         "decline_text": "app1 confesses to {PRONOUN/app1/poss} mentor that {PRONOUN/app1/subject} {VERB/app1/do/does} not feel ready for {PRONOUN/app1/poss} assessment. {PRONOUN/app1/poss/CAP} mentor looks disappointed but seems to understand and offers to postpone the test until next moon. Part of app1 cannot help but wonder if the other apprentices will think poorly of {PRONOUN/app1/object}.",
         "chance_of_success": 60,
         "success_outcomes": [


### PR DESCRIPTION
## About The Pull Request

Adding a "warrior": [-1, -1] constraint to a patrol that is specifically meant for only apprentices. Previously, the constraints only accounted for "normal adults" which made it possible to generate the patrol with adolescent warriors, which then resulted in pronoun errors in the text because the game was unable to find "app2". I also mandated that at least 2 apprentices be present, which should add another layer of protection against the bug that occurred.

I also changed the first pronoun to app1's name, because it was odd that app1 doesn't get explicitly named in the first sentence.

## Linked Issues

#3121 

## Proof of Testing

![image](https://github.com/user-attachments/assets/52adec1a-8b34-4922-8f75-4ae61721984f)

