### PR TITLE
Fix ProfileScreen UIWindow bug.

### DIFF
--- a/scripts/game_structure/ui_elements.py
+++ b/scripts/game_structure/ui_elements.py
@@ -11,7 +11,7 @@ from pygame_gui.core.interfaces import IUIManagerInterface
 from pygame_gui.core.text.html_parser import HTMLParser
 from pygame_gui.core.text.text_box_layout import TextBoxLayout
 from pygame_gui.core.utility import translate
-from pygame_gui.elements import UIAutoResizingContainer
+from pygame_gui.elements import UIAutoResizingContainer, UIWindow
 
 from scripts.game_structure import image_cache
 from scripts.game_structure.game_essentials import game
@@ -1452,3 +1452,4 @@ class UIImageHorizontalSlider(pygame_gui.elements.UIHorizontalSlider):
             },
             visible=self.visible,
         )
+        

--- a/scripts/game_structure/windows.py
+++ b/scripts/game_structure/windows.py
@@ -668,10 +668,12 @@ class ChangeCatName(UIWindow):
             elif event.ui_element == self.back_button:
                 game.all_screens["profile screen"].exit_screen()
                 game.all_screens["profile screen"].screen_switches()
+                del game.all_screens["profile screen"].windows["cat_name_window"]
                 self.kill()
         elif event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE and game.settings["keybinds"]:
             game.all_screens["profile screen"].exit_screen()
             game.all_screens["profile screen"].screen_switches()
+            del game.all_screens["profile screen"].windows["cat_name_window"]
             self.kill()
         return super().process_event(event)
 
@@ -1233,10 +1235,12 @@ class KillCat(UIWindow):
             elif event.ui_element == self.back_button:
                 game.all_screens["profile screen"].exit_screen()
                 game.all_screens["profile screen"].screen_switches()
+                del game.all_screens["profile screen"].windows["kill_cat_window"]
                 self.kill()
         elif event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE and game.settings["keybinds"]:
             game.all_screens["profile screen"].exit_screen()
             game.all_screens["profile screen"].screen_switches()
+            del game.all_screens["profile screen"].windows["kill_cat_window"]
             self.kill()
 
         return super().process_event(event)
@@ -2034,6 +2038,7 @@ class ChangeCatToggles(UIWindow):
             if event.ui_element == self.back_button:
                 game.all_screens["profile screen"].exit_screen()
                 game.all_screens["profile screen"].screen_switches()
+                del game.all_screens["profile screen"].windows["cat_toggles_window"]
                 self.kill()
             elif event.ui_element == self.checkboxes["prevent_fading"]:
                 self.the_cat.prevent_fading = not self.the_cat.prevent_fading
@@ -2050,6 +2055,7 @@ class ChangeCatToggles(UIWindow):
         elif event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE and game.settings["keybinds"]:
             game.all_screens["profile screen"].exit_screen()
             game.all_screens["profile screen"].screen_switches()
+            del game.all_screens["profile screen"].windows["cat_toggles_window"]
             self.kill()
 
         return super().process_event(event)

--- a/scripts/game_structure/windows.py
+++ b/scripts/game_structure/windows.py
@@ -669,7 +669,7 @@ class ChangeCatName(UIWindow):
                 game.all_screens["profile screen"].exit_screen()
                 game.all_screens["profile screen"].screen_switches()
                 self.kill()
-        elif event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE:
+        elif event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE and game.settings["keybinds"]:
             game.all_screens["profile screen"].exit_screen()
             game.all_screens["profile screen"].screen_switches()
             self.kill()
@@ -1234,7 +1234,7 @@ class KillCat(UIWindow):
                 game.all_screens["profile screen"].exit_screen()
                 game.all_screens["profile screen"].screen_switches()
                 self.kill()
-        elif event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE:
+        elif event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE and game.settings["keybinds"]:
             game.all_screens["profile screen"].exit_screen()
             game.all_screens["profile screen"].screen_switches()
             self.kill()
@@ -2047,7 +2047,7 @@ class ChangeCatToggles(UIWindow):
             elif event.ui_element == self.checkboxes["prevent_mates"]:
                 self.the_cat.no_mates = not self.the_cat.no_mates
                 self.refresh_checkboxes()
