### PR TITLE
Bugfixes - Typos!

### DIFF
--- a/resources/lang/en/events/ceremonies/ceremony-master.json
+++ b/resources/lang/en/events/ceremonies/ceremony-master.json
@@ -1984,7 +1984,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "(old_name) almost sobs as {PRONOUN/m_c/object} {VERB/m_c/spot/spots} dead_par1 and dead_par2 step out of the starry crowd to congratulate {PRONOUN/m_c/object} on completing {PRONOUN/m_c/poss} training. dead_par2 rests {PRONOUN/dead_par2/poss} muzzle on (old_name)'s head, naming {PRONOUN/m_c/object} m_c, and welcoming {PRONOUN/m_c/object} as a full medicine cat."
+    "(old_name) almost sobs as {PRONOUN/m_c/subject} {VERB/m_c/spot/spots} dead_par1 and dead_par2 step out of the starry crowd to congratulate {PRONOUN/m_c/object} on completing {PRONOUN/m_c/poss} training. dead_par2 rests {PRONOUN/dead_par2/poss} muzzle on (old_name)'s head, naming {PRONOUN/m_c/object} m_c, and welcoming {PRONOUN/m_c/object} as a full medicine cat."
   ],
   "med_50": [
     [

--- a/resources/lang/en/events/lead_ceremony_sc.json
+++ b/resources/lang/en/events/lead_ceremony_sc.json
@@ -478,7 +478,7 @@
       "rank": ["warrior", "elder", "medicine cat", "mediator", "apprentice", "deputy"],
       "life_giving": [
         {
-          "text": "r_c gazes at the lonesome leader with a deep sympathy as {PRONOUN/r_c/subject} approach, sensing the weight of {PRONOUN/m_c/poss} solitude. m_c's eyes begin to well up as a life for [virtue] flows through {PRONOUN/m_c/object}, a warm embrace that wards off the cold isolation, even if for a brief moment.",
+          "text": "r_c gazes at the lonesome leader with a deep sympathy as {PRONOUN/r_c/subject} {VERB/approach/approaches}, sensing the weight of {PRONOUN/m_c/poss} solitude. m_c's eyes begin to well up as a life for [virtue] flows through {PRONOUN/m_c/object}, a warm embrace that wards off the cold isolation, even if for a brief moment.",
           "virtue": ["gratitude", "bravery", "trust", "affection", "friendship", "love", "determination", "endurance", "hope", "humor", "certainty", "devotion", "healing", "strength", "unity"]
         }
       ]

--- a/resources/lang/en/patrols/plains/border/greenleaf.json
+++ b/resources/lang/en/patrols/plains/border/greenleaf.json
@@ -818,7 +818,7 @@
                 ],
                 "history_text": {
                     "scar": "Killing a juvenile coyote and being driven off by its parents left its scars on r_c.",
-                    "reg_death": "r_c died to keep coyotes away from c_n's borders.",
+                    "reg_death": "m_c died to keep coyotes away from c_n's borders.",
                     "lead_death": "keeping coyotes away from c_n's borders"
                 },
                 "relationships": [

--- a/resources/lang/en/patrols/plains/border/greenleaf.json
+++ b/resources/lang/en/patrols/plains/border/greenleaf.json
@@ -789,7 +789,7 @@
                 "dead_cats":["r_c"],
                 "history_text": {
                     "scar": "Killing a juvenile coyote and being driven off by its parents left its scars on r_c.",
-                    "reg_death": "r_c died to keep coyotes away from c_n's borders.",
+                    "reg_death": "m_c died to keep coyotes away from c_n's borders.",
                     "lead_death": "keeping coyotes away from c_n's borders"
                 },
                 "relationships": [

--- a/resources/lang/en/snippet_collections.json
+++ b/resources/lang/en/snippet_collections.json
@@ -515,7 +515,7 @@
         ["knowing a secret that can never be revealed"],
         ["a truth unbelieved", "a truth concealed", "a truth never revealed"],
         ["a weakness in {PRONOUN/cat_tag/poss} legs"],
-        ["a belly so empty {PRONOUN/cat_tag/subject} feel nauseous"],
+        ["a belly so empty {PRONOUN/cat_tag/subject} {VERB/feel/feels} nauseous"],
         ["a home no longer welcoming", "a home long lost", "a home once forgotten"],
         ["oozing corruption"]
       ],


### PR DESCRIPTION
## About The Pull Request

Fixing some typos and fixing one of those damn r_c tag issues :)

- Patrol pln_bord_greenleaf_coyote_small_patrol1 - fixed r_c tag in death history to m_c addressing #3201
     - Additional tag change in second death history event in this patrol that was uncaught 
- Verb tagging approach in lonesome_warrior addressing https://github.com/ClanGenOfficial/clangen/issues/1818#issuecomment-2571848386
- Verb tagging nauseous in clar_list addressing https://github.com/ClanGenOfficial/clangen/issues/1818#issuecomment-2615994120
- Pronoun tagging error changing object to subject in med_49 of ceremonies.json addressing https://github.com/ClanGenOfficial/clangen/issues/1818#issuecomment-2620710208
 
## Linked Issues

#3201
https://github.com/ClanGenOfficial/clangen/issues/1818#issuecomment-2571848386
https://github.com/ClanGenOfficial/clangen/issues/1818#issuecomment-2615994120
https://github.com/ClanGenOfficial/clangen/issues/1818#issuecomment-2620710208

## Proof of Testing

![image](https://github.com/user-attachments/assets/c616ddde-850b-4c95-875b-69295f8eb5d1)
![image](https://github.com/user-attachments/assets/34af66ea-668a-44b5-bf1c-a0fa4338c370) - virtue is a little funky due to having to replace default to properly test this in my testing!
![image](https://github.com/user-attachments/assets/295461ef-a0e8-42f4-b715-cb59bcd0bc7a) - Ignore it appearing twice, result of local testing chances tweaks! 

The final push addressing med_49 I know will work as it is a very minor tagging correction!

## Changelog/Credits

flamedash - Typo fixes
