### PR TITLE
[BUGFIX, ENHANCEMENT] Several typo fixes, slight edits to moon events

### DIFF
--- a/resources/dicts/events/death/general.json
+++ b/resources/dicts/events/death/general.json
@@ -5589,7 +5589,7 @@
         ],
         "tags": [],
         "weight": 20,
-        "event_text": "m_c is found within a few fox-lengths of camp, {PRONOUN/m_c/poss} tiny body cold and covered in bites. The scent of mouse hangs heavy in the air...",
+        "event_text": "m_c is found within a few fox-lengths of camp after sneaking out, cold and covered in bite-marks. The scent of rat hangs heavy in the air...",
         "m_c": {
             "status": [
                 "kitten"
@@ -5598,7 +5598,7 @@
         },
         "history": [{
             "cats": ["m_c"],
-            "reg_death": "m_c was killed by a feisty mouse."
+            "reg_death": "m_c was killed by a rat."
         }]
     },
     {
@@ -5613,7 +5613,7 @@
             "no_body"
         ],
         "weight": 20,
-        "event_text": "m_c can be heard boasting that {PRONOUN/m_c/subject}'{VERB/m_c/re/s} ready to be made an apprentice <i>right now</i>, and that {PRONOUN/m_c/subject}'{VERB/m_c/re/s} already one of the best hunters in the Clan. That evening, to prove {PRONOUN/m_c/poss} point, {PRONOUN/m_c/subject} {VERB/m_c/sneak/sneaks} out of camp, intending to catch something for the fresh-kill pile. A frantic search party follows {PRONOUN/m_c/poss} trail, only to find blood and the foul stench of a shrew at the end.",
+        "event_text": "m_c can be heard boasting that {PRONOUN/m_c/subject}'{VERB/m_c/re/s} ready to be made an apprentice <i>right now</i>, and that {PRONOUN/m_c/subject}'{VERB/m_c/re/s} already one of the best hunters in the Clan. That evening, to prove {PRONOUN/m_c/poss} point, {PRONOUN/m_c/subject} {VERB/m_c/sneak/sneaks} out of camp, intending to catch something for the fresh-kill pile. A frantic search party follows {PRONOUN/m_c/poss} trail, only to find blood and the stench of raccoon at the end.",
         "m_c": {
             "status": [
                 "kitten"
@@ -5622,7 +5622,7 @@
         },
         "history": [{
             "cats": ["m_c"],
-            "reg_death": "m_c was eaten by a shrew."
+            "reg_death": "m_c was eaten by a raccoon."
         }]
     },
   {

--- a/resources/dicts/events/misc/forest.json
+++ b/resources/dicts/events/misc/forest.json
@@ -71,7 +71,7 @@
     "season": ["newleaf","greenleaf"],
     "subtype": ["accessory"],
     "weight": 20,
-    "event_text": "A small flock of sparrows has decided to start frequenting the branches high above camp and, much to the annoyance of most, have dropped plenty of feathers everwhere as they preen. m_c thinks they're pretty though and decides to keep some.",
+    "event_text": "A small flock of sparrows has decided to start frequenting the branches high above camp. To the annoyance of many, their preening has dropped plenty of feathers around camp; m_c thinks they're pretty, though, and decides to keep some.",
     "new_accessory": ["SPARROW FEATHERS"]
   }
 ]

--- a/resources/dicts/patrols/beach/med/any.json
+++ b/resources/dicts/patrols/beach/med/any.json
@@ -263,12 +263,12 @@
             "normal adult": [-1, -1]
         },
         "weight": 20,
