### PR TITLE
fix: crash on no audio devices

### DIFF
--- a/main.py
+++ b/main.py
@@ -277,7 +277,12 @@ del loading_animation
 del load_data
 
 pygame.mixer.pre_init(buffer=44100)
-pygame.mixer.init()
+try:
+    pygame.mixer.init()
+except pygame.error:
+    print("Failed to initialize sound. Sound will be disabled.")
+    music_manager.audio_disabled = True
+    music_manager.muted = True
 AllScreens.start_screen.screen_switches()
 
 # dev screen info now lives in scripts/screens/screens_core
@@ -355,7 +360,7 @@ while 1:
         game.all_screens[game.last_screen_forupdate].exit_screen()
         game.all_screens[game.current_screen].screen_switches()
         game.switch_screens = False
-    if not pygame.mixer.music.get_busy() and not music_manager.muted:
+    if not music_manager.audio_disabled and not pygame.mixer.music.get_busy() and not music_manager.muted:
         music_manager.play_queued()
 
     debugmode.update1(clock)

--- a/scripts/game_structure/audio.py
+++ b/scripts/game_structure/audio.py
@@ -16,15 +16,20 @@ creation_screens = ["make clan screen"]
 
 class MusicManager:
     def __init__(self):
-        self.playlists = {}
+        
         self.current_playlist = []
         self.biome_playlist = []
         self.number_of_tracks = len(self.current_playlist)
         self.volume = game.settings["music_volume"] / 100
         self.muted = False
+        self.audio_disabled = False
         self.current_track = None
         self.queued_track = None
 
+        
+        self.load_playlists()
+    def load_playlists(self):
+        self.playlists = {}
         # loading playlists
         try:
             with open("resources/audio/music.json", "r") as f:
@@ -42,7 +47,7 @@ class MusicManager:
         """
         checks if playlist currently playing is appropriate for the given screen and changes the playlist if needed
         """
-        if self.muted:
+        if self.muted or self.audio_disabled:
             return
 
         self.biome_playlist = self.get_biome_music()
@@ -158,16 +163,30 @@ class MusicManager:
         pauses current music track
         """
         self.muted = True
-        pygame.mixer.music.pause()
+        if not self.audio_disabled:
+            pygame.mixer.music.pause()
 
     def unmute_music(self, screen):
         """
         unpauses current music track, then double checks if the track is appropriate for the screen before changing
         if necessary
         """
-        self.muted = False
+        
+        if self.audio_disabled:
+            try:
+                pygame.mixer.init()
+                self.load_playlists()
+                sound_manager.load_sounds()
+                self.audio_disabled = False
+                self.muted = False
+            except pygame.error:
+                self.muted = True
+                return False
+        else:
+            self.muted = False
         pygame.mixer.music.unpause()
         self.check_music(screen)
+        return True
 
     def change_volume(self, new_volume):
         """changes the volume, int given should be between 0 and 100"""
@@ -210,10 +229,13 @@ music_manager = MusicManager()
 
 class _SoundManager:
     def __init__(self):
-        self.sounds = {}
         self.volume = game.settings["sound_volume"] / 100
         self.pressed = None
 
+        self.load_sounds()
+    
+    def load_sounds(self):
+        self.sounds = {}
         # open up the sound dictionary
         try:
             with open("resources/audio/sounds.json", "r") as f:
@@ -263,7 +285,7 @@ class _SoundManager:
     def play(self, sound, button=None):
         """plays the given sound, if an ImageButton is passed through then the sound_id of the ImageButton will be
         used instead"""
-        if music_manager.muted:
+        if music_manager.muted or music_manager.audio_disabled:
             return
 
         if button and hasattr(button, "sound_id"):

--- a/scripts/screens/Screens.py
+++ b/scripts/screens/Screens.py
@@ -241,7 +241,7 @@ class Screens:
     def show_mute_buttons(cls):
         """This shows all mute buttons, and makes them interact-able."""
 
-        if music_manager.muted:
+        if music_manager.muted or music_manager.audio_disabled:
             cls.menu_buttons["unmute_button"].show()
             cls.menu_buttons["mute_button"].hide()
         else:
@@ -253,14 +253,12 @@ class Screens:
         This will fail if event.type != pygame_gui.UI_BUTTON_START_PRESS"""
         if event.ui_element == Screens.menu_buttons["mute_button"]:
             music_manager.mute_music()
-            Screens.menu_buttons["mute_button"].hide()
-            Screens.menu_buttons["unmute_button"].show()
+            Screens.show_mute_buttons()
             return True
         elif event.ui_element == Screens.menu_buttons["unmute_button"]:
-            music_manager.unmute_music(self.name)
-            Screens.menu_buttons["unmute_button"].hide()
-            Screens.menu_buttons["mute_button"].show()
-            return True
+            out = music_manager.unmute_music(self.name)
+            Screens.show_mute_buttons()
+            return out
         else:
             return False
 


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

This fixes the crash when there are no audio devices, and forcefully disabled audio
When it is disabled, the unmute button tries to reinitalize mixer, and if it works it reloads all the music and sounds and unmutes as normal

## Why This Is Good For ClanGen

<!-- If this is a bug fix, you can remove this section. -->
<!-- Please add a short description of why you think these changes would benefit the game. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->
<!-- If you have multiple features that can stand on their own, or unrelated bugfixes, please create separate PRs for them. -->

I have seen multiple reports about this in official-tech-support

## Linked Issues

<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->
#3195 3195

## Proof of Testing

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

https://github.com/user-attachments/assets/7a36fca7-6804-4215-8dec-8c188c184a86


