### PR TITLE
[BUGFIX] Making sure there's a responsible adult on the patrol

### DIFF
--- a/resources/lang/en/patrols/beach/med/greenleaf.json
+++ b/resources/lang/en/patrols/beach/med/greenleaf.json
@@ -6033,8 +6033,8 @@
         "max_cats": 6,
         "min_max_status": {
             "healer cats": [1, 6],
-            "all apprentices": [2, 6],
-            "medicine cat": [1, 6]
+            "all apprentices": [1, 5],
+            "medicine cat": [1, 5]
         },
         "weight": 20,
         "intro_text": "app1 shovels tansy into {PRONOUN/app1/poss} mouth without a care in the world. p_l stops {PRONOUN/app1/object}, and tells {PRONOUN/app1/object} {PRONOUN/app1/subject} really <i>should</i> have a care.",

--- a/resources/lang/en/patrols/beach/med/greenleaf.json
+++ b/resources/lang/en/patrols/beach/med/greenleaf.json
@@ -6033,7 +6033,8 @@
         "max_cats": 6,
         "min_max_status": {
             "healer cats": [1, 6],
-            "all apprentices": [1, 6]
+            "all apprentices": [2, 6],
+            "medicine cat": [1, 6]
         },
         "weight": 20,
         "intro_text": "app1 shovels tansy into {PRONOUN/app1/poss} mouth without a care in the world. p_l stops {PRONOUN/app1/object}, and tells {PRONOUN/app1/object} {PRONOUN/app1/subject} really <i>should</i> have a care.",

--- a/resources/lang/en/patrols/beach/med/leaf-fall.json
+++ b/resources/lang/en/patrols/beach/med/leaf-fall.json
@@ -5919,8 +5919,8 @@
         "max_cats": 6,
         "min_max_status": {
             "healer cats": [1, 6],
-            "all apprentices": [2, 6],
-            "medicine cat": [1, 6]
+            "all apprentices": [1, 5],
+            "medicine cat": [1, 5]
         },
         "weight": 20,
         "intro_text": "app1 shovels tansy into {PRONOUN/app1/poss} mouth without a care in the world. p_l stops {PRONOUN/app1/object}, and tells {PRONOUN/app1/object} {PRONOUN/app1/subject} really <i>should</i> have a care.",

--- a/resources/lang/en/patrols/beach/med/leaf-fall.json
+++ b/resources/lang/en/patrols/beach/med/leaf-fall.json
@@ -5919,7 +5919,8 @@
         "max_cats": 6,
         "min_max_status": {
             "healer cats": [1, 6],
-            "all apprentices": [1, 6]
+            "all apprentices": [2, 6],
+            "medicine cat": [1, 6]
         },
         "weight": 20,
         "intro_text": "app1 shovels tansy into {PRONOUN/app1/poss} mouth without a care in the world. p_l stops {PRONOUN/app1/object}, and tells {PRONOUN/app1/object} {PRONOUN/app1/subject} really <i>should</i> have a care.",

--- a/resources/lang/en/patrols/beach/med/newleaf.json
+++ b/resources/lang/en/patrols/beach/med/newleaf.json
@@ -5924,8 +5924,8 @@
         "max_cats": 6,
         "min_max_status": {
             "healer cats": [1, 6],
-            "all apprentices": [2, 6],
-            "medicine cat": [1, 6]
+            "all apprentices": [1, 5],
+            "medicine cat": [1, 5]
         },
         "weight": 20,
         "intro_text": "app1 shovels tansy into {PRONOUN/app1/poss} mouth without a care in the world. p_l stops {PRONOUN/app1/object}, and tells {PRONOUN/app1/object} {PRONOUN/app1/subject} really <i>should</i> have a care.",

--- a/resources/lang/en/patrols/beach/med/newleaf.json
+++ b/resources/lang/en/patrols/beach/med/newleaf.json
@@ -5924,7 +5924,8 @@
         "max_cats": 6,
         "min_max_status": {
             "healer cats": [1, 6],
-            "all apprentices": [1, 6]
+            "all apprentices": [2, 6],
+            "medicine cat": [1, 6]
         },
         "weight": 20,
         "intro_text": "app1 shovels tansy into {PRONOUN/app1/poss} mouth without a care in the world. p_l stops {PRONOUN/app1/object}, and tells {PRONOUN/app1/object} {PRONOUN/app1/subject} really <i>should</i> have a care.",

