### PR TITLE
[BUGFIX] Clearing screen properly displays the opened tab at start

### DIFF
--- a/scripts/screens/ClearingScreen.py
+++ b/scripts/screens/ClearingScreen.py
@@ -78,7 +78,6 @@ class ClearingScreen(Screens):
     def handle_event(self, event):
         if event.type == pygame_gui.UI_BUTTON_START_PRESS:
             self.mute_button_pressed(event)
-            self.hungry_tab.disable()
 
             if event.ui_element == self.back_button:
                 self.change_screen(game.last_screen_forupdate)
@@ -347,6 +346,7 @@ class ClearingScreen(Screens):
             manager=MANAGER,
         )
         self.cat_tab_open = self.hungry_tab
+        self.hungry_tab.disable()
         self.current_page = 1
         self.update_cats_list()
         self.update_nutrition_cats()

--- a/scripts/screens/ClearingScreen.py
+++ b/scripts/screens/ClearingScreen.py
@@ -78,6 +78,7 @@ class ClearingScreen(Screens):
     def handle_event(self, event):
         if event.type == pygame_gui.UI_BUTTON_START_PRESS:
             self.mute_button_pressed(event)
+            self.hungry_tab.disable()
 
             if event.ui_element == self.back_button:
                 self.change_screen(game.last_screen_forupdate)


### PR DESCRIPTION
## About The Pull Request

Fixes a small visual bug with the clearing screen not displaying the correct tab upon opening

## Linked Issues

#3343 

## Proof of Testing

https://github.com/user-attachments/assets/c25ed83a-d4ec-4729-b1d8-9a0db23d9f5f
