### PR TITLE
BUGFIX : Fix Focus screen not updating with new clans

### DIFF
--- a/scripts/screens/WarriorDenScreen.py
+++ b/scripts/screens/WarriorDenScreen.py
@@ -302,8 +302,6 @@ class WarriorDenScreen(Screens):
         # delete previous created text if possible
         if "current_focus" in self.focus_information:
             self.focus_information["current_focus"].kill()
-        if "time" in self.focus_information:
-            self.focus_information["time"].kill()
         if self.focus_text:
             self.focus_text.kill()
 
@@ -322,7 +320,7 @@ class WarriorDenScreen(Screens):
 
         last_change_text = "unknown"
         next_change = "0 moons"
-        if game.clan.last_focus_change:
+        if game.clan.last_focus_change == 0 or game.clan.last_focus_change:
             last_change_text = "moon " + str(game.clan.last_focus_change)
             moons = (
                 game.clan.last_focus_change

--- a/scripts/screens/WarriorDenScreen.py
+++ b/scripts/screens/WarriorDenScreen.py
@@ -320,7 +320,7 @@ class WarriorDenScreen(Screens):
 
         last_change_text = "unknown"
         next_change = "0 moons"
-        if game.clan.last_focus_change == 0 or game.clan.last_focus_change:
+        if isinstance(game.clan.last_focus_change, int):
             last_change_text = "moon " + str(game.clan.last_focus_change)
             moons = (
                 game.clan.last_focus_change


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
A clan with an age of 0 was prevented from updating the Focus screen due to 0 being detected as a NoneType, this accounts for that edgecase.  I also removed an unused ["time"] element.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
Fixes #3168 
I believe will also take care of #3330 once this is also merged to dev?
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
![image](https://github.com/user-attachments/assets/afbe0cbf-3526-4c18-98c9-794fab0260ec)

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Warrior's Den screen now correctly updates for Clans on Moon 0
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
