### PR TITLE
[BUGFIX] Clan camp randomizer + quick start to include fjord

### DIFF
--- a/scripts/screens/MakeClanScreen.py
+++ b/scripts/screens/MakeClanScreen.py
@@ -483,7 +483,7 @@ class MakeClanScreen(Screens):
         elif event.ui_element == self.elements["random_background"]:
             # Select a random biome and background
             self.biome_selected = self.random_biome_selection()
-            if self.biome_selected in ("Forest", "Mountainous"):
+            if self.biome_selected in ("Forest", "Mountainous", "Beach"):
                 self.selected_camp_tab = randrange(1, 5)
             else:
                 self.selected_camp_tab = randrange(1, 4)
@@ -1256,7 +1256,7 @@ class MakeClanScreen(Screens):
     def random_quick_start(self):
         self.clan_name = self.random_clan_name()
         self.biome_selected = self.random_biome_selection()
-        if self.biome_selected in ("Forest", "Mountainous"):
+        if self.biome_selected in ("Forest", "Mountainous", "Beach"):
             self.selected_camp_tab = randrange(1, 5)
         else:
             self.selected_camp_tab = randrange(1, 4)


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

Noticed while I was playing ClanGen that when you randomize the clan biome + camp background that fjord wasn't randomly selected, ever. Decided to fix this unnoticed issue! 

## Why This Is Good For ClanGen

Random + quick start works as intended containing all possible biomes and backgrounds

## Linked Issues

none surprisingly

## Proof of Testing

https://github.com/user-attachments/assets/dd9d2b75-3036-425b-a514-110aec370b7c

should also work for the quick start (I didn't want to have to keep doing quick start until fjord showed up.)

## Changelog/Credits

- Fjord camp background included in the selection pool for beach biome during quick start and camp randomize
