### PR TITLE
[CONTENT] Eye color prefixes for the orange color

### DIFF
--- a/resources/dicts/names/names.json
+++ b/resources/dicts/names/names.json
@@ -308,7 +308,8 @@
     "COBALT": ["Blue", "Blue", "Ice", "Icy", "Sky", "Lake", "Frost", "Water", "Frosty", "Rime"],
     "SUNLITICE": ["Sun", "Ice", "Icy", "Frost", "Dawn", "Dusk", "Odd", "Glow", "Mouse"],
     "GREENYELLOW": ["Green", "Yellow", "Tawny", "Hazel", "Gold", "Daisy", "Sand", "Sandy", "Weed"],
-    "SILVER": ["Gray", "Stone", "Silver", "Silver", "Moon", "Rain", "Storm", "Pale", "Light"]
+    "SILVER": ["Gray", "Stone", "Silver", "Silver", "Moon", "Rain", "Storm", "Pale", "Light"],
+	"ORANGE": ["Amber", "Sun", "Fire", "Honey", "Flame", "Blaze", "Pumpkin", "Red", "Ember", "Orange"]
   },
 
   "loner_names": [

--- a/resources/dicts/names/names.json
+++ b/resources/dicts/names/names.json
@@ -309,7 +309,7 @@
     "SUNLITICE": ["Sun", "Ice", "Icy", "Frost", "Dawn", "Dusk", "Odd", "Glow", "Mouse"],
     "GREENYELLOW": ["Green", "Yellow", "Tawny", "Hazel", "Gold", "Daisy", "Sand", "Sandy", "Weed"],
     "SILVER": ["Gray", "Stone", "Silver", "Silver", "Moon", "Rain", "Storm", "Pale", "Light"],
-	"ORANGE": ["Amber", "Sun", "Fire", "Honey", "Flame", "Blaze", "Pumpkin", "Red", "Ember", "Orange"]
+    "ORANGE": ["Amber", "Sun", "Fire", "Honey", "Flame", "Blaze", "Pumpkin", "Red", "Ember", "Orange"]
   },
 
   "loner_names": [


### PR DESCRIPTION
## About The Pull Request
I had forgotten to add eye color prefixes for the new color, so this adds them in.

## Why This Is Good For ClanGen

It could get buggy if the game decides to name a cat after their eye color, but it's not listed.

## Proof of Testing

![kuva](https://github.com/user-attachments/assets/d5f08b99-12cf-4f77-a983-e5239f568ab3)
![Näyttökuva 2025-01-01 030832](https://github.com/user-attachments/assets/8a02b996-e672-4b29-a2ab-4536e467f882)
Cats with orange eyes, with prefixes chosen by their eye color