### PR TITLE
Add seizure prone thoughts

### DIFF
--- a/resources/lang/en/thoughts/alive/general.json
+++ b/resources/lang/en/thoughts/alive/general.json
@@ -6114,5 +6114,40 @@
                 "severe headache"
             ]
         }
+    },
+    {
+        "id": "seizure_prone_gen",
+        "thoughts": [
+            "Is bothered by the sunlight flickering through the trees",
+            "Makes sure to drink water before a training session",
+            "Wonders what {PRONOUN/m_c/subject} {VERB/look/looks} like during a seizure",
+            "Feels like the sun is too bright today",
+            "Feels dizzier than usual today"
+        ],
+        "perm_conditions": {
+            "m_c": [
+                "seizure prone"
+            ]
+        },
+        "random_living_status": [
+            "living"
+        ]
+    },
+    {
+        "id": "seizure_prone_gen_to_alive_gen",
+        "thoughts": [
+            "Tries to explain what a seizure feels like to r_c, but only confuses {PRONOUN/r_c/object} more",
+            "Stood up too quickly and nearly passed out, spooking r_c",
+            "Keeps spacing out mid-conversation"
+        ],
+        "perm_conditions": {
+            "m_c": [
+                "seizure prone"
+            ]
+        },
+        "random_living_status": [
+            "living"
+        ]
     }
+
 ]


### PR DESCRIPTION
## About The Pull Request

Adds 8 new thoughts for the permanent condition, seizure prone. Of note, while I have seziures, I do not have epilepsy, so while I tried to be general with my seizure-related descriptions, I am just one guy.

## Why This Is Good For ClanGen

Part of the project to add more specific throughts for disabilities/permanent conditions


## Proof of Testing
![image](https://github.com/user-attachments/assets/6c3fece2-45bc-442a-905e-746d4624c805)


## Changelog/Credits

credits to dinofelisdruid !!
