### PR TITLE
[BUGFIX] s_c will now pick medicine cat

### DIFF
--- a/resources/dicts/patrols/forest/med/greenleaf.json
+++ b/resources/dicts/patrols/forest/med/greenleaf.json
@@ -4076,7 +4076,7 @@
                 "exp": 20,
                 "weight": 20,
                 "stat_skill": ["SENSE,2", "CLEVER,3"],
-                "can_have_stat": ["r_c"],
+                "can_have_stat": ["p_l"],
                 "herbs": ["lungwort"],
                 "relationships": [
                     {
@@ -4093,7 +4093,7 @@
                 "exp": 20,
                 "weight": 20,
                 "stat_trait": ["thoughtful", "confident", "loyal", "responsible", "arrogant"],
-                "can_have_stat": ["r_c"],
+                "can_have_stat": ["p_l"],
                 "herbs": ["lungwort"],
                 "relationships": [
                     {

--- a/resources/dicts/patrols/forest/med/leaf-fall.json
+++ b/resources/dicts/patrols/forest/med/leaf-fall.json
@@ -2974,7 +2974,7 @@
                 "exp": 20,
                 "weight": 20,
                 "stat_skill": ["SENSE,2", "CLEVER,3"],
-                "can_have_stat": ["r_c"],
+                "can_have_stat": ["p_l"],
                 "herbs": ["lungwort"],
                 "relationships": [
                     {
@@ -2991,7 +2991,7 @@
                 "exp": 20,
                 "weight": 20,
                 "stat_trait": ["thoughtful", "confident", "loyal", "responsible", "arrogant"],
-                "can_have_stat": ["r_c"],
+                "can_have_stat": ["p_l"],
                 "herbs": ["lungwort"],
                 "relationships": [
                     {

--- a/resources/dicts/patrols/mountainous/med/greenleaf.json
+++ b/resources/dicts/patrols/mountainous/med/greenleaf.json
@@ -2961,7 +2961,7 @@
                 "exp": 20,
                 "weight": 20,
                 "stat_skill": ["SENSE,2", "CLEVER,3"],
-                "can_have_stat": ["r_c"],
+                "can_have_stat": ["p_l"],
                 "herbs": ["lungwort"],
                 "relationships": [
                     {
@@ -2978,7 +2978,7 @@
                 "exp": 20,
                 "weight": 20,
                 "stat_trait": ["thoughtful", "confident", "loyal", "responsible", "arrogant"],
-                "can_have_stat": ["r_c"],
+                "can_have_stat": ["p_l"],
                 "herbs": ["lungwort"],
                 "relationships": [
                     {

--- a/resources/dicts/patrols/mountainous/med/leaf-fall.json
+++ b/resources/dicts/patrols/mountainous/med/leaf-fall.json
@@ -2970,7 +2970,7 @@
                 "exp": 20,
                 "weight": 20,
                 "stat_skill": ["SENSE,2", "CLEVER,3"],
-                "can_have_stat": ["r_c"],
+                "can_have_stat": ["p_l"],
                 "herbs": ["lungwort"],
                 "relationships": [
                     {
@@ -2987,7 +2987,7 @@
                 "exp": 20,
                 "weight": 20,
                 "stat_trait": ["thoughtful", "confident", "loyal", "responsible", "arrogant"],
-                "can_have_stat": ["r_c"],
+                "can_have_stat": ["p_l"],
                 "herbs": ["lungwort"],
                 "relationships": [
                     {

--- a/resources/dicts/patrols/mountainous/med/newleaf.json
+++ b/resources/dicts/patrols/mountainous/med/newleaf.json
@@ -2958,7 +2958,7 @@
                 "exp": 20,
                 "weight": 20,
                 "stat_skill": ["SENSE,2", "CLEVER,3"],
-                "can_have_stat": ["r_c"],
+                "can_have_stat": ["p_l"],
                 "herbs": ["lungwort"],
                 "relationships": [
                     {
@@ -2975,7 +2975,7 @@
                 "exp": 20,
                 "weight": 20,
                 "stat_trait": ["thoughtful", "confident", "loyal", "responsible", "arrogant"],
-                "can_have_stat": ["r_c"],
+                "can_have_stat": ["p_l"],
                 "herbs": ["lungwort"],
                 "relationships": [
                     {

--- a/resources/dicts/patrols/plains/med/greenleaf.json
+++ b/resources/dicts/patrols/plains/med/greenleaf.json
@@ -3147,7 +3147,7 @@
                 "exp": 20,
                 "weight": 20,
                 "stat_skill": ["SENSE,2", "CLEVER,3"],
-                "can_have_stat": ["r_c"],
+                "can_have_stat": ["p_l"],
                 "herbs": ["lungwort"],
                 "relationships": [
                     {
@@ -3164,7 +3164,7 @@
                 "exp": 20,
                 "weight": 20,
                 "stat_trait": ["thoughtful", "confident", "loyal", "responsible", "arrogant"],
-                "can_have_stat": ["r_c"],
+                "can_have_stat": ["p_l"],
                 "herbs": ["lungwort"],
                 "relationships": [
                     {

--- a/resources/dicts/patrols/plains/med/leaf-fall.json
+++ b/resources/dicts/patrols/plains/med/leaf-fall.json
@@ -2966,7 +2966,7 @@
                 "exp": 20,
                 "weight": 20,
                 "stat_skill": ["SENSE,2", "CLEVER,3"],
-                "can_have_stat": ["r_c"],
+                "can_have_stat": ["p_l"],
                 "herbs": ["lungwort"],
                 "relationships": [
                     {
@@ -2983,7 +2983,7 @@
                 "exp": 20,
                 "weight": 20,
                 "stat_trait": ["thoughtful", "confident", "loyal", "responsible", "arrogant"],
-                "can_have_stat": ["r_c"],
+                "can_have_stat": ["p_l"],
                 "herbs": ["lungwort"],
                 "relationships": [
                     {

--- a/resources/dicts/patrols/plains/med/newleaf.json
+++ b/resources/dicts/patrols/plains/med/newleaf.json
@@ -2090,7 +2090,7 @@
                 "exp": 20,
                 "weight": 20,
                 "stat_skill": ["SENSE,2", "CLEVER,3"],
-                "can_have_stat": ["r_c"],
+                "can_have_stat": ["p_l"],
                 "herbs": ["lungwort"],
                 "relationships": [
                     {


### PR DESCRIPTION
## About The Pull Request

Fixing outcomes of lungwort patrols so that the s_c will always be chosen as p_l (aka the medicine cat) instead of r_c (who had the possibility of being a warrior) in a sentence where s_c is always the medicine cat.

## Linked Issues

Fixes #3163 

## Proof of Testing

![image](https://github.com/user-attachments/assets/6106602e-8754-44db-9127-c0e29215bc56)
