### PR TITLE
[BUGFIX] Move backstory categories

### DIFF
--- a/resources/dicts/backstories.json
+++ b/resources/dicts/backstories.json
@@ -9,15 +9,6 @@
         "outsider_roots_backstories": [
             "outsider_roots1", "outsider_roots2"
         ],
-        "baby_clancat_backstories": [
-            "halfclan1", "halfclan2", "outsider_roots1", "abandoned3"
-        ],
-        "baby_loner_backstories": [
-            "outsider_roots2", "abandoned1", "abandoned2"
-        ],
-        "baby_kittypet_backstories": [
-            "abandoned4"
-        ],
         "half_clan_backstories": [
             "halfclan1", "halfclan2"
         ],
@@ -66,6 +57,15 @@
         ],
         "outsider_backstories": [
             "outsider1", "outsider2", "outsider3"
+        ],
+        "baby_clancat_backstories": [
+            "halfclan1", "halfclan2", "outsider_roots1", "abandoned3"
+        ],
+        "baby_loner_backstories": [
+            "outsider_roots2", "abandoned1", "abandoned2"
+        ],
+        "baby_kittypet_backstories": [
+            "abandoned4"
         ]
     },
     "conversion": {


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
The "baby" categories I added were to assist with assigning socials to the kits rather than providing a broad category for profile display purposes. However, that's okay! Cause the profile just searches for the first category with the backstory in it, so I've moved the babies below all the others.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
Fixes #3689
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
<img width="206" height="68" alt="image" src="https://github.com/user-attachments/assets/7d7756fc-3c2d-49ae-9790-563c1185b1b0" />
This was broken before, now it ain't
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Profiles now display the correct backstory type
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
