### PR TITLE
making sprites update correctly for sick & injured

### DIFF
--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -332,6 +332,8 @@ class Cat:
         # Private Sprite
         self._sprite: Optional[pygame.Surface] = None
         self._sprite_mask: Optional[pygame.Mask] = None
+        self._sprite_working: bool = self.not_working()
+        """used to store whether we should be displaying sick sprite or not"""
 
         # SAVE CAT INTO ALL_CATS DICTIONARY IN CATS-CLASS
         self.all_cats[self.ID] = self
@@ -3336,8 +3338,9 @@ class Cat:
     @property
     def sprite(self):
         # Update the sprite
-        if self.pelt.rebuild_sprite:
+        if self.pelt.rebuild_sprite or self.not_working() != self._sprite_working:
             self.pelt.rebuild_sprite = False
+            self._sprite_working = self.not_working()
             update_sprite(self)
             update_mask(self)
         return self._sprite

--- a/scripts/events_module/relationship/romantic_events.py
+++ b/scripts/events_module/relationship/romantic_events.py
@@ -439,6 +439,8 @@ class RomanticEvents:
     def handle_breakup(cat_from: Cat, cat_to: Cat) -> bool:
         """Handles cats breaking up their relationship"""
 
+        RomanticEvents.rebuild_dicts()
+
         if cat_from.ID not in cat_to.mate:
             return False
 

--- a/scripts/screens/SpriteInspectScreen.py
+++ b/scripts/screens/SpriteInspectScreen.py
@@ -393,7 +393,7 @@ class SpriteInspectScreen(Screens):
             scars_hidden=not self.scars_shown,
             acc_hidden=not self.acc_shown,
             always_living=self.override_dead_lineart,
-            no_not_working=self.override_not_working,
+            disable_sick_sprite=self.override_not_working,
         )
 
         self.cat_elements["cat_image"] = pygame_gui.elements.UIImage(

--- a/scripts/utility.py
+++ b/scripts/utility.py
@@ -2655,7 +2655,7 @@ def generate_sprite(
     scars_hidden=False,
     acc_hidden=False,
     always_living=False,
-    no_not_working=False,
+    disable_sick_sprite=False,
 ) -> pygame.Surface:
     """
     Generates the sprite for a cat, with optional arguments that will override certain things.
@@ -2664,7 +2664,7 @@ def generate_sprite(
     :param scars_hidden: If True, doesn't display the cat's scars. If False, display cat scars.
     :param acc_hidden: If True, hide the accessory. If false, show the accessory.
     :param always_living: If True, always show the cat with living lineart
-    :param no_not_working: If true, never use the not_working lineart.
+    :param disable_sick_sprite: If true, never use the not_working lineart.
                     If false, use the cat.not_working() to determine the no_working art.
     """
 
@@ -2680,7 +2680,7 @@ def generate_sprite(
 
     # setting the cat_sprite (bc this makes things much easier)
     if (
-        not no_not_working
+        not disable_sick_sprite
         and cat.not_working()
         and age != "newborn"
         and game.config["cat_sprites"]["sick_sprites"]


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
Missed a flag to set whether or not a cat is sick/injured. Now we track whether the last sprite displayed was for a sick or a healthy cat & void the saved sprite appropriately. Also fixes a minor bug encountered whilst testing this where a breakup (chill breakup, in this case) was crashing the game if it was the first kind of relationship event to be rolled on startup.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
Fixes #3581
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits

<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
