### PR TITLE
[BUGFIX] Fixed problems related to raiding other Clans

### DIFF
--- a/scripts/events.py
+++ b/scripts/events.py
@@ -775,7 +775,7 @@ class Events:
             for condition_type, value in involved_cats.items():
                 game.cur_events_list.append(
                     Single_Event(
-                        i18n.t(text_snippet, condition=condition_type, count=value),
+                        i18n.t(text_snippet, condition=condition_type, count=len(value)),
                         "health",
                         value,
                     )

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -748,16 +748,16 @@ class Events:
                         chosen_injury = random.choice(possible_injuries)
                         cat.get_injured(chosen_injury)
                         involved_cats["injured"].append(cat.ID)
-                else:
-                    chance = game.config["focus"]["hoarding"]["illness_chance"]
-                    if not int(random.random() * chance):  # 1/chance
-                        possible_illnesses = []
-                        injury_dict = game.config["focus"]["hoarding"]["illnesses"]
-                        for illness, amount in injury_dict.items():
-                            possible_illnesses.extend([illness] * amount)
-                        chosen_illness = random.choice(possible_illnesses)
-                        cat.get_ill(chosen_illness)
-                        involved_cats["sick"].append(cat.ID)
+                    else:
+                        chance = game.config["focus"]["hoarding"]["illness_chance"]
+                        if not int(random.random() * chance):  # 1/chance
+                            possible_illnesses = []
+                            injury_dict = game.config["focus"]["hoarding"]["illnesses"]
+                            for illness, amount in injury_dict.items():
+                                possible_illnesses.extend([illness] * amount)
+                            chosen_illness = random.choice(possible_illnesses)
+                            cat.get_ill(chosen_illness)
+                            involved_cats["sick"].append(cat.ID)
 
             # if it is raiding, lower the relation to other clans
             if game.clan.clan_settings.get("raid other clans"):


### PR DESCRIPTION
## About The Pull Request
I found a crash caused when trying to raid other Clans (one or more) using the focus feature. Whenever you tried to raid any Clan, the game crashed upon moonskipping with the following crash log:

![image](https://github.com/user-attachments/assets/4e4d8ed4-cd14-4ef0-86a4-9c5f5cabf137)

The crash was caused by a list being passed through a count, instead of the length of said list.

Upon fixing this, I realized cats that were getting sick because of the current focus weren't being listed in the event:
![image](https://github.com/user-attachments/assets/4ea28323-db00-4a15-af3c-6b3a5fe0c967)

This was caused by an indentation problem, which was making the code completely skip the loop to correctly add the sick cats' IDs to the event. 

## Proof of Testing
![image](https://github.com/user-attachments/assets/57f26985-6a5e-4073-837b-7e171daa2026)
![image](https://github.com/user-attachments/assets/ed2f3941-fc49-4ff2-93bc-2f0fd895a00d)
![image](https://github.com/user-attachments/assets/ed5b678a-0f92-4bd2-9dda-15dd7818c297)


## Changelog/Credits
[BUGFIX] Fixed raid focus causing crash + cats getting sick with focus not being listed in event.
