### PR TITLE
Fixing white_patches check for heterochromia odds

### DIFF
--- a/scripts/cat/pelts.py
+++ b/scripts/cat/pelts.py
@@ -807,6 +807,14 @@ class Pelt:
             self.pattern = "MINIMALFOUR"
 
     def init_eyes(self, parents):
+        """ Sets eye color for this cat's pelt. Takes parents' eye colors into account.
+        Heterochromia is possible based on the white-ness of the pelt, so the pelt color and white_patches must be
+        set before this function is called.
+
+        :param parents: List[Cat] representing this cat's parents
+
+        :return: None
+        """
         if not parents:
             self.eye_colour = choice(Pelt.eye_colours)
         else:
@@ -816,12 +824,9 @@ class Pelt:
 
         # White patches must be initalized before eye color.
         num = game.config["cat_generation"]["base_heterochromia"]
-        if (
-            self.white_patches in [Pelt.high_white, Pelt.mostly_white, "FULLWHITE"]
-            or self.colour == "WHITE"
-        ):
-            num = num - 90
         if self.white_patches == "FULLWHITE" or self.colour == "WHITE":
+            num -= 90
+        elif self.white_patches in Pelt.high_white or self.white_patches in Pelt.mostly_white:
             num -= 10
         for _par in parents:
             if _par.pelt.eye_colour2:

--- a/scripts/cat/pelts.py
+++ b/scripts/cat/pelts.py
@@ -824,9 +824,14 @@ class Pelt:
 
         # White patches must be initalized before eye color.
         num = game.config["cat_generation"]["base_heterochromia"]
+        if (
+            self.white_patches in Pelt.high_white
+            or self.white_patches in Pelt.mostly_white
+            or self.white_patches == "FULLWHITE"
+            or self.colour == "WHITE"
+        ):
+            num = num - 90
         if self.white_patches == "FULLWHITE" or self.colour == "WHITE":
-            num -= 90
-        elif self.white_patches in Pelt.high_white or self.white_patches in Pelt.mostly_white:
             num -= 10
         for _par in parents:
             if _par.pelt.eye_colour2:


### PR DESCRIPTION
## About The Pull Request

In pelts.py, the odds of heterochromia was not properly increased for cats with mostly/high/full white_patches, because the condition was checking against a nested list. This fixes the check while preserving its original odds as closely as possible.

Effectively this slightly increases the odds of heterochromia for cats with mostly_ and high_white white patches.

## Why This Is Good For ClanGen

we want the code to work as intended, especially since we've been communicating publicly that the odds are increased for cats with white_patches

## Linked Issues

Fixes #3373 

## Proof of Testing

added some print statements to visualize - 
![image](https://github.com/user-attachments/assets/97c78d9d-38ee-4943-943f-1365a2196949)

and the litter of 4 from the printout - 
![image](https://github.com/user-attachments/assets/67a28bee-d279-42f9-82ed-f47bd1624cbc)
![image](https://github.com/user-attachments/assets/c35ca6b0-4456-4b19-a10b-c339d47c68fe)
![image](https://github.com/user-attachments/assets/2c04b340-63d6-4a08-9ccf-eed4a31ad727)
![image](https://github.com/user-attachments/assets/e62e45b7-5ead-4612-bac4-8467925db7d0)


## Changelog/Credits

<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
