### PR TITLE
ci: Bump down poetry version for 3.8 tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           architecture: 'x64'
+      - name: Switch Poetry Python environment
+        if: matrix.python-version == '3.8'
+        run: poetry env use 3.8
       - name: install dependencies
         run: poetry install
       - name: Run unit tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,14 +8,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.11']
+        include:
+          # v2 of poetry dropped support for 3.8
+          - python-version: '3.8'
+            test-poetry-version: '1.8.5'
+          - python-version: '3.11'
+            test-poetry-version: 'latest'
     steps:
       - uses: actions/checkout@v4
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-          architecture: 'x64'
       - name: Download the test saves
         run: wget https://github.com/ImLvna/clangen-unittest-saves/archive/refs/heads/main.zip -O tests/saves.zip
       - name: Unzip
@@ -27,7 +27,12 @@ jobs:
       - name: Install poetry
         uses: abatilo/actions-poetry@v3
         with:
-          poetry-version: latest
+          poetry-version: ${{ matrix.test-poetry-version }}
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: 'x64'
       - name: install dependencies
         run: poetry install
       - name: Run unit tests


### PR DESCRIPTION
## About The Pull Request

v2 of Poetry dropped support for Python 3.8, so this bumps Poetry back down to 1.8.5 for the 3.8 test run. Also had to swap the order of the Poetry and Python setup because otherwise the pipx Poetry installation fails with `TypeError: 'ABCMeta' object is not subscriptable`.

## Why This Is Good For ClanGen

ci runs will stop failing due to Poetry failing to install.
