### PR TITLE
ENHANCEMENT: Event JSON cleanup

### DIFF
--- a/resources/lang/en/cat/eyes.en.json
+++ b/resources/lang/en/cat/eyes.en.json
@@ -21,6 +21,6 @@
         "GREENYELLOW": "green-yellow",
         "BRONZE": "bronze",
         "SILVER": "silver",
-		"ORANGE": "orange"
+	"ORANGE": "orange"
     }
 }

--- a/resources/lang/en/events/death/beach.json
+++ b/resources/lang/en/events/death/beach.json
@@ -1,33 +1,18 @@
 [
     {
         "event_id": "bch_death_drown_any1",
-        "location": [
-            "beach"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "no_body",
-            "all_lives"
-        ],
+        "location": ["beach"],
+        "season": ["any"],
+        "tags": ["no_body", "all_lives"],
         "weight": 20,
         "event_text": "m_c was washed out to sea, never to be seen again.",
         "m_c": {
-            "age": [
-                "adolescent",
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
+            "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
             "dies": true
         },
         "history": [
             {
-                "cats": [
-                    "m_c"
-                ],
+                "cats": ["m_c"],
                 "reg_death": "m_c was washed out to sea.",
                 "lead_death": "{VERB/m_c/were/was} washed out to sea"
             }
@@ -35,12 +20,8 @@
     },
     {
         "event_id": "bch_death_poison_any1",
-        "location": [
-            "beach"
-        ],
-        "season": [
-            "any"
-        ],
+        "location": ["beach"],
+        "season": ["any"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c was poisoned by a sea creature and died.",
@@ -49,9 +30,7 @@
         },
         "history": [
             {
-                "cats": [
-                    "m_c"
-                ],
+                "cats": ["m_c"],
                 "reg_death": "m_c was killed by a poisonous sea creature.",
                 "lead_death": "{VERB/m_c/were/was} killed by a poisonous sea creature"
             }
@@ -59,123 +38,62 @@
     },
     {
         "event_id": "bch_death_drown_any2",
-        "location": [
-            "beach"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "no_body",
-            "all_lives"
-        ],
+        "location": ["beach"],
+        "season": ["any"],
+        "tags": ["no_body", "all_lives"],
         "weight": 20,
         "event_text": "m_c was lost to the sea while trying to save r_c from drowning.",
         "m_c": {
-            "age": [
-                "adolescent",
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "trait": [
-                "bold",
-                "ambitious",
-                "compassionate",
-                "daring",
-                "confident",
-                "fierce",
-                "loyal",
-                "loving",
-                "responsible"
-            ],
+            "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+            "trait": ["bold", "ambitious", "compassionate", "daring", "confident", "fierce", "loyal", "loving", "responsible"],
             "dies": true
         },
         "r_c": {
-            "age": [
-                "any"
-            ],
-            "status": [
-                "any"
-            ]
+            "age": ["any"],
+            "status": ["any"]
         },
         "injury": [
             {
-                "cats": [
-                    "r_c"
-                ],
-                "injuries": [
-                    "water in their lungs", "shock"
-                ]
+                "cats": ["r_c"],
+                "injuries": ["water in their lungs", "shock"]
             }
         ],
         "history": [
             {
-                "cats": [
-                    "m_c"
-                ],
+                "cats": ["m_c"],
                 "reg_death": "m_c was lost to the sea while trying to save r_c.",
                 "lead_death": "{VERB/m_c/were/was} washed out to sea while trying to save r_c"
             }
         ],
         "relationships": [
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "platonic",
-                    "trust",
-                    "respect"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["platonic", "trust", "respect"],
                 "amount": 15
             },
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "dislike"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["dislike"],
                 "amount": -15
             }
         ]
     },
     {
         "event_id": "bch_death_abyss_any1",
-        "location": [
-            "beach:camp3"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "no_body"
-        ],
+        "location": ["beach:camp3"],
+        "season": ["any"],
+        "tags": ["no_body"],
         "weight": 20,
         "event_text": "m_c found {PRONOUN/m_c/self} staring at an odd shadow in the sea. One distracted paw slipped and {PRONOUN/m_c/subject} fell into the waves, where something large and unseen tangled around {PRONOUN/m_c/object}, dragging {PRONOUN/m_c/object} into the abyss.",
         "m_c": {
-            "age": [
-                "adolescent",
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
+            "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
             "dies": true
         },
         "history": [
             {
-                "cats": [
-                    "m_c"
-                ],
+                "cats": ["m_c"],
                 "reg_death": "m_c was taken by a mysterious sea creature.",
                 "lead_death": "{VERB/m_c/were/was} taken by a mysterious sea creature"
             }
@@ -183,346 +101,197 @@
     },
     {
         "event_id": "bch_death_drown_any3",
-        "location": [
-            "beach"
-        ],
-        "season": [
-            "any"
-        ],
-        "sub_type": [
-            "war"
-        ],
+        "location": ["beach"],
+        "season": ["any"],
+        "sub_type": ["war"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c drowned after being pushed out to sea by o_c_n warriors.",
         "m_c": {
-            "status": [
-                "apprentice",
-                "warrior",
-                "leader",
-                "deputy",
-                "mediator",
-                "mediator apprentice",
-                "medicine cat",
-                "medicine cat apprentice"
-            ],
+            "status": ["apprentice", "warrior", "leader", "deputy", "mediator", "mediator apprentice", "medicine cat", "medicine cat apprentice"],
             "dies": true
         },
         "history": [
             {
-                "cats": [
-                    "m_c"
-                ],
+                "cats": ["m_c"],
                 "reg_death": "m_c was pushed out to sea by enemy warriors.",
                 "lead_death": "{VERB/m_c/were/was} pushed out to sea by enemy warriors"
             }
         ],
         "other_clan": {
-            "current_rep": [
-                "hostile"
-            ],
+            "current_rep": ["hostile"],
             "changed": -3
         }
     },
     {
         "event_id": "bch_death_heat_multiapp1",
-        "location": [
-            "beach"
-        ],
-        "season": [
-            "greenleaf",
-            "newleaf",
-            "leaf-fall"
-        ],
-        "tags": [
-            "classic"
-        ],
+        "location": ["beach"],
+        "season": ["greenleaf", "newleaf", "leaf-fall"],
+        "tags": ["classic"],
         "weight": 20,
         "event_text": "m_c had not realized {PRONOUN/m_c/poss} fatal mistake until {PRONOUN/m_c/subject} felt {PRONOUN/m_c/poss} paws get clammy and {PRONOUN/m_c/poss} blood, once burning hot and dry after being out in the sun with no water nor shade, turned cold. As the world turned right-side up and {PRONOUN/m_c/poss} consciousness faded right before {PRONOUN/m_c/poss} eyes, m_c knew {PRONOUN/m_c/subject} {VERB/m_c/were/was} beyond saving, as dehydration and overheating claimed the last bits of {PRONOUN/m_c/poss} strength.",
         "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ],
+            "age": ["adolescent"],
+            "status": ["apprentice"],
             "dies": true
         },
         "history": [
             {
-                "cats": [
-                    "m_c"
-                ],
+                "cats": ["m_c"],
                 "reg_death": "m_c succumbed to dehydration and overheating."
             }
         ]
     },
     {
         "event_id": "bch_death_heat_multiapp2",
-        "location": [
-            "beach"
-        ],
-        "season": [
-            "greenleaf",
-            "newleaf",
-            "leaf-fall"
-        ],
+        "location": ["beach"],
+        "season": ["greenleaf", "newleaf", "leaf-fall"],
         "tags": [],
         "weight": 20,
         "event_text": "r_c noticed m_c hadn't shown up for training again, yet after further prodding realized {PRONOUN/m_c/subject} hadn't been at camp for a few days. However, r_c never expected to find m_c like this: dead and dried out, their tattered pelt lifeless and dull.",
         "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ],
-            "relationship_status": [
-                "app/mentor"
-            ],
+            "age": ["adolescent"],
+            "status": ["apprentice"],
+            "relationship_status": ["app/mentor"],
             "dies": true
         },
         "r_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult"
-            ],
-            "status": [
-                "any"
-            ]
+            "age": ["young adult", "adult", "senior adult"],
+            "status": ["any"]
         },
         "history": [
             {
-                "cats": [
-                    "m_c"
-                ],
+                "cats": ["m_c"],
                 "reg_death": "m_c died due to dehydration and overheating."
             }
         ]
     },
     {
         "event_id": "bch_death_heat_multiapp3",
-        "location": [
-            "beach"
-        ],
-        "season": [
-            "greenleaf",
-            "newleaf",
-            "leaf-fall"
-        ],
+        "location": ["beach"],
+        "season": ["greenleaf", "newleaf", "leaf-fall"],
         "tags": [],
         "weight": 20,
         "event_text": "r_c realizes {PRONOUN/r_c/subject} {VERB/r_c/haven't/hasn't} seen m_c around camp for a few days. Checking {PRONOUN/m_c/poss} favorite spots yields nothing, so r_c decides to go out and search for {PRONOUN/m_c/object} in the Clan's territory. However, r_c could never have expected to find m_c's shriveled-up body, clearly dead for some time now.",
         "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ],
+            "age": ["adolescent"],
+            "status": ["apprentice"],
             "relationship_status": [],
             "dies": true
         },
         "r_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult"
-            ],
-            "status": [
-                "any"
-            ]
+            "age": ["young adult", "adult", "senior adult"],
+            "status": ["any"]
         },
         "history": [
             {
-                "cats": [
-                    "m_c"
-                ],
+                "cats": ["m_c"],
                 "reg_death": "m_c died due to dehydration and heat exhaustion."
             }
         ]
     },
     {
         "event_id": "bch_death_heat_multichild1",
-        "location": [
-            "beach"
-        ],
-        "season": [
-            "greenleaf",
-            "newleaf",
-            "leaf-fall"
-        ],
+        "location": ["beach"],
+        "season": ["greenleaf", "newleaf", "leaf-fall"],
         "tags": [],
         "weight": 20,
         "event_text": "r_c is frantic with worry; m_c, {PRONOUN/r_c/poss} child, hadn't been seen around camp, no matter who {PRONOUN/r_c/subject} asked and where {PRONOUN/r_c/subject} searched. It's not until r_c stumbles across m_c's body, withered under the sun, that {PRONOUN/r_c/subject} {VERB/r_c/realize/realizes} with a despairing sound {PRONOUN/r_c/poss} greatest fears have come true.",
         "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ],
-            "relationship_status": [
-                "child/parent"
-            ],
+            "age": ["adolescent"],
+            "status": ["apprentice"],
+            "relationship_status": ["child/parent"],
             "dies": true
         },
         "r_c": {
-            "age": [
-                "any"
-            ],
-            "status": [
-                "any"
-            ]
+            "age": ["any"],
+            "status": ["any"]
         },
         "history": [
             {
-                "cats": [
-                    "m_c"
-                ],
+                "cats": ["m_c"],
                 "reg_death": "m_c shriveled up under the sun from heat exhaustion and dehydration."
             }
         ]
     },
     {
         "event_id": "bch_death_heat_multiapp4",
-        "location": [
-            "beach"
-        ],
-        "season": [
-            "greenleaf",
-            "newleaf",
-            "leaf-fall"
-        ],
+        "location": ["beach"],
+        "season": ["greenleaf", "newleaf", "leaf-fall"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c couldn't speak, yell for help, or beg StarClan to give {PRONOUN/m_c/object} a sign they were still with {PRONOUN/m_c/object}, {PRONOUN/m_c/poss} tongue having swelled up inside {PRONOUN/m_c/poss} dried mouth. As m_c collapses, feeling {PRONOUN/m_c/poss} body internally shut down because of dehydration and heat exhaustion, {PRONOUN/m_c/subject} {VERB/m_c/pray/prays} that {PRONOUN/m_c/poss} Clanmates locate m_c's body before {PRONOUN/m_c/subject} {VERB/m_c/become/becomes} unrecognizable under the sun.",
         "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ],
+            "age": ["adolescent"],
+            "status": ["apprentice"],
             "dies": true
         },
         "history": [
             {
-                "cats": [
-                    "m_c"
-                ],
+                "cats": ["m_c"],
                 "reg_death": "m_c was claimed by dehydration and heat exhaustion."
             }
         ]
     },
     {
         "event_id": "bch_death_heat_multiapp5",
-        "location": [
-            "beach"
-        ],
-        "season": [
-            "greenleaf",
-            "newleaf",
-            "leaf-fall"
-        ],
+        "location": ["beach"],
+        "season": ["greenleaf", "newleaf", "leaf-fall"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c knew {PRONOUN/m_c/subject} made a mistake, as {PRONOUN/m_c/subject} felt {PRONOUN/m_c/poss} last bits of strength slip away from {PRONOUN/m_c/object} and {PRONOUN/m_c/poss} heart stopped beating. {PRONOUN/m_c/poss/CAP} body was only discovered days later, r_c wailing at the shriveled body of {PRONOUN/r_c/poss} apprentice, who succumbed to heat and dehydration.",
         "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ],
-            "relationship_status": [
-                "app/mentor"
-            ],
+            "age": ["adolescent"],
+            "status": ["apprentice"],
+            "relationship_status": ["app/mentor"],
             "dies": true
         },
         "r_c": {
-            "age": [
-                "any"
-            ],
-            "status": [
-                "any"
-            ]
+            "age": ["any"],
+            "status": ["any"]
         },
         "history": [
             {
-                "cats": [
-                    "m_c"
-                ],
+                "cats": ["m_c"],
                 "reg_death": "m_c succumbed to dehydration and heat exhaustion."
             }
         ]
     },
     {
         "event_id": "bch_death_heat_multiapp6",
-        "location": [
-            "beach"
-        ],
-        "season": [
-            "greenleaf",
-            "newleaf",
-            "leaf-fall"
-        ],
+        "location": ["beach"],
+        "season": ["greenleaf", "newleaf", "leaf-fall"],
         "tags": [],
         "weight": 20,
         "event_text": "It was purely accidental that r_c stumbled across m_c's decaying body in the sunlight, simply hoping to stretch {PRONOUN/r_c/poss} paws outside of camp. Now, r_c must explain to m_c's remaining family or friends that {PRONOUN/m_c/subject} {VERB/m_c/are/is} never returning home, having been caught unprepared under the treacherous sun.",
         "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ],
+            "age": ["adolescent"],
+            "status": ["apprentice"],
             "relationship_status": [],
             "dies": true
         },
         "r_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult"
-            ],
-            "status": [
-                "any"
-            ]
+            "age": ["young adult", "adult", "senior adult"],
+            "status": ["any"]
         },
         "history": [
             {
-                "cats": [
-                    "m_c"
-                ],
+                "cats": ["m_c"],
                 "reg_death": "m_c was caught outside unprepared for the heat, dying because of dehydration and overheating."
             }
         ]
     },
     {
         "event_id": "bch_death_heat_multichild2",
-        "location": [
-            "beach"
-        ],
-        "season": [
-            "greenleaf",
-            "newleaf",
-            "leaf-fall"
-        ],
+        "location": ["beach"],
+        "season": ["greenleaf", "newleaf", "leaf-fall"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c never meant to meet StarClan this way, rotting away under the sun after fainting from dehydration, heat exhaustion, and overexertion. r_c tragically discovers {PRONOUN/m_c/poss} body, unable to stop {PRONOUN/r_c/poss} desperate wails at the sight of {PRONOUN/r_c/poss} child's body.",
         "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ],
-            "relationship_status": [
-                "child/parent"
-            ],
+            "age": ["adolescent"],
+            "status": ["apprentice"],
+            "relationship_status": ["child/parent"],
             "dies": true
         },
         "r_c": {
@@ -531,9 +300,7 @@
         },
         "history": [
             {
-                "cats": [
-                    "m_c"
-                ],
+                "cats": ["m_c"],
                 "reg_death": "m_c tragically died due to dehydration and overheating."
             }
         ]
@@ -552,32 +319,18 @@
         "weight": 20,
         "event_text": "r_c's mournful sounds pierced through c_n's territory as {PRONOUN/r_c/subject} stumbled on the lifeless, decaying corpse of m_c. m_c had disappeared from camp days ago, having not returned, but only now did r_c understand why {PRONOUN/r_c/poss} child didn't come back home: m_c was caught out in the treacherous sun, ill-prepared, succumbing to dehydration and exhaustion.",
         "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ],
-            "relationship_status": [
-                "child/parent"
-            ],
+            "age": ["adolescent"],
+            "status": ["apprentice"],
+            "relationship_status": ["child/parent"],
             "dies": true
         },
         "r_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult"
-            ],
-            "status": [
-                "any"
-            ]
+            "age": ["young adult", "adult", "senior adult"],
+            "status": ["any"]
         },
         "history": [
             {
-                "cats": [
-                    "m_c"
-                ],
+                "cats": ["m_c"],
                 "reg_death": "m_c died because of overheating and dehydration.",
                 "lead_death": "died of overheating and dehydration"
             }
@@ -585,407 +338,185 @@
     },
     {
         "event_id": "bch_death_heat_multiromance1",
-        "location": [
-            "beach"
-        ],
-        "season": [
-            "greenleaf",
-            "newleaf",
-            "leaf-fall"
-        ],
+        "location": ["beach"],
+        "season": ["greenleaf", "newleaf", "leaf-fall"],
         "tags": ["romantic"],
         "weight": 20,
         "event_text": "m_c asked r_c to meet them at their unique spot, which r_c readily accepted and journeyed through the territory. Yet, with a heartbroken sound that clawed its way out of r_c's throat, {PRONOUN/r_c/subject} {VERB/r_c/stumble/stumbles} upon m_c's body, passing from dehydration; r_c curses m_c for tainting what could have been a good memory of {PRONOUN/r_c/inposs}.",
         "m_c": {
-            "age": [
-                "any"
-            ],
-            "status": [
-                "any"
-            ],
+            "age": ["any"],
+            "status": ["any"],
             "relationship_status": [],
             "dies": true
         },
         "r_c": {
-            "age": [
-                "any"
-            ],
-            "status": [
-                "any"
-            ],
-            "trait": [
-                "ambitious",
-                "bloodthirsty",
-                "cold",
-                "fierce",
-                "shameless",
-                "strict",
-                "troublesome",
-                "vengeful"
-            ]
+            "age": ["any"],
+            "status": ["any"],
+            "trait": ["ambitious", "bloodthirsty", "cold", "fierce", "shameless", "strict", "troublesome", "vengeful"]
         },
         "history": [
             {
-                "cats": [
-                    "m_c"
-                ],
+                "cats": ["m_c"],
                 "reg_death": "m_c was caught unprepared in the heat and died of dehydration and heat exhaustion.",
                 "lead_death": "{VERB/m_c/were/was} caught unprepared in the heat and died of dehydration and heat exhaustion"
             }
         ],
         "relationships": [
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "romantic"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["romantic"],
                 "amount": -5
             }
         ]
     },
     {
         "event_id": "bch_death_heat_multiromance2",
-        "location": [
-            "beach"
-        ],
-        "season": [
-            "greenleaf",
-            "newleaf",
-            "leaf-fall"
-        ],
+        "location": ["beach"],
+        "season": ["greenleaf", "newleaf", "leaf-fall"],
         "tags": ["romantic"],
         "weight": 20,
         "event_text": "m_c had invited r_c out days earlier, aiming to train and grow closer together. However, when r_c arrived, m_c never showed up; m_c wasn't seen around camp, nor had {PRONOUN/m_c/subject} been to training. It wasn't until r_c stumbles upon {PRONOUN/m_c/poss} body, the former succumbing to dehydration and exhaustion, that {PRONOUN/r_c/subject} {VERB/r_c/understand/understands} why.",
         "m_c": {
-            "status": [
-                "apprentice"
-            ],
+            "status": ["apprentice"],
             "dies": true
         },
         "r_c": {
-            "age": [
-                "adolescent",
-                "young adult"
-            ],
-            "status": [
-                "apprentice"
-            ]
+            "age": ["adolescent", "young adult"],
+            "status": ["apprentice"]
         },
         "history": [
             {
-                "cats": [
-                    "m_c"
-                ],
+                "cats": ["m_c"],
                 "reg_death": "m_c was ill-prepared for the heat and succumbed to dehydration."
             }
         ]
     },
     {
         "event_id": "bch_death_murder_cliffdrop1",
-        "location": [
-            "beach"
-        ],
-        "season": [
-            "any"
-        ],
-        "sub_type": [
-            "murder"
-        ],
-        "tags": [
-            "all_lives",
-            "no_body"
-        ],
+        "location": ["beach"],
+        "season": ["any"],
+        "sub_type": ["murder"],
+        "tags": ["all_lives", "no_body"],
         "weight": 40,
         "event_text": "m_c was pushed off a cliff into the rock-filled waves below. r_c stood at the edge, eyes narrowed and unblinking, until the body slid beneath the waves.",
         "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
+            "age": ["young adult", "adult", "senior adult", "senior"],
             "relationship_status": [],
-            "trait": [
-                "adventurous",
-                "daring",
-                "bold",
-                "childish",
-                "confident",
-                "playful"
-            ],
+            "trait": ["adventurous", "daring", "bold", "childish", "confident", "playful"],
             "dies": true
         },
         "r_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult"
