### PR TITLE
[BUGFIX] Remove save bloat

### DIFF
--- a/scripts/cat/status.py
+++ b/scripts/cat/status.py
@@ -503,8 +503,12 @@ class Status:
         # checks that we don't add a duplicate group/rank pairing
         if self.group_history:
             last_entry = self.group_history[-1]
+            if len(self.group_history) > 1 and last_entry["moons_as"] == 0:
+                self.group_history.remove(last_entry)
+                last_entry = self.group_history[-1]
             if last_entry["group"] == self.group and last_entry["rank"] == new_rank:
                 return
+            # remove 0 moons history to avoid save bloat
 
         self.group_history.append(
             {"group": self.group, "rank": new_rank, "moons_as": 0}

--- a/scripts/cat/status.py
+++ b/scripts/cat/status.py
@@ -507,12 +507,12 @@ class Status:
         # checks that we don't add a duplicate group/rank pairing
         if self.group_history:
             last_entry = self.group_history[-1]
+            # remove 0 moons history to avoid save bloat
             if len(self.group_history) > 1 and last_entry["moons_as"] == 0:
                 self.group_history.remove(last_entry)
                 last_entry = self.group_history[-1]
             if last_entry["group"] == self.group and last_entry["rank"] == new_rank:
                 return
-            # remove 0 moons history to avoid save bloat
 
         self.group_history.append(
             {"group": self.group, "rank": new_rank, "moons_as": 0}

--- a/scripts/cat/status.py
+++ b/scripts/cat/status.py
@@ -393,6 +393,10 @@ class Status:
 
         for record in self.standing_history:
             if record["group"] == group:
+                duplicates = record["standing"].count(new_standing)
+                if duplicates > 1:
+                    removed_index = record["standing"].index(new_standing)
+                    record["standing"].pop(removed_index)
                 record["standing"].append(new_standing)
                 return
 


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
I've added some protection to avoid save bloat.  For rank changes, we now check if the prior rank was held for 0 moons, if it was then we remove it from the history.  This does ignore `group_history`s that only have one entry, in order to avoid screwing up newly converted saves (and to avoid a crash caused by the save conversion).

For the standing, I didn't want to just change it to a `set`.  The ability for duplicates to be held is intended, as we look at the last entry in the standing list to see what the cat's current standing is and in some situations we may *want* to know if a cat has been exiled/lost twice.  So, I've found a compromise.  When standings are changed, we now look for duplicate standings in the entry.  If 2 or more duplicates exist, we remove the earliest duplicate.  This means that we'll still know if a cat has held specific standings twice in their life, the maximum knowledge I think we will ever reasonably need. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Why This Is Good For ClanGen
Status rank and standing changes can get bloated if players flip flop cats between ranks or afterlives.  In some ways, this is intended, as we want a detailed history.  However, if players are just being indecisive, this becomes a problem.
<!-- If this is a bug fix, you can remove this section. -->
<!-- Please add a short description of why you think these changes would benefit the game. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->
<!-- If you have multiple features that can stand on their own, or unrelated bugfixes, please create separate PRs for them. -->

## Linked Issues
#3694
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
<img width="435" height="195" alt="image" src="https://github.com/user-attachments/assets/5d4fea44-e754-4093-a21f-d176ea395885" />
<img width="399" height="206" alt="image" src="https://github.com/user-attachments/assets/d997441e-8a16-42c9-a021-71ce2bc787d0" />

Standing change where you can see that the `KNOWN` at index 0 is removed before a new `KNOWN` is added.

<img width="456" height="173" alt="image" src="https://github.com/user-attachments/assets/7e73e23d-cfd2-49e1-a265-549c4b6e87ec" />

Group history before any rank changes.
<img width="468" height="319" alt="image" src="https://github.com/user-attachments/assets/3fecd4a6-6f68-4ddc-808c-93682031e392" />
After rank change, we now have two entries. Let's try going back to warrior.
<img width="491" height="236" alt="image" src="https://github.com/user-attachments/assets/25c0b5cf-4b42-4016-8257-8984279ac387" />
Rank is changed to warrior and the 0 `moons_as` rank was removed.  We also haven't added a second warrior entry, we're just reusing the first.
Now let's try going from warrior, to med, to mediator
<img width="495" height="319" alt="image" src="https://github.com/user-attachments/assets/dd4864ad-ee9c-4aaa-a99b-db0ca1f64fc9" />
Warrior to medicine
<img width="556" height="335" alt="image" src="https://github.com/user-attachments/assets/c3d8b0fc-ef57-4c44-ab07-7ddd95558b29" />
Medicine to mediator. You can see that the medicine rank was removed and replaced with mediator.

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Group history and standing history saves should be less of a bloat when many changes are made to a cat's status.
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
