### PR TITLE
[ENHANCEMENT] get_last_living_group() func

### DIFF
--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -648,7 +648,7 @@ class Cat:
 
         # handle grief
         # since we just yeeted them to their afterlife, we gotta check their previous group affiliation, not current
-        if game.clan and self.status.group_history[-2]["group"] == CatGroup.PLAYER_CLAN:
+        if game.clan and self.status.get_last_living_group() == CatGroup.PLAYER_CLAN:
             self.grief(body)
 
         # mark the sprite as outdated

--- a/scripts/cat/status.py
+++ b/scripts/cat/status.py
@@ -551,6 +551,19 @@ class Status:
 
         return past_ranks[-1]
 
+    def get_last_living_group(self) -> Optional[CatGroup]:
+        """
+        Returns the last group this cat belonged to before death. If the cat had no group before dying, this will return None.
+        """
+        history = self.group_history
+        history.reverse()
+
+        for entry in history:
+            if not entry["group"] or not entry["group"].is_afterlife():
+                return entry["group"]
+
+        return None
+
     def is_lost(self, group: CatGroup = None) -> bool:
         """
         Returns True if the cat is considered "lost" by a group.


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
Adds a new func to the status class: `get_last_living_group()` that returns the last group a cat was a part of before dying. If the cat wasn't part of a group, it returns None.

I also updated the doc page to include the function.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Why This Is Good For ClanGen
Makes it easier to grab this info!

<!-- If this is a bug fix, you can remove this section. -->
<!-- Please add a short description of why you think these changes would benefit the game. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->
<!-- If you have multiple features that can stand on their own, or unrelated bugfixes, please create separate PRs for them. -->

## Linked Issues
Closes #3680
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
<img width="865" height="313" alt="image" src="https://github.com/user-attachments/assets/700cddaa-b4a0-4d2c-9051-3073820817fc" />
Stepped through the func while in debug. Reversal worked as intended and the correct group was returned.
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Adds `get_last_living_group()` to the status class
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
