### PR TITLE
[BUGFIX] Missing Relationship Descriptor in Grief Event

### DIFF
--- a/resources/dicts/events/death/death_reactions/general/general_romantic.json
+++ b/resources/dicts/events/death/death_reactions/general/general_romantic.json
@@ -1,7 +1,7 @@
 {
   "general": {
     "body": [
-      "r_c bends over the body of {PRONOUN/r_c/poss}, wailing {PRONOUN/r_c/poss} despair into m_c's fur. {PRONOUN/r_c/subject/CAP} {VERB/r_c/sit/sits} vigil next to the body, wishing {PRONOUN/r_c/subject} could wake from this nightmare.",
+      "r_c bends over the body of {PRONOUN/r_c/poss} beloved, wailing {PRONOUN/r_c/poss} despair into m_c's fur. {PRONOUN/r_c/subject/CAP} {VERB/r_c/sit/sits} vigil next to the body, wishing {PRONOUN/r_c/subject} could wake from this nightmare.",
       "r_c stares dully at m_c, the world fading from awareness as {PRONOUN/r_c/subject} {VERB/r_c/try/tries} to comprehend {PRONOUN/m_c/poss} death. All the things they'll never do together, the places r_c wanted to show {PRONOUN/r_c/object}, the life they could have lived by each other's sides, all wiped away in an instant.",
       "r_c is inconsolable at the news of m_c's death, howling {PRONOUN/r_c/poss} grief to the stars even as {PRONOUN/r_c/poss} Clanmates try to support and comfort {PRONOUN/r_c/object}.",
       "r_c shakes {PRONOUN/r_c/poss} head, refusing to believe the news of m_c's death until {PRONOUN/r_c/subject} {VERB/r_c/see/sees} m_c's body.",


### PR DESCRIPTION
## About The Pull Request

Adding one word to correct a sentence missing its object. I used "beloved" instead of mate because this is an event for general romantic grief (not mate-specific romantic grief).

## Linked Issues

#3116 

## Proof of Testing

I can't ensure any particular grief event, but I can show that I didn't break the grief events lol.
![image](https://github.com/user-attachments/assets/08c86ab5-6240-4a68-8082-a0073ae0c3ee)
