### PR TITLE
[BUGFIX] Med den & Herb Keyerror Crashes

### DIFF
--- a/resources/lang/en/screens/med_den.en.json
+++ b/resources/lang/en/screens/med_den.en.json
@@ -9,7 +9,7 @@
         "out_den": "out of den",
         "minor": "minor",
         "meds_cover": {
-            "one": "m_c can care for a Clan of up to %{clansize} members, including {PRONOUN/med_name/self}.",
+            "one": "m_c can care for a Clan of up to %{clansize} members, including {PRONOUN/m_c/self}.",
             "many": "c_n's medicine cats can care for a Clan of up to %{clansize} members, including themselves."
         },
         "expiration": "It was discovered that some stores of %{herbs} were too old to be of use anymore.",

--- a/scripts/clan_resources/herb/herb_supply.py
+++ b/scripts/clan_resources/herb/herb_supply.py
@@ -50,6 +50,13 @@ class HerbSupply:
         # med den log for current moon
         self.log = []
 
+        # ensures all herbs in HERBS are present as keys in self.storage and self.collected because KEYERRORS SUCK
+        for herb in self.base_herb_list:
+            if herb not in self.storage:
+                self.storage[herb] = []
+            if herb not in self.collected:
+                self.collected[herb] = 0
+
     @property
     def combined_supply_dict(self) -> dict:
         """


### PR DESCRIPTION
## About The Pull Request

Fixes the following
Fixes #3416 - Replaces one instance of med_name with m_c because med_name cant be a med apprentice

All of the following are fixed because of a quick check to add empty key values to avoid a crash when a herb's value is 0 and its number isn't properly updated because it "doesn't exist"
#3500 
#3425 
#3350 

## Linked Issues

Fixes https://github.com/ClanGenOfficial/clangen/issues/3416
Fixes https://github.com/ClanGenOfficial/clangen/issues/3500
Fixes https://github.com/ClanGenOfficial/clangen/issues/3425
Fixes https://github.com/ClanGenOfficial/clangen/issues/3350

## Proof of Testing

Hhhhh I dont have images but trust me when I say that I installed a temporary check to ensure the keyerror fix was working and it properly did alongside no more med den crash so yk, PRETTY sure it works :D
