### PR TITLE
April Fools hats will appear on April Fools

### DIFF
--- a/scripts/cat/sprites.py
+++ b/scripts/cat/sprites.py
@@ -5,6 +5,7 @@ from copy import copy
 import pygame
 import ujson
 
+from scripts.special_dates import SpecialDate, is_today
 from scripts.game_structure.game_essentials import game
 
 logger = logging.getLogger(__name__)
@@ -161,7 +162,7 @@ class Sprites:
             "fadedarkforest",
             "symbols",
         ]:
-            if "lineart" in x and game.config["fun"]["april_fools"]:
+            if "lineart" in x and (game.config["fun"]["april_fools"] or is_today(SpecialDate.APRIL_FOOLS)):
                 self.spritesheet(f"sprites/aprilfools{x}.png", x)
             else:
                 self.spritesheet(f"sprites/{x}.png", x)


### PR DESCRIPTION
## About The Pull Request

Replaces lineart with the hat lineart on April Fools.

Technically there's another April Fools thing that's supposed to happen (newborns roaming and patrolling) but we'd have to fix a circular import to get that working with the special date code.

## Why This Is Good For ClanGen
* It's fun
* I forgot to add it when I added automatic special date support

## Proof of Testing
No hats on April 2nd :( 
![image](https://github.com/user-attachments/assets/e4cafb29-a983-4592-8d0e-1ff51c5c2ea3)

Hats on April 1st :)
![image](https://github.com/user-attachments/assets/eac71dea-1318-410a-be81-549a19b36185)


## Changelog/Credits

Hats will now automatically appear on April Fools.