### PR TITLE
CONTENT: New Wetland and Desert Events

### DIFF
--- a/resources/lang/en/events/death/desert.json
+++ b/resources/lang/en/events/death/desert.json
@@ -24,7 +24,7 @@
           "season": ["any"],
           "tags": [],
           "weight": 20,
-          "event_text": "m_c chased a kangaroo rat into a burrow, only to run right into the fangs of a surprised rattlesnake. {PRONOUN/m_c/subject/CAP} didn't make it back to camp...",
+          "event_text": "m_c chased a kangaroo rat into a burrow, only to run right into the fangs of a surprised rattlesnake.",
           "m_c": {
               "status": ["apprentice", "warrior", "deputy", "leader"],
               "dies": true

--- a/resources/lang/en/events/death/desert.json
+++ b/resources/lang/en/events/death/desert.json
@@ -100,7 +100,7 @@
           "season": ["any"],
           "tags": [],
           "weight": 20,
-          "event_text": "m_c was out hunting and spotted a scorpion, {PRONOUN/m_c/subject} pounced to catch it to show off to c_n, but one misplaced paw on the stinger sent m_c to StarClan.",
+          "event_text": "m_c was out hunting and spotted a scorpion, {PRONOUN/m_c/subject} pounced to catch it, but one misplaced paw on the stinger sent m_c to StarClan.",
           "m_c": {
               "status": ["apprentice", "warrior", "deputy", "leader"],
               "trait": ["ambitious", "bold", "charismatic", "competitive", "daring", "flamboyant", "insecure", "strange", "troublesome"],

--- a/resources/lang/en/events/death/desert.json
+++ b/resources/lang/en/events/death/desert.json
@@ -24,7 +24,7 @@
           "season": ["any"],
           "tags": [],
           "weight": 20,
-          "event_text": "m_c was chasing a kangaroo rat down when it dashed into a burrow, when m_c stuck a paw in after it {PRONOUN/m_c/subject} instead felt the fangs of a surprised rattlesnake sinking into {PRONOUN/m_c/object}, joining the rat in StarClan",
+          "event_text": "m_c chased a kangaroo rat into a burrow, only to run right into the fangs of a surprised rattlesnake. {PRONOUN/m_c/subject/CAP} didn't make it back to camp...",
           "m_c": {
               "status": ["apprentice", "warrior", "deputy", "leader"],
               "dies": true
@@ -43,7 +43,7 @@
           "season": ["any"],
           "tags": [],
           "weight": 20,
-          "event_text": "m_c was out training alone, practicing jumping from one rock to another, however {PRONOUN/m_c/subject} forgot one crucial step as an angry rattlesnake slithered out from under the rock {PRONOUN/m_c/subject} landed on, striking and killing m_c",
+          "event_text": "m_c was out training {PRONOUN/m_c/poss} agility by jumping from rock to rock. {PRONOUN/m_c/subject/CAP} didn't notice the rattlesnake until their paw landed on top of it, earning {PRONOUN/m_c/object} a nasty bite and a lethal dose of venom.",
           "m_c": {
               "status": ["apprentice"],
               "dies": true

--- a/resources/lang/en/events/death/desert.json
+++ b/resources/lang/en/events/death/desert.json
@@ -1,0 +1,23 @@
+[
+  {
+          "event_id": "dst_death_any1_PLACEHOLDER",
+          "location": ["desert"],
+          "season": [
+              "any"
+          ],
+          "tags": [],
+          "weight": 20,
+          "event_text": "m_c was bitten and killed by a rattlesnake out in the territory.",
+          "m_c": {
+              "status": [ "apprentice", "warrior", "deputy", "leader"],
+              "dies": true
+          },
+          "history": [
+              {
+              "cats": ["m_c"],
+              "reg_death": "m_c was killed by a rattlesnake.",
+              "lead_death": "{VERB/m_c/were/was} killed by a rattlesnake."
+              }
+          ]
+  }
+]

--- a/resources/lang/en/events/death/desert.json
+++ b/resources/lang/en/events/death/desert.json
@@ -43,7 +43,7 @@
           "season": ["any"],
           "tags": [],
           "weight": 20,
-          "event_text": "m_c was out training {PRONOUN/m_c/poss} agility by jumping from rock to rock. {PRONOUN/m_c/subject/CAP} didn't notice the rattlesnake until their paw landed on top of it, earning {PRONOUN/m_c/object} a nasty bite and a lethal dose of venom.",
+          "event_text": "m_c jumped on top of a rattlesnake by mistake and was killed by the ensuing bite.",
           "m_c": {
               "status": ["apprentice"],
               "dies": true

--- a/resources/lang/en/events/death/desert.json
+++ b/resources/lang/en/events/death/desert.json
@@ -24,7 +24,7 @@
           "season": ["any"],
           "tags": [],
           "weight": 20,
-          "event_text": "m_c was out hunting when {PRONOUN/m_c/subject} heard a rattling noise, {PRONOUN/m_c/subject} went to investigate but the jaws of a rattlesnake quickly took {PRONOUN/m_c/object} to StarClan",
+          "event_text": "m_c was chasing a kangaroo rat down when it dashed into a burrow, when m_c stuck a paw in after it {PRONOUN/m_c/subject} instead felt the fangs of a surprised rattlesnake sinking into {PRONOUN/m_c/object}, joining the rat in StarClan",
           "m_c": {
               "status": ["apprentice", "warrior", "deputy", "leader"],
               "dies": true
@@ -43,7 +43,7 @@
           "season": ["any"],
           "tags": [],
           "weight": 20,
-          "event_text": "m_c was out training alone when {PRONOUN/m_c/subject} heard a bizarre rattling noise coming from a snake, moving closer to try to hunt it m_c was bitten and killed before anycat could help {PRONOUN/m_c/object}",
+          "event_text": "m_c was out training alone, practicing jumping from one rock to another, however {PRONOUN/m_c/subject} forgot one crucial step as an angry rattlesnake slithered out from under the rock {PRONOUN/m_c/subject} landed on, striking and killing m_c",
           "m_c": {
               "status": ["apprentice"],
               "dies": true

--- a/resources/lang/en/events/death/desert.json
+++ b/resources/lang/en/events/death/desert.json
@@ -43,7 +43,7 @@
           "season": ["any"],
           "tags": [],
           "weight": 20,
-          "event_text": "m_c was out training alone when {PRONOUN/m_c/subject} heard a bizzare rattling noise coming from a snake, moving closer to try to hunt it m_c was bitten and killed before anycat could help {PRONOUN/m_c/object}",
+          "event_text": "m_c was out training alone when {PRONOUN/m_c/subject} heard a bizarre rattling noise coming from a snake, moving closer to try to hunt it m_c was bitten and killed before anycat could help {PRONOUN/m_c/object}",
           "m_c": {
               "status": ["apprentice"],
               "dies": true
@@ -71,7 +71,7 @@
               {
               "cats": ["m_c"],
               "reg_death": "m_c was mislead by a mirage thinking it was water.",
-              "lead_death": "{VERB/m_c/were/was} misead by a mirage thinking it was water."
+              "lead_death": "{VERB/m_c/were/was} mislead by a mirage thinking it was water."
               }
           ]
   },

--- a/resources/lang/en/events/death/desert.json
+++ b/resources/lang/en/events/death/desert.json
@@ -100,7 +100,7 @@
           "season": ["any"],
           "tags": [],
           "weight": 20,
-          "event_text": "m_c was out hunting and spotted a scorpion, {PRONOUN/m_c/subject} pounced to catch it, but one misplaced paw on the stinger sent m_c to StarClan.",
+          "event_text": "m_c was mistakenly stung by a scorpion during a hunt and succumbed to the venom.",
           "m_c": {
               "status": ["apprentice", "warrior", "deputy", "leader"],
               "trait": ["ambitious", "bold", "charismatic", "competitive", "daring", "flamboyant", "insecure", "strange", "troublesome"],

--- a/resources/lang/en/events/death/desert.json
+++ b/resources/lang/en/events/death/desert.json
@@ -62,7 +62,7 @@
           "season": ["greenleaf", "newleaf"],
           "tags": [],
           "weight": 20,
-          "event_text": "m_c was out alone in the territory searching for water, however the mirage from the intense heat led {PRONOUN/m_c/object} to keep walking further away from any real water source.",
+          "event_text": "m_c died of dehydration after mistakenly following a mirage.",
           "m_c": {
               "status": ["apprentice", "warrior", "deputy", "leader"],
               "dies": true

--- a/resources/lang/en/events/death/desert.json
+++ b/resources/lang/en/events/death/desert.json
@@ -103,7 +103,7 @@
           "event_text": "m_c was out hunting and spotted a scorpion, {PRONOUN/m_c/subject} pounced to catch it to show off to c_n, but one misplaced paw on the stinger sent m_c to StarClan.",
           "m_c": {
               "status": ["apprentice", "warrior", "deputy", "leader"],
-              "trait": ["ambitious", "bold", "charismatic", "competitive", "daring", "flamboyant", "insecure", "strange", "troublesome"]
+              "trait": ["ambitious", "bold", "charismatic", "competitive", "daring", "flamboyant", "insecure", "strange", "troublesome"],
               "dies": true
           },
           "history": [

--- a/resources/lang/en/events/death/desert.json
+++ b/resources/lang/en/events/death/desert.json
@@ -28,7 +28,7 @@
           ],
           "tags": [],
           "weight": 20,
-          "event_text": "Whilst m_c was out hunting {PRONOUN/m_c/subject} heard an all too familiar rattling from the dry underbrush, but it was far too late as the fangs of the deadly snake sunk into m_c, the venom killing {PRONOUN/m_c/object} swiftly.",
+          "event_text": "m_c was out hunting when {PRONOUN/m_c/subject} heard a rattling noise, {PRONOUN/m_c/subject} went to investigate but the jaws of a rattlesnake quickly took {PRONOUN/m_c/object} to StarClan",
           "m_c": {
               "status": ["apprentice", "warrior", "deputy", "leader"],
               "dies": true
@@ -49,7 +49,7 @@
           ],
           "tags": [],
           "weight": 20,
-          "event_text": "After venturing out on a solo hunting practice m_c heard a strange rattling sound from the grass, moving closer to investigaate m_c was startled by the jaws of a rattlesnake! Before {PRONOUN/m_c/poss} mentor could find {PRONOUN/m_c/object} the rattlesnake's venom had claimed yet another life.",
+          "event_text": "m_c was out training alone when {PRONOUN/m_c/subject} heard a bizzare rattling noise coming from a snake, moving closer to try to hunt it m_c was bitten and killed before anycat could help {PRONOUN/m_c/object}",
           "m_c": {
               "status": ["apprentice"],
               "dies": true
@@ -70,7 +70,7 @@
           ],
           "tags": [],
           "weight": 20,
-          "event_text": "m_c had forgotten to fill up on water before heading out into the territory, but thankfully {PRONOUN/m_c/subject} {VERB/m_c/spot/spots} a water pool in the distance! Yet the further {PRONOUN/m_c/subject} {VERB/m_c/walk/walks} the pool seems to never get any closer... m_c collapses from thirst before {PRONOUN/m_c/subject} could realize {PRONOUN/m_c/subject} {VERB/m_c/were/was} chasing a mirage.",
+          "event_text": "m_c was out alone in the territory searching for water, however the mirage from the intense heat led {PRONOUN/m_c/object} to keep walking further away from any real water source.",
           "m_c": {
               "status": ["apprentice", "warrior", "deputy", "leader"],
               "dies": true
@@ -112,7 +112,7 @@
           ],
           "tags": [],
           "weight": 20,
-          "event_text": "Whilst m_c was out in the territory hunting {PRONOUN/m_c/subject} spotted a scorpion! Thinking it would be a great catch to show off to {PRONOUN/m_c/poss} peers {PRONOUN/m_c/subject} pounced on it, but at the feeling of something stabbing into {PRONOUN/m_c/poss} paw, {PRONOUN/m_c/subject} knew that the only cats {PRONOUN/m_c/subject} would impress were in StarClan.",
+          "event_text": "m_c was out hunting and spotted a scorpion, {PRONOUN/m_c/subject} pounced to catch it to show off to c_n, but one misplaced paw on the stinger sent m_c to StarClan.",
           "m_c": {
               "status": ["apprentice", "warrior", "deputy", "leader"],
               "trait": ["ambitious", "bold", "charismatic", "competitive", "daring", "flamboyant", "insecure", "strange", "troublesome"]

--- a/resources/lang/en/events/death/desert.json
+++ b/resources/lang/en/events/death/desert.json
@@ -1,6 +1,6 @@
 [
   {
-          "event_id": "dst_death_any1_PLACEHOLDER",
+          "event_id": "dst_death_any_rattlesnake1",
           "location": ["desert"],
           "season": [
               "any"
@@ -9,7 +9,7 @@
           "weight": 20,
           "event_text": "m_c was killed by a rattlesnake out in the territory.",
           "m_c": {
-              "status": [ "apprentice", "warrior", "deputy", "leader"],
+              "status": ["apprentice", "warrior", "deputy", "leader"],
               "dies": true
           },
           "history": [
@@ -17,6 +17,112 @@
               "cats": ["m_c"],
               "reg_death": "m_c was killed by a rattlesnake.",
               "lead_death": "{VERB/m_c/were/was} killed by a rattlesnake."
+              }
+          ]
+  },
+  {
+          "event_id": "dst_death_any_rattlesnake2",
+          "location": ["desert"],
+          "season": [
+              "any"
+          ],
+          "tags": [],
+          "weight": 20,
+          "event_text": "Whilst m_c was out hunting {PRONOUN/m_c/subject} heard an all too familiar rattling from the dry underbrush, but it was far too late as the fangs of the deadly snake sunk into m_c, the venom killing {PRONOUN/m_c/object} swiftly.",
+          "m_c": {
+              "status": ["apprentice", "warrior", "deputy", "leader"],
+              "dies": true
+          },
+          "history": [
+              {
+              "cats": ["m_c"],
+              "reg_death": "m_c was killed by a rattlesnake.",
+              "lead_death": "{VERB/m_c/were/was} killed by a rattlesnake."
+              }
+          ]
+  },
+  {
+          "event_id": "dst_death_app_rattlesnake3",
+          "location": ["desert"],
+          "season": [
+              "any"
+          ],
+          "tags": [],
+          "weight": 20,
+          "event_text": "After venturing out on a solo hunting practice m_c heard a strange rattling sound from the grass, moving closer to investigaate m_c was startled by the jaws of a rattlesnake! Before {PRONOUN/m_c/poss} mentor could find {PRONOUN/m_c/object} the rattlesnake's venom had claimed yet another life.",
+          "m_c": {
+              "status": ["apprentice"],
+              "dies": true
+          },
+          "history": [
+              {
+              "cats": ["m_c"],
+              "reg_death": "m_c was killed by a rattlesnake.",
+              "lead_death": "{VERB/m_c/were/was} killed by a rattlesnake."
+              }
+          ]
+  },
+  {
+          "event_id": "dst_death_any_mirage1",
+          "location": ["desert"],
+          "season": [
+              "greenleaf", "newleaf"
+          ],
+          "tags": [],
+          "weight": 20,
+          "event_text": "m_c had forgotten to fill up on water before heading out into the territory, but thankfully {PRONOUN/m_c/subject} {VERB/m_c/spot/spots} a water pool in the distance! Yet the further {PRONOUN/m_c/subject} {VERB/m_c/walk/walks} the pool seems to never get any closer... m_c collapses from thirst before {PRONOUN/m_c/subject} could realize {PRONOUN/m_c/subject} {VERB/m_c/were/was} chasing a mirage.",
+          "m_c": {
+              "status": ["apprentice", "warrior", "deputy", "leader"],
+              "dies": true
+          },
+          "history": [
+              {
+              "cats": ["m_c"],
+              "reg_death": "m_c was mislead by a mirage thinking it was water.",
+              "lead_death": "{VERB/m_c/were/was} misead by a mirage thinking it was water."
+              }
+          ]
+  },
+  {
+          "event_id": "dst_death_any_scorpion1",
+          "location": ["desert"],
+          "season": [
+              "any"
+          ],
+          "tags": [],
+          "weight": 20,
+          "event_text": "m_c was killed after being stung by a scorpion.",
+          "m_c": {
+              "status": ["apprentice", "warrior", "deputy", "leader"],
+              "dies": true
+          },
+          "history": [
+              {
+              "cats": ["m_c"],
+              "reg_death": "m_c was killed by a scorpion.",
+              "lead_death": "{VERB/m_c/were/was} killed by a scorpion."
+              }
+          ]
+  },
+  {
+          "event_id": "dst_death_any_scorpion2",
+          "location": ["desert"],
+          "season": [
+              "any"
+          ],
+          "tags": [],
+          "weight": 20,
+          "event_text": "Whilst m_c was out in the territory hunting {PRONOUN/m_c/subject} spotted a scorpion! Thinking it would be a great catch to show off to {PRONOUN/m_c/poss} peers {PRONOUN/m_c/subject} pounced on it, but at the feeling of something stabbing into {PRONOUN/m_c/poss} paw, {PRONOUN/m_c/subject} knew that the only cats {PRONOUN/m_c/subject} would impress were in StarClan.",
+          "m_c": {
+              "status": ["apprentice", "warrior", "deputy", "leader"],
+              "trait": ["ambitious", "bold", "charismatic", "competitive", "daring", "flamboyant", "insecure", "strange", "troublesome"]
+              "dies": true
+          },
+          "history": [
+              {
+              "cats": ["m_c"],
+              "reg_death": "m_c was killed by a scorpion.",
+              "lead_death": "{VERB/m_c/were/was} killed by a scorpion."
               }
           ]
   }

--- a/resources/lang/en/events/death/desert.json
+++ b/resources/lang/en/events/death/desert.json
@@ -7,7 +7,7 @@
           ],
           "tags": [],
           "weight": 20,
-          "event_text": "m_c was bitten and killed by a rattlesnake out in the territory.",
+          "event_text": "m_c was killed by a rattlesnake out in the territory.",
           "m_c": {
               "status": [ "apprentice", "warrior", "deputy", "leader"],
               "dies": true

--- a/resources/lang/en/events/death/desert.json
+++ b/resources/lang/en/events/death/desert.json
@@ -2,9 +2,7 @@
   {
           "event_id": "dst_death_any_rattlesnake1",
           "location": ["desert"],
-          "season": [
-              "any"
-          ],
+          "season": ["any"],
           "tags": [],
           "weight": 20,
           "event_text": "m_c was killed by a rattlesnake out in the territory.",
@@ -23,9 +21,7 @@
   {
           "event_id": "dst_death_any_rattlesnake2",
           "location": ["desert"],
-          "season": [
-              "any"
-          ],
+          "season": ["any"],
           "tags": [],
           "weight": 20,
           "event_text": "m_c was out hunting when {PRONOUN/m_c/subject} heard a rattling noise, {PRONOUN/m_c/subject} went to investigate but the jaws of a rattlesnake quickly took {PRONOUN/m_c/object} to StarClan",
@@ -44,9 +40,7 @@
   {
           "event_id": "dst_death_app_rattlesnake3",
           "location": ["desert"],
-          "season": [
-              "any"
-          ],
+          "season": ["any"],
           "tags": [],
           "weight": 20,
           "event_text": "m_c was out training alone when {PRONOUN/m_c/subject} heard a bizzare rattling noise coming from a snake, moving closer to try to hunt it m_c was bitten and killed before anycat could help {PRONOUN/m_c/object}",
@@ -65,9 +59,7 @@
   {
           "event_id": "dst_death_any_mirage1",
           "location": ["desert"],
-          "season": [
-              "greenleaf", "newleaf"
-          ],
+          "season": ["greenleaf", "newleaf"],
           "tags": [],
           "weight": 20,
           "event_text": "m_c was out alone in the territory searching for water, however the mirage from the intense heat led {PRONOUN/m_c/object} to keep walking further away from any real water source.",
@@ -86,9 +78,7 @@
   {
           "event_id": "dst_death_any_scorpion1",
           "location": ["desert"],
-          "season": [
-              "any"
-          ],
+          "season": ["any"],
           "tags": [],
           "weight": 20,
           "event_text": "m_c was killed after being stung by a scorpion.",
@@ -107,9 +97,7 @@
   {
           "event_id": "dst_death_any_multitraitscorpion2",
           "location": ["desert"],
-          "season": [
-              "any"
-          ],
+          "season": ["any"],
           "tags": [],
           "weight": 20,
           "event_text": "m_c was out hunting and spotted a scorpion, {PRONOUN/m_c/subject} pounced to catch it to show off to c_n, but one misplaced paw on the stinger sent m_c to StarClan.",

--- a/resources/lang/en/events/death/desert.json
+++ b/resources/lang/en/events/death/desert.json
@@ -105,7 +105,7 @@
           ]
   },
   {
-          "event_id": "dst_death_any_scorpion2",
+          "event_id": "dst_death_any_multitraitscorpion2",
           "location": ["desert"],
           "season": [
               "any"

--- a/resources/lang/en/events/death/wetlands.json
+++ b/resources/lang/en/events/death/wetlands.json
@@ -1,7 +1,7 @@
 [
   {
         "event_id": "wtlnd_death_any_PLACEHOLDER",
-        "location": ["forest"],
+        "location": ["wetlands"],
         "season": [
             "any"
         ],

--- a/resources/lang/en/events/death/wetlands.json
+++ b/resources/lang/en/events/death/wetlands.json
@@ -2,14 +2,12 @@
   {
         "event_id": "wtlnd_death_any_quicksand",
         "location": ["wetlands"],
-        "season": [
-            "any"
-        ],
+        "season": ["any"],
         "tags": [],
         "weight": 10,
         "event_text": "m_c got stuck in quicksand and wasn't found in time.",
         "m_c": {
-            "status": [ "apprentice", "warrior", "deputy", "leader"],
+            "status": ["apprentice", "warrior", "deputy", "leader"],
             "dies": true
         },
         "history": [
@@ -23,14 +21,12 @@
   {
         "event_id": "wtlnd_death_any_cottonmouth",
         "location": ["wetlands"],
-        "season": [
-            "greenleaf", "newleaf", "leaf-fall"
-        ],
+        "season": ["greenleaf", "newleaf", "leaf-fall"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c was out hunting when {PRONOUN/m_c/subject} found a snake with a strikingly white mouth, moving to hunt it m_c was bitten and killed by the lightning quick reptile.",
         "m_c": {
-            "status": [ "apprentice", "warrior", "deputy", "leader"],
+            "status": ["apprentice", "warrior", "deputy", "leader"],
             "dies": true
         },
         "history": [

--- a/resources/lang/en/events/death/wetlands.json
+++ b/resources/lang/en/events/death/wetlands.json
@@ -24,7 +24,7 @@
         "season": ["greenleaf", "newleaf", "leaf-fall"],
         "tags": [],
         "weight": 20,
-        "event_text": "m_c was out hunting when {PRONOUN/m_c/subject} found a snake with a strikingly white mouth, moving to hunt it m_c was bitten and killed by the lightning quick reptile.",
+        "event_text": "m_c was killed by a snake with a strikingly white mouth.",
         "m_c": {
             "status": ["apprentice"],
             "dies": true

--- a/resources/lang/en/events/death/wetlands.json
+++ b/resources/lang/en/events/death/wetlands.json
@@ -1,0 +1,23 @@
+[
+  {
+        "event_id": "wtlnd_death_any_PLACEHOLDER",
+        "location": ["forest"],
+        "season": [
+            "any"
+        ],
+        "tags": [],
+        "weight": 20,
+        "event_text": "m_c got stuck in quicksand and wasn't found in time.",
+        "m_c": {
+            "status": [ "apprentice", "warrior", "deputy", "leader"],
+            "dies": true
+        },
+        "history": [
+            {
+            "cats": ["m_c"],
+            "reg_death": "m_c died after getting trapped in quicksand.",
+            "lead_death": "{VERB/m_c/were/was} stuck in quicksand."
+            }
+        ]
+  }  
+]

--- a/resources/lang/en/events/death/wetlands.json
+++ b/resources/lang/en/events/death/wetlands.json
@@ -1,12 +1,12 @@
 [
   {
-        "event_id": "wtlnd_death_any_PLACEHOLDER",
+        "event_id": "wtlnd_death_any_quicksand",
         "location": ["wetlands"],
         "season": [
             "any"
         ],
         "tags": [],
-        "weight": 20,
+        "weight": 10,
         "event_text": "m_c got stuck in quicksand and wasn't found in time.",
         "m_c": {
             "status": [ "apprentice", "warrior", "deputy", "leader"],
@@ -19,5 +19,26 @@
             "lead_death": "{VERB/m_c/were/was} stuck in quicksand."
             }
         ]
-  }  
+  },
+  {
+        "event_id": "wtlnd_death_any_cottonmouth",
+        "location": ["wetlands"],
+        "season": [
+            "greenleaf", "newleaf", "leaf-fall"
+        ],
+        "tags": [],
+        "weight": 20,
+        "event_text": "m_c was out hunting when {PRONOUN/m_c/subject} found a snake curled up on the ground, its mouth wide open with a strikingly white color. Moving closer to try to take the extra fresh-kill back, m_c was struck by the lightning quick jaws of the snake, its venom rapidly taking hold and sending m_c to StarClan shortly after.",
+        "m_c": {
+            "status": [ "apprentice", "warrior", "deputy", "leader"],
+            "dies": true
+        },
+        "history": [
+            {
+            "cats": ["m_c"],
+            "reg_death": "m_c was killed by a cottonmouth snake.",
+            "lead_death": "{VERB/m_c/were/was} killed by a cottonmouth snake."
+            }
+        ]
+  }
 ]

--- a/resources/lang/en/events/death/wetlands.json
+++ b/resources/lang/en/events/death/wetlands.json
@@ -28,7 +28,7 @@
         ],
         "tags": [],
         "weight": 20,
-        "event_text": "m_c was out hunting when {PRONOUN/m_c/subject} found a snake curled up on the ground, its mouth wide open with a strikingly white color. Moving closer to try to take the extra fresh-kill back, m_c was struck by the lightning quick jaws of the snake, its venom rapidly taking hold and sending m_c to StarClan shortly after.",
+        "event_text": "m_c was out hunting when {PRONOUN/m_c/subject} found a snake with a strikingly white mouth, moving to hunt it m_c was bitten and killed by the lightning quick reptile.",
         "m_c": {
             "status": [ "apprentice", "warrior", "deputy", "leader"],
             "dies": true

--- a/resources/lang/en/events/death/wetlands.json
+++ b/resources/lang/en/events/death/wetlands.json
@@ -19,14 +19,14 @@
         ]
   },
   {
-        "event_id": "wtlnd_death_any_cottonmouth",
+        "event_id": "wtlnd_death_app_cottonmouth",
         "location": ["wetlands"],
         "season": ["greenleaf", "newleaf", "leaf-fall"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c was out hunting when {PRONOUN/m_c/subject} found a snake with a strikingly white mouth, moving to hunt it m_c was bitten and killed by the lightning quick reptile.",
         "m_c": {
-            "status": ["apprentice", "warrior", "deputy", "leader"],
+            "status": ["apprentice"],
             "dies": true
         },
         "history": [

--- a/resources/lang/en/events/injury/desert.json
+++ b/resources/lang/en/events/injury/desert.json
@@ -47,53 +47,5 @@
                 "injuries": ["snake bite"]
             }
         ]
-    },
-   {
-        "event_id": "dst_injury_heatexhaustion_anymultiage1",
-        "location": ["desert"],
-        "season": ["newleaf", "greenleaf"],
-        "weight": 20,
-        "event_text": "m_c was out on patrol for too long, returning to camp panting and feeling dizzy.",
-        "m_c": {
-            "age": ["adolescent", "young adult", "adult", "senior adult"]
-        },
-        "injury": [
-            {
-                "cats": ["m_c"],
-                "injuries": ["heat exhaustion"]
-            }
-        ]
-    },
-   {
-        "event_id": "dst_injury_heatexhaustion_anymultiage2",
-        "location": ["desert"],
-        "season": ["newleaf", "greenleaf"],
-        "weight": 20,
-        "event_text": "m_c was out patrolling and didn't take enough time to rest, coming back to camp feeling weak and nauseous.",
-        "m_c": {
-            "age": ["adolescent", "young adult", "adult", "senior adult"]
-        },
-        "injury": [
-            {
-                "cats": ["m_c"],
-                "injuries": ["heat exhaustion"]
-            }
-        ]
-    },
-   {
-        "event_id": "dst_injury_heatstroke_anymultiage1",
-        "location": ["desert"],
-        "season": ["greenleaf"],
-        "weight": 20,
-        "event_text": "m_c was out on patrol for too long in the sweltering Greenleaf heat, the patrol returning to camp with an overheated and disoriented m_c.",
-        "m_c": {
-            "age": ["adolescent", "young adult", "adult", "senior adult"]
-        },
-        "injury": [
-            {
-                "cats": ["m_c"],
-                "injuries": ["heat stroke"]
-            }
-        ]
     }
 ]

--- a/resources/lang/en/events/injury/desert.json
+++ b/resources/lang/en/events/injury/desert.json
@@ -1,33 +1,34 @@
 [
    {
         "event_id": "dst_injury_bruisessore_anymultiage1_PLACEHOLDER",
-        "location": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
+        "location": ["desert"],
+        "season": ["any"],
         "weight": 20,
         "event_text": "As m_c was out scouring the territory, {PRONOUN/m_c/subject} took a bad tumble over a rock hidden by the dusty ground.",
         "m_c": {
-            "age": [
-                "adolescent",
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ]
+            "age": ["adolescent", "young adult", "adult", "senior adult", "senior"]
         },
         "injury": [
             {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "bruises",
-                    "sore"
-                ]
+                "cats": ["m_c"],
+                "injuries": ["bruises", "sore"]
             }
         ]
     },
+   {
+        "event_id": "dst_injury_bruisessore_anymultiage1_PLACEHOLDER",
+        "location": ["any"],
+        "season": ["Greenleaf", "Newleaf"],
+        "weight": 20,
+        "event_text": ".",
+        "m_c": {
+            "age": ["adolescent", "young adult", "adult", "senior adult", "senior"]
+        },
+        "injury": [
+            {
+                "cats": ["m_c"],
+                "injuries": ["bruises", "sore"]
+            }
+        ]
+    }
 ]

--- a/resources/lang/en/events/injury/desert.json
+++ b/resources/lang/en/events/injury/desert.json
@@ -4,7 +4,7 @@
         "location": ["desert"],
         "season": ["any"],
         "weight": 20,
-        "event_text": "m_c was out in the territory and took a bad tumble over a rock hidden by the dusty ground.",
+        "event_text": "m_c took a bad tumble over a rock hidden by the dusty ground.",
         "m_c": {
             "age": ["adolescent", "young adult", "adult", "senior adult", "senior"]
         },

--- a/resources/lang/en/events/injury/desert.json
+++ b/resources/lang/en/events/injury/desert.json
@@ -4,7 +4,7 @@
         "location": ["desert"],
         "season": ["any"],
         "weight": 20,
-        "event_text": "As m_c was out scouring the territory, {PRONOUN/m_c/subject} took a bad tumble over a rock hidden by the dusty ground.",
+        "event_text": "m_c was out in the territory and took a bad tumble over a rock hidden by the dusty ground.",
         "m_c": {
             "age": ["adolescent", "young adult", "adult", "senior adult", "senior"]
         },
@@ -20,7 +20,7 @@
         "location": ["desert"],
         "season": ["any"],
         "weight": 20,
-        "event_text": "Despite m_c's mentor's protests, {PRONOUN/m_c/subject} dashes off and tumbles face first into a cactus, thankfully the medicine cat is able to remove the spines with little difficulty.",
+        "event_text": "m_c dashes off from {PRONOUN/m_c/poss} mentor and tumbles face first into a cactus, thankfully the medicine cat is able to remove the spines with little difficulty.",
         "m_c": {
             "age": ["adolescent"],
             "trait": ["adventurous", "arrogant", "bold", "childish", "confident", "daring", "oblivious", "playful", "rebellious", "shameless", "troublesome"]
@@ -53,7 +53,7 @@
         "location": ["desert"],
         "season": ["newleaf", "greenleaf"],
         "weight": 20,
-        "event_text": "m_c was out on patrol and pushed {PRONOUN/m_c/self} too hard, returning to camp panting and feeling dizzy.",
+        "event_text": "m_c was out on patrol for too long, returning to camp panting and feeling dizzy.",
         "m_c": {
             "age": ["adolescent", "young adult", "adult", "senior adult"]
         },
@@ -69,7 +69,7 @@
         "location": ["desert"],
         "season": ["newleaf", "greenleaf"],
         "weight": 20,
-        "event_text": "m_c was out patrolling and didn't take enough time to rest away from the sun, coming back to camp feeling weak and nauseous.",
+        "event_text": "m_c was out patrolling and didn't take enough time to rest, coming back to camp feeling weak and nauseous.",
         "m_c": {
             "age": ["adolescent", "young adult", "adult", "senior adult"]
         },
@@ -85,7 +85,7 @@
         "location": ["desert"],
         "season": ["greenleaf"],
         "weight": 20,
-        "event_text": "m_c was out on patrol and pushed {PRONOUN/m_c/self} too hard despite the sweltering Greenleaf heat, the patrol returning to camp with an overheated and disoriented m_c.",
+        "event_text": "m_c was out on patrol for too long despite the sweltering Greenleaf heat, the patrol returned to camp with an overheated and disoriented m_c.",
         "m_c": {
             "age": ["adolescent", "young adult", "adult", "senior adult"]
         },

--- a/resources/lang/en/events/injury/desert.json
+++ b/resources/lang/en/events/injury/desert.json
@@ -23,7 +23,7 @@
         "event_text": "Despite m_c's mentor's protests, {PRONOUN/m_c/subject} dashes off and tumbles face first into a cactus, thankfully the medicine cat is able to remove the spines with little difficulty.",
         "m_c": {
             "age": ["adolescent"],
-            "trait": ["adventerous", "arrogant", "bold", "childish", "confident", "daring", "oblivious", "playful", "rebelious", "shamelesS", "troublesome"]
+            "trait": ["adventurous", "arrogant", "bold", "childish", "confident", "daring", "oblivious", "playful", "rebellious", "shameless", "troublesome"]
         },
         "injury": [
             {
@@ -69,7 +69,7 @@
         "location": ["desert"],
         "season": ["newleaf", "greenleaf"],
         "weight": 20,
-        "event_text": "m_c was out patroling and didnt take enough time to rest away from the sun, coming back to camp feeling weak and nauseous.",
+        "event_text": "m_c was out patrolling and didn't take enough time to rest away from the sun, coming back to camp feeling weak and nauseous.",
         "m_c": {
             "age": ["apprentice", "young adult", "adult", "senior adult"]
         },

--- a/resources/lang/en/events/injury/desert.json
+++ b/resources/lang/en/events/injury/desert.json
@@ -85,7 +85,7 @@
         "location": ["desert"],
         "season": ["greenleaf"],
         "weight": 20,
-        "event_text": "m_c was out on patrol for too long despite the sweltering Greenleaf heat, the patrol returned to camp with an overheated and disoriented m_c.",
+        "event_text": "m_c was out on patrol for too long in the sweltering Greenleaf heat, the patrol returned to camp with an overheated and disoriented m_c.",
         "m_c": {
             "age": ["adolescent", "young adult", "adult", "senior adult"]
         },

--- a/resources/lang/en/events/injury/desert.json
+++ b/resources/lang/en/events/injury/desert.json
@@ -7,7 +7,7 @@
             "any"
         ],
         "weight": 20,
-        "event_text": "As m_c was out scouring the territory, {PRONOUN/m_c/subject} took a bad tumble over a rock hidden in the sand.",
+        "event_text": "As m_c was out scouring the territory, {PRONOUN/m_c/subject} took a bad tumble over a rock hidden by the dusty ground.",
         "m_c": {
             "age": [
                 "adolescent",

--- a/resources/lang/en/events/injury/desert.json
+++ b/resources/lang/en/events/injury/desert.json
@@ -37,7 +37,7 @@
         "location": ["desert"],
         "season": ["any"],
         "weight": 20,
-        "event_text": "A snake managed to slither its way into camp and m_c got bitten by it.",
+        "event_text": "A snake managed to slither into camp and bite m_c.",
         "m_c": {
             "age": ["any"]
         },

--- a/resources/lang/en/events/injury/desert.json
+++ b/resources/lang/en/events/injury/desert.json
@@ -85,7 +85,7 @@
         "location": ["desert"],
         "season": ["greenleaf"],
         "weight": 20,
-        "event_text": "m_c was out on patrol for too long in the sweltering Greenleaf heat, the patrol returned to camp with an overheated and disoriented m_c.",
+        "event_text": "m_c was out on patrol for too long in the sweltering Greenleaf heat, the patrol returning to camp with an overheated and disoriented m_c.",
         "m_c": {
             "age": ["adolescent", "young adult", "adult", "senior adult"]
         },

--- a/resources/lang/en/events/injury/desert.json
+++ b/resources/lang/en/events/injury/desert.json
@@ -55,7 +55,7 @@
         "weight": 20,
         "event_text": "m_c was out on patrol and pushed {PRONOUN/m_c/self} too hard, returning to camp panting and feeling dizzy.",
         "m_c": {
-            "age": ["apprentice", "young adult", "adult", "senior adult"]
+            "age": ["adolescent", "young adult", "adult", "senior adult"]
         },
         "injury": [
             {
@@ -71,7 +71,7 @@
         "weight": 20,
         "event_text": "m_c was out patrolling and didn't take enough time to rest away from the sun, coming back to camp feeling weak and nauseous.",
         "m_c": {
-            "age": ["apprentice", "young adult", "adult", "senior adult"]
+            "age": ["adolescent", "young adult", "adult", "senior adult"]
         },
         "injury": [
             {
@@ -87,7 +87,7 @@
         "weight": 20,
         "event_text": "m_c was out on patrol and pushed {PRONOUN/m_c/self} too hard despite the sweltering Greenleaf heat, the patrol returning to camp with an overheated and disoriented m_c.",
         "m_c": {
-            "age": ["apprentice", "young adult", "adult", "senior adult"]
+            "age": ["adolescent", "young adult", "adult", "senior adult"]
         },
         "injury": [
             {

--- a/resources/lang/en/events/injury/desert.json
+++ b/resources/lang/en/events/injury/desert.json
@@ -1,4 +1,5 @@
-{
+[
+   {
         "event_id": "dst_injury_bruisessore_anymultiage1_PLACEHOLDER",
         "location": [
             "any"
@@ -29,3 +30,4 @@
             }
         ]
     },
+]

--- a/resources/lang/en/events/injury/desert.json
+++ b/resources/lang/en/events/injury/desert.json
@@ -1,0 +1,31 @@
+{
+        "event_id": "dst_injury_bruisessore_anymultiage1_PLACEHOLDER",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "weight": 20,
+        "event_text": "As m_c was out scouring the territory, {PRONOUN/m_c/subject} took a bad tumble over a rock hidden in the sand.",
+        "m_c": {
+            "age": [
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult",
+                "senior"
+            ]
+        },
+        "injury": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "injuries": [
+                    "bruises",
+                    "sore"
+                ]
+            }
+        ]
+    },

--- a/resources/lang/en/events/injury/desert.json
+++ b/resources/lang/en/events/injury/desert.json
@@ -1,6 +1,6 @@
 [
    {
-        "event_id": "dst_injury_bruisessore_anymultiage1_PLACEHOLDER",
+        "event_id": "dst_injury_bruisessore_anymultiage1",
         "location": ["desert"],
         "season": ["any"],
         "weight": 20,
@@ -16,18 +16,83 @@
         ]
     },
    {
-        "event_id": "dst_injury_bruisessore_anymultiage1_PLACEHOLDER",
-        "location": ["any"],
-        "season": ["Greenleaf", "Newleaf"],
+        "event_id": "dst_injury_scrapessmallcuts_appmultitrait1",
+        "location": ["desert"],
+        "season": ["any"],
         "weight": 20,
-        "event_text": ".",
+        "event_text": "Despite m_c's mentor's protests, {PRONOUN/m_c/subject} dashes off and tumbles face first into a cactus, thankfully the medicine cat is able to remove the spines with little difficulty.",
         "m_c": {
-            "age": ["adolescent", "young adult", "adult", "senior adult", "senior"]
+            "age": ["adolescent"],
+            "trait": ["adventerous", "arrogant", "bold", "childish", "confident", "daring", "oblivious", "playful", "rebelious", "shamelesS", "troublesome"]
         },
         "injury": [
             {
                 "cats": ["m_c"],
-                "injuries": ["bruises", "sore"]
+                "injuries": ["scrapes", "small cut"]
+            }
+        ]
+    },
+   {
+        "event_id": "dst_injury_snake_any1",
+        "location": ["desert"],
+        "season": ["any"],
+        "weight": 20,
+        "event_text": "A snake managed to slither its way into camp and m_c got bitten by it.",
+        "m_c": {
+            "age": ["any"]
+        },
+        "injury": [
+            {
+                "cats": ["m_c"],
+                "injuries": ["snake bite"]
+            }
+        ]
+    },
+   {
+        "event_id": "dst_injury_heatexhaustion_anymultiage1",
+        "location": ["desert"],
+        "season": ["newleaf", "greenleaf"],
+        "weight": 20,
+        "event_text": "m_c was out on patrol and pushed {PRONOUN/m_c/self} too hard, returning to camp panting and feeling dizzy.",
+        "m_c": {
+            "age": ["apprentice", "young adult", "adult", "senior adult"]
+        },
+        "injury": [
+            {
+                "cats": ["m_c"],
+                "injuries": ["heat exhaustion"]
+            }
+        ]
+    },
+   {
+        "event_id": "dst_injury_heatexhaustion_anymultiage2",
+        "location": ["desert"],
+        "season": ["newleaf", "greenleaf"],
+        "weight": 20,
+        "event_text": "m_c was out patroling and didnt take enough time to rest away from the sun, coming back to camp feeling weak and nauseous.",
+        "m_c": {
+            "age": ["apprentice", "young adult", "adult", "senior adult"]
+        },
+        "injury": [
+            {
+                "cats": ["m_c"],
+                "injuries": ["heat exhaustion"]
+            }
+        ]
+    },
+   {
+        "event_id": "dst_injury_heatstroke_anymultiage1",
+        "location": ["desert"],
+        "season": ["greenleaf"],
+        "weight": 20,
+        "event_text": "m_c was out on patrol and pushed {PRONOUN/m_c/self} too hard despite the sweltering Greenleaf heat, the patrol returning to camp with an overheated and disoriented m_c.",
+        "m_c": {
+            "age": ["apprentice", "young adult", "adult", "senior adult"]
+        },
+        "injury": [
+            {
+                "cats": ["m_c"],
+                "injuries": ["heat stroke"]
             }
         ]
     }

--- a/resources/lang/en/events/injury/desert.json
+++ b/resources/lang/en/events/injury/desert.json
@@ -20,7 +20,7 @@
         "location": ["desert"],
         "season": ["any"],
         "weight": 20,
-        "event_text": "m_c dashes off from {PRONOUN/m_c/poss} mentor and tumbles face first into a cactus, thankfully the medicine cat is able to remove the spines with little difficulty.",
+        "event_text": "m_c dashed off from {PRONOUN/m_c/poss} mentor and tumbled face first into a cactus. Thankfully, the medicine cat was able to remove the spines with little difficulty.",
         "m_c": {
             "age": ["adolescent"],
             "trait": ["adventurous", "arrogant", "bold", "childish", "confident", "daring", "oblivious", "playful", "rebellious", "shameless", "troublesome"]

--- a/resources/lang/en/events/injury/wetlands.json
+++ b/resources/lang/en/events/injury/wetlands.json
@@ -20,7 +20,7 @@
         "location": ["wetlands"],
         "season": ["any"],
         "weight": 20,
-        "event_text": "m_c was out in the territory when {PRONOUN/m_c/subject} came across a cluster of red berries and ate some, later r_c found them barely alive and rushed {PRONOUN/m_c/object} back to camp.",
+        "event_text": "m_c ate some red berries out in the territory and was rushed back to camp by r_c.",
         "m_c": {
             "age": ["adolescent"],
             "not_skill": ["HEALER,1"]

--- a/resources/lang/en/events/injury/wetlands.json
+++ b/resources/lang/en/events/injury/wetlands.json
@@ -56,7 +56,7 @@
         "location": ["wetlands"],
         "season": ["any"],
         "weight": 20,
-        "event_text": "m_c was stalking through the tall grass of the marsh hunting, however {PRONOUN/m_c/subject} stepped on a hidden snake and it bit {PRONOUN/m_c/object}!",
+        "event_text": "m_c was bitten by a hidden snake whilst hunting in the marsh.",
         "m_c": {
             "age": ["adolescent", "young adult", "adult", "senior adult"]
         },

--- a/resources/lang/en/events/injury/wetlands.json
+++ b/resources/lang/en/events/injury/wetlands.json
@@ -1,31 +1,17 @@
 [
   {
         "event_id": "wtlnd_injury_sore_anymultiage1_PLACEHOLDER",
-        "location": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
+        "location": ["wetlands"],
+        "season": ["any"],
         "weight": 20,
         "event_text": "m_c took a walk through an especially muddy and dense part of the territory, the next day {PRONOUN/m_c/subject} woke up sore.",
         "m_c": {
-            "age": [
-                "adolescent",
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ]
+            "age": ["adolescent", "young adult", "adult", "senior adult", "senior"]
         },
         "injury": [
             {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "sore"
-                ]
+                "cats": ["m_c"],
+                "injuries": ["sore"]
             }
         ]
     },

--- a/resources/lang/en/events/injury/wetlands.json
+++ b/resources/lang/en/events/injury/wetlands.json
@@ -4,7 +4,7 @@
         "location": ["wetlands"],
         "season": ["any"],
         "weight": 20,
-        "event_text": "m_c took a walk through an especially muddy and dense part of the territory, the next day {PRONOUN/m_c/subject} woke up sore.",
+        "event_text": "Earlier this moon m_c walked through an especially muddy and dense part of the territory, the next day {PRONOUN/m_c/subject} woke up sore.",
         "m_c": {
             "age": ["adolescent", "young adult", "adult", "senior adult", "senior"]
         },
@@ -20,7 +20,7 @@
         "location": ["wetlands"],
         "season": ["any"],
         "weight": 20,
-        "event_text": "m_c was out in the territory when {PRONOUN/m_c/subject} came across a cluster of red berries, deciding to eat some thinking they were edible, later r_c found them barely alive and rushed {PRONOUN/m_c/object} back to camp.",
+        "event_text": "m_c was out in the territory when {PRONOUN/m_c/subject} came across a cluster of red berries and ate some, later r_c found them barely alive and rushed {PRONOUN/m_c/object} back to camp.",
         "m_c": {
             "age": ["adolescent"],
             "not_skill": ["HEALER,1"]
@@ -40,7 +40,7 @@
         "location": ["wetlands"],
         "season": ["any"],
         "weight": 20,
-        "event_text": "Whilst m_c was working on a pathway through the dense undergrowth, {PRONOUN/m_c/subject} nicked {PRONOUN/m_c/self} when weaving through the branches of a spiky tree.",
+        "event_text": "m_c was weaving through the undergrowth and nicked {PRONOUN/m_c/self} on the low branches of a spiky tree.",
         "m_c": {
             "age": ["adolescent", "young adult", "adult", "senior adult"]
         },
@@ -56,7 +56,7 @@
         "location": ["wetlands"],
         "season": ["any"],
         "weight": 20,
-        "event_text": "Whilst m_c was stalking through the tall grass of the marsh hunting, for a brief moment {PRONOUN/m_c/subject} could've sworn {PRONOUN/m_c/subject} felt something slither by, and was proven correct when a snake's fangs sunk into {PRONOUN/m_c/object}!",
+        "event_text": "m_c was stalking through the tall grass of the marsh hunting, however {PRONOUN/m_c/subject} stepped on a hidden snake and it bit {PRONOUN/m_c/object}!",
         "m_c": {
             "age": ["adolescent", "young adult", "adult", "senior adult"]
         },

--- a/resources/lang/en/events/injury/wetlands.json
+++ b/resources/lang/en/events/injury/wetlands.json
@@ -40,7 +40,7 @@
         "location": ["wetlands"],
         "season": ["any"],
         "weight": 20,
-        "event_text": "m_c was weaving through the undergrowth and nicked {PRONOUN/m_c/self} on the low branches of a spiky tree.",
+        "event_text": "m_c nicked {PRONOUN/m_c/self} on the low branches of a spiky tree.",
         "m_c": {
             "age": ["adolescent", "young adult", "adult", "senior adult"]
         },

--- a/resources/lang/en/events/injury/wetlands.json
+++ b/resources/lang/en/events/injury/wetlands.json
@@ -40,7 +40,7 @@
         "location": ["wetlands"],
         "season": ["any"],
         "weight": 20,
-        "event_text": "Whilst m_c was working on a pathway through the dense undergrowth, {PRONOUN/m_c/subject} nicked {PRONOUN/m_c/self} when weaving through the branches of a spikey tree.",
+        "event_text": "Whilst m_c was working on a pathway through the dense undergrowth, {PRONOUN/m_c/subject} nicked {PRONOUN/m_c/self} when weaving through the branches of a spiky tree.",
         "m_c": {
             "age": ["adolescent", "young adult", "adult", "senior adult"]
         },
@@ -56,7 +56,7 @@
         "location": ["wetlands"],
         "season": ["any"],
         "weight": 20,
-        "event_text": "Whilst m_c was stalking through the tall grass of the marsh hunting, for a breif moment {PRONOUN/m_c/subject} couldve sworn {PRONOUN/m_c/subject} felt something slither by, and was proven correct when a snake's fangs sunk into {PRONOUN/m_c/object}!",
+        "event_text": "Whilst m_c was stalking through the tall grass of the marsh hunting, for a brief moment {PRONOUN/m_c/subject} could've sworn {PRONOUN/m_c/subject} felt something slither by, and was proven correct when a snake's fangs sunk into {PRONOUN/m_c/object}!",
         "m_c": {
             "age": ["adolescent", "young adult", "adult", "senior adult"]
         },

--- a/resources/lang/en/events/injury/wetlands.json
+++ b/resources/lang/en/events/injury/wetlands.json
@@ -1,6 +1,6 @@
 [
   {
-        "event_id": "wtlnd_injury_sore_anymultiage1_PLACEHOLDER",
+        "event_id": "wtlnd_injury_sore_anymultiage1",
         "location": ["wetlands"],
         "season": ["any"],
         "weight": 20,
@@ -15,4 +15,56 @@
             }
         ]
     },
+  {
+        "event_id": "wtlnd_injury_poisoned_app1",
+        "location": ["wetlands"],
+        "season": ["any"],
+        "weight": 20,
+        "event_text": "m_c was out in the territory when {PRONOUN/m_c/subject} came across a cluster of red berries, deciding to eat some thinking they were edible, later r_c found them barely alive and rushed {PRONOUN/m_c/object} back to camp.",
+        "m_c": {
+            "age": ["adolescence"],
+            "not_skill": ["HEALER,1"]
+        },
+        "r_c": {
+          "age": ["young adult", "adult", "senior adult"]
+        },
+        "injury": [
+            {
+                "cats": ["m_c"],
+                "injuries": ["poisoned"]
+            }
+        ]
+    },
+  {
+        "event_id": "wtlnd_injury_smallcut_anymultiage1",
+        "location": ["wetlands"],
+        "season": ["any"],
+        "weight": 20,
+        "event_text": "Whilst m_c was working on a pathway through the dense undergrowth, {PRONOUN/m_c/subject} nicked {PRONOUN/m_c/self} when weaving through the branches of a spikey tree.",
+        "m_c": {
+            "age": ["adolescent", "young adult", "adult", "senior adult"]
+        },
+        "injury": [
+            {
+                "cats": ["m_c"],
+                "injuries": ["small cut"]
+            }
+        ]
+    },
+  {
+        "event_id": "wtlnd_injury_snakebite_anymultiage1",
+        "location": ["wetlands"],
+        "season": ["any"],
+        "weight": 20,
+        "event_text": "Whilst m_c was stalking through the tall grass of the marsh hunting, for a breif moment {PRONOUN/m_c/subject} couldve sworn {PRONOUN/m_c/subject} felt something slither by, and was proven correct when a snake's fangs sunk into {PRONOUN/m_c/object}!",
+        "m_c": {
+            "age": ["adolescent", "young adult", "adult", "senior adult"]
+        },
+        "injury": [
+            {
+                "cats": ["m_c"],
+                "injuries": ["snake bite"]
+            }
+        ]
+    }
 ]

--- a/resources/lang/en/events/injury/wetlands.json
+++ b/resources/lang/en/events/injury/wetlands.json
@@ -4,7 +4,7 @@
         "location": ["wetlands"],
         "season": ["any"],
         "weight": 20,
-        "event_text": "Earlier this moon m_c walked through an especially muddy and dense part of the territory, the next day {PRONOUN/m_c/subject} woke up sore.",
+        "event_text": "m_c woke up sore after walking through an especially muddy and dense part of the territory.",
         "m_c": {
             "age": ["adolescent", "young adult", "adult", "senior adult", "senior"]
         },

--- a/resources/lang/en/events/injury/wetlands.json
+++ b/resources/lang/en/events/injury/wetlands.json
@@ -22,7 +22,7 @@
         "weight": 20,
         "event_text": "m_c was out in the territory when {PRONOUN/m_c/subject} came across a cluster of red berries, deciding to eat some thinking they were edible, later r_c found them barely alive and rushed {PRONOUN/m_c/object} back to camp.",
         "m_c": {
-            "age": ["adolescence"],
+            "age": ["adolescent"],
             "not_skill": ["HEALER,1"]
         },
         "r_c": {

--- a/resources/lang/en/events/injury/wetlands.json
+++ b/resources/lang/en/events/injury/wetlands.json
@@ -1,0 +1,32 @@
+[
+  {
+        "event_id": "wtlnd_injury_sore_anymultiage1_PLACEHOLDER",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "weight": 20,
+        "event_text": "m_c took a walk through an especially muddy and dense part of the territory, the next day {PRONOUN/m_c/subject} woke up sore.",
+        "m_c": {
+            "age": [
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult",
+                "senior"
+            ]
+        },
+        "injury": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "injuries": [
+                    "sore"
+                ]
+            }
+        ]
+    },
+]

--- a/resources/lang/en/events/misc/desert.json
+++ b/resources/lang/en/events/misc/desert.json
@@ -37,7 +37,7 @@
     "location": ["desert"],
     "season": ["newleaf", "greenleaf", "leaf-fall"],
     "weight": 20,
-    "event_text": "The things {PRONOUN/m_c/subject} saw today, omen_list_sight/m_c... {PRONOUN/m_c/subject/CAP} {VERB/m_c/consider/considers} what these omens may entail for c_n.",
+    "event_text": "The things {PRONOUN/m_c/subject} saw in the sand today, omen_list_sight/m_c... {PRONOUN/m_c/subject/CAP} {VERB/m_c/consider/considers} what these omens may entail for c_n.",
     "m_c": {
       "status": ["medicine cat", "medicine cat apprentice"],
       "skill": ["OMEN,2"]

--- a/resources/lang/en/events/misc/desert.json
+++ b/resources/lang/en/events/misc/desert.json
@@ -4,7 +4,7 @@
     "location": ["desert"],
     "season": ["newleaf", "greenleaf", "leaf-fall"],
     "weight": 20,
-    "event_text": "m_c was sniffing at an odd lump in the sand when suddenly a very upset lizard burst out and gave {PRONOUN/m_c/object} a nip on the nose! It sprinted away before {PRONOUN/m_c/subject} could give it payback.",
+    "event_text": "m_c was sniffing at an odd lump in the sand when suddenly an upset lizard gave {PRONOUN/m_c/object} a nip on the nose and dashed away!",
     "m_c": {
       "status": ["warrior", "apprentice", "kitten", "elder"]
     }
@@ -26,7 +26,7 @@
     "location": ["desert"],
     "season": ["newleaf", "greenleaf"],
     "weight": 20,
-    "event_text": "m_c is out combating the heat of the desert to find valuable herbs, yet in the distant mirage {PRONOUN/m_c/subject} {VERB/m_c/keep/keeps} seeing prophecy_list_sight/m_c. {PRONOUN/m_c/subject/CAP} {VERB/m_c/continue/continues} gathering what herbs {PRONOUN/m_c/subject} can, debating what it could mean for c_n.",
+    "event_text": "m_c is out finding valuable herbs, but in the distant mirage {PRONOUN/m_c/subject} sees prophecy_list_sight/m_c. {PRONOUN/m_c/subject/CAP} {VERB/m_c/continue/continues} gathering, attempting to decipher what the visions could mean.",
     "m_c": {
       "status": ["medicine cat", "medicine cat apprentice"],
       "skill": ["PROPHET,2"]
@@ -37,7 +37,7 @@
     "location": ["desert"],
     "season": ["newleaf", "greenleaf", "leaf-fall"],
     "weight": 20,
-    "event_text": "The things {PRONOUN/m_c/subject} saw today, omen_list_sight/m_c... m_c hides {PRONOUN/m_c/self} in a cool dusty dip by a large rock, needing privacy as {PRONOUN/m_c/subject} {VERB/m_c/consider/considers} what these omens may entail for c_n.",
+    "event_text": "The things {PRONOUN/m_c/subject} saw today, omen_list_sight/m_c... {PRONOUN/m_c/subject/CAP} {VERB/m_c/consider/considers} what these omens may entail for c_n.",
     "m_c": {
       "status": ["medicine cat", "medicine cat apprentice"],
       "skill": ["OMEN,2"]

--- a/resources/lang/en/events/misc/desert.json
+++ b/resources/lang/en/events/misc/desert.json
@@ -1,12 +1,46 @@
 [
   {
-    "event_id": "dst_misc_angrylizard_PLACEHOLDER",
+    "event_id": "dst_misc_any_angrylizard",
     "location": ["desert"],
     "season": ["newleaf", "greenleaf", "leaf-fall"],
     "weight": 20,
     "event_text": "m_c was sniffing at an odd lump in the sand when suddenly a very upset lizard burst out and gave {PRONOUN/m_c/object} a nip on the nose! It sprinted away before {PRONOUN/m_c/subject} could give it payback.",
     "m_c": {
       "status": ["warrior", "apprentice", "kitten", "elder"]
+    }
+  },
+  {
+    "event_id": "dst_misc_war_anyapps1",
+    "location": ["desert"],
+    "season": ["any"],
+    "sub_type": ["war"],
+    "tags": ["clan:apprentice"],
+    "weight": 15,
+    "event_text": "The apprentices of the Clan are taking special training to learn how to blind their enemies with dust from the ground.",
+    "m_c": {
+      "status": ["apprentice"]
+    }
+  },
+  {
+    "event_id": "dst_misc_multiprophecymedcatprophet1",
+    "location": ["desert"],
+    "season": ["newleaf", "greenleaf"],
+    "weight": 20,
+    "event_text": "m_c is out combating the heat of the desert to find valuable herbs, yet in the distant mirage {PRONOUN/m_c/subject} {VERB/m_c/keep/keeps} seeing prophecy_list_sight/m_c. {PRONOUN/m_c/subject/CAP} {VERB/m_c/continue/continues} gathering what herbs {PRONOUN/m_c/subject} can, debating what it could mean for c_n.",
+    "m_c": {
+      "status": ["medicine cat", "medicine cat apprentice"],
+      "skill": ["PROPHET,2"]
+    }
+  },
+  {
+    "event_id": "dst_misc_multiomenmedcatomen1",
+    "location": ["desert"],
+    "season": ["newleaf", "greenleaf", "leaf-fall"],
+    "weight": 20,
+    "event_text": "The things {PRONOUN/m_c/subject} saw today, omen_list_sight/m_c... m_c hides {PRONOUN/m_c/self} in a cool dusty dip by a large rock, needing privacy as {PRONOUN/m_c/subject} {VERB/m_c/consider/considers} what these omens may entail for c_n.",
+    "m_c": {
+      "status": ["medicine cat", "medicine cat apprentice"],
+      "skill": ["OMEN,2"]
     }
   }
 ]

--- a/resources/lang/en/events/misc/desert.json
+++ b/resources/lang/en/events/misc/desert.json
@@ -26,7 +26,7 @@
     "location": ["desert"],
     "season": ["newleaf", "greenleaf"],
     "weight": 20,
-    "event_text": "m_c is out finding valuable herbs, but in the distant mirage {PRONOUN/m_c/subject} sees prophecy_list_sight/m_c. {PRONOUN/m_c/subject/CAP} {VERB/m_c/continue/continues} gathering, attempting to decipher what the visions could mean.",
+    "event_text": "While out gathering valuable herbs, m_c sees a vision of prophecy_list_sight/m_c.",
     "m_c": {
       "status": ["medicine cat", "medicine cat apprentice"],
       "skill": ["PROPHET,2"]

--- a/resources/lang/en/events/misc/desert.json
+++ b/resources/lang/en/events/misc/desert.json
@@ -4,7 +4,7 @@
     "location": ["desert"],
     "season": ["newleaf", "greenleaf", "leaf-fall"],
     "weight": 20,
-    "event_text": "m_c was sniffing at an odd lump in the sand when suddenly an upset lizard gave {PRONOUN/m_c/object} a nip on the nose and dashed away!",
+    "event_text": "m_c was nipped on the nose when {PRONOUN/m_c/subject} investigated an odd, lizard-shaped lump in the sand.",
     "m_c": {
       "status": ["warrior", "apprentice", "kitten", "elder"]
     }

--- a/resources/lang/en/events/misc/desert.json
+++ b/resources/lang/en/events/misc/desert.json
@@ -1,0 +1,12 @@
+[
+  {
+    "event_id": "dst_misc_angrylizard_PLACEHOLDER",
+    "location": ["desert"],
+    "season": ["newleaf", "greenleaf", "leaf-fall"],
+    "weight": 20,
+    "event_text": "m_c was sniffing at an odd lump in the sand when suddenly a very upset lizard burst out and gave {PRONOUN/m_c/object} a nip on the nose! It sprinted away before {PRONOUN/m_c/subject} could give it payback.",
+    "m_c": {
+      "status": ["warrior", "apprentice", "kitten", "elder"]
+    }
+  }
+]

--- a/resources/lang/en/events/misc/desert.json
+++ b/resources/lang/en/events/misc/desert.json
@@ -16,7 +16,7 @@
     "sub_type": ["war"],
     "tags": ["clan:apprentice"],
     "weight": 15,
-    "event_text": "The apprentices of the Clan are taking special training to learn how to blind their enemies with dust from the ground.",
+    "event_text": "The apprentices of the Clan are taking special training to learn how to blind their enemies by kicking up dust.",
     "m_c": {
       "status": ["apprentice"]
     }

--- a/resources/lang/en/events/misc/wetlands.json
+++ b/resources/lang/en/events/misc/wetlands.json
@@ -1,12 +1,34 @@
 [
   {
-    "event_id": "wtlnd_misc_stingingnettleboop_PLACEHOLDER",
+    "event_id": "wtlnd_misc_any_stingingnettleboop",
     "location": ["wetlands"],
     "season": ["newleaf", "greenleaf", "leaf-fall"],
     "weight": 20,
     "event_text": "Whilst m_c was poking around in the undergrowth, {PRONOUN/m_c/subject} ran nose first into a stinging nettle plant - Ouch!",
     "m_c": {
       "status": ["apprentice", "warrior", "elder", "kitten"]
+    }
+  },
+  {
+    "event_id": "wtlnd_misc_multiprophecymedcatprophet1",
+    "location": ["wetlands"],
+    "season": ["newleaf", "greenleaf", "leaf-fall"],
+    "weight": 20,
+    "event_text": "Wading through the wetlands, m_c keeps seeing prophecy_list_sight/m_c in the shallow water underpaw. {PRONOUN/m_c/subject/CAP} {VERB/m_c/shiver/shivers} as a cold breeze ruffles {PRONOUN/m_c/poss} fur, {PRONOUN/m_c/subject} {VERB/m_c/need/needs} to tell c_n immediately about what {PRONOUN/m_c/subject} saw.",
+    "m_c": {
+      "status": ["medicine cat", "medicine cat apprentice"],
+      "skill": ["PROPHET,2"]
+    }
+  },
+  {
+    "event_id": "wtlnd_misc_multiomenmedcatomen1",
+    "location": ["wetlands"],
+    "season": ["newleaf", "greenleaf", "leaf-fall"],
+    "weight": 20,
+    "event_text": "The things m_c saw in the ripples of the marsh today, omen_list_sight/m_c... m_c conceals {PRONOUN/m_c/self} with the frogs deep inside the reeds lining the marsh, needing privacy as {PRONOUN/m_c/subject} {VERB/m_c/consider/considers} what these omens may foretell.",
+    "m_c": {
+      "status": ["medicine cat", "medicine cat apprentice"],
+      "skill": ["OMEN,2"]
     }
   }
 ]

--- a/resources/lang/en/events/misc/wetlands.json
+++ b/resources/lang/en/events/misc/wetlands.json
@@ -1,0 +1,12 @@
+[
+  {
+    "event_id": "wtlnd_misc_stingingnettleboop_PLACEHOLDER",
+    "location": ["wetlands"],
+    "season": ["newleaf", "greenleaf", "leaf-fall"],
+    "weight": 20,
+    "event_text": "whilst m_c was poking around in the undergrowth {PRONOUN/m_c/subject} ran nose first into a stinging nettle plant - Ouch!",
+    "m_c": {
+      "status": ["apprentice", "warrior", "elder", "kitten"],
+    }
+  }
+]

--- a/resources/lang/en/events/misc/wetlands.json
+++ b/resources/lang/en/events/misc/wetlands.json
@@ -14,7 +14,7 @@
     "location": ["wetlands"],
     "season": ["newleaf", "greenleaf", "leaf-fall"],
     "weight": 20,
-    "event_text": "Wading through the wetlands, m_c keeps seeing prophecy_list_sight/m_c in the shallow water underpaw. {PRONOUN/m_c/subject/CAP} {VERB/m_c/shiver/shivers} as a cold breeze ruffles {PRONOUN/m_c/poss} fur, {PRONOUN/m_c/subject} {VERB/m_c/need/needs} to tell c_n immediately about what {PRONOUN/m_c/subject} saw.",
+    "event_text": "m_c keeps seeing prophecy_list_sight/m_c in the water underpaw... {PRONOUN/m_c/subject/CAP} continues wading forward with {PRONOUN/m_c/poss} mission, debating the vision.",
     "m_c": {
       "status": ["medicine cat", "medicine cat apprentice"],
       "skill": ["PROPHET,2"]
@@ -25,7 +25,7 @@
     "location": ["wetlands"],
     "season": ["newleaf", "greenleaf", "leaf-fall"],
     "weight": 20,
-    "event_text": "The things m_c saw in the ripples of the marsh today, omen_list_sight/m_c... m_c conceals {PRONOUN/m_c/self} with the frogs deep inside the reeds lining the marsh, needing privacy as {PRONOUN/m_c/subject} {VERB/m_c/consider/considers} what these omens may foretell.",
+    "event_text": "The things m_c saw in the ripples of the marsh today, omen_list_sight/m_c... {PRONOUN/m_c/subject/CAP} {VERB/m_c/consider/considers} what these omens may foretell.",
     "m_c": {
       "status": ["medicine cat", "medicine cat apprentice"],
       "skill": ["OMEN,2"]
@@ -35,8 +35,8 @@
     "event_id": "wtlnd_misc_multiage_blueheron",
     "location": ["wetlands"],
     "season": ["newleaf", "greenleaf", "leaf-fall"],
-    "weight": 20,
-    "event_text": "m_c was feeling overwhelmed and took a walk out in the territory, after sitting down in a quiet clearing {PRONOUN/m_c/subject} saw a large blue heron fly and land right infront of {PRONOUN/m_c/object}! m_c loafed and watched the elegant bird with intrigue, wondering if it means anything.",
+    "weight": 10,
+    "event_text": "m_c took a walk out in the territory and saw a large blue heron fly close overhead! How lucky!",
     "m_c": {
       "age": ["adolescent", "young adult", "adult", "senior adult", "senior"]
     }

--- a/resources/lang/en/events/misc/wetlands.json
+++ b/resources/lang/en/events/misc/wetlands.json
@@ -38,7 +38,7 @@
     "weight": 20,
     "event_text": "m_c was feeling overwhelmed and took a walk out in the territory, after sitting down in a quiet clearing {PRONOUN/m_c/subject} saw a large blue heron fly and land right infront of {PRONOUN/m_c/object}! m_c loafed and watched the elegant bird with intrigue, wondering if it means anything.",
     "m_c": {
-      "age": ["adolescence", "young adult", "adult", "senior adult", "senior"]
+      "age": ["adolescent", "young adult", "adult", "senior adult", "senior"]
     }
   }
 ]

--- a/resources/lang/en/events/misc/wetlands.json
+++ b/resources/lang/en/events/misc/wetlands.json
@@ -4,7 +4,7 @@
     "location": ["wetlands"],
     "season": ["newleaf", "greenleaf", "leaf-fall"],
     "weight": 20,
-    "event_text": "Whilst m_c was poking around in the undergrowth {PRONOUN/m_c/subject} ran nose first into a stinging nettle plant - Ouch!",
+    "event_text": "Whilst m_c was poking around in the undergrowth, {PRONOUN/m_c/subject} ran nose first into a stinging nettle plant - Ouch!",
     "m_c": {
       "status": ["apprentice", "warrior", "elder", "kitten"]
     }

--- a/resources/lang/en/events/misc/wetlands.json
+++ b/resources/lang/en/events/misc/wetlands.json
@@ -4,7 +4,7 @@
     "location": ["wetlands"],
     "season": ["newleaf", "greenleaf", "leaf-fall"],
     "weight": 20,
-    "event_text": "whilst m_c was poking around in the undergrowth {PRONOUN/m_c/subject} ran nose first into a stinging nettle plant - Ouch!",
+    "event_text": "Whilst m_c was poking around in the undergrowth {PRONOUN/m_c/subject} ran nose first into a stinging nettle plant - Ouch!",
     "m_c": {
       "status": ["apprentice", "warrior", "elder", "kitten"]
     }

--- a/resources/lang/en/events/misc/wetlands.json
+++ b/resources/lang/en/events/misc/wetlands.json
@@ -6,7 +6,7 @@
     "weight": 20,
     "event_text": "whilst m_c was poking around in the undergrowth {PRONOUN/m_c/subject} ran nose first into a stinging nettle plant - Ouch!",
     "m_c": {
-      "status": ["apprentice", "warrior", "elder", "kitten"],
+      "status": ["apprentice", "warrior", "elder", "kitten"]
     }
   }
 ]

--- a/resources/lang/en/events/misc/wetlands.json
+++ b/resources/lang/en/events/misc/wetlands.json
@@ -30,5 +30,15 @@
       "status": ["medicine cat", "medicine cat apprentice"],
       "skill": ["OMEN,2"]
     }
+  },
+  {
+    "event_id": "wtlnd_misc_multiage_blueheron",
+    "location": ["wetlands"],
+    "season": ["newleaf", "greenleaf", "leaf-fall"],
+    "weight": 20,
+    "event_text": "m_c was feeling overwhelmed and took a walk out in the territory, after sitting down in a quiet clearing {PRONOUN/m_c/subject} saw a large blue heron fly and land right infront of {PRONOUN/m_c/object}! m_c loafed and watched the elegant bird with intrigue, wondering if it means anything.",
+    "m_c": {
+      "age": ["adolescence", "young adult", "adult", "senior adult", "senior"]
+    }
   }
 ]

--- a/resources/lang/en/events/misc/wetlands.json
+++ b/resources/lang/en/events/misc/wetlands.json
@@ -14,7 +14,7 @@
     "location": ["wetlands"],
     "season": ["newleaf", "greenleaf", "leaf-fall"],
     "weight": 20,
-    "event_text": "m_c keeps seeing prophecy_list_sight/m_c in the water underpaw... {PRONOUN/m_c/subject/CAP} continues wading forward with {PRONOUN/m_c/poss} mission, debating the vision.",
+    "event_text": "m_c keeps seeing prophecy_list_sight/m_c in the water underpaw...",
     "m_c": {
       "status": ["medicine cat", "medicine cat apprentice"],
       "skill": ["PROPHET,2"]

--- a/resources/lang/en/events/new_cat/desert.json
+++ b/resources/lang/en/events/new_cat/desert.json
@@ -1,21 +1,12 @@
 [
   {
         "event_id": "dst_new_cat_loner1",
-        "location": [
-            "desert"
-        ],
-        "season": [
-            "any"
-        ],
+        "location": ["desert"],
+        "season": ["any"],
         "weight": 5,
         "event_text": "The desert is a deadly place for a lone wanderer. n_c:0 readily accepts m_c's offer to join c_n.",
         "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
+            "age": ["young adult", "adult", "senior adult", "senior"],
             "status": ["any"]
           },
         "new_cat": [
@@ -31,102 +22,62 @@
             }
           ],
           "outsider": {
-              "current_rep": [
-                  "welcoming"
-              ],
+              "current_rep": ["welcoming"],
               "changed": 1
           }
     },
     {
         "event_id": "dst_new_cat_loner2",
-        "location": [
-            "desert"
-        ],
-        "season": [
-            "any"
-        ],
+        "location": ["desert"],
+        "season": ["any"],
         "weight": 5,
         "event_text": "m_c finds a wandering loner while on patrol. Though c_n may not be fond of outsiders, no cat can deny new blood is hard to come by and inevitably needed. n_c:0 is allowed to join the Clan.",
         "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
+            "age": ["young adult", "adult", "senior adult", "senior"],
             "status": ["leader", "deputy", "medicine cat", "warrior"]
           },
         "new_cat": [
           ["loner"]
         ],
           "outsider": {
-              "current_rep": [
-                  "hostile"
-              ],
+              "current_rep": ["hostile"],
               "changed": 1
           }
     },
     {
         "event_id": "dst_new_cat_loner3",
-        "location": [
-            "desert"
-        ],
-        "season": [
-            "any"
-        ],
+        "location": ["desert"],
+        "season": ["any"],
         "weight": 5,
         "event_text": "m_c finds a wandering loner while on patrol. New blood is hard to come by in the desert, and n_c:0 is readily accepted into the Clan.",
         "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
+            "age": ["young adult", "adult", "senior adult", "senior"],
             "status": ["leader", "deputy", "medicine cat", "warrior"]
           },
         "new_cat": [
           ["loner"]
         ],
           "outsider": {
-              "current_rep": [
-                  "neutral", "welcoming"
-              ],
+              "current_rep": ["neutral", "welcoming"],
               "changed": 1
           }
     },
     {
         "event_id": "dst_new_cat_abandoned_litter",
-        "location": [
-            "desert"
-        ],
-        "season": [
-            "any"
-        ],
+        "location": ["desert"],
+        "season": ["any"],
         "weight": 5,
         "event_text": "m_c finds an abandoned litter while on patrol and rushes them back to camp. Such young cats were lucky to have survived under the hot desert sun.",
         "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
+            "age": ["young adult", "adult", "senior adult", "senior"],
             "status": ["leader", "deputy", "medicine cat", "warrior"]
           },
         "new_cat": [
             ["age:has_kits", "meeting", "loner", "can_birth"],
-            [
-                "new_name",
-                "parent:0",
-                "backstory:abandoned1",
-                "litter"
-            ]
+            ["new_name", "parent:0", "backstory:abandoned1", "litter"]
         ],
         "outsider": {
-              "current_rep": [
-                  "neutral", "welcoming"
-              ],
+              "current_rep": ["neutral", "welcoming"],
               "changed": 1
           }
     }

--- a/resources/lang/en/events/new_cat/wetlands.json
+++ b/resources/lang/en/events/new_cat/wetlands.json
@@ -4,7 +4,7 @@
         "location": ["wetlands"],
         "season": ["any"],
         "weight": 5,
-        "event_text": "m_c returned to camp carrying a muddy kitten, and explains that {PRONOUN/m_c/subject} found {PRONOUN/n_c:0/object} wandering - lost - around the marsh, no parent in sight.",
+        "event_text": "m_c returned to camp carrying a muddy kitten, explaining that {PRONOUN/m_c/subject} found {PRONOUN/n_c:0/object} wandering around the marsh, no parent in sight.",
         "m_c": {
             "age": ["young adult", "adult", "senior adult", "senior"],
             "status": ["any"]

--- a/resources/lang/en/events/new_cat/wetlands.json
+++ b/resources/lang/en/events/new_cat/wetlands.json
@@ -31,7 +31,7 @@
         "location": ["wetlands"],
         "season": ["any"],
         "weight": 5,
-        "event_text": "m_c found an abandoned kitten wandering around the marsh and carries {PRONOUN/n_c:0/object} back to camp. Though c_n isn't happy about it, m_c persuades them to let n_c:0 stay in the Clan.",
+        "event_text": "m_c found an abandoned kitten wandering around the marsh and carried {PRONOUN/n_c:0/object} back to camp. Though c_n isn't happy about it, m_c persuades them to let n_c:0 stay in the Clan.",
         "m_c": {
             "age": ["young adult", "adult", "senior adult", "senior"],
             "status": ["any"],

--- a/resources/lang/en/events/new_cat/wetlands.json
+++ b/resources/lang/en/events/new_cat/wetlands.json
@@ -1,6 +1,6 @@
 [
   {
-        "event_id": "wtlnd_new_cat_lost_kitten1_PLACEHOLDER",
+        "event_id": "wtlnd_new_cat_lost_kitten1",
         "location": [
             "wetlands"
         ],
@@ -43,7 +43,7 @@
         }
     },
   {
-        "event_id": "wtlnd_new_cat_lost_kitten2_PLACEHOLDER",
+        "event_id": "wtlnd_new_cat_lost_kitten2",
         "location": [
             "wetlands"
         ],
@@ -93,5 +93,40 @@
             ],
             "changed": 1
         }
+    },
+    {
+        "event_id": "wtlnd_new_cat_abandoned_litter",
+        "location": [
+            "wetlands"
+        ],
+        "season": [
+            "any"
+        ],
+        "weight": 5,
+        "event_text": "m_c finds an abandoned litter buried in the reeds while on patrol and rushes them back to camp. Such young cats were lucky that m_c found them before something else did.",
+        "m_c": {
+            "age": [
+                "young adult",
+                "adult",
+                "senior adult",
+                "senior"
+            ],
+            "status": ["leader", "deputy", "medicine cat", "warrior"]
+          },
+        "new_cat": [
+            ["age:has_kits", "meeting", "loner", "can_birth"],
+            [
+                "new_name",
+                "parent:0",
+                "backstory:abandoned1",
+                "litter"
+            ]
+        ],
+        "outsider": {
+              "current_rep": [
+                  "neutral", "welcoming"
+              ],
+              "changed": 1
+          }
     }
 ]

--- a/resources/lang/en/events/new_cat/wetlands.json
+++ b/resources/lang/en/events/new_cat/wetlands.json
@@ -1,32 +1,18 @@
 [
   {
         "event_id": "wtlnd_new_cat_lost_kitten1",
-        "location": [
-            "wetlands"
-        ],
-        "season": [
-            "any"
-        ],
+        "location": ["wetlands"],
+        "season": ["any"],
         "weight": 5,
         "event_text": "m_c returned to camp carrying a muddy kitten, and explains that {PRONOUN/m_c/subject} found {PRONOUN/n_c:0/object} wandering - lost - around the marsh, no parent in sight.",
         "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": [
-                "any"
-            ]
+            "age": ["young adult", "adult", "senior adult", "senior"],
+            "status": ["any"]
         },
         "new_cat": [
-            [
-                "backstory:abandoned1, abandoned4",
-                "age:kitten"
-            ]
+            ["backstory:abandoned1, abandoned4", "age:kitten"]
         ],
-		"relationships": [
+	"relationships": [
           {
             "cats_from": ["m_c"],
             "cats_to": ["n_c:0"],
@@ -36,41 +22,25 @@
           }
         ],
         "outsider": {
-            "current_rep": [
-                "welcoming"
-            ],
+            "current_rep": ["welcoming"],
             "changed": 1
         }
     },
   {
         "event_id": "wtlnd_new_cat_lost_kitten2",
-        "location": [
-            "wetlands"
-        ],
-        "season": [
-            "any"
-        ],
+        "location": ["wetlands"],
+        "season": ["any"],
         "weight": 5,
         "event_text": "m_c found an abandoned kitten wandering around the marsh and carries {PRONOUN/n_c:0/object} back to camp. Though c_n isn't happy about it, m_c persuades them to let n_c:0 stay in the Clan.",
         "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": [
-                "any"
-            ],
+            "age": ["young adult", "adult", "senior adult", "senior"],
+            "status": ["any"],
 	    "trait": ["compassionate", "loving", "responsible", "thoughtful"]
         },
         "new_cat": [
-            [
-                "backstory:abandoned1, abandoned4",
-                "age:kitten"
-            ]
+            ["backstory:abandoned1, abandoned4", "age:kitten"]
         ],
-		"relationships": [
+	"relationships": [
           {
             "cats_from": ["m_c"],
             "cats_to": ["n_c:0"],
@@ -88,44 +58,26 @@
 
         ],
         "outsider": {
-            "current_rep": [
-                "hostile"
-            ],
+            "current_rep": ["hostile"],
             "changed": 1
         }
     },
     {
         "event_id": "wtlnd_new_cat_abandoned_litter",
-        "location": [
-            "wetlands"
-        ],
-        "season": [
-            "any"
-        ],
+        "location": ["wetlands"],
+        "season": ["any"],
         "weight": 5,
         "event_text": "m_c finds an abandoned litter buried in the reeds while on patrol and rushes them back to camp. Such young cats were lucky that m_c found them before something else did.",
         "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
+            "age": ["young adult", "adult", "senior adult", "senior"],
             "status": ["leader", "deputy", "medicine cat", "warrior"]
           },
         "new_cat": [
             ["age:has_kits", "meeting", "loner", "can_birth"],
-            [
-                "new_name",
-                "parent:0",
-                "backstory:abandoned1",
-                "litter"
-            ]
+            ["new_name", "parent:0", "backstory:abandoned1", "litter"]
         ],
         "outsider": {
-              "current_rep": [
-                  "neutral", "welcoming"
-              ],
+              "current_rep": ["neutral", "welcoming"],
               "changed": 1
           }
     }

--- a/resources/lang/en/events/new_cat/wetlands.json
+++ b/resources/lang/en/events/new_cat/wetlands.json
@@ -1,0 +1,97 @@
+[
+  {
+        "event_id": "wtlnd_new_cat_lost_kitten1_PLACEHOLDER",
+        "location": [
+            "wetlands"
+        ],
+        "season": [
+            "any"
+        ],
+        "weight": 5,
+        "event_text": "m_c returned to camp carrying a muddy kitten, and explains that {PRONOUN/m_c/subject} found {PRONOUN/n_c:0/object} wandering - lost - around the marsh, no parent in sight.",
+        "m_c": {
+            "age": [
+                "young adult",
+                "adult",
+                "senior adult",
+                "senior"
+            ],
+            "status": [
+                "any"
+            ]
+        },
+        "new_cat": [
+            [
+                "backstory:abandoned1, abandoned4",
+                "age:kitten"
+            ]
+        ],
+		"relationships": [
+          {
+            "cats_from": ["m_c"],
+            "cats_to": ["n_c:0"],
+            "mutual": true,
+            "values": ["comfort", "platonic"],
+            "amount": 10
+          }
+        ],
+        "outsider": {
+            "current_rep": [
+                "welcoming"
+            ],
+            "changed": 1
+        }
+    },
+  {
+        "event_id": "wtlnd_new_cat_lost_kitten2_PLACEHOLDER",
+        "location": [
+            "wetlands"
+        ],
+        "season": [
+            "any"
+        ],
+        "weight": 5,
+        "event_text": "m_c found an abandoned kitten wandering around the marsh and carries {PRONOUN/n_c:0/object} back to camp. Though c_n isn't happy about it, m_c persuades them to let n_c:0 stay in the Clan.",
+        "m_c": {
+            "age": [
+                "young adult",
+                "adult",
+                "senior adult",
+                "senior"
+            ],
+            "status": [
+                "any"
+            ],
+	    "trait": ["compassionate", "loving", "responsible", "thoughtful"]
+        },
+        "new_cat": [
+            [
+                "backstory:abandoned1, abandoned4",
+                "age:kitten"
+            ]
+        ],
+		"relationships": [
+          {
+            "cats_from": ["m_c"],
+            "cats_to": ["n_c:0"],
+            "mutual": true,
+            "values": ["comfort", "platonic"],
+            "amount": 10
+          },
+	  {
+            "cats_from": ["clan"],
+            "cats_to": ["m_c", "n_c:0"],
+            "values": ["dislike"],
+            "amount": 5
+	  }
+
+
+        ],
+        "outsider": {
+            "current_rep": [
+                "hostile"
+            ],
+            "changed": 1
+        }
+    }
+]

--- a/resources/lang/en/events/new_cat/wetlands.json
+++ b/resources/lang/en/events/new_cat/wetlands.json
@@ -67,7 +67,7 @@
         "location": ["wetlands"],
         "season": ["any"],
         "weight": 5,
-        "event_text": "m_c finds an abandoned litter buried in the reeds while on patrol and rushes them back to camp. Such young cats were lucky that m_c found them before something else did.",
+        "event_text": "m_c found an abandoned litter concealed in the reeds and rushed them back to camp. Such young kits were lucky that m_c found them before something else did.",
         "m_c": {
             "age": ["young adult", "adult", "senior adult", "senior"],
             "status": ["leader", "deputy", "medicine cat", "warrior"]


### PR DESCRIPTION
## About The Pull Request

Adds the following events
- 6 Desert Deaths
- 2 Wetlands Deaths
- 3 Desert Injuries
- 4 Wetlands Injuries
- 4 Desert Misc
- 4 Wetlands Misc
- 3 Wetlands New Cat

Additionally cleaning up the Desert New Cat events by reorganizing lines.

## Why This Is Good For ClanGen

Trade offer:
I give you, more wetlands and desert events
You give me, another thing to add onto things I contributed

## Linked Issues

Helps with lack of event content for the new biomes
Conversations correcting and rewriting the text
- https://discord.com/channels/1003759225522110524/1261072298245619854/1357149595964018830
- https://discord.com/channels/1003759225522110524/1101276997751164948/1354681729767571587
- More in these channels, giant text walls? Probably me!

## Proof of Testing
(No in-game way of testing their functionality yet sadly D:)
The game does run with these changes and passes all the required checks.
![image](https://github.com/user-attachments/assets/b9a61380-4590-4d57-8637-a11cdba5d2b7)

## Changelog/Credits

Changelog || More desert and wetlands events! (Refer to earlier if you wish to include exact numbers)
Credits || flamedash - writing