### PR TITLE
Added more names

### DIFF
--- a/resources/dicts/names/names.json
+++ b/resources/dicts/names/names.json
@@ -22,7 +22,7 @@
     "daze", "dazzle", "dew", "dream", "drift", "drizzle", "drop", "dusk", "dust", "eagle", "ear", "ears", "echo", "egg", "ember", 
     "eye", "eyes", "face", "falcon", "fall", "fang", "feather", "fern", "fin", "fire", "fish", "flake", "flame", "flare", "flash", 
     "fleck", "flick", "flicker", "flight", "flip", "flit", "flood", "flow", "flower", "fluff", "fog", "fox", "freeze", "frost", "fruit", 
-    "fuzz", "gale", "gaze", "ghost", "glare", "gleam", "glide", "glint", "glow", "goose", "gorse", "grass", "growl", "hail", "hare", 
+    "fuzz", "frill", "gale", "gaze", "ghost", "glare", "gleam", "glide", "glint", "glow", "goose", "gorse", "grass", "growl", "hail", "hare", 
     "haven", "hawk", "haze", "heather", "hiss", "hollow", "holly", "honey", "hope", "howl", "husk", "ice", "iris", "ivy", "jaw", 
     "jay", "joy", "jumble", "jump", "kestrel", "kick", "kite", "knoll", "lake", "larch", "laurel", "leaf", "leap", "leg", "leopard", 
     "light", "lightning", "lilac", "lily", "lion", "lotus", "mallow", "mane", "mark", "mask", "meadow", "mimic", "minnow", "mist", 
@@ -33,9 +33,9 @@
     "seed", "seeker", "shade", "shadow", "shard", "shell", "shimmer", "shine", "shiver", "shock", "shriek", "sight", "silk", "skip", 
     "skitter", "sky", "slash", "slip", "snap", "snarl", "snout", "snow", "soar", "song", "spark", "speck", "speckle", "spider", 
     "spike", "spirit", "splash", "splinter", "spore", "spot", "spots", "spring", "sprout", "stalk", "stem", "step", "sting", "stone", 
-    "storm", "streak", "stream", "strike", "stripe", "sun", "swarm", "swipe", "swoop", "talon", "tangle",
+    "storm", "streak", "stream", "strike", "stride", "stripe", "sun", "swarm", "swipe", "swoop", "talon", "tangle",
     "thistle", "thorn", "thrift", "throat", "thrush", "thud", "thunder", "tiger", "timber", "toe", "tooth", "trail", "tree", 
