### PR TITLE
[BUGFIX] Typos in constraints and injuries for thoughts

### DIFF
--- a/resources/dicts/thoughts/alive/alive_outside/kitten.json
+++ b/resources/dicts/thoughts/alive/alive_outside/kitten.json
@@ -29,7 +29,7 @@
             "Wishes {PRONOUN/m_c/poss} parent was here",
             "Is crying quietly"
         ],
-        "main_backstory_constraint": ["outsider1", "halfclan1", "outsider_roots1", "halfclan2", "outsider_roots2", "abandoned1", "abandoned2", "abandoned3", "abandoned4", "orphaned1", "orphaned2", "orphaned3", "orphaned4", "orpahned5", "orphaned6", "clanborn", "clan_founder"]
+        "main_backstory_constraint": ["outsider1", "halfclan1", "outsider_roots1", "halfclan2", "outsider_roots2", "abandoned1", "abandoned2", "abandoned3", "abandoned4", "orphaned1", "orphaned2", "orphaned3", "orphaned4", "orphaned5", "orphaned6", "clanborn", "clan_founder"]
     },
     {
         "id": "lost_new_kitten_thoughts",

--- a/resources/dicts/thoughts/alive/elder.json
+++ b/resources/dicts/thoughts/alive/elder.json
@@ -1275,9 +1275,6 @@
         "main_age_constraint": [
             "adolescent"
         ],
-        "random_age_constraint": [
-            "any"
-        ],
         "random_living_status": [
             "living"
         ]
@@ -1419,9 +1416,6 @@
         ],
         "main_age_constraint": [
             "adolescent"
-        ],
-        "random_age_constraint": [
-            "any"
         ]
     },
     {
@@ -1508,9 +1502,6 @@
         },
         "main_status_constraint": [
             "elder"
-        ],
-        "main_age_constraint": [
-            "any"
         ],
         "random_status_constraint": [
             "any"

--- a/resources/dicts/thoughts/alive/elder.json
+++ b/resources/dicts/thoughts/alive/elder.json
@@ -1551,8 +1551,8 @@
             "m_c": [
                 "lost a leg",
                 "lost their tail",
-                "born without leg",
-                "born without tail"
+                "born without a leg",
+                "born without a tail"
             ]
         },
         "main_status_constraint": [
@@ -1575,8 +1575,8 @@
             "m_c": [
                 "lost a leg",
                 "lost their tail",
-                "born without leg",
-                "born without tail"
+                "born without a leg",
+                "born without a tail"
             ]
         },
         "main_status_constraint": [
@@ -1618,7 +1618,7 @@
         "perm_conditions": {
             "m_c": [
                 "lost a leg",
-                "born without leg"
+                "born without a leg"
             ]
         },
         "main_status_constraint": [
@@ -1638,10 +1638,10 @@
         ],
         "perm_conditions": {
             "m_c": [
-                "born without leg"
+                "born without a leg"
             ],
             "r_c": [
-                "born without leg"
+                "born without a leg"
             ]
         },
         "main_status_constraint": [
@@ -1661,11 +1661,11 @@
         ],
         "perm_conditions": {
             "m_c": [
-                "born without leg",
+                "born without a leg",
                 "lost a leg"
             ],
             "r_c": [
-                "born without leg"
+                "born without a leg"
             ]
         },
         "main_status_constraint": [
@@ -1686,7 +1686,7 @@
         "perm_conditions": {
             "m_c": [
                 "lost their tail",
-                "born without tail"
+                "born without a tail"
             ]
         },
         "main_status_constraint": [
@@ -1708,7 +1708,7 @@
         "perm_conditions": {
             "m_c": [
                 "lost their tail",
-                "born without tail"
+                "born without a tail"
             ]
         },
         "main_status_constraint": [
@@ -1727,11 +1727,11 @@
         "perm_conditions": {
             "m_c": [
                 "lost their tail",
-                "born without tail"
+                "born without a tail"
             ],
             "r_c": [
                 "lost their tail",
-                "born without tail"
+                "born without a tail"
             ]
         },
         "main_status_constraint": [
@@ -1753,11 +1753,11 @@
         "perm_conditions": {
             "m_c": [
                 "lost their tail",
-                "born without tail"
+                "born without a tail"
             ],
             "r_c": [
                 "lost their tail",
-                "born without tail"
+                "born without a tail"
             ]
         },
         "main_status_constraint": [
@@ -1801,7 +1801,7 @@
         "perm_conditions": {
             "m_c": [
                 "lost their tail",
-                "born without tail"
+                "born without a tail"
             ]
         },
         "main_status_constraint": [

--- a/resources/dicts/thoughts/alive/kitten.json
+++ b/resources/dicts/thoughts/alive/kitten.json
@@ -207,7 +207,7 @@
             "Is telling on r_c for something m_c was told {PRONOUN/m_c/subject} couldn't do"
         ],
         "main_trait_constraint": [
-            "attention_seeker",
+            "attention-seeker",
             "bossy",
             "know-it-all",
             "noisy",
@@ -775,7 +775,7 @@
             "kitten"
         ],
         "relationship_constraint": [
-            "stranger"
+            "strangers"
         ],
         "random_living_status": [
             "starclan"

--- a/resources/dicts/thoughts/alive/medicine_cat_apprentice.json
+++ b/resources/dicts/thoughts/alive/medicine_cat_apprentice.json
@@ -280,7 +280,7 @@
             "Prays to StarClan that the passed newborn kits get to feel the wind across their pelt"
         ],
         "biome": [
-            "Plains"
+            "plains"
         ],
         "random_living_status": [
             "starclan"

--- a/resources/dicts/thoughts/alive/newborn.json
+++ b/resources/dicts/thoughts/alive/newborn.json
@@ -51,7 +51,7 @@
             "newborn"
         ],
         "relationship_constraint": [
-            "sibling"
+            "siblings"
         ],
         "random_living_status": [
             "living"

--- a/resources/dicts/thoughts/alive/warrior.json
+++ b/resources/dicts/thoughts/alive/warrior.json
@@ -84,7 +84,7 @@
     {
         "id": "ambitious_forest_warrior",
         "biome": [
-            "Forest"
+            "forest"
         ],
         "thoughts": [
             "Wishes {PRONOUN/m_c/poss} pelt would turn silver as the moon, just like the wolves"

--- a/resources/dicts/thoughts/dead/darkforest/exiled.json
+++ b/resources/dicts/thoughts/dead/darkforest/exiled.json
@@ -41,7 +41,6 @@
         "compassionate",
         "faithful",
         "loving",
-        "patient",
         "thoughtful",
         "nervous",
         "wise",

--- a/resources/dicts/thoughts/dead/darkforest/medicine_cat.json
+++ b/resources/dicts/thoughts/dead/darkforest/medicine_cat.json
@@ -22,8 +22,8 @@
                "Is trying to teach r_c poisonous herbs in {PRONOUN/r_c/poss} dreams"
             ],
         "random_status_constraint": [
-              "medicine cat apprrentice"
-            ],
+          "medicine cat apprentice"
+        ],
         "random_living_status" : [
               "living"
             ]


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->

## About The Pull Request
* Fixes some typos in thoughts and some things that were typed slightly wrong for constraints and injuries:
  * orpahned5 -> orphaned5
  * medicine cat apprrentice -> medicine cat apprentice
  * born without tail -> born without a leg
  * born without leg -> born without a leg
  * attention_seeker -> attention-seeker
  * stranger -> strangers
  * sibling -> siblings
  * Plains -> plains
  * Forest -> forest
* Removes ‘any’ constraint in thoughts that used it for age constraints, because it’s not supported by the code. Not including the property as a constraint is equivalent to the desired behaviour. 
* Removes removed trait "patient" from a thought constraint. 
