### PR TITLE
[CRASHFIX] missed cat from history refactor

### DIFF
--- a/scripts/events_module/short/handle_short_events.py
+++ b/scripts/events_module/short/handle_short_events.py
@@ -811,7 +811,6 @@ class HandleShortEvents:
                         )
                     if possible_scar or possible_death:
                         cat.history.add_possible_history(
-                            cat,
                             injury,
                             scar_text=possible_scar,
                             death_text=possible_death,


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
Just a cat arg that was missed in the history refactor, removing it should fix that crash.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
Fixes #3652
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
![image](https://github.com/user-attachments/assets/7af2612c-9d60-4ad6-b455-c7f75a564230)
Did some moonskips without a crash and had injury events appearing normally.
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Game no longer crashes when attempting to assign injury history
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
