### PR TITLE
[BUGFIX] Fix patrol crashing when there's no deputy

### DIFF
--- a/resources/lang/en/patrols/general/hunting.json
+++ b/resources/lang/en/patrols/general/hunting.json
@@ -440,7 +440,7 @@
         "biome": ["any"],
         "season": ["any"],
         "types": ["hunting"],
-        "tags": [],
+        "tags": ["clan:deputy"],
         "patrol_art": "gen_hunt_sneakprey",
         "min_cats": 2,
         "max_cats": 6,
@@ -550,7 +550,7 @@
         "biome": ["any"],
         "season": ["any"],
         "types": ["hunting"],
-        "tags": [],
+        "tags": ["clan:deputy"],
         "patrol_art": "gen_hunt_sneakprey",
         "min_cats": 2,
         "max_cats": 6,
@@ -640,7 +640,7 @@
                         "cats_to": ["clan", "patrol"],
                         "cats_from": ["app1"],
                         "mutual": false,
-                        "values": ["jealous"    ],
+                        "values": ["jealous"],
                         "amount": 5
                     }
                 ],

--- a/schemas/patrol.schema.json
+++ b/schemas/patrol.schema.json
@@ -273,15 +273,23 @@
         "description": "Tags are used for some filtering purposes, and some odd-and-ends. Tags never affect outcome.",
         "type": "array",
         "items": {
-          "enum": [
-            "romantic",
-            "rom_two_apps",
-            "disaster",
-            "new_cat",
-            "halloween",
-            "april_fools",
-            "new_years",
-            "cruel_season"
+          "anyOf": [
+            {
+              "enum": [
+                "romantic",
+                "rom_two_apps",
+                "disaster",
+                "new_cat",
+                "halloween",
+                "april_fools",
+                "new_years",
+                "cruel_season"
+              ]
+            },
+            {
+              "type": "string",
+              "pattern": "^clan:(.+)$"
+            }
           ]
         }
       },

--- a/scripts/events_module/event_filters.py
+++ b/scripts/events_module/event_filters.py
@@ -102,7 +102,8 @@ def event_for_tags(tags: list, cat, other_cat=None) -> bool:
 
             if rank in ["leader", "deputy"] and not get_alive_status_cats(cat, [rank]):
                 return False
-            elif not len(get_alive_status_cats(cat, [rank])) >= 2:
+            
+            if rank not in ["leader", "deputy"] and not len(get_alive_status_cats(cat, [rank])) >= 2:
                 return False
     
     special_date = get_special_date()

--- a/scripts/events_module/patrol/patrol.py
+++ b/scripts/events_module/patrol/patrol.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: ascii -*-
 import random
+import re
 from copy import deepcopy
 from itertools import repeat
 from os.path import exists as path_exists
@@ -27,6 +28,7 @@ from scripts.utility import (
     filter_relationship_type,
     get_special_snippet_list,
     adjust_list_text,
+    get_alive_status_cats,
 )
 from scripts.game_structure.localization import load_lang_resource
 
@@ -589,6 +591,27 @@ class Patrol:
                 if not (num[0] <= self.patrol_statuses.get(sta, -1) <= num[1]):
                     flag = True
                     break
+            if flag:
+                continue
+
+            flag = False
+            for _tag in patrol.tags:
+                rank_match = re.match(r"clan:(.+)", _tag)
+                if not rank_match:
+                    continue
+                ranks = [x for x in rank_match.group(1).split(",")]
+
+                for rank in ranks:
+                    if rank == "apps":
+                        if not get_alive_status_cats(
+                                Cat,
+                                ["apprentice", "medicine cat apprentice", "mediator apprentice"]):
+                            flag = True
+                        else:
+                            continue
+
+                    if rank in ["leader", "deputy"] and not get_alive_status_cats(Cat, [rank]):
+                        flag = True
             if flag:
                 continue
 

--- a/scripts/events_module/patrol/patrol.py
+++ b/scripts/events_module/patrol/patrol.py
@@ -612,6 +612,8 @@ class Patrol:
 
                     if rank in ["leader", "deputy"] and not get_alive_status_cats(Cat, [rank]):
                         flag = True
+                    elif not len(get_alive_status_cats(Cat, [rank])) >= 2:
+                        flag = True
             if flag:
                 continue
 

--- a/scripts/events_module/patrol/patrol_outcome.py
+++ b/scripts/events_module/patrol/patrol_outcome.py
@@ -132,11 +132,6 @@ class PatrolOutcome:
                 if not isinstance(out.stat_cat, Cat):
                     continue
 
-            if "lead_name" in out.text and not game.clan.leader:
-                continue
-            if "dep_name" in out.text and not game.clan.deputy:
-                continue
-
             # TODO: outcome relationship constraints
             # if not patrol._satify_relationship_constaints(patrol, out.relationship_constaints):
             #    continue

--- a/scripts/events_module/patrol/patrol_outcome.py
+++ b/scripts/events_module/patrol/patrol_outcome.py
@@ -132,6 +132,11 @@ class PatrolOutcome:
                 if not isinstance(out.stat_cat, Cat):
                     continue
 
+            if "lead_name" in out.text and not game.clan.leader:
+                continue
+            if "dep_name" in out.text and not game.clan.deputy:
+                continue
+
             # TODO: outcome relationship constraints
             # if not patrol._satify_relationship_constaints(patrol, out.relationship_constaints):
             #    continue


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->
Had a crash brought to my attention and replicated it on basegame - patrols can cause a crash if they include dep_name in outcome, while the Clan has no deputy.
Added a few lines into the outcome filtering that exclude any outcomes with lead_name or dep_name while the needed cats don't exist

## Linked Issues

#3444
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->
Repeated the patrol about 10 times with no further crashes
![image](https://github.com/user-attachments/assets/27286867-0e47-45c6-a87b-15eada097f95)
![image](https://github.com/user-attachments/assets/eaf68c73-917d-4c00-90b9-6688681eef84)

## Changelog/Credits

<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
