### PR TITLE
[FEATURE] Facet tags for cat object gathering

### DIFF
--- a/docs/dev/writing/patrols.md
+++ b/docs/dev/writing/patrols.md
@@ -782,6 +782,20 @@ What each parameter does, and what the options are for outcomes.
 | "clan"        | Feelings toward the entire clan are effected                              |
 | "n_c:{index}" | Feelings toward the new cat(s) with the index number {index} are effected |
 
+> Group modifiers: These will modify the cats already being gathered according to the other strings. For example, a block with `"cats_from": ["clan", "low_lawful"]` will gather all the cats in the Clan with a 0-8 lawfulness facet.  These can be combined to get cats with specific ranges of multiple facets.
+
+| modifier     |                                                |
+|--------------|------------------------------------------------|
+| low_lawful   | cats with a 0-8 lawfulness facet are affected  |
+| high_lawful  | cats with a 9-16 lawfulness facet are affected |
+| low_social   | cats with a 0-8 sociable facet are affected    |
+| high_social  | cats with a 9-16 sociable facet are affected   |
+| low_stable   | cats with a 0-8 stability facet are affected   |
+| high_stable  | cats with a 9-16 stability facet are affected  |
+| low_aggress  | cats with a 0-8 aggression facet are affected  |
+| high_aggress | cats with a 9-16 aggression facet are affected |
+
+
 >**mutual: bool :** Optional. Controls if the relation effect will be applied in both directions. 
 
 | bool  |                                                                                                                                              |

--- a/docs/dev/writing/shortevents.md
+++ b/docs/dev/writing/shortevents.md
@@ -443,21 +443,35 @@ lowercase season names + "any"
 
 >**cats_from: List[str] :** The cat's whose relationship values are being edited. You are changing how the "cats_from" feels. 
 
-| string      |                                   |
-|-------------|-----------------------------------|
-| m_c         | main cat's feelings are affected  |
-| r_c   | other cat's feelings are affected |
-| n_c:{index} | new cat's feelings are affected   |
-| clan | the clan's feelings are affected (experimental, unsupported in old format and not sure if i can make work)   |
+| string      |                                                                                                            |
+|-------------|------------------------------------------------------------------------------------------------------------|
+| m_c         | main cat's feelings are affected                                                                           |
+| r_c         | other cat's feelings are affected                                                                          |
+| n_c:{index} | new cat's feelings are affected                                                                            |
+| clan        | the clan's feelings are affected (experimental, unsupported in old format and not sure if i can make work) |
+
 
 >**cats_to: List[str] :** The target of the relationship. You can changing how "cats_from" feel about "cats_to"
 
-| string      |                                            |
-|-------------|--------------------------------------------|
-| m_c        | feelings toward the main cat are affected  |
-| r_c   | feelings toward the other_cat are affected |
-| n_c:{index} | feelings toward the new cat are affected   |
-| clan | feelings toward the clan are affected (experimental, unsupported in old format and not sure if i can make work)   |
+| string      |                                                                                                                 |
+|-------------|-----------------------------------------------------------------------------------------------------------------|
+| m_c         | feelings toward the main cat are affected                                                                       |
+| r_c         | feelings toward the other_cat are affected                                                                      |
+| n_c:{index} | feelings toward the new cat are affected                                                                        |
+| clan        | feelings toward the clan are affected (experimental, unsupported in old format and not sure if i can make work) |
+
+> Group modifiers: These will modify the cats already being gathered according to the other strings. For example, a block with `"cats_from": ["clan", "low_lawful"]` will gather all the cats in the Clan with a 0-8 lawfulness facet.  These can be combined to get cats with specific ranges of multiple facets.
+
+| modifier     |                                                |
+|--------------|------------------------------------------------|
+| low_lawful   | cats with a 0-8 lawfulness facet are affected  |
+| high_lawful  | cats with a 9-16 lawfulness facet are affected |
+| low_social   | cats with a 0-8 sociable facet are affected    |
+| high_social  | cats with a 9-16 sociable facet are affected   |
+| low_stable   | cats with a 0-8 stability facet are affected   |
+| high_stable  | cats with a 9-16 stability facet are affected  |
+| low_aggress  | cats with a 0-8 aggression facet are affected  |
+| high_aggress | cats with a 9-16 aggression facet are affected |
 
 >**mutual: bool :** Optional. Controls if the relation effect will be applied in both directions. 
 
