### PR TITLE
[BUGFIX] Lead ceremony including cats who weren't dead at the time

### DIFF
--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -1492,7 +1492,7 @@ class Cat:
             outro = "this should not appear"
 
         full_ceremony = "<br><br>".join([intro, all_lives, outro])
-        return full_ceremony
+        self.history.lead_ceremony = full_ceremony
 
     # ---------------------------------------------------------------------------- #
     #                              moon skip functions                             #

--- a/scripts/cat/history.py
+++ b/scripts/cat/history.py
@@ -527,7 +527,7 @@ class History:
         """
 
         if not self.lead_ceremony:
-            self.add_lead_ceremony()
+            self.cat.generate_lead_ceremony()
         return str(self.lead_ceremony)
 
     def get_possible_history(self, condition=None):

--- a/scripts/clan.py
+++ b/scripts/clan.py
@@ -244,6 +244,10 @@ class Clan:
                 )
             other_clan = OtherClan(name=other_clan_name)
             self.all_clans.append(other_clan)
+
+        # create leader's ceremony
+        self.leader.generate_lead_ceremony()
+
         self.save_clan()
         save_clanlist(self.name)
         switch_set_value(Switch.clan_list, read_clans())
@@ -313,7 +317,7 @@ class Clan:
         """
 
         if leader:
-            leader.history.add_lead_ceremony()
+            leader.generate_lead_ceremony()
             self.leader = leader
             Cat.all_cats[leader.ID].rank_change(CatRank.LEADER)
             self.leader_predecessors += 1

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -1176,6 +1176,7 @@ class Events:
                 game.cur_events_list.append(
                     Single_Event(text, "ceremony", game.clan.deputy.ID)
                 )
+                cat.generate_lead_ceremony()
                 self.ceremony_accessory = True
                 self.gain_accessories(cat)
                 game.clan.deputy = None
@@ -2280,7 +2281,7 @@ class Events:
         if leader_invalid:
             self.perform_ceremonies(
                 game.clan.leader
-            )  # This is where the deputy will be make leader
+            )  # This is where the deputy will be made leader
 
             if game.clan.leader:
                 leader_dead = game.clan.leader.dead

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -1176,7 +1176,6 @@ class Events:
                 game.cur_events_list.append(
                     Single_Event(text, "ceremony", game.clan.deputy.ID)
                 )
-                cat.generate_lead_ceremony()
                 self.ceremony_accessory = True
                 self.gain_accessories(cat)
                 game.clan.deputy = None

--- a/scripts/screens/MakeClanScreen.py
+++ b/scripts/screens/MakeClanScreen.py
@@ -2178,6 +2178,7 @@ class MakeClanScreen(Screens):
             starting_members=self.members,
             starting_season=self.selected_season,
         )
+        game.clan.leader.generate_lead_ceremony()
         game.clan.create_clan()
         game.cur_events_list.clear()
         game.herb_events_list.clear()

--- a/scripts/screens/MakeClanScreen.py
+++ b/scripts/screens/MakeClanScreen.py
@@ -2178,7 +2178,6 @@ class MakeClanScreen(Screens):
             starting_members=self.members,
             starting_season=self.selected_season,
         )
-        game.clan.leader.generate_lead_ceremony()
         game.clan.create_clan()
         game.cur_events_list.clear()
         game.herb_events_list.clear()


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
The reason for these issues is due to us not generating a lead ceremony until the ceremony window is opened, thus if a player delays opening it then cats who couldn't have been dead when the ceremony *should* have occurred will be included.

I've fixed this by having lead ceremonies generated at the time of clan creation and deputy promotion.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
#3723
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
<img width="723" height="560" alt="image" src="https://github.com/user-attachments/assets/a075b7e0-e396-4bbc-8df2-86cd6062e7ca" />
Made a new clan and timeskipped till a death occurred, then opened the leader's ceremony, newly dead cat does not appear.

<img width="775" height="607" alt="image" src="https://github.com/user-attachments/assets/16a5b7e8-839a-4621-a360-8a027a0c82f6" />
Then killed the leader and timeskipped till another cat died. Checked the lead ceremony and the newly dead cat (mouseprance) doesn't appear.
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Cats will no longer travel back in time to attend a leader's life ceremony that occurred before they had died.
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
