### PR TITLE
[BUGFIX] Misformatted Patrols 

### DIFF
--- a/resources/dicts/patrols/beach/hunting/any.json
+++ b/resources/dicts/patrols/beach/hunting/any.json
@@ -2384,7 +2384,7 @@
                     {
                         "cats": ["r_c"],
                         "injuries": ["beak_bite"],
-                        "scars": ["beak_scars"]
+                        "scars": ["BEAKCHEEK", "BEAKLOWER", "BEAKSIDE"]
                     }
                 ],
                 "history_text": {
@@ -2419,7 +2419,7 @@
                     {
                         "cats": ["r_c"],
                         "injuries": ["beak_bite"],
-                        "scars": ["beak_scars"]
+                        "scars": ["BEAKCHEEK", "BEAKLOWER", "BEAKSIDE"]
                     }
                 ],
                 "history_text": {
@@ -2572,7 +2572,7 @@
                     {
                         "cats": ["r_c"],
                         "injuries": ["beak_bite"],
-                        "scars": ["beak_scars"]
+                        "scars": ["BEAKCHEEK", "BEAKLOWER", "BEAKSIDE"]
                     }
                 ],
                 "history_text": { 
@@ -2743,7 +2743,7 @@
                     {
                         "cats": ["r_c"],
                         "injuries": ["beak_bite"],
-                        "scars": ["beak_scars"]
+                        "scars": ["BEAKCHEEK", "BEAKLOWER", "BEAKSIDE"]
                     }
                 ],
                 "history_text": {

--- a/resources/dicts/patrols/forest/hunting/greenleaf.json
+++ b/resources/dicts/patrols/forest/hunting/greenleaf.json
@@ -243,7 +243,7 @@
                     {
                         "cats": ["r_c"],
                         "injuries": ["broken bone"],
-                        "scars": ["bone_scars"]
+                        "scars": ["MANLEG", "TOETRAP", "FOUR"]
                     }
                 ],
                 "history_text": {
@@ -579,7 +579,11 @@
                     {
                         "cats": ["r_c"],
                         "injuries": ["claw-wound", "non_lethal"],
-                        "scars": ["claw_scars"]
+                        "scars": [
+                            "ONE", "TWO", "SNOUT", "TAILSCAR", "CHEEK",
+                            "SIDE", "THROAT", "TAILBASE", "BELLY", "FACE",
+                            "BRIDGE", "HINDLEG", "BACK", "SCRATCHSIDE"
+                ]
                     }
                 ],
                 "history_text": { "scar": "m_c was scarred by a downed hawk." },

--- a/resources/dicts/patrols/general/border.json
+++ b/resources/dicts/patrols/general/border.json
@@ -1756,10 +1756,12 @@
                 "exp": 10,
                 "weight": 5,
                 "art": "gen_battle_rogue_warrior",