--- a/resources/lang/en/patrols/desert/med/leaf-bare.json
+++ b/resources/lang/en/patrols/desert/med/leaf-bare.json
@@ -865,8 +865,8 @@
         "max_cats": 6,
         "min_max_status": {
             "healer cats": [1, 6],
-            "all apprentices": [2, 6],
-            "medicine cat": [1, 6]
+            "all apprentices": [1, 5],
+            "medicine cat": [1, 5]
         },
         "weight": 20,
         "intro_text": "app1 shovels tansy into {PRONOUN/app1/poss} mouth without a care in the world. p_l stops {PRONOUN/app1/object}, and tells {PRONOUN/app1/object} {PRONOUN/app1/subject} really <i>should</i> have a care.",

--- a/resources/lang/en/patrols/desert/med/leaf-bare.json
+++ b/resources/lang/en/patrols/desert/med/leaf-bare.json
@@ -865,7 +865,8 @@
         "max_cats": 6,
         "min_max_status": {
             "healer cats": [1, 6],
-            "all apprentices": [1, 6]
+            "all apprentices": [2, 6],
+            "medicine cat": [1, 6]
         },
         "weight": 20,
         "intro_text": "app1 shovels tansy into {PRONOUN/app1/poss} mouth without a care in the world. p_l stops {PRONOUN/app1/object}, and tells {PRONOUN/app1/object} {PRONOUN/app1/subject} really <i>should</i> have a care.",

--- a/resources/lang/en/patrols/desert/med/leaf-fall.json
+++ b/resources/lang/en/patrols/desert/med/leaf-fall.json
@@ -887,8 +887,8 @@
         "max_cats": 6,
         "min_max_status": {
             "healer cats": [1, 6],
-            "all apprentices": [2, 6],
-            "medicine cat": [1, 6]
+            "all apprentices": [1, 5],
+            "medicine cat": [1, 5]
         },
         "weight": 20,
         "intro_text": "app1 shovels tansy into {PRONOUN/app1/poss} mouth without a care in the world. p_l stops {PRONOUN/app1/object}, and tells {PRONOUN/app1/object} {PRONOUN/app1/subject} really <i>should</i> have a care.",

--- a/resources/lang/en/patrols/desert/med/leaf-fall.json
+++ b/resources/lang/en/patrols/desert/med/leaf-fall.json
@@ -887,7 +887,8 @@
         "max_cats": 6,
         "min_max_status": {
             "healer cats": [1, 6],
-            "all apprentices": [1, 6]
+            "all apprentices": [2, 6],
+            "medicine cat": [1, 6]
         },
         "weight": 20,
         "intro_text": "app1 shovels tansy into {PRONOUN/app1/poss} mouth without a care in the world. p_l stops {PRONOUN/app1/object}, and tells {PRONOUN/app1/object} {PRONOUN/app1/subject} really <i>should</i> have a care.",

--- a/resources/lang/en/patrols/desert/med/newleaf.json
+++ b/resources/lang/en/patrols/desert/med/newleaf.json
@@ -887,8 +887,8 @@
         "max_cats": 6,
         "min_max_status": {
             "healer cats": [1, 6],
-            "all apprentices": [2, 6],
-            "medicine cat": [1, 6]
+            "all apprentices": [1, 5],
+            "medicine cat": [1, 5]
         },
         "weight": 20,
         "intro_text": "app1 shovels tansy into {PRONOUN/app1/poss} mouth without a care in the world. p_l stops {PRONOUN/app1/object}, and tells {PRONOUN/app1/object} {PRONOUN/app1/subject} really <i>should</i> have a care.",

--- a/resources/lang/en/patrols/desert/med/newleaf.json
+++ b/resources/lang/en/patrols/desert/med/newleaf.json
@@ -887,7 +887,8 @@
         "max_cats": 6,
         "min_max_status": {
             "healer cats": [1, 6],
-            "all apprentices": [1, 6]
+            "all apprentices": [2, 6],
+            "medicine cat": [1, 6]
         },
         "weight": 20,
         "intro_text": "app1 shovels tansy into {PRONOUN/app1/poss} mouth without a care in the world. p_l stops {PRONOUN/app1/object}, and tells {PRONOUN/app1/object} {PRONOUN/app1/subject} really <i>should</i> have a care.",

