### PR TITLE
Fixes exiled cats having wrong suffixes & adds tests

### DIFF
--- a/scripts/cat/names.py
+++ b/scripts/cat/names.py
@@ -158,11 +158,9 @@ class Name:
                     self.prefix[-1] + self.suffix[:2],
                 )
                 if any(
-                    i != possible_three_letter[0][0]
-                    for i in possible_three_letter[0]
+                    i != possible_three_letter[0][0] for i in possible_three_letter[0]
                 ) and any(
-                    i != possible_three_letter[1][0]
-                    for i in possible_three_letter[1]
+                    i != possible_three_letter[1][0] for i in possible_three_letter[1]
                 ):
                     triple_letter = False
                 if (
@@ -187,9 +185,10 @@ class Name:
 
         # Add possible prefix categories to list.
         possible_prefix_categories = []
-        if eyes in self.names_dict["eye_prefixes"] and game.config["cat_name_controls"][
-                        "allow_eye_names"
-                    ]:
+        if (
+            eyes in self.names_dict["eye_prefixes"]
+            and game.config["cat_name_controls"]["allow_eye_names"]
+        ):
             possible_prefix_categories.append(self.names_dict["eye_prefixes"][eyes])
         if colour in self.names_dict["colour_prefixes"]:
             possible_prefix_categories.append(
@@ -263,7 +262,7 @@ class Name:
         # then suffixes based on ages (fixes #2004, just trust me)
 
         # Handles suffix assignment with outside cats
-        if self.cat.status in ["exiled", "lost"]:
+        if self.cat.status not in ["rogue", "loner", "kittypet"] and self.cat.outside:
             adjusted_status: str = ""
             if self.cat.moons >= 15:
                 adjusted_status = "warrior"
@@ -278,8 +277,10 @@ class Name:
             else:
                 adjusted_status = "warrior"
 
-            if adjusted_status != "warrior":
-                return self.prefix + self.names_dict["special_suffixes"][adjusted_status]
+            if adjusted_status != "warrior" and not self.specsuffix_hidden:
+                return (
+                    self.prefix + self.names_dict["special_suffixes"][adjusted_status]
+                )
         if (
             self.cat.status in self.names_dict["special_suffixes"]
             and not self.specsuffix_hidden

--- a/tests/test_cat.py
+++ b/tests/test_cat.py
@@ -11,7 +11,6 @@ os.environ["SDL_AUDIODRIVER"] = "dummy"
 
 
 class TestCreationAge(unittest.TestCase):
-
     # test that a cat with 1-5 moons has the age of a kitten
     def test_kitten(self):
         test_cat = Cat(moons=5)
@@ -26,7 +25,7 @@ class TestCreationAge(unittest.TestCase):
     def test_young_adult(self):
         test_cat = Cat(moons=12)
         self.assertEqual(test_cat.age, "young adult")
-    
+
     # test that a cat with 48-95 moons has the age of an adult
     def test_adult(self):
         test_cat = Cat(moons=48)
@@ -44,7 +43,6 @@ class TestCreationAge(unittest.TestCase):
 
 
 class TestRelativesFunction(unittest.TestCase):
-
     # test that is_parent returns True for a parent1-cat relationship and False otherwise
     def test_is_parent(self):
         parent = Cat()
@@ -89,7 +87,6 @@ class TestRelativesFunction(unittest.TestCase):
 
 
 class TestPossibleMateFunction(unittest.TestCase):
-
     # test that is_potential_mate returns False for cats that are related to each other
     def test_relation(self):
         grand_parent = Cat()
@@ -115,7 +112,9 @@ class TestPossibleMateFunction(unittest.TestCase):
         self.assertFalse(kit.is_potential_mate(sibling1, for_love_interest=True))
         self.assertFalse(kit.is_potential_mate(sibling2, for_love_interest=True))
         self.assertFalse(kit.is_potential_mate(kit, for_love_interest=True))
-        self.assertFalse(sibling1.is_potential_mate(grand_parent, for_love_interest=True))
+        self.assertFalse(
+            sibling1.is_potential_mate(grand_parent, for_love_interest=True)
+        )
         self.assertFalse(sibling1.is_potential_mate(sibling1, for_love_interest=True))
         self.assertFalse(sibling1.is_potential_mate(sibling2, for_love_interest=True))
         self.assertFalse(sibling1.is_potential_mate(kit, for_love_interest=True))
@@ -145,9 +144,15 @@ class TestPossibleMateFunction(unittest.TestCase):
 
         # check for setting
         self.assertFalse(
-            senior_adult_cat1.is_potential_mate(young_adult_cat1, for_love_interest=False, age_restriction=True))
+            senior_adult_cat1.is_potential_mate(
+                young_adult_cat1, for_love_interest=False, age_restriction=True
+            )
+        )
         self.assertTrue(
-            senior_adult_cat1.is_potential_mate(young_adult_cat1, for_love_interest=False, age_restriction=False))
+            senior_adult_cat1.is_potential_mate(
+                young_adult_cat1, for_love_interest=False, age_restriction=False
+            )
+        )
 
         # check invalid constellations
         self.assertFalse(kitten_cat1.is_potential_mate(kitten_cat2))
@@ -250,9 +255,15 @@ class TestPossibleMateFunction(unittest.TestCase):
         self.assertTrue(young_adult_cat1.is_potential_mate(young_adult_cat2, True))
         self.assertTrue(young_adult_cat1.is_potential_mate(adult_cat_in_range1, True))
         self.assertTrue(adult_cat_in_range1.is_potential_mate(young_adult_cat1, True))
-        self.assertTrue(adult_cat_in_range1.is_potential_mate(adult_cat_in_range2, True))
-        self.assertTrue(adult_cat_in_range1.is_potential_mate(adult_cat_out_range1, True))
-        self.assertTrue(adult_cat_out_range1.is_potential_mate(adult_cat_out_range2, True))
+        self.assertTrue(
+            adult_cat_in_range1.is_potential_mate(adult_cat_in_range2, True)
+        )
+        self.assertTrue(
+            adult_cat_in_range1.is_potential_mate(adult_cat_out_range1, True)
+        )
+        self.assertTrue(
+            adult_cat_out_range1.is_potential_mate(adult_cat_out_range2, True)
+        )
         self.assertTrue(adult_cat_out_range1.is_potential_mate(senior_adult_cat1, True))
         self.assertTrue(senior_adult_cat1.is_potential_mate(adult_cat_out_range1, True))
         self.assertTrue(senior_adult_cat1.is_potential_mate(senior_adult_cat2, True))
@@ -272,7 +283,7 @@ class TestPossibleMateFunction(unittest.TestCase):
         self.assertFalse(dead_cat.is_potential_mate(normal_cat))
         self.assertFalse(normal_cat.is_potential_mate(dead_cat))
 
-    @patch('scripts.game_structure.game_essentials.game.settings')
+    @patch("scripts.game_structure.game_essentials.game.settings")
     def test_possible_setting(self, settings):
         mentor = Cat(moons=50)
         former_appr = Cat(moons=20)
@@ -292,7 +303,6 @@ class TestPossibleMateFunction(unittest.TestCase):
 
 
 class TestMateFunctions(unittest.TestCase):
-
     # test that set_mate adds the mate's ID to the cat's mate list
     def test_set_mate(self):
         # given
@@ -334,7 +344,7 @@ class TestMateFunctions(unittest.TestCase):
         old_relation1 = deepcopy(relation1)
         relation2 = Relationship(cat2, cat1)
         old_relation2 = deepcopy(relation1)
-        
+
         cat1.relationships[cat2.ID] = relation1
         cat2.relationships[cat1.ID] = relation2
 
@@ -366,12 +376,32 @@ class TestMateFunctions(unittest.TestCase):
         cat1 = Cat()
         cat2 = Cat()
         relation1 = Relationship(
-            cat1, cat2, family=False, mates=True, romantic_love=40, platonic_like=40, dislike=0, comfortable=40,
-            trust=20, admiration=20, jealousy=20)
+            cat1,
+            cat2,
+            family=False,
+            mates=True,
+            romantic_love=40,
+            platonic_like=40,
+            dislike=0,
+            comfortable=40,
+            trust=20,
+            admiration=20,
+            jealousy=20,
+        )
         old_relation1 = deepcopy(relation1)
         relation2 = Relationship(
-            cat2, cat1, family=False, mates=True, romantic_love=40, platonic_like=40, dislike=0, comfortable=40,
-            trust=20, admiration=20, jealousy=20)
+            cat2,
+            cat1,
+            family=False,
+            mates=True,
+            romantic_love=40,
+            platonic_like=40,
+            dislike=0,
+            comfortable=40,
+            trust=20,
+            admiration=20,
+            jealousy=20,
+        )
         old_relation2 = deepcopy(relation2)
         cat1.mate.append(cat2.ID)
         cat2.mate.append(cat1.ID)
