### PR TITLE
Add Visual Studio Code snippets

### DIFF
--- a/.vscode/clangen.code-snippets
+++ b/.vscode/clangen.code-snippets
@@ -1,0 +1,36 @@
+{
+  "Clangen patrol template (minimal)": {
+    "prefix": "clangen-patrol-minimal",
+    "scope": "json",
+    "body": [
+      "{",
+      "    \"patrol_id\": \"$1\",",
+      "    \"biome\": [$2],",
+      "    \"season\": [$3],",
+      "    \"types\": [$4],",
+      "    \"tags\": [$5],",
+      "    \"patrol_art\": ${6:null},",
+      "    \"min_cats\": ${7:1},",
+      "    \"max_cats\": ${8:6},",
+      "    \"weight\": ${9:20},",
+      "    \"chance_of_success\": ${10:50},",
+      "    \"intro_text\": \"$11\",",
+      "    \"decline_text\": \"$12\",",
+      "    \"success_outcomes\": [$13],",
+      "    \"fail_outcomes\": [$14]",
+      "}"
+    ],
+    "description": "Clangen patrol template, with only the required fields."
+  },
+  "Clangen outcome template (minimal)": {
+    "prefix": "clangen-patrol-outcome-minimal",
+    "body": [
+      "{",
+      "    \"text\": \"$1\",",
+      "    \"exp\": ${2:0},",
+      "    \"weight\": ${3:20}",
+      "}"
+    ],
+    "description": "Clangen outcome template, with only the required fields."
+  }
+}

--- a/.vscode/clangen.code-snippets
+++ b/.vscode/clangen.code-snippets
@@ -32,5 +32,49 @@
       "}"
     ],
     "description": "Clangen outcome template, with only the required fields."
+  },
+  "pronoun_tag_subject": {
+    "prefix": ["they"],
+    "body": ["{PRONOUN/${1|m_c,r_c,s_c,p_l,n_c|}/subject${2|},/CAP}|}$0"]
+  },
+  "pronoun_tag_object": {
+    "prefix": ["them"],
+    "body": ["{PRONOUN/${1|m_c,r_c,s_c,p_l,n_c|}/object${2|},/CAP}|}$0"]
+  },
+  "pronoun_tag_poss": {
+    "prefix": ["their"],
+    "body": ["{PRONOUN/${1|m_c,r_c,s_c,p_l,n_c|}/poss${2|},/CAP}|}$0"]
+  },
+  "pronoun_tag_inposs": {
+    "prefix": ["theirs"],
+    "body": ["{PRONOUN/${1|m_c,r_c,s_c,p_l,n_c|}/inposs${2|},/CAP}|}$0"]
+  },
+  "pronoun_tag_self": {
+    "prefix": ["themself"],
+    "body": ["{PRONOUN/${1|m_c,r_c,s_c,p_l,n_c|}/self${2|},/CAP}|}$0"]
+  },
+  "pronoun_tag_verbs": {
+    "prefix": ["verbtag"],
+    "body": ["{VERB/${1|m_c,r_c,s_c,p_l,n_c|}/${2:run}/${3:runs}}$0"]
+  },
+  "pronoun_tag_subject_is": {
+    "prefix": ["they're"],
+    "body": ["{PRONOUN/m_c/subject${2|},/CAP}|}{VERB/m_c/'re/'s}$0"]
+  },
+  "pronoun_is": {
+    "prefix": ["are"],
+    "body": ["{VERB/${1|m_c,r_c,s_c,p_l,n_c|}/are/is}$0"]
+  },
+  "pronoun_do_not": {
+    "prefix": ["don't"],
+    "body": ["{VERB/${1|m_c,r_c,s_c,p_l,n_c|}/don't/doesn't}$0"]
+  },
+  "pronoun_have": {
+    "prefix": ["have"],
+    "body": ["{VERB/${1|m_c,r_c,s_c,p_l,n_c|}/have/has}$0"]
+  },
+  "pronoun_do": {
+    "prefix": ["do"],
+    "body": ["{VERB/${1|m_c,r_c,s_c,p_l,n_c|}/do/does}$0"]
   }
 }


### PR DESCRIPTION
## About The Pull Request

Adds Visual Studio Code snippets for pronoun tags and patrols from [my extension](https://github.com/cgen-tools/clangen-vscode-extension):
* `clangen-patrol-minimal`: creates a patrol json object with only the required fields
* `clangen-patrol-outcome-minimal`: creates a patrol outcome json object with only the required fields
* `they`, `them`, `theirs`, `themself`: creates pronoun tag corresponding to the pronoun
* `do`, `have`, `don't`, `are`, `they're`: creates verb tags corresponding to irregular verbs
* `verbtag`: creates a verb pronoun tag

## Why This Is Good For ClanGen

Makes writing patrols slightly easier. Also works really well in conjunction with the Visual Studio Code's autocomplete from the JSON schema.

## Demo

![loading](https://github.com/user-attachments/assets/656ce76f-06f8-488a-9bb4-f7d97286946d)