--- a/resources/lang/en/patrols/forest/med/greenleaf.json
+++ b/resources/lang/en/patrols/forest/med/greenleaf.json
@@ -730,7 +730,8 @@
         "max_cats": 6,
         "min_max_status": {
             "healer cats": [1, 6],
-            "all apprentices": [1, 6]
+            "all apprentices": [2, 6],
+            "medicine cat": [1, 6]
         },
         "weight": 20,
         "intro_text": "app1 shovels tansy into {PRONOUN/app1/poss} mouth without a care in the world. p_l stops {PRONOUN/app1/object}, and tells {PRONOUN/app1/object} {PRONOUN/app1/subject} really <i>should</i> have a care.",

--- a/resources/lang/en/patrols/forest/med/greenleaf.json
+++ b/resources/lang/en/patrols/forest/med/greenleaf.json
@@ -730,8 +730,8 @@
         "max_cats": 6,
         "min_max_status": {
             "healer cats": [1, 6],
-            "all apprentices": [2, 6],
-            "medicine cat": [1, 6]
+            "all apprentices": [1, 5],
+            "medicine cat": [1, 5]
         },
         "weight": 20,
         "intro_text": "app1 shovels tansy into {PRONOUN/app1/poss} mouth without a care in the world. p_l stops {PRONOUN/app1/object}, and tells {PRONOUN/app1/object} {PRONOUN/app1/subject} really <i>should</i> have a care.",

--- a/resources/lang/en/patrols/forest/med/leaf-fall.json
+++ b/resources/lang/en/patrols/forest/med/leaf-fall.json
@@ -6347,8 +6347,8 @@
         "max_cats": 6,
         "min_max_status": {
             "healer cats": [1, 6],
-            "all apprentices": [2, 6],
-            "medicine cat": [1, 6]
+            "all apprentices": [1, 5],
+            "medicine cat": [1, 5]
         },
         "weight": 20,
         "intro_text": "app1 shovels tansy into {PRONOUN/app1/poss} mouth without a care in the world. p_l stops {PRONOUN/app1/object}, and tells {PRONOUN/app1/object} {PRONOUN/app1/subject} really <i>should</i> have a care.",

--- a/resources/lang/en/patrols/forest/med/leaf-fall.json
+++ b/resources/lang/en/patrols/forest/med/leaf-fall.json
@@ -6347,7 +6347,8 @@
         "max_cats": 6,
         "min_max_status": {
             "healer cats": [1, 6],
-            "all apprentices": [1, 6]
+            "all apprentices": [2, 6],
+            "medicine cat": [1, 6]
         },
         "weight": 20,
         "intro_text": "app1 shovels tansy into {PRONOUN/app1/poss} mouth without a care in the world. p_l stops {PRONOUN/app1/object}, and tells {PRONOUN/app1/object} {PRONOUN/app1/subject} really <i>should</i> have a care.",

--- a/resources/lang/en/patrols/forest/med/newleaf.json
+++ b/resources/lang/en/patrols/forest/med/newleaf.json
@@ -6446,8 +6446,8 @@
         "max_cats": 6,
         "min_max_status": {
             "healer cats": [1, 6],
-            "all apprentices": [2, 6],
-            "medicine cat": [1, 6]
+            "all apprentices": [1, 5],
+            "medicine cat": [1, 5]
         },
         "weight": 20,
         "intro_text": "app1 shovels tansy into {PRONOUN/app1/poss} mouth without a care in the world. p_l stops {PRONOUN/app1/object}, and tells {PRONOUN/app1/object} {PRONOUN/app1/subject} really <i>should</i> have a care.",

--- a/resources/lang/en/patrols/forest/med/newleaf.json
+++ b/resources/lang/en/patrols/forest/med/newleaf.json
@@ -6446,7 +6446,8 @@
         "max_cats": 6,
         "min_max_status": {
             "healer cats": [1, 6],
-            "all apprentices": [1, 6]
+            "all apprentices": [2, 6],
+            "medicine cat": [1, 6]
         },
         "weight": 20,
         "intro_text": "app1 shovels tansy into {PRONOUN/app1/poss} mouth without a care in the world. p_l stops {PRONOUN/app1/object}, and tells {PRONOUN/app1/object} {PRONOUN/app1/subject} really <i>should</i> have a care.",

--- a/resources/lang/en/patrols/mountainous/med/greenleaf.json
+++ b/resources/lang/en/patrols/mountainous/med/greenleaf.json
@@ -6502,7 +6502,8 @@
         "max_cats": 6,
         "min_max_status": {
             "healer cats": [1, 6],
-            "all apprentices": [1, 6]
+            "all apprentices": [2, 6],
+            "medicine cat": [1, 6]
         },
         "weight": 20,
         "intro_text": "app1 shovels tansy into {PRONOUN/app1/poss} mouth without a care in the world. p_l stops {PRONOUN/app1/object}, and tells {PRONOUN/app1/object} {PRONOUN/app1/subject} really <i>should</i> have a care.",

