### PR TITLE
[BUGFIX] Fixing cat list group dropdown

### DIFF
--- a/scripts/game_structure/ui_elements.py
+++ b/scripts/game_structure/ui_elements.py
@@ -2012,6 +2012,8 @@ class UIDropDown(UIDropDownContainer):
             ui_scale(pygame.Rect(dropdown_rect)),
             manager=manager,
             container=self,
+            resize_left=False,
+            resize_top=False,
             anchors=(
                 {
                     "top_target": self.parent_button,

--- a/scripts/screens/ListScreen.py
+++ b/scripts/screens/ListScreen.py
@@ -151,7 +151,7 @@ class ListScreen(Screens):
                 if event.ui_element.text == "screens.list.view_dead":
                     # changing dropdown options
                     self.choose_group_dropdown.new_item_list(self.dead_group_names)
-                    self.choose_group_dropdown.disable_child("general.starclan")
+                    self.choose_group_dropdown.set_selected_list(["general.starclan"])
                     self.sort_by_dropdown.new_item_list(self.dead_filter_names)
                     self.sort_by_dropdown.disable_child(
                         f"screens.list.filter_{game.sort_type}"
@@ -165,7 +165,7 @@ class ListScreen(Screens):
                 else:
                     # changing dropdown options
                     self.choose_group_dropdown.new_item_list(self.living_group_names)
-                    self.choose_group_dropdown.disable_child("general.your_clan")
+                    self.choose_group_dropdown.set_selected_list(["general.your_clan"])
                     self.sort_by_dropdown.new_item_list(self.dead_filter_names)
                     if game.sort_type == "death":
                         game.sort_type = "rank"


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
Honestly not sure why this one decided to extend it's container to the left in a neverending loop, but regardless, it's fixed now and shouldn't happen to any other dropdowns either.

Also updated how it handles changing the selected list, as i had improved this in my EventEdit PR, but at the time didn't think to pull the changes into this screen as well.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Proof of Testing
![image](https://github.com/user-attachments/assets/d9fb5a86-4aba-4ad2-a112-0057034f0402)
You can see there's no massively long container extending off the left, as there was before i fixed this
![image](https://github.com/user-attachments/assets/96cd0e2a-a333-400b-8d8d-c43535fe36eb)
Prior to my fix, the choose group dropdowns for dead groups wouldn't be visible as they would be created out of the game screen bounds.  They're now created at the correct coords.
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Cat list change group dropdown is no longer trying to run away
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
