### PR TITLE
[ENHANCEMENT] Allow cats to have multiple accessories

### DIFF
--- a/resources/game_config.json
+++ b/resources/game_config.json
@@ -206,7 +206,8 @@
 		"elder_modifier": 20,
 		"happy_trait_modifier": -30,
 		"grumpy_trait_modifier": 30,
-		"ceremony_modifier": -20
+		"ceremony_modifier": -20,
+		"multiple_acc_modifier": 50
 	},
 	"transition_related": {
 		"base_trans_chance": 256,

--- a/scripts/cat/pelts.py
+++ b/scripts/cat/pelts.py
@@ -304,14 +304,6 @@ class Pelt:
         "BULB BLUE",
         "CLOVER",
         "DAISY",
-        "CLOVER",
-        "DAISY",
-        "LILY OF THE VALLEY",
-        "HEATHER",
-        "SNAPDRAGON",
-        "GORSE",
-        "BULB WHITE",
-        "BULB YELLOW",
         "DRY HERBS",
         "DRY CATMINT",
         "DRY NETTLES",
@@ -401,6 +393,53 @@ class Pelt:
         "PURPLENYLON",
         "MULTINYLON",
         "INDIGONYLON",
+    ]
+
+    head_accessories = [
+        "MOTH WINGS",
+        "ROSY MOTH WINGS",
+        "MORPHO BUTTERFLY",
+        "MONARCH BUTTERFLY",
+        "CICADA WINGS",
+        "BLACK CICADA",
+        "MAPLE LEAF",
+        "HOLLY",
+        "BLUE BERRIES",
+        "FORGET ME NOTS",
+        "RYE STALK",
+        "CATTAIL",
+        "POPPY",
+        "ORANGE POPPY",
+        "CYAN POPPY",
+        "WHITE POPPY",
+        "PINK POPPY",
+        "BLUEBELLS",
+        "LILY OF THE VALLEY",
+        "SNAPDRAGON",
+        "NETTLE",
+        "HEATHER",
+        "GORSE",
+        "JUNIPER",
+        "RASPBERRY",
+        "LAVENDER",
+        "OAK LEAVES",
+        "CATMINT",
+        "MAPLE SEED",
+        "LAUREL",
+        "BULB WHITE",
+        "BULB YELLOW",
+        "BULB ORANGE",
+        "BULB PINK",
+        "BULB BLUE",
+        "DRY CATMINT",
+        "DRY NETTLES",
+        "DRY LAURELS",
+    ]
+
+    body_accessories = [
+        "HERBS",
+        "PETALS",
+        "DRY HERBS"
     ]
 
     tabbies = ["Tabby", "Ticked", "Mackerel", "Classic", "Sokoke", "Agouti"]
@@ -652,7 +691,7 @@ class Pelt:
         tortiepattern: str = None,
         vitiligo: str = None,
         points: str = None,
-        accessory: str = None,
+        accessory: list = None,
         paralyzed: bool = False,
         opacity: int = 100,
         scars: list = None,
@@ -805,6 +844,10 @@ class Pelt:
             self.pattern = "MINIMALTHREE"
         elif self.pattern == "MINIMAL4":
             self.pattern = "MINIMALFOUR"
+
+        if isinstance(self.accessory, str):
+            self.accessory = [self.accessory]
+
 
     def init_eyes(self, parents):
         if not parents:
@@ -1171,7 +1214,7 @@ class Pelt:
 
     def init_accessories(self, age):
         if age == "newborn":
-            self.accessory = None
+            self.accessory = []
             return
 
         acc_display_choice = random.randint(0, 80)
@@ -1181,11 +1224,11 @@ class Pelt:
             acc_display_choice = random.randint(0, 100)
 
         if acc_display_choice == 1:
-            self.accessory = choice(
+            self.accessory = [choice(
                 [choice(Pelt.plant_accessories), choice(Pelt.wild_accessories)]
-            )
+            )]
         else:
-            self.accessory = None
+            self.accessory = []
 
     def init_pattern(self):
         if self.name in Pelt.torties:

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -1709,8 +1709,8 @@ class Events:
         if cat.dead or cat.outside:
             return
 
-        # check if cat already has acc
-        if cat.pelt.accessory:
+        # check if cat already has max acc
+        if cat.pelt.accessory and len(cat.pelt.accessory) == 3:
             self.ceremony_accessory = False
             return
 
@@ -1751,6 +1751,8 @@ class Events:
             "nervous",
         ]:
             chance += acc_chances["grumpy_trait_modifier"]