--- a/resources/lang/en/patrols/mountainous/med/greenleaf.json
+++ b/resources/lang/en/patrols/mountainous/med/greenleaf.json
@@ -6502,8 +6502,8 @@
         "max_cats": 6,
         "min_max_status": {
             "healer cats": [1, 6],
-            "all apprentices": [2, 6],
-            "medicine cat": [1, 6]
+            "all apprentices": [1, 5],
+            "medicine cat": [1, 5]
         },
         "weight": 20,
         "intro_text": "app1 shovels tansy into {PRONOUN/app1/poss} mouth without a care in the world. p_l stops {PRONOUN/app1/object}, and tells {PRONOUN/app1/object} {PRONOUN/app1/subject} really <i>should</i> have a care.",

--- a/resources/lang/en/patrols/mountainous/med/leaf-fall.json
+++ b/resources/lang/en/patrols/mountainous/med/leaf-fall.json
@@ -6548,7 +6548,8 @@
         "max_cats": 6,
         "min_max_status": {
             "healer cats": [1, 6],
-            "all apprentices": [1, 6]
+            "all apprentices": [2, 6],
+            "medicine cat": [1, 6]
         },
         "weight": 20,
         "intro_text": "app1 shovels tansy into {PRONOUN/app1/poss} mouth without a care in the world. p_l stops {PRONOUN/app1/object}, and tells {PRONOUN/app1/object} {PRONOUN/app1/subject} really <i>should</i> have a care.",

--- a/resources/lang/en/patrols/mountainous/med/leaf-fall.json
+++ b/resources/lang/en/patrols/mountainous/med/leaf-fall.json
@@ -6548,8 +6548,8 @@
         "max_cats": 6,
         "min_max_status": {
             "healer cats": [1, 6],
-            "all apprentices": [2, 6],
-            "medicine cat": [1, 6]
+            "all apprentices": [1, 5],
+            "medicine cat": [1, 5]
         },
         "weight": 20,
         "intro_text": "app1 shovels tansy into {PRONOUN/app1/poss} mouth without a care in the world. p_l stops {PRONOUN/app1/object}, and tells {PRONOUN/app1/object} {PRONOUN/app1/subject} really <i>should</i> have a care.",

--- a/resources/lang/en/patrols/mountainous/med/newleaf.json
+++ b/resources/lang/en/patrols/mountainous/med/newleaf.json
@@ -6427,7 +6427,8 @@
         "max_cats": 6,
         "min_max_status": {
             "healer cats": [1, 6],
-            "all apprentices": [1, 6]
+            "all apprentices": [2, 6],
+            "medicine cat": [1, 6]
         },
         "weight": 20,
         "intro_text": "app1 shovels tansy into {PRONOUN/app1/poss} mouth without a care in the world. p_l stops {PRONOUN/app1/object}, and tells {PRONOUN/app1/object} that {PRONOUN/app1/subject} really <i>should</i> have a care.",

--- a/resources/lang/en/patrols/mountainous/med/newleaf.json
+++ b/resources/lang/en/patrols/mountainous/med/newleaf.json
@@ -6427,8 +6427,8 @@
         "max_cats": 6,
         "min_max_status": {
             "healer cats": [1, 6],
-            "all apprentices": [2, 6],
-            "medicine cat": [1, 6]
+            "all apprentices": [1, 5],
+            "medicine cat": [1, 5]
         },
         "weight": 20,
         "intro_text": "app1 shovels tansy into {PRONOUN/app1/poss} mouth without a care in the world. p_l stops {PRONOUN/app1/object}, and tells {PRONOUN/app1/object} that {PRONOUN/app1/subject} really <i>should</i> have a care.",

--- a/resources/lang/en/patrols/plains/med/greenleaf.json
+++ b/resources/lang/en/patrols/plains/med/greenleaf.json
@@ -6786,7 +6786,8 @@
         "max_cats": 6,
         "min_max_status": {
             "healer cats": [1, 6],
-            "all apprentices": [1, 6]
+            "all apprentices": [2, 6],
+            "medicine cat": [1, 6]
         },
         "weight": 20,
         "intro_text": "app1 shovels tansy into {PRONOUN/app1/poss} mouth without a care in the world. p_l stops {PRONOUN/app1/object}, and tells {PRONOUN/app1/object} {PRONOUN/app1/subject} really <i>should</i> have a care.",