@@ -519,7 +533,7 @@ lowercase season names + "any"
 
 >**type:str:** indicates the supply being affected
 
-| string                               | effect                                                                 |
+| string                               | effect                                                           |
 |--------------------------------------|------------------------------------------------------------------|
 | freshkill                            | this event affects the freshkill supply                          |
 | all_herb                             | this event affects the herb supply as a whole                    |
@@ -529,12 +543,12 @@ lowercase season names + "any"
 >**trigger:list[str]:** indicates when the event can trigger, include all possible trigger times
 
 | string   | effect                                                                                                                   |
-|----------|--------------------------------------------------------------------------------------------------------------------|
-| always   | triggers regardless of current supply amount (be careful with this, only use with "freshkill", "all_herb" and "any_herb"                                   |
-| low      | triggers when indicated supply is low (unable to support at least half of clan)                                    |
-| adequate | triggers when indicated supply is adequate (can support at least half the clan, but is not enough for a full moon) |
-| full     | triggers when indicated supply is full (able to support all of clan for 1 moon, but not multiple moons)            |
-| excess   | triggers when indicated supply is at least twice the needed supply for 1 moon                                      |
+|----------|--------------------------------------------------------------------------------------------------------------------------|
+| always   | triggers regardless of current supply amount (be careful with this, only use with "freshkill", "all_herb" and "any_herb" |
+| low      | triggers when indicated supply is low (unable to support at least half of clan)                                          |
+| adequate | triggers when indicated supply is adequate (can support at least half the clan, but is not enough for a full moon)       |
+| full     | triggers when indicated supply is full (able to support all of clan for 1 moon, but not multiple moons)                  |
+| excess   | triggers when indicated supply is at least twice the needed supply for 1 moon                                            |
 
 >**adjust:str:** indicates how the supply should be adjusted
 

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -33,7 +33,8 @@
         "relationships": [
             {
                 "cats_from": [
-                    "clan"
+                    "clan",
+                    "high_lawful"
                 ],
                 "cats_to": [
                     "m_c"
@@ -182,7 +183,7 @@
         "relationships": [
             {
                 "cats_from": [
-                    "clan"
+                    "clan", "high_lawful"
                 ],
                 "cats_to": [
                     "m_c"
@@ -675,7 +676,7 @@
         "relationships": [
             {
                 "cats_from": [
-                    "clan"
+                    "clan", "high_lawful"
                 ],
                 "cats_to": [
                     "m_c"
@@ -683,6 +684,19 @@
                 "mutual": false,
                 "values": [
                     "dislike"
+                ],
+                "amount": 20
+            },
+            {
+                "cats_from": [
+                    "clan", "high_aggress", "low_lawful"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "mutual": false,
+                "values": [
+                    "respect"
                 ],
                 "amount": 20
             },

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -183,7 +183,8 @@
         "relationships": [
             {
                 "cats_from": [
-                    "clan", "high_lawful"
+                    "clan",
+                    "high_lawful"
                 ],
                 "cats_to": [
                     "m_c"
@@ -676,7 +677,8 @@
         "relationships": [
             {
                 "cats_from": [
-                    "clan", "high_lawful"
+                    "clan",
+                    "high_lawful"
                 ],
                 "cats_to": [
                     "m_c"
@@ -689,7 +691,9 @@
             },
             {
                 "cats_from": [
-                    "clan", "high_aggress", "low_lawful"
+                    "clan",
+                    "high_aggress",
+                    "low_lawful"
                 ],
                 "cats_to": [
                     "m_c"
@@ -1261,7 +1265,27 @@
             "status": [
                 "any"
             ]
-        }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "clan",
+                    "high_lawful",
+                    "high_stable"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "mutual": false,
+                "values": [
+                    "respect",
+                    "platonic",
+                    "trust",
+                    "comfort"
+                ],
+                "amount": -10
+            }
+        ]
     },
     {
         "event_id": "gen_misc_any_misc14",
@@ -3833,14 +3857,29 @@
                     "platonic"
                 ],
                 "amount": 10
+            },
+            {
+                "cats_from": [
+                    "clan",
+                    "high_lawful",
+                    "high_stable"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "mutual": false,
+                "values": [
+                    "respect",
+                    "trust"
+                ],
+                "amount": -5
             }
         ],
-        "outsider": {
-            "current_rep": [
-                "any"
-            ],
-            "changed": -5
-        }
+        "outsider": {},
+        "current_rep": [
+            "any"
+        ],
+        "changed": -5
     },
     {
         "event_id": "multi_misc_any_scandalous_kittypet2",
@@ -3883,14 +3922,29 @@
                     "platonic"
                 ],
                 "amount": 15
+            },
+            {
+                "cats_from": [
+                    "clan",
+                    "high_lawful",
+                    "high_stable"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "mutual": false,
+                "values": [
+                    "respect",
+                    "trust"
+                ],
+                "amount": -5
             }
         ],
-        "outsider": {
-            "current_rep": [
-                "any"
-            ],
-            "changed": 5
-        }
+        "outsider": {},
+        "current_rep": [
+            "any"
+        ],
+        "changed": 5
     },
     {
         "event_id": "multi_misc_any_scandalous_kittypet3",
@@ -3934,14 +3988,29 @@
                     "platonic"
                 ],
                 "amount": 10
+            },
+            {
+                "cats_from": [
+                    "clan",
+                    "high_lawful",
+                    "high_stable"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "mutual": false,
+                "values": [
+                    "respect",
+                    "trust"
+                ],
+                "amount": -5
             }
         ],
-        "outsider": {
-            "current_rep": [
-                "any"
-            ],
-            "changed": 7
-        }
+        "outsider": {},
+        "current_rep": [
+            "any"
+        ],
+        "changed": 7
     },
     {
         "event_id": "multi_misc_any_scandalous_kittypet4",
@@ -4343,12 +4412,29 @@
                 "senior"
             ]
         },
-        "other_clan": {
-            "current_rep": [
-                "any"
-            ],
-            "changed": 1
-        }
+        "relationships": [
+            {
+                "cats_from": [
+                    "clan",
+                    "high_lawful",
+                    "high_stable"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "mutual": false,
+                "values": [
+                    "respect",
+                    "trust"
+                ],
+                "amount": -5
+            }
+        ],
+        "other_clan": {},
+        "current_rep": [
+            "any"
+        ],
+        "changed": 1
     },
     {
         "event_id": "multi_misc_any_scandalous_other_clan2",
@@ -4702,14 +4788,29 @@
                     "platonic"
                 ],
                 "amount": 15
+            },
+            {
+                "cats_from": [
+                    "clan",
+                    "high_lawful",
+                    "high_stable"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "mutual": false,
+                "values": [
+                    "respect",
+                    "trust"
+                ],
+                "amount": -5
             }
         ],
-        "outsider": {
-            "current_rep": [
-                "any"
-            ],
-            "changed": 5
-        }
+        "outsider": {},
+        "current_rep": [
+            "any"
+        ],
+        "changed": 5
     },
     {
         "event_id": "multi_misc_any_scandalous_loner3",
@@ -4778,7 +4879,26 @@
                 "senior adult",
                 "senior"
             ]
-        }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "clan",
+                    "high_lawful",
+                    "high_stable"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "mutual": false,
+                "values": [
+                    "respect",
+                    "trust",
+                    "comfort"
+                ],
+                "amount": -10
+            }
+        ]
     },
     {
         "event_id": "multi_misc_any_scandalous_rogue1",
@@ -4822,14 +4942,29 @@
                     "platonic"
                 ],
                 "amount": 10
+            },
+            {
+                "cats_from": [
+                    "clan",
+                    "high_lawful",
+                    "high_stable"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "mutual": false,
+                "values": [
+                    "respect",
+                    "trust"
+                ],
+                "amount": -5
             }
         ],