-        elif event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE:
+        elif event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE and game.settings["keybinds"]:
             game.all_screens["profile screen"].exit_screen()
             game.all_screens["profile screen"].screen_switches()
             self.kill()

--- a/scripts/game_structure/windows.py
+++ b/scripts/game_structure/windows.py
@@ -589,7 +589,6 @@ class ChangeCatName(UIWindow):
                 manager=MANAGER,
                 container=self,
             )
-        game.all_screens["profile screen"].window_open = True
         self.set_blocking(True)
 
     def process_event(self, event):
@@ -670,7 +669,6 @@ class ChangeCatName(UIWindow):
             elif event.ui_element == self.back_button:
                 game.all_screens["profile screen"].exit_screen()
                 game.all_screens["profile screen"].screen_switches()
-                game.all_screens["profile screen"].window_open = False
                 self.kill()
         return super().process_event(event)
 
@@ -1189,7 +1187,6 @@ class KillCat(UIWindow):
                 container=self,
             )
         self.set_blocking(True)
-        game.all_screens["profile screen"].window_open = True
 
     def process_event(self, event):
         super().process_event(event)
@@ -1221,7 +1218,6 @@ class KillCat(UIWindow):
                 update_sprite(self.the_cat)
                 game.all_screens["profile screen"].exit_screen()
                 game.all_screens["profile screen"].screen_switches()
-                game.all_screens["profile screen"].window_open = False
                 self.kill()
             elif event.ui_element == self.all_lives_check:
                 self.take_all = False
@@ -1234,7 +1230,6 @@ class KillCat(UIWindow):
             elif event.ui_element == self.back_button:
                 game.all_screens["profile screen"].exit_screen()
                 game.all_screens["profile screen"].screen_switches()
-                game.all_screens["profile screen"].window_open = False
                 self.kill()
 
         return super().process_event(event)
@@ -1949,8 +1944,6 @@ class ChangeCatToggles(UIWindow):
             container=self,
         )
 
-        game.all_screens["profile screen"].window_open = True
-
         # Text
 
     def refresh_checkboxes(self):
@@ -2034,7 +2027,6 @@ class ChangeCatToggles(UIWindow):
             if event.ui_element == self.back_button:
                 game.all_screens["profile screen"].exit_screen()
                 game.all_screens["profile screen"].screen_switches()
-                game.all_screens["profile screen"].window_open = False
                 self.kill()
             elif event.ui_element == self.checkboxes["prevent_fading"]:
                 self.the_cat.prevent_fading = not self.the_cat.prevent_fading

--- a/scripts/game_structure/windows.py
+++ b/scripts/game_structure/windows.py
@@ -54,7 +54,6 @@ from scripts.utility import (
 if TYPE_CHECKING:
     from scripts.screens.Screens import Screens
 
-
 class SymbolFilterWindow(UIWindow):
     def __init__(self):
         super().__init__(
@@ -670,6 +669,10 @@ class ChangeCatName(UIWindow):
                 game.all_screens["profile screen"].exit_screen()
                 game.all_screens["profile screen"].screen_switches()
                 self.kill()
+        elif event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE:
+            game.all_screens["profile screen"].exit_screen()
+            game.all_screens["profile screen"].screen_switches()
+            self.kill()
         return super().process_event(event)
 
 
@@ -1231,6 +1234,10 @@ class KillCat(UIWindow):
                 game.all_screens["profile screen"].exit_screen()
                 game.all_screens["profile screen"].screen_switches()
                 self.kill()
+        elif event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE:
+            game.all_screens["profile screen"].exit_screen()
+            game.all_screens["profile screen"].screen_switches()
+            self.kill()
 
         return super().process_event(event)
 
@@ -2040,6 +2047,10 @@ class ChangeCatToggles(UIWindow):
             elif event.ui_element == self.checkboxes["prevent_mates"]:
                 self.the_cat.no_mates = not self.the_cat.no_mates
                 self.refresh_checkboxes()
+        elif event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE:
+            game.all_screens["profile screen"].exit_screen()
+            game.all_screens["profile screen"].screen_switches()
+            self.kill()
 
         return super().process_event(event)
 

--- a/scripts/game_structure/windows.py
+++ b/scripts/game_structure/windows.py
@@ -589,6 +589,7 @@ class ChangeCatName(UIWindow):
                 manager=MANAGER,
                 container=self,
             )
+        game.all_screens["profile screen"].window_open = True
         self.set_blocking(True)
 
     def process_event(self, event):
@@ -669,6 +670,7 @@ class ChangeCatName(UIWindow):
             elif event.ui_element == self.back_button:
                 game.all_screens["profile screen"].exit_screen()
                 game.all_screens["profile screen"].screen_switches()
+                game.all_screens["profile screen"].window_open = False
                 self.kill()
         return super().process_event(event)
 
@@ -1187,6 +1189,7 @@ class KillCat(UIWindow):
                 container=self,
             )
         self.set_blocking(True)