-            ],
-            "status": [
-                "any"
-            ],
-            "skill": [
-                "HUNTER,2",
-                "CLEVER,2",
-                "SENSE,2",
-                "INSIGHTFUL,1"
-            ],
-            "trait": [
-                "bloodthirsty",
-                "ambitious",
-                "bold",
-                "careful",
-                "calm",
-                "cold",
-                "fierce",
-                "insecure",
-                "nervous",
-                "responsible",
-                "sneaky",
-                "strict",
-                "vengeful",
-                "wise"
-            ]
+            "age": ["young adult", "adult", "senior adult"],
+            "status": ["any"],
+            "skill": ["HUNTER,2", "CLEVER,2", "SENSE,2", "INSIGHTFUL,1"],
+            "trait": ["bloodthirsty", "ambitious", "bold", "careful", "calm", "cold", "fierce", "insecure", "nervous", "responsible", "sneaky", "strict", "vengeful", "wise"]
         },
         "history": [
             {
-                "cats": [
-                    "m_c"
-                ],
+                "cats": ["m_c"],
                 "reg_death": "m_c died when {PRONOUN/m_c/subject} {VERB/m_c/were/was} shoved off a cliff by r_c",
                 "lead_death": "{VERB/m_c/were/was} shoved off a cliff by r_c"
             }
         ],
         "relationships": [
             {
-                "cats_from": [
-                    "m_c"
-                ],
-                "cats_to": [
-                    "r_c"
-                ],
+                "cats_from": ["m_c"],
+                "cats_to": ["r_c"],
                 "mutual": true,
-                "values": [
-                    "dislike"
-                ],
+                "values": ["dislike"],
                 "amount": 25
             },
             {
-                "cats_from": [
-                    "m_c"
-                ],
-                "cats_to": [
-                    "r_c"
-                ],
+                "cats_from": ["m_c"],
+                "cats_to": ["r_c"],
                 "mutual": false,
-                "values": [
-                    "trust"
-                ],
+                "values": ["trust"],
                 "amount": -25
             }
         ]
     },
     {
         "event_id": "bch_death_murder_cliffdrop2",
-        "location": [
-            "beach"
-        ],
-        "season": [
-            "any"
-        ],
-        "sub_type": [
-            "murder"
-        ],
-        "tags": [
-            "all_lives",
-            "no_body"
-        ],
+        "location": ["beach"],
+        "season": ["any"],
+        "sub_type": ["murder"],
+        "tags": ["all_lives", "no_body"],
         "weight": 40,
         "event_text": "m_c was pushed off a cliff into the rock-filled waves below. r_c insists it was an accident and that m_c slipped on loose shale.",
         "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "trait": [
-                "adventurous",
-                "daring",
-                "bold",
-                "childish",
-                "confident",
-                "playful"
-            ],
+            "age": ["young adult", "adult", "senior adult", "senior"],
+            "trait": ["adventurous", "daring", "bold", "childish", "confident", "playful"],
             "dies": true
         },
         "r_c": {
-            "age": [
-                "adult",
-                "young adult",
-                "senior adult"
-            ],
-            "status": [
-                "any"
-            ],
-            "skill": [
-                "HUNTER,2",
-                "CLEVER,2",
-                "SENSE,2",
-                "INSIGHTFUL,1"
-            ],
-            "trait": [
-                "bloodthirsty",
-                "ambitious",
-                "bold",
-                "careful",
-                "calm",
-                "cold",
-                "fierce",
-                "insecure",
-                "nervous",
-                "responsible",
-                "sneaky",
-                "strict",
-                "vengeful",
-                "wise"
-            ]
+            "age": ["adult", "young adult", "senior adult"],
+            "status": ["any"],
+            "skill": ["HUNTER,2", "CLEVER,2", "SENSE,2", "INSIGHTFUL,1"],
+            "trait": ["ambitious", "bloodthirsty", "bold", "careful", "calm", "cold", "fierce", "insecure", "nervous", "responsible", "sneaky", "strict", "vengeful", "wise"]
         },
         "history": [
             {
-                "cats": [
-                    "m_c"
-                ],
+                "cats": ["m_c"],
                 "reg_death": "m_c died when {PRONOUN/m_c/subject} {VERB/m_c/were/was} shoved off a cliff by r_c",
                 "lead_death": "{VERB/m_c/were/was} shoved off a cliff by r_c"
             }
         ],
         "relationships": [
             {
-                "cats_from": [
-                    "m_c"
-                ],
-                "cats_to": [
-                    "r_c"
-                ],
+                "cats_from": ["m_c"],
+                "cats_to": ["r_c"],
                 "mutual": true,
-                "values": [
-                    "dislike"
-                ],
+                "values": ["dislike"],
                 "amount": 25
             },
             {
-                "cats_from": [
-                    "m_c"
-                ],
-                "cats_to": [
-                    "r_c"
-                ],
+                "cats_from": ["m_c"],
+                "cats_to": ["r_c"],
                 "mutual": false,
-                "values": [
-                    "trust"
-                ],
+                "values": ["trust"],
                 "amount": -25
             }
         ]
     },
     {
         "event_id": "bch_death_murder_anyleader1",
-        "location": [
-            "beach"
-        ],
-        "season": [
-            "any"
-        ],
-        "sub_type": [
-            "murder"
-        ],
-        "tags": [
-            "all_lives",
-            "no_body"
-        ],
+        "location": ["beach"],
+        "season": ["any"],
+        "sub_type": ["murder"],
+        "tags": ["all_lives", "no_body"],
         "weight": 40,
         "event_text": "Usually m_c is well aware of when the high tide will come in, but today {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} distracted and run ragged with Clan business. Trapped against the cliffs with treacherous waves pulling at {PRONOUN/m_c/poss} paws, the last thing {PRONOUN/m_c/subject} {VERB/m_c/see/sees} is the smug grin of r_c sat high above on the rocks.",
         "m_c": {
-            "status": [
-                "leader"
-            ],
-            "trait": [
-                "responsible",
-                "loyal",
-                "lonesome"
-            ],
+            "status": ["leader"],
+            "trait": ["responsible", "loyal", "lonesome"],
             "dies": true
         },
         "r_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult"
-            ],
-            "status": [
-                "any"
-            ],
-            "skill": [
-                "HUNTER,2",
-                "CLEVER,2",
-                "SENSE,2",
-                "SPEAKER,2"
-            ],
-            "trait": [
-                "ambitious",
-                "bold",
-                "careful",
-                "calm",
-                "cold",
-                "confident",
-                "daring",
-                "lonesome",
-                "shameless",
-                "sneaky",
-                "strange",
-                "vengeful",
-                "wise"
-            ]
+            "age": ["young adult", "adult", "senior adult"],
+            "status": ["any"],
+            "skill": ["HUNTER,2", "CLEVER,2", "SENSE,2", "SPEAKER,2"],
+            "trait": ["ambitious", "bold", "careful", "calm", "cold", "confident", "daring", "lonesome", "shameless", "sneaky", "strange", "vengeful", "wise"]
         },
         "history": [
             {
-                "cats": [
-                    "m_c"
-                ],
+                "cats": ["m_c"],
                 "lead_death": "{VERB/m_c/were/was} trapped in the tides by r_c"
             }
         ],
         "relationships": [
             {
-                "cats_from": [
-                    "m_c"
-                ],
-                "cats_to": [
-                    "r_c"
-                ],
+                "cats_from": ["m_c"],
+                "cats_to": ["r_c"],
                 "mutual": true,
-                "values": [
-                    "dislike"
-                ],
+                "values": ["dislike"],
                 "amount": 25
             },
             {
-                "cats_from": [
-                    "m_c"
-                ],
-                "cats_to": [
-                    "r_c"
-                ],
+                "cats_from": ["m_c"],
+                "cats_to": ["r_c"],
                 "mutual": false,
-                "values": [
-                    "trust"
-                ],
+                "values": ["trust"],
                 "amount": -25
             }
         ]

--- a/resources/lang/en/events/death/forest.json
+++ b/resources/lang/en/events/death/forest.json
@@ -2,10 +2,8 @@
     {
         "event_id": "fst_death_war_any1",
         "location": ["forest"],
-        "season": [
-            "any"
-        ],
-        "sub_type": [ "war" ],
+        "season": ["any"],
+        "sub_type": ["war"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c was killed by a falling branch during a battle in a heavily wooded area of the forest.",
@@ -24,22 +22,13 @@
     {
         "event_id": "fst_death_dog_any1",
         "location": ["forest"],
-        "season": [
-            "any"
-        ],
+        "season": ["any"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c was found dead underneath an oak tree with dog scent wreathing around {PRONOUN/m_c/object}.",
         "m_c": {
-            "not_skill": [
-                "CLIMBER,2"
-            ],
-            "trait": [
-                "nervous",
-                "daring",
-                "ambitious",
-                "oblivious"
-            ],
+            "not_skill": ["CLIMBER,2"],
+            "trait": ["nervous", "daring", "ambitious","oblivious"],
             "dies": true
         },
         "history": [
@@ -53,9 +42,7 @@
     {
         "event_id": "fst_death_tree_any1",
         "location": ["forest"],
-        "season": [
-            "any"
-        ],
+        "season": ["any"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c was crushed when a tree fell into camp.",
@@ -73,49 +60,43 @@
     {
         "event_id": "gen_death_owl_anylead3",
         "location": ["forest:camp1_camp2_camp4"],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "no_body"
-        ],
+        "season": ["any"],
+        "tags": ["no_body"],
         "weight": 20,
         "event_text": "m_c was carried off by an owl, never to be seen again.",
         "m_c": {
-            "age": [
-                "kitten", "adolescent"
-            ],
+            "age": ["kitten", "adolescent"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c was carried away by an owl."
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_rook_any1",
         "location": ["forest:camp2"],
-        "season": [
-            "any"
-        ],
+        "season": ["any"],
         "tags": ["no_body"],
         "weight": 20,
         "event_text": "r_c, guarding camp, yowls a warning as {PRONOUN/r_c/subject} {VERB/r_c/spot/spots} a circling shadow, right above m_c. r_c starts sprinting to m_c's position but can't get there in time, not before m_c is carried high into the sky by a rook.",
         "m_c": {
-            "age": [ "kitten", "adolescent"],
-            "status": [ "any" ],
+            "age": ["kitten", "adolescent"],
+            "status": ["any"],
             "dies": true
         },
         "r_c": {
             "age": ["any"],
             "status": ["apprentice", "warrior", "deputy"],
-            "not_skill": [
-                "RUNNER,2"
-            ]
+            "not_skill": ["RUNNER,2"]
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c was grabbed by a rook, never to be seen again."
-        }]
+            }
+        ]
     }
 ]

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -1,121 +1,75 @@
 [
     {
         "event_id": "gen_death_murder_any1",
-        "location": [ "any" ],
-        "season": [
-            "any"
-        ],
+        "location": ["any"],
+        "season": ["any"],
         "sub_type": ["murder"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c was murdered. The culprit is unknown.",
         "m_c": {
-            "status": [
-                "kitten",
-                "apprentice",
-                "warrior",
-                "deputy",
-                "medicine cat apprentice",
-                "medicine cat",
-                "mediator apprentice",
-                "mediator",
-                "elder"
-            ],
+            "status": ["kitten", "apprentice", "warrior", "deputy", "medicine cat apprentice", "medicine cat", "mediator apprentice", "mediator", "elder"],
             "dies": true
         },
         "r_c": {
             "age": ["adolescent", "young adult", "adult", "senior adult"],
-            "status": [ "any" ]
+            "status": ["any"]
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c was secretly murdered by r_c."
-        }],
+            }
+        ],
         "relationships": [
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "platonic"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["platonic"],
                 "amount": -15
             },
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "dislike"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["dislike"],
                 "amount": 15
             }
         ]
     },
     {
         "event_id": "gen_death_murder_any2",
-        "location": [ "any" ],
-        "season": [
-            "any"
-        ],
-        "sub_type": [ "murder" ],
+        "location": ["any"],
+        "season": ["any"],
+        "sub_type": ["murder"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c was murdered. r_c stands over {PRONOUN/m_c/object}, blood dripping from {PRONOUN/r_c/poss} pelt.",
         "m_c": {
             "age": ["any"],
-            "status": [
-                "kitten",
-                "apprentice",
-                "warrior",
-                "deputy",
-                "medicine cat apprentice",
-                "medicine cat",
-                "mediator apprentice",
-                "mediator",
-                "elder"
-            ],
+            "status": ["kitten", "apprentice", "warrior", "deputy", "medicine cat apprentice", "medicine cat", "mediator apprentice", "mediator", "elder"],
             "dies": true
         },
         "r_c": {
             "age": ["adolescent", "young adult", "adult", "senior adult"],
-            "skill": [
-                "FIGHTER,2"
-            ]
+            "skill": ["FIGHTER,2"]
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c was murdered by r_c."
-        }],
+            }
+        ],
         "relationships": [
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "platonic"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["platonic"],
                 "amount": -15
             },
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "dislike"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["dislike"],
                 "amount": 15
             }
         ]
@@ -123,66 +77,38 @@
     {
         "event_id": "gen_death_murder_any3",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
-        "sub_type":  [
-            "murder"
-        ],
+        "season": ["any"],
+        "sub_type":  ["murder"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c was murdered by r_c in cold blood.",
         "m_c": {
-            "age": [ "any" ],
-            "status": [
-                "kitten",
-                "apprentice",
-                "warrior",
-                "deputy",
-                "medicine cat apprentice",
-                "medicine cat",
-                "mediator apprentice",
-                "mediator",
-                "elder"
-            ],
-            "not_skill": [
-                "FIGHTER,2"
-            ],
+            "age": ["any"],
+            "status": ["kitten", "apprentice", "warrior", "deputy", "medicine cat apprentice", "medicine cat", "mediator apprentice", "mediator", "elder"],
+            "not_skill": ["FIGHTER,2"],
             "dies": true
         },
         "r_c": {
-            "age": [ "adolescent", "young adult", "adult", "senior adult" ],
-            "skill": [
-                "FIGHTER,2"
-            ]
+            "age": ["adolescent", "young adult", "adult", "senior adult"],
+            "skill": ["FIGHTER,2"]
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c was murdered by r_c."
-        }],
+            }
+        ],
         "relationships": [
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "platonic"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["platonic"],
                 "amount": -15
             },
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "dislike"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["dislike"],
                 "amount": 15
             }
         ]
@@ -190,65 +116,38 @@
     {
         "event_id": "gen_death_murder_any4",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
-        "sub_type": [ "murder" ],
+        "season": ["any"],
+        "sub_type": ["murder"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c was murdered by r_c in cold blood. r_c has made the death look accidental.",
         "m_c": {
-            "status": [
-                "kitten",
-                "apprentice",
-                "warrior",
-                "deputy",
-                "medicine cat apprentice",
-                "medicine cat",
-                "mediator apprentice",
-                "mediator",
-                "elder"
-            ],
-            "not_skill": [
-                "FIGHTER,2"
-            ],
+            "status": ["kitten", "apprentice", "warrior", "deputy", "medicine cat apprentice", "medicine cat", "mediator apprentice", "mediator", "elder"],
+            "not_skill": ["FIGHTER,2"],
             "dies": true
         },
         "r_c": {
-            "age": [ "adolescent", "young adult", "adult", "senior adult" ],
-            "status": [ "any" ],
-            "skill": [
-                "FIGHTER,2",
-                "CLEVER,3"
-            ]
+            "age": ["adolescent", "young adult", "adult", "senior adult"],
+            "status": ["any"],
+            "skill": ["FIGHTER,2", "CLEVER,3"]
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c was secretly murdered by r_c, who made the death look accidental."
-        }],
+            }
+        ],
         "relationships": [
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "platonic"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["platonic"],
                 "amount": -15
             },
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "dislike"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["dislike"],
                 "amount": 15
             }
         ]
@@ -256,62 +155,37 @@
     {
         "event_id": "gen_death_murder_anymed1",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
-        "sub_type": [ "murder" ],
+        "season": ["any"],
+        "sub_type": ["murder"],
         "tags": [],
         "weight": 30,
         "event_text": "r_c killed m_c by feeding {PRONOUN/m_c/object} deathberries.",
         "m_c": {
-            "status": [
-                "kitten",
-                "apprentice",
-                "warrior",
-                "deputy",
-                "medicine cat apprentice",
-                "medicine cat",
-                "mediator apprentice",
-                "mediator",
-                "elder"
-            ],
-            "not_skill": [
-                "CLEVER,2"
-            ],
+            "status": ["kitten", "apprentice", "warrior", "deputy", "medicine cat apprentice", "medicine cat", "mediator apprentice", "mediator", "elder"],
+            "not_skill": ["CLEVER,2"],
             "dies": true
         },
         "r_c": {
-            "age": [ "any" ],
-            "status": [ "medicine cat apprentice", "medicine cat" ]
+            "age": ["any"],
+            "status": ["medicine cat apprentice", "medicine cat"]
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c was murdered by r_c, who fed {PRONOUN/m_c/object} deathberries."
-        }],
+            }
+        ],
         "relationships": [
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "dislike"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["dislike"],
                 "amount": 15
             },
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "platonic",
-                    "comfort"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["platonic", "comfort"],
                 "amount": -15
             }
         ]
@@ -319,63 +193,38 @@
     {
         "event_id": "gen_death_murder_anymed2",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
-        "sub_type": [ "murder" ],
+        "season": ["any"],
+        "sub_type": ["murder"],
         "tags": [],
         "weight": 30,
         "event_text": "r_c killed m_c by feeding {PRONOUN/m_c/object} foxglove seeds.",
         "m_c": {
-            "age": [ "any" ],
-            "status": [
-                "kitten",
-                "apprentice",
-                "warrior",
-                "deputy",
-                "medicine cat apprentice",
-                "medicine cat",
-                "mediator apprentice",
-                "mediator",
-                "elder"
-            ],
-            "not_skill": [
-                "CLEVER,2"
-            ],
+            "age": ["any"],
+            "status": ["kitten", "apprentice", "warrior", "deputy", "medicine cat apprentice", "medicine cat", "mediator apprentice", "mediator", "elder"],
+            "not_skill": ["CLEVER,2"],
             "dies": true
         },
         "r_c": {
-            "age": [ "any" ],
-            "status": [ "medicine cat apprentice", "medicine cat" ]
+            "age": ["any"],
+            "status": ["medicine cat apprentice", "medicine cat"]
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c was murdered by r_c, who fed {PRONOUN/m_c/object} foxglove seeds."
-        }],
+            }
+        ],
         "relationships": [
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "dislike"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["dislike"],
                 "amount": 15
             },
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "platonic",
-                    "comfort"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["platonic","comfort"],
                 "amount": -15
             }
         ]
@@ -383,63 +232,38 @@
     {
         "event_id": "gen_death_murder_anymed3",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
-        "sub_type": [ "murder" ],
+        "season": ["any"],
+        "sub_type": ["murder"],
         "tags": [],
         "weight": 30,
         "event_text": "r_c killed m_c by feeding {PRONOUN/m_c/object} nightshade berries.",
         "m_c": {
-            "age": [ "any" ],
-            "status": [
-                "kitten",
-                "apprentice",
-                "warrior",
-                "deputy",
-                "medicine cat apprentice",
-                "medicine cat",
-                "mediator apprentice",
-                "mediator",
-                "elder"
-            ],
-            "not_skill": [
-                "CLEVER,2"
-            ],
+            "age": ["any"],
+            "status": ["kitten", "apprentice", "warrior", "deputy", "medicine cat apprentice", "medicine cat", "mediator apprentice", "mediator", "elder"],
+            "not_skill": ["CLEVER,2"],
             "dies": true
         },
         "r_c": {
-            "age": [ "any" ],
-            "status": ["medicine cat apprentice", "medicine cat" ]
+            "age": ["any"],
+            "status": ["medicine cat apprentice", "medicine cat"]
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c was murdered by r_c, who fed {PRONOUN/m_c/object} nightshade berries."
-        }],
+            }
+        ],
         "relationships": [
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "dislike"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["dislike"],
                 "amount": 15
             },
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "platonic",
-                    "comfort"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["platonic", "comfort"],
                 "amount": -15
             }
         ]