-        "outsider": {
-            "current_rep": [
-                "any"
-            ],
-            "changed": 5
-        }
+        "outsider": {},
+        "current_rep": [
+            "any"
+        ],
+        "changed": 5
     },
     {
         "event_id": "gen_misc_any_scandalous_rogue2",
@@ -4869,14 +5004,29 @@
                     "platonic"
                 ],
                 "amount": 15
+            },
+            {
+                "cats_from": [
+                    "clan",
+                    "high_lawful",
+                    "high_stable"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "mutual": false,
+                "values": [
+                    "respect",
+                    "trust"
+                ],
+                "amount": -5
             }
         ],
-        "outsider": {
-            "current_rep": [
-                "any"
-            ],
-            "changed": 5
-        }
+        "outsider": {},
+        "current_rep": [
+            "any"
+        ],
+        "changed": 5
     },
     {
         "event_id": "multi_misc_any_scandalous_rogue3",

--- a/scripts/screens/EventEditScreen.py
+++ b/scripts/screens/EventEditScreen.py
@@ -1910,7 +1910,20 @@ class EventEditScreen(Screens):
         involved_cats.extend(new_cat_list)
 
         if include_clan:
-            involved_cats.extend(["some_clan", "clan"])
+            involved_cats.extend(
+                [
+                    "some_clan",
+                    "clan",
+                    "low_lawful",
+                    "high_lawful",
+                    "low_social",
+                    "high_social",
+                    "low_stable",
+                    "high_stable",
+                    "low_aggress",
+                    "high_aggress",
+                ]
+            )
 
         return involved_cats
 

--- a/scripts/utility.py
+++ b/scripts/utility.py
@@ -1398,8 +1398,7 @@ def gather_cat_objects(
     """
     gathers cat objects from list of abbreviations used within an event format block
     :param Cat Cat: Cat class
-    :param list[str] abbr_list: The list of abbreviations, supports "m_c", "r_c", "p_l", "s_c", "app1" through "app6",
-    "clan", "some_clan", "patrol", "multi", "n_c{index}"
+    :param list[str] abbr_list: The list of abbreviations
     :param event: the controlling class of the event (e.g. Patrol, HandleShortEvents), default None
     :param Cat stat_cat: if passing the Patrol class, must include stat_cat separately
     :param Cat extra_cat: if not passing an event class, include the single affected cat object here. If you are not
@@ -1407,6 +1406,8 @@ def gather_cat_objects(
     The other cat abbreviations will not work.
     :return: list of cat objects
     """
+
+    clan_cats = [x for x in Cat.all_cats_list if not (x.dead or x.outside or x.exiled)]
     out_set = set()
 
     for abbr in abbr_list:
@@ -1417,6 +1418,12 @@ def gather_cat_objects(
                 out_set.add(event.main_cat)
         elif abbr == "r_c":
             out_set.add(event.random_cat)
+        elif re.match(r"n_c:[0-9]+", abbr):
+            index = re.match(r"n_c:([0-9]+)", abbr).group(1)
+            index = int(index)
+            if index < len(event.new_cats):
+                out_set.update(event.new_cats[index])
+        # PATROL SPECIFIC
         elif abbr == "p_l":
             out_set.add(event.patrol_leader)
         elif abbr == "s_c":
@@ -1433,27 +1440,36 @@ def gather_cat_objects(
             out_set.add(event.patrol_apprentices[4])
         elif abbr == "app6" and len(event.patrol_apprentices) >= 6:
             out_set.add(event.patrol_apprentices[5])
-        elif abbr == "clan":
-            out_set.update(
-                [x for x in Cat.all_cats_list if not (x.dead or x.outside or x.exiled)]
-            )
-        elif abbr == "some_clan":  # 1 / 8 of clan cats are affected
-            clan_cats = [
-                x for x in Cat.all_cats_list if not (x.dead or x.outside or x.exiled)
-            ]
-            out_set.update(
-                sample(clan_cats, randint(1, max(1, round(len(clan_cats) / 8))))
-            )
         elif abbr == "patrol":
             out_set.update(event.patrol_cats)
         elif abbr == "multi":
             cat_num = randint(1, max(1, len(event.patrol_cats) - 1))
             out_set.update(sample(event.patrol_cats, cat_num))
-        elif re.match(r"n_c:[0-9]+", abbr):
-            index = re.match(r"n_c:([0-9]+)", abbr).group(1)
-            index = int(index)
-            if index < len(event.new_cats):
-                out_set.update(event.new_cats[index])
+        # OVERALL CLAN CATS
+        elif abbr == "clan":
+            out_set.update(clan_cats)
+        elif abbr == "some_clan":  # 1 / 8 of clan cats are affected
+            out_set.update(
+                sample(clan_cats, randint(1, max(1, round(len(clan_cats) / 8))))
+            )
+        # FACET CATS IN CLAN
+        elif abbr == "high_social":
+            out_set = {c for c in out_set if c.personality.sociability > 8}
+        elif abbr == "low_social":
+            out_set = {c for c in out_set if c.personality.sociability <= 8}
+        elif abbr == "high_lawful":
+            out_set = {c for c in out_set if c.personality.lawfulness > 8}
+        elif abbr == "low_lawful":
+            out_set = {c for c in out_set if c.personality.lawfulness <= 8}
+        elif abbr == "high_stable":
+            out_set = {c for c in out_set if c.personality.stability > 8}
+        elif abbr == "low_stable":
+            out_set = {c for c in out_set if c.personality.stability <= 8}
+        elif abbr == "high_aggress":
+            out_set = {c for c in out_set if c.personality.aggression > 8}
+        elif abbr == "low_aggress":
+            out_set = {c for c in out_set if c.personality.aggression <= 8}
+
         else:
             print(f"WARNING: Unsupported abbreviation {abbr}")
 


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
This adds new tags that can be used within any ShortEvent and Patrol parameter block that needs a cat list inputted, such as the injury block or relationships block.  These will likely see the most use in just relationship blocks, though.

These tags allow you to constrain the cats being gathered by a certain personality facet value.  This means it does need to be used in conjunction with other cat tags, typically group tags like `clan` or `patrol`. You can also use multiple tags to constrain across multiple facet ranges.  There is a `low` and `high` version for each facet, with low covering the 0-8 range and high covering the 9-16 range.

Tags are as follows:
- `low_lawful`
- `high_lawful`
- `low_social`
- `high_social`
- `low_stable`
- `high_stable`
- `low_aggress`
- `high_aggress`

ShortEvent and Patrol documentation has been updates, as has the Event Editor.

I've also added these tags to some of our existing ShortEvents, wherever it felt applicable. Murder reveals that feature a clan-wide reveal, breaking the warrior code, fraternizing with twolegs/outsiders, ect.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Why This Is Good For ClanGen
This makes it far easier for us to apply wide changes across groups of cats in a more controlled manner. Previously, if we wanted a group to have varying reactions, we had to just rely on choosing a random selection of cats within a group. 

I think this also satisfies #2430, it's a slightly different application, but this is a better implementation imo
<!-- If this is a bug fix, you can remove this section. -->
<!-- Please add a short description of why you think these changes would benefit the game. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->
<!-- If you have multiple features that can stand on their own, or unrelated bugfixes, please create separate PRs for them. -->

## Proof of Testing
![image](https://github.com/user-attachments/assets/9789ec3b-96db-49c2-adbe-c36154fbd1fc)
Updated documentation.

![image](https://github.com/user-attachments/assets/5ad6a0e3-f3a4-431d-a39c-150fbacabe50)
![image](https://github.com/user-attachments/assets/6c3cea2d-9bc2-4f32-8d6c-6e662ca7d407)
![image](https://github.com/user-attachments/assets/5818ee96-57f8-4d1f-97fb-15352640eb71)
Cinnamon broke the warrior code! You can see this now gets added to the relationship log. I just had this event pull down the respect, trust, and comfort the other cat has for Cinnamon, you can see that those values are mostly gone now.

Across the Clan, only Robinstripe and Moonflare had a relationship change from this event.  Robinstripe is adventurous and Moonflare and thoughtful, which both fit into the `high_lawful` `high_stable` constraint I gave this event.

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Changes across groups of cats can now be done according to each cat's personality facets.
- Some moon events will now apply more specific relationship reactions across groups of cats. For example, if a cat is seen taking food from a Twoleg, their more lawful Clanmates will have a negative reaction  (my favorite event change is with the murder reveal where the murderer tells the whole clan that they had to do it, that the cat they murdered was plotting against them. lawful clanmates may not like that, but more aggressive clanmates might find it justifiable)

<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
