### PR TITLE
Certain cats no longer think in 3rd person

### DIFF
--- a/resources/lang/en/thoughts/alive/general.json
+++ b/resources/lang/en/thoughts/alive/general.json
@@ -207,7 +207,6 @@
             "warrior",
             "medicine cat",
             "mediator",
-            "deputy",
             "leader",
             "elder"
         ],
@@ -266,7 +265,6 @@
             "medicine cat",
             "mediator",
             "deputy",
-            "leader",
             "elder"
         ],
         "random_status_constraint": [
@@ -317,7 +315,6 @@
             "mediator apprentice",
             "warrior",
             "medicine cat",
-            "mediator",
             "deputy",
             "leader",
             "elder"
@@ -340,8 +337,6 @@
         ],
         "main_status_constraint": [
             "apprentice",
-            "medicine cat apprentice",
-            "mediator apprentice",
             "warrior",
             "medicine cat",
             "mediator",


### PR DESCRIPTION
## About The Pull Request

Fixing a situation where cats are able to refer to themselves in 3rd person as a result of them being on both mc and rc sides of thought categories when they only were supposed to be on rc side

## Why This Is Good For ClanGen

Fixes and issue players have been noticing. Not a bug fix per say, just removed few tags that should not have been applied where they were. Leaders will no longer have thoughts about themself in the 3rd person, same with deputies, medicine cats, and medicine cat apprentices as they have been removed from the Mc side

## Proof of Testing

Can't prove a lack of something but the minor changes in the files should speak for themselves