@@ -447,63 +271,38 @@
     {
         "event_id": "gen_death_murder_anymed4",
         "location": ["forest", "plains", "beach"],
-        "season": [
-            "any"
-        ],
-        "sub_type": [ "murder" ],
+        "season": ["any"],
+        "sub_type": ["murder"],
         "tags": [],
         "weight": 30,
         "event_text": "r_c killed m_c by feeding {PRONOUN/m_c/object} water hemlock.",
         "m_c": {
-            "age": [ "any" ],
-            "status": [
-                "kitten",
-                "apprentice",
-                "warrior",
-                "deputy",
-                "medicine cat apprentice",
-                "medicine cat",
-                "mediator apprentice",
-                "mediator",
-                "elder"
-            ],
-            "not_skill": [
-                "CLEVER,2"
-            ],
+            "age": ["any"],
+            "status": ["kitten", "apprentice", "warrior", "deputy", "medicine cat apprentice", "medicine cat", "mediator apprentice", "mediator", "elder"],
+            "not_skill": ["CLEVER,2"],
             "dies": true
         },
         "r_c": {
-            "age": [ "any" ],
-            "status": [ "medicine cat apprentice", "medicine cat" ]
+            "age": ["any"],
+            "status": ["medicine cat apprentice", "medicine cat"]
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c was murdered by r_c, who fed {PRONOUN/m_c/object} water hemlock."
-        }],
+            }
+        ],
         "relationships": [
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "dislike"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["dislike"],
                 "amount": 15
             },
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "platonic",
-                    "comfort"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["platonic","comfort"],
                 "amount": -15
             }
         ]
@@ -511,63 +310,38 @@
     {
         "event_id": "gen_death_murder_anymed5",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
-        "sub_type": [ "murder" ],
+        "season": ["any"],
+        "sub_type": ["murder"],
         "tags": [],
         "weight": 30,
         "event_text": "r_c killed m_c by consciously giving {PRONOUN/m_c/object} the wrong herbs.",
         "m_c": {
-            "age": [ "any" ],
-            "status": [
-                "kitten",
-                "apprentice",
-                "warrior",
-                "deputy",
-                "medicine cat apprentice",
-                "medicine cat",
-                "mediator apprentice",
-                "mediator",
-                "elder"
-            ],
-            "not_skill": [
-                "CLEVER,2"
-            ],
+            "age": ["any"],
+            "status": ["kitten", "apprentice", "warrior", "deputy", "medicine cat apprentice", "medicine cat", "mediator apprentice", "mediator", "elder"],
+            "not_skill": ["CLEVER,2"],
             "dies": true
         },
         "r_c": {
-            "age": [ "any" ],
-            "status": [ "medicine cat apprentice", "medicine cat" ]
+            "age": ["any"],
+            "status": ["medicine cat apprentice", "medicine cat"]
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c was murdered by r_c, who purposefully fed {PRONOUN/m_c/object} the wrong herbs."
-        }],
+            }
+        ],
         "relationships": [
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "dislike"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["dislike"],
                 "amount": 15
             },
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "platonic",
-                    "comfort"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["platonic", "comfort"],
                 "amount": -15
             }
         ]
@@ -575,40 +349,28 @@
     {
         "event_id": "gen_death_fox_any1",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
+        "season": ["any"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c was found dead near a fox den.",
         "m_c": {
-            "age": [ "adolescent", "young adult", "adult", "senior adult"],
-            "not_skill": [
-                "FIGHTER,2"
-            ],
-            "trait": [
-                "daring",
-                "adventurous",
-                "bold",
-                "fierce",
-                "loyal",
-                "lonesome",
-                "troublesome"
-            ],
+            "age": ["adolescent", "young adult", "adult", "senior adult"],
+            "not_skill": ["FIGHTER,2"],
+            "trait": ["adventurous", "bold", "daring", "fierce", "loyal", "lonesome", "troublesome"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c was killed by a fox.",
             "lead_death": "{VERB/m_c/were/was} killed by a fox"
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_snake_any1",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
+        "season": ["any"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c was bitten by a snake and succumbed to the venom.",
@@ -616,83 +378,65 @@
             "age": ["adolescent", "young adult", "adult", "senior adult"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c was killed by a snake.",
             "lead_death": "{VERB/m_c/were/was} bitten by a snake"
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_snake_any2",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
+        "season": ["any"],
         "weight": 20,
         "event_text": "m_c saved r_c from a snake but was bitten in the process. The venom killed {PRONOUN/m_c/object}.",
         "m_c": {
-            "age": [ "adolescent", "young adult", "adult", "senior adult", "senior"],
-            "status": [ "any" ],
-            "trait": [
-                "bold",
-                "ambitious",
-                "compassionate",
-                "daring",
-                "confident",
-                "fierce",
-                "loyal",
-                "loving",
-                "responsible",
-                "righteous",
-                "vengeful"
-            ],
+            "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+            "status": ["any"],
+            "trait": ["ambitious", "bold", "compassionate", "confident", "daring", "fierce", "loyal", "loving", "responsible", "righteous", "vengeful"],
             "dies": true
         },
         "r_c": {
-            "age": [ "newborn", "kitten" ],
-            "status": [ "any" ]
+            "age": ["newborn", "kitten"],
+            "status": ["any"]
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c was killed by a snake while saving a kit.",
             "lead_death": "died saving a kit from a snake"
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_missing_any1",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "all_lives"
-        ],
+        "season": ["any"],
+        "tags": ["all_lives"],
         "weight": 20,
         "event_text": "m_c went missing and was found dead out in the territory.",
         "m_c": {
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c went missing and was found dead.",
             "lead_death": "went missing and {VERB/m_c/were/was} found dead"
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_border_any1",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "all_lives"
-        ],
+        "season": ["any"],
+        "tags": ["all_lives"],
         "weight": 20,
         "event_text": "m_c was found dead near the o_c_n border.",
         "m_c": {
-            "not_skill": [
-                "FIGHTER,2"
-            ],
+            "not_skill": ["FIGHTER,2"],
             "dies": true
         },
         "history": [
@@ -700,7 +444,7 @@
             "cats": ["m_c"],
             "reg_death": "m_c was found dead near the o_c_n border.",
             "lead_death": "to mysterious circumstances near the o_c_n border"
-        }
+            }
         ],
         "other_clan": {
             "current_rep": ["any"],
@@ -710,9 +454,7 @@
     {
         "event_id": "gen_death_siege_any1",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
+        "season": ["any"],
         "sub_type": ["war"],
         "tags": [],
         "weight": 20,
@@ -723,163 +465,102 @@
         "r_c": {
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c", "r_c"],
             "reg_death": "This cat died when o_c_n tried to break into camp.",
             "lead_death": "tried to defend the Clan from o_c_n"
-        }],
+            }
+        ],
         "other_clan": {
-            "current_rep": [
-                "hostile"
-            ],
+            "current_rep": ["hostile"],
             "changed": -3
         }
     },
     {
         "event_id": "gen_death_siege_any2",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
+        "season": ["any"],
         "tags": [],
         "weight": 20,
         "event_text": "o_c_n attempted to break into the camp. m_c died defending the nursery, r_c huddled beneath {PRONOUN/m_c/poss} cooling body.",
         "m_c": {
             "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
-            "trait": [
-                "vengeful",
-                "bloodthirsty",
-                "loving",
-                "bold",
-                "confident",
-                "daring",
-                "faithful",
-                "fierce",
-                "loyal",
-                "responsible",
-                "righteous"
-            ],
+            "trait": ["vengeful", "bloodthirsty", "loving", "bold", "confident", "daring", "faithful", "fierce", "loyal", "responsible", "righteous"],
             "dies": true
         },
         "r_c": {
-            "age": [
-                "newborn",
-                "kitten"
-            ],
-            "status": [ "any" ]
+            "age": ["newborn", "kitten"],
+            "status": ["any"]
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c died defending r_c from o_c_n warriors.",
             "lead_death": "died defending the nursery"
-        }],
+            }
+        ],
         "relationships": [
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "platonic",
-                    "respect"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["platonic", "respect"],
                 "amount": 15
             },
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "trust"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["trust"],
                 "amount": 25
             },
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "dislike"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["dislike"],
                 "amount": -15
             }
         ],
         "other_clan": {
-            "current_rep": [
-                "hostile"
-            ],
+            "current_rep": ["hostile"],
             "changed": -3
         }
     },
     {
         "event_id": "gen_death_fire_any1",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
+        "season": ["any"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c was burnt alive while trying to save r_c from a fire.",
         "m_c": {
             "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
-            "status": [ "any" ],
+            "status": ["any"],
             "relationship_status": [],
-            "trait": [
-                "bold",
-                "ambitious",
-                "compassionate",
-                "daring",
-                "confident",
-                "fierce",
-                "loyal",
-                "loving",
-                
-                "responsible"
-            ],
+            "trait": ["bold", "ambitious", "compassionate", "daring", "confident", "fierce", "loyal", "loving", "responsible"],
             "dies": true
         },
         "r_c": {
-            "age": [ "any" ],
-            "status": [ "any" ]
+            "age": ["any"],
+            "status": ["any"]
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c was killed in a fire while trying to save r_c.",
             "lead_death": "{VERB/m_c/were/was} burnt alive saving r_c"
-        }],
+            }
+        ],
         "relationships": [
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "platonic",
-                    "trust",
-                    "respect"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["platonic", "trust", "respect"],
                 "amount": 15
             },
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "dislike"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["dislike"],
                 "amount": -15
             }
         ]