-        "intro_text": "app1 pads out of camp, ready to gather some herbs at the behest of {PRONOUN/app1/poss} mentor. The wind gently rustles through the beach grass as {PRONOUN/app1/subject} {VERB/app1/pad/pads} along.",
-        "decline_text": "Before {PRONOUN/app1/subject} {VERB/app1/get/gets} more than a few pawsteps away, {PRONOUN/app1/poss} mentor calls {PRONOUN/app1/object} back. Apparently, something more pressing has come up.",
+        "intro_text": "p_l pads out of camp, ready to gather some herbs for the Clan. The wind gently rustles through the beach grass as {PRONOUN/p_l/subject} {VERB/p_l/pad/pads} along.",
+        "decline_text": "Before {PRONOUN/p_l/subject} {VERB/p_l/get/gets} more than a few pawsteps away, {PRONOUN/p_l/subject}{VERB/p_l/'re/'s} called back to camp. Apparently, something more pressing has come up.",
         "chance_of_success": 50,
         "success_outcomes": [
             {
-                "text": "p_l is plucking some rosemary when {PRONOUN/p_l/poss} attention is suddenly grabbed by omen_list_sight/m_c. The fur on {PRONOUN/p_l/poss} back begins to prickle slightly, the sound of {PRONOUN/p_l/poss} heartbeat like thunder in {PRONOUN/p_l/poss} ears. {PRONOUN/p_l/subject/CAP} {VERB/p_l/turn/turns} and hare back to camp, herbs forgotten. {PRONOUN/p_l/subject/CAP} {VERB/p_l/need/needs} to tell {PRONOUN/p_l/poss} mentor about this as soon as possible!",
+                "text": "p_l is plucking some rosemary when {PRONOUN/p_l/poss} attention is suddenly grabbed by omen_list_sight/m_c. The fur on {PRONOUN/p_l/poss} back begins to prickle slightly, the sound of {PRONOUN/p_l/poss} heartbeat like thunder in {PRONOUN/p_l/poss} ears. {PRONOUN/p_l/subject/CAP} {VERB/p_l/turn/turns} and {VERB/p_l/hare/hares} back to camp, herbs forgotten. {PRONOUN/p_l/subject/CAP} {VERB/p_l/need/needs} to tell someone about this as soon as possible!",
                 "exp": 20,
                 "weight": 20,
                 "herbs": ["rosemary"]
@@ -276,7 +276,7 @@
         ],
         "fail_outcomes": [
             {
-                "text": "app1 feels a pit of dread beginning to form in {PRONOUN/app1/poss} belly - {PRONOUN/app1/subject}{VERB/app1/'ve/'s} forgotten where to find the herb {PRONOUN/app1/poss} mentor wanted. {PRONOUN/app1/subject/CAP} {VERB/app1/taste/tastes} the air, hoping desperately for some hint of its tell-tale scent, but it's a useless effort. {PRONOUN/app1/subject/CAP}'ll have to swallow {PRONOUN/app1/poss} pride and return to ask for directions.",
+                "text": "p_l feels a pit of dread beginning to form in {PRONOUN/p_l/poss} belly - {PRONOUN/p_l/subject}{VERB/p_l/'ve/'s} forgotten where to find the herb {PRONOUN/p_l/subject} needed. {PRONOUN/p_l/subject/CAP} {VERB/p_l/taste/tastes} the air, hoping desperately for some hint of its tell-tale scent, but it's a useless effort. {PRONOUN/p_l/subject/CAP}'ll have to swallow {PRONOUN/p_l/poss} pride and return to ask for directions.",
                 "exp": 0,
                 "weight": 20
             }

--- a/resources/dicts/patrols/forest/hunting/greenleaf.json
+++ b/resources/dicts/patrols/forest/hunting/greenleaf.json
@@ -3952,7 +3952,7 @@
                 "prey": ["medium"]
             },
             {
-                "text": "r_c cautiously begins stalking the squirrel. To no one's surprise, the squirrel notices {PRONOUN/r_c/object} before {PRONOUN/r_c/subject}{VERB/r_c/'re/'s} close enough and scurries up the tree. r_c takes off after it, scaling the tree quickly. {PRONOUN/r_c/subject/CAP} {VERB/r_c/manage/manages} to catch the squirrel, but the slippery bark under-paw causes {PRONOUN/r_c/object} to fall. r_c hits the ground with a thud, the breath knocked out of {PRONOUN/r_c/subject}, but the squirrel still in {PRONOUN/r_c/poss} grasp.",
+                "text": "r_c cautiously begins stalking the squirrel. To no one's surprise, the squirrel notices {PRONOUN/r_c/object} before {PRONOUN/r_c/subject}{VERB/r_c/'re/'s} close enough and scurries up the tree. r_c takes off after it, scaling the tree quickly. {PRONOUN/r_c/subject/CAP} {VERB/r_c/manage/manages} to catch the squirrel, but the slippery bark under-paw causes {PRONOUN/r_c/object} to fall. r_c hits the ground with a thud, the breath knocked out of {PRONOUN/r_c/object}, but the squirrel still in {PRONOUN/r_c/poss} grasp.",
                 "exp": 15,
                 "weight": 25,
                 "prey": ["medium"],

--- a/resources/dicts/patrols/forest/med/any.json
+++ b/resources/dicts/patrols/forest/med/any.json
@@ -228,12 +228,12 @@
             "healer cats": [1, 6]
         },
         "weight": 20,
-        "intro_text": "app1 pads out of camp, ready to gather some herbs at the behest of {PRONOUN/app1/poss} mentor. The wind gently rustles through the trees as {PRONOUN/app1/subject} {VERB/app1/pad/pads} along.",
-        "decline_text": "Before {PRONOUN/app1/subject} {VERB/app1/get/gets} more than a few pawsteps away, {PRONOUN/app1/poss} mentor calls {PRONOUN/app1/object} back. Apparently, something more pressing has come up.",
+        "intro_text": "p_l pads out of camp, ready to gather some herbs for the Clan. The wind gently rustles through the trees as {PRONOUN/p_l/subject} {VERB/p_l/pad/pads} along.",
+        "decline_text": "Before {PRONOUN/p_l/subject} {VERB/p_l/get/gets} more than a few pawsteps away, {PRONOUN/p_l/subject}{VERB/p_l/'re/'s} called back to camp. Apparently, something more pressing has come up.",
         "chance_of_success": 50,
         "success_outcomes": [
             {
-                "text": "p_l is plucking some blackberry leaves when {PRONOUN/p_l/poss} attention is suddenly grabbed by omen_list_sight/p_l. The fur on {PRONOUN/p_l/poss} back begins to prickle slightly, the sound of {PRONOUN/p_l/poss} heartbeat like thunder in {PRONOUN/p_l/poss} ears. {PRONOUN/p_l/subject/CAP} {VERB/p_l/turn/turns} and {VERB/p_l/hare/hares} back to camp, herbs forgotten. {PRONOUN/p_l/subject/CAP} {VERB/p_l/need/needs} to tell {PRONOUN/p_l/poss} mentor about this as soon as possible!",
+                "text": "p_l is plucking some blackberry leaves when {PRONOUN/p_l/poss} attention is suddenly grabbed by omen_list_sight/p_l. The fur on {PRONOUN/p_l/poss} back begins to prickle slightly, the sound of {PRONOUN/p_l/poss} heartbeat like thunder in {PRONOUN/p_l/poss} ears. {PRONOUN/p_l/subject/CAP} {VERB/p_l/turn/turns} and {VERB/p_l/hare/hares} back to camp, herbs forgotten. {PRONOUN/p_l/subject/CAP} {VERB/p_l/need/needs} to tell someone about this as soon as possible!",
                 "exp": 20,
                 "weight": 20,
                 "herbs": ["blackberry"]
@@ -241,7 +241,7 @@
         ],
         "fail_outcomes": [
             {
-                "text": "app1 feels a pit of dread beginning to form in {PRONOUN/app1/poss} belly - {PRONOUN/app1/subject}{VERB/app1/'ve/'s} forgotten where to find the herb {PRONOUN/app1/poss} mentor wanted. {PRONOUN/app1/subject/CAP} {VERB/app1/taste/tastes} the air, hoping desperately for some hint of its tell-tale scent, but it's a useless effort. {PRONOUN/app1/subject/CAP}'ll have to swallow {PRONOUN/app1/poss} pride and return to ask for directions.",
+                "text": "p_l feels a pit of dread beginning to form in {PRONOUN/p_l/poss} belly - {PRONOUN/p_l/subject}{VERB/p_l/'ve/'s} forgotten where to find the herb {PRONOUN/p_l/subject} needed. {PRONOUN/p_l/subject/CAP} {VERB/p_l/taste/tastes} the air, hoping desperately for some hint of its tell-tale scent, but it's a useless effort. {PRONOUN/p_l/subject/CAP}'ll have to swallow {PRONOUN/p_l/poss} pride and return to ask for directions.",
                 "exp": 0,
                 "weight": 20
             }

--- a/resources/dicts/relationship_events/normal_interactions/comfortable/increase.json
+++ b/resources/dicts/relationship_events/normal_interactions/comfortable/increase.json
@@ -280,7 +280,7 @@
 			"r_c's words of comfort mean more to m_c than {PRONOUN/r_c/subject} {VERB/r_c/know/knows}.",
 			"m_c gets excellent advice from r_c about something {PRONOUN/m_c/subject} had been worrying about.",
 			"r_c says something very sincere and comforting to m_c.",
-			"m_c can tell r_c worries about {PRONOUN/m_c/object} health and safety.",
+			"m_c can tell r_c worries about {PRONOUN/m_c/poss} health and safety.",
 			"m_c overhears r_c saying something nice about {PRONOUN/m_c/object}.",
 			"m_c has had a lot of good dreams about r_c lately.",
 			"Whenever r_c's name is mentioned, m_c relaxes.",


### PR DESCRIPTION
## About The Pull Request

Fixes a small pawful of pronoun typos, rewords an accessory event, and edits two kit deaths to reference different predators.

## Why This Is Good For ClanGen

Discussion on the shrew and mouse kit deaths happened here; https://discord.com/channels/1003759225522110524/1101276997751164948/1316475992218407053

Rewording for the sparrow accessory event helps it read better and flow more smoothly, as well as fixing a typo.

## Linked Issues
https://github.com/ClanGenOfficial/clangen/issues/1818#issuecomment-2525193672
https://github.com/ClanGenOfficial/clangen/issues/1818#issuecomment-2532670847
https://github.com/ClanGenOfficial/clangen/issues/1818#issuecomment-2532755858

## Proof of Testing

![image](https://github.com/user-attachments/assets/4787c396-81a8-4fd1-8d8f-996a41d742b6)
![image](https://github.com/user-attachments/assets/619d1d74-5d3f-4175-ba6d-5361cdaee74e)

## Changelog/Credits

Pronoun fixes, slight event editing
