### PR TITLE
BUGFIX: adjust patrol to prevent cat dupe

### DIFF
--- a/resources/dicts/patrols/general/training.json
+++ b/resources/dicts/patrols/general/training.json
@@ -5993,9 +5993,11 @@
                 ]
             },
             {
-                "text": "The cats have a wonderful training session. Everyone agrees that app1 using a side pounce to hook r_c's feet out from under {PRONOUN/r_c/object} was definitely a highlight, though r_c maintains it'd be a bit different if {PRONOUN/r_c/subject} {VERB/r_c/weren't/wasn't} standing waiting to be pounced on as a static target.",
+                "text": "The cats have a wonderful training session. Everyone agrees that app1 using a side pounce to hook s_c's feet out from under {PRONOUN/s_c/object} was definitely a highlight, though s_c maintains it'd be a bit different if {PRONOUN/s_c/subject} {VERB/s_c/weren't/wasn't} standing waiting to be pounced on as a static target.",
                 "exp": 30,
                 "weight": 10,
+                "stat_trait": ["arrogant", "confident", "insecure", "ambitious", "strict", "gloomy"],
+                "can_have_stat": ["p_l", "app2"],
                 "relationships": [
                     {
                         "cats_to": ["patrol"],


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
This patrol wasn't doing enough to ensure r_c and app1 where different cats.  I've made it so that only a second app or the p_l (who *cannot* be an app due to patrol makeup constraints) can be the second cat, I've also made it trait restrained bc why not, it felt like a good outcome for trait fun
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
Fixes #3217 
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
![image](https://github.com/user-attachments/assets/4ea50791-611e-4863-a2dd-29b0eb1b6b2d)
Same outcome from the bug report, but two different kitties
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Cats will no longer attack themselves during a successful gen_train_huntingskill3 patrol
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
