### PR TITLE
[BUGFIX] Multi death patrols no longer give all leader lives lost text + pronoun tagging error

### DIFF
--- a/resources/lang/en/cat/history.en.json
+++ b/resources/lang/en/cat/history.en.json
@@ -14,6 +14,8 @@
         "graduation_normal": "{PRONOUN/m_c/subject/CAP} graduated at %{age} moons old.",
         "graduation_late": "{PRONOUN/m_c/subject/CAP} graduated late at %{age} moons old.",
         "mentored": "{PRONOUN/m_c/subject/CAP} mentored %{apprentices}.",
+
+         "comment": "Leader live strings for history text or text where m_c is included in the area its being called to",
         "leader_death_final": "lost {PRONOUN/m_c/poss} final life",
         "leader_death_all": "lost all of {PRONOUN/m_c/poss} lives",
         "leader_death_remaining": "lost the rest of {PRONOUN/m_c/poss} lives",
@@ -24,9 +26,25 @@
         "leader_death_retired": "lost {PRONOUN/m_c/poss} last remaining life",
         "leader_death_default": "lost a life",
         "leader_lost_lives": {
+            "one": "lost a life.",
+            "many": "lost %{count} lives."
+        },
+
+        "comment_two": "Leader live strings for text where m_c is not included where its being called to, ie patrol outcome text",
+        "n_leader_death_final": "m_c lost {PRONOUN/m_c/poss} final life",
+        "n_leader_death_all": "m_c lost all of {PRONOUN/m_c/poss} lives",
+        "n_leader_death_remaining": "m_c lost the rest of {PRONOUN/m_c/poss} lives",
+        "n_leader_death_cardinal": {
+            "one": "m_c lost {PRONOUN/m_c/poss} %{cardinal} life",
+            "many": "m_c lost {PRONOUN/m_c/poss} %{cardinal} lives"
+        },
+        "n_leader_death_retired": "m_c lost {PRONOUN/m_c/poss} last remaining life",
+        "n_leader_death_default": "m_c lost a life",
+        "n_leader_lost_lives": {
             "one": "m_c lost a life.",
             "many": "m_c lost %{count} lives."
         },
+        
         "regular_death": "%{cats} died.",
         "death_cause": "%{death} when {PRONOUN/m_c/subject} %{text}.",
         "murdered": "%{name} murdered %{victims}.",

--- a/resources/lang/en/events/relationship_events/normal_interactions/trust/increase.json
+++ b/resources/lang/en/events/relationship_events/normal_interactions/trust/increase.json
@@ -60,7 +60,7 @@
 			"m_c thinks about how r_c is always reliable.",
 			"m_c notices how r_c is being helpful around camp.",
 			"m_c has faith in r_c.",
-			"m_c is grateful that r_c has kept a secret of {PRONOUN/m_c/poss}s.",
+			"m_c is grateful that r_c has kept a secret of {PRONOUN/m_c/inposs}.",
 			"r_c seems respectful of m_c's boundaries as of late.",
 			"r_c explained something in detail to m_c that others wouldn't explain to {PRONOUN/m_c/object}.",
 			"m_c overhears r_c dispelling a false rumor about a Clanmate.",

--- a/scripts/events_module/patrol/patrol_outcome.py
+++ b/scripts/events_module/patrol/patrol_outcome.py
@@ -516,8 +516,7 @@ class PatrolOutcome:
                     game.clan.leader_lives = 0
                     results.append(
                         event_text_adjust(
-                            Cat, i18n.t("cat.history.n_leader_death_all"),
-                            main_cat=_cat
+                            Cat, i18n.t("cat.history.n_leader_death_all"), main_cat=_cat
                         )
                     )
                 elif "some_lives" in self.dead_cats:

--- a/scripts/events_module/patrol/patrol_outcome.py
+++ b/scripts/events_module/patrol/patrol_outcome.py
@@ -516,7 +516,8 @@ class PatrolOutcome:
                     game.clan.leader_lives = 0
                     results.append(
                         event_text_adjust(
-                            Cat, i18n.t("cat.history.leader_death_all"), main_cat=_cat
+                            Cat, i18n.t("cat.history.n_leader_death_all"),
+                            main_cat=_cat
                         )
                     )
                 elif "some_lives" in self.dead_cats:
@@ -525,7 +526,7 @@ class PatrolOutcome:
                     results.append(
                         event_text_adjust(
                             Cat,
-                            i18n.t("cat.history.leader_death_all", count=lives_lost),
+                            i18n.t("cat.history.n_leader_lost_lives", count=lives_lost),
                             main_cat=_cat,
                         )
                     )
@@ -534,7 +535,7 @@ class PatrolOutcome:
                     results.append(
                         event_text_adjust(
                             Cat,
-                            i18n.t("cat.history.leader_death_all", count=1),
+                            i18n.t("cat.history.n_leader_lost_lives", count=1),
                             main_cat=_cat,
                         )
                     )


### PR DESCRIPTION
## About The Pull Request

Fixes 1 poss tag to inposs

Fixes leader death text on multi death patrols to display only 1 life lost text instead of all, localization text error basically

## Linked Issues

https://github.com/ClanGenOfficial/clangen/issues/1818#issuecomment-2875242739
Fixes #3526 
Fixes #3449 
Fixes #3448 
Fixes #3405 

## Proof of Testing

Displays properly, I don't have an image on hand but I promise you I tested this and it works