-    "trot", "tumble", "twist", "valley", "watcher", "water", "wave", "web", "whisper", "whistle", "willow", "wind", "wing", "wish", "wisp", 
+    "trot", "tumble", "twist", "valley", "watcher", "water", "wave", "web", "weaver", "whisper", "whistle", "willow", "wind", "wing", "wish", "wisp", 
     "zoom"
   ],
   "pelt_suffixes": {
@@ -76,7 +76,7 @@
   "normal_prefixes": [
     "Adder", "Alder", "Ant", "Antler", "Aphid", "Apple", "Apricot", "Arch", "Aspen", "Aster", 
     "Badger", "Barley", "Basil", "Bass", "Bay", "Beam", "Bear", "Beaver", "Bee", "Beech", "Beetle", "Berry", "Big", "Billow", "Birch", 
-    "Bird", "Bite", "Bitter", "Bittern", "Bliss", "Blizzard", "Bloom", "Blossom", "Blotch", "Bluebell", "Bluff", "Bog", "Borage", 
+    "Bird", "Bite", "Bitter", "Bittern", "Blazing", "Bliss", "Blizzard", "Bloom", "Blossom", "Blotch", "Bluebell", "Bluff", "Bog", "Borage", 
     "Bough", "Boulder", "Bounce", "Bracken", "Bramble", "Brave", "Breeze", "Briar", "Bright", "Brindle", "Bristle", "Broken", "Brook", 
     "Brush", "Bubbling", "Bud", "Bug", "Bumble", "Burdock", "Burr", "Burrow", "Bush", "Butterfly", "Buzzard", 
     "Carnation", "Carp", "Caterpillar", "Cave", "Cedar", "Chaffinch", "Chasing", "Cherry", "Chervil", "Chestnut", "Chirp", "Chive",
@@ -85,32 +85,32 @@
     "Current", "Cypress", "Dahlia", "Daisy", "Dancing", "Dapple", "Dappled", "Dart", "Dash", "Dawn", "Dazzle", "Dew", "Dog", "Down", 
     "Downy", "Dream", "Drift", "Drizzle", "Droplet", "Dry", "Duck", "Dusk", "Eagle", "Echo", "Edelweiss", "Eel", "Egret", "Elder", "Elm", 
     "Ermine", "Faith", "Falcon", "Fallen", "Falling", "Fallow", "Fawn", "Feather", "Fennel", "Fern", "Ferret", "Fickle", "Fidget", 
-    "Fierce", "Fin", "Finch", "Fir", "Fish", "Flail", "Flash", "Flax", "Fleck", "Fleet", "Flicker", "Flight", "Flint", "Flip", 
-    "Flit", "Float", "Flood", "Flower", "Fluff", "Fluffy", "Flutter", "Fly", "Fog", "Foggy", "Freckle", "Fringe", "Frog", "Frond", "Fruit", 
-    "Fumble", "Furled", "Furze", "Fuzz", "Fuzzy", "Gale", "Gander", "Gardenia", "Garlic", "Gentle", "Gill", "Glade", "Goose", "Gorge", 
-    "Gorse", "Grass", "Gravel", "Grouse", "Gull", "Guppy", "Gust", "Hail", "Half", "Hare", "Hatch", "Haven", "Hawk", "Hay", "Hazel", 
-    "Hazy", "Heart", "Heath", "Heavy", "Hemlock", "Heron", "Hill", "Hollow", "Holly", "Honey", "Hoot", "Hop", "Hope", "Hornet", 
-    "Hound", "Howl", "Hush", "Hyacinth", "Iris", "Ivy", "Jackdaw", "Jagged", "Jay", "Jumble", "Jump", "Junco", "Juniper", "Kestrel", 
-    "Kink", "Kite", "Lake", "Larch", "Lark", "Laurel", "Lavender", "Leaf", "Leap", "Leopard", "Lichen", "Light", "Lightning", "Lilac", 
+    "Fierce", "Fin", "Finch", "Fir", "Fish", "Flail", "Flash", "Flax", "Flea", "Fleck", "Fleet", "Flicker", "Flight", "Flint", "Flip", 
+    "Flit", "Float", "Flood", "Flower", "Fluff", "Fluffy", "Flutter", "Fly", "Fog", "Foggy", "Freckle", "Frill", "Frilled", "Fringe", "Frog",   
+    "Frond", "Fruit", "Fumble", "Furled", "Furze", "Fuzz", "Fuzzy", "Gale", "Gander", "Gardenia", "Garlic", "Gentle", "Gill", "Glacier", "Glade",   
+    "Gorge", "Gorse", "Grass", "Gravel", "Grouse", "Gull", "Guppy", "Gust", "Hail", "Half", "Hare", "Hatch", "Haven", "Hawk", "Hay", "Hazel", 
+    "Goose", "Hazy", "Heart", "Heath", "Heavy", "Hemlock", "Heron", "Hibiscus", "Hill", "Hollow", "Holly", "Honey", "Hoot", "Hop", "Hope", "Hornet", 
+    "Hound", "Howl", "Hum", "Humming", "Hush", "Hyacinth", "Iris", "Ivy", "Jackdaw", "Jagged", "Jay", "Jumble", "Jump", "Junco", "Juniper", 
+    "Kestrel", "Kink", "Kite", "Lake", "Larch", "Lark", "Laurel", "Lavender", "Leaf", "Leap", "Leopard", "Lichen", "Light", "Lightning", "Lilac", 
     "Lily", "Lion", "Little", "Lizard", "Locust", "Long", "Lotus", "Loud", "Low", "Luck", "Lupine", "Lynx", "Mallow", "Mantis", 
-    "Maple", "Marigold", "Marsh", "Meadow", "Midge", "Milk", "Milkweed", "Mink", "Minnow", "Mistle", "Mite", "Mole", "Moon",
+    "Maple", "Marigold", "Marsh", "Meadow", "Mellow", "Midge", "Milk", "Milkweed", "Mink", "Minnow", "Mistle", "Mite", "Mole", "Moon",
     "Moor", "Morning", "Moss", "Mossy", "Moth", "Mottle", "Mottled", "Mouse", "Mumble", "Murk", "Myrtle", "Nectar", "Needle",
-    "Nettle", "Newt", "Nightingale", "Nimble", "Nut", "Oak", "Oat", "Odd", "One", "Oriole", "Osprey", "Pansy", "Panther", "Parsley",
+    "Nettle", "Newt", "Nightingale", "Nimble", "Nut", "Oak", "Oat", "Odd", "One", "Oriole", "Osprey", "Owlet", "Pansy", "Panther", "Parsley",
     "Partridge", "Patch", "Patchouli", "Peak", "Pear", "Peat", "Perch", "Petal", "Petunia", "Pheasant", "Pigeon", "Pike", "Pine",
     "Piper", "Plover", "Plum", "Pod", "Pond", "Pool", "Pop", "Poppy", "Posy", "Pounce", "Prance", "Prickle", "Prim", "Primrose",
     "Puddle", "Python", "Quail", "Quick", "Quiet", "Quill", "Quiver", "Rabbit", "Raccoon", "Ragged", "Rain", "Rainbow", "Rat",
     "Rattle", "Raven", "Reed", "Ridge", "Rift", "Rindle", "Ripple", "River", "Roach", "Roar", "Rook", "Root", "Rose", "Rosy",
     "Rowan", "Rubble", "Runnel", "Running", "Rush", "Rustle", "Rye", "Sable", "Sapling", "Scorch", "Scratch", "Seed", "Serpent", "Shard",
-    "Sharp", "Shell", "Shimmer", "Shine", "Shining", "Shivering", "Short", "Shrew", "Shrub", "Shy", "Silent", "Silk", "Silky", "Silt", "Skip",
-    "Sky", "Slate", "Sleek", "Sleepy", "Sleet", "Slight", "Slip", "Sloe", "Slope", "Slumber", "Small", "Snail", "Snake", "Snap",
-    "Sneeze", "Snip", "Snowy", "Soft", "Song", "Sorrel", "Spark", "Sparrow", "Speckle", "Spider", "Spike", "Splash", "Splinter",
+    "Sharp", "Shell", "Shimmer", "Shine", "Shining", "Shivering", "Short", "Shrew", "Shrub", "Shy", "Silent", "Silk", "Silky", "Silt", "Skulk",
+    "Skip", "Sky", "Slate", "Sleek", "Sleepy", "Sleet", "Slight", "Slip", "Sloe", "Slope", "Slumber", "Small", "Snail", "Snake", "Snap", 
+    "Sneeze", "Snip", "Snowy", "Soft", "Solemn", "Somber", "Song", "Sorrel", "Spark", "Sparrow", "Speckle", "Spider", "Spike", "Splash", "Splinter",
     "Spore", "Spot", "Spotted", "Spring", "Sprout", "Spruce", "Squirrel", "Starling", "Stem", "Stoat", "Stork", "Streak", "Stream", "Stretch", 
     "Strike", "Stripe", "Stumpy", "Sunny", "Swallow", "Swamp", "Swarm", "Sweet", "Swift", "Sycamore", "Tadpole", "Tall", "Talon", "Tangle", 
-    "Tansy", "Tawny", "Tempest", "Thistle", "Thorn", "Thrift", "Thrush", "Thunder", "Thyme", "Tiger", "Timber", "Tiny", "Toad", 
-    "Torn", "Tremble", "Trickle", "Trout", "Tuft", "Tulip", "Tumble", "Turtle", "Valley", "Vine", "Vixen", "Wasp", "Weasel", "Web", 
+    "Tansy", "Tawny", "Tempest", "Termite", "Thistle", "Thorn", "Thrift", "Thrush", "Thunder", "Thyme", "Tiger", "Timber", "Tiny", "Toad", 
+    "Torn", "Tremble", "Trickle", "Trout", "Tuft", "Tulip", "Tumble", "Turtle", "Valley", "Vine", "Vixen", "Wasp", "Weasel", "Weaver", "Web", 
     "Weed", "Weevil", "Wet", "Wheat", "Whimsy", "Whirl", "Whisker", "Whisper", "Whispering", "Whistle", "Whorl", "Wild", "Willow", 
     "Wind", "Wing", "Wish", "Wisteria", "Wolf", "Wolverine", "Wood", "Worm", "Wren", "Yarrow", "Yew", 
-    "Zinnia"
+    "Zap", "Zinnia"
   ],
 
   "clan_prefixes": [
@@ -218,29 +218,29 @@
   "biome_prefixes": {
     "Forest": [
     "Acorn","Almond", "Antler", "Aspen", "Badger", "Bark", "Bat", "Beech", "Birch", "Boar", "Branch", "Branch", "Buck", "Canopy",
-    "Cedar", "Civet", "Deer", "Doe", "Elk", "Fern", "Fern", "Fir", "Forest", "Frond", "Grouse", "Grove", "Honey", "Log", "Lynx", "Magnolia",
-    "Maple", "Moose", "Moss", "Moss", "Mushroom", "Oak", "Oak", "Pine", "Robin", "Robin", "Sap", "Skunk", "Sparrow", "Sprig",
-    "Spruce", "Squirrel", "Squirrel", "Stag", "Stick", "Stump", "Tarantula", "Thicket", "Twig", "Twig", "Wood", "Wolf", "Coati"
+    "Cedar", "Civet", "Crimini", "Deer", "Doe", "Elk", "Enoki", "Fern", "Fern", "Fir", "Forest", "Frond", "Ginkgo", "Grouse", "Grove", "Honey", 
+    "Log", "Lynx", "Magnolia", "Maple", "Moose", "Morel", "Moss", "Moss", "Mushroom", "Oak", "Oak", "Pine", "Robin", "Robin", "Sap", "Sequoia", "Skunk", 
+    "Sparrow", "Sprig", "Spruce", "Squirrel", "Squirrel", "Stag", "Stick", "Stump", "Tarantula", "Thicket", "Twig", "Twig", "Wood", "Wolf", "Coati"
     ],
     "Beach": [
     "Albatross", "Algae", "Anchovy", "Anemone", "Avocet", "Bass", "Barnacle", "Barracuda", "Beluga", "Brine", "Clam", "Coast",
     "Coconut", "Cod", "Conch", "Coral", "Cove", "Crab", "Current", "Delta", "Dolphin", "Dolphin", "Drip", "Drop", "Eel", "Fin", "Flounder",
-    "Foam", "Gannet", "Gull", "Gull", "Hermit", "Jellyfish", "Lagoon", "Lake", "Marlin", "Nacre", "Ocean", "Octopus", "Palm", "Pearl", "Pearl",
-    "Pearly", "Pelican", "Pool", "Pool", "Ripple", "Reef", "Ripple", "Sago", "Salmon", "Salt", "Sand", "Sand", "Sardine",  "Scale", "Scale", "Sea",
-    "Seabass", "Seagull", "Shark", "Shell", "Shimmer", "Shimmer", "Shore", "Slug", "Snail", "Splash", "Squid",
-    "Tide", "Tidal", "Torrent", "Wave", "Wave", "Whale", "Coati"
+    "Foam", "Gannet", "Gull", "Gull", "Hermit", "Herring", "Island", "Jellyfish", "Kelp", "Lagoon", "Lake", "Lobster", "Manta", "Marlin", "Moray",
+    "Pearly", "Pelican", "Pool", "Pool", "Prawn", "Ripple", "Ripple", "Remora", "Reef", "Sago", "Salmon", "Salt", "Sand", "Sand", "Sardine",  "Scale", "Scale", "Sea",
+    "Nacre", "Ocean", "Octopus", "Oyster", "Palm", "Pearl", "Pearl", "Seabass", "Seagull", "Shark", "Shell", "Shimmer", "Shrimp", "Shimmer", "Shore", "Slug", 
+    "Snail", "Snook", "Splash", "Squid", "Sturgeon", "Tide", "Tidal", "Torrent", "Tuna", "Wave", "Wave", "Whale", "Coati"
     ],
     "Plains": [
-    "Anise", "Barley", "Barley", "Bison", "Breeze", "Breeze", "Burrow", "Butterfly", "Cow", "Cow", "Dandelion", "Elk", "Ewe", "Field", "Field",
-    "Flutter", "Gopher", "Grass", "Grass", "Grouse", "Hare", "Heather", "Heather", "Horse", "Lamb", "Meadow", "Oat", "Plover",
+    "Anise", "Barley", "Barley", "Baobab", "Bison", "Breeze", "Breeze", "Burrow", "Butterfly", "Cow", "Cow", "Dandelion", "Elk", "Ewe", "Field", "Field",
+    "Flutter", "Gopher", "Grass", "Grass", "Grouse", "Hare", "Heather", "Heather", "Horse", "Lamb", "Meadow", "Oat", "Plover", "Pig",
     "Poppy", "Poppy", "Pollen", "Prairie", "Pronghorn", "Roan", "Rustle", "Rye", "Rye", "Sage", "Sedge", "Sheep", "Swish", "Tunnel", "Tarantula",
     "Wheat", "Wheat", "Willow", "Willow", "Wool", "Woolly", "Coati"
     ],
     "Mountainous": [
-    "Alpaca", "Alpine", "Avalanche", "Basalt", "Blizzard", "Boulder", "Caribou", "Cavern", "Cave", "Chamois", "Chasm", "Cliff", "Cliff", "Crag",
-    "Eagle", "Eagle", "Echo", "Echo", "Flint", "Goat", "Granite", "Gravel", "High", "Lichen",
-    "Mountain", "Peak", "Pebble", "Pinnacle", "Rock", "Rocky", "Ram", "Salt", "Shale", "Shard", "Spire", "Stone", "Steppe",
-    "Summit", "Volcano", "Yucca", "Whistle", "Whisper", "Whisper", "Mica", "Frigid", "Abyss"
+    "Agate", "Alpaca", "Alpine", "Avalanche", "Basalt", "Blizzard", "Boulder", "Caribou", "Cavern", "Cave", "Chamois", "Chasm", "Chough", "Cliff", "Cliff", "Crag",
+    "Eagle", "Eagle", "Echo", "Echo", "Flint", "Goat", "Granite", "Gravel", "High", "Ibex", "Lichen",
+    "Mountain", "Peak", "Pebble", "Pika", "Pinnacle", "Rock", "Rocky", "Ram", "Jasper", "Salt", "Shale", "Shard", "Spire", "Stone", "Steppe",
+    "Summit", "Volcano", "Yak", "Yucca", "Whistle", "Whisper", "Whisper", "Mica", "Frigid", "Abyss"
     ],
     "Wetlands": [
     "Willow", "Marsh", "Bog", "Lotus", "Reed", "Frog", "Toad", "Stork", "Civet", "Crane", "Duck", "Heron", "Ibis", "Mangrove",
@@ -256,7 +256,7 @@
     "Yucca", "Salt", "Dingo", "Mirage", "Cobra", "Cheetah", "Caracal", "Scorpion", "Lion", "Antelope", "Gazelle", "Oryx",
     "Camel", "Meerkat", "Skull", "Rye", "Jackrabbit", "Needle", "Aloe", "Acacia", "Viper",
     "Snake", "Poison", "Venom", "Tiapan", "Fang", "Blister", "Blaze", "Burn", "Scorch", "Smolder", "Jerboa", "Fennec", "Mamba", "Coati",
-    "Addax"
+    "Addax", "Emu", "Hyena", "Ostrich", "Scarab"
     ]
   },
 
@@ -315,7 +315,7 @@
     "Abby", "Abigail", "Abuko", "Abyss", "Acacia", "Ace", "Adaliz", "Adam", "Admiral", "Adora", "Aether", "Agatha", "Agent Smith", "Agnes", "Ah ha", "Ah", "Aidan", "Aiden", "Akila", "Akilah", "Alaska", 
     "Alastair", "Alba", "Albedo", "Albert", "Alberto", "Alcina", "Alcor", "Alcyone", "Aldrich", "Alec", "Alex", "Alexa", "Alfie", "Alfred", "Alfredo", "Algernon", "Alice", "Alien", "Alma", "Alonzo", 
     "Alphonse", "Alphys", "Altair", "Alvin", "Amanda", "Amani", "Amaretto", "Amari", "Amaya", "Amber", "Amelia", "Amethyst", "Amigo", "Amir", "Amity", "Amongus", "Amor", "Amy", "Ana", "Anais", "Ananya", 
-    "Andrew", "Andromeda", "Angel", "Anita", "Anju", "Ankha", "Antares", "Anubis", "Anya", "Apex", "Aphrodite", "Apple Cider", "Apple Pencil", "April", "Apu", "Aquarius", "Arch", "Archibald", "Archie", 
+    "Andrew", "Andromeda", "Angel", "Angler", "Anita", "Anju", "Ankha", "Antares", "Anubis", "Anya", "Apex", "Aphrodite", "Apple Cider", "Apple Pencil", "April", "Apu", "Aquarius", "Arch", "Archibald", "Archie", 
     "Archimedes", "Arcturus", "Ari", "Ariel", "Aries", "Armageddon", "Armin", "Arroyo", "Artemis", "Artificer", "Arusha", "Asgore", "Ashe", "Askari", "Aspen", "Asriel", "Astrid", "Atlas", "Atticus", 
     "Aubrey", "August", "Augustus", "Aurora", "Ava", "Avellana", "Avery", "Award Winning Smile", "Axel", "Azimuth", "Azizi", "Azula", "Azurite", "Baba Yaga", "Baby Dog", "Baby", "Bacchus", "Backflip", 
     "Bacon", "Badru", "Bagel", "Bagheera", "Bahati", "Baihu", "Bailey", "Baisel", "Baja Blast", "Baldie", "Baldwin", "Baliyo", "Baloo", "Bamboo", "Bandit", "Banshee", "Banzai", "Baobei", "Baojin", 
@@ -324,9 +324,9 @@
     "Betsy", "Beverly", "Bianca", "Bibelot", "Bibimbap", "Bidoof", "Big Mac", "Big Man", "Big Papa Huge Time", "Bigwig", "Bill Bailey", "Bill", "Billy", "Bingo", "Bingsu", "Binx", "Birb", "Bird of Paradise", 
     "Birdie", "Biscuit", "Biscuits B. Bakin", "Bismuth", "Bitnara", "Bixbite", "Bixby", "Black Widow", "Blade", "Blahaj", "Blair", "Blaire", "Blanche", "Blavingad", "Bliklotep", "Blinky Stubbins", 
     "Blinky", "Blitzo", "Blu", "Bluebell", "Bluebird", "Bluey", "Bob", "Boba", "Bobby", "Bohr Model", "Bok Choy", "Bokshiri", "Bologna", "Bolt", "Bombalurina", "Bombon", "Bonbon", "Bongo", "Boni", 
-    "Bonkers", "Bonnie", "Bonny", "Boo", "Boobear", "Booker", "Boots", "Brandy", "Brandywine", "Bren", "Brian", "Brick", "Brioche", "Broccoli", "Brooklyn", "Broom", "Brother Dubious", "Bruce", "Bruno", 
+    "Bonkers", "Bonnie", "Bonny", "Boo", "Boobear", "Booker", "Boots", "Brandy", "Brandywine", "Bren", "Brian", "Brick", "Brioche", "Broccoli", "Brisket", "Brooklyn", "Broom", "Brother Dubious", "Bruce", "Bruno", 
     "Brutus", "Bub", "Buchito", "Buddy", "Buffy", "Bugbear", "Bulgogi", "Bulgogi", "Bullwinkle", "Bumblebee", "Bun", "Bunga", "Bunny", "Burger", "Burm", "Burning Skies", "Business Frog", "Bustopher Jones", 
-    "Buttercup", "Buttermilk", "Butternut", "Butters", "Butterscotch", "Byeol", "Caakiri", "Cadence", "Cady", "Caesar", "Cake", "Calamari", "Call of Greatness", "Call of the Void", "Callie", 
+    "Buttercup", "Buttermilk", "Butternut", "Butters", "Butterscotch", "Button", "Byeol", "Caakiri", "Cadence", "Cady", "Caesar", "Cake", "Calamari", "Call of Greatness", "Call of the Void", "Callie", 
     "Calliope", "Callisto", "Calorimetry", "Calvin", "Calypso", "Camilo", "Camouflage", "Campion", "Candi", "Candy", "Canela", "Canned Beans", "Canned Tuna", "Cannelloni", "Cannoli", "Canopus", "Capella", "Cappuccino", 
     "Capricorn", "Captain", "Captain Curly", "Car Alarm", "Caramel", "Cardamom", "Cardboard", "Carlotta", "Carmen", "Carmin", "Carolina", "Caroline", "Carrie", "Cashmere", "Casper", "Cassandra", "Cassidy", "Castor", 
     "Cat", "Catalina", "Catie", "Catrick", "Catty", "Cauliflower", "Cayenne", "Cece", "Cecelia", "Celebi", "Celeste", "Celia", "Centauri", "Centipede", "Cerberus", "Ceres", "Chai", "Chance", "Chanel", 
@@ -381,7 +381,7 @@
     "Mint", "Minty", "Mira", "Miranda", "Miriam", "Miso", "Miss Marple", "Missile Launcher", "Misty", "Mitaine", "Mitochondria", "Mitski", "Mitsubishi", "Mittens", "Mitzi", "Mitzy Moo Moo", "Miyun", 
     "Mizan", "Mizar", "Mizu", "Mocha", "Mochi", "Moira", "Mojito", "Mojo", "Mollie", "Molly Murder Mittens", "Molly", "Momo", "Monika", "Monster", "Monte", "Monzi", "Moo", "Moomin", "Moon", "Mooncake", 
     "Mop", "Mora", "Morb", "Morbius", "Mordred", "Morel", "Morpeko", "Morphius", "Morrhar", "Morty", "Mosaic", "Mosi", "Mowgli", "Moxie", "Mozzarella", "Mr. Anderson", "Mr. Kitty Whiskers", "Mr. Kitty", 
-    "Mr. Midnight", "Mr. Mistoffolees", "Mr. Mustard", "Mr. Oreo", "Mr. President", "Mr. Princess", "Mr. Sir", "Mr. Whiskers", "Mr. Wigglebottom", "Mucha", "Mudkip", "Mufasa", "Muffet", "Muffy", 
+    "Mr. Midnight", "Mr. Mistoffolees", "Mr. Mustard", "Mr. Oreo", "Mr. President", "Mr. Princess", "Mr. Sir", "Mr. Whiskers", "Mr. Wigglebottom", "Mucha", "Mudkip", "Mudskipper", "Mufasa", "Muffet", "Muffy", 
     "Mullido", "Mumbai", "Mungojerrie", "Munkustrap", "Murder", "Mushroom", "Mustard", "Myko", "Myler", "Mystic", "Nabi", "Nadia", "Nadir", "Nadja", "Nagi", "Nagito", "Nakala", "Nakeena", "Nala", 
     "Namielle", "Namu", "Nandor", "Naomi", "Napkin", "Nari", "Neapolitan", "Nebula", "Neel", "Nefertiti", "Neil", "Nemo", "Neo", "Neobiani", "Nephrite", "Neptune", "Ness", "Nessie", "Neuron", 
     "Neuroscientist", "Neutron", "Nevaeh", "Neytiri", "Nezuko", "Nibblenephim", "Nibbles", "Nibbly", "Nick", "Nidorina", "Nightcat", "Nightmare", "Nikki", "Nile", "Niles", "Nimbus", "Nine", "Ninetales", 
@@ -409,7 +409,7 @@
     "Seven", "Shaka", "Shamash", "Shampoo", "Shamwow", "Shani", "Shanty", "Shari", "Shay", "Shenzi", "Shep", "Sherb", "Sherbet", "Sherman", "Shilin", "Shiloh", "Shimmer", "Shino", "Shinx", "Shiver", 
     "Shortbread", "Shrimp Fried Rice", "Shrimp", "Shukura", "Shuvai", "Siiri", "Sillabub", "Silly", "Silva", "Silvally", "Silver", "Silvia", "Sim", "Simba", "Simon", "Simone", "Siren", "Siri", "Sirius", 
     "Six Grains of Gravel", "Skimbleshanks", "Skittles", "Skitty", "Skrunkly", "Skylar", "Skyrim", "Slinky", "Sloane", "Sloth", "Slug", "Slurpuff", "Slushie", "Smarty Pants", "Smile", "Smiley", "Smoke", 
-    "Smoky", "Smoothie", "Smores", "Snaggles", "Sneakers", "Snek", "Snickers", "Snom", "Snook", "Snoots", "Snotlout", "Snowball", "Snowbell", "Snufkin", "Snuggles", "Snuttig", "Soap Bubbles", "Soap", 
+    "Smoky", "Smoothie", "Smores", "Snaggles", "Snapshot", "Sneakers", "Snek", "Snickers", "Snom", "Snook", "Snoots", "Snotlout", "Snowball", "Snowbell", "Snufkin", "Snuggles", "Snuttig", "Soap Bubbles", "Soap", 
     "Soccer Ball", "Socks", "Soda Pop", "Sofa", "Sofanthiel", "Sofrito", "Sol", "Solanum", "Soleil", "Solstice", "Sona", "Sonata", "Sonic", "Sonnet", "Sookie", "Soos", "Sooty", "Sophie", "Sorbet", 
     "Soren", "Sotast", "Soup", "Sox", "Spam", "Sparkle", "Sparky", "Spatula", "Speedwell", "Spicy", "Spinach", "Spinel", "Spock", "Spooky", "Spoon", "Spore", "Spots", "Sprigatito", "Squeak", "Sriracha", 
     "Stan", "Stanley", "Star", "Stardust", "Starfish", "Stargazer", "Starry", "Static", "Steak", "Stella", "Steve", "Steven", "Stink Mink", "Stinkbutt", "Stinky", "Stitches", "Stolas", "Story", 
@@ -422,7 +422,7 @@
     "Togepi", "Tom", "Tomato Soup", "Tomato", "Toni", "Tonka", "Toothless", "Top Hat", "Topaz", "Toph", "Topi", "Torchic", "Toriel", "Toro", "Torque", "Tortellini", "Tortilla", "Totoro", "Toulouse", 
     "Toxel", "Toyota", "Tracer", "Tractor", "Traveler", "Treasure", "Tribble", "Trick", "Trinity", "Trinket", "Trip", "Triscuit", "Triton", "Trixie", "Trouble Nuggets", "Trouble", "Troublemaker", 
     "Truffle", "Trumpet", "Tucker", "Tuffnut", "Tumble", "Tumblebrutus", "Tumo", "Turbo", "Twiggy", "Twilight", "Twinkle Lights", "Twister", "Twix", "Two Sprouts", "Tyler", "Tyson", "Uba", "Ula", 
-    "Ulyssa", "Umbreon", "Umbriel", "Uncle Butter", "Undyne", "Union", "Uriel", "Ursala", "Valence Electron", "Valente", "Valentina", "Valentino", "Van Pelt", "Vanessa", "Vanilla", "Vasco", "Vaxx", "Vega", "Velociraptor", 
+    "Ulyssa", "Umbreon", "Umbriel", "Uncle Butter", "Undyne", "Union", "Uriel", "Ursala", "Vacuum", "Valence Electron", "Valente", "Valentina", "Valentino", "Van Pelt", "Vanessa", "Vanilla", "Vasco", "Vaxx", "Vega", "Velociraptor", 
     "Venti", "Venture", "Venus", "Veronica", "Vervain", "Vesper", "Vesta", "Via", "Victini", "Victor", "Victoria", "Vida", "Viktor", "Vinnie", "Vinyl", "Violet", "Virgo", "Vivian", "Vivienne", "Void Walker", 
     "Void Worm", "Void", "Volkswagen", "Voltage", "Vox", "Vulpix", "Wade", "Waffle", "Wagyu", "Wally", "Walnut", "Walter", "Wanda", "Wanderer", "War", "Warren Peace", "Wasabi", "Watches the Path", 
     "Webby", "Wednesday", "Wendy", "Weston", "Whiskers", "Whiskey", "Whisper", "Whitney", "Whiz Kid", "Wiggity Wacks", "Wigglebutt", "Wiggly", "Wiggog Yrath", "Wikipedia", "Wilbur", "Willow", 

--- a/resources/dicts/names/names.json
+++ b/resources/dicts/names/names.json
@@ -88,14 +88,14 @@
     "Fierce", "Fin", "Finch", "Fir", "Fish", "Flail", "Flash", "Flax", "Flea", "Fleck", "Fleet", "Flicker", "Flight", "Flint", "Flip", 
     "Flit", "Float", "Flood", "Flower", "Fluff", "Fluffy", "Flutter", "Fly", "Fog", "Foggy", "Freckle", "Frill", "Frilled", "Fringe", "Frog",   
     "Frond", "Fruit", "Fumble", "Furled", "Furze", "Fuzz", "Fuzzy", "Gale", "Gander", "Gardenia", "Garlic", "Gentle", "Gill", "Glacier", "Glade",   
-    "Gorge", "Gorse", "Grass", "Gravel", "Grouse", "Gull", "Guppy", "Gust", "Hail", "Half", "Hare", "Hatch", "Haven", "Hawk", "Hay", "Hazel", 
-    "Goose", "Hazy", "Heart", "Heath", "Heavy", "Hemlock", "Heron", "Hibiscus", "Hill", "Hollow", "Holly", "Honey", "Hoot", "Hop", "Hope", "Hornet", 
-    "Hound", "Howl", "Hum", "Humming", "Hush", "Hyacinth", "Iris", "Ivy", "Jackdaw", "Jagged", "Jay", "Jumble", "Jump", "Junco", "Juniper", 
+    "Goose", "Gorge", "Gorse", "Grass", "Gravel", "Grouse", "Gull", "Guppy", "Gust", "Hail", "Half", "Hare", "Hatch", "Haven", "Hawk", "Hay", "Hazel", 
+    "Hazy", "Heart", "Heath", "Heavy", "Hemlock", "Heron", "Hibiscus", "Hill", "Hollow", "Holly", "Honey", "Hoot", "Hop", "Hope", "Hornet", 
+    "Hound", "Howl", "Humming", "Hush", "Hyacinth", "Iris", "Ivy", "Jackdaw", "Jagged", "Jay", "Jumble", "Jump", "Junco", "Juniper", 
     "Kestrel", "Kink", "Kite", "Lake", "Larch", "Lark", "Laurel", "Lavender", "Leaf", "Leap", "Leopard", "Lichen", "Light", "Lightning", "Lilac", 
     "Lily", "Lion", "Little", "Lizard", "Locust", "Long", "Lotus", "Loud", "Low", "Luck", "Lupine", "Lynx", "Mallow", "Mantis", 
     "Maple", "Marigold", "Marsh", "Meadow", "Mellow", "Midge", "Milk", "Milkweed", "Mink", "Minnow", "Mistle", "Mite", "Mole", "Moon",
     "Moor", "Morning", "Moss", "Mossy", "Moth", "Mottle", "Mottled", "Mouse", "Mumble", "Murk", "Myrtle", "Nectar", "Needle",
-    "Nettle", "Newt", "Nightingale", "Nimble", "Nut", "Oak", "Oat", "Odd", "One", "Oriole", "Osprey", "Owlet", "Pansy", "Panther", "Parsley",
+    "Nettle", "Newt", "Nightingale", "Nimble", "Nut", "Oak", "Oat", "Odd", "One", "Oriole", "Osprey", "Pansy", "Panther", "Parsley",
     "Partridge", "Patch", "Patchouli", "Peak", "Pear", "Peat", "Perch", "Petal", "Petunia", "Pheasant", "Pigeon", "Pike", "Pine",
     "Piper", "Plover", "Plum", "Pod", "Pond", "Pool", "Pop", "Poppy", "Posy", "Pounce", "Prance", "Prickle", "Prim", "Primrose",
     "Puddle", "Python", "Quail", "Quick", "Quiet", "Quill", "Quiver", "Rabbit", "Raccoon", "Ragged", "Rain", "Rainbow", "Rat",
@@ -103,7 +103,7 @@
     "Rowan", "Rubble", "Runnel", "Running", "Rush", "Rustle", "Rye", "Sable", "Sapling", "Scorch", "Scratch", "Seed", "Serpent", "Shard",
     "Sharp", "Shell", "Shimmer", "Shine", "Shining", "Shivering", "Short", "Shrew", "Shrub", "Shy", "Silent", "Silk", "Silky", "Silt", "Skulk",
     "Skip", "Sky", "Slate", "Sleek", "Sleepy", "Sleet", "Slight", "Slip", "Sloe", "Slope", "Slumber", "Small", "Snail", "Snake", "Snap", 
-    "Sneeze", "Snip", "Snowy", "Soft", "Solemn", "Somber", "Song", "Sorrel", "Spark", "Sparrow", "Speckle", "Spider", "Spike", "Splash", "Splinter",
+    "Sneeze", "Snip", "Snowy", "Soft", "Song", "Sorrel", "Spark", "Sparrow", "Speckle", "Spider", "Spike", "Splash", "Splinter",
     "Spore", "Spot", "Spotted", "Spring", "Sprout", "Spruce", "Squirrel", "Starling", "Stem", "Stoat", "Stork", "Streak", "Stream", "Stretch", 
     "Strike", "Stripe", "Stumpy", "Sunny", "Swallow", "Swamp", "Swarm", "Sweet", "Swift", "Sycamore", "Tadpole", "Tall", "Talon", "Tangle", 
     "Tansy", "Tawny", "Tempest", "Termite", "Thistle", "Thorn", "Thrift", "Thrush", "Thunder", "Thyme", "Tiger", "Timber", "Tiny", "Toad", 
@@ -218,7 +218,7 @@
   "biome_prefixes": {
     "Forest": [
     "Acorn","Almond", "Antler", "Aspen", "Badger", "Bark", "Bat", "Beech", "Birch", "Boar", "Branch", "Branch", "Buck", "Canopy",
-    "Cedar", "Civet", "Crimini", "Deer", "Doe", "Elk", "Enoki", "Fern", "Fern", "Fir", "Forest", "Frond", "Ginkgo", "Grouse", "Grove", "Honey", 
+    "Cedar", "Civet", "Deer", "Doe", "Elk", "Enoki", "Fern", "Fern", "Fir", "Forest", "Frond", "Ginkgo", "Grouse", "Grove", "Honey", 
     "Log", "Lynx", "Magnolia", "Maple", "Moose", "Morel", "Moss", "Moss", "Mushroom", "Oak", "Oak", "Pine", "Robin", "Robin", "Sap", "Sequoia", "Skunk", 
     "Sparrow", "Sprig", "Spruce", "Squirrel", "Squirrel", "Stag", "Stick", "Stump", "Tarantula", "Thicket", "Twig", "Twig", "Wood", "Wolf", "Coati"
     ],
@@ -247,7 +247,7 @@
     "Swamp", "Murk", "Algae", "Mud", "Mire", "Splash", "Mosquito", "Mallard", "Goose", "Peat", "Bog", "Skink", "Tamarack",
     "Spruce", "Beaver", "Wade", "Cypress", "Magnolia", "Skunk", "Mosquito", "Lily", "Bayou", "Clay", "Grebe", "Egret",
     "Creek", "Skip", "Reed", "Bullrush", "Beetle", "Bug", "Vine", "Creeper", "Buffalo", "Rush", "Swam", "Cygnet", "Gosling",
-    "Cormorant", "Stork", "Moorhen", "Spoonbill", "Kingfisher", "Plover", "Alligator", "Crocodile", "Newt", "Eel",
+    "Cormorant", "Stork", "Moorhen", "Spoonbill", "Kingfisher", "Plover", "Newt", "Eel",
     "Axolotl", "Salamander", "Gar", "Coati"
     ],
     "Desert": [
@@ -437,10 +437,10 @@
     "squid", "swan", "thrush", "tiger", "turtle"
 	],
 	"animal_prefixes": [
-		"Addax", "Adder", "Albatross", "Alligator", "Alpaca", "Ant", "Antelope", "Aphid", "Avocet", "Axolotl", "Badger", "Barracuda", "Bass", "Bat", "Bear", "Beaver", 
+		"Addax", "Adder", "Albatross", "Alpaca", "Ant", "Antelope", "Aphid", "Avocet", "Axolotl", "Badger", "Barracuda", "Bass", "Bat", "Bear", "Beaver", 
     "Bee", "Beetle", "Beluga", "Bird", "Bison", "Bittern", "Boar", "Buck", "Buffalo", "Bug", "Butterfly", "Camel", "Canary", "Caracal", "Caribou", "Carp", 
     "Caterpillar", "Chaffinch", "Chamois", "Cheetah", "Chick", "Cicada", "Civet", "Clam", "Coati", "Cobra", "Cod", "Condor", "Coral", "Cormorant", "Cougar", "Cow", 
-    "Coyote", "Crab", "Crane", "Crocodile", "Crow", "Curlew", "Cygnet", "Deer", "Dingo", "Doe", "Dog", "Dolphin", "Dove", "Duck", "Eagle", "Egret", "Elk", "Ermine", 
+    "Coyote", "Crab", "Crane", "Crow", "Curlew", "Cygnet", "Deer", "Dingo", "Doe", "Dog", "Dolphin", "Dove", "Duck", "Eagle", "Egret", "Elk", "Ermine", 
     "Ewe", "Falcon", "Fawn", "Fennec", "Ferret", "Finch", "Fish", "Fox", "Frog", "Gander", "Gannet", "Gar", "Gazelle", "Goat", "Goose", "Gosling", "Grackle", "Grebe", 
     "Grouse", "Gull", "Guppy", "Hare", "Hawk", "Heron", "Hornet", "Horse", "Hound", "Ibis", "Jackal", "Jackdaw", "Jackrabbit", "Jay", "Jellyfish", "Jerboa", "Junco", 
     "Kestrel", "Kingfisher", "Kite", "Lamb", "Lark", "Leopard", "Lion", "Lizard", "Loach", "Locust", "Lynx", "Magpie", "Mamba", "Mantis", "Marlin", "Meerkat", "Midge", 


### PR DESCRIPTION
## About The Pull Request

- Added a few dozen prefixes, couple suffixes, and a few loner names
- Removed Alligator and Crocodile prefixes

## Why This Is Good For ClanGen

To add more variety into the name pool, giving more unique combinations.

## Proof of Testing

![zapweaver](https://github.com/user-attachments/assets/abbaadf5-a785-4b27-9ee7-269fa1480683)

## Changelog/Credits

- Added 44 prefixes, 3 suffixes, and 6 loner names
- Xeptoid, names