+        if cat.pelt.accessory and len(cat.pelt.accessory) >= 1:
+            chance += acc_chances["multiple_acc_modifier"]
         if self.ceremony_accessory:
             chance += acc_chances["ceremony_modifier"]
 

--- a/scripts/events_module/short/handle_short_events.py
+++ b/scripts/events_module/short/handle_short_events.py
@@ -399,8 +399,21 @@ class HandleShortEvents:
                     if acc in acc_list:
                         acc_list.remove(acc)
 
+        acc_categories = ["collars", "head_accessories", "tail_accessories", "body_accessories"]
+
+        if self.main_cat.pelt.accessory:
+            for acc in self.main_cat.pelt.accessory:
+                for category in acc_categories:
+                    if acc in getattr(pelts, category):
+                        for accessory in getattr(pelts, category):
+                            if accessory in acc_list:
+                                acc_list.remove(accessory)
+
         if acc_list:
-            self.main_cat.pelt.accessory = random.choice(acc_list)
+            if self.main_cat.pelt.accessory:
+                self.main_cat.pelt.accessory.append(random.choice(acc_list))
+            else:
+                self.main_cat.pelt.accessory = [random.choice(acc_list)]
 
     def handle_transition(self):
         """

--- a/scripts/events_module/short/handle_short_events.py
+++ b/scripts/events_module/short/handle_short_events.py
@@ -412,7 +412,6 @@ class HandleShortEvents:
                                 acc_list.remove(accessory)
 
         if not acc_list:
-            print("Not accessories for", self.main_cat.name)
             return False
 
         if self.main_cat.pelt.accessory:

--- a/scripts/events_module/short/handle_short_events.py
+++ b/scripts/events_module/short/handle_short_events.py
@@ -401,15 +401,15 @@ class HandleShortEvents:
                     if acc in acc_list:
                         acc_list.remove(acc)
 
-        acc_categories = ["collars", "head_accessories", "tail_accessories", "body_accessories"]
-
+        accessory_groups = [pelts.collars, pelts.head_accessories, pelts.tail_accessories, pelts.body_accessories]
         if self.main_cat.pelt.accessory:
             for acc in self.main_cat.pelt.accessory:
-                for category in acc_categories:
-                    if acc in getattr(pelts, category):
-                        for accessory in getattr(pelts, category):
-                            if accessory in acc_list:
-                                acc_list.remove(accessory)
+                # find which accessory group it belongs to
+                for i, lst in enumerate(accessory_groups):
+                    if acc in lst:
+                        # remove that group from possible accessories
+                        acc_list = [a for a in acc_list if a not in accessory_groups[i]]
+                        break
 
         if not acc_list:
             return False

--- a/scripts/events_module/short/handle_short_events.py
+++ b/scripts/events_module/short/handle_short_events.py
@@ -196,7 +196,9 @@ class HandleShortEvents:
 
         # give accessory
         if self.chosen_event.new_accessory:
-            self.handle_accessories()
+            if self.handle_accessories() is False:
+                return
+
 
         # change relationships before killing anyone
         if self.chosen_event.relationships:
@@ -409,11 +411,15 @@ class HandleShortEvents:
                             if accessory in acc_list:
                                 acc_list.remove(accessory)
 
-        if acc_list:
-            if self.main_cat.pelt.accessory:
-                self.main_cat.pelt.accessory.append(random.choice(acc_list))
-            else:
-                self.main_cat.pelt.accessory = [random.choice(acc_list)]
+        if not acc_list:
+            print("Not accessories for", self.main_cat.name)
+            return False
+
+        if self.main_cat.pelt.accessory:
+            self.main_cat.pelt.accessory.append(random.choice(acc_list))
+        else:
+            self.main_cat.pelt.accessory = [random.choice(acc_list)]
+
 
     def handle_transition(self):
         """

--- a/scripts/screens/ProfileScreen.py
+++ b/scripts/screens/ProfileScreen.py
@@ -192,15 +192,15 @@ class ProfileScreen(Screens):
             elif event.ui_element == self.conditions_tab_button:
                 self.toggle_conditions_tab()
             elif (
-                "leader_ceremony" in self.profile_elements
-                and event.ui_element == self.profile_elements["leader_ceremony"]
+                    "leader_ceremony" in self.profile_elements
+                    and event.ui_element == self.profile_elements["leader_ceremony"]
             ):
                 self.change_screen("ceremony screen")
             elif event.ui_element == self.profile_elements["med_den"]:
                 self.change_screen("med den screen")
             elif (
-                "mediation" in self.profile_elements
-                and event.ui_element == self.profile_elements["mediation"]
+                    "mediation" in self.profile_elements
+                    and event.ui_element == self.profile_elements["mediation"]
             ):
                 self.change_screen("mediation screen")
             elif event.ui_element == self.profile_elements["favourite_button"]:
