### PR TITLE
[BUGFIX] Fix afterlife switching shenanigans

### DIFF
--- a/scripts/screens/ProfileScreen.py
+++ b/scripts/screens/ProfileScreen.py
@@ -562,7 +562,7 @@ class ProfileScreen(Screens):
 
         # Instructor thoughts
         if self.the_cat.dead and game.clan.instructor is self.the_cat:
-            if not self.the_cat.status.group == CatGroup.STARCLAN:  # StarClan
+            if self.the_cat.status.group == CatGroup.STARCLAN:  # StarClan
                 self.the_cat.thought = i18n.t(
                     "screens.profile.guide_thought_sc", clan=game.clan.name
                 )

--- a/scripts/screens/ProfileScreen.py
+++ b/scripts/screens/ProfileScreen.py
@@ -313,15 +313,16 @@ class ProfileScreen(Screens):
                                 new_group=CatGroup.STARCLAN
                             )
                             self.the_cat.thought = i18n.t(
-                                "screens.profile.guide_thought_df", clan=game.clan.name
+                                "screens.profile.guide_thought_sc", clan=game.clan.name
                             )
                         # SC -> DF
                         else:
                             self.the_cat.status.add_to_group(
                                 new_group=CatGroup.DARK_FOREST
                             )
+
                             self.the_cat.thought = i18n.t(
-                                "screens.profile.guide_thought_sc", clan=game.clan.name
+                                "screens.profile.guide_thought_df", clan=game.clan.name
                             )
                         self.the_cat.pelt.rebuild_sprite = True
                     else:

--- a/scripts/screens/ProfileScreen.py
+++ b/scripts/screens/ProfileScreen.py
@@ -312,33 +312,40 @@ class ProfileScreen(Screens):
                             self.the_cat.status.add_to_group(
                                 new_group=CatGroup.STARCLAN
                             )
+                            self.the_cat.thought = i18n.t(
+                                "screens.profile.guide_thought_df", clan=game.clan.name
+                            )
                         # SC -> DF
                         else:
                             self.the_cat.status.add_to_group(
                                 new_group=CatGroup.DARK_FOREST
                             )
+                            self.the_cat.thought = i18n.t(
+                                "screens.profile.guide_thought_sc", clan=game.clan.name
+                            )
                         self.the_cat.pelt.rebuild_sprite = True
-                    # DF -> UR
-                    if self.the_cat.status.group == CatGroup.DARK_FOREST:
-                        self.the_cat.status.add_to_group(
-                            new_group=CatGroup.UNKNOWN_RESIDENCE
-                        )
-                        self.the_cat.thought = (
-                            "Is surprised to find themself walking among a foreign land"
-                        )
-                    # UR -> SC
-                    elif self.the_cat.status.group == CatGroup.UNKNOWN_RESIDENCE:
-                        self.the_cat.status.add_to_group(new_group=CatGroup.STARCLAN)
-                        self.the_cat.thought = (
-                            "Is relieved to once again hunt in StarClan"
-                        )
-                    # SC -> DF
                     else:
-                        self.the_cat.status.add_to_group(new_group=CatGroup.DARK_FOREST)
-                        self.the_cat.thought = (
-                            "Is distraught after being sent to the Place of No Stars"
-                        )
-                    self.the_cat.pelt.rebuild_sprite = True
+                        # DF -> UR
+                        if self.the_cat.status.group == CatGroup.DARK_FOREST:
+                            self.the_cat.status.add_to_group(
+                                new_group=CatGroup.UNKNOWN_RESIDENCE
+                            )
+                            self.the_cat.thought = "Is surprised to find themself walking among a foreign land"
+                        # UR -> SC
+                        elif self.the_cat.status.group == CatGroup.UNKNOWN_RESIDENCE:
+                            self.the_cat.status.add_to_group(
+                                new_group=CatGroup.STARCLAN
+                            )
+                            self.the_cat.thought = (
+                                "Is relieved to once again hunt in StarClan"
+                            )
+                        # SC -> DF
+                        else:
+                            self.the_cat.status.add_to_group(
+                                new_group=CatGroup.DARK_FOREST
+                            )
+                            self.the_cat.thought = "Is distraught after being sent to the Place of No Stars"
+                        self.the_cat.pelt.rebuild_sprite = True
 
                 self.clear_profile()
                 self.build_profile()
@@ -561,12 +568,6 @@ class ProfileScreen(Screens):
             elif self.the_cat.status.group == CatGroup.DARK_FOREST:  # Dark Forest
                 self.the_cat.thought = i18n.t(
                     "screens.profile.guide_thought_df", clan=game.clan.name
-                )
-            elif (
-                self.the_cat.status.group == CatGroup.UNKNOWN_RESIDENCE
-            ):  # Unknown Residence
-                self.the_cat.thought = i18n.t(
-                    "screens.profile.guide_thought_sc", clan=game.clan.name
                 )
 
         self.profile_elements["cat_name"] = pygame_gui.elements.UITextBox(

--- a/scripts/screens/ProfileScreen.py
+++ b/scripts/screens/ProfileScreen.py
@@ -2156,14 +2156,21 @@ class ProfileScreen(Screens):
             )
             text = "screens.profile.exile"
             if self.the_cat.dead:
-                text = "screens.profile.exile_df"
-                layer = self.df
-                if self.the_cat.status.group == CatGroup.DARK_FOREST:
-                    text = "screens.profile.send_ur"
-                    layer = self.ur
-                elif self.the_cat.status.group == CatGroup.UNKNOWN_RESIDENCE:
-                    text = "screens.profile.guide_sc"
-                    layer = self.sc
+                if self.the_cat == game.clan.instructor:
+                    text = "screens.profile.exile_df"
+                    layer = self.df
+                    if self.the_cat.status.group == CatGroup.DARK_FOREST:
+                        text = "screens.profile.guide_sc"
+                        layer = self.sc
+                else:
+                    text = "screens.profile.exile_df"
+                    layer = self.df
+                    if self.the_cat.status.group == CatGroup.DARK_FOREST:
+                        text = "screens.profile.send_ur"
+                        layer = self.ur
+                    elif self.the_cat.status.group == CatGroup.UNKNOWN_RESIDENCE:
+                        text = "screens.profile.guide_sc"
+                        layer = self.sc
 
                 self.exile_layer = pygame_gui.elements.UIImage(
                     ui_scale(pygame.Rect((578, 450), (172, 46))),

--- a/scripts/screens/ProfileScreen.py
+++ b/scripts/screens/ProfileScreen.py
@@ -306,6 +306,18 @@ class ProfileScreen(Screens):
                     self.update_disabled_buttons_and_text()
                 # if the cat is dead, moves them to the opposite afterlife
                 if self.the_cat.dead:
+                    if self.the_cat == game.clan.instructor:
+                        # DF -> SC
+                        if self.the_cat.status.group == CatGroup.DARK_FOREST:
+                            self.the_cat.status.add_to_group(
+                                new_group=CatGroup.STARCLAN
+                            )
+                        # SC -> DF
+                        else:
+                            self.the_cat.status.add_to_group(
+                                new_group=CatGroup.DARK_FOREST
+                            )
+                        self.the_cat.pelt.rebuild_sprite = True
                     # DF -> UR
                     if self.the_cat.status.group == CatGroup.DARK_FOREST:
                         self.the_cat.status.add_to_group(

--- a/scripts/screens/ProfileScreen.py
+++ b/scripts/screens/ProfileScreen.py
@@ -320,7 +320,7 @@ class ProfileScreen(Screens):
                         self.the_cat.thought = (
                             "Is relieved to once again hunt in StarClan"
                         )
-                    # SC -> UR
+                    # SC -> DF
                     else:
                         self.the_cat.status.add_to_group(new_group=CatGroup.DARK_FOREST)
                         self.the_cat.thought = (
@@ -2148,7 +2148,7 @@ class ProfileScreen(Screens):
                 if self.the_cat.status.group == CatGroup.DARK_FOREST:
                     text = "screens.profile.send_ur"
                     layer = self.ur
-                elif self.the_cat.status.group == CatGroup.STARCLAN:
+                elif self.the_cat.status.group == CatGroup.UNKNOWN_RESIDENCE:
                     text = "screens.profile.guide_sc"
                     layer = self.sc
 


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
This made my head hurt to figure out and I desperately want to refactor the profile screen now

Guides will no longer be able to switch to the UR and the normal cat switching loop is now correctly matched to it's buttons. I've also fixed the guide having normal cat thoughts while in SC.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
Fixes #3747
Fixes #3716
Fixes #3693
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
<img width="736" height="393" alt="image" src="https://github.com/user-attachments/assets/f8c65eee-8fd5-45ee-bcd9-92ac9ed999c0" />
<img width="732" height="512" alt="image" src="https://github.com/user-attachments/assets/cac3b460-b9f4-4ffa-a9e9-34e1ed89cb0f" />

Guide only switches between DF and SC

<img width="734" height="408" alt="image" src="https://github.com/user-attachments/assets/46454d28-3e99-404b-9a26-6997480a3a70" />
<img width="752" height="464" alt="image" src="https://github.com/user-attachments/assets/4a5e2f5d-5c39-4439-95da-d172cda0fe0b" />
<img width="723" height="463" alt="image" src="https://github.com/user-attachments/assets/3a44b4ed-b1e4-4bf2-baac-87baa0e7d779" />

Buttons now match with their destinations

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Afterlife change buttons on profiles now send cats to the correct afterlife
- Guide cat no longer has normal cat thoughts while in StarClan
- Guide cats are no longer allowed to go to the Unknown Residence
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