--- a/resources/lang/en/patrols/plains/med/greenleaf.json
+++ b/resources/lang/en/patrols/plains/med/greenleaf.json
@@ -6786,8 +6786,8 @@
         "max_cats": 6,
         "min_max_status": {
             "healer cats": [1, 6],
-            "all apprentices": [2, 6],
-            "medicine cat": [1, 6]
+            "all apprentices": [1, 5],
+            "medicine cat": [1, 5]
         },
         "weight": 20,
         "intro_text": "app1 shovels tansy into {PRONOUN/app1/poss} mouth without a care in the world. p_l stops {PRONOUN/app1/object}, and tells {PRONOUN/app1/object} {PRONOUN/app1/subject} really <i>should</i> have a care.",

--- a/resources/lang/en/patrols/plains/med/leaf-fall.json
+++ b/resources/lang/en/patrols/plains/med/leaf-fall.json
@@ -6339,7 +6339,8 @@
         "max_cats": 6,
         "min_max_status": {
             "healer cats": [1, 6],
-            "all apprentices": [1, 6]
+            "all apprentices": [2, 6],
+            "medicine cat": [1, 6]
         },
         "weight": 20,
         "intro_text": "app1 shovels tansy into {PRONOUN/app1/poss} mouth without a care in the world. p_l stops {PRONOUN/app1/object}, and tells {PRONOUN/app1/object} {PRONOUN/app1/subject} really <i>should</i> have a care.",

--- a/resources/lang/en/patrols/plains/med/leaf-fall.json
+++ b/resources/lang/en/patrols/plains/med/leaf-fall.json
@@ -6339,8 +6339,8 @@
         "max_cats": 6,
         "min_max_status": {
             "healer cats": [1, 6],
-            "all apprentices": [2, 6],
-            "medicine cat": [1, 6]
+            "all apprentices": [1, 5],
+            "medicine cat": [1, 5]
         },
         "weight": 20,
         "intro_text": "app1 shovels tansy into {PRONOUN/app1/poss} mouth without a care in the world. p_l stops {PRONOUN/app1/object}, and tells {PRONOUN/app1/object} {PRONOUN/app1/subject} really <i>should</i> have a care.",

--- a/resources/lang/en/patrols/plains/med/newleaf.json
+++ b/resources/lang/en/patrols/plains/med/newleaf.json
@@ -6435,7 +6435,8 @@
         "max_cats": 6,
         "min_max_status": {
             "healer cats": [1, 6],
-            "all apprentices": [1, 6]
+            "all apprentices": [2, 6],
+            "medicine cat": [1, 6]
         },
         "weight": 20,
         "intro_text": "app1 shovels tansy into {PRONOUN/app1/poss} mouth without a care in the world. p_l stops {PRONOUN/app1/object}, and tells {PRONOUN/app1/object} {PRONOUN/app1/subject} really <i>should</i> have a care.",

--- a/resources/lang/en/patrols/plains/med/newleaf.json
+++ b/resources/lang/en/patrols/plains/med/newleaf.json
@@ -6435,8 +6435,8 @@
         "max_cats": 6,
         "min_max_status": {
             "healer cats": [1, 6],
-            "all apprentices": [2, 6],
-            "medicine cat": [1, 6]
+            "all apprentices": [1, 5],
+            "medicine cat": [1, 5]
         },
         "weight": 20,
         "intro_text": "app1 shovels tansy into {PRONOUN/app1/poss} mouth without a care in the world. p_l stops {PRONOUN/app1/object}, and tells {PRONOUN/app1/object} {PRONOUN/app1/subject} really <i>should</i> have a care.",

--- a/resources/lang/en/patrols/wetlands/med/greenleaf.json
+++ b/resources/lang/en/patrols/wetlands/med/greenleaf.json
@@ -688,8 +688,8 @@
         "max_cats": 6,
         "min_max_status": {
             "healer cats": [1, 6],
-            "all apprentices": [2, 6],
-            "medicine cat": [1, 6]
+            "all apprentices": [1, 5],
+            "medicine cat": [1, 5]
         },
         "weight": 20,
         "intro_text": "app1 shovels tansy into {PRONOUN/app1/poss} mouth without a care in the world. p_l stops {PRONOUN/app1/object}, and tells {PRONOUN/app1/object} {PRONOUN/app1/subject} really <i>should</i> have a care.",