@@ -270,26 +270,26 @@ class ProfileScreen(Screens):
                 ]:
                     self.the_cat.genderalign = self.the_cat.gender
                 elif (
-                    self.the_cat.gender == "male"
-                    and self.the_cat.genderalign == "female"
+                        self.the_cat.gender == "male"
+                        and self.the_cat.genderalign == "female"
                 ):
                     self.the_cat.genderalign = self.the_cat.gender
                 elif (
-                    self.the_cat.gender == "female"
-                    and self.the_cat.genderalign == "male"
+                        self.the_cat.gender == "female"
+                        and self.the_cat.genderalign == "male"
                 ):
                     self.the_cat.genderalign = self.the_cat.gender
 
                 # if the cat is cis (gender & gender align are the same) then set them to trans
                 # cis males -> trans female first
                 elif (
-                    self.the_cat.gender == "male" and self.the_cat.genderalign == "male"
+                        self.the_cat.gender == "male" and self.the_cat.genderalign == "male"
                 ):
                     self.the_cat.genderalign = "trans female"
                 # cis females -> trans male
                 elif (
-                    self.the_cat.gender == "female"
-                    and self.the_cat.genderalign == "female"
+                        self.the_cat.gender == "female"
+                        and self.the_cat.genderalign == "female"
                 ):
                     self.the_cat.genderalign = "trans male"
                 # if the cat is trans then set them to nonbinary
@@ -536,15 +536,15 @@ class ProfileScreen(Screens):
         if self.the_cat is None:
             return
         if (
-            self.the_cat.dead
-            and game.clan.instructor.ID == self.the_cat.ID
-            and self.the_cat.df is False
+                self.the_cat.dead
+                and game.clan.instructor.ID == self.the_cat.ID
+                and self.the_cat.df is False
         ):
             is_sc_instructor = True
         elif (
-            self.the_cat.dead
-            and game.clan.instructor.ID == self.the_cat.ID
-            and self.the_cat.df is True
+                self.the_cat.dead
+                and game.clan.instructor.ID == self.the_cat.ID
+                and self.the_cat.df is True
         ):
             is_df_instructor = True
 
@@ -629,9 +629,9 @@ class ProfileScreen(Screens):
             starting_height=2,
         )
         if not (self.the_cat.dead or self.the_cat.outside) and (
-            self.the_cat.status in ["medicine cat", "medicine cat apprentice"]
-            or self.the_cat.is_ill()
-            or self.the_cat.is_injured()
+                self.the_cat.status in ["medicine cat", "medicine cat apprentice"]
+                or self.the_cat.is_ill()
+                or self.the_cat.is_injured()
         ):
             self.profile_elements["med_den"].show()
         else:
@@ -734,7 +734,8 @@ class ProfileScreen(Screens):
             output += "\n"
             output += i18n.t(
                 "screens.profile.accessory_label",
-                accessory=i18n.t(f"cat.accessories.{the_cat.pelt.accessory}", count=0),
+                accessory=adjust_list_text(
+                    [i18n.t(f"cat.accessories.{acc}", count=0) for acc in the_cat.pelt.accessory])
             )
             # NEWLINE ----------
 
@@ -806,9 +807,9 @@ class ProfileScreen(Screens):
 
         # STATUS
         if (
-            the_cat.outside
-            and not the_cat.exiled
-            and the_cat.status not in ["kittypet", "loner", "rogue", "former Clancat"]
+                the_cat.outside
+                and not the_cat.exiled
+                and the_cat.status not in ["kittypet", "loner", "rogue", "former Clancat"]
         ):
             output += f"<font color='#FF0000'>{i18n.t('general.lost', count=1)}</font>"
         elif the_cat.exiled:
