### PR TITLE
BUGFIX: Clan symbol displaying as "blank"

### DIFF
--- a/scripts/cat/sprites.py
+++ b/scripts/cat/sprites.py
@@ -774,7 +774,7 @@ class Sprites:
             pygame.Color(game.config["theme"]["dark_mode_clan_symbols"])
             if not force_light and game.settings["dark mode"]
             else pygame.Color(game.config["theme"]["light_mode_clan_symbols"]),
-            distance=0.2,
+            distance=0,
         )
         del var
 


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->
Changes line 777 distance=0.2 to distance=0

This caused the symbol to display as a square because "distance" is meant to be distance away from the specified color so it's recoloring everything including the transparency instead of JUST the color specified

## Why This Is Good For ClanGen

<!-- If this is a bug fix, you can remove this section. -->
<!-- Please add a short description of why you think these changes would benefit the game. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->
<!-- If you have multiple features that can stand on their own, or unrelated bugfixes, please create separate PRs for them. -->
unsquares your clangen *beams*

## Linked Issues

Fixes: #3318

<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing

![image](https://github.com/user-attachments/assets/e21f3f5b-21b2-46be-8f46-fc5d86640002)
![image](https://github.com/user-attachments/assets/ab9ca65a-d8c2-496c-b7af-405e5ccd46ed)
![image](https://github.com/user-attachments/assets/7707f8d3-02de-47a3-bfad-4f38dd79a878)

## Changelog/Credits

- Clan symbol code no longer recolors the transparent pixels
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