+        game.all_screens["profile screen"].window_open = True
 
     def process_event(self, event):
         super().process_event(event)
@@ -1218,6 +1221,7 @@ class KillCat(UIWindow):
                 update_sprite(self.the_cat)
                 game.all_screens["profile screen"].exit_screen()
                 game.all_screens["profile screen"].screen_switches()
+                game.all_screens["profile screen"].window_open = False
                 self.kill()
             elif event.ui_element == self.all_lives_check:
                 self.take_all = False
@@ -1230,6 +1234,7 @@ class KillCat(UIWindow):
             elif event.ui_element == self.back_button:
                 game.all_screens["profile screen"].exit_screen()
                 game.all_screens["profile screen"].screen_switches()
+                game.all_screens["profile screen"].window_open = False
                 self.kill()
 
         return super().process_event(event)
@@ -1944,6 +1949,8 @@ class ChangeCatToggles(UIWindow):
             container=self,
         )
 
+        game.all_screens["profile screen"].window_open = True
+
         # Text
 
     def refresh_checkboxes(self):
@@ -2027,6 +2034,7 @@ class ChangeCatToggles(UIWindow):
             if event.ui_element == self.back_button:
                 game.all_screens["profile screen"].exit_screen()
                 game.all_screens["profile screen"].screen_switches()
+                game.all_screens["profile screen"].window_open = False
                 self.kill()
             elif event.ui_element == self.checkboxes["prevent_fading"]:
                 self.the_cat.prevent_fading = not self.the_cat.prevent_fading

--- a/scripts/screens/ProfileScreen.py
+++ b/scripts/screens/ProfileScreen.py
@@ -180,6 +180,7 @@ class ProfileScreen(Screens):
         self.the_cat = None
         self.checkboxes = {}
         self.profile_elements = {}
+        self.windows = {}
 
     def handle_event(self, event):
         if event.type == pygame_gui.UI_BUTTON_START_PRESS:
@@ -264,7 +265,7 @@ class ProfileScreen(Screens):
                 else:
                     print("invalid next cat", self.previous_cat)
 
-            elif event.key == pygame.K_ESCAPE:
+            elif event.key == pygame.K_ESCAPE and len(self.windows) <= 0:
                 self.close_current_tab()
                 self.change_screen(game.last_screen_forProfile)
 
@@ -289,7 +290,7 @@ class ProfileScreen(Screens):
         # Personal Tab
         elif self.open_tab == "personal":
             if event.ui_element == self.change_name_button:
-                ChangeCatName(self.the_cat)
+                self.windows["cat_name_window"] = ChangeCatName(self.the_cat)
             elif event.ui_element == self.specify_gender_button:
                 self.change_screen("change gender screen")
             # when button is pressed...
@@ -346,11 +347,11 @@ class ProfileScreen(Screens):
                 self.build_profile()
                 self.update_disabled_buttons_and_text()
             elif event.ui_element == self.cat_toggles_button:
-                ChangeCatToggles(self.the_cat)
+                self.windows["cat_toggles_window"] = ChangeCatToggles(self.the_cat)
         # Dangerous Tab
         elif self.open_tab == "dangerous":
             if event.ui_element == self.kill_cat_button:
