### PR TITLE
Fixes name crashes

### DIFF
--- a/scripts/events_module/patrol/patrol.py
+++ b/scripts/events_module/patrol/patrol.py
@@ -797,9 +797,6 @@ class Patrol:
         return (success_outcome if success else fail_outcome, success)
 
     def update_resources(self, biome_dir, leaf):
-        resource_dir = f"resources/lang/{i18n.config.get('locale')}/patrols/"
-        fallback_dir = f"resources/lang/{i18n.config.get('fallback')}/patrols/"
-
         resources = [
             ("HUNTING_SZN", f"{biome_dir}hunting/{leaf}.json"),
             ("HUNTING", f"{biome_dir}hunting/any.json"),

--- a/scripts/events_module/patrol/patrol.py
+++ b/scripts/events_module/patrol/patrol.py
@@ -816,6 +816,7 @@ class Patrol:
             ("BORDER_GEN", "general/border.json"),
             ("MEDCAT_GEN", "general/medcat.json"),
             ("TRAINING_GEN", "general/training.json"),
+            ("DISASTER", "disaster.json"),
         ]
         for patrol_property, location in resources:
             try:

--- a/scripts/events_module/patrol/patrol_outcome.py
+++ b/scripts/events_module/patrol/patrol_outcome.py
@@ -820,18 +820,20 @@ class PatrolOutcome:
 
         for i, attribute_list in enumerate(self.new_cat):
             patrol.new_cats.append(
-                create_new_cat_block(Cat, Relationship, patrol, in_event_cats, i, attribute_list)
+                create_new_cat_block(
+                    Cat, Relationship, patrol, in_event_cats, i, attribute_list
+                )
             )
             dead = []
             outside = []
             new = []
             for cat in patrol.new_cats[-1]:
                 if cat.dead:
-                    dead.append(cat.name)
+                    dead.append(str(cat.name))
                 elif cat.outside:
-                    outside.append(cat.name)
+                    outside.append(str(cat.name))
                 else:
-                    new.append(cat.name)
+                    new.append(str(cat.name))
             for type_list, string in [
                 (dead, "screens.patrol.dead_outsider"),
                 (outside, "screens.patrol.met_outsider"),


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->

## About The Pull Request
I will burn the Name class to the ground. The reason this crash was occurring is because the cat's name is a class and needs explicitly casting to str before use. I missed it I'm sorry

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Why This Is Good For ClanGen

<!-- If this is a bug fix, you can remove this section. -->
<!-- Please add a short description of why you think these changes would benefit the game. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->
<!-- If you have multiple features that can stand on their own, or unrelated bugfixes, please create separate PRs for them. -->

## Linked Issues
Fixes #3298
Fixes #3300 
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits

<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
