### PR TITLE
Bugfix: MedDen localization

### DIFF
--- a/scripts/screens/MedDenScreen.py
+++ b/scripts/screens/MedDenScreen.py
@@ -564,7 +564,7 @@ class MedDenScreen(Screens):
                         condition_list.extend(
                             [
                                 i18n.t(f"conditions.permanent_conditions.{permcond}")
-                                for permcond in list(cat.injuries.keys())
+                                for permcond in list(cat.permanent_condition.keys())
                             ]
                         )
             conditions = ",<br>".join(condition_list)


### PR DESCRIPTION
## About The Pull Request

Just ran into this bug in the wild, haven't seen an issue opened for it so I just fixed it myself. Localization of permanent conditions in medicine den was calling to injury keys instead of permanent conditions.

## Why This Is Good For ClanGen

Fixes a bug :)

## Proof of Testing

BEFORE: 
![Screenshot 2025-04-03 082638](https://github.com/user-attachments/assets/fedebb17-683d-428e-85ae-3328f88cc900)
AFTER:
![Screenshot 2025-04-03 082754](https://github.com/user-attachments/assets/ecae903a-a078-4662-9891-4c0c8b2a65f1)



## Changelog/Credits

credit to dinofelisDruid
