### PR TITLE
[BUGFIX] Outsiders now display properly in the leader's den

### DIFF
--- a/scripts/screens/LeaderDenScreen.py
+++ b/scripts/screens/LeaderDenScreen.py
@@ -984,7 +984,7 @@ class LeaderDenScreen(Screens):
             i
             for i in Cat.all_cats.values()
             if not i.dead
-            and not i.status.is_outsider
+            and i.status.is_outsider
             and i.status.is_near(CatGroup.PLAYER_CLAN)
         ]
 


### PR DESCRIPTION
## About The Pull Request
When pulling cats for the 'outsiders' tab in the leaders den, the function called all cats that were NOT outsiders, due to a typo in the line. This just removes the 'not' so it pulls outsiders instead.

## Linked Issues
I don't see any issues related to this, but I noticed it in my own game.

## Proof of Testing
![Screenshot 2025-07-07 215619](https://github.com/user-attachments/assets/bc1e9ead-38cd-4b95-9fe7-5b549ea10e4c)
Sporestar's entire Clan is on the 'outsiders' tab, behaving as lost cats gameplay-wise. This was on an edited save, so I made a new Clan to check if the bug would appear there too.

![Screenshot 2025-07-07 222022](https://github.com/user-attachments/assets/9232e9af-d9cb-47e7-8866-bdae8e71d301)
Redstar (fresh, unedited Clan), with the fix, now only sees exiled warrior Rowandream in the 'outsiders' tab.