### PR TITLE
Added Text for Hoarding and Raiding Results

### DIFF
--- a/resources/lang/en/hardcoded.en.json
+++ b/resources/lang/en/hardcoded.en.json
@@ -71,7 +71,7 @@
         },
         "focus_injury_hoarding": {
             "zero": "Luckily, nobody in the Clan got %{condition} due to hoarding.",
-			"one": "A cat got %{condition} due to hoarding herbs and prey.",
+            "one": "A cat got %{condition} due to hoarding herbs and prey.",
             "many": "Multiple cats got %{condition} due to hoarding herbs and prey."
         },
         "focus_injury_raiding": {

--- a/resources/lang/en/hardcoded.en.json
+++ b/resources/lang/en/hardcoded.en.json
@@ -70,10 +70,12 @@
             "many": "With the focus of the Clan, %{amount} pieces of prey were... acquired."
         },
         "focus_injury_hoarding": {
-            "one": "A cat got %{condition} due to hoarding herbs and prey.",
+            "zero": "Luckily, nobody in the Clan got %{condition} due to hoarding.",
+			"one": "A cat got %{condition} due to hoarding herbs and prey.",
             "many": "Multiple cats got %{condition} due to hoarding herbs and prey."
         },
         "focus_injury_raiding": {
+            "zero": "Luckily, nobody in the Clan got %{condition} during raids.",
             "one": "A cat got %{condition} while raiding other Clans for more prey.",
             "many": "Multiple cats got %{condition} while raiding other Clans for more prey."
         },


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

I added new categories inside hardcoded.en.json to include text that prints if no cats receive conditions while the Clan is currently hoarding or raiding other Clans.

## Why This Is Good For ClanGen

It prevents text from printing every moon skip that claims that a cat got sick and injured during a moon skip, despite it not happening - which could confuse the player. 

## Proof of Testing

![image](https://github.com/user-attachments/assets/a9d3a36c-6b89-4de0-83e9-4765321c72bd)
![image](https://github.com/user-attachments/assets/cb2da65a-9138-479e-8ba3-3d5c12a03816)
![image](https://github.com/user-attachments/assets/4ca368ee-4c22-4786-a4fd-ffd08459f180)

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits

N/A
