### PR TITLE
War Balancing

### DIFF
--- a/resources/game_config.json
+++ b/resources/game_config.json
@@ -265,7 +265,9 @@
 		]
 	},
 	"event_generation": {
-		"debug_ensure_event_id": null
+		"debug_ensure_event_id": null,
+		"debug_type_override": null,
+		"debug_override_requirements": false
 	},
 	"death_related": {
 		"leader_death_chance": 50,
@@ -292,7 +294,7 @@
 		"expanded_injury_chance": 250,
 		"cruel season_injury_chance": 150,
 		"permanent_condition_chance": 15,
-		"war_injury_modifier": 240
+		"war_injury_modifier": 235
 	},
 	"clan_creation": {
 		"rerolls": 3,

--- a/resources/game_config.json
+++ b/resources/game_config.json
@@ -294,7 +294,7 @@
 		"expanded_injury_chance": 250,
 		"cruel season_injury_chance": 150,
 		"permanent_condition_chance": 15,
-		"war_injury_modifier": 235
+		"war_injury_modifier": 225
 	},
 	"clan_creation": {
 		"rerolls": 3,

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -1133,7 +1133,7 @@ class Events:
                 war_events = self.WAR_TXT["conclusion_events"]
             else:  # try to influence the relation with warring clan
                 game.clan.war["duration"] += 1
-                choice = random.choice(["rel_up", "rel_up", "neutral", "rel_down"])
+                choice = random.choice(["rel_up", "neutral", "rel_down"])
                 game.switches["war_rel_change_type"] = choice
                 war_events = self.WAR_TXT["progress_events"][choice]
                 if enemy_clan.relations < 0:
@@ -1158,6 +1158,7 @@ class Events:
                     game.clan.war["at_war"] = True
                     game.clan.war["enemy"] = other_clan.name
                     war_events = self.WAR_TXT["trigger_events"]
+                    game.switches["war_rel_change_type"] = "rel_down"
 
         # if nothing happened, return
         if not war_events or not enemy_clan:
@@ -1172,6 +1173,7 @@ class Events:
                 if not game.clan.medicine_cat and "med_name" in event:
                     war_events.remove(event)
 
+        # grab our war "notice" for this moon
         event = random.choice(war_events)
         event = ongoing_event_text_adjust(
             Cat, event, other_clan_name=f"{enemy_clan.name}Clan", clan=game.clan

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -1142,7 +1142,6 @@ class Events:
                     enemy_clan.relations += 2
                 elif choice == "rel_down" and enemy_clan.relations > 1:
                     enemy_clan.relations -= 1
-            print(enemy_clan.relations)
 
         else:  # try to start a war if no war in progress
             for other_clan in game.clan.all_clans:

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -1114,11 +1114,11 @@ class Events:
                     enemy_clan = other_clan
                     break
 
-            threshold = 5
+            threshold = 10
             if enemy_clan.temperament == "bloodthirsty":
-                threshold = 10
+                threshold = 12
             if enemy_clan.temperament in ["mellow", "amiable", "gracious"]:
-                threshold = 3
+                threshold = 7
 
             threshold -= int(game.clan.war["duration"])
             if enemy_clan.relations < 0:
@@ -1129,7 +1129,7 @@ class Events:
                 game.clan.war["at_war"] = False
                 game.clan.war["enemy"] = None
                 game.clan.war["duration"] = 0
-                enemy_clan.relations += 12
+                enemy_clan.relations += 2
                 war_events = self.WAR_TXT["conclusion_events"]
             else:  # try to influence the relation with warring clan
                 game.clan.war["duration"] += 1
@@ -1142,6 +1142,7 @@ class Events:
                     enemy_clan.relations += 2
                 elif choice == "rel_down" and enemy_clan.relations > 1:
                     enemy_clan.relations -= 1
+            print(enemy_clan.relations)
 
         else:  # try to start a war if no war in progress
             for other_clan in game.clan.all_clans:

--- a/scripts/events_module/short/handle_short_events.py
+++ b/scripts/events_module/short/handle_short_events.py
@@ -108,7 +108,11 @@ class HandleShortEvents:
         self.involved_cats = [self.main_cat.ID]
 
         # check for war and assign self.other_clan accordingly
-        if game.clan.war.get("at_war", False) and randint(1, 5) != 1:
+        war_chance = 5
+        # if the war didn't go badly, then we decrease the chance of this event being war-focused
+        if game.switches["war_rel_change_type"] != "rel_down":
+            war_chance = 2
+        if game.clan.war.get("at_war", False) and randint(1, war_chance) != 1:
             enemy_clan = get_warring_clan()
             self.other_clan = enemy_clan
             self.other_clan_name = f"{self.other_clan.name}Clan"

--- a/scripts/game_structure/game_essentials.py
+++ b/scripts/game_structure/game_essentials.py
@@ -612,12 +612,16 @@ class Game:
 
         # Apply war if needed
         if self.clan and self.clan.war.get("at_war", False) and args in war_effected:
-            # Grabs the modifer
-            mod = self.config
-            for key in war_effected[args]:
-                mod = mod[key]
+            rel_change_type = game.switches["war_rel_change_type"]
+            # if the war was positively affected this moon, we don't apply war modifier
+            # this way we only see increased death/injury when the war is going badly or is neutral
+            if rel_change_type != "rel_up":
+                # Grabs the modifier
+                mod = self.config
+                for key in war_effected[args]:
+                    mod = mod[key]
 
-            config_value -= mod
+                config_value -= mod
 
         return config_value
 


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
Just fiddling some more to try and get wars feeling a bit more interesting.

- Brought the war injury modifier down a tad, it was feeling too aggressive.
- Pulled the thresholds for war ending up a bit.  Now you have to at least reach neutral relations for a war to end, though some clan temperaments change how high the relations need to get.
- Decreased the relation bonus that is applied when wars end. This was a bit too high, meaning that a war ending would through you immediately into ally range with the enemy clan.  Now it just pulls relations up a tad bit, but it would very easy to dip back into hostile territory.
- There was a bias toward `rel_up` changes during war, I've removed that. Now `rel_up`, `neutral`, and `rel_down` are all equally possible state changes.
- The first moon of a war is now indicated as a `rel_down` war state, which means it'll come with the higher chance of injury and death.
- Chances of an event being a `war` event are now decreased on moons where the war state is `neutral` or `rel_up`. This should hopefully bring some of the repetitiveness down, since we don't have a ton of `rel_up` and `neutral` war events.
- War injury and death modifiers are now only applied on moons with `rel_down` war states. This way we aren't getting a ridiculous amount of injuries/deaths that are unrelated to the war (but are still.. caused? by the war lmao)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Why This Is Good For ClanGen
Wars feel a bit janky, this is an attempt to fix them a bit! Though the next step is just to increase our range of war events. We don't have many!
<!-- If this is a bug fix, you can remove this section. -->
<!-- Please add a short description of why you think these changes would benefit the game. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->
<!-- If you have multiple features that can stand on their own, or unrelated bugfixes, please create separate PRs for them. -->

## Proof of Testing
![image](https://github.com/user-attachments/assets/eb965785-dd03-44c4-8c27-74b021bc6025)
Wars still begin and run all the way through without issue. I ran quite a few while counting up injured/dead events to see how things were feeling lol
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Brought the war injury modifier down a tad, it was feeling too aggressive.
- Pulled the thresholds for war ending up a bit.  Now you have to at least reach neutral relations for a war to end, though some clan temperaments change how high the relations need to get.
- Decreased the relation bonus that is applied when wars end. This was a bit too high, meaning that a war ending would through you immediately into ally range with the enemy clan.  Now it just pulls relations up a tad bit, but it would very easy to dip back into hostile territory.
- There was a bias toward `rel_up` changes during war, I've removed that. Now `rel_up`, `neutral`, and `rel_down` are all equally possible state changes.
- The first moon of a war is now indicated as a `rel_down` war state, which means it'll come with the higher chance of injury and death.
- Chances of an event being a `war` event are now decreased on moons where the war state is `neutral` or `rel_up`. This should hopefully bring some of the repetitiveness down, since we don't have a ton of `rel_up` and `neutral` war events.
- War injury and death modifiers are now only applied on moons with `rel_down` war states. This way we aren't getting a ridiculous amount of injuries/deaths that are unrelated to the war (but are still.. caused? by the war lmao)
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
