### PR TITLE
[BUGFIX] allowing dead newborns to have newborn thoughts

### DIFF
--- a/resources/lang/en/thoughts/dead/darkforest/newborn.json
+++ b/resources/lang/en/thoughts/dead/darkforest/newborn.json
@@ -13,6 +13,9 @@
             "Is clouded in confusion and fear",
             "Feels trapped in the sticky mud",
             "Is feeling incredibly lonely"
+        ],
+        "main_age_constraint": [
+            "newborn"
         ]
     },
     {
@@ -27,6 +30,9 @@
         ],
         "random_living_status": [
             "living"
+        ],
+        "main_age_constraint": [
+            "newborn"
         ]
     }
 ]

--- a/resources/lang/en/thoughts/dead/starclan/newborn.json
+++ b/resources/lang/en/thoughts/dead/starclan/newborn.json
@@ -10,6 +10,9 @@
             "Tries to practice walking to play with the other cats",
             "Attempts to snarl but can only manage a tiny mewl",
             "Rolls through the starry grass"
+        ],
+        "main_age_constraint": [
+            "newborn"
         ]
     },
     {
@@ -25,6 +28,9 @@
         ],
         "random_living_status": [
             "living"
+        ],
+        "main_age_constraint": [
+            "newborn"
         ]
     },
     {
@@ -37,6 +43,9 @@
         ],
         "random_living_status": [
             "starclan"
+        ],
+        "main_age_constraint": [
+            "newborn"
         ]
     }
 ]

--- a/resources/lang/en/thoughts/dead/unknownresidence/newborn.json
+++ b/resources/lang/en/thoughts/dead/unknownresidence/newborn.json
@@ -9,6 +9,9 @@
         ],
         "main_age_constraint": [
             "newborn"
+        ],
+        "main_age_constraint": [
+            "newborn"
         ]
     },
     {
@@ -26,6 +29,9 @@
         ],
         "random_living_status": [
             "living"
+        ],
+        "main_age_constraint": [
+            "newborn"
         ]
     }
 ]


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
Forgot to newborn-ify the dead newborn thoughts when I changed newborn to requiring explicit inclusion. Fixes #3792 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Proof of Testing
<img width="1171" height="304" alt="image" src="https://github.com/user-attachments/assets/79ad28c2-239f-4576-aa31-4dd4503b2bc3" />
This clan previously gave shitton of thought errors, but now it errors no more
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- dead newborns can once again think
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