@@ -887,258 +568,218 @@
     {
         "event_id": "gen_death_greencough_leafbare1",
         "location": ["any"],
-        "season": [
-            "leaf-bare"
-        ],
-        "tags": [
-            "classic"
-        ],
+        "season": ["leaf-bare"],
+        "tags": ["classic"],
         "weight": 20,
         "event_text": "m_c died after catching greencough.",
         "m_c": {
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c died of greencough.",
             "lead_death": "died of greencough"
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_infection_any1",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "classic"
-        ],
+        "season": ["any"],
+        "tags": ["classic"],
         "weight": 20,
         "event_text": "m_c died from infected wounds.",
         "m_c": {
-            "age": [ "any" ],
-            "status": [ "any" ],
+            "age": ["any"],
+            "status": ["any"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c died from infected wounds.",
             "lead_death": "died from infected wounds"
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_badprey_anydoubledeath1",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "classic"
-        ],
+        "season": ["any"],
+        "tags": ["classic"],
         "weight": 20,
         "event_text": "m_c and r_c die from eating tainted prey.",
         "m_c": {
-            "age": [ "any" ],
-            "status": [ "any" ],
+            "age": ["any"],
+            "status": ["any"],
             "relationship_status": [],
             "dies": true
         },
         "r_c": {
-            "age": [ "any" ],
-            "status": [ "any" ],
+            "age": ["any"],
+            "status": ["any"],
             "dies": true
         },
-        "history": [{
-            "cats": [ "m_c", "r_c" ],
+        "history": [
+            {
+            "cats": ["m_c", "r_c"],
             "reg_death": "m_c died from eating tainted prey.",
             "lead_death": "ate tainted prey"
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_drown_any1",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
+        "season": ["any"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c fell into the river. r_c drowned alongside m_c while trying to rescue {PRONOUN/m_c/object}.",
         "m_c": {
-            "age": [ "adolescent", "young adult", "adult", "senior adult", "senior" ],
-            "status": [ "any" ],
+            "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+            "status": ["any"],
             "dies": true
         },
         "r_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult"
-            ],
-            "status": [ "any" ],
-            "trait": [
-                "bold",
-                "ambitious",
-                "compassionate",
-                "daring",
-                "confident",
-                "fierce",
-                "loyal",
-                "loving",
-                
-                "responsible"
-            ],
+            "age": ["young adult", "adult", "senior adult"],
+            "status": ["any"],
+            "trait": ["bold", "ambitious", "compassionate", "daring", "confident", "fierce", "loyal", "loving", "responsible"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c", "r_c"],
             "reg_death": "This cat drowned alongside a Clanmate.",
             "lead_death": "drowned alongside a Clanmate"
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_rogue_anydoubledeath1",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
+        "season": ["any"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c and r_c are killed by a gang of rogues.",
         "m_c": {
-            "age": [
-            "young adult",
-            "adult",
-            "senior adult" ],
-            "status": [ "any" ],
+            "age": ["young adult", "adult", "senior adult"],
+            "status": ["any"],
             "dies": true
         },
         "r_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult"
-            ],
-            "status": [ "any" ],
+            "age": ["young adult", "adult", "senior adult"],
+            "status": ["any"],
             "dies": true
         },
-        "history": [{
-            "cats": [ "m_c", "r_c" ],
+        "history": [
+            {
+            "cats": ["m_c", "r_c"],
             "reg_death": "m_c was killed by a gang of rogues.",
             "lead_death": "{VERB/m_c/were/was} killed by a gang of rogues"
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_greencough_any1",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "classic"
-        ],
+        "season": ["any"],
+        "tags": ["classic"],
         "weight": 20,
         "event_text": "r_c and m_c die of greencough.",
         "m_c": {
-            "age": [ "any" ],
-            "status": [ "any" ],
+            "age": ["any"],
+            "status": ["any"],
             "dies": true
         },
         "r_c": {
-            "age": [ "any" ],
-            "status": [ "any" ],
+            "age": ["any"],
+            "status": ["any"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c", "r_c"],
             "reg_death": "This cat died of greencough.",
             "lead_death": "died of greencough"
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_yellowcough_any1",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "classic"
-        ],
+        "season": ["any"],
+        "tags": ["classic"],
         "weight": 20,
         "event_text": "r_c and m_c die of yellowcough.",
         "m_c": {
-            "age": [ "any" ],
-            "status": [ "any" ],
+            "age": ["any"],
+            "status": ["any"],
             "dies": true
         },
         "r_c": {
-            "age": [ "any" ],
-            "status": [ "any" ],
+            "age": ["any"],
+            "status": ["any"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c", "r_c"],
             "reg_death": "This cat died of yellowcough.",
             "lead_death": "died of yellowcough"
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_any1",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "classic"
-        ],
+        "season": ["any"],
+        "tags": ["classic"],
         "weight": 20,
         "event_text": "A bad case of greencough strikes the Clan, taking r_c and m_c's lives.",
         "m_c": {
-            "age": [ "any" ],
-            "status": [ "any" ],
+            "age": ["any"],
+            "status": ["any"],
             "dies": true
         },
         "r_c": {
-            "age": [ "any" ],
-            "status": [ "any" ],
+            "age": ["any"],
+            "status": ["any"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c", "r_c"],
             "reg_death": "This cat died of greencough.",
             "lead_death": "died of greencough"
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_curious_any1",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
+        "season": ["any"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c sneaked out of camp, intending to discover more about {PRONOUN/m_c/poss} origins. After a long morning search, c_n found {PRONOUN/m_c/poss} cooling body.",
         "m_c": {
-            "age": [ "adolescent", "young adult"],
-            "status": [ "apprentice", "mediator apprentice", "medicine cat apprentice", "warrior", "mediator", "medicine cat", "deputy" ],
-            "backstory": [
-                "abandoned1",
-                "abandoned2",
-                "abandoned3"
-            ],
+            "age": ["adolescent", "young adult"],
+            "status": ["apprentice", "mediator apprentice", "medicine cat apprentice", "warrior", "mediator", "medicine cat", "deputy" ],
+            "backstory": ["abandoned1", "abandoned2", "abandoned3"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            { 
             "cats": ["m_c"],
             "reg_death": "Curiosity killed this cat."
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_war_any1",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
-        "sub_type": [ "war" ],
+        "season": ["any"],
+        "sub_type": ["war"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c sacrificed {PRONOUN/m_c/self} for r_c in a battle with o_c_n.",
@@ -1149,36 +790,24 @@
         "r_c": {
             "status": ["apprentice", "warrior", "deputy", "leader"]
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c sacrificed {PRONOUN/m_c/self} for r_c in battle.",
             "lead_death": "sacrificed {PRONOUN/m_c/self} for r_c in battle."
-        }],
+            }
+        ],
         "relationships": [
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "platonic",
-                    "trust",
-                    "respect"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["platonic", "trust", "respect"],
                 "amount": 15
             },
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "dislike"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["dislike"],
                 "amount": -15
             }
         ],
@@ -1190,10 +819,8 @@
     {
         "event_id": "gen_death_war_any2",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
-        "sub_type": [ "war" ],
+        "season": ["any"],
+        "sub_type": ["war"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c threw {PRONOUN/m_c/self} in front of an oncoming attack meant for r_c, taking the deadly blow instead.",
@@ -1213,29 +840,15 @@
         ],
         "relationships": [
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "platonic",
-                    "trust",
-                    "respect"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["platonic", "trust", "respect"],
                 "amount": 15
             },
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "dislike"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["dislike"],
                 "amount": -15
             }
         ],
@@ -1247,10 +860,8 @@
     {
         "event_id": "gen_death_war_any3",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
-        "sub_type": [ "war" ],
+        "season": ["any"],
+        "sub_type": ["war"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c stayed behind and fought a losing battle to give r_c time to escape.",
@@ -1261,36 +872,24 @@
         "r_c": {
             "status": ["apprentice", "warrior", "deputy", "leader"]
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c sacrificed {PRONOUN/m_c/self} for r_c in battle.",
             "lead_death": "sacrificed {PRONOUN/m_c/self} for r_c in battle."
-        }],
+            }
+        ],
         "relationships": [
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "platonic",
-                    "trust",
-                    "respect"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["platonic", "trust", "respect"],
                 "amount": 15
             },
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "dislike"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["dislike"],
                 "amount": -15
             }
         ],
@@ -1302,10 +901,8 @@
     {
         "event_id": "gen_death_war_any4",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
-        "sub_type": [ "war" ],
+        "season": ["any"],
+        "sub_type": ["war"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c used {PRONOUN/m_c/poss} own body to shield r_c from a surprise o_c_n ambush, even though it meant certain death.",
@@ -1314,39 +911,27 @@
             "dies": true
         },
         "r_c": {
-            "age": [ "adolescent", "young adult", "adult", "senior adult" ],
-            "status": [ "any" ]
+            "age": ["adolescent", "young adult", "adult", "senior adult"],
+            "status": ["any"]
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c sacrificed {PRONOUN/m_c/self} for r_c in an ambush.",
             "lead_death": "sacrificed {PRONOUN/m_c/self} for r_c in an ambush."
-        }],
+            }
+        ],
         "relationships": [
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "platonic",
-                    "trust",
-                    "respect"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["platonic", "trust", "respect"],
                 "amount": 15
             },
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "dislike"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["dislike"],
                 "amount": -15
             }
         ],
@@ -1358,10 +943,8 @@
     {
         "event_id": "gen_death_war_sacrifice1",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
-        "sub_type": [ "war" ],
+        "season": ["any"],
+        "sub_type": ["war"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c was killed while investigating enemy territory.",
@@ -1369,10 +952,12 @@
             "status": ["apprentice", "warrior"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c was killed investigating enemy territory."
-        }],
+            }
+        ],
         "other_clan": {
             "current_rep": ["hostile"],
             "changed": -3
@@ -1381,12 +966,8 @@
     {
         "event_id": "gen_death_war_multi1",
         "location": ["any"],
-        "season": [
-            "leaf-fall",
-            "newleaf",
-            "greenleaf"
-        ],
-        "sub_type": [ "war" ],
+        "season": ["leaf-fall", "newleaf", "greenleaf"],
+        "sub_type": ["war"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c drowned in a river while trying to escape from a sudden o_c_n attack.",
@@ -1395,11 +976,13 @@
             "not_skill": ["SWIMMER,2"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c drowned in a river attempting to escape an enemy attack.",
             "lead_death": "drowned in a river attempting to escape an enemy attack."
-        }],
+            }
+        ],
         "other_clan": {
             "current_rep": ["hostile"],
             "changed": -2
@@ -1408,22 +991,22 @@
     {
         "event_id": "gen_death_war_any7",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
-        "sub_type": [ "war" ],
-        "tags": [ "some_lives" ],
+        "season": ["any"],
+        "sub_type": ["war"],
+        "tags": ["some_lives"],
         "weight": 20,
         "event_text": "m_c fell into a pit trap set by o_c_n's warriors.",
         "m_c": {
-            "age": [ "adolescent", "young adult", "adult", "senior adult" ],
+            "age": ["adolescent", "young adult", "adult", "senior adult"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c fell into a pit trap set by an enemy Clan.",
             "lead_death": "fell into a pit trap set by an enemy Clan."
-        }],
+            }
+        ],
         "other_clan": {
             "current_rep": ["hostile"],
             "changed": -3
@@ -1432,22 +1015,22 @@
     {
         "event_id": "gen_death_war_any8",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
-        "sub_type": [ "war" ],
-        "tags": [ "some_lives" ],
+        "season": ["any"],
+        "sub_type": ["war"],
+        "tags": ["some_lives"],
         "weight": 20,
         "event_text": "m_c was hit by a monster while escaping across a Thunderpath from o_c_n warriors.",
         "m_c": {
-            "status": [ "apprentice", "warrior", "deputy", "leader" ],
+            "status": ["apprentice", "warrior", "deputy", "leader"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c was hit by a monster.",
             "lead_death": "{VERB/m_c/were/was} hit by a monster."
-        }],
+            }
+        ],
         "other_clan": {
             "current_rep": ["hostile"],
             "changed": -3
@@ -1456,32 +1039,28 @@
     {
         "event_id": "gen_death_age_any1",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
-        "sub_type": [ "old_age" ],
+        "season": ["any"],
+        "sub_type": ["old_age"],
         "tags": ["all_lives"],
         "weight": 20,
         "event_text": "m_c wandered out into the territory and was later found dead, a peaceful expression on {PRONOUN/m_c/poss} face.",
         "m_c": {
-            "age": [ "senior" ],
+            "age": ["senior"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c died of old age.",
             "lead_death": "died of old age"
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_age_any2",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
-        "sub_type": [
-            "old_age"
-        ],
+        "season": ["any"],
+        "sub_type": ["old_age"],
         "tags": ["all_lives"],
         "weight": 20,
         "event_text": "m_c was found stiff and curled up in {PRONOUN/m_c/poss} nest. It seems {PRONOUN/m_c/subject} died in {PRONOUN/m_c/poss} sleep.",
@@ -1489,21 +1068,19 @@
             "age": ["senior"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c died of old age.",
             "lead_death": "died of old age"
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_age_any3",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
-        "sub_type": [
-            "old_age"
-        ],
+        "season": ["any"],
+        "sub_type": ["old_age"],
         "tags": ["all_lives"],
         "weight": 20,
         "event_text": "m_c faded more and more as the days went by, until one day, {PRONOUN/m_c/subject} {VERB/m_c/were/was} found dead in {PRONOUN/m_c/poss} nest.",
@@ -1511,146 +1088,116 @@
             "age": ["senior"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c died of old age.",
             "lead_death": "died of old age"
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_age_any4",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
-        "sub_type": [
-            "old_age"
-        ],
+        "season": ["any"],
+        "sub_type": ["old_age"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c is suddenly struck by a sharp pain in {PRONOUN/m_c/poss} chest. {PRONOUN/m_c/subject/CAP} {VERB/m_c/are/is} found later that day, cold.",
         "m_c": {
-            "age": [ "senior" ],
+            "age": ["senior"],
             "status": ["medicine cat", "mediator", "elder"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c died of a heart attack."
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_age_any5",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
-        "sub_type": [ "old_age" ],
-        "tags": [ "all_lives" ],
+        "season": ["any"],
+        "sub_type": ["old_age"],
+        "tags": ["all_lives"],
         "weight": 20,
         "event_text": "m_c and r_c loved each other so much they could not be parted, even by death. c_n found their bodies still wrapped around each other in the morning.",
         "m_c": {
-            "age": [ "senior" ],
-            "status": [ "any" ],
-            "relationship_status": [
-                "mates"
-            ],
+            "age": ["senior"],
+            "status": ["any"],
+            "relationship_status": ["mates"],
             "dies": true
         },
         "r_c": {
-            "age": [ "senior" ],
-            "status": [ "any" ],
+            "age": ["senior"],
+            "status": ["any"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c", "r_c"],
             "reg_death": "This cat died from old age.",
             "lead_death": "lost all remaining lives from old age."
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_predator_any1",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
-        "tags": [ "no_body", "all_lives" ],
+        "season": ["any"],
+        "tags": ["no_body", "all_lives"],
         "weight": 20,
         "event_text": "m_c met their end to the long claws of a predator. Later, c_n found only {PRONOUN/m_c/poss} blood and a foul smell.",
         "m_c": {
-            "age": [ "adolescent", "young adult", "adult", "senior adult" ],
+            "age": ["adolescent", "young adult", "adult", "senior adult"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c was killed by an unknown predator.",
             "lead_death": "{VERB/m_c/were/was} killed by an unknown predator."
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_murder_anydep1",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
-        "sub_type": [ "murder"],
+        "season": ["any"],
+        "sub_type": ["murder"],
         "tags": [],
         "weight": 30,
         "event_text": "m_c was murdered by r_c in cold blood in the hope of taking {PRONOUN/m_c/poss} place.",
         "m_c": {
-            "status": [
-                "deputy"
-            ],
-            "not_skill": [
-                "FIGHTER,2"
-            ],
+            "status": ["deputy"],
+            "not_skill": ["FIGHTER,2"],
             "dies": true
         },
         "r_c": {
-            "age": [ "any" ],
-            "status": [ "warrior" ],
-            "skill": [
-                "FIGHTER,2"
-            ],
-            "trait": [
-                "ambitious",
-                "cold",
-                "righteous",
-                "loyal",
-                "vengeful",
-                "sneaky",
-                "bloodthirsty"
-            ]
+            "age": ["any"],
+            "status": ["warrior"],
+            "skill": ["FIGHTER,2"],
+            "trait": ["ambitious", "cold", "righteous", "loyal", "vengeful", "sneaky", "bloodthirsty"]
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c was murdered by r_c."
-        }],
+            }
+        ],
         "relationships": [
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "dislike"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["dislike"],
                 "amount": 15
             },
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "platonic",
-                    "trust",
-                    "comfort"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["platonic", "trust", "comfort"],
                 "amount": -15
             }
         ]
@@ -1658,66 +1205,39 @@
     {
         "event_id": "gen_death_murder_anydep2",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
-        "sub_type": [ "murder" ],
+        "season": ["any"],
+        "sub_type": ["murder"],
         "tags": [],
         "weight": 30,
         "event_text": "m_c was murdered by r_c in cold blood. r_c staged the death as an accident and hopes to take {PRONOUN/m_c/poss} place.",
         "m_c": {
-            "status": [
-                "deputy"
-            ],
-            "not_skill": [
-                "FIGHTER,2"
-            ],
+            "status": ["deputy"],
+            "not_skill": ["FIGHTER,2"],
             "dies": true
         },
         "r_c": {
-            "age": [ "any" ],
-            "status": [ "warrior" ],
-            "skill": [
-                "CLEVER,2"
-            ],
-            "trait": [
-                "ambitious",
-                "cold",
-                "righteous",
-                "loyal",
-                "vengeful",
-                "sneaky"
-            ]
+            "age": ["any"],
+            "status": ["warrior"],
+            "skill": ["CLEVER,2"],
+            "trait": ["ambitious", "cold", "righteous", "loyal", "vengeful", "sneaky"]
         },
-        "history": [{
-            "cats": [ "m_c", "r_c" ],
+        "history": [
+            {
+            "cats": ["m_c", "r_c"],
             "reg_death": "m_c was secretly murdered by r_c."
-        }],
+            }
+        ],
         "relationships": [
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "dislike"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["dislike"],
                 "amount": 15
             },
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "platonic",
-                    "trust",
-                    "comfort"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["platonic", "trust", "comfort"],
                 "amount": -15
             }
         ]
@@ -1725,53 +1245,37 @@
     {
         "event_id": "gen_death_murder_any5",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
-        "sub_type": [ "murder" ],
-        "tags": [ "all_lives" ],
+        "season": ["any"],
+        "sub_type": ["murder"],
+        "tags": ["all_lives"],
         "weight": 20,
         "event_text": "Lured by trickery and deceptive words, m_c was shoved into a ravine by r_c, killing {PRONOUN/m_c/object}.",
         "m_c": {
-            "status": [
-                "deputy", "leader"
-            ],
+            "status": ["deputy", "leader"],
             "dies": true
         },
         "r_c": {
-            "age": [ "any" ],
-            "status": [ "warrior", "deputy" ]
+            "age": ["any"],
+            "status": ["warrior", "deputy"]
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c {VERB/m_c/were/was} pushed into a ravine by r_c.",
             "lead_death": "{VERB/m_c/were/was} pushed into a ravine by r_c"
-        }],
+            }
+        ],
         "relationships": [
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "dislike"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["dislike"],
                 "amount": 15
             },
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "platonic",
-                    "trust",
-                    "comfort"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["platonic", "trust", "comfort"],
                 "amount": -15
             }
         ]
@@ -1779,63 +1283,39 @@
     {
         "event_id": "gen_death_murder_leafbareice1",
         "location": ["any"],
-        "season": [
-            "leaf-bare"
-        ],
+        "season": ["leaf-bare"],
         "sub_type": ["murder"],
         "tags": ["all_lives"],
         "weight": 20,
         "event_text": "r_c tricked m_c into playing on thin ice. {PRONOUN/r_c/subject/CAP} watched closely as m_c disappeared beneath the surface.",
         "m_c": {
             "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
-            "not_skill": [
-                "PROPHET,3",
-                "OMEN,3",
-                "SWIMMER,3"
-            ],
-            "trait": [
-                "daring",
-                "adventurous",
-                "oblivious",
-                "bold",
-                "childish"
-            ],
+            "not_skill": ["PROPHET,3", "OMEN,3", "SWIMMER,3"],
+            "trait": ["daring", "adventurous", "oblivious", "bold", "childish"],
             "dies": true
         },
         "r_c": {
-            "age": [ "adolescent", "young adult", "adult", "senior adult" ],
-            "status": [ "any" ]
+            "age": ["adolescent", "young adult", "adult", "senior adult"],
+            "status": ["any"]
         },
-        "history": [{
-            "cats": ["m_c" ],
+        "history": [
+            {
+            "cats": ["m_c"],
             "reg_death": "m_c was lured onto thin ice by r_c, resulting in {PRONOUN/m_c/poss} death.",
             "lead_death": "{VERB/m_c/were/was} lured onto thin ice by r_c and fell through, becoming trapped underwater"
-        }],
+            }
+        ],
         "relationships": [
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "dislike"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["dislike"],
                 "amount": 15
             },
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "platonic",
-                    "trust",
-                    "comfort"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["platonic", "trust", "comfort"],
                 "amount": -15
             }
         ]
@@ -1843,176 +1323,146 @@
     {
         "event_id": "gen_death_drown_multi1",
         "location": ["any"],
-        "season": [
-            "newleaf",
-            "leaf-bare"
-        ],
+        "season": ["newleaf", "leaf-bare"],
         "tags": ["all_lives"],
         "weight": 20,
         "event_text": "Last c_n heard, m_c and r_c were going out to play. They don't return, and the ice on a nearby pond is cracked.",
         "m_c": {
             "age": ["adolescent", "young adult", "adult", "senior adult"],
-            "not_skill": [
-                "PROPHET,3",
-                "OMEN,3",
-                "SWIMMER,3"
-            ],
-            "trait": [
-                "daring",
-                "adventurous",
-                "oblivious",
-                "bold",
-                "childish"
-            ],
+            "not_skill": ["PROPHET,3", "OMEN,3", "SWIMMER,3"],
+            "trait": ["daring", "adventurous", "oblivious", "bold", "childish"],
             "dies": true
         },
         "r_c": {
-            "age": [ "adolescent", "young adult", "adult", "senior adult" ],
-            "status": [ "any" ],
-            "not_skill": [
-                "PROPHET,3",
-                "OMEN,3",
-                "SWIMMER,3"
-            ],
-            "trait": [
-                "daring",
-                "adventurous",
-                "oblivious",
-                "bold",
-                "childish"
-            ],
+            "age": ["adolescent", "young adult", "adult", "senior adult"],
+            "status": ["any"],
+            "not_skill": ["PROPHET,3", "OMEN,3", "SWIMMER,3"],
+            "trait": ["daring", "adventurous", "oblivious", "bold", "childish"],
             "dies": true
         },
-        "history": [{
-            "cats": [ "m_c", "r_c" ],
+        "history": [
+            {
+            "cats": ["m_c", "r_c"],
             "reg_death": "m_c and r_c went to play on the ice of a frozen pond, not knowing it was too thin.",
             "lead_death": "fell through thin ice and drowned"
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_sinkhole_any1",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "no_body",
-            "all_lives"
-        ],
+        "season": ["any"],
+        "tags": ["no_body", "all_lives"],
         "weight": 20,
         "event_text": "m_c fell into a sinkhole and was never seen again.",
         "m_c": {
             "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c fell into a sinkhole.",
             "lead_death": "fell into a sinkhole"
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_bury_any1",
         "location": ["beach", "plains", "forest"],
-        "season": [
-            "any"
-        ],
+        "season": ["any"],
         "tags": ["all_lives"],
         "weight": 20,
         "event_text": "m_c fell into a hidden burrow and was buried alive.",
         "m_c": {
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c fell into a hidden burrow.",
             "lead_death": "{VERB/m_c/were/was} buried alive in a hidden burrow"
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_bury_any2",
         "location": ["plains", "forest", "beach"],
-        "season": [
-            "any"
-        ],
-        "tags": [ "all_lives" ],
+        "season": ["any"],
+        "tags": ["all_lives"],
         "weight": 20,
         "event_text": "m_c was buried alive when a burrow collapsed on {PRONOUN/m_c/object}.",
         "m_c": {
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c was buried alive when a burrow collapsed.",
             "lead_death": "{VERB/m_c/were/was} buried alive in a hidden burrow"
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_heat_greenleaf1",
         "location": ["any"],
-        "season": [
-            "greenleaf"
-        ],
-        "tags": [
-            "classic"
-        ],
+        "season": ["greenleaf"],
+        "tags": ["classic"],
         "weight": 20,
         "event_text": "m_c died from dehydration and heat stroke.",
         "m_c": {
-            "age": [ "any" ],
-            "status": [ "any" ],
+            "age": ["any"],
+            "status": ["any"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c died of dehydration and heat stroke.",
             "lead_death": "died of dehydration and heat stroke"
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_freeze_leafbare1",
         "location": ["mountainous", "forest", "plains"],
-        "season": [
-            "leaf-bare"
-        ],
-        "tags": [
-            "all_lives"
-        ],
+        "season": ["leaf-bare"],
+        "tags": ["all_lives"],
         "weight": 20,
         "event_text": "m_c froze to death during a harsh snowstorm.",
         "m_c": {
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c froze to death.",
             "lead_death": "froze to death"
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_freeze_leafbare2",
         "location": ["mountainous", "forest", "plains"],
-        "season": [
-            "leaf-bare"
-        ],
+        "season": ["leaf-bare"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c was found dead and cold in the snow.",
         "m_c": {
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c froze to death.",
             "lead_death": "froze to death"
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_drown_leafbare1",
         "location": ["any"],
-        "season": [
-            "leaf-bare"
-        ],
+        "season": ["leaf-bare"],
         "tags": ["all_lives"],
         "weight": 20,
         "event_text": "m_c was walking on the ice, when it cracked and {PRONOUN/m_c/subject} fell in.",
@@ -2020,32 +1470,34 @@
             "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c froze to death after falling through ice.",
             "lead_death": "fell through thin ice and drowned"
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_bury_any3",
         "location": ["plains", "forest"],
-        "season": [
-            "any"
-        ],
+        "season": ["any"],
         "sub_type": ["war"],
-        "tags": [ "all_lives" ],
+        "tags": ["all_lives"],
         "weight": 20,
         "event_text": "m_c was sealed in a cramped rabbit burrow by o_c_n warriors. {PRONOUN/m_c/subject/CAP} didn't make it out alive.",
         "m_c": {
-            "age": [ "adolescent", "young adult", "adult", "senior adult" ],
-            "status": [ "any" ],
+            "age": ["adolescent", "young adult", "adult", "senior adult"],
+            "status": ["any"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c suffocated underground.",
             "lead_death": "{VERB/m_c/were/was} suffocated underground."
-        }],
+            }
+        ],
         "other_clan": {
             "current_rep": ["hostile"],
             "changed": -3
@@ -2054,77 +1506,54 @@
     {
         "event_id": "gen_death_skirmish_any1",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
+        "season": ["any"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c died in a border skirmish against o_c_n.",
         "m_c": {
-            "status": [
-                "warrior",
-                "deputy",
-                "leader"
-            ],
-            "not_skill": [
-                "FIGHTER,2"
-            ],
+            "status": ["warrior", "deputy", "leader"],
+            "not_skill": ["FIGHTER,2"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c died in a border skirmish against o_c_n.",
             "lead_death": "died in a border skirmish against o_c_n"
-        }],
+            }
+        ],
         "other_clan": {
-            "current_rep": [
-                "hostile",
-                "neutral"
-            ],
+            "current_rep": ["hostile","neutral"],
             "changed": -3
         }
     },
     {
         "event_id": "gen_death_war_any9",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
-        "sub_type": [ "war" ],
+        "season": ["any"],
+        "sub_type": ["war"],
         "tags": [],
         "weight": 20,
         "event_text": "Blinded by blood in the midst of battle, r_c fatally mistakes m_c for a foe.",
         "m_c": {
-            "status": [
-                "warrior",
-                "deputy",
-                "leader"
-            ],
+            "status": ["warrior", "deputy", "leader"],
             "dies": true
         },
         "r_c": {
-            "status": [
-                "apprentice",
-                "warrior",
-                "deputy",
-                "leader" ]
+            "status": ["apprentice", "warrior", "deputy", "leader"]
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c was accidentally killed by r_c in battle.",
             "lead_death": "{VERB/m_c/were/was} accidentally killed by r_c in battle"
-        }],
+            }
+        ],
         "relationships": [
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "trust"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["trust"],
                 "amount": -15
             }
         ],
@@ -2136,428 +1565,287 @@
     {
         "event_id": "gen_death_ocsave_any1",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
+        "season": ["any"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c was killed while trying to save the medicine cat of o_c_n.",
         "m_c": {
-            "status": [
-                "apprentice",
-                "warrior",
-                "deputy",
-                "leader",
-                "medicine cat apprentice",
-                "medicine cat",
-                "mediator apprentice",
-                "mediator"
-            ],
-            "not_skill": [
-                "FIGHTER,2"
-            ],
-            "trait": [
-                "bold",
-                "charismatic",
-                "confident",
-                "daring",
-                "compassionate",
-                "loving",
-                "responsible",
-                "thoughtful",
-                "strange"
-            ],
+            "status": ["apprentice", "warrior", "deputy", "leader", "medicine cat apprentice", "medicine cat", "mediator apprentice", "mediator"],
+            "not_skill": ["FIGHTER,2"],
+            "trait": ["bold", "charismatic", "confident", "daring", "compassionate", "loving", "responsible", "thoughtful", "strange"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c was killed while trying to save o_c_n's medicine cat.",
             "lead_death": "{VERB/m_c/were/was} killed while trying to save o_c_n's medicine cat"
-        }],
+            }
+        ],
         "other_clan": {
-            "current_rep": [
-                "hostile",
-                "neutral",
-                "ally"
-            ],
+            "current_rep": ["hostile", "neutral", "ally"],
             "changed": 5
         }
     },
     {
         "event_id": "gen_death_ockill_any1",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
+        "season": ["any"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c was killed by the deputy of o_c_n.",
         "m_c": {
-            "status": [
-                "warrior",
-                "deputy",
-                "leader"
-            ],
-            "not_skill": [
-                "FIGHTER,3"
-            ],
+            "status": ["warrior", "deputy", "leader"],
+            "not_skill": ["FIGHTER,3"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c was killed by the deputy of o_c_n.",
             "lead_death": "{VERB/m_c/were/was} killed by the deputy of o_c_n"
-        }],
+            }
+        ],
         "other_clan": {
-            "current_rep": [
-                "hostile",
-                "neutral"
-            ],
+            "current_rep": ["hostile", "neutral"],
             "changed": -3
         }
     },
     {
         "event_id": "gen_death_ocsave_any2",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
+        "season": ["any"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c was killed while trying to save the deputy of o_c_n.",
         "m_c": {
-            "status": [
-                "apprentice",
-                "warrior",
-                "deputy",
-                "leader",
-                "medicine cat apprentice",
-                "medicine cat",
-                "mediator apprentice",
-                "mediator"
-            ],
-            "not_skill": [
-                "FIGHTER,2"
-            ],
-            "trait": [
-                "bold",
-                "charismatic",
-                "confident",
-                "daring",
-                "compassionate",
-                "loving",
-                "responsible",
-                "thoughtful",
-                "strange"
-            ],
+            "status": ["apprentice", "warrior", "deputy", "leader", "medicine cat apprentice", "medicine cat", "mediator apprentice", "mediator"],
+            "not_skill": ["FIGHTER,2"],
+            "trait": ["bold", "charismatic", "confident", "daring", "compassionate", "loving", "responsible", "thoughtful", "strange"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c was killed while trying to save o_c_n's deputy.",
             "lead_death": "{VERB/m_c/were/was} killed while trying to save o_c_n's deputy"
-        }],
+            }
+        ],
         "other_clan": {
-            "current_rep": [
-                "neutral",
-                "ally"
-            ],
+            "current_rep": ["neutral", "ally"],
             "changed": 5
         }
     },
     {
         "event_id": "gen_death_ockill_any2",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
+        "season": ["any"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c was killed by the leader of o_c_n.",
         "m_c": {
-            "status": [
-                "warrior",
-                "deputy",
-                "leader"
-            ],
-            "not_skill": [
-                "FIGHTER,3"
-            ],
+            "status": ["warrior", "deputy", "leader"],
+            "not_skill": ["FIGHTER,3"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c was killed by the leader of o_c_n.",
             "lead_death": "{VERB/m_c/were/was} killed by the leader of o_c_n"
-        }],
+            }
+        ],
         "other_clan": {
-            "current_rep": [
-                "hostile",
-                "neutral"
-            ],
+            "current_rep": ["hostile", "neutral"],
             "changed": -3
         }
     },
     {
         "event_id": "gen_death_ocsave_any3",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
+        "season": ["any"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c was killed while trying to save the leader of o_c_n.",
         "m_c": {
-            "status": [
-                "apprentice",
-                "warrior",
-                "deputy",
-                "leader",
-                "medicine cat apprentice",
-                "medicine cat",
-                "mediator apprentice",
-                "mediator"
-            ],
-            "not_skill": [
-                "FIGHTER,2"
-            ],
-            "trait": [
-                "bold",
-                "charismatic",
-                "confident",
-                "daring",
-                "compassionate",
-                "loving",
-                "responsible",
-                "thoughtful",
-                "strange"
-            ],
+            "status": ["apprentice", "warrior", "deputy", "leader", "medicine cat apprentice", "medicine cat", "mediator apprentice", "mediator"],
+            "not_skill": ["FIGHTER,2"],
+            "trait": ["bold", "charismatic", "confident", "daring", "compassionate", "loving", "responsible", "thoughtful", "strange"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c was killed while trying to save o_c_n's leader.",
             "lead_death": "{VERB/m_c/were/was} killed while trying to save o_c_n's leader"
-        }],
+            }
+        ],
         "other_clan": {
-            "current_rep": [
-                "neutral",
-                "ally"
-            ],
+            "current_rep": ["neutral", "ally"],
             "changed": 5
         }
     },
     {
         "event_id": "gen_death_skirmish_any2",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
+        "season": ["any"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c and r_c are killed in a border skirmish against o_c_n.",
         "m_c": {
-            "status": [
-                "apprentice",
-                "warrior",
-                "deputy",
-                "leader"
-            ],
-            "not_skill": [
-                "FIGHTER,2"
-            ],
+            "status": ["apprentice", "warrior", "deputy", "leader"],
+            "not_skill": ["FIGHTER,2"],
             "dies": true
         },
         "r_c": {
-            "status": [
-                "apprentice",
-                "warrior",
-                "deputy",
-                "leader"
-            ],
-            "not_skill": [
-                "FIGHTER,2"
-            ],
+            "status": ["apprentice", "warrior", "deputy", "leader"],
+            "not_skill": ["FIGHTER,2"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c", "r_c"],
             "reg_death": "This cat died in a border skirmish against o_c_n.",
             "lead_death": "{VERB/m_c/were/was} killed in a border skirmish against o_c_n."
-        }],
+            }
+        ],
         "other_clan": {
-            "current_rep": [
-                "hostile",
-                "neutral"
-            ],
+            "current_rep": ["hostile", "neutral"],
             "changed": -3
         }
     },
     {
         "event_id": "gen_death_bury_multi1",
         "location": ["mountainous", "forest"],
-        "season": [
-            "leaf-fall",
-            "leaf-bare"
-        ],
-        "tags": [ "all_lives", "no_body" ],
+        "season": ["leaf-fall", "leaf-bare"],
+        "tags": ["all_lives", "no_body"],
         "weight": 20,
         "event_text": "m_c was buried alive in an avalanche.",
         "m_c": {
             "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
-            "status": [ "any" ],
+            "status": ["any"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c was buried alive in an avalanche.",
             "lead_death": "{VERB/m_c/were/was} buried alive in an avalanche"
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_bury_multi2",
         "location": ["any"],
-        "season": [
-            "greenleaf",
-            "newleaf",
-            "leaf-fall"
-        ],
-        "tags": [ "all_lives", "no_body" ],
+        "season": ["greenleaf", "newleaf", "leaf-fall"],
+        "tags": ["all_lives", "no_body"],
         "weight": 20,
         "event_text": "m_c was buried alive in a landslide.",
         "m_c": {
             "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c was buried alive in a landslide.",
             "lead_death": "{VERB/m_c/were/was} buried alive in a landslide"
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_bury_newleaf1",
         "location": ["plains", "mountainous"],
-        "season": [
-            "newleaf"
-        ],
+        "season": ["newleaf"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c was buried alive in a mudslide.",
         "m_c": {
-            "age": [ "adolescent", "young adult", "adult", "senior adult", "senior"],
-            "status": [ "any" ],
+            "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+            "status": ["any"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c was buried alive in a mudslide.",
             "lead_death": "{VERB/m_c/were/was} buried alive in a mudslide"
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_cliff_any1",
         "location": ["mountainous", "beach", "forest"],
-        "season": [
-            "any"
-        ],
+        "season": ["any"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c slipped off a cliff onto the sharp rocks at the bottom.",
         "m_c": {
             "age": ["adolescent", "young adult", "adult", "senior adult" ],
-            "status": [ "any" ],
-            "trait": [
-                "playful",
-                "childish"
-            ],
+            "status": ["any"],
+            "trait": ["playful", "childish"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c slipped off the edge of a cliff.",
             "lead_death": "slipped off the edge of a cliff"
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_cliff_anylead1",
-        "location": [
-            "mountainous", "forest", "beach"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "all_lives"
-        ],
+        "location": ["mountainous", "forest", "beach"],
+        "season": ["any"],
+        "tags": ["all_lives"],
         "weight": 20,
         "event_text": "m_c slipped off a cliff onto the sharp rocks at the bottom and couldn't recover.",
         "m_c": {
-            "status": [
-                "leader"
-            ],
+            "status": ["leader"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "lead_death": "slipped off the edge of a cliff"
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_murder_anycliff1",
         "location": ["beach", "mountainous", "forest"],
-        "season": [
-            "any"
-        ],
-        "sub_type": [ "murder" ],
+        "season": ["any"],
+        "sub_type": ["murder"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c was pushed off a cliff onto the sharp rocks at the bottom.",
         "m_c": {
-            "status": [ "apprentice", "mediator apprentice", "medicine cat apprentice", "warrior", "medicine cat", "mediator", "deputy" ],
-            "not_skill": [
-                "PROPHET,3",
-                "OMEN,3",
-                "FIGHTER,3"
-            ],
+            "status": ["apprentice", "mediator apprentice", "medicine cat apprentice", "warrior", "medicine cat", "mediator", "deputy"],
+            "not_skill": ["PROPHET,3", "OMEN,3", "FIGHTER,3"],
             "dies": true
         },
         "r_c": {
             "status": [ "apprentice", "mediator apprentice", "medicine cat apprentice", "warrior", "medicine cat", "mediator", "deputy" ],
-            "skill": [
-                "CLEVER,2",
-                "HUNTER,3"
-            ]
+            "skill": ["CLEVER,2", "HUNTER,3"]
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c was pushed off a cliff by r_c."
-        }],
+            }
+        ],
         "relationships": [
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "dislike"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["dislike"],
                 "amount": 15
             },
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "platonic",
-                    "trust",
-                    "comfort"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["platonic", "trust", "comfort"],
                 "amount": -15
             }
         ]
@@ -2565,124 +1853,86 @@
     {
         "event_id": "gen_death_war_any5",
         "location": ["mountainous", "forest", "beach"],
-        "season": [
-            "any"
-        ],
-        "sub_type": [ "war" ],
-        "tags": [ "some_lives"],
+        "season": ["any"],
+        "sub_type": ["war"],
+        "tags": ["some_lives"],
         "weight": 20,
         "event_text": "m_c was killed by a falling boulder that o_c_n warriors pushed from a cliff above {PRONOUN/m_c/object}.",
         "m_c": {
-            "status": [ "apprentice", "warrior", "deputy", "leader" ],
+            "status": ["apprentice", "warrior", "deputy", "leader"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c was crushed by a falling boulder.",
             "lead_death": "{VERB/m_c/were/was} crushed by a falling boulder."
-        }],
+            }
+        ],
         "other_clan": {
-            "current_rep": [
-                "hostile"
-            ],
+            "current_rep": ["hostile"],
             "changed": -3
         }
     },
     {
         "event_id": "gen_death_hawk_any1",
         "location": ["forest:camp1_camp4", "plains:camp1_camp3", "mountainous:camp1_camp4", "beach:camp1_camp3"],
-        "season": [
-            "any"
-        ],
+        "season": ["any"],
         "tags": ["no_body"],
         "weight": 20,
         "event_text": "r_c yowled a warning as {PRONOUN/r_c/subject} saw a circling shadow, right above m_c. r_c couldn't get there before m_c was carried high into the sky.",
         "m_c": {
-            "age": [ "kitten", "adolescent"],
-            "status": [ "any" ],
+            "age": ["kitten", "adolescent"],
+            "status": ["any"],
             "dies": true
         },
         "r_c": {
-            "age": [ "any" ],
+            "age": ["any"],
             "status": ["apprentice", "warrior", "deputy"],
-            "not_skill": [
-                "RUNNER,2"
-            ]
+            "not_skill": ["RUNNER,2"]
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c was grabbed by a hawk, never to be seen again."
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_hawk_any2",
         "location": ["forest:camp1_camp4", "plains:camp1_camp3", "mountainous:camp1_camp4", "beach:camp1_camp3"],
-        "season": [
-            "any"
-        ],
+        "season": ["any"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c was killed defending r_c from a hawk.",
         "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "not_skill": [
-                "FIGHTER,2"
-            ],
-            "trait": [
-                "bold",
-                "bloodthirsty",
-                "ambitious",
-                "daring",
-                "confident",
-                "fierce",
-                "loyal",
-                "loving",
-                
-                "responsible",
-                "righteous",
-                "vengeful"
-            ],
+            "age": ["young adult", "adult", "senior adult", "senior"],
+            "not_skill": ["FIGHTER,2"],
+            "trait": ["bold", "bloodthirsty", "ambitious", "daring", "confident", "fierce", "loyal", "loving", "responsible", "righteous", "vengeful"],
             "dies": true
         },
         "r_c": {
-            "age": [ "kitten", "adolescent"],
-            "status": [ "any" ]
+            "age": ["kitten", "adolescent"],
+            "status": ["any"]
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c died defending r_c from a hawk",
             "lead_death": "defended r_c from a hawk"
-        }],
+            }
+        ],
         "relationships": [
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "platonic",
-                    "trust",
-                    "respect"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["platonic", "trust", "respect"],
                 "amount": 15
             },
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "dislike"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["dislike"],
                 "amount": -15
             }
         ]
@@ -2690,291 +1940,220 @@
     {
         "event_id": "gen_death_eagle_anylead3",
         "location": ["forest:camp1_camp4", "plains:camp1_camp3", "mountainous:camp1_camp4", "beach:camp1_camp3"],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "no_body"
-        ],
+        "season": ["any"],
+        "tags": ["no_body"],
         "weight": 20,
         "event_text": "m_c was carried off by an eagle, never to be seen again.",
         "m_c": {
-            "age": [
-                "kitten", "adolescent"
-            ],
+            "age": ["kitten", "adolescent"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c was carried away by an eagle."
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_river_multiriver2",
-        "location": [
-            "forest", "mountainous", "plains", "wetlands"
-        ],
-        "season": [
-            "greenleaf",
-            "newleaf",
-            "leaf-fall"
-        ],
-        "tags": [
-            "all_lives",
-            "no_body"
-        ],
+        "location": ["forest", "mountainous", "plains", "wetlands"],
+        "season": ["greenleaf", "newleaf", "leaf-fall"],
+        "tags": ["all_lives", "no_body"],
         "weight": 20,
         "event_text": "m_c fell into a river and was swept away by the current, never to be seen again.",
         "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
+        "age": ["young adult", "adult", "senior adult", "senior"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c was swept away by the river.",
             "lead_death": "{VERB/m_c/were/was} swept away by the river"
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_hawk_any2",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "no_body"
-        ],
+        "season": ["any"],
+        "tags": ["no_body"],
         "weight": 20,
         "event_text": "m_c was taken by a hawk, never to be seen again.",
         "m_c": {
-            "age": [
-                "kitten", "adolescent"
-            ],
-            "status": [
-                "any"
-            ],
+            "age": ["kitten", "adolescent"],
+            "status": ["any"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c was taken by a hawk."
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_weak_any1",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
+        "season": ["any"],
         "tags": [],
         "weight": 30,
         "event_text": "m_c grew weak as the days passed and now walks the stars of Silverpelt.",
         "m_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": [
-                "kitten"
-            ],
+            "age": ["kitten"],
+            "status": ["kitten"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c failed to thrive."
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_drown_multi2",
         "location": ["plains", "forest", "mountainous"],
-        "season": [
-            "leaf-fall",
-            "newleaf",
-            "greenleaf"
-        ],
+        "season": ["leaf-fall", "newleaf", "greenleaf"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c fell into a river and drowned.",
         "m_c": {
-            "age": [
-                "adolescent", "young adult", "adult", "senior adult", "senior"
-            ],
-            "not_skill": [
-                "SWIMMER,2"
-                ],
+            "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+            "not_skill": ["SWIMMER,2"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c fell into the river and drowned.",
             "lead_death": "fell into the river and drowned"
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_sneak_any1",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
+        "season": ["any"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c was killed when {PRONOUN/m_c/subject} snuck out of camp.",
         "m_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": [
-                "kitten"
-            ],
-            "trait": [
-                "troublesome",
-                "daring",
-                "impulsive",
-                "attention-seeker"
-            ],
+            "age": ["kitten"],
+            "status": ["kitten"],
+            "trait": ["troublesome", "daring", "impulsive", "attention-seeker"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c died when {PRONOUN/m_c/subject} snuck out of camp."
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_poison_any1",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
+        "season": ["any"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c died after getting into the herb stores and accidentally eating deathberries.",
         "m_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": [
-                "kitten"
-            ],
-            "trait": [
-                "troublesome",
-                "impulsive",
-                "attention-seeker"
-                
-            ],
+            "age": ["kitten"],
+            "status": ["kitten"],
+            "trait": ["troublesome", "impulsive", "attention-seeker"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c died when {PRONOUN/m_c/subject} got into the herb stores and ate deathberries."
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_snake_any3",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
+        "season": ["any"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c was killed in {PRONOUN/m_c/poss} sleep by a snake that had snuck into camp.",
         "m_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": [
-                "kitten"
-            ],
+            "age": ["kitten"],
+            "status": ["kitten"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c was killed by a snake."
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_kittencough_multi1",
         "location": ["any"],
-        "season": [
-            "leaf-fall",
-            "leaf-bare"
-        ],
-        "tags": [
-            "classic"
-        ],
+        "season": ["leaf-fall", "leaf-bare"],
+        "tags": ["classic"],
         "weight": 20,
         "event_text": "m_c died of kittencough.",
         "m_c": {
-            "age": [
-                "kitten"
-            ],
+            "age": ["kitten"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c died of kittencough."
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_kittencough_any1",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "classic"
-        ],
+        "season": ["any"],
+        "tags": ["classic"],
         "weight": 20,
         "event_text": "r_c and m_c die from a bout of kittencough.",
         "m_c": {
-            "age": [
-                "kitten"
-            ],
+            "age": ["kitten"],
             "dies": true
         },
         "r_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": [ "kitten" ],
+            "age": ["kitten"],
+            "status": ["kitten"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c", "r_c"],
             "reg_death": "This cat died of kittencough."
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_greencough_any2",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "classic"
-        ],
+        "season": ["any"],
+        "tags": ["classic"],
         "weight": 20,
         "event_text": "Greencough reaches the nursery. r_c and m_c die.",
         "m_c": {
-            "age": [
-                "kitten"
-            ],
+            "age": ["kitten"],
             "dies": true
         },
         "r_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": [ "kitten" ],
+            "age": ["kitten"],
+            "status": ["kitten"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c", "r_c"],
             "reg_death": "This cat died of greencough."
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_murder_anykit1",

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -2158,55 +2158,37 @@
     {
         "event_id": "gen_death_murder_anykit1",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
-        "sub_type": [ "murder" ],
+        "season": ["any"],
+        "sub_type": ["murder"],
         "tags": [],
         "weight": 20,
         "event_text": "r_c invited m_c to private battle training. When m_c slipped and hit {PRONOUN/m_c/poss} head, {PRONOUN/m_c/subject} never woke back up.",
         "m_c": {
-            "age": [
-                "kitten"
-            ],
+            "age": ["kitten"],
             "dies": true
         },
         "r_c": {
-            "age": [ "adolescent", "young adult", "adult", "senior adult"],
-            "status": [ "apprentice", "warrior", "deputy", "leader"],
-            "skill": [
-                "FIGHTER,1"
-            ]
+            "age": ["adolescent", "young adult", "adult", "senior adult"],
+            "status": ["apprentice", "warrior", "deputy", "leader"],
+            "skill": ["FIGHTER,1"]
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c was killed in battle training with r_c."
-        }],
+            }
+        ],
         "relationships": [
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "dislike"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["dislike"],
                 "amount": 15
             },
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "platonic",
-                    "trust",
-                    "comfort"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["platonic", "trust", "comfort"],
                 "amount": -15
             }
         ]
@@ -2214,52 +2196,36 @@
     {
         "event_id": "gen_death_murder_anykit2",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
-        "sub_type": [ "murder" ],
+        "season": ["any"],
+        "sub_type": ["murder"],
         "tags": [],
         "weight": 20,
         "event_text": "r_c suggested m_c try some shiny red berries. m_c's excitement faded with {PRONOUN/m_c/poss} life.",
         "m_c": {
-            "age": [
-                "kitten"
-            ],
+            "age": ["kitten"],
             "dies": true
         },
         "r_c": {
-            "age": [ "adolescent", "young adult", "adult", "senior adult" ],
-            "status": [ "apprentice", "warrior", "deputy", "leader" ]
+            "age": ["adolescent", "young adult", "adult", "senior adult"],
+            "status": ["apprentice", "warrior", "deputy", "leader"]
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c ate deathberries and succumbed to the poison."
-        }],
+            }
+        ],
         "relationships": [
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "dislike"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["dislike"],
                 "amount": 15
             },
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "platonic",
-                    "trust",
-                    "comfort"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["platonic", "trust", "comfort"],
                 "amount": -15
             }
         ]
@@ -2272,56 +2238,36 @@
             "newleaf",
             "leaf-fall"
         ],
-        "sub_type": [ "murder" ],
+        "sub_type": ["murder"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c sneaked out of camp and misjudged the jump across a stream. r_c watched without concern as {PRONOUN/m_c/subject} disappeared under the water.",
         "m_c": {
-            "age": [
-                "kitten"
-            ],
-            "trait": [
-                "daring",
-                "troublesome",
-                "attention-seeker",
-                "impulsive"
-                
-            ],
+            "age": ["kitten"],
+            "trait": ["daring", "troublesome", "attention-seeker", "impulsive"],
             "dies": true
         },
         "r_c": {
-            "age": [ "adolescent", "young adult", "adult", "senior adult"],
-            "status": [ "any" ]
+            "age": ["adolescent", "young adult", "adult", "senior adult"],
+            "status": ["any"]
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c drowned in a stream while r_c watched."
-        }],
+            }
+        ],
         "relationships": [
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "dislike"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["dislike"],
                 "amount": 15
             },
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "platonic",
-                    "trust",
-                    "comfort"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["platonic", "trust", "comfort"],
                 "amount": -15
             }
         ]
@@ -2329,38 +2275,25 @@
     {
         "event_id": "gen_death_ockill_anymed1",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
+        "season": ["any"],
         "subtype": ["war"],
         "tags": [],
         "weight": 20,
         "event_text": "o_c_n warriors broke into the camp and killed m_c after damaging the herb stores.",
         "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": [
-                "medicine cat"
-            ],
-            "not_skill": [
-                "FIGHTER,2",
-                "OMEN,3",
-                "PROPHET,3"
-            ],
+            "age": ["young adult", "adult", "senior adult", "senior"],
+            "status": ["medicine cat"],
+            "not_skill": ["FIGHTER,2", "OMEN,3", "PROPHET,3"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c was killed when o_c_n warriors broke into camp."
-        }],
+            }
+        ],
         "other_clan": {
-            "current_rep": [
-                "hostile"
-            ],
+            "current_rep": ["hostile"],
             "changed": -3
         },
         "supplies": [
@@ -2374,36 +2307,25 @@
     {
         "event_id": "gen_death_ockill_anymed2",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
+        "season": ["any"],
         "subtype": ["war"],
         "tags": [],
         "weight": 20,
         "event_text": "o_c_n warriors broke into the camp and killed m_c after damaging the stockpiled prey.",
         "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "not_skill": [
-                "FIGHTER,2",
-                "OMEN,3",
-                "PROPHET,3"
-            ],
+            "age": ["young adult", "adult", "senior adult", "senior"],
+            "not_skill": ["FIGHTER,2", "OMEN,3", "PROPHET,3"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c was killed when o_c_n warriors broke into camp.",
             "lead_death": "when o_c_n warrior broke into camp"
-        }],
+            }
+        ],
         "other_clan": {
-            "current_rep": [
-                "hostile"
-            ],
+            "current_rep": ["hostile"],
             "changed": -3
         },
         "supplies": [
@@ -2422,356 +2344,259 @@
         "weight": 20,
         "event_text": "m_c was killed by a o_c_n warrior while pulling an injured r_c away from battle.",
         "m_c": {
-            "status": [
-                "medicine cat apprentice", "medicine cat"
-            ],
+            "status": ["medicine cat apprentice", "medicine cat"],
             "relationship_status": [],
-            "not_skill": [
-                "FIGHTER,2"
-            ],
-            "trait": [
-                "compassionate",
-                "calm",
-                "bold",
-                "ambitious",
-                "daring",
-                "fierce",
-                "loving",
-                "loyal",
-                "responsible",
-                "thoughtful"
-            ],
+            "not_skill": ["FIGHTER,2"],
+            "trait": ["compassionate", "calm", "bold", "ambitious", "daring", "fierce", "loving", "loyal", "responsible", "thoughtful"],
             "dies": true
         },
         "r_c": {
-            "age": [ "adolescent", "young adult", "adult", "senior adult"],
-            "status": [ "apprentice", "warrior", "deputy", "leader"]
+            "age": ["adolescent", "young adult", "adult", "senior adult"],
+            "status": ["apprentice", "warrior", "deputy", "leader"]
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c was killed by a o_c_n warrior while trying to aid an injured Clanmate."
-        }],
+            }
+        ],
         "relationships": [
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "trust",
-                    "respect"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["trust", "respect"],
                 "amount": 15
             }
         ],
         "other_clan": {
-            "current_rep": [
-                "hostile",
-                "neutral"
-            ],
+            "current_rep": ["hostile", "neutral"],
             "changed": -3
         }
     },
     {
         "event_id": "gen_death_greencough_leafbaremed1",
         "location": ["any"],
-        "season": [
-            "leaf-bare"
-        ],
-        "tags": [
-            "classic"
-        ],
+        "season": ["leaf-bare"],
+        "tags": ["classic"],
         "weight": 20,
         "event_text": "m_c caught greencough while caring for {PRONOUN/m_c/poss} patients and couldn't manage to fight it off.",
         "m_c": {
-            "status": [
-                "medicine cat"
-            ],
-            "trait": [
-                "compassionate",
-                "calm",
-                "bold",
-                "ambitious",
-                "fierce",
-                "loving",
-                "loyal",
-                "responsible",
-                "thoughtful"
-            ],
+            "status": ["medicine cat"],
+            "trait": ["compassionate", "calm", "bold", "ambitious", "fierce", "loving", "loyal", "responsible", "thoughtful"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c died of greencough."
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_wander_any1",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
+        "season": ["any"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c wandered out into the territory and was later found dead.",
         "m_c": {
-            "age": [
-                "adolescent",
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
+            "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
             "status": [],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c died while wandering the territory."
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_fox_any2",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
+        "season": ["any"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c was having a peaceful stroll outside of camp, when {PRONOUN/m_c/subject} {VERB/m_c/were/was} attacked and killed by a fox.",
         "m_c": {
-            "age": [
-                "adolescent",
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": [ "any" ],
+            "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+            "status": ["any"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c was killed by a fox.",
             "lead_death": "{VERB/m_c/were/was} killed by a fox"
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_badger_any1",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
+        "season": ["any"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c was having a peaceful stroll outside of camp, when {PRONOUN/m_c/subject} {VERB/m_c/were/was} attacked and killed by a badger.",
         "m_c": {
-            "age": [
-                "adolescent",
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": [ "any" ],
+            "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+            "status": ["any"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c was killed by a badger.",
             "lead_death": "{VERB/m_c/were/was} killed by a badger"
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_dog_any1",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
+        "season": ["any"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c was having a peaceful stroll outside of camp, when {PRONOUN/m_c/subject} {VERB/m_c/were/was} attacked and killed by a dog.",
         "m_c": {
-            "age": [
-                "adolescent",
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
+            "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
             "status": [ "any" ],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c was killed by a dog.",
             "lead_death": "{VERB/m_c/were/was} killed by a dog"
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_whitecough_leafbare1",
         "location": ["any"],
-        "season": [
-            "leaf-bare"
-        ],
-        "tags": [
-            "classic"
-        ],
+        "season": ["leaf-bare"],
+        "tags": ["classic"],
         "weight": 20,
         "event_text": "m_c, already feeling weak, couldn't make it through a case of whitecough.",
         "m_c": {
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c died of whitecough.",
             "lead_death": "died of whitecough"
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_illness_leafbare1",
         "location": ["any"],
-        "season": [
-            "leaf-bare"
-        ],
-        "tags": [
-            "classic"
-        ],
+        "season": ["leaf-bare"],
+        "tags": ["classic"],
         "weight": 20,
         "event_text": "m_c was too weak to recover from an illness and passed away.",
         "m_c": {
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c succumbed to illness.",
             "lead_death": "succumbed to illness"
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_greencough_leafbare2",
         "location": ["any"],
-        "season": [
-            "leaf-bare"
-        ],
-        "tags": [
-            "classic"
-        ],
+        "season": ["leaf-bare"],
+        "tags": ["classic"],
         "weight": 20,
         "event_text": "m_c was taken quickly by a case of greencough.",
         "m_c": {
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c died of greencough.",
             "lead_death": "died of greencough"
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_stress_anywar1",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
+        "season": ["any"],
         "sub_type": ["war"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c suffered a heart attack due to the stress of the ongoing war.",
         "m_c": {
-            "age": [
-                "senior",
-                "adult",
-                "senior adult"
-            ],
-            "dies": true
-        },
-        "history": [{
-            "cats": ["m_c"],
-            "reg_death": "m_c died of a heart attack due to stress.",
-            "lead_death": "died of a heart attack due to stress"
-        }]
-    },
-    {
-        "event_id": "gen_death_lightning_multilead1",
-        "location": ["any"],
-        "season": [
-            "greenleaf",
-            "newleaf",
-            "leaf-fall"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "Lightning struck in camp, killing m_c.",
-        "m_c": {
-            "age": [
-                "kitten",
-                "adolescent",
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "dies": true
-        },
-        "history": [{
-            "cats": ["m_c"],
-            "reg_death": "m_c died when {PRONOUN/m_c/subject} {VERB/m_c/were/was} struck by lightning.",
-            "lead_death": "{VERB/m_c/were/was} struck by lightning"
-        }]
-    },
-    {
-        "event_id": "gen_death_flood_multilead1",
-        "location": [
-            "forest", "mountainous", "plains", "beach", "wetlands"
-        ],
-        "season": [
-            "greenleaf",
-            "newleaf"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was swept away by a flood.",
-        "m_c": {
-            "age": [
-                "adolescent",
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "dies": true
-        },
-        "history": [{
-            "cats": ["m_c"],
-            "reg_death": "m_c was swept away by a flood.",
-            "lead_death": "{VERB/m_c/were/was} swept away by a flood"
-        }]
-    },
-    {
-        "event_id": "gen_death_tree_any1",
-        "location": [ "beach", "forest", "mountainous" ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c fell from the top branches of a tree.",
-        "m_c": {
-            "age": [
-                "adolescent",
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
+            "age": ["senior", "adult", "senior adult"],
             "dies": true
         },
         "history": [
             {
-                "cats": [ "m_c" ],
+            "cats": ["m_c"],
+            "reg_death": "m_c died of a heart attack due to stress.",
+            "lead_death": "died of a heart attack due to stress"
+            }
+        ]
+    },
+    {
+        "event_id": "gen_death_lightning_multilead1",
+        "location": ["any"],
+        "season": ["greenleaf", "newleaf", "leaf-fall"],
+        "tags": [],
+        "weight": 20,
+        "event_text": "Lightning struck in camp, killing m_c.",
+        "m_c": {
+            "age": ["kitten", "adolescent", "young adult", "adult", "senior adult", "senior"],
+            "dies": true
+        },
+        "history": [
+            {
+            "cats": ["m_c"],
+            "reg_death": "m_c died when {PRONOUN/m_c/subject} {VERB/m_c/were/was} struck by lightning.",
+            "lead_death": "{VERB/m_c/were/was} struck by lightning"
+            }
+        ]
+    },
+    {
+        "event_id": "gen_death_flood_multilead1",
+        "location": ["forest", "mountainous", "plains", "beach", "wetlands"],
+        "season": ["greenleaf","newleaf"],
+        "tags": [],
+        "weight": 20,
+        "event_text": "m_c was swept away by a flood.",
+        "m_c": {
+            "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+            "dies": true
+        },
+        "history": [
+            {
+            "cats": ["m_c"],
+            "reg_death": "m_c was swept away by a flood.",
+            "lead_death": "{VERB/m_c/were/was} swept away by a flood"
+            }
+        ]
+    },
+    {
+        "event_id": "gen_death_tree_any1",
+        "location": [ "beach", "forest", "mountainous" ],
+        "season": ["any"],
+        "tags": [],
+        "weight": 20,
+        "event_text": "m_c fell from the top branches of a tree.",
+        "m_c": {
+            "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+            "dies": true
+        },
+        "history": [
+            {
+                "cats": ["m_c"],
                 "reg_death": "m_c fell from a tall tree.",
                 "lead_death": "fell from a tall tree"
             }
@@ -2780,19 +2605,13 @@
     {
         "event_id": "gen_death_dog_any2",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
+        "season": ["any"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c died in a fight with a dog.",
         "m_c": {
-            "status": [
-                "apprentice", "warrior", "deputy", "leader"
-            ],
-            "not_skill": [
-                "FIGHTER,2"
-            ],
+            "status": ["apprentice", "warrior", "deputy", "leader"],
+            "not_skill": ["FIGHTER,2"],
             "dies": true
         },
         "history": [
@@ -2806,57 +2625,47 @@
     {
         "event_id": "gen_death_badger_anyfight1",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
+        "season": ["any"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c died in a fight with a badger.",
         "m_c": {
-            "status": [
-                "apprentice", "warrior", "deputy", "leader"
-            ],
-            "not_skill": [
-                "FIGHTER,2"
-            ],
+            "status": ["apprentice", "warrior", "deputy", "leader"],
+            "not_skill": ["FIGHTER,2"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c was killed by a badger.",
             "lead_death": "{VERB/m_c/were/was} killed by a badger"
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_rogue_any1",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
+        "season": ["any"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c died in a fight with a rogue.",
         "m_c": {
-            "status": [
-                "apprentice", "warrior", "deputy", "leader"
-            ],
-            "not_skill": [
-                "FIGHTER,2"
-            ],
+            "status": ["apprentice", "warrior", "deputy", "leader"],
+            "not_skill": ["FIGHTER,2"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c was killed in a fight with a rogue.",
             "lead_death": "fought a rogue"
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_spider_any1",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
+        "season": ["any"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c was bitten by a venomous spider.",
@@ -2872,115 +2681,75 @@
     {
         "event_id": "gen_death_badprey_any1",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
+        "season": ["any"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c ate tainted fresh-kill and died.",
         "m_c": {
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c died after eating tainted fresh-kill.",
             "lead_death": "ate tainted fresh-kill"
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_warned_anylead1",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
+        "season": ["any"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c failed to interpret a warning sign from StarClan and couldn't foresee the circumstances of {PRONOUN/m_c/poss} death.",
         "m_c": {
-            "status": [
-                "leader"
-            ],
-            "not_skill": [
-                "CLEVER,2",
-                "STAR,2"
-            ],
+            "status": ["leader"],
+            "not_skill": ["CLEVER,2", "STAR,2"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "lead_death": "failed to interpret a warning from StarClan"
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_dog_anylead1",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
+        "season": ["any"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c was killed defending r_c from a dog.",
         "m_c": {
-            "age": [
-                "adolescent",
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "not_skill": [
-                "FIGHTER,2"
-            ],
-            "trait": [
-                "bold",
-                "bloodthirsty",
-                "ambitious",
-                "daring",
-                "confident",
-                "fierce",
-                "loyal",
-                "loving",
-                "responsible",
-                "righteous",
-                "vengeful"
-            ],
+            "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+            "not_skill": ["FIGHTER,2"],
+            "trait": ["bold", "bloodthirsty", "ambitious", "daring", "confident", "fierce", "loyal", "loving", "responsible", "righteous", "vengeful"],
             "dies": true
         },
         "r_c": {
-            "age": [ "any" ],
-            "status": [ "any" ]
+            "age": ["any"],
+            "status": ["any"]
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c died defending r_c from a dog",
             "lead_death": "defended r_c from a dog"
-        }],
+            }
+        ],
         "relationships": [
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "platonic",
-                    "comfort",
-                    "trust",
-                    "respect"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["platonic", "comfort", "trust", "respect"],
                 "amount": 15
             },
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "dislike"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["dislike"],
                 "amount": -15
             }
         ]
@@ -2988,74 +2757,38 @@
     {
         "event_id": "gen_death_badger_anylead2",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
+        "season": ["any"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c was killed defending r_c from a badger.",
         "m_c": {
-            "age": [
-                "adolescent",
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "not_skill": [
-                "FIGHTER,3"
-            ],
-            "trait": [
-                "bold",
-                "bloodthirsty",
-                "ambitious",
-                "daring",
-                "confident",
-                "fierce",
-                "loyal",
-                "loving",
-                
-                "responsible",
-                "righteous",
-                "vengeful"
-            ],
+            "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+            "not_skill": ["FIGHTER,3"],
+            "trait": ["bold", "bloodthirsty", "ambitious", "daring", "confident", "fierce", "loyal", "loving", "responsible", "righteous", "vengeful"],
             "dies": true
         },
         "r_c": {
-            "age": [ "any" ],
-            "status": [ "any" ]
+            "age": ["any"],
+            "status": ["any"]
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c" ],
             "reg_death": "m_c died defending r_c from a badger.",
             "lead_death": "defended r_c from a badger"
-        }],
+            }
+        ],
         "relationships": [
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "platonic",
-                    "comfort",
-                    "trust",
-                    "respect"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["platonic", "comfort", "trust", "respect"],
                 "amount": 15
             },
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "dislike"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["dislike"],
                 "amount": -15
             }
         ]
@@ -3063,74 +2796,38 @@
     {
         "event_id": "gen_death_fox_anylead2",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
+        "season": ["any"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c was killed defending r_c from a fox.",
         "m_c": {
-            "age": [
-                "adolescent",
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "not_skill": [
-                "FIGHTER,2"
-            ],
-            "trait": [
-                "bold",
-                "bloodthirsty",
-                "ambitious",
-                "daring",
-                "confident",
-                "fierce",
-                "loyal",
-                "loving",
-                
-                "responsible",
-                "righteous",
-                "vengeful"
-            ],
+            "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+            "not_skill": ["FIGHTER,2"],
+            "trait": ["bold", "bloodthirsty", "ambitious", "daring", "confident", "fierce", "loyal", "loving", "responsible", "righteous", "vengeful"],
             "dies": true
         },
         "r_c": {
-            "age": [ "any" ],
-            "status": [ "any" ]
+            "age": ["any"],
+            "status": ["any"]
         },
-        "history": [{
+        "history": [
+            {
             "cats": [ "m_c", "r_c"],
             "reg_death": "m_c died defending r_c from a fox.",
             "lead_death": "defended r_c from a fox"
-        }],
+            }
+        ],
         "relationships": [
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "platonic",
-                    "comfort",
-                    "trust",
-                    "respect"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["platonic", "comfort", "trust", "respect"],
                 "amount": 15
             },
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "dislike"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["dislike"],
                 "amount": -15
             }
         ]
@@ -3138,68 +2835,37 @@
     {
         "event_id": "gen_death_drown_anylead1",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
+        "season": ["any"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c died while saving r_c from drowning.",
         "m_c": {
-            "age": [
-                "adolescent",
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "trait": [
-                "bold",
-                "compassionate",
-                "ambitious",
-                "daring",
-                "confident",
-                "fierce",
-                "loyal",
-                "loving",
-                "responsible"
-            ],
+            "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+            "trait": ["bold", "compassionate", "ambitious", "daring", "confident", "fierce", "loyal", "loving", "responsible"],
             "dies": true
         },
         "r_c": {
-            "age": [ "any" ],
-            "status": [ "any" ]
+            "age": ["any"],
+            "status": ["any"]
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c died saving r_c from drowning.",
             "lead_death": "saved r_c from drowning"
-        }],
+            }
+        ],
         "relationships": [
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "platonic",
-                    "comfort",
-                    "trust",
-                    "respect"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["platonic", "comfort", "trust", "respect"],
                 "amount": 15
             },
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "dislike"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["dislike"],
                 "amount": -15
             }
         ]
@@ -3207,68 +2873,37 @@
     {
         "event_id": "gen_death_monster_anylead1",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
+        "season": ["any"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c saved r_c from a monster but was run over in the process.",
         "m_c": {
-            "age": [
-                "adolescent",
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "trait": [
-                "bold",
-                "ambitious",
-                "compassionate",
-                "daring",
-                "confident",
-                "fierce",
-                "loyal",
-                "loving",
-                "responsible"
-            ],
+            "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+            "trait": ["bold", "ambitious", "compassionate", "daring", "confident", "fierce", "loyal", "loving", "responsible"],
             "dies": true
         },
         "r_c": {
-            "age": [ "any" ],
-            "status": [ "any" ]
+            "age": ["any"],
+            "status": ["any"]
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c died saving r_c from a monster.",
             "lead_death": "saved r_c from a monster"
-        }],
+            }
+        ],
         "relationships": [
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "platonic",
-                    "comfort",
-                    "trust",
-                    "respect"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["platonic", "comfort", "trust", "respect"],
                 "amount": 15
             },
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "dislike"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["dislike"],
                 "amount": -15
             }
         ]
@@ -3276,70 +2911,37 @@
     {
         "event_id": "gen_death_snake_anylead2",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
+        "season": ["any"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c saved r_c from a snake and was bitten in the process. The venom killed {PRONOUN/m_c/object}.",
         "m_c": {
-            "age": [
-                "adolescent",
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "trait": [
-                "bold",
-                "ambitious",
-                "compassionate",
-                "daring",
-                "confident",
-                "fierce",
-                "loyal",
-                "loving",
-                "responsible",
-                "righteous",
-                "vengeful"
-            ],
+            "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+            "trait": ["bold", "ambitious", "compassionate", "daring", "confident", "fierce", "loyal", "loving", "responsible", "righteous", "vengeful"],
             "dies": true
         },
         "r_c": {
-            "age": [ "any" ],
-            "status": [ "any" ]
+            "age": ["any"],
+            "status": ["any"]
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c died saving r_c from a snake.",
             "lead_death": "saved r_c from a snake"
-        }],
+            }
+        ],
         "relationships": [
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "platonic",
-                    "comfort",
-                    "trust",
-                    "respect"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["platonic", "comfort", "trust", "respect"],
                 "amount": 15
             },
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "dislike"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["dislike"],
                 "amount": -15
             }
         ]
@@ -3347,534 +2949,356 @@
     {
         "event_id": "gen_death_ockill_anylead1",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "clan:kitten"
-        ],
+        "season": ["any"],
+        "tags": ["clan:kitten"],
         "subtype": ["war"],
         "weight": 20,
         "event_text": "m_c was killed defending the kits from o_c_n warriors.",
         "m_c": {
-            "age": [
-                "adolescent",
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "not_skill": [
-                "FIGHTER,3"
-            ],
-            "trait": [
-                "bold",
-                "bloodthirsty",
-                "ambitious",
-                "compassionate",
-                "daring",
-                "confident",
-                "fierce",
-                "loyal",
-                "loving",
-                "responsible",
-                "righteous",
-                "vengeful"
-            ],
+            "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+            "not_skill": ["FIGHTER,3"],
+            "trait": ["bold", "bloodthirsty", "ambitious", "compassionate", "daring", "confident", "fierce", "loyal", "loving", "responsible", "righteous", "vengeful"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c died defending the kits from o_c_n warriors",
             "lead_death": "defended the kits from o_c_n warriors"
-        }],
+            }
+        ],
         "other_clan": {
-            "current_rep": [
-                "hostile"
-            ],
+            "current_rep": ["hostile"],
             "changed": -3
         }
     },
     {
         "event_id": "gen_death_ockill_anylead2",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
+        "season": ["any"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c was killed defending r_c from o_c_n warriors.",
         "m_c": {
-            "age": [
-                "adolescent",
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
+            "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
             "relationship_status": [],
-            "not_skill": [
-                "FIGHTER,3"
-            ],
-            "trait": [
-                "bold",
-                "bloodthirsty",
-                "ambitious",
-                "compassionate",
-                "daring",
-                "confident",
-                "fierce",
-                "loyal",
-                "loving",
-                "responsible",
-                "righteous",
-                "vengeful"
-            ],
+            "not_skill": ["FIGHTER,3"],
+            "trait": ["bold", "bloodthirsty", "ambitious", "compassionate", "daring", "confident", "fierce", "loyal", "loving", "responsible", "righteous", "vengeful"],
             "dies": true
         },
         "r_c": {
-            "age": [ "adolescent", "young adult", "adult", "senior adult" ],
-            "status": [ "apprentice", "warrior", "medicine cat apprentice", "medicine cat", "deputy"]
+            "age": ["adolescent", "young adult", "adult", "senior adult"],
+            "status": ["apprentice", "warrior", "medicine cat apprentice", "medicine cat", "deputy"]
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c died defending r_c from o_c_n warriors.",
             "lead_death": "defended r_c from o_c_n warriors"
-        }],
+            }
+        ],
         "relationships": [
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "platonic",
-                    "comfort",
-                    "trust",
-                    "respect"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["platonic", "comfort", "trust", "respect"],
                 "amount": 15
             },
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "dislike"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["dislike"],
                 "amount": -15
             }
         ],
         "other_clan": {
-            "current_rep": [
-                "hostile",
-                "neutral"
-            ],
+            "current_rep": ["hostile", "neutral"],
             "changed": -3
         }
     },
     {
         "event_id": "gen_death_ockill_anylead3",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
+        "season": ["any"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c was killed by an apprentice from o_c_n.",
         "m_c": {
-            "age": [
-                "adolescent",
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "not_skill": [
-                "FIGHTER,1"
-            ],
+            "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+            "not_skill": ["FIGHTER,1"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c was killed by a o_c_n apprentice.",
             "lead_death": "fought an apprentice from o_c_n"
-        }],
+            }
+        ],
         "other_clan": {
-            "current_rep": [
-                "hostile",
-                "neutral"
-            ],
+            "current_rep": ["hostile", "neutral"],
             "changed": -3
         }
     },
     {
         "event_id": "gen_death_ocsave_anylead1",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
+        "season": ["any"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c died trying to save a o_c_n apprentice.",
         "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "not_skill": [
-                "FIGHTER,2"
-            ],
-            "trait": [
-                "bold",
-                "compassionate",
-                "confident",
-                "daring",
-                "fierce",
-                "loving",
-                "responsible",
-                "strange",
-                "wise"
-            ],
+            "age": ["young adult", "adult", "senior adult", "senior"],
+            "not_skill": ["FIGHTER,2"],
+            "trait": ["bold", "compassionate", "confident", "daring", "fierce", "loving", "responsible", "strange", "wise"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c died trying to save an apprentice from o_c_n.",
             "lead_death": "saved an apprentice from o_c_n"
-        }],
+            }
+        ],
         "other_clan": {
-            "current_rep": [
-                "neutral",
-                "ally"
-            ],
+            "current_rep": ["neutral", "ally"],
             "changed": 5
         }
     },
     {
         "event_id": "gen_death_age_anylead1",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
-        "sub_type": [ "old_age" ],
-        "tags": [ "some_lives" ],
+        "season": ["any"],
+        "sub_type": ["old_age"],
+        "tags": ["some_lives"],
         "weight": 20,
         "event_text": "m_c lost some lives to {PRONOUN/m_c/poss} old age.",
         "m_c": {
-            "age": [
-                "senior"
-            ],
-            "status": [
-                "leader"
-            ],
+            "age": ["senior"],
+            "status": ["leader"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "lead_death": "succumbed to old age"
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_age_anylead2",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
-        "sub_type": [ "old_age" ],
-        "tags": [ "all_lives" ],
+        "season": ["any"],
+        "sub_type": ["old_age"],
+        "tags": ["all_lives"],
         "weight": 20,
         "event_text": "m_c has lost all of {PRONOUN/m_c/poss} remaining lives to old age.",
         "m_c": {
-            "age": [
-                "senior"
-            ],
-            "status": [
-                "leader"
-            ],
+            "age": ["senior"],
+            "status": ["leader"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "lead_death": "succumbed to old age"
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_rogue_anylead2",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "all_lives"
-        ],
+        "season": ["any"],
+        "tags": ["all_lives"],
         "weight": 20,
         "event_text": "m_c was brutally attacked by a rogue, and lost all of {PRONOUN/m_c/poss} lives.",
         "m_c": {
-            "status": [
-                "leader"
-            ],
-            "not_skill": [
-                "FIGHTER,2"
-            ],
+            "status": ["leader"],
+            "not_skill": ["FIGHTER,2"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "lead_death": "{VERB/m_c/were/was} brutally attacked by a rogue"
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_dog_anylead2",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "all_lives"
-        ],
+        "season": ["any"],
+        "tags": ["all_lives"],
         "weight": 20,
         "event_text": "m_c was mauled by dogs and lost all of {PRONOUN/m_c/poss} lives.",
         "m_c": {
-            "status": [
-                "leader"
-            ],
-            "not_skill": [
-                "FIGHTER,2"
-            ],
+            "status": ["leader"],
+            "not_skill": ["FIGHTER,2"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "lead_death": "{VERB/m_c/were/was} mauled by dogs"
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_fire_anylead1",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "all_lives",
-            "no_body"
-        ],
+        "season": ["any"],
+        "tags": ["all_lives", "no_body"],
         "weight": 20,
         "event_text": "m_c was burnt alive while trying to save {PRONOUN/m_c/poss} Clanmates from a fire.",
         "m_c": {
-            "status": [
-                "leader"
-            ],
-            "trait": [
-                "bold",
-                "ambitious",
-                "compassionate",
-                "daring",
-                "confident",
-                "fierce",
-                "loyal",
-                "loving",
-                "responsible"
-            ],
+            "status": ["leader"],
+            "trait": ["bold", "ambitious", "compassionate", "daring", "confident", "fierce", "loyal", "loving", "responsible"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "lead_death": "{VERB/m_c/were/was} killed in a fire trying to save {PRONOUN/m_c/poss} Clanmates"
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_ockill_anylead7",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
+        "season": ["any"],
         "sub_type": ["war"],
-        "tags": [
-            "all_lives"
-        ],
+        "tags": ["all_lives"],
         "weight": 20,
         "event_text": "m_c was brutally murdered by a warrior from o_c_n, who cruelly took all {PRONOUN/m_c/poss} lives.",
         "m_c": {
-            "status": [
-                "leader"
-            ],
-            "not_skill": [
-                "FIGHTER,2"
-            ],
+            "status": ["leader"],
+            "not_skill": ["FIGHTER,2"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "lead_death": "{VERB/m_c/were/was} brutally murdered by a warrior from o_c_n"
-        }],
+            }
+        ],
         "other_clan": {
-            "current_rep": [
-                "hostile"
-            ],
+            "current_rep": ["hostile"],
             "changed": -3
         }
     },
     {
         "event_id": "gen_death_ockill_anylead8",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
+        "season": ["any"],
         "sub_type": ["war"],
-        "tags": [
-            "all_lives"
-        ],
+        "tags": ["all_lives"],
         "weight": 20,
         "event_text": "m_c was brutally murdered by the leader of o_c_n, who cruelly took all {PRONOUN/m_c/poss} lives.",
         "m_c": {
-            "status": [
-                "leader"
-            ],
-            "not_skill": [
-                "FIGHTER,3"
-            ],
+            "status": ["leader"],
+            "not_skill": ["FIGHTER,3"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "lead_death": "{VERB/m_c/were/was} brutally murdered by the leader of o_c_n"
-        }],
+            }
+        ],
         "other_clan": {
-            "current_rep": [
-                "hostile"
-            ],
+            "current_rep": ["hostile"],
             "changed": -3
         }
     },
     {
         "event_id": "gen_death_ockill_anylead9",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
+        "season": ["any"],
         "sub_type": ["war"],
-        "tags": [
-            "all_lives"
-        ],
+        "tags": ["all_lives"],
         "weight": 20,
         "event_text": "m_c was brutally murdered by the deputy of o_c_n, who cruelly took all {PRONOUN/m_c/poss} lives.",
         "m_c": {
-            "status": [
-                "leader"
-            ],
-            "not_skill": [
-                "FIGHTER,2"
-            ],
+            "status": ["leader"],
+            "not_skill": ["FIGHTER,2"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "lead_death": "{VERB/m_c/were/was} brutally murdered by the deputy of o_c_n"
-        }],
+            }
+        ],
         "other_clan": {
-            "current_rep": [
-                "hostile"
-            ],
+            "current_rep": ["hostile"],
             "changed": -3
         }
     },
     {
         "event_id": "gen_death_greencough_multilead2",
         "location": ["any"],
-        "season": [
-            "leaf-fall",
-            "leaf-bare"
-        ],
-        "tags": [
-            "classic",
-            "some_lives"
-        ],
+        "season": ["leaf-fall", "leaf-bare"],
+        "tags": ["classic", "some_lives"],
         "weight": 20,
         "event_text": "m_c caught greencough and died more than once, despite the efforts of StarClan.",
         "m_c": {
-            "status": [
-                "leader"
-            ],
+            "status": ["leader"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "lead_death": "contracted greencough"
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_whitecough_multilead2",
         "location": ["any"],
-        "season": [
-            "leaf-fall",
-            "leaf-bare"
-        ],
-        "tags": [
-            "classic",
-            "some_lives"
-        ],
+        "season": ["leaf-fall", "leaf-bare"],
+        "tags": ["classic", "some_lives"],
         "weight": 20,
         "event_text": "m_c caught whitecough and died more than once, despite the efforts of StarClan.",
         "m_c": {
-            "status": [
-                "leader"
-            ],
+            "status": ["leader"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "lead_death": "contracted whitecough"
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_yellowcough_multilead2",
         "location": ["any"],
-        "season": [
-            "leaf-fall",
-            "leaf-bare"
-        ],
-        "tags": [
-            "classic",
-            "some_lives"
-        ],
+        "season": ["leaf-fall", "leaf-bare"],
+        "tags": ["classic", "some_lives"],
         "weight": 20,
         "event_text": "m_c caught yellowcough and died more than once, despite the efforts of StarClan.",
         "m_c": {
-            "status": [
-                "leader"
-            ],
+            "status": ["leader"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "lead_death": "contracted yellowcough"
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_age_anylead3",
         "location": ["any"],
         "season": ["any"],
         "sub_type": ["old_age"],
-        "tags": [
-            "some_lives"
-        ],
+        "tags": ["some_lives"],
         "weight": 20,
         "event_text": "m_c lost lives to old age, {PRONOUN/m_c/poss} body slowly becoming more and more frail.",
         "m_c": {
-            "age": [
-                "senior"
-            ],
-            "status": [
-                "leader"
-            ],
+            "age": ["senior"],
+            "status": ["leader"],
             "dies": true
         },
         "history": [
@@ -3895,62 +3319,48 @@
         "weight": 20,
         "event_text": "m_c collapsed in the midst of camp, losing {PRONOUN/m_c/poss} remaining lives to old age.",
         "m_c": {
-            "age": [
-                "senior"
-            ],
-            "status": [
-                "leader"
-            ],
+            "age": ["senior"],
+            "status": ["leader"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "lead_death": "died of old age"
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_age_anylead5",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
-        "sub_type": [ "old_age" ],
-        "tags": [ ],
+        "season": ["any"],
+        "sub_type": ["old_age"],
+        "tags": [],
         "weight": 20,
         "event_text": "One day, the deputy found m_c dead in the leader's den, a life lost to old age.",
         "m_c": {
-            "age": [
-                "senior"
-            ],
-            "status": [
-                "leader"
-            ],
+            "age": ["senior"],
+            "status": ["leader"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "lead_death": "died of old age"
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_age_anylead6",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
+        "season": ["any"],
         "sub_type": [ "old_age" ],
-        "tags": [
-            "all_lives"
-        ],
+        "tags": ["all_lives"],
         "weight": 20,
         "event_text": "One day, m_c is found dead in the leader's den, never to rise again.",
         "m_c": {
-            "age": [
-                "senior"
-            ],
-            "status": [
-                "leader"
-            ],
+            "age": ["senior"],
+            "status": ["leader"],
             "dies": true
         },
         "history": [
@@ -3963,65 +3373,37 @@
     {
         "event_id": "gen_death_age_anylead7",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
+        "season": ["any"],
         "sub_type": [ "old_age" ],
-        "tags": [
-            "all_lives"
-        ],
+        "tags": ["all_lives"],
         "weight": 20,
         "event_text": "m_c's remaining lives were taken by old age.",
         "m_c": {
-            "age": [
-                "senior"
-            ],
-            "status": [
-                "leader"
-            ],
+            "age": ["senior"],
+            "status": ["leader"],
             "dies": true
         },
         "history": [
             {
             "cats": ["m_c"],
             "lead_death": "died of old age"
-        }
+            }
         ]
     },
     {
         "event_id": "gen_death_murder_anymonster1",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
+        "season": ["any"],
         "sub_type": [ "murder" ],
         "tags": ["low_lives"],
         "weight": 15,
         "event_text": "m_c was pushed under a monster by r_c.",
         "m_c": {
-            "status": [
-                "apprentice",
-                "warrior",
-                "deputy",
-                "leader",
-                "medicine cat apprentice",
-                "medicine cat",
-                "mediator apprentice",
-                "mediator"
-            ],
+            "status": ["apprentice", "warrior", "deputy", "leader", "medicine cat apprentice", "medicine cat", "mediator apprentice", "mediator"],
             "dies": true
         },
         "r_c": {
-            "status": [
-                "apprentice",
-                "warrior",
-                "deputy",
-                "leader",
-                "medicine cat apprentice",
-                "medicine cat",
-                "mediator apprentice",
-                "mediator"
-            ]
+            "status": ["apprentice", "warrior", "deputy", "leader", "medicine cat apprentice", "medicine cat", "mediator apprentice", "mediator"]
         },
         "history": [
             {
@@ -4032,29 +3414,15 @@
         ],
         "relationships": [
             {
-                "cats_from": [
-                    "m_c"
-                ],
-                "cats_to": [
-                    "r_c"
-                ],
-                "values": [
-                    "platonic",
-                    "comfort",
-                    "trust"
-                ],
+                "cats_from": ["m_c"],
+                "cats_to": ["r_c"],
+                "values": ["platonic", "comfort", "trust"],
                 "amount": -15
             },
             {
-                "cats_from": [
-                    "m_c"
-                ],
-                "cats_to": [
-                    "r_c"
-                ],
-                "values": [
-                    "dislike"
-                ],
+                "cats_from": ["m_c"],
+                "cats_to": ["r_c"],
+                "values": ["dislike"],
                 "amount": 15
             }
         ]
@@ -4062,24 +3430,14 @@
     {
         "event_id": "gen_death_murder_anylead2",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
-        "sub_type": [
-            "murder"
-        ],
-        "tags": [
-            "all_lives"
-        ],
+        "season": ["any"],
+        "sub_type": ["murder"],
+        "tags": ["all_lives"],
         "weight": 20,
         "event_text": "m_c was murdered by r_c in cold blood in order to take {PRONOUN/m_c/poss} place.",
         "m_c": {
-            "status": [
-                "leader"
-            ],
-            "not_skill": [
-                "FIGHTER,2"
-            ],
+            "status": ["leader"],
+            "not_skill": ["FIGHTER,2"],
             "dies": true
         },
         "r_c": {
@@ -4087,31 +3445,19 @@
             "skill": [
                 "FIGHTER,2"
             ],
-            "trait": [
-                "vengeful",
-                "ambitious",
-                "bloodthirsty",
-                "righteous",
-                "fierce",
-                "cold",
-                "sneaky"
-            ]
+            "trait": ["vengeful", "ambitious", "bloodthirsty", "righteous", "fierce", "cold", "sneaky"]
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "lead_death": "{VERB/m_c/were/was} murdered by r_c"
-        }],
+            }
+        ],
         "relationships": [
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "platonic"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["platonic"],
                 "amount": -15
             }
         ]
@@ -4119,37 +3465,20 @@
     {
         "event_id": "gen_death_murder_anylead3",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
-        "sub_type": [ "murder" ],
-        "tags": [ "some_lives", "mid_lives"],
+        "season": ["any"],
+        "sub_type": ["murder"],
+        "tags": ["some_lives", "mid_lives"],
         "weight": 40,
         "event_text": "r_c attempted to murder m_c, but miscalculated how many lives {PRONOUN/m_c/subject} had. m_c retaliated with a killing blow.",
         "m_c": {
-            "status": [
-                "leader"
-            ],
-            "skill": [
-                "FIGHTER,2"
-            ],
+            "status": ["leader"],
+            "skill": ["FIGHTER,2"],
             "dies": true
         },
         "r_c": {
             "status": ["deputy"],
-            "not_skill": [
-                "CLEVER,2",
-                "CLEVER,3"
-            ],
-            "trait": [
-                "vengeful",
-                "ambitious",
-                "bloodthirsty",
-                "righteous",
-                "fierce",
-                "cold",
-                "sneaky"
-            ],
+            "not_skill": ["CLEVER,2", "CLEVER,3"],
+            "trait": ["vengeful", "ambitious", "bloodthirsty", "righteous", "fierce", "cold", "sneaky"],
             "dies": true
         },
         "history": [
@@ -4164,29 +3493,15 @@
         ],
         "relationships": [
             {
-                "cats_from": [
-                    "m_c"
-                ],
-                "cats_to": [
-                    "r_c"
-                ],
-                "values": [
-                    "platonic",
-                    "trust",
-                    "respect"
-                ],
+                "cats_from": ["m_c"],
+                "cats_to": ["r_c"],
+                "values": ["platonic", "trust", "respect"],
                 "amount": -15
             },
             {
-                "cats_from": [
-                    "m_c"
-                ],
-                "cats_to": [
-                    "r_c"
-                ],
-                "values": [
-                    "dislike"
-                ],
+                "cats_from": ["m_c"],
+                "cats_to": ["r_c"],
+                "values": ["dislike"],
                 "amount": 15
             }
         ]
@@ -4194,27 +3509,19 @@
     {
         "event_id": "gen_death_murder_anylead4",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
+        "season": ["any"],
         "sub_type": ["murder"],
-        "tags": [
-            "all_lives"
-        ],
+        "tags": ["all_lives"],
         "weight": 20,
         "event_text": "m_c and r_c were ambushed by a pack of dogs, but r_c was nowhere to be found when m_c looked for help.",
         "m_c": {
-            "status": [
-                "leader"
-            ],
-            "not_skill": [
-                "FIGHTER,3"
-            ],
+            "status": ["leader"],
+            "not_skill": ["FIGHTER,3"],
             "dies": true
         },
         "r_c": {
-            "age": [ "young adult", "adult", "senior adult" ],
-            "status": [ "any" ]
+            "age": ["young adult", "adult", "senior adult"],
+            "status": ["any"]
         },
         "history": [
             {
@@ -4224,29 +3531,15 @@
         ],
         "relationships": [
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "platonic",
-                    "trust",
-                    "respect"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["platonic", "trust", "respect"],
                 "amount": -15
             },
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "dislike"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["dislike"],
                 "amount": 15
             }
         ]
@@ -4254,62 +3547,21 @@
     {
         "event_id": "gen_death_murder_anyleader4",
         "location": ["beach", "forest", "mountainous", "wetlands", "plains"],
-        "season": [
-            "any"
-        ],
-        "sub_type": [ "murder" ],
-        "tags": [
-            "clan:kitten",
-            "lives_remain",
-            "kit_manipulated"
-        ],
+        "season": ["any"],
+        "sub_type": ["murder"],
+        "tags": ["clan:kitten", "lives_remain", "kit_manipulated"],
         "weight": 20,
         "event_text": "m_c lost a life while saving a kit from drowning. The kit seemed wary of r_c afterwards, but no one notices.",
         "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": [
-                "leader"
-            ],
-            "trait": [
-                "ambitious",
-                "bold",
-                "compassionate",
-                "confident",
-                "daring",
-                "fierce",
-                "loving",
-                "loyal",
-                "responsible",
-                "righteous",
-                "thoughtful",
-                "vengeful"
-            ],
+            "age": ["young adult", "adult", "senior adult", "senior"],
+            "status": ["leader"],
+            "trait": ["ambitious", "bold", "compassionate", "confident", "daring", "fierce", "loving", "loyal", "responsible", "righteous", "thoughtful", "vengeful"],
             "dies": true
         },
         "r_c": {
-            "age": [ "young adult", "adult", "senior adult", "senior" ],
-            "skill": [
-                "CLEVER,2",
-                "SPEAKER,2"
-            ],
-            "trait": [
-                "ambitious",
-                "careful",
-                "calm",
-                "cold",
-                "confident",
-                "daring",
-                "shameless",
-                "sneaky",
-                "strange",
-                "vengeful",
-                "wise"
-            ]
+            "age": ["young adult", "adult", "senior adult", "senior"],
+            "skill": ["CLEVER,2", "SPEAKER,2"],
+            "trait": ["ambitious", "careful", "calm", "cold", "confident", "daring", "shameless", "sneaky", "strange", "vengeful", "wise"]
         },
         "history": [
             {
@@ -4321,390 +3573,264 @@
     {
         "event_id": "gen_death_curious_anylead1",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
-        "tags": [ "some_lives" ],
+        "season": ["any"],
+        "tags": ["some_lives"],
         "weight": 20,
         "event_text": "m_c snuck out of camp to investigate {PRONOUN/m_c/poss} origins. {PRONOUN/m_c/subject/CAP} returned in the morning, haggard and haunted.",
         "m_c": {
-            "age": [
-                "young adult"
-            ],
-            "status": [
-                "leader"
-            ],
-            "backstory": [
-                "abandoned1",
-                "abandoned2",
-                "abandoned3"
-            ],
+            "age": ["young adult"],
+            "status": ["leader"],
+            "backstory": ["abandoned1", "abandoned2", "abandoned3"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "lead_death": "became a bit too curious"
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_ockill_anylead10",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "lives_remain"
-        ],
+        "season": ["any"],
+        "tags": ["lives_remain"],
         "weight": 20,
         "event_text": "o_c_n attempted to break into the camp. m_c died defending the nursery. r_c remained hidden beneath {PRONOUN/m_c/poss} body as StarClan brought m_c back to life.",
         "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": [
-                "leader"
-            ],
-            "trait": [
-                "vengeful",
-                "bloodthirsty",
-                "loving",
-                "bold",
-                "confident",
-                "daring",
-                "faithful",
-                "fierce",
-                "loyal",
-                "responsible",
-                "righteous"
-            ],
+            "age": ["young adult", "adult", "senior adult", "senior"],
+            "status": ["leader"],
+            "trait": ["vengeful", "bloodthirsty", "loving", "bold", "confident", "daring", "faithful", "fierce", "loyal", "responsible", "righteous"],
             "dies": true
         },
         "r_c": {
-            "age": [
-                "newborn",
-                "kitten"
-            ],
-            "status": [ "any" ]
+            "age": ["newborn", "kitten"],
+            "status": ["any"]
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "lead_death": "defended r_c from o_c_n warriors"
-        }],
+            }
+        ],
         "other_clan": {
-            "current_rep": [
-                "hostile"
-            ],
+            "current_rep": ["hostile"],
             "changed": -3
         }
     },
     {
         "event_id": "gen_death_train_any1",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
+        "season": ["any"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c died in a training accident.",
         "m_c": {
-            "status": [
-                "apprentice"
-            ],
+            "status": ["apprentice"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c died in a training accident."
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_ockill_anyapp1",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
+        "season": ["any"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c was killed by o_c_n warriors when {PRONOUN/m_c/subject} accidentally wandered over the border.",
         "m_c": {
-            "status": [
-                "apprentice",
-                "mediator apprentice",
-                "medicine cat apprentice"
-            ],
-            "trait": [
-                "nervous",
-                "strange",
-                "childish",
-                "troublesome",
-                "lonesome"
-            ],
+            "status": ["apprentice", "mediator apprentice", "medicine cat apprentice"],
+            "trait": ["nervous", "strange", "childish", "troublesome", "lonesome"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c was killed by o_c_n warriors after accidentally trespassing."
-        }],
+            }
+        ],
         "other_clan": {
-            "current_rep": [
-                "hostile",
-                "neutral"
-            ],
+            "current_rep": ["hostile", "neutral"],
             "changed": -3
         }
     },
     {
         "event_id": "gen_death_ockill_anyapp2",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
+        "season": ["any"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c was killed by o_c_n warriors after deliberately crossing the border.",
         "m_c": {
-            "status": [
-                "apprentice"
-            ],
-            "trait": [
-                "daring",
-                "bold",
-                "confident",
-                "playful",
-                "fierce",
-                "ambitious",
-                "bloodthirsty",
-                "fierce",
-                "shameless",
-                "troublesome",
-                "vengeful",
-                "strange",
-                "sneaky"
-            ],
+            "status": ["apprentice"],
+            "trait": ["daring", "bold", "confident", "playful", "fierce", "ambitious", "bloodthirsty", "fierce", "shameless", "troublesome", "vengeful", "strange", "sneaky"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c was killed by o_c_n warriors after deliberately trespassing."
-        }],
+            }
+        ],
         "other_clan": {
-            "current_rep": [
-                "hostile",
-                "neutral"
-            ],
+            "current_rep": ["hostile", "neutral"],
             "changed": -3
         }
     },
     {
         "event_id": "gen_death_murder_anyapp1",
         "location": ["any"],
-        "season": [
-            "any"
-        ],
-        "sub_type": [ "murder" ],
+        "season": ["any"],
+        "sub_type": ["murder"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c died during battle training with r_c. {PRONOUN/r_c/subject/CAP} exclaimed that it was all an accident.",
         "m_c": {
-            "age": [
-                "adolescent", "young adult"
-            ],
-            "status": [
-                "apprentice"
-            ],
+            "age": ["adolescent", "young adult"],
+            "status": ["apprentice"],
             "relationship_status": ["app/mentor"],
             "dies": true
         },
         "r_c": {
-            "age": [ "any" ],
-            "status": [ "any"],
-            "skill": [
-                "FIGHTER,1"
-            ]
+            "age": ["any"],
+            "status": ["any"],
+            "skill": ["FIGHTER,1"]
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c was killed in battle training with r_c."
-        }],
+            }
+        ],
         "relationships": [
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "dislike"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["dislike"],
                 "amount": 15
             },
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "platonic"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["platonic"],
                 "amount": -15
             }
         ]
     },
     {
         "event_id": "gen_death_freeze_leafbarekit1",
-        "location": [
-            "any"
-        ],
-        "season": [
-            "leaf-bare"
-        ],
+        "location": ["any"],
+        "season": ["leaf-bare"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c disappeared from the nursery and was later found dead, not far from camp.",
         "m_c": {
-            "status": [
-                "kitten"
-            ],
-            "trait": [
-                "daring",
-                "impulsive",
-                "attention-seeker",
-                "troublesome"
-            ],
+            "status": ["kitten"],
+            "trait": ["daring", "impulsive", "attention-seeker", "troublesome"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c froze to death."
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_drown_leafbarekit1",
-        "location": [
-            "forest", "plains", "mountainous", "beach", "wetlands"
-        ],
-        "season": [
-            "leaf-bare"
-        ],
+        "location": ["forest", "plains", "mountainous", "beach", "wetlands"],
+        "season": ["leaf-bare"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c was playing on the ice when it cracked and {PRONOUN/m_c/subject} fell in.",
         "m_c": {
-            "status": [
-                "kitten"
-            ],
-            "trait": [
-                "daring",
-                "attention-seeker",
-                "impulsive"
-            ],
+            "status": ["kitten"],
+            "trait": ["daring", "attention-seeker", "impulsive"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c froze to death after falling through ice."
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_predator_anykit1",
-        "location": [
-            "any"
-        ],
-        "season": [
-            "leaf-fall",
-            "leaf-bare"
-        ],
-        "tags": [
-            "no_body"
-        ],
+        "location": ["any"],
+        "season": ["leaf-fall", "leaf-bare"],
+        "tags": ["no_body"],
         "weight": 20,
         "event_text": "m_c wandered away from camp in the night, never to be seen again.",
         "m_c": {
-            "status": [
-                "kitten"
-            ],
+            "status": ["kitten"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c was eaten by a predator."
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_predator_anykit2",
-        "location": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "no_body"
-        ],
+        "location": ["any"],
+        "season": ["any"],
+        "tags": ["no_body"],
         "weight": 20,
         "event_text": "m_c vanished from camp after sneaking out. The search parties find nothing but blood.",
         "m_c": {
-            "status": [
-                "kitten"
-            ],
+            "status": ["kitten"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c was eaten by a predator."
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_mouse_anykit1",
-        "location": [
-            "forest", "plains", "mountainous", "wetlands"
-        ],
-        "season": [
-            "any"
-        ],
+        "location": ["forest", "plains", "mountainous", "wetlands"],
+        "season": ["any"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c was found within a few fox-lengths of camp after sneaking out, cold and covered in bite-marks. The scent of rat hung heavy in the air.",
         "m_c": {
-            "status": [
-                "kitten"
-            ],
+            "status": ["kitten"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c was killed by a rat."
-        }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_shrew_anykit",
-        "location": [
-            "forest", "plains", "mountainous", "wetlands"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "no_body"
-        ],
+        "location": ["forest", "plains", "mountainous", "wetlands"],
+        "season": ["any"],
+        "tags": ["no_body"],
         "weight": 20,
         "event_text": "m_c boasted about how ready {PRONOUN/m_c/subject} {VERB/m_c/were/was} for apprentice-ship. {PRONOUN/m_c/subject/CAP} snuck away to prove it and the Clan finds only blood and raccoon-scent in the morning.",
         "m_c": {
-            "status": [
-                "kitten"
-            ],
+            "status": ["kitten"],
             "dies": true
         },
-        "history": [{
+        "history": [
+            {
             "cats": ["m_c"],
             "reg_death": "m_c was eaten by a raccoon."
-        }]
+            }
+        ]
     },
   {
     "event_id": "multi_death_massdeath_flood1",

--- a/resources/lang/en/events/death/mountainous.json
+++ b/resources/lang/en/events/death/mountainous.json
@@ -2,10 +2,7 @@
     {
         "event_id": "mtn_death_bury_multicamp1",
         "location": ["mountainous:camp1"],
-        "season": [
-            "leaf-fall",
-            "leaf-bare"
-        ],
+        "season": ["leaf-fall", "leaf-bare"],
         "tags": ["all_lives", "no_body"],
         "weight": 20,
         "event_text": "m_c was buried alive when an avalanche hit the camp.",

--- a/resources/lang/en/events/disasters/forest.json
+++ b/resources/lang/en/events/disasters/forest.json
@@ -1,12 +1,8 @@
 [
     {
         "event": "Great Blizzard",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "Leaf-bare"
-        ],
+        "camp": ["any"],
+        "season": ["Leaf-bare"],
         "tags": [],
         "priority": "primary",
         "duration": 2,
@@ -19,9 +15,7 @@
                 "The snow doesn't seem to have an end to it, the nights and days the same dreary shade of white. It is all c_n can do to dig themselves out of their nests each morning."
             ]
         },
-        "conclusion_events": [
-            "The dazzling light of the sun shines brightly on white, still snow. The blizzard has ended, though leaf-bare still continues."
-        ],
+        "conclusion_events": ["The dazzling light of the sun shines brightly on white, still snow. The blizzard has ended, though leaf-bare still continues."],
         "secondary_disasters": [
             {
                 "disaster": "Barren Land",
@@ -52,12 +46,8 @@
     },
     {
         "event": "Drought",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "Greenleaf"
-        ],
+        "camp": ["any"],
+        "season": ["Greenleaf"],
         "tags": [],
         "priority": "primary",
         "duration": 3,
@@ -121,13 +111,8 @@
     },
     {
         "event": "Wildfire",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "Greenleaf",
-            "Leaf-fall"
-        ],
+        "camp": ["any"],
+        "season": ["Greenleaf", "Leaf-fall"],
         "tags": [],
         "priority": "both",
         "duration": 5,
@@ -200,13 +185,8 @@
     },
     {
         "event": "Terrible Cold",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "Leaf-fall",
-            "Leaf-bare"
-        ],
+        "camp": ["any"],
+        "season": ["Leaf-fall", "Leaf-bare"],
         "tags": [],
         "priority": "both",
         "duration": 2,
@@ -233,12 +213,8 @@
     },
     {
         "event": "Floods",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "Newleaf"
-        ],
+        "camp": ["any"],
+        "season": ["Newleaf"],
         "tags": [],
         "priority": "both",
         "duration": 3,
@@ -282,12 +258,8 @@
     },
     {
         "event": "Twoleg Invasion",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "Greenleaf"
-        ],
+        "camp": ["any"],
+        "season": ["Greenleaf"],
         "tags": [],
         "priority": "both",
         "duration": 2,
@@ -326,15 +298,8 @@
     },
     {
         "event": "Prey Sickness",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "Newleaf",
-            "Greenleaf",
-            "Leaf-fall",
-            "Leaf-bare"
-        ],
+        "camp": ["any"],
+        "season": ["any"],
         "tags": [],
         "priority": "both",
         "duration": 2,
@@ -356,14 +321,8 @@
     },
     {
         "event": "Horrible Storms",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "Newleaf",
-            "Greenleaf",
-            "Leaf-fall"
-        ],
+        "camp": ["any"],
+        "season": ["Newleaf", "Greenleaf", "Leaf-fall"],
         "tags": [],
         "priority": "both",
         "duration": 2,
@@ -409,15 +368,8 @@
     },
     {
         "event": "Famine",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "Newleaf",
-            "Greenleaf",
-            "Leaf-fall",
-            "Leaf-bare"
-        ],
+        "camp": ["any"],
+        "season": ["any"],
         "tags": [],
         "priority": "secondary",
         "duration": 3,
@@ -445,15 +397,8 @@
     },
     {
         "event": "Barren Land",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "Newleaf",
-            "Greenleaf",
-            "Leaf-fall",
-            "Leaf-bare"
-        ],
+        "camp": ["any"],
+        "season": ["any"],
         "tags": [],
         "priority": "secondary",
         "duration": 3,
@@ -481,15 +426,8 @@
     },
     {
         "event": "Camp Destruction",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "Newleaf",
-            "Greenleaf",
-            "Leaf-fall",
-            "Leaf-bare"
-        ],
+        "camp": ["any"],
+        "season": ["any"],
         "tags": [],
         "priority": "secondary",
         "duration": 3,

--- a/resources/lang/en/events/injury/beach.json
+++ b/resources/lang/en/events/injury/beach.json
@@ -428,13 +428,7 @@
         "weight": 30,
         "event_text": "m_c was dragged out into the ocean by the tide, and inhaled a lot of water before managing to get out. {PRONOUN/m_c/subject/CAP}{VERB/m_c/'ve/'s} been hacking and sputtering ever since.",
         "m_c": {
-            "age": [
-                "adolescent",
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ]
+            "age": ["adolescent", "young adult", "adult", "senior adult", "senior"]
         },
         "injury": [
             {

--- a/resources/lang/en/events/injury/forest.json
+++ b/resources/lang/en/events/injury/forest.json
@@ -130,13 +130,7 @@
         "weight": 30,
         "event_text": "m_c's tail was badly injured by a falling tree.",
         "m_c": {
-            "age": [
-                "adolescent",
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ]
+            "age": ["adolescent", "young adult", "adult", "senior adult", "senior"]
         },
         "injury": [
             {
@@ -161,13 +155,7 @@
         "weight": 30,
         "event_text": "A fire rages through the forest. m_c manages to escape, though not unscathed by the experience.",
         "m_c": {
-            "age": [
-                "adolescent",
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ]
+            "age": ["adolescent", "young adult", "adult", "senior adult", "senior"]
         },
         "injury": [
             {
@@ -194,7 +182,7 @@
         "event_text": "The dry greenleaf weather leads to a fire bursting to life in camp, dangerously close to the nursery. There's still one kit inside! m_c dives into the den and makes it out, burnt, but with r_c safely swinging in {PRONOUN/m_c/poss} grasp.",
         "m_c": {
             "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
-            "trait": [ "ambitious", "bold", "daring", "fierce", "responsible" ]
+            "trait": ["ambitious", "bold", "daring", "fierce", "responsible"]
         },
         "r_c": {
             "age": ["kitten"],
@@ -219,13 +207,13 @@
             {
                 "cats_from": ["r_c"],
                 "cats_to": ["m_c"],
-                "values": [ "platonic", "comfort", "trust", "respect"],
+                "values": ["platonic", "comfort", "trust", "respect"],
                 "amount": 30
             },
             {
                 "cats_from": ["r_c"],
                 "cats_to": ["m_c"],
-                "values": [ "dislike"],
+                "values": ["dislike"],
                 "amount": -30
             }
         ]
@@ -243,12 +231,12 @@
         },
         "r_c": {
             "status": ["apprentice"],
-            "trait": [ "daring", "adventurous", "oblivious", "bold", "childish" ]
+            "trait": [ "daring", "adventurous", "oblivious", "bold", "childish"]
         },
         "injury": [
             {
                 "cats": [ "m_c", "r_c"], 
-                "injuries": [ "shivering" ],
+                "injuries": ["shivering"],
                 "scars": ["FROSTMITT", "FROSTSOCK"]
             }
         ],
@@ -261,9 +249,9 @@
         ],
         "relationships": [
             {
-                "cats_from": [ "r_c" ], 
-                "cats_to": [ "m_c" ],
-                "values": [ "platonic", "comfort", "trust", "respect", "dislike" ],
+                "cats_from": ["r_c"], 
+                "cats_to": ["m_c"],
+                "values": ["platonic", "comfort", "trust", "respect", "dislike"],
                 "amount": -5
             }
         ]
@@ -271,17 +259,17 @@
     {
         "event_id": "fst_injury_headache_anymultitraitmultistatus1",
         "location": ["forest"],
-        "season": [ "any" ],
+        "season": ["any"],
         "weight": 30,
         "event_text": "Chasing a mouse through a dense area, m_c accidentally collides with a low-hanging branch, leaving {PRONOUN/m_c/object} to return to camp empty-pawed and with splitting head pain.",
         "m_c": {
             "status": ["apprentice", "warrior", "deputy", "leader"],
-            "trait": [ "ambitious", "childish", "playful", "bold", "daring", "confident", "adventurous", "competitive", "oblivious" ]
+            "trait": ["ambitious", "childish", "playful", "bold", "daring", "confident", "adventurous", "competitive", "oblivious"]
         },
         "injury": [
             {
-                "cats": [ "m_c" ], 
-                "injuries": [ "headache" ]
+                "cats": ["m_c"], 
+                "injuries": ["headache"]
             }
         ]
     }

--- a/resources/lang/en/events/injury/mountainous.json
+++ b/resources/lang/en/events/injury/mountainous.json
@@ -7,13 +7,7 @@
         "event_text": "m_c thought {PRONOUN/m_c/subject} {VERB/m_c/were/was} walking on a snowdrift until it gave way and {PRONOUN/m_c/subject} fell down the mountain, breaking {PRONOUN/m_c/poss} leg.",
         "m_c": {
 
-            "age": [
-                "adolescent",
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ]
+            "age": ["adolescent", "young adult", "adult", "senior adult", "senior"]
         },
         "injury": [
             {
@@ -38,13 +32,7 @@
         "weight": 20,
         "event_text": "m_c fell from a cliff and somehow survived, though not without breaking {PRONOUN/m_c/poss} leg.",
         "m_c": {
-            "age": [
-                "adolescent",
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ]
+            "age": ["adolescent", "young adult", "adult", "senior adult", "senior"]
         },
         "injury": [
             {
@@ -69,13 +57,7 @@
         "weight": 20,
         "event_text": "m_c's tail was badly injured by falling rocks.",
         "m_c": {
-            "age": [
-                "adolescent",
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ]
+            "age": ["adolescent", "young adult", "adult", "senior adult", "senior"]
         },
         "injury": [
             {

--- a/resources/lang/en/events/injury/plains.json
+++ b/resources/lang/en/events/injury/plains.json
@@ -40,13 +40,7 @@
         "weight": 30,
         "event_text": "m_c is feeling extremely sore from the long distances {PRONOUN/m_c/subject}{VERB/m_c/'ve/'s} run lately.",
         "m_c": {
-            "age": [
-                "adolescent",
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ]
+            "age": ["adolescent", "young adult", "adult", "senior adult", "senior"]
         },
         "injury": [
             {


### PR DESCRIPTION
## About The Pull Request

Primarily a code side thing, but removing unneeded lines and compacting the events to make them look prettier! 
Reduces some of these event files by a couple thousand lines
Also removes an extra tab in eyes.en.json

## Why This Is Good For ClanGen

Decreases total amount of lines in the event files and makes it quicker to scroll through

## Proof of Testing
Game runs without crashing!
![image](https://github.com/user-attachments/assets/0752cd07-37d2-4bad-bfbb-ace8c79b656e)


## Changelog/Credits

N/A