### PR TITLE
Handle random herb count & reduce code duplication

### DIFF
--- a/scripts/clan_resources/herb/herb_supply.py
+++ b/scripts/clan_resources/herb/herb_supply.py
@@ -453,8 +453,13 @@ class HerbSupply:
                 found_herbs[herb] = choices(population=[1, 2, 3], weights=weight, k=1)[0] * quantity_modifier
                 amount_of_herbs -= 1
 
-        list_of_herb_strs = []
+        return self.handle_found_herbs_outcomes(found_herbs)
 
+    def handle_found_herbs_outcomes(self, found_herbs: dict = {}):
+        """
+        Handles adding herbs to the collection and preparing outcome for patrols
+        """
+        list_of_herb_strs = []
         if found_herbs:
             for herb, count in found_herbs.items():
                 # add it to the collection

--- a/scripts/events_module/patrol/patrol_outcome.py
+++ b/scripts/events_module/patrol/patrol_outcome.py
@@ -687,15 +687,15 @@ class PatrolOutcome:
         else:
             patrol_size_modifier = 1
 
-        full_amount_count = 0
-
         if "random_herbs" in self.herbs:
+            # get random herbs, add to storage, and get patrol outcome msg
             list_of_herb_strs, found_herbs = game.clan.herb_supply.get_found_herbs(
                 med_cat=patrol.patrol_leader,
                 general_amount_bonus=large_bonus,
                 specific_quantity_bonus=patrol_size_modifier,
             )
         else:
+            # get the correct herbs for this patrol
             found_herbs = {}
             for herb in [
                 x for x in self.herbs if x not in ["many_herbs", "random_herbs"]
@@ -707,19 +707,12 @@ class PatrolOutcome:
 
                 found_herbs[herb] = amount
 
-            for herb, count in found_herbs.items():
-                game.clan.herb_supply.add_herb(herb, count)
-                full_amount_count += count
-                if count > 1:
-                    list_of_herb_strs.append(
-                        f"{count} {game.clan.herb_supply.herb[herb].plural_display}"
-                    )
-                else:
-                    list_of_herb_strs.append(
-                        f"{count} {game.clan.herb_supply.herb[herb].singular_display}"
-                    )
+            # add found_herbs to storage and get patrol outcome msg
+            list_of_herb_strs, found_herbs = game.clan.herb_supply.handle_found_herbs_outcomes(found_herbs)
 
         herb_string = adjust_list_text(list_of_herb_strs).capitalize()
+
+        full_amount_count = sum(found_herbs.values())
 
         game.herb_events_list.append(
             i18n.t(


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->

## About The Pull Request

- "random_herb" patrols now correctly print out that herbs were gathered
- Reduces code duplication of herb collection/logging

## Linked Issues

Fixes #3368

## Proof of Testing

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

Many herbs visible from patrol outcome:
![image](https://github.com/user-attachments/assets/80a220a0-444a-4abb-94d2-caea3c90dcf9)

Another example:
![image](https://github.com/user-attachments/assets/dbf4e494-3cce-496e-b70a-3d1cd40882cd)