--- a/resources/lang/en/patrols/wetlands/med/greenleaf.json
+++ b/resources/lang/en/patrols/wetlands/med/greenleaf.json
@@ -688,7 +688,8 @@
         "max_cats": 6,
         "min_max_status": {
             "healer cats": [1, 6],
-            "all apprentices": [1, 6]
+            "all apprentices": [2, 6],
+            "medicine cat": [1, 6]
         },
         "weight": 20,
         "intro_text": "app1 shovels tansy into {PRONOUN/app1/poss} mouth without a care in the world. p_l stops {PRONOUN/app1/object}, and tells {PRONOUN/app1/object} {PRONOUN/app1/subject} really <i>should</i> have a care.",

--- a/resources/lang/en/patrols/wetlands/med/leaf-fall.json
+++ b/resources/lang/en/patrols/wetlands/med/leaf-fall.json
@@ -688,8 +688,8 @@
         "max_cats": 6,
         "min_max_status": {
             "healer cats": [1, 6],
-            "all apprentices": [2, 6],
-            "medicine cat": [1, 6]
+            "all apprentices": [1, 5],
+            "medicine cat": [1, 5]
         },
         "weight": 20,
         "intro_text": "app1 shovels tansy into {PRONOUN/app1/poss} mouth without a care in the world. p_l stops {PRONOUN/app1/object}, and tells {PRONOUN/app1/object} {PRONOUN/app1/subject} really <i>should</i> have a care.",

--- a/resources/lang/en/patrols/wetlands/med/leaf-fall.json
+++ b/resources/lang/en/patrols/wetlands/med/leaf-fall.json
@@ -688,7 +688,8 @@
         "max_cats": 6,
         "min_max_status": {
             "healer cats": [1, 6],
-            "all apprentices": [1, 6]
+            "all apprentices": [2, 6],
+            "medicine cat": [1, 6]
         },
         "weight": 20,
         "intro_text": "app1 shovels tansy into {PRONOUN/app1/poss} mouth without a care in the world. p_l stops {PRONOUN/app1/object}, and tells {PRONOUN/app1/object} {PRONOUN/app1/subject} really <i>should</i> have a care.",

--- a/resources/lang/en/patrols/wetlands/med/newleaf.json
+++ b/resources/lang/en/patrols/wetlands/med/newleaf.json
@@ -688,8 +688,8 @@
         "max_cats": 6,
         "min_max_status": {
             "healer cats": [1, 6],
-            "all apprentices": [2, 6],
-            "medicine cat": [1, 6]
+            "all apprentices": [1, 5],
+            "medicine cat": [1, 5]
         },
         "weight": 20,
         "intro_text": "app1 shovels tansy into {PRONOUN/app1/poss} mouth without a care in the world. p_l stops {PRONOUN/app1/object}, and tells {PRONOUN/app1/object} {PRONOUN/app1/subject} really <i>should</i> have a care.",

--- a/resources/lang/en/patrols/wetlands/med/newleaf.json
+++ b/resources/lang/en/patrols/wetlands/med/newleaf.json
@@ -688,7 +688,8 @@
         "max_cats": 6,
         "min_max_status": {
             "healer cats": [1, 6],
-            "all apprentices": [1, 6]
+            "all apprentices": [2, 6],
+            "medicine cat": [1, 6]
         },
         "weight": 20,
         "intro_text": "app1 shovels tansy into {PRONOUN/app1/poss} mouth without a care in the world. p_l stops {PRONOUN/app1/object}, and tells {PRONOUN/app1/object} {PRONOUN/app1/subject} really <i>should</i> have a care.",


### PR DESCRIPTION
## About The Pull Request

Correcting a bug by editing patrol constraints for a patrol that involves a meddie apprentice eating a bunch of tansy while p_l tries to stop them. Previously, it was possible to generate the patrol with only apprentices, which led to p_l and app1 being the same cat. The constraints have been changed to ensure that there is an adult meddie to be chosen as p_l to prevent self-interaction.

## Linked Issues

No Github bug report but
![image](https://github.com/user-attachments/assets/d9b4a58c-b8ab-4cc0-b3b2-24b1388d1048)
here is an image of the problem

## Proof of Testing

![image](https://github.com/user-attachments/assets/44e6d196-b58f-4628-92c6-6f5aa1727386)

The patrol generating correctly