@@ -398,11 +428,10 @@ class TestMateFunctions(unittest.TestCase):
         self.assertGreater(old_relation2.comfortable, relation2.comfortable)
         self.assertGreater(old_relation2.trust, relation2.trust)
         self.assertGreaterEqual(old_relation2.admiration, relation2.admiration)
-        self.assertGreaterEqual(old_relation2.jealousy, relation2.jealousy)  
+        self.assertGreaterEqual(old_relation2.jealousy, relation2.jealousy)
 
 
 class TestUpdateMentor(unittest.TestCase):
-
     # test that an exiled cat apprentice becomes a former apprentice
     def test_exile_apprentice(self):
         # given
@@ -421,3 +450,139 @@ class TestUpdateMentor(unittest.TestCase):
         self.assertFalse(app.ID in mentor.apprentice)
         self.assertTrue(app.ID in mentor.former_apprentices)
         self.assertIsNone(app.mentor)
+
+
+class TestNameRepr(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        os.environ["SDL_VIDEODRIVER"] = "dummy"
+        os.environ["SDL_AUDIODRIVER"] = "dummy"
+
+    def test_clancats(self):
+        """
+        Test that basic clancats return the correct names
+        :return:
+        """
+        statuses = [
+            [["newborn"], 0, "kit"],
+            [["kitten"], 1, "kit"],
+            [
+                ["apprentice", "medicine cat apprentice", "mediator apprentice"],
+                6,
+                "paw",
+            ],
+            [["warrior", "medicine cat", "mediator", "elder", "deputy"], 14, "test"],
+            [["leader"], 14, "star"],
+        ]
+        for testset, moons, suffix in statuses:
+            for status in testset:
+                with self.subTest("clancats", status=status):
+                    cat = Cat(moons=moons, status=status, suffix="test")
+                    self.assertTrue(str(cat.name).endswith(suffix))
+
+    def test_specsuffix_clancats(self):
+        """
+        Test that clancats with suppressed special suffixes return the correct names
+        :return:
+        """
+        statuses = [
+            [["newborn"], 0, "test"],
+            [["kitten"], 1, "test"],
+            [
+                ["apprentice", "medicine cat apprentice", "mediator apprentice"],
+                6,
+                "test",
+            ],
+            [["warrior", "medicine cat", "mediator", "elder", "deputy"], 14, "test"],
+            [["leader"], 14, "test"],
+        ]
+        for testset, moons, suffix in statuses:
+            for status in testset:
+                with self.subTest("clancats specsuffix", status=status):
+                    cat = Cat(moons=moons, status=status, suffix="test")
+                    cat.name.specsuffix_hidden = True
+                    self.assertTrue(str(cat.name).endswith(suffix))
+
+    def test_outsiders(self):
+        """
+        Test that basic outsiders return the correct name
+        :return:
+        """
+        outsider_statuses = ["loner", "rogue", "kittypet"]
+        ex_clancat_statuses = ["former Clancat", "exiled"]
+
+        age_suffix = [[0, "kit"], [1, "kit"], [6, "paw"], [14, "test"]]
+
+        for status in outsider_statuses:
+            for moons, suffix in age_suffix:
+                with self.subTest("outsiders", status=status, moons=moons):
+                    cat = Cat(status=status, moons=moons, suffix="test")
+                    cat.outside = True
+                    self.assertTrue(str(cat.name).endswith("test"))
+
+        for status in ex_clancat_statuses:
+            for moons, suffix in age_suffix:
+                with self.subTest("Clan-like names", status=status, moons=moons):
+                    cat = Cat(status=status, moons=moons, suffix="test")
+                    cat.outside = True
+                    self.assertTrue(str(cat.name).endswith(suffix))
+
+    def test_specsuffix_outsiders(self):
+        """
+        Test that outsiders with hidden special suffixes return the correct name
+        :return:
+        """
+        outsider_statuses = ["loner", "rogue", "kittypet"]
+        ex_clancat_statuses = ["former Clancat", "exiled"]
+
+        age_suffix = [[0, "kit"], [1, "kit"], [6, "paw"], [14, "test"]]
+
+        for status in outsider_statuses:
+            for moons, suffix in age_suffix:
+                with self.subTest("outsiders", status=status, moons=moons):
+                    cat = Cat(status=status, moons=moons, suffix="test")
+                    cat.outside = True
+                    cat.name.specsuffix_hidden = True
+                    self.assertTrue(str(cat.name).endswith("test"))
+
+        for status in ex_clancat_statuses:
+            for moons, suffix in age_suffix:
+                with self.subTest("Clan-like names", status=status, moons=moons):
+                    cat = Cat(status=status, moons=moons, suffix="test")
+                    cat.name.specsuffix_hidden = True
+                    self.assertTrue(str(cat.name).endswith("test"))
+
+    def test_lost(self):
+        """
+        Test that lost cats return the correct suffix
+        :return:
+        """
+        statuses = [
+            ["newborn", 0, "kit"],
+            ["kitten", 1, "kit"],
+            ["apprentice", 6, "paw"],
+            ["warrior", 14, "test"],
+        ]
+        for status, moons, suffix in statuses:
+            with self.subTest("lost clancats", moons=moons):
+                cat = Cat(status=status, moons=moons, suffix="test")
+                cat.outside = True
+                self.assertTrue(str(cat.name).endswith(suffix))
+
+    def test_specsuffix_lost(self):
+        """
+        Test that lost cats with specsuffix return the correct suffix
+        :return:
+        """
+        statuses = [
+            ["newborn", 0, "kit"],
+            ["kitten", 1, "kit"],
+            ["apprentice", 6, "paw"],
+            ["warrior", 14, "test"],
+        ]
+        for status, moons, suffix in statuses:
+            with self.subTest("lost clancats", status=status):
+                cat = Cat(status=status, moons=moons, suffix="test")
+                cat.outside = True
+                cat.name.specsuffix_hidden = True
+                self.assertTrue(str(cat.name).endswith("test"))


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->

## About The Pull Request

Fixes a bug where cats with ignore special suffix enabled would no longer do that after being exiled

Found & fixed another bug where the suffix detection code did not trigger for lost cats as their status is not set to "lost". Would like to refactor the entire function since it can be made much cleaner but felt that's more of a development branch task than a stable hotfix one.

Also adds some tests to ensure names work the way we expect them to going forward.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
Fixes #3376 
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
![image](https://github.com/user-attachments/assets/53563e42-5e5e-48c2-892e-3d718af4c9fb)
newborn exile (i'm a monster)
![image](https://github.com/user-attachments/assets/88a4e32d-2f48-4c32-8172-6190bffdb6d5)
kitten exile (still a monster)
![image](https://github.com/user-attachments/assets/96cdefb5-f65d-436b-bfcb-9be5ede583e4)
apprentice exile (oatberry im sorry ily)
![image](https://github.com/user-attachments/assets/c8ff5bcc-e987-496f-a55a-ec5b8d866379)

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits

<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
