### PR TITLE
[BUGFIX] murder reveal and transition events not found

### DIFF
--- a/resources/lang/en/events/injury/beach.json
+++ b/resources/lang/en/events/injury/beach.json
@@ -808,7 +808,7 @@
         "season": [
             "any"
         ],
-        "frequency": 3,
+        "frequency": 1,
         "event_text": "m_c was dragged out into the ocean by the tide, and inhaled a lot of water before managing to get out. {PRONOUN/m_c/subject/CAP}{VERB/m_c/'ve/'s} been hacking and sputtering ever since.",
         "m_c": {
             "age": [

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -8819,7 +8819,7 @@
         "sub_type": [
             "transition"
         ],
-        "frequency": 2,
+        "frequency": 4,
         "event_text": "m_c has realized that she-cat doesn't describe how {PRONOUN/m_c/subject} {VERB/m_c/feel/feels} anymore.",
         "m_c": {
             "gender": [
@@ -8842,7 +8842,7 @@
         "sub_type": [
             "transition"
         ],
-        "frequency": 2,
+        "frequency": 4,
         "event_text": "m_c has realized that tom doesn't describe how {PRONOUN/m_c/subject} {VERB/m_c/feel/feels} anymore.",
         "m_c": {
             "gender": [

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -13,7 +13,7 @@
         "tags": [
             "clan_wide"
         ],
-        "frequency": 1,
+        "frequency": 4,
         "event_text": "m_c can't keep this secret anymore. {PRONOUN/m_c/subject/CAP} {VERB/m_c/request/requests} a Clan meeting, where {PRONOUN/m_c/subject} {VERB/m_c/reveal/reveals} the terrible secret {PRONOUN/m_c/subject}{VERB/m_c/'ve/'s} kept; {PRONOUN/m_c/subject} killed mur_c.",
         "m_c": {
             "age": [
@@ -73,7 +73,7 @@
         "sub_type": [
             "murder_reveal"
         ],
-        "frequency": 2,
+        "frequency": 3,
         "event_text": "r_c is stunned when {PRONOUN/r_c/subject} {VERB/r_c/discover/discovers} m_c carelessly bragging about killing mur_c to a wandering loner.",
         "m_c": {
             "age": [
@@ -115,7 +115,7 @@
         "sub_type": [
             "murder_reveal"
         ],
-        "frequency": 2,
+        "frequency": 3,
         "event_text": "m_c is truthful when r_c questions {PRONOUN/m_c/object} about mur_c's strange death. m_c claims that mur_c deserved to die after what {PRONOUN/mur_c/subject} did to m_c.",
         "m_c": {
             "age": [
@@ -161,7 +161,7 @@
         "tags": [
             "clan_wide"
         ],
-        "frequency": 1,
+        "frequency": 4,
         "event_text": "m_c boldly confesses to the entire Clan that {PRONOUN/m_c/subject} killed mur_c. m_c claims that mur_c deserved to pay for what {PRONOUN/mur_c/subject} did.",
         "m_c": {
             "age": [
@@ -226,7 +226,7 @@
         "tags": [
             "clan_wide"
         ],
-        "frequency": 2,
+        "frequency": 3,
         "event_text": "m_c's cold eyes don't blink when {PRONOUN/m_c/subject} {VERB/m_c/are/is} accused of murdering mur_c, and only simply states that the Clan is better off without mur_c anyways.",
         "m_c": {
             "age": [
@@ -297,7 +297,7 @@
         "sub_type": [
             "murder_reveal"
         ],
-        "frequency": 1,
+        "frequency": 2,
         "event_text": "r_c avoids m_c at all costs after accidentally witnessing mur_c's murder. r_c knows {PRONOUN/r_c/subject} can't keep it a secret but is terrified of what m_c might do.",
         "m_c": {
             "age": [
@@ -456,7 +456,7 @@
         "sub_type": [
             "murder_reveal"
         ],
-        "frequency": 2,
+        "frequency": 3,
         "event_text": "m_c laughs menacingly as r_c accuses {PRONOUN/m_c/object} of murdering mur_c. So what if {PRONOUN/m_c/subject} did? What is r_c going to do about it?",
         "m_c": {
             "age": [
@@ -553,7 +553,7 @@
         "sub_type": [
             "murder_reveal"
         ],
-        "frequency": 1,
+        "frequency": 2,
         "event_text": "r_c overheard m_c muttering in {PRONOUN/m_c/poss} sleep, claws slashing at the air. {PRONOUN/m_c/poss/CAP} muttering confirms what r_c always suspected -  m_c was the one responsible for mur_c's death.",
         "m_c": {
             "age": [

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -2248,7 +2248,7 @@ class Events:
     def coming_out(self, cat):
         """turnin' the kitties trans..."""
 
-        if cat.age.is_baby():
+        if cat.age.is_baby() or cat.gender != cat.genderalign:
             return
 
         transing_chance = constants.CONFIG["transition_related"]

--- a/scripts/events_module/short/handle_short_events.py
+++ b/scripts/events_module/short/handle_short_events.py
@@ -5,10 +5,8 @@ import i18n
 
 from scripts.clan_resources.herb.herb import HERBS
 from scripts.events_module.future.future_event import prep_event
-from scripts.game_structure import localization
 from scripts.cat.cats import Cat
-from scripts.cat.enums import CatAge, CatRank
-from scripts.cat.history import History
+from scripts.cat.enums import CatRank
 from scripts.cat.pelts import Pelt
 from scripts.cat_relations.relationship import Relationship
 from scripts.clan_package.settings import get_clan_setting


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Why This Is Good For ClanGen
Turns out murder_reveals just had *no* common frequency events. I've rebalanced their frequencies so that the majority are 4s.  Transition events, likewise, were all 2s and are now 4s.  I also moved the genderalign check into the `coming_out` func since that seems like a waste to only check it when we're all the way into filtering.
Also hit one of the injury events since a tester was complaining of it's frequency.
<!-- If this is a bug fix, you can remove this section. -->
<!-- Please add a short description of why you think these changes would benefit the game. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->
<!-- If you have multiple features that can stand on their own, or unrelated bugfixes, please create separate PRs for them. -->

## Linked Issues
Fixes #3767
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
<img width="563" height="260" alt="image" src="https://github.com/user-attachments/assets/9e1049ca-4964-4a5b-84c5-82667e29ed62" />
plenty of warnings, but not for murder reveals and transitions lmao
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Murder reveal and transitions events had their frequencies rebalanced, there should be less warning spam about these events not being found.
- Transition events are no longer searched for if the cat is already trans
- `bch_injury_waterinlungs_any1` should occur less frequently
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
