### PR TITLE
[ENHANCEMENT] n_c:{index} now works in exclude_involved for shortevents

### DIFF
--- a/scripts/events_module/short/handle_short_events.py
+++ b/scripts/events_module/short/handle_short_events.py
@@ -190,15 +190,22 @@ class HandleShortEvents:
             self.handle_mass_death()
             if len(self.multi_cat) <= 2:
                 return
-            
+
+        # create new cats (must happen here so that new cats can be included in further changes)
+        self.handle_new_cats()
+
         # remove cats from involved_cats if theyre supposed to be
         if self.chosen_event.r_c and "r_c" in self.chosen_event.exclude_involved:
             self.involved_cats.remove(self.random_cat.ID)
         if "m_c" in self.chosen_event.exclude_involved:
             self.involved_cats.remove(self.main_cat.ID)
 
-        # create new cats (must happen here so that new cats can be included in further changes)
-        self.handle_new_cats()
+        for n_c in self.new_cats:
+            nc_index = self.new_cats.index(n_c)
+            n_c_string = f"n_c:{nc_index}"
+            if n_c_string in self.chosen_event.exclude_involved:
+                if n_c[0].ID in self.involved_cats:
+                    self.involved_cats.remove(str(n_c[0].ID))
 
         # give accessory
         if self.chosen_event.new_accessory:
@@ -347,7 +354,11 @@ class HandleShortEvents:
                         Cat, i18n.t("defaults.event_dead_outsider"), main_cat=cat
                     )
                 elif cat.outside:
-                    if "unknown" in attribute_list:
+                    n_c_index = self.new_cats.index([cat])
+                    if (
+                        f"n_c:{n_c_index}" in self.chosen_event.exclude_involved or
+                        "unknown" in attribute_list
+                    ):
                         extra_text = ""
                     else:
                         extra_text = event_text_adjust(


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
just realised i only included m_c and r_c in my original PR D: n_c can now be excluded from shortevents!
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Why This Is Good For ClanGen
new cats can be generated by events in the background! who knows where they came from! this also accomplishes what the "unknown" tag does, removing the "encountered" text if the cat is in exclude_involved.

<!-- If this is a bug fix, you can remove this section. -->
<!-- Please add a short description of why you think these changes would benefit the game. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->
<!-- If you have multiple features that can stand on their own, or unrelated bugfixes, please create separate PRs for them. -->

## Linked Issues

<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
i wrote a quick test event for this (which has since been removed):
![Screenshot 2025-04-29 163231](https://github.com/user-attachments/assets/a982f3ca-5fd7-498c-b76a-64c475bb579e)
this event generates three cats: one kit and two parents. the kit joins the clan, while the parents do not. thanks to exclude_involved, the kit and m_c are the only involved cats in the event.
![Screenshot 2025-04-29 163136](https://github.com/user-attachments/assets/5e618e1f-bb32-4c1a-839a-27716257700f)
heres the kits profile, showing that they do have two new loner parents that were not in the event:
![Screenshot 2025-04-29 163256](https://github.com/user-attachments/assets/4bd925e6-d223-4fd7-a207-e2b33d1aa93a)

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
N/A
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
