### PR TITLE
[BUGFIX] fix old rank name finding

### DIFF
--- a/scripts/cat/names.py
+++ b/scripts/cat/names.py
@@ -9,7 +9,7 @@ import random
 import ujson
 
 from scripts.game_structure import constants
-from scripts.cat.enums import CatRank
+from scripts.cat.enums import CatRank, CatGroup
 from scripts.housekeeping.datadir import get_save_dir
 
 
@@ -266,19 +266,14 @@ class Name:
 
         # Handles suffix assignment with outside cats
         if self.cat.status.is_former_clancat:
-            if self.cat.moons == 0:
-                adjusted_status = CatRank.NEWBORN
-            elif self.cat.moons < 6:
-                adjusted_status = CatRank.KITTEN
-            elif self.cat.moons < 12:
-                adjusted_status = CatRank.APPRENTICE
-            else:
-                adjusted_status = CatRank.WARRIOR
+            old_rank = self.cat.status.find_prior_clan_rank(CatGroup.PLAYER_CLAN)
 
-            if adjusted_status != CatRank.WARRIOR and not self.specsuffix_hidden:
-                return (
-                    self.prefix + self.names_dict["special_suffixes"][adjusted_status]
-                )
+            if (
+                old_rank in self.names_dict["special_suffixes"]
+                and not self.specsuffix_hidden
+            ):
+                return self.prefix + self.names_dict["special_suffixes"][old_rank]
+
         if (
             self.cat.status.rank in self.names_dict["special_suffixes"]
             and not self.specsuffix_hidden

--- a/scripts/cat/names.py
+++ b/scripts/cat/names.py
@@ -266,7 +266,7 @@ class Name:
 
         # Handles suffix assignment with outside cats
         if self.cat.status.is_former_clancat:
-            old_rank = self.cat.status.find_prior_clan_rank(CatGroup.PLAYER_CLAN)
+            old_rank = self.cat.status.find_prior_clan_rank()
 
             if (
                 old_rank in self.names_dict["special_suffixes"]

--- a/tests/test_cat.py
+++ b/tests/test_cat.py
@@ -527,25 +527,6 @@ class TestNameRepr(unittest.TestCase):
             {"rank": CatRank.ROGUE},
             {"rank": CatRank.KITTYPET},
         ]
-        former_clancat_status = {
-            "group_history": [
-                {"group": CatGroup.OTHER_CLAN1, "rank": CatRank.WARRIOR, "moons_as": 1},
-                {"group": None, "rank": CatRank.LONER, "moons_as": 1},
-            ],
-            "standing_history": [
-                {"group": CatGroup.OTHER_CLAN1, "standing": ["member", "known"]}
-            ],
-        }
-        exiled_status = {
-            "group_history": [
-                {"group": CatGroup.PLAYER_CLAN, "rank": CatRank.WARRIOR, "moons_as": 1},
-                {"group": None, "rank": CatRank.LONER, "moons_as": 1},
-            ],
-            "standing_history": [
-                {"group": CatGroup.PLAYER_CLAN, "standing": ["member", "exiled"]}
-            ],
-        }
-        ex_clancat_statuses = [former_clancat_status, exiled_status]
 
         age_suffix = [[0, "kit"], [1, "kit"], [6, "paw"], [14, "test"]]
 
@@ -555,11 +536,51 @@ class TestNameRepr(unittest.TestCase):
                     cat = Cat(status_dict=status, moons=moons, suffix="test")
                     self.assertTrue(str(cat.name).endswith("test"))
 
-        for status in ex_clancat_statuses:
-            for moons, suffix in age_suffix:
-                with self.subTest("Clan-like names", status_dict=status, moons=moons):
-                    cat = Cat(status_dict=status, moons=moons, suffix="test")
-                    self.assertTrue(str(cat.name).endswith(suffix))
+        exiled_kit = {
+            "group_history": [
+                {
+                    "group": CatGroup.PLAYER_CLAN,
+                    "rank": CatRank.KITTEN,
+                    "moons_as": 1,
+                },
+                {"group": None, "rank": CatRank.LONER, "moons_as": 20},
+            ],
+            "standing_history": [
+                {"group": CatGroup.PLAYER_CLAN, "standing": ["member", "exiled"]}
+            ],
+        }
+        exiled_app = {
+            "group_history": [
+                {
+                    "group": CatGroup.PLAYER_CLAN,
+                    "rank": CatRank.APPRENTICE,
+                    "moons_as": 1,
+                },
+                {"group": None, "rank": CatRank.LONER, "moons_as": 20},
+            ],
+            "standing_history": [
+                {"group": CatGroup.PLAYER_CLAN, "standing": ["member", "exiled"]}
+            ],
+        }
+        exiled_warrior = {
+            "group_history": [
+                {"group": CatGroup.PLAYER_CLAN, "rank": CatRank.WARRIOR, "moons_as": 1},
+                {"group": None, "rank": CatRank.LONER, "moons_as": 1},
+            ],
+            "standing_history": [
+                {"group": CatGroup.PLAYER_CLAN, "standing": ["member", "exiled"]}
+            ],
+        }
+        ex_clancat_statuses = [
+            [exiled_kit, "kit"],
+            [exiled_app, "paw"],
+            [exiled_warrior, "test"],
+        ]
+
+        for status, suffix in ex_clancat_statuses:
+            with self.subTest("Exiled cat names", status_dict=status, suffix=suffix):
+                cat = Cat(status_dict=status, moons=20, suffix="test")
+                self.assertTrue(str(cat.name).endswith(suffix))
 
     def test_specsuffix_outsiders(self):
         """


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
Our old way of finding the names of former clancat outsiders depended entirely on age, which meant that adult cats who haven't gotten home to receive a name ceremony would still be referred to as their warrior names.  In the bug report, the cat still had the correct name on their profile, but this is because they were in StarClan and had taken their prior Clan rank again, so they were marked as an apprentice once more and didn't need to pull their age to find a rank!  I bet if we had seen that cat's profile pre-death, they would have also had the wrong name there.

I adjusted our test to fit our new system.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
Fixes #3740
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
<img width="538" height="158" alt="image" src="https://github.com/user-attachments/assets/04444f80-5be5-44e8-a77f-fde65ae6b94d" />

Poor flamepaw dies, but at least they have the right name!
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Cats lost while still an apprentice who die before being found will no longer be referred to by their warrior name in the death event.
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