-                "injury": {
-                    "cats": ["r_c"],
-                    "injuries": ["battle_injury", "battle_injury"]
-                },
+                "injury": [
+                    {
+                        "cats": ["r_c"],
+                        "injuries": ["battle_injury", "battle_injury"]
+                    }
+                ],
                 "history_text": {
                     "reg_death": "m_c died from {PRONOUN/r_c/poss} injuries after a fight with a rogue.",
                     "scar": "m_c was scarred in a fight with a rogue."
@@ -1818,10 +1820,12 @@
                 "text": "While they are bickering, r_c trips, and p_l snickers, earning r_c's ire.",
                 "exp": 0,
                 "weight": 20,
-                "injury": {
-                    "cats": ["r_c"],
-                    "injuries": ["minor_injury"]
-                },
+                "injury": [
+                    {
+                        "cats": ["r_c"],
+                        "injuries": ["minor_injury"]
+                    }
+                ],
                 "relationships": [
                     {
                         "cats_to": ["p_l"],
@@ -1950,10 +1954,12 @@
                 "exp": 10,
                 "weight": 15,
                 "art": "gen_otherclan_ambush",
-                "injury": {
-                    "cats": ["r_c"],
-                    "injuries": ["battle_injury", "battle_injury"]
-                },
+                "injury": [
+                    {
+                        "cats": ["r_c"],
+                        "injuries": ["battle_injury", "battle_injury"]
+                    }
+                ],
                 "history_text": {
                     "scar": "m_c was scarred after being ambushed on patrol.",
                     "reg_death": "m_c died of injuries sustained in an ambush.",
@@ -2014,10 +2020,12 @@
                 "exp": 0,
                 "weight": 10,
                 "art": "gen_warrior_infighting",
-                "injury": {
-                    "cats": ["r_c", "p_l"],
-                    "injuries": ["minor_injury","minor_injury","battle_injury"]
-                },
+                "injury": [
+                    {
+                        "cats": ["r_c", "p_l"],
+                        "injuries": ["minor_injury","minor_injury","battle_injury"]
+                    }
+                ],
                 "history_text": {
                     "scar": "m_c was scarred after brawling with a Clanmate.",
                     "reg_death": "m_c died from injuries sustained in a brawl with a Clanmate.",

--- a/resources/dicts/patrols/general/border.json
+++ b/resources/dicts/patrols/general/border.json
@@ -3158,12 +3158,12 @@
         "injuries": [ "grief stricken" ]
     }
 ],
-    "history_text": [
+    "history_text":
                 {
                     "scar": "m_c was scarred by {PRONOUN/m_c/poss} mate's Clanmates.",
                     "reg_death": "m_c died from injuries inflicted by {PRONOUN/m_c/poss} mate's Clanmates."
                 }
-            ],
+            ,
     "relationships": [
 {
             "cats_to": ["p_l"],

--- a/resources/dicts/patrols/general/border.json
+++ b/resources/dicts/patrols/general/border.json
@@ -3435,7 +3435,7 @@
 			"cats_to": [ "n_c:1" ],
 			"cats_from": [ "n_c:0" ],
 			"mutual": false,
-			"values": [ "romantic", "platonic", "trust", "comfort", "admiration" ],
+			"values": [ "romantic", "platonic", "trust", "comfort", "respect" ],
 			"amount": 55
         },	
         {
@@ -3476,7 +3476,7 @@
         "cats_to": [ "n_c:1" ],
         "cats_from": [ "n_c:0" ],
         "mutual": false,
-        "values": [ "romantic", "platonic", "trust", "comfort", "admiration" ],
+        "values": [ "romantic", "platonic", "trust", "comfort", "respect" ],
         "amount": 55
     },	
     {
@@ -3511,7 +3511,7 @@
                 "cats_to": [ "n_c:1" ],
                 "cats_from": [ "n_c:0" ],
                 "mutual": false,
-                "values": [ "romantic", "platonic", "trust", "comfort", "admiration" ],
+                "values": [ "romantic", "platonic", "trust", "comfort", "respect" ],
                 "amount": 55
             },	
             {
@@ -3553,7 +3553,7 @@
             "cats_to": [ "n_c:1" ],
             "cats_from": [ "n_c:0" ],
             "mutual": false,
-            "values": [ "romantic", "platonic", "trust", "comfort", "admiration" ],
+            "values": [ "romantic", "platonic", "trust", "comfort", "respect" ],
             "amount": 55
         },	
         {
@@ -3596,7 +3596,7 @@
                 "cats_to": [ "n_c:1" ],
                 "cats_from": [ "n_c:0" ],
                 "mutual": false,
-                "values": [ "romantic", "platonic", "trust", "comfort", "admiration" ],
+                "values": [ "romantic", "platonic", "trust", "comfort", "respect" ],
                 "amount": 55
             },	
             {
@@ -3644,7 +3644,7 @@
         "cats_to": [ "n_c:1" ],
         "cats_from": [ "n_c:0" ],
         "mutual": false,
-        "values": [ "romantic", "platonic", "trust", "comfort", "admiration" ],
+        "values": [ "romantic", "platonic", "trust", "comfort", "respect" ],
         "amount": 55
     },
     {
@@ -3768,7 +3768,7 @@
                 "cats_to": [ "n_c:1" ],
                 "cats_from": [ "n_c:0" ],
                 "mutual": false,
-                "values": [ "romantic", "platonic", "trust", "comfort", "admiration" ],
+                "values": [ "romantic", "platonic", "trust", "comfort", "respect" ],
                 "amount": 55
             },	
             {
@@ -3808,7 +3808,7 @@
                         "cats_to": [ "n_c:1" ],
                         "cats_from": [ "n_c:0" ],
                         "mutual": false,
-                        "values": [ "romantic", "platonic", "trust", "comfort", "admiration" ],
+                        "values": [ "romantic", "platonic", "trust", "comfort", "respect" ],
                         "amount": 55
                     },	
                     {
@@ -3890,14 +3890,14 @@
         "cats_to": [ "p_l" ],
         "cats_from": [ "n_c:1" ],
         "mutual": false,
-        "values": [ "romantic", "platonic", "comfort", "trust", "admiration" ],
+        "values": [ "romantic", "platonic", "comfort", "trust", "respect" ],
         "amount": 15
     },
     {
         "cats_to": [ "n_c:1" ],
         "cats_from": [ "n_c:0" ],
         "mutual": false,
-        "values": [ "romantic", "platonic", "trust", "comfort", "admiration" ],
+        "values": [ "romantic", "platonic", "trust", "comfort", "respect" ],
         "amount": 55
     },	
     {

--- a/resources/dicts/patrols/general/border.json
+++ b/resources/dicts/patrols/general/border.json
@@ -1779,7 +1779,7 @@
                 "exp": 10,
                 "weight": 10,
                 "can_have_stat": ["p_l"],
-                "stat_trait": ["troublesome", "fierce", "bloodthirsty", "cold", "childish", "shameless", "vengeful", "arrogant", "competitive", "grumpy", "cunning", "oblivous", "rebellious"],
+                "stat_trait": ["troublesome", "fierce", "bloodthirsty", "cold", "childish", "shameless", "vengeful", "arrogant", "competitive", "grumpy", "cunning", "oblivious", "rebellious"],
                 "relationships": [
                     {
                         "cats_to": ["s_c"],
@@ -1848,7 +1848,7 @@
                 "exp": 0,
                 "weight": 10,
                 "can_have_stat": ["p_l"],
-                "stat_trait": ["troublesome", "fierce", "bloodthirsty", "cold", "childish", "shameless", "vengeful", "arrogant", "competitive", "grumpy", "cunning", "oblivous", "rebellious"],
+                "stat_trait": ["troublesome", "fierce", "bloodthirsty", "cold", "childish", "shameless", "vengeful", "arrogant", "competitive", "grumpy", "cunning", "oblivious", "rebellious"],
                 "relationships": [
                     {
                         "cats_to": ["s_c"],
@@ -1974,7 +1974,7 @@
                 "exp": 10,
                 "weight": 10,
                 "can_have_stat": ["p_l"],
-                "stat_trait": ["troublesome", "fierce", "bloodthirsty", "cold", "childish", "shameless", "vengeful", "arrogant", "competitive", "grumpy", "cunning", "oblivous", "rebellious"],
+                "stat_trait": ["troublesome", "fierce", "bloodthirsty", "cold", "childish", "shameless", "vengeful", "arrogant", "competitive", "grumpy", "cunning", "oblivious", "rebellious"],
                 "relationships": [
                     {
                         "cats_to": ["s_c"],
@@ -2077,7 +2077,7 @@
                 "exp": 0,
                 "weight": 10,
                 "can_have_stat": ["p_l"],
-                "stat_trait": ["troublesome", "fierce", "bloodthirsty", "cold", "childish", "shameless", "vengeful", "arrogant", "competitive", "grumpy", "cunning", "oblivous", "rebellious"],
+                "stat_trait": ["troublesome", "fierce", "bloodthirsty", "cold", "childish", "shameless", "vengeful", "arrogant", "competitive", "grumpy", "cunning", "oblivious", "rebellious"],
                 "relationships": [
                     {
                         "cats_to": ["s_c"],

--- a/resources/dicts/patrols/general/border.json
+++ b/resources/dicts/patrols/general/border.json
@@ -3624,7 +3624,7 @@
                 "cats_to": [ "p_l" ],
                 "cats_from": [ "n_c:0" ],
                 "mutual": false,
-                "values": [ "jealousy", "dislike" ],
+                "values": [ "jealous", "dislike" ],
                 "amount": 15
             }
     ],
@@ -3883,7 +3883,7 @@
         "cats_to": [ "p_l" ],
         "cats_from": [ "n_c:0" ],
         "mutual": false,
-        "values": [ "dislike", "jealousy" ],
+        "values": [ "dislike", "jealous" ],
         "amount": 35
     },
     {

--- a/resources/dicts/patrols/general/border.json
+++ b/resources/dicts/patrols/general/border.json
@@ -2798,7 +2798,7 @@
                 {
                     "cats_from": ["n_c:0", "n_c:1"],
                     "cats_to": ["patrol"],
-                    "mutual": "true",
+                    "mutual": true,
                     "values": ["platonic", "trust", "comfort"],
                     "amount": 10
                 }

--- a/resources/dicts/patrols/general/border.json
+++ b/resources/dicts/patrols/general/border.json
@@ -2871,8 +2871,8 @@
                 }
             ],
             "new_cat": [
-                ["kittypet", "meeting", "existing"],
-                ["kittypet", "meeting", "existing"]
+                ["kittypet", "meeting", "exists"],
+                ["kittypet", "meeting", "exists"]
             ],
             "outsider_rep": -1
         },
@@ -2898,7 +2898,7 @@
                 }
             ],
             "new_cat": [
-                ["dead", "meeting", "existing", "kittypet"],
+                ["dead", "meeting", "exists", "kittypet"],
                 ["kittypet", "meeting"]
             ],
             "outsider_rep": -2

--- a/resources/dicts/patrols/mountainous/hunting/any.json
+++ b/resources/dicts/patrols/mountainous/hunting/any.json
@@ -1073,7 +1073,7 @@
                 "injury": [
                     {
                         "cats": ["r_c"],
-                        "injuries": ["persistent headache"]
+                        "injuries": ["persistent headaches"]
                     }
                 ]
             },


### PR DESCRIPTION
## About The Pull Request

Fixes some slightly misformatted patrols.

* Changes scar pools to the scars that are in the pools, because scars can't be specified by pool in injury outcomes
* admiration -> respect and jealousy -> jealous in relationship outcome blocks (this is so confusing...)
* existing -> exists for new cats
* Switches a "true" string to `true` boolean
* persistent headache -> persistent headaches
* Injury outcomes are a list of objects
* History text is an object