### PR TITLE
[DEV QOL]  Stop window from opening for a split second whenever you run tests

### DIFF
--- a/tests/test_cat.py
+++ b/tests/test_cat.py
@@ -3,12 +3,11 @@ import unittest
 from copy import deepcopy
 from unittest.mock import patch
 
-from scripts.cat.cats import Cat
-from scripts.cat_relations.relationship import Relationship
-
 os.environ["SDL_VIDEODRIVER"] = "dummy"
 os.environ["SDL_AUDIODRIVER"] = "dummy"
 
+from scripts.cat.cats import Cat
+from scripts.cat_relations.relationship import Relationship
 
 class TestCreationAge(unittest.TestCase):
 

--- a/tests/test_conditions.py
+++ b/tests/test_conditions.py
@@ -1,13 +1,13 @@
 import os
 import unittest
-
 import ujson
+
+os.environ["SDL_VIDEODRIVER"] = "dummy"
+os.environ["SDL_AUDIODRIVER"] = "dummy"
 
 from scripts.cat.cats import Cat
 from scripts.conditions import medical_cats_condition_fulfilled
 
-os.environ["SDL_VIDEODRIVER"] = "dummy"
-os.environ["SDL_AUDIODRIVER"] = "dummy"
 
 
 class TestsMedCondition(unittest.TestCase):

--- a/tests/test_filter_patrol.py
+++ b/tests/test_filter_patrol.py
@@ -1,16 +1,15 @@
 import os
 import unittest
 
+os.environ["SDL_VIDEODRIVER"] = "dummy"
+os.environ["SDL_AUDIODRIVER"] = "dummy"
+
 from scripts.cat.cats import Cat
 from scripts.cat_relations.relationship import Relationship
 from scripts.clan import Clan
 from scripts.patrol.patrol import PatrolEvent, Patrol
 
 from scripts.utility import filter_relationship_type
-
-os.environ["SDL_VIDEODRIVER"] = "dummy"
-os.environ["SDL_AUDIODRIVER"] = "dummy"
-
 
 # TODO: redo them! Filtering is not working like this anymore, but it got removed from .github/workflows/test.yml
 # so they are not failing!

--- a/tests/test_freshkill.py
+++ b/tests/test_freshkill.py
@@ -1,6 +1,9 @@
+import os
 import unittest
-
 import ujson
+
+os.environ["SDL_VIDEODRIVER"] = "dummy"
+os.environ["SDL_AUDIODRIVER"] = "dummy"
 
 from scripts.cat.cats import Cat
 from scripts.cat.skills import Skill, SkillPath

--- a/tests/test_group_interaction.py
+++ b/tests/test_group_interaction.py
@@ -1,13 +1,12 @@
 import os
 import unittest
 
-from scripts.cat.cats import Cat, Relationship
-from scripts.cat.skills import Skill, SkillPath
-from scripts.events_module.relationship.group_events import GroupEvents, GroupInteraction
-
 os.environ["SDL_VIDEODRIVER"] = "dummy"
 os.environ["SDL_AUDIODRIVER"] = "dummy"
 
+from scripts.cat.cats import Cat, Relationship
+from scripts.cat.skills import Skill, SkillPath
+from scripts.events_module.relationship.group_events import GroupEvents, GroupInteraction
 
 class MainCatFiltering(unittest.TestCase):
     def test_main_cat_status_one(self):

--- a/tests/test_handle_short_events.py
+++ b/tests/test_handle_short_events.py
@@ -1,4 +1,8 @@
+import os
 import unittest
+
+os.environ["SDL_VIDEODRIVER"] = "dummy"
+os.environ["SDL_AUDIODRIVER"] = "dummy"
 
 from scripts.cat.cats import Cat
 from scripts.events_module.handle_short_events import HandleShortEvents

--- a/tests/test_interactions.py
+++ b/tests/test_interactions.py
@@ -1,4 +1,8 @@
+import os
 import unittest
+
+os.environ["SDL_VIDEODRIVER"] = "dummy"
+os.environ["SDL_AUDIODRIVER"] = "dummy"
 
 from scripts.cat.cats import Cat, Relationship
 from scripts.cat.skills import SkillPath, Skill

--- a/tests/test_patrol_condition.py
+++ b/tests/test_patrol_condition.py
@@ -1,4 +1,8 @@
+import os
 import unittest
+
+os.environ["SDL_VIDEODRIVER"] = "dummy"
+os.environ["SDL_AUDIODRIVER"] = "dummy"
 
 from scripts.cat.cats import Cat
 from scripts.cat.history import History