@@ -917,9 +918,9 @@ class ProfileScreen(Screens):
 
         # NUTRITION INFO (if the game is in the correct mode)
         if (
-            game.clan.game_mode in ["expanded", "cruel season"]
-            and the_cat.is_alive()
-            and FRESHKILL_ACTIVE
+                game.clan.game_mode in ["expanded", "cruel season"]
+                and the_cat.is_alive()
+                and FRESHKILL_ACTIVE
         ):
             # Check to only show nutrition for clan cats
             if str(the_cat.status) not in [
@@ -946,8 +947,8 @@ class ProfileScreen(Screens):
         if the_cat.is_disabled():
             for condition in the_cat.permanent_condition:
                 if (
-                    the_cat.permanent_condition[condition]["born_with"] is True
-                    and the_cat.permanent_condition[condition]["moons_until"] != -2
+                        the_cat.permanent_condition[condition]["born_with"] is True
+                        and the_cat.permanent_condition[condition]["moons_until"] != -2
                 ):
                     continue
                 output += i18n.t("general.has_permanent_condition")
@@ -1192,8 +1193,8 @@ class ProfileScreen(Screens):
         if self.the_cat.backstory:
             bs_blurb = i18n.t(f"cat.backstories.{self.the_cat.backstory}")
         if (
-            self.the_cat.status in ["kittypet", "loner", "rogue", "former Clancat"]
-            and self.the_cat.dead
+                self.the_cat.status in ["kittypet", "loner", "rogue", "former Clancat"]
+                and self.the_cat.dead
         ):
             bs_blurb = i18n.t(
                 "cat.backstories.cats_outside_the_clan_dead",
@@ -1323,20 +1324,20 @@ class ProfileScreen(Screens):
             ]
 
             influence_history += (
-                i18n.t(
-                    "cat.history.training_mentors",
-                    count=len(valid_former_mentors) if valid_former_mentors else 0,
-                    mentors=adjust_list_text(
-                        valid_former_mentors if valid_former_mentors else [""]
-                    ),
-                )
-                + " "
+                    i18n.t(
+                        "cat.history.training_mentors",
+                        count=len(valid_former_mentors) if valid_former_mentors else 0,
+                        mentors=adjust_list_text(
+                            valid_former_mentors if valid_former_mentors else [""]
+                        ),
+                    )
+                    + " "
             )
 
             # Second, do the facet/personality effect
             trait_influence = []
             if "trait" in mentor_influence and isinstance(
-                mentor_influence["trait"], dict
+                    mentor_influence["trait"], dict
             ):
                 for _mentor in mentor_influence["trait"]:
                     # If the strings are not set (empty list), continue.
@@ -1364,7 +1365,7 @@ class ProfileScreen(Screens):
 
             skill_influence = []
             if "skill" in mentor_influence and isinstance(
-                mentor_influence["skill"], dict
+                    mentor_influence["skill"], dict
             ):
                 for _mentor in mentor_influence["skill"]:
                     # If the strings are not set (empty list), continue.
@@ -1395,8 +1396,8 @@ class ProfileScreen(Screens):
         graduation_history = ""
         if app_ceremony:
             graduation_history = (
-                i18n.t("cat.history.graduation_honor", honor=app_ceremony["honor"])
-                + " "
+                    i18n.t("cat.history.graduation_honor", honor=app_ceremony["honor"])
+                    + " "
             )
 
             grad_age = app_ceremony["graduation_age"]
@@ -1730,8 +1731,8 @@ class ProfileScreen(Screens):
             [i, self.get_condition_details(i)]
             for i in self.the_cat.permanent_condition
             if not (
-                self.the_cat.permanent_condition[i]["born_with"]
-                and self.the_cat.permanent_condition[i]["moons_until"] != -2
+                    self.the_cat.permanent_condition[i]["born_with"]
+                    and self.the_cat.permanent_condition[i]["moons_until"] != -2
             )
         ]
         all_illness_injuries.extend(
@@ -1838,7 +1839,7 @@ class ProfileScreen(Screens):
             else:
                 # moons with the condition if not born with condition
                 moons_with = (
-                    game.clan.age - self.the_cat.permanent_condition[name]["moon_start"]
+                        game.clan.age - self.the_cat.permanent_condition[name]["moon_start"]
                 )
                 text_list.append(
                     i18n.t("general.had_perm_condition_for", count=moons_with)
@@ -2111,10 +2112,10 @@ class ProfileScreen(Screens):
                 self.change_adoptive_parent_button.enable()
 
             if (
-                self.the_cat.age
-                not in ["young adult", "adult", "senior adult", "senior"]
-                or self.the_cat.exiled
-                or self.the_cat.outside
+                    self.the_cat.age
+                    not in ["young adult", "adult", "senior adult", "senior"]
+                    or self.the_cat.exiled
+                    or self.the_cat.outside
             ):
                 self.choose_mate_button.disable()
             else:
@@ -2127,10 +2128,10 @@ class ProfileScreen(Screens):
             else:
                 self.manage_roles.enable()
             if (
-                self.the_cat.status
-                not in ["apprentice", "medicine cat apprentice", "mediator apprentice"]
-                or self.the_cat.dead
-                or self.the_cat.outside
+                    self.the_cat.status
+                    not in ["apprentice", "medicine cat apprentice", "mediator apprentice"]
+                    or self.the_cat.dead
+                    or self.the_cat.outside
             ):
                 self.change_mentor_button.disable()
             else:
@@ -2143,7 +2144,7 @@ class ProfileScreen(Screens):
                     "screens.profile.change_gender_transfemale"
                 )
             elif (
-                self.the_cat.gender == "female" and self.the_cat.genderalign == "female"
+                    self.the_cat.gender == "female" and self.the_cat.genderalign == "female"
             ):
                 self.cis_trans_button.set_text(
                     "screens.profile.change_gender_transmale"

--- a/scripts/utility.py
+++ b/scripts/utility.py
@@ -894,7 +894,7 @@ def create_new_cat(
 
         # give em a collar if they got one
         if accessory:
-            new_cat.pelt.accessory = accessory
+            new_cat.pelt.accessory = [accessory]
 
         # give apprentice aged cat a mentor
         if new_cat.age == "adolescent":
@@ -2295,14 +2295,14 @@ def event_text_adjust(
     # acc_plural (only works for main_cat's acc)
     if "acc_plural" in text:
         text = text.replace(
-            "acc_plural", i18n.t(f"cat.accessories.{main_cat.pelt.accessory}", count=2)
+            "acc_plural", i18n.t(f"cat.accessories.{main_cat.pelt.accessory[-1]}", count=2)
         )
 
     # acc_singular (only works for main_cat's acc)
     if "acc_singular" in text:
         text = text.replace(
             "acc_singular",
-            i18n.t(f"cat.accessories.{main_cat.pelt.accessory}", count=1),
+            i18n.t(f"cat.accessories.{main_cat.pelt.accessory[-1]}", count=1),
         )
 
     if "given_herb" in text:
@@ -2852,21 +2852,27 @@ def generate_sprite(
                     )
 
         # draw accessories
-        if not acc_hidden:
-            if cat.pelt.accessory in cat.pelt.plant_accessories:
-                new_sprite.blit(
-                    sprites.sprites["acc_herbs" + cat.pelt.accessory + cat_sprite],
-                    (0, 0),
-                )
-            elif cat.pelt.accessory in cat.pelt.wild_accessories:
-                new_sprite.blit(
-                    sprites.sprites["acc_wild" + cat.pelt.accessory + cat_sprite],
-                    (0, 0),
-                )
-            elif cat.pelt.accessory in cat.pelt.collars:
-                new_sprite.blit(
-                    sprites.sprites["collars" + cat.pelt.accessory + cat_sprite], (0, 0)
-                )
+        from scripts.cat.pelts import Pelt
+        if not acc_hidden and cat.pelt.accessory:
+            cat_accessories = cat.pelt.accessory
+            categories = ["collars", "tail_accessories", "body_accessories", "head_accessories"]
+            for category in categories:
+                for accessory in cat_accessories:
+                    if accessory in getattr(Pelt, category):
+                        if accessory in cat.pelt.plant_accessories:
+                            new_sprite.blit(
+                                sprites.sprites["acc_herbs" + accessory + cat_sprite],
+                                (0, 0),
+                            )
+                        elif accessory in cat.pelt.wild_accessories:
+                            new_sprite.blit(
+                                sprites.sprites["acc_wild" + accessory + cat_sprite],
+                                (0, 0),
+                            )
+                        elif accessory in cat.pelt.collars:
+                            new_sprite.blit(
+                                sprites.sprites["collars" + accessory + cat_sprite], (0, 0)
+                            )
 
         # Apply fading fog
         if (


### PR DESCRIPTION
## About The Pull Request

Cats are now able to have up to 3 different accessories.
All accessories have been divided into sections according to the body parts they cover: head, collar, body and tail (so they can't have multiple accessories for the same body part). These categories also determine the rendering order in the sprite generation, to avoid overlapping visuals being weird.
After getting the first accessory, there's a lower chance of getting a second and third one, which can be customized in game_config.
Old save files will convert the accessory attribute of each cat from string to list.

## Why This Is Good For ClanGen

It will add more variety and uniqueness for cats in the Clan, and it's a feature that was already suggested as an enhancement by senior devs.

## Linked Issues
Fixes: #2320

## Proof of Testing
Beta testing thread: https://discord.com/channels/1003759225522110524/1336115112053833738
![image](https://github.com/user-attachments/assets/094cf45f-818d-4d6f-8ca0-e5ffbd54e700)

## Changelog/Credits
Enhancement: Allow cats to have multiple accessories
