### PR TITLE
no more zombie cats!

### DIFF
--- a/scripts/cat/status.py
+++ b/scripts/cat/status.py
@@ -555,7 +555,7 @@ class Status:
         """
         Returns the last group this cat belonged to before death. If the cat had no group before dying, this will return None.
         """
-        history = self.group_history
+        history = self.group_history.copy()
         history.reverse()
 
         for entry in history:


### PR DESCRIPTION
idk where the default template has gone, sorry.

This should stop cats from being killed and not dying. We were accidentally reversing the cat's actual group history, Benjamin Button style.

Fixes #3696
Fixes #3687

Possibly also #3688, further testing required (couldn't get a murder to trigger in testing)

## Proof of Testing

Sleetlotus alive
<img width="940" height="859" alt="image" src="https://github.com/user-attachments/assets/23947ec6-9ec7-4356-ba37-eec6b611af57" />

Sleetlotus dead
<img width="940" height="859" alt="image" src="https://github.com/user-attachments/assets/f5ea65b3-6de9-49cd-84fa-26e8e53f14bc" />