--- a/tests/test_pronouns.py
+++ b/tests/test_pronouns.py
@@ -12,15 +12,13 @@ import os
 import re
 import sys
 import unittest
-
 import ujson
-
-from scripts.cat.cats import Cat
-from scripts.utility import process_text
 
 os.environ["SDL_VIDEODRIVER"] = "dummy"
 os.environ["SDL_AUDIODRIVER"] = "dummy"
 
+from scripts.cat.cats import Cat
+from scripts.utility import process_text
 
 def test():
     """Iterate through all files in 'resources'

--- a/tests/test_relation_events.py
+++ b/tests/test_relation_events.py
@@ -2,15 +2,14 @@ import os
 import unittest
 from unittest.mock import patch
 
+os.environ["SDL_VIDEODRIVER"] = "dummy"
+os.environ["SDL_AUDIODRIVER"] = "dummy"
+
 from scripts.cat.cats import Cat
 from scripts.cat_relations.relationship import Relationship
 from scripts.clan import Clan
 from scripts.events_module.relationship.pregnancy_events import Pregnancy_Events
 from scripts.events_module.relationship.romantic_events import Romantic_Events
-
-os.environ["SDL_VIDEODRIVER"] = "dummy"
-os.environ["SDL_AUDIODRIVER"] = "dummy"
-
 
 class CanHaveKits(unittest.TestCase):
     def test_prevent_kits(self):

--- a/tests/test_romantic_events.py
+++ b/tests/test_romantic_events.py
@@ -1,4 +1,8 @@
+import os
 import unittest
+
+os.environ["SDL_VIDEODRIVER"] = "dummy"
+os.environ["SDL_AUDIODRIVER"] = "dummy"
 
 from scripts.cat.cats import Cat, Relationship
 from scripts.events_module.relationship.romantic_events import Romantic_Events

--- a/tests/test_save.py
+++ b/tests/test_save.py
@@ -2,17 +2,11 @@ import os
 import shutil
 import unittest
 
+os.environ["SDL_VIDEODRIVER"] = "dummy"
+os.environ["SDL_AUDIODRIVER"] = "dummy"
+
 from scripts.game_structure.game_essentials import Game
 from scripts.housekeeping.datadir import get_save_dir
-
-os.environ["SDL_VIDEODRIVER"] = "dummy"
-os.environ["SDL_AUDIODRIVER"] = "dummy"
-
-os.environ["SDL_VIDEODRIVER"] = "dummy"
-os.environ["SDL_AUDIODRIVER"] = "dummy"
-
-os.environ["SDL_VIDEODRIVER"] = "dummy"
-os.environ["SDL_AUDIODRIVER"] = "dummy"
 
 if not os.path.exists("tests/testSaves"):
     num_example_saves = 0

--- a/tests/test_thoughts.py
+++ b/tests/test_thoughts.py
@@ -1,12 +1,11 @@
 import os
 import unittest
 
-from scripts.cat.cats import Cat
-from scripts.cat.thoughts import Thoughts
-
 os.environ["SDL_VIDEODRIVER"] = "dummy"
 os.environ["SDL_AUDIODRIVER"] = "dummy"
 
+from scripts.cat.cats import Cat
+from scripts.cat.thoughts import Thoughts
 
 class TestNotWorkingThoughts(unittest.TestCase):
     def setUp(self):

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -1,6 +1,9 @@
 import os
 import unittest
 
+os.environ["SDL_VIDEODRIVER"] = "dummy"
+os.environ["SDL_AUDIODRIVER"] = "dummy"
+
 from scripts.cat.cats import Cat
 from scripts.cat_relations.relationship import Relationship
 from scripts.utility import (
@@ -9,10 +12,6 @@ from scripts.utility import (
     get_amount_of_cats_with_relation_value_towards,
     get_alive_clan_queens
 )
-
-os.environ["SDL_VIDEODRIVER"] = "dummy"
-os.environ["SDL_AUDIODRIVER"] = "dummy"
-
 
 class TestPersonalityCompatibility(unittest.TestCase):
 


### PR DESCRIPTION
## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

Moves the `SDL_VIDEODRIVER` and `SDL_AUDIODRIVER` dummy declarations to be above the game imports in the tests and adds them to tests that didn't have them but should have them. The game imports run code that uses those drivers so, previously, by the time the drivers were declared as `dummy`, the game window had already opened.

## Why This Is Good For ClanGen

Visual Studio Code automatically runs tests on save, which also opens the window for a split second. This can be slightly annoying.