### PR TITLE
[ENHANCEMENT] War event filtering and balancing

### DIFF
--- a/resources/game_config.json
+++ b/resources/game_config.json
@@ -272,8 +272,8 @@
 		"classic_death_chance": 500,
 		"expanded_death_chance": 350,
 		"cruel season_death_chance": 300,
-		"war_death_modifier_leader": 95,
-		"war_death_modifier": 250,
+		"war_death_modifier_leader": 35,
+		"war_death_modifier": 330,
 		"base_random_murder_chance": 25,
 		"base_murder_kill_chance": 80,
 		"old_age_death_start": 150,
@@ -292,7 +292,7 @@
 		"expanded_injury_chance": 250,
 		"cruel season_injury_chance": 150,
 		"permanent_condition_chance": 15,
-		"war_injury_modifier": 100
+		"war_injury_modifier": 240
 	},
 	"clan_creation": {
 		"rerolls": 3,

--- a/scripts/events_module/generate_events.py
+++ b/scripts/events_module/generate_events.py
@@ -247,13 +247,6 @@ class GenerateEvents:
         final_events = []
         incorrect_format = []
 
-        # Chance to bypass the skill or trait requirements.
-        trait_skill_bypass = 15
-
-        # check if generated event should be a war event
-        if "war" in sub_types and random.randint(1, 10) == 1:
-            sub_types.remove("war")
-
         for event in possible_events:
             if event.history:
                 if (

--- a/scripts/events_module/short/handle_short_events.py
+++ b/scripts/events_module/short/handle_short_events.py
@@ -100,7 +100,7 @@ class HandleShortEvents:
         self.involved_cats = [self.main_cat.ID]
 
         # check for war and assign self.other_clan accordingly
-        if game.clan.war.get("at_war", False) and random.randint(1, 3) != 1:
+        if game.clan.war.get("at_war", False) and random.randint(1, 5) != 1:
             enemy_clan = get_warring_clan()
             self.other_clan = enemy_clan
             self.other_clan_name = f"{self.other_clan.name}Clan"

--- a/scripts/events_module/short/handle_short_events.py
+++ b/scripts/events_module/short/handle_short_events.py
@@ -100,7 +100,7 @@ class HandleShortEvents:
         self.involved_cats = [self.main_cat.ID]
 
         # check for war and assign self.other_clan accordingly
-        if game.clan.war.get("at_war", False):
+        if game.clan.war.get("at_war", False) and random.randint(1, 3) != 1:
             enemy_clan = get_warring_clan()
             self.other_clan = enemy_clan
             self.other_clan_name = f"{self.other_clan.name}Clan"


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
Previously, we didn't handle war event filtering all that well.  During a war, you couldn't get any events with non-warring clans and repetitive events were common due to the filtering.

I've changed it so that during a war, 1/5 events won't be war focused.  When events aren't war focused, they're now able to freely choose a random other clan for the event to potentially include.

I've also tweaked the balance for death and injury during a war. Turns out, we had actually made it impossible for leaders to die during war. Not ideal lol
New balances:
- 1/15 chance for leader death
- 1/20 chance for any cat's death
- 1/10 chance for injury

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Why This Is Good For ClanGen
Helps balance out the events during wars.
<!-- If this is a bug fix, you can remove this section. -->
<!-- Please add a short description of why you think these changes would benefit the game. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->
<!-- If you have multiple features that can stand on their own, or unrelated bugfixes, please create separate PRs for them. -->

## Proof of Testing
![image](https://github.com/user-attachments/assets/e4684c7c-93bf-45fb-a170-5c7932eec73f)
Moonskips just fine! I was able to get some war events as well as non-war events. War ended just fine.
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- During a war, 1/5 of events will not be war focused, this is changed from the previous 1/10 chance.
- If the event is not war focused, a random other clan will be chosen to potentially appear in the event. Previously, a war would mean the other clan was always the warring clan.
- Rebalanced war chances:
  - 1/15 chance for leader death
  - 1/20 chance for any cat's death
  - 1/10 chance for injury
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
