### PR TITLE
[BUGFIX] Crashing due to changelog triggering text adjust

### DIFF
--- a/scripts/utility.py
+++ b/scripts/utility.py
@@ -2199,7 +2199,7 @@ def event_text_adjust(
             )
 
     # new_cats (include pre version)
-    if "n_c" in text:
+    if "n_c" in text and new_cats:
         for i, cat_list in enumerate(new_cats):
             if len(new_cats) > 1:
                 pronoun = localization.get_new_pronouns("default plural")[0]


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
Apparently the changelog gets run through the event_text_adjust via the localisation stuff? Don't really understand what's going on there, but it was causing a crash when it tried to replace n_c (which was in the title of a recent PR) but had no new_cats to use.  Fixed it by just requiring there to be new_cats before it attempts replacement of the abbr.  Probably would be good to fix the root of the issue, but I don't understand the translation stuff well enough for that.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Proof of Testing
It opened and displayed the changelog correctly after my fix. I'm dumb and didn't get a screenshot and the changelog doesn't appear on subsequent restarts of the program lol
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- n_c being present in a changelog entry no longer crashes the game.
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
