### PR TITLE
BUGFIX : lead_death and status fix 

### DIFF
--- a/resources/dicts/events/injury/general.json
+++ b/resources/dicts/events/injury/general.json
@@ -3394,7 +3394,8 @@
                     "m_c"
                 ],
                 "scar": "m_c was scarred by a Clanmate that r_c encouraged {PRONOUN/m_c/object} to fight.",
-                "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after a fight with a Clanmate that r_c encouraged."
+                "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after a fight with a Clanmate that r_c encouraged.",
+                "lead_death": "died from {PRONOUN/m_c/poss} wounds after a fight with a Clanmate that r_c encouraged"
             }
         ],
         "relationships": [
@@ -3440,12 +3441,10 @@
         "m_c": {
             "age": [
                 "adolescent",
-                "young adult",
-                "adult",
-                "senior adult"
+                "young adult"
             ],
             "status": [
-                "any"
+                "apprentice"
             ],
             "not_skill": [
                 "FIGHTER,3"

--- a/resources/dicts/events/injury/general.json
+++ b/resources/dicts/events/injury/general.json
@@ -3394,8 +3394,8 @@
                     "m_c"
                 ],
                 "scar": "m_c was scarred by a Clanmate that r_c encouraged {PRONOUN/m_c/object} to fight.",
-                "reg_death": "m_c died after r_c encouraged {PRONOUN/m_c/object} to fight a Clanmate",
-                "lead_death": "died after r_c encouraged {PRONOUN/m_c/object} to fight a Clanmate"
+                "reg_death": "m_c died from wounds sustained during a fight that r_c encouraged.",
+                "lead_death": "died from wounds sustained during a fight that r_c encouraged"
             }
         ],
         "relationships": [

--- a/resources/dicts/events/injury/general.json
+++ b/resources/dicts/events/injury/general.json
@@ -3394,8 +3394,8 @@
                     "m_c"
                 ],
                 "scar": "m_c was scarred by a Clanmate that r_c encouraged {PRONOUN/m_c/object} to fight.",
-                "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after a fight with a Clanmate that r_c encouraged.",
-                "lead_death": "died from {PRONOUN/m_c/poss} wounds after a fight with a Clanmate that r_c encouraged"
+                "reg_death": "m_c died after r_c encouraged {PRONOUN/m_c/object} to fight a Clanmate",
+                "lead_death": "died after r_c encouraged {PRONOUN/m_c/object} to fight a Clanmate"
             }
         ],
         "relationships": [


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
Adds a lead_death segment to an event that was missing it and adds an "apprentice" constraint to an event meant only for apps
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
Fixes #3129 
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
![image](https://github.com/user-attachments/assets/373326b0-92a1-46fe-9d6e-f221bd1dcc00)
History displays correctly (you have no idea how painful it was to force this to happen)
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Adds a lead_death segment to an event that was missing it and adds an "apprentice" constraint to an event meant only for apps
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
