### PR TITLE
[CONTENT] Patrol for 2 Med Apps

### DIFF
--- a/resources/lang/en/patrols/general/medcat.json
+++ b/resources/lang/en/patrols/general/medcat.json
@@ -4374,7 +4374,7 @@
             "art": "gen_med_warappmedapp_herbcontest"
             },
             {
-                "text": "s_c leads app2 to a plentiful, herb-rich area and harvests them with the practiced ease of a full medicine cat. app2 wonders what the point of {PRONOUN/app2/object} being there even is if s_c can do it all {PRONOUN/s_c/self}.",
+                "text": "s_c leads app2 to a plentiful, herb-rich area and harvests them with the practiced ease of a full medicine cat. app2 wonders what the point of {PRONOUN/app2/object} being there is if s_c can do it all {PRONOUN/s_c/self}.",
                 "exp": 30,
                 "weight": 10,
                 "stat_skill": ["HEALER,1", "SENSE,1"],
@@ -4425,7 +4425,7 @@
             "art": "app_cat_looking_up"
             },
             {
-                "text": "s_c seems uncertain of {PRONOUN/s_c/self}, and app2 reminds {PRONOUN/s_c/object} that {PRONOUN/s_c/subject}{VERB/s_c/'re/'s} a medicine cat apprentice for a reason. Grateful for {PRONOUN/app2/poss} confidence in {PRONOUN/s_c/object}, s_c leads the two of them in a successful patrol.",
+                "text": "s_c seems uncertain of {PRONOUN/s_c/self}, and app2 reminds {PRONOUN/s_c/object} that {PRONOUN/s_c/subject}{VERB/s_c/'re/'s} a medicine cat apprentice for a reason. Grateful for {PRONOUN/app2/poss} confidence in {PRONOUN/s_c/object}, s_c leads the two of them on a successful patrol.",
                 "exp": 30,
                 "weight": 20,
                 "stat_trait": ["insecure", "nervous", "childish", "gloomy"],
@@ -4500,9 +4500,9 @@
                 "art": "gen_bump_heads_apps"
             },
             {
-                "text": "As they gather herbs, s_c suddenly stops and calls app2 over to show {PRONOUN/app2/object} omen_list_sight. The apprentices discuss what it might mean while returning to camp.",
+                "text": "As they gather herbs, s_c suddenly stops and calls app2 over to show {PRONOUN/app2/object} omen_list_sight. The apprentices discuss what it might mean on their way back to camp.",
                 "exp": 30,
-                "weight": 10,
+                "weight": 30,
                 "stat_skill": [ "OMEN,1"],
                 "can_have_stat": ["app1"],
                 "herbs": ["random_herbs"],
@@ -4518,9 +4518,9 @@
                 "art": "gen_app_crouching_perplexed"
             },
             {
-                "text": "app2 scents juniper off to their left. s_c scents clair_list_smell to the right. No matter how carefully {PRONOUN/app2/subject} {VERB/app2/scent/scents} the air, app2 can't catch the scent and suggests it might be a sign. They discuss it while herb-gathering",
+                "text": "app2 scents juniper off to {PRONOUN/app2/poss} left. s_c scents clair_list_smell to the right. No matter how carefully {PRONOUN/app2/subject} {VERB/app2/scent/scents} the air, app2 can't catch that scent and suggests it might be a sign. They discuss it while herb-gathering",
                 "exp": 30,
-                "weight": 10,
+                "weight": 30,
                 "stat_skill": [ "CLAIRVOYANT,1"],
                 "can_have_stat": ["app1"],
                 "herbs": ["random_herbs"],
@@ -4538,7 +4538,7 @@
             {
                 "text": "As the apprentices gather herbs, app2 brushes {PRONOUN/app2/poss} pelt against s_c's. s_c is filled with prophecy_list_emotion. {PRONOUN/s_c/subject/CAP} {VERB/s_c/share/shares} this with app2, wondering if it might be a sign.",
                 "exp": 30,
-                "weight": 10,
+                "weight": 30,
                 "stat_skill": [ "PROPHET,1"],
                 "can_have_stat": ["app1"],
                 "herbs": ["random_herbs"],
@@ -4554,9 +4554,9 @@
                 "art": "gen_speaking_cat_app"
             },
             {
-                "text": "s_c strikes up conversation with app2 as they gather herbs, wondering what {PRONOUN/app2/subject} {VERB/app2/think/thinks} about StarClan and fate. app2 takes the question seriously and the apprentices discuss.",
+                "text": "s_c strikes up conversation with app2 as they gather herbs, wondering what {PRONOUN/app2/subject} {VERB/app2/think/thinks} about StarClan and fate. app2 takes the question seriously and the apprentices discuss as they work.",
                 "exp": 30,
-                "weight": 10,
+                "weight": 20,
                 "stat_skill": [ "STAR,1"],
                 "can_have_stat": ["app1"],
                 "herbs": ["random_herbs"],
@@ -4574,7 +4574,7 @@
             {
                 "text": "s_c and app2 have a productive gathering patrol, but app2 can't say {PRONOUN/app2/subject} particularly {VERB/app2/enjoy/enjoys} s_c's company. Something about {PRONOUN/s_c/object} gets on {PRONOUN/app2/poss} nerves.",
                 "exp": 30,
-                "weight": 10,
+                "weight": 15,
                 "stat_trait": [ "ambitious", "strict", "arrogant", "shameless", "childish", "cold", "competitive", "grumpy", "gloomy", "troublesome", "oblivious"],
                 "can_have_stat": ["app1"],
                 "herbs": ["random_herbs"],
@@ -4599,7 +4599,7 @@
             {
                 "text": "s_c turns the gathering into a competition, and app2 finds {PRONOUN/app2/self} getting invested. A little extra incentive proves helpful, and both apprentices bring back hefty bundles of herbs.",
                 "exp": 30,
-                "weight": 5,
+                "weight": 20,
                 "stat_trait": ["ambitious", "arrogant", "competitive", "daring", "childish", "troublesome"],
                 "can_have_stat": ["app1"],
                 "herbs": ["many_herbs", "random_herbs"],
@@ -4648,9 +4648,9 @@
                 "art": "gen_train_argueAA"
             },
             {
-                "text": "s_c struggles to lead the patrol, but r_c is relieved to see that even {PRONOUN/s_c/subject} {VERB/c_c/fail/fails} sometimes, too. Though they return empty-pawed, r_c feels closer to p_l.",
+                "text": "s_c does a poor job of leading the patrol, but r_c is actually relieved to see that even {PRONOUN/s_c/subject} {VERB/c_c/fail/fails} sometimes, too. Though they return empty-pawed, r_c feels closer to p_l.",
                 "exp": 0,
-                "weight": 20,
+                "weight": 30,
                 "stat_skill": ["SENSE,1", "HEALER,1"],
                 "can_have_stat": ["p_l"],
                     "relationships": [
@@ -4674,7 +4674,7 @@
             {
                 "text": "p_l leads r_c to the wrong area, and r_c starts an argument about who should be leading the patrol. Too embarrassed to admit {PRONOUN/p_l/poss} mistake, p_l argues back, and the patrol gets nothing done.",
                 "exp": 0,
-                "weight": 10,
+                "weight": 20,
                     "relationships": [
                 {
                             "cats_to": ["p_l"],
@@ -4693,8 +4693,8 @@
                 {
                     "cats_to": ["r_c"],
                     "cats_from": ["p_l"],
-                    "mutual": true,
-                    "values": ["dislike", "jealous"],
+                    "mutual": false,
+                    "values": ["jealous"],
                     "amount": 10
                 }
                 ],
@@ -4703,14 +4703,14 @@
             {
                 "text": "p_l leads s_c to the wrong area. s_c is gracious about the mistake, but p_l feels humiliated anyway.",
                 "exp": 0,
-                "weight": 10,
+                "weight": 30,
                 "stat_trait": ["calm", "wise", "compassionate", "thoughtful", "loving", "oblivious", "loyal"],
                 "can_have_stat": ["r_c"],
                     "relationships": [
                 {
                             "cats_to": ["p_l"],
                             "cats_from": ["s_c"],
-                            "mutual": true,
+                            "mutual": false,
                             "values": ["respect", "trust"],
                             "amount": -5
                 },
@@ -4734,7 +4734,7 @@
             {
                 "text": "app1 and app2 have a great walk together, chattering away like starlings. Unfortunately, they were sent to gather herbs, not hang out.",
                 "exp": 0,
-                "weight": 10,
+                "weight": 40,
                     "relationships": [
                 {
                             "cats_to": ["app1"],
@@ -4754,9 +4754,9 @@
                 "art": "gen_app_siblings"
             },
             {
-                "text": "p_l picks and bundles some raspberry and daisy leaves. s_c waggles {PRONOUN/s_c/poss} haunches to pounce on them, batting at the leaves and shredding them to bits. p_l is entertained by s_c's antics, but they return empty-pawed.",
+                "text": "p_l picks and bundles some raspberry and daisy leaves. s_c waggles {PRONOUN/s_c/poss} haunches and pounces on them, batting at the leaves and shredding them to bits. p_l is entertained by s_c's antics, but they return empty-pawed.",
                 "exp": 0,
-                "weight": 10,
+                "weight": 20,
                 "stat_trait": ["childish", "playful"],
                 "can_have_stat": ["r_c"],
                     "relationships": [
@@ -4777,9 +4777,9 @@
                 ]
             },
             {
-                "text": "p_l picks and bundles some raspberry and daisy leaves. s_c waggles {PRONOUN/s_c/poss} haunches to pounce on them, batting at the leaves and shredding them to bits. p_l is frustrated by {PRONOUN/s_c/poss} antics and the ruined herbs, and stalks back to camp with {PRONOUN/p_l/poss} ears pinned back.",
+                "text": "p_l picks and bundles some raspberry and daisy leaves. s_c waggles {PRONOUN/s_c/poss} haunches and pounces on them, batting at the leaves and shredding them to bits. p_l is frustrated by {PRONOUN/s_c/poss} antics and the ruined herbs, and stalks back to camp with {PRONOUN/p_l/poss} ears pinned back.",
                 "exp": 0,
-                "weight": 10,
+                "weight": 30,
                 "stat_trait": ["childish", "playful"],
                 "can_have_stat": ["r_c"],
                     "relationships": [
@@ -4803,7 +4803,7 @@
             {
                 "text": "s_c is awkward and unconfident leading the patrol, and r_c isn't sure how to support {PRONOUN/s_c/object}. The patrol doesn't get much done.",
                 "exp": 0,
-                "weight": 10,
+                "weight": 20,
                 "stat_trait": ["insecure", "nervous", "childish", "gloomy"],
                 "can_have_stat": ["p_l"],
                     "relationships": [
@@ -4820,7 +4820,7 @@
             {
                 "text": "s_c strikes up conversation with app2 as they gather herbs, wondering what {PRONOUN/app2/subject} {VERB/app2/think/thinks} about StarClan and fate. app2 doesn't take the conversation seriously and s_c ends the patrol early, feeling annoyed.",
                 "exp": 30,
-                "weight": 10,
+                "weight": 20,
                 "stat_skill": [ "STAR,1"],
                 "can_have_stat": ["app1"],
                 "herbs": ["random_herbs"],
@@ -4845,7 +4845,7 @@
             {
                 "text": "s_c turns the gathering into a competition, but app2 refuses to play {PRONOUN/s_c/poss} game. Eventually, s_c grows so frustrated that {PRONOUN/s_c/subject} {VERB/s_c/stalk/stalks} off and {VERB/s_c/abandon/abandons} the patrol.",
                 "exp": 0,
-                "weight": 5,
+                "weight": 20,
                 "stat_trait": ["ambitious", "arrogant", "competitive", "daring", "childish", "troublesome"],
                 "can_have_stat": ["app1"],
                     "relationships": [
@@ -4867,9 +4867,9 @@
                 "art": "gen_train_argueAA"
             },
             {
-                "text": "s_c gets sidetracked by a prey scent and catches a lizard. r_c is irritated; they're here to gather herbs, not hunt.",
+                "text": "s_c gets sidetracked by a prey scent and catches a lizard. r_c is irritated. They're here to gather herbs, not hunt.",
                 "exp": 0,
-                "weight": 5,
+                "weight": 20,
                 "stat_skill": ["HUNTER,1"],
                 "can_have_stat": ["p_l"],
                 "prey": ["very_small"],

--- a/resources/lang/en/patrols/general/medcat.json
+++ b/resources/lang/en/patrols/general/medcat.json
@@ -4354,7 +4354,7 @@
             "text": "app1 takes the lead and finds a great patch from which to harvest. app2 is impressed and helps {PRONOUN/app1/object} carry plenty back.",
             "exp": 30,
             "weight": 5,
-            "herbs": ["many_herbs"],
+            "herbs": ["many_herbs", "random_herbs"],
                 "relationships": [
             {
                         "cats_to": ["app1"],
@@ -4379,7 +4379,7 @@
                 "weight": 10,
                 "stat_skill": ["HEALER,1", "SENSE,1"],
                 "can_have_stat": ["app1"],
-                "herbs": ["many_herbs"],
+                "herbs": ["many_herbs", "random_herbs"],
                     "relationships": [
                 {
                             "cats_to": ["app1"],
@@ -4405,7 +4405,7 @@
             "stat_skill": ["HEALER,1", "SENSE,1"],
             "stat_trait": ["confident", "ambitious", "shameless", "arrogant", "competitive", "confident", "bold"],
             "can_have_stat": ["app1"],
-            "herbs": ["many_herbs"],
+            "herbs": ["many_herbs", "random_herbs"],
                 "relationships": [
                     {
                         "cats_to": ["app1"],
@@ -4602,7 +4602,7 @@
                 "weight": 5,
                 "stat_trait": ["ambitious", "arrogant", "competitive", "daring", "childish", "troublesome"],
                 "can_have_stat": ["app1"],
-                "herbs": ["many_herbs"],
+                "herbs": ["many_herbs", "random_herbs"],
                     "relationships": [
                 {
                             "cats_to": ["app1"],

--- a/resources/lang/en/patrols/general/medcat.json
+++ b/resources/lang/en/patrols/general/medcat.json
@@ -4308,5 +4308,589 @@
                     }
             }
         ]
+    },
+    {
+        "patrol_id": "gen_med_apps",
+        "biome": ["any"],
+        "season": ["any"],
+        "types": ["herb_gathering"],
+        "tags": [],
+        "patrol_art": "gen_app_meadow",
+        "min_cats": 2,
+        "max_cats": 2,
+        "min_max_status": {
+            "medicine cat apprentice": [2, 2]
+        },
+        "weight": 20,
+        "chance_of_success": 50,
+        "intro_text": "app1 and app2 head out to collect herbs together.",
+        "decline_text": "A Clanmate calls them back to camp",
+        "success_outcomes":
+        [
+            {
+            "text": "app1 and app2 work together to hunt down, pick, and bundle herbs. They return to camp feeling more confident in each other and in their own skills.",
+            "exp": 30,
+            "weight": 10,
+            "herbs": ["random_herbs"],
+                "relationships": [
+            {
+                        "cats_to": ["app1"],
+                        "cats_from": ["app2"],
+                        "mutual": true,
+                        "values": ["comfort", "respect", "platonic"],
+                        "amount": 10
+            },  
+            {
+                        "cats_to": ["app1"],
+                        "cats_from": ["app2"],
+                        "mutual": true,
+                        "values": ["dislike"],
+                        "amount": -5
+                    }
+            ],
+            "art": "gen_med_warappmedapp_herbcontest"
+            },
+            {
+            "text": "app1 takes the lead and finds a great patch from which to harvest. app2 is impressed and helps {PRONOUN/app1/object} carry plenty back.",
+            "exp": 30,
+            "weight": 5,
+            "herbs": ["many_herbs"],
+                "relationships": [
+            {
+                        "cats_to": ["app1"],
+                        "cats_from": ["app2"],
+                        "mutual": false,
+                        "values": ["platonic", "respect"],
+                        "amount": 10
+            },  
+            {
+                        "cats_to": ["app1"],
+                        "cats_from": ["app2"],
+                        "mutual": true,
+                        "values": ["platonic", "comfort"],
+                        "amount": 5
+                    }
+            ],
+            "art": "gen_med_warappmedapp_herbcontest"
+            },
+            {
+                "text": "s_c leads app2 to a plentiful, herb-rich area and harvests them with the practiced ease of a full medicine cat. app2 wonders what the point of {PRONOUN/app2/object} being there even is if s_c can do it all {PRONOUN/s_c/self}.",
+                "exp": 30,
+                "weight": 10,
+                "stat_skill": ["HEALER,1", "SENSE,1"],
+                "can_have_stat": ["app1"],
+                "herbs": ["many_herbs"],
+                    "relationships": [
+                {
+                            "cats_to": ["app1"],
+                            "cats_from": ["app2"],
+                            "mutual": false,
+                            "values": ["dislike", "respect"],
+                            "amount": 5
+                },  
+                {
+                            "cats_to": ["app1"],
+                            "cats_from": ["app2"],
+                            "mutual": false,
+                            "values": ["jealous"],
+                            "amount": 10
+                        }
+                ],
+                "art": "app_cat_looking_up"
+                },
+                {
+            "text": "s_c bosses app2 around the whole time. To make matters worse, s_c <i>is</i> right about the best places and techniques for herb-gathering. The patrol is highly productive, but app2 seethes with resentment.",
+            "exp": 30,
+            "weight": 20,
+            "stat_skill": ["HEALER,1", "SENSE,1"],
+            "stat_trait": ["confident", "ambitious", "shameless", "arrogant", "competitive", "confident", "bold"],
+            "can_have_stat": ["app1"],
+            "herbs": ["many_herbs"],
+                "relationships": [
+                    {
+                        "cats_to": ["app1"],
+                        "cats_from": ["app2"],
+                        "mutual": false,
+                        "values": ["dislike", "respect"],
+                        "amount": 10
+            },  
+            {
+                        "cats_to": ["app1"],
+                        "cats_from": ["app2"],
+                        "mutual": false,
+                        "values": ["jealous"],
+                        "amount": 15
+                    }
+            ],
+            "art": "app_cat_looking_up"
+            },
+            {
+                "text": "s_c seems uncertain of {PRONOUN/s_c/self}, and app2 reminds {PRONOUN/s_c/object} that {PRONOUN/s_c/subject}{VERB/s_c/'re/'s} a medicine cat apprentice for a reason. Grateful for {PRONOUN/app2/poss} confidence in {PRONOUN/s_c/object}, s_c leads the two of them in a successful patrol.",
+                "exp": 30,
+                "weight": 20,
+                "stat_trait": ["insecure", "nervous", "childish", "gloomy"],
+                "can_have_stat": ["app1"],
+                "herbs": ["random_herbs"],
+                    "relationships": [
+                {
+                            "cats_to": ["app1"],
+                            "cats_from": ["app2"],
+                            "mutual": true,
+                            "values": ["platonic", "comfort"],
+                            "amount": 5
+                },  
+                {
+                            "cats_to": ["app2"],
+                            "cats_from": ["app1"],
+                            "mutual": false,
+                            "values": ["platonic", "comfort", "trust"],
+                            "amount": 10
+                        }
+                ],
+                "art": "gen_bump_heads_apps"
+            },
+            {
+                "text": "While they're gathering, s_c comments that app2 seems down about something. {PRONOUN/app2/subject/CAP} {VERB/app2/confess/confesses} what's been bothering {PRONOUN/app2/object} lately, and s_c gives {PRONOUN/app2/object} a sympathetic ear and some good advice.",
+                "exp": 30,
+                "weight": 20,
+                "stat_trait": ["loving", "compassionate", "wise", "calm", "thoughtful"],
+                "can_have_stat": ["app1"],
+                "herbs": ["random_herbs"],
+                    "relationships": [
+                {
+                            "cats_to": ["app1"],
+                            "cats_from": ["app2"],
+                            "mutual": true,
+                            "values": ["platonic"],
+                            "amount": 5
+                },  
+                {
+                            "cats_to": ["app1"],
+                            "cats_from": ["app2"],
+                            "mutual": false,
+                            "values": ["platonic", "comfort", "trust"],
+                            "amount": 10
+                        }
+                ],
+                "art": "gen_bump_heads_apps"
+            },
+            {
+                "text": "While they're gathering, s_c comments that app2 seems down about something. {PRONOUN/app2/subject/CAP} {VERB/app2/confess/confesses} what's been bothering {PRONOUN/app2/object} lately, and s_c gives {PRONOUN/app2/object} a sympathetic ear and some good advice.",
+                "exp": 30,
+                "weight": 20,
+                "stat_skill": [ "INSIGHTFUL,1", "MEDIATOR,1"],
+                "can_have_stat": ["app1"],
+                "herbs": ["random_herbs"],
+                    "relationships": [
+                {
+                            "cats_to": ["app1"],
+                            "cats_from": ["app2"],
+                            "mutual": true,
+                            "values": ["platonic"],
+                            "amount": 5
+                },  
+                {
+                            "cats_to": ["app1"],
+                            "cats_from": ["app2"],
+                            "mutual": false,
+                            "values": ["platonic", "comfort", "trust"],
+                            "amount": 10
+                        }
+                ],
+                "art": "gen_bump_heads_apps"
+            },
+            {
+                "text": "As they gather herbs, s_c suddenly stops and calls app2 over to show {PRONOUN/app2/object} omen_list_sight. The apprentices discuss what it might mean while returning to camp.",
+                "exp": 30,
+                "weight": 10,
+                "stat_skill": [ "OMEN,1"],
+                "can_have_stat": ["app1"],
+                "herbs": ["random_herbs"],
+                    "relationships": [
+                {
+                            "cats_to": ["app1"],
+                            "cats_from": ["app2"],
+                            "mutual": true,
+                            "values": ["platonic", "trust"],
+                            "amount": 5
+                }
+                ],
+                "art": "gen_app_crouching_perplexed"
+            },
+            {
+                "text": "app2 scents juniper off to their left. s_c scents clair_list_smell to the right. No matter how carefully {PRONOUN/app2/subject} {VERB/app2/scent/scents} the air, app2 can't catch the scent and suggests it might be a sign. They discuss it while herb-gathering",
+                "exp": 30,
+                "weight": 10,
+                "stat_skill": [ "CLAIRVOYANT,1"],
+                "can_have_stat": ["app1"],
+                "herbs": ["random_herbs"],
+                    "relationships": [
+                {
+                            "cats_to": ["app1"],
+                            "cats_from": ["app2"],
+                            "mutual": true,
+                            "values": ["platonic", "trust"],
+                            "amount": 5
+                }
+                ],
+                "art": "gen_apprentice_found_scent_clanmate"
+            },
+            {
+                "text": "As the apprentices gather herbs, app2 brushes {PRONOUN/app2/poss} pelt against s_c's. s_c is filled with prophecy_list_emotion. {PRONOUN/s_c/subject/CAP} {VERB/s_c/share/shares} this with app2, wondering if it might be a sign.",
+                "exp": 30,
+                "weight": 10,
+                "stat_skill": [ "PROPHET,1"],
+                "can_have_stat": ["app1"],
+                "herbs": ["random_herbs"],
+                    "relationships": [
+                {
+                            "cats_to": ["app1"],
+                            "cats_from": ["app2"],
+                            "mutual": true,
+                            "values": ["platonic", "trust"],
+                            "amount": 5
+                }
+                ],
+                "art": "gen_speaking_cat_app"
+            },
+            {
+                "text": "s_c strikes up conversation with app2 as they gather herbs, wondering what {PRONOUN/app2/subject} {VERB/app2/think/thinks} about StarClan and fate. app2 takes the question seriously and the apprentices discuss.",
+                "exp": 30,
+                "weight": 10,
+                "stat_skill": [ "STAR,1"],
+                "can_have_stat": ["app1"],
+                "herbs": ["random_herbs"],
+                    "relationships": [
+                {
+                            "cats_to": ["app1"],
+                            "cats_from": ["app2"],
+                            "mutual": true,
+                            "values": ["platonic", "trust", "respect", "comfort"],
+                            "amount": 5
+                }
+                ],
+                "art": "gen_speaking_cat_app"
+            },
+            {
+                "text": "s_c and app2 have a productive gathering patrol, but app2 can't say {PRONOUN/app2/subject} particularly {VERB/app2/enjoy/enjoys} s_c's company. Something about {PRONOUN/s_c/object} gets on {PRONOUN/app2/poss} nerves.",
+                "exp": 30,
+                "weight": 10,
+                "stat_trait": [ "ambitious", "strict", "arrogant", "shameless", "childish", "cold", "competitive", "grumpy", "gloomy", "troublesome", "oblivious"],
+                "can_have_stat": ["app1"],
+                "herbs": ["random_herbs"],
+                    "relationships": [
+                {
+                            "cats_to": ["app1"],
+                            "cats_from": ["app2"],
+                            "mutual": false,
+                            "values": ["platonic", "comfort"],
+                            "amount": -5
+                },
+                {
+                    "cats_to": ["app1"],
+                    "cats_from": ["app2"],
+                    "mutual": false,
+                    "values": ["dislike"],
+                    "amount": 10
+                }
+                ],
+                "art": "app_cat_looking_up"
+            },
+            {
+                "text": "s_c turns the gathering into a competition, and app2 finds {PRONOUN/app2/self} getting invested. A little extra incentive proves helpful, and both apprentices bring back hefty bundles of herbs.",
+                "exp": 30,
+                "weight": 5,
+                "stat_trait": ["ambitious", "arrogant", "competitive", "daring", "childish", "troublesome"],
+                "can_have_stat": ["app1"],
+                "herbs": ["many_herbs"],
+                    "relationships": [
+                {
+                            "cats_to": ["app1"],
+                            "cats_from": ["app2"],
+                            "mutual": true,
+                            "values": ["platonic", "comfort", "respect"],
+                            "amount": 5
+                },
+                {
+                    "cats_to": ["app1"],
+                    "cats_from": ["app2"],
+                    "mutual": false,
+                    "values": ["dislike"],
+                    "amount": -5
+                }
+                ],
+                "art": "fst_hunt_fun4"
+            }
+
+        ],
+        "fail_outcomes":
+        [
+            {
+                "text": "No matter how much they search, neither apprentice can find a patch of herbs ready to be harvested. app1 blames app2, and app2 blames app1. They return to camp still squabbling.",
+                "exp": 0,
+                "weight": 20,
+                    "relationships": [
+                {
+                            "cats_to": ["app1"],
+                            "cats_from": ["app2"],
+                            "mutual": true,
+                            "values": ["platonic", "comfort", "respect"],
+                            "amount": -5
+                },
+                {
+                    "cats_to": ["app1"],
+                    "cats_from": ["app2"],
+                    "mutual": true,
+                    "values": ["dislike"],
+                    "amount": 10
+                }
+                ],
+                "art": "gen_train_argueAA"
+            },
+            {
+                "text": "s_c struggles to lead the patrol, but r_c is relieved to see that even {PRONOUN/s_c/subject} {VERB/c_c/fail/fails} sometimes, too. Though they return empty-pawed, r_c feels closer to p_l.",
+                "exp": 0,
+                "weight": 20,
+                "stat_skill": ["SENSE,1", "HEALER,1"],
+                "can_have_stat": ["p_l"],
+                    "relationships": [
+                {
+                            "cats_to": ["p_l"],
+                            "cats_from": ["r_c"],
+                            "mutual": false,
+                            "values": ["platonic", "comfort", "trust"],
+                            "amount": 5
+                },
+                {
+                    "cats_to": ["p_l"],
+                    "cats_from": ["r_c"],
+                    "mutual": true,
+                    "values": ["jealous"],
+                    "amount": -10
+                }
+                ],
+                "art": "gen_happy_cat2"
+            },
+            {
+                "text": "p_l leads r_c to the wrong area, and r_c starts an argument about who should be leading the patrol. Too embarrassed to admit {PRONOUN/p_l/poss} mistake, p_l argues back, and the patrol gets nothing done.",
+                "exp": 0,
+                "weight": 10,
+                    "relationships": [
+                {
+                            "cats_to": ["p_l"],
+                            "cats_from": ["r_c"],
+                            "mutual": true,
+                            "values": ["platonic", "comfort", "respect"],
+                            "amount": -5
+                },
+                {
+                    "cats_to": ["p_l"],
+                    "cats_from": ["r_c"],
+                    "mutual": true,
+                    "values": ["dislike"],
+                    "amount": 10
+                },
+                {
+                    "cats_to": ["r_c"],
+                    "cats_from": ["p_l"],
+                    "mutual": true,
+                    "values": ["dislike", "jealous"],
+                    "amount": 10
+                }
+                ],
+                "art": "gen_train_argueAA"
+            },
+            {
+                "text": "p_l leads s_c to the wrong area. s_c is gracious about the mistake, but p_l feels humiliated anyway.",
+                "exp": 0,
+                "weight": 10,
+                "stat_trait": ["calm", "wise", "compassionate", "thoughtful", "loving", "oblivious", "loyal"],
+                "can_have_stat": ["r_c"],
+                    "relationships": [
+                {
+                            "cats_to": ["p_l"],
+                            "cats_from": ["s_c"],
+                            "mutual": true,
+                            "values": ["respect", "trust"],
+                            "amount": -5
+                },
+                {
+                    "cats_to": ["p_l"],
+                    "cats_from": ["s_c"],
+                    "mutual": true,
+                    "values": ["comfort"],
+                    "amount": -5
+                },
+                {
+                    "cats_to": ["s_c"],
+                    "cats_from": ["p_l"],
+                    "mutual": false,
+                    "values": ["dislike", "jealous", "respect"],
+                    "amount": 5
+                }
+                ],
+                "art": "gen_train_patrolapprenticesessionfail"
+            },
+            {
+                "text": "app1 and app2 have a great walk together, chattering away like starlings. Unfortunately, they were sent to gather herbs, not hang out.",
+                "exp": 0,
+                "weight": 10,
+                    "relationships": [
+                {
+                            "cats_to": ["app1"],
+                            "cats_from": ["app2"],
+                            "mutual": true,
+                            "values": ["comfort", "platonic"],
+                            "amount": 10
+                },
+                {
+                    "cats_to": ["app1"],
+                    "cats_from": ["app2"],
+                    "mutual": true,
+                    "values": ["dislike"],
+                    "amount": -5
+        }
+                ],
+                "art": "gen_app_siblings"
+            },
+            {
+                "text": "p_l picks and bundles some raspberry and daisy leaves. s_c waggles {PRONOUN/s_c/poss} haunches to pounce on them, batting at the leaves and shredding them to bits. p_l is entertained by s_c's antics, but they return empty-pawed.",
+                "exp": 0,
+                "weight": 10,
+                "stat_trait": ["childish", "playful"],
+                "can_have_stat": ["r_c"],
+                    "relationships": [
+                {
+                            "cats_to": ["p_l"],
+                            "cats_from": ["s_c"],
+                            "mutual": true,
+                            "values": ["comfort", "platonic"],
+                            "amount": 5
+                },
+                {
+                    "cats_to": ["s_c"],
+                    "cats_from": ["p_l"],
+                    "mutual": false,
+                    "values": ["respect"],
+                    "amount": -10
+        }
+                ]
+            },
+            {
+                "text": "p_l picks and bundles some raspberry and daisy leaves. s_c waggles {PRONOUN/s_c/poss} haunches to pounce on them, batting at the leaves and shredding them to bits. p_l is frustrated by {PRONOUN/s_c/poss} antics and the ruined herbs, and stalks back to camp with {PRONOUN/p_l/poss} ears pinned back.",
+                "exp": 0,
+                "weight": 10,
+                "stat_trait": ["childish", "playful"],
+                "can_have_stat": ["r_c"],
+                    "relationships": [
+                {
+                            "cats_to": ["s_c"],
+                            "cats_from": ["p_l"],
+                            "mutual": false,
+                            "values": ["comfort", "platonic", "respect"],
+                            "amount": -5
+                },
+                {
+                    "cats_to": ["s_c"],
+                    "cats_from": ["p_l"],
+                    "mutual": false,
+                    "values": ["dislike"],
+                    "amount": 10
+        }
+                ],
+                "art": "gen_angry_cat_app"
+            },
+            {
+                "text": "s_c is awkward and unconfident leading the patrol, and r_c isn't sure how to support {PRONOUN/s_c/object}. The patrol doesn't get much done.",
+                "exp": 0,
+                "weight": 10,
+                "stat_trait": ["insecure", "nervous", "childish", "gloomy"],
+                "can_have_stat": ["p_l"],
+                    "relationships": [
+                {
+                            "cats_to": ["s_c"],
+                            "cats_from": ["r_c"],
+                            "mutual": false,
+                            "values": ["trust", "platonic", "respect"],
+                            "amount": -5
+                }
+                ],
+                "art": "gen_train_patrolapprenticesessionfail"
+            },
+            {
+                "text": "s_c strikes up conversation with app2 as they gather herbs, wondering what {PRONOUN/app2/subject} {VERB/app2/think/thinks} about StarClan and fate. app2 doesn't take the conversation seriously and s_c ends the patrol early, feeling annoyed.",
+                "exp": 30,
+                "weight": 10,
+                "stat_skill": [ "STAR,1"],
+                "can_have_stat": ["app1"],
+                "herbs": ["random_herbs"],
+                    "relationships": [
+                {
+                            "cats_to": ["app2"],
+                            "cats_from": ["s_c"],
+                            "mutual": false,
+                            "values": ["platonic", "trust", "respect", "comfort"],
+                            "amount": -5
+                },
+                {
+                    "cats_to": ["app2"],
+                    "cats_from": ["s_c"],
+                    "mutual": false,
+                    "values": ["dislike"],
+                    "amount": 10
+        }
+                ],
+                "art": "gen_train_argueAA"
+            },
+            {
+                "text": "s_c turns the gathering into a competition, but app2 refuses to play {PRONOUN/s_c/poss} game. Eventually, s_c grows so frustrated that {PRONOUN/s_c/subject} {VERB/s_c/stalk/stalks} off and {VERB/s_c/abandon/abandons} the patrol.",
+                "exp": 0,
+                "weight": 5,
+                "stat_trait": ["ambitious", "arrogant", "competitive", "daring", "childish", "troublesome"],
+                "can_have_stat": ["app1"],
+                    "relationships": [
+                {
+                            "cats_to": ["s_c"],
+                            "cats_from": ["app2"],
+                            "mutual": true,
+                            "values": ["platonic", "comfort", "respect"],
+                            "amount": -5
+                },
+                {
+                    "cats_to": ["app2"],
+                    "cats_from": ["s_c"],
+                    "mutual": false,
+                    "values": ["dislike"],
+                    "amount": 5
+                }
+                ],
+                "art": "gen_train_argueAA"
+            },
+            {
+                "text": "s_c gets sidetracked by a prey scent and catches a lizard. r_c is irritated; they're here to gather herbs, not hunt.",
+                "exp": 0,
+                "weight": 5,
+                "stat_skill": ["HUNTER,1"],
+                "can_have_stat": ["p_l"],
+                "prey": ["very_small"],
+                    "relationships": [
+                {
+                            "cats_to": ["s_c"],
+                            "cats_from": ["r_c"],
+                            "mutual": true,
+                            "values": ["platonic", "comfort", "respect"],
+                            "amount": -5
+                },
+                {
+                    "cats_to": ["s_c"],
+                    "cats_from": ["r_c"],
+                    "mutual": false,
+                    "values": ["dislike"],
+                    "amount": 5
+                }
+                ],
+                "art": "gen_train_argueAA"
+            }
+        ]
     }
 ]

--- a/resources/lang/en/snippet_collections.json
+++ b/resources/lang/en/snippet_collections.json
@@ -166,9 +166,9 @@
         ["the strength of a warrior", "the steadfastness of a warrior", "a warrior's loyalty"],
         ["the ache of an elder's bones", "the wisdom of an elder"],
         ["the sensation of falling"],
-        ["the feeling of flight"],
+        ["the weightlessness of flight"],
         ["a half-remembered promise"],
-        ["a foreboding feeling"],
+        ["a foreboding dread"],
         ["the embrace of a family"]
       ],
       "forest": [


### PR DESCRIPTION
## About The Pull Request

New patrol to fill the gap of no patrols specifically for two medicine cat apprentices. Tons of outcomes for different skills and traits. I also slightly edited the snippet collection to fit better with the sentence flow.

still need to figure out why I got a result with "no herbs were found" but once that's fixed, this PR is ready to go.

## Why This Is Good For ClanGen

As above: filling a need.

## Proof of Testing

![image](https://github.com/user-attachments/assets/194275a5-3d39-4900-a0b7-5ae0c1c6ad53)
![image](https://github.com/user-attachments/assets/76dfe2a7-e8c4-44b5-b7ae-c95e83f2fe2e)
![image](https://github.com/user-attachments/assets/a643ff83-0844-46f0-b814-3b24f6d22720)
![image](https://github.com/user-attachments/assets/f7efe0ba-0580-45e6-a2d8-d4f860330358)
