### PR TITLE
Bugfix: Horizontal anchors invalid

### DIFF
--- a/scripts/screens/MakeClanScreen.py
+++ b/scripts/screens/MakeClanScreen.py
@@ -1378,7 +1378,6 @@ class MakeClanScreen(Screens):
             anchors={
                 "left_target": self.elements["random_clan_checkbox"],
                 "top_target": self.elements["random_clan_checkbox"],
-                "centerx": self.elements["random_clan_checkbox"],
             },
         )
         self.elements["mode_details"] = pygame_gui.elements.UITextBox(


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

Removed centerx anchor from random_clan_checkbox_label in MakeClanScreen to get rid of horizontal anchors error. According to [this section of the pygame gui docs](https://pygame-gui.readthedocs.io/en/latest/layout_guide.html#anchor-targets), you may receive errors if you mix anchor targets with anchor direction scheming which I believe is what was happening here. Unsure if this should be merged into development or release as it only affects devs?

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues

Fixes: #3381 

<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing

<img width="1613" alt="Screenshot 2025-03-26 at 9 25 04 PM" src="https://github.com/user-attachments/assets/1c946f3a-d92e-4e9e-9046-ecc41c0203b9" />

The error was appearing at this point; it is no longer present.

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits

- Fixed bug where a warning about invalid horizontal anchors appeared on opening make clan screen

<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