-                KillCat(self.the_cat)
+                self.windows["kill_cat_window"] = KillCat(self.the_cat)
             elif event.ui_element == self.exile_cat_button:
                 if not self.the_cat.dead and not self.the_cat.exiled:
                     Cat.exile(self.the_cat)

--- a/scripts/screens/ProfileScreen.py
+++ b/scripts/screens/ProfileScreen.py
@@ -134,6 +134,8 @@ class ProfileScreen(Screens):
     # helps with exiting the screen
     open_tab = None
 
+    window_open = False
+
     def __init__(self, name=None):
         super().__init__(name)
         self.condition_data = {}
@@ -247,7 +249,7 @@ class ProfileScreen(Screens):
                 self.handle_tab_events(event)
 
         elif event.type == pygame.KEYDOWN and game.settings["keybinds"]:
-            if event.key == pygame.K_LEFT:
+            if event.key == pygame.K_LEFT and not self.window_open:
                 if isinstance(Cat.fetch_cat(self.previous_cat), Cat):
                     self.clear_profile()
                     game.switches["cat"] = self.previous_cat
@@ -255,7 +257,7 @@ class ProfileScreen(Screens):
                     self.update_disabled_buttons_and_text()
                 else:
                     print("invalid previous cat", self.previous_cat)
-            elif event.key == pygame.K_RIGHT:
+            elif event.key == pygame.K_RIGHT and not self.window_open:
                 if isinstance(Cat.fetch_cat(self.next_cat), Cat):
                     self.clear_profile()
                     game.switches["cat"] = self.next_cat
@@ -263,8 +265,7 @@ class ProfileScreen(Screens):
                     self.update_disabled_buttons_and_text()
                 else:
                     print("invalid next cat", self.previous_cat)
-
-            elif event.key == pygame.K_ESCAPE:
+            elif event.key == pygame.K_ESCAPE and not self.window_open:
                 self.close_current_tab()
                 self.change_screen(game.last_screen_forProfile)
 

--- a/scripts/screens/ProfileScreen.py
+++ b/scripts/screens/ProfileScreen.py
@@ -134,8 +134,6 @@ class ProfileScreen(Screens):
     # helps with exiting the screen
     open_tab = None
 
-    window_open = False
-
     def __init__(self, name=None):
         super().__init__(name)
         self.condition_data = {}
@@ -249,7 +247,7 @@ class ProfileScreen(Screens):
                 self.handle_tab_events(event)
 
         elif event.type == pygame.KEYDOWN and game.settings["keybinds"]:
-            if event.key == pygame.K_LEFT and not self.window_open:
+            if event.key == pygame.K_LEFT:
                 if isinstance(Cat.fetch_cat(self.previous_cat), Cat):
                     self.clear_profile()
                     game.switches["cat"] = self.previous_cat
@@ -257,7 +255,7 @@ class ProfileScreen(Screens):
                     self.update_disabled_buttons_and_text()
                 else:
                     print("invalid previous cat", self.previous_cat)
-            elif event.key == pygame.K_RIGHT and not self.window_open:
+            elif event.key == pygame.K_RIGHT:
                 if isinstance(Cat.fetch_cat(self.next_cat), Cat):
                     self.clear_profile()
                     game.switches["cat"] = self.next_cat
@@ -265,7 +263,8 @@ class ProfileScreen(Screens):
                     self.update_disabled_buttons_and_text()
                 else:
                     print("invalid next cat", self.previous_cat)
-            elif event.key == pygame.K_ESCAPE and not self.window_open:
+
+            elif event.key == pygame.K_ESCAPE:
                 self.close_current_tab()
                 self.change_screen(game.last_screen_forProfile)
 


### PR DESCRIPTION
## About The Pull Request
Prevents the use of keybinds when a window is open on ProfileScreen.
Forces the debug menu to always be on top.

## Linked Issues
fixes: #3178

## Proof of Testing

https://github.com/user-attachments/assets/6d47248a-4318-4ca4-835b-50ebd8a2a5c0
(Key 27 is Escape)
