### PR TITLE
[BUGFIXES] UI fixes

### DIFF
--- a/scripts/screens/ClanScreen.py
+++ b/scripts/screens/ClanScreen.py
@@ -86,16 +86,14 @@ class ClanScreen(Screens):
                 self.update_buttons_and_text()
             if event.ui_element == self.med_den_label:
                 self.change_screen("med den screen")
-            else:
-                self.menu_button_pressed(event)
             if event.ui_element == self.clearing_label:
                 self.change_screen("clearing screen")
-            else:
-                self.menu_button_pressed(event)
             if event.ui_element == self.warrior_den_label:
                 self.change_screen("warrior den screen")
             if event.ui_element == self.leader_den_label:
                 self.change_screen("leader den screen")
+            else:
+                self.menu_button_pressed(event)
 
         elif event.type == pygame.KEYDOWN and game_setting_get("keybinds"):
             if event.key == pygame.K_RIGHT:

--- a/scripts/screens/ClanSettingsScreen.py
+++ b/scripts/screens/ClanSettingsScreen.py
@@ -25,6 +25,7 @@ from scripts.utility import (
     ui_scale_offset,
 )  # pylint: disable=redefined-builtin
 from .Screens import Screens
+from .screens_core.screens_core import rebuild_den_dropdown
 from ..cat import save_load
 from ..clan_package.settings import get_clan_setting, switch_clan_setting
 from ..cat.enums import CatRank, CatGroup
@@ -230,6 +231,10 @@ class ClanSettingsScreen(Screens):
         """
         TODO: DOCS
         """
+        rebuild_den_dropdown(
+            left_align=not get_clan_setting("moons and seasons"),
+            game_mode=game.clan.game_mode,
+        )
         self.clear_sub_settings_buttons_and_text()
         self.general_settings_button.kill()
         del self.general_settings_button

--- a/scripts/screens/ListScreen.py
+++ b/scripts/screens/ListScreen.py
@@ -333,13 +333,16 @@ class ListScreen(Screens):
             switch_set_value(Switch.sort_type, "rank")
 
         # CHOOSE GROUP DROPDOWN
+        starting_select = f"general.{self.current_group}"
         self.choose_group_dropdown = UIDropDown(
             pygame.Rect((-2, 0), (190, 34)),
             parent_text="screens.list.choose_group",
-            item_list=self.living_group_names,
+            item_list=self.living_group_names
+            if self.death_status == "living"
+            else self.dead_group_names,
             manager=MANAGER,
             container=self.cat_list_bar,
-            starting_selection=["general.your_clan"],
+            starting_selection=[starting_select],
             anchors={"left_target": self.cat_list_bar_elements["view_button"]},
         )
 
@@ -473,9 +476,6 @@ class ListScreen(Screens):
         # Determine the starting list of cats.
         self.get_cat_list()
         self.update_cat_list()
-        game.last_list_forProfile = (
-            "your_clan"  # wipe the saved last_list to avoid inconsistencies
-        )
 
     def display_change_save(self) -> Dict:
         variable_dict = super().display_change_save()

--- a/scripts/screens/MakeClanScreen.py
+++ b/scripts/screens/MakeClanScreen.py
@@ -24,9 +24,11 @@ from scripts.game_structure.ui_elements import (
 from scripts.utility import get_text_box_theme, ui_scale, ui_scale_blit, ui_scale_offset
 from scripts.utility import ui_scale_dimensions
 from .Screens import Screens
+from .screens_core.screens_core import rebuild_den_dropdown
 from ..cat import save_load
 from ..cat.enums import CatRank
 from ..cat.sprites import sprites
+from ..clan_package.settings import get_clan_setting
 from ..game_structure.game.settings import game_setting_set, game_setting_get
 from ..game_structure.game.switches import switch_get_value, Switch
 from ..game_structure.screen_settings import MANAGER, screen
@@ -2185,6 +2187,11 @@ class MakeClanScreen(Screens):
         game.clan.save_herb_supply(game.clan)
         Cat.grief_strings.clear()
         Cat.sort_cats()
+
+        rebuild_den_dropdown(
+            left_align=not get_clan_setting("moons and seasons"),
+            game_mode=game.clan.game_mode,
+        )
 
     def get_camp_art_path(self, campnum) -> Optional[str]:
         if not campnum:

--- a/scripts/screens/MedDenScreen.py
+++ b/scripts/screens/MedDenScreen.py
@@ -660,7 +660,7 @@ class MedDenScreen(Screens):
             if count <= 0:
                 continue
             if herb == "cobwebs":
-                self.herbs["cobweb1"] = pygame_gui.elements.UIImage(
+                self.herbs["cobweb1"] = UIModifiedImage(
                     ui_scale(pygame.Rect((108, 95), (396, 224))),
                     pygame.transform.scale(
                         pygame.image.load(
@@ -670,8 +670,9 @@ class MedDenScreen(Screens):
                     ),
                     manager=MANAGER,
                 )
+                self.herbs["cobweb1"].disable()
                 if count > 1:
-                    self.herbs["cobweb2"] = pygame_gui.elements.UIImage(
+                    self.herbs["cobweb2"] = UIModifiedImage(
                         ui_scale(pygame.Rect((108, 95), (396, 224))),
                         pygame.transform.scale(
                             pygame.image.load(
@@ -681,8 +682,9 @@ class MedDenScreen(Screens):
                         ),
                         manager=MANAGER,
                     )
+                    self.herbs["cobweb2"].disable()
                 continue
-            self.herbs[herb] = pygame_gui.elements.UIImage(
+            self.herbs[herb] = UIModifiedImage(
                 ui_scale(pygame.Rect((108, 95), (396, 224))),
                 pygame.transform.scale(
                     pygame.image.load(
@@ -692,6 +694,7 @@ class MedDenScreen(Screens):
                 ),
                 manager=MANAGER,
             )
+            self.herbs[herb].disable()
 
     def exit_screen(self):
         self.meds_messages.kill()

--- a/scripts/screens/Screens.py
+++ b/scripts/screens/Screens.py
@@ -27,10 +27,10 @@ from scripts.game_structure.screen_settings import (
 )
 from scripts.game_structure.ui_elements import UIImageButton
 from scripts.game_structure.windows import SaveCheck, EventLoading
+from scripts.screens.screens_core.screens_core import rebuild_den_dropdown
 from scripts.utility import (
     update_sprite,
     ui_scale,
-    ui_scale_dimensions,
     ui_scale_blit,
     get_current_season,
 )
@@ -47,6 +47,8 @@ class Screens:
 
     menu_buttons = scripts.screens.screens_core.screens_core.menu_buttons
     game_frame = scripts.screens.screens_core.screens_core.game_frame
+
+    dens = ["dens_bar", "lead_den", "med_cat_den", "warrior_den", "clearing"]
 
     active_bg: Optional[str] = None
 
@@ -85,21 +87,12 @@ class Screens:
         switch_set_value(Switch.cur_screen, new_screen)
         game.switch_screens = True
         game.rpc.update_rpc.set()
-        if game.clan:
-            if get_clan_setting("moons and seasons"):
-                x_shift = 1358
-                y_shift = 70
-                if new_screen == "events screen":
-                    x_shift = 0
-                    y_shift = 0
-            else:
-                x_shift = 0
-                y_shift = 0
-        else:
-            x_shift = 0
-            y_shift = 0
 
-        Screens.mns_ui_offset(x_shift, y_shift)
+        if game.last_screen_forupdate == "start screen":
+            rebuild_den_dropdown(
+                left_align=not get_clan_setting("moons and seasons"),
+                game_mode=game.clan.game_mode,
+            )
 
     def __init__(self, name=None):
         self.active_blur_bg = None
@@ -236,23 +229,11 @@ class Screens:
         """This shows all menu buttons, and makes them interact-able."""
         # Check if the setting for moons and seasons UI is on so stats button can be moved
         cls.update_moon_and_season()
+
         for name, button in cls.menu_buttons.items():
-            if name == "dens":
-                if (
-                    get_clan_setting("moons and seasons")
-                    and switch_get_value(Switch.cur_screen) == "events screen"
-                ):
-                    button.show()
-                elif (
-                    not get_clan_setting("moons and seasons")
-                    and switch_get_value(Switch.cur_screen) != "camp screen"
-                ):
-                    button.show()
-                button.hide()
             if name in [
                 "moons_n_seasons",
                 "moons_n_seasons_arrow",
-                "dens",
                 "med_cat_den",
                 "lead_den",
                 "clearing",
@@ -349,42 +330,12 @@ class Screens:
 
     @classmethod
     def update_dens(cls):
-        dens = ["dens_bar", "lead_den", "med_cat_den", "warrior_den", "clearing"]
-        for den in dens:
+        for den in cls.dens:
             # if dropdown is visible, hide
             if cls.menu_buttons[den].visible:
                 cls.menu_buttons[den].hide()
-            else:  # else, show
-                if game.clan.game_mode != "classic":
-                    cls.menu_buttons[den].show()
-                elif den == "clearing":
-                    if cls.menu_buttons["dens_bar"].get_relative_rect()[2:] != [
-                        10,
-                        125,
-                    ]:
-                        # redraw this to be shorter
-                        cls.menu_buttons["dens_bar"].kill()
-                        scripts.screens.screens_core.screens_core.menu_buttons.update(
-                            {
-                                "dens_bar": pygame_gui.elements.UIImage(
-                                    ui_scale(pygame.Rect((40, 60), (10, 125))),
-                                    pygame.transform.scale(
-                                        image_cache.load_image(
-                                            "resources/images/vertical_bar.png"
-                                        ).convert_alpha(),
-                                        ui_scale_dimensions((10, 125)),
-                                    ),
-                                    visible=True,
-                                    starting_height=1,
-                                    manager=MANAGER,
-                                )
-                            }
-                        )
-                        cls.menu_buttons[
-                            den
-                        ] = scripts.screens.screens_core.screens_core.menu_buttons[den]
-                else:
-                    cls.menu_buttons[den].show()
+            else:
+                cls.menu_buttons[den].show()
 
     @classmethod
     def update_heading_text(cls, text, text_kwargs=None):
@@ -392,182 +343,6 @@ class Screens:
         cls.menu_buttons["heading"].set_text(text, text_kwargs=text_kwargs)
 
         # Update if moons and seasons UI is on
-
-    @classmethod
-    def mns_ui_offset(cls, x_shift, y_shift):
-        """shifts the dens UI by the given amount - needed for positioning around the MnS widget"""
-        try:
-            if cls.menu_buttons["dens"]:
-                cls.menu_buttons["dens"].kill()
-            if cls.menu_buttons["dens_bar"]:
-                cls.menu_buttons["dens_bar"].kill()
-                del cls.menu_buttons["dens_bar"]
-            if cls.menu_buttons["lead_den"]:
-                cls.menu_buttons["lead_den"].kill()
-                del cls.menu_buttons["lead_den"]
-            if cls.menu_buttons["med_cat_den"]:
-                cls.menu_buttons["med_cat_den"].kill()
-                del cls.menu_buttons["med_cat_den"]
-            if cls.menu_buttons["warrior_den"]:
-                cls.menu_buttons["warrior_den"].kill()
-                del cls.menu_buttons["warrior_den"]
-            if cls.menu_buttons["clearing"]:
-                cls.menu_buttons["clearing"].kill()
-                del cls.menu_buttons["clearing"]
-        except:
-            pass
-        if y_shift != 0:
-            cls.menu_buttons.update(
-                {
-                    "dens_bar": pygame_gui.elements.UIImage(
-                        ui_scale(
-                            pygame.Rect((142 + x_shift, 120 + y_shift), (20, 320))
-                        ),
-                        pygame.transform.scale(
-                            image_cache.load_image(
-                                "resources/images/vertical_bar.png"
-                            ).convert_alpha(),
-                            (380, 70),
-                        ),
-                        visible=False,
-                        starting_height=5,
-                        manager=MANAGER,
-                    )
-                }
-            )
-            cls.menu_buttons.update(
-                {
-                    "lead_den": UIImageButton(
-                        ui_scale(
-                            pygame.Rect((-12 + x_shift, 200 + y_shift), (224, 56))
-                        ),
-                        "",
-                        visible=False,
-                        manager=MANAGER,
-                        object_id="#lead_den_button",
-                        starting_height=6,
-                    )
-                }
-            )
-            cls.menu_buttons.update(
-                {
-                    "med_cat_den": UIImageButton(
-                        ui_scale(
-                            pygame.Rect((-90 + x_shift, 280 + y_shift), (302, 56))
-                        ),
-                        "",
-                        visible=False,
-                        manager=MANAGER,
-                        object_id="#med_den_button",
-                        starting_height=6,
-                    )
-                }
-            )
-            cls.menu_buttons.update(
-                {
-                    "warrior_den": UIImageButton(
-                        ui_scale(
-                            pygame.Rect((-30 + x_shift, 360 + y_shift), (242, 56))
-                        ),
-                        "",
-                        visible=False,
-                        manager=MANAGER,
-                        object_id="#warrior_den_button",
-                        starting_height=6,
-                    )
-                }
-            )
-            cls.menu_buttons.update(
-                {
-                    "clearing": UIImageButton(
-                        ui_scale(pygame.Rect((50 + x_shift, 440 + y_shift), (162, 56))),
-                        "",
-                        visible=False,
-                        manager=MANAGER,
-                        object_id="#clearing_button",
-                        starting_height=6,
-                    )
-                }
-            )
-        else:
-            cls.menu_buttons.update(
-                {
-                    "dens_bar": pygame_gui.elements.UIImage(
-                        ui_scale(pygame.Rect((80 + x_shift, 120 + y_shift), (20, 320))),
-                        pygame.transform.scale(
-                            image_cache.load_image(
-                                "resources/images/vertical_bar.png"
-                            ).convert_alpha(),
-                            (380, 70),
-                        ),
-                        visible=False,
-                        starting_height=5,
-                        manager=MANAGER,
-                    )
-                }
-            )
-            cls.menu_buttons.update(
-                {
-                    "lead_den": UIImageButton(
-                        ui_scale(pygame.Rect((50 + x_shift, 200 + y_shift), (224, 56))),
-                        "",
-                        visible=False,
-                        manager=MANAGER,
-                        object_id="#lead_den_button",
-                        starting_height=6,
-                    )
-                }
-            )
-            cls.menu_buttons.update(
-                {
-                    "med_cat_den": UIImageButton(
-                        ui_scale(pygame.Rect((50 + x_shift, 280 + y_shift), (302, 56))),
-                        "",
-                        visible=False,
-                        manager=MANAGER,
-                        object_id="#med_den_button",
-                        starting_height=6,
-                    )
-                }
-            )
-            cls.menu_buttons.update(
-                {
-                    "warrior_den": UIImageButton(
-                        ui_scale(pygame.Rect((50 + x_shift, 360 + y_shift), (242, 56))),
-                        "",
-                        visible=False,
-                        manager=MANAGER,
-                        object_id="#warrior_den_button",
-                        starting_height=6,
-                    )
-                }
-            )
-            cls.menu_buttons.update(
-                {
-                    "clearing": UIImageButton(
-                        ui_scale(pygame.Rect((50 + x_shift, 440 + y_shift), (162, 56))),
-                        "",
-                        visible=False,
-                        manager=MANAGER,
-                        object_id="#clearing_button",
-                        starting_height=6,
-                    )
-                }
-            )
-
-        if switch_get_value(Switch.cur_screen) != "camp screen":
-            cls.menu_buttons.update(
-                {
-                    "dens": UIImageButton(
-                        ui_scale(pygame.Rect((50 + x_shift, 120 + y_shift), (142, 60))),
-                        "",
-                        visible=False,
-                        manager=MANAGER,
-                        object_id="#dens_button",
-                        starting_height=6,
-                    )
-                }
-            )
 
     @classmethod
     def update_moon_and_season(cls):

--- a/scripts/screens/screens_core/screens_core.py
+++ b/scripts/screens/screens_core/screens_core.py
@@ -177,63 +177,8 @@ def rebuild_core(*, should_rebuild_bgs=True):
         object_id="#arrow_mns_button",
         starting_height=5,
     )
-    menu_buttons["dens_bar"] = pygame_gui.elements.UIImage(
-        ui_scale(pygame.Rect((40, 5), (10, 160))),
-        pygame.transform.scale(
-            image_cache.load_image("resources/images/vertical_bar.png").convert_alpha(),
-            ui_scale_dimensions((380, 70)),
-        ),
-        visible=False,
-        starting_height=5,
-        manager=MANAGER,
-        anchors={"top_target": menu_buttons["main_menu"]},
-    )
-    menu_buttons["dens"] = UISurfaceImageButton(
-        ui_scale(pygame.Rect((25, 5), (71, 30))),
-        "screens.core.dens",
-        get_button_dict(ButtonStyles.SQUOVAL, (71, 30)),
-        visible=False,
-        manager=MANAGER,
-        object_id="@buttonstyles_squoval",
-        starting_height=6,
-        anchors={"top_target": menu_buttons["main_menu"]},
-    )
-    menu_buttons["lead_den"] = UISurfaceImageButton(
-        ui_scale(pygame.Rect((25, 100), (112, 28))),
-        "screens.core.leader_den",
-        get_button_dict(ButtonStyles.ROUNDED_RECT, (112, 28)),
-        visible=False,
-        manager=MANAGER,
-        object_id="@buttonstyles_rounded_rect",
-        starting_height=6,
-    )
-    menu_buttons["med_cat_den"] = UISurfaceImageButton(
-        ui_scale(pygame.Rect((25, 140), (151, 28))),
-        "screens.core.medicine_cat_den",
-        get_button_dict(ButtonStyles.ROUNDED_RECT, (151, 28)),
-        object_id="@buttonstyles_rounded_rect",
-        visible=False,
-        manager=MANAGER,
-        starting_height=6,
-    )
-    menu_buttons["warrior_den"] = UISurfaceImageButton(
-        ui_scale(pygame.Rect((25, 180), (121, 28))),
-        "screens.core.warriors_den",
-        get_button_dict(ButtonStyles.ROUNDED_RECT, (121, 28)),
-        object_id="@buttonstyles_rounded_rect",
-        visible=False,
-        manager=MANAGER,
-        starting_height=6,
-    )
-    menu_buttons["clearing"] = UISurfaceImageButton(
-        ui_scale(pygame.Rect((25, 220), (81, 28))),
-        "screens.core.clearing",
-        get_button_dict(ButtonStyles.ROUNDED_RECT, (81, 28)),
-        visible=False,
-        manager=MANAGER,
-        object_id="@buttonstyles_rounded_rect",
-        starting_height=6,
-    )
+
+    rebuild_den_dropdown()
 
     rebuild_mute("default")
 
@@ -265,6 +210,142 @@ def rebuild_core(*, should_rebuild_bgs=True):
 
     if should_rebuild_bgs:
         rebuild_bgs()
+
+
+def rebuild_den_dropdown(left_align: bool = True, game_mode: str = "expanded"):
+    """
+    Rebuild the den dropdown
+    :param left_align: Set True if the buttons should be on the left-hand side of the screen, False if they should be on the right-hand side
+    """
+
+    if "dens_bar" in menu_buttons:
+        menu_buttons["dens_bar"].kill()
+
+    x_pos = 40
+    if not left_align:
+        x_pos = 755
+
+    if game_mode != "classic":
+        menu_buttons["dens_bar"] = pygame_gui.elements.UIImage(
+            ui_scale(pygame.Rect((x_pos, 5), (10, 170))),
+            pygame.transform.scale(
+                image_cache.load_image(
+                    "resources/images/vertical_bar.png"
+                ).convert_alpha(),
+                ui_scale_dimensions((10, 160)),
+            ),
+            visible=False,
+            starting_height=5,
+            manager=MANAGER,
+            anchors={
+                "top_target": menu_buttons["main_menu"]
+                if left_align
+                else menu_buttons["clan_settings"]
+            },
+        )
+    else:
+        menu_buttons["dens_bar"] = pygame_gui.elements.UIImage(
+            ui_scale(pygame.Rect((x_pos, 5), (10, 140))),
+            pygame.transform.scale(
+                image_cache.load_image(
+                    "resources/images/vertical_bar.png"
+                ).convert_alpha(),
+                ui_scale_dimensions((10, 160)),
+            ),
+            visible=False,
+            starting_height=5,
+            manager=MANAGER,
+            anchors={
+                "top_target": menu_buttons["main_menu"]
+                if left_align
+                else menu_buttons["clan_settings"]
+            },
+        )
+
+    x_pos = 25
+    if not left_align:
+        x_pos = 704
+
+    if "dens" in menu_buttons:
+        menu_buttons["dens"].kill()
+    menu_buttons["dens"] = UISurfaceImageButton(
+        ui_scale(pygame.Rect((x_pos, 5), (71, 30))),
+        "screens.core.dens",
+        get_button_dict(ButtonStyles.SQUOVAL, (71, 30)),
+        visible=False,
+        manager=MANAGER,
+        object_id="@buttonstyles_squoval",
+        starting_height=6,
+        anchors={
+            "top_target": menu_buttons["main_menu"]
+            if left_align
+            else menu_buttons["clan_settings"]
+        },
+    )
+
+    if not left_align:
+        x_pos = 663
+    if "lead_den" in menu_buttons:
+        menu_buttons["lead_den"].kill()
+    menu_buttons["lead_den"] = UISurfaceImageButton(
+        ui_scale(pygame.Rect((x_pos, 10), (112, 28))),
+        "screens.core.leader_den",
+        get_button_dict(ButtonStyles.ROUNDED_RECT, (112, 28)),
+        visible=False,
+        manager=MANAGER,
+        object_id="@buttonstyles_rounded_rect",
+        starting_height=6,
+        anchors={
+            "top_target": menu_buttons["dens"],
+        },
+    )
+
+    if not left_align:
+        x_pos = 625
+    if "med_cat_den" in menu_buttons:
+        menu_buttons["med_cat_den"].kill()
+    menu_buttons["med_cat_den"] = UISurfaceImageButton(
+        ui_scale(pygame.Rect((x_pos, 10), (151, 28))),
+        "screens.core.medicine_cat_den",
+        get_button_dict(ButtonStyles.ROUNDED_RECT, (151, 28)),
+        object_id="@buttonstyles_rounded_rect",
+        visible=False,
+        manager=MANAGER,
+        starting_height=6,
+        anchors={"top_target": menu_buttons["lead_den"]},
+    )
+
+    if not left_align:
+        x_pos = 654
+    if "warrior_den" in menu_buttons:
+        menu_buttons["warrior_den"].kill()
+    menu_buttons["warrior_den"] = UISurfaceImageButton(
+        ui_scale(pygame.Rect((x_pos, 10), (121, 28))),
+        "screens.core.warriors_den",
+        get_button_dict(ButtonStyles.ROUNDED_RECT, (121, 28)),
+        object_id="@buttonstyles_rounded_rect",
+        visible=False,
+        manager=MANAGER,
+        starting_height=6,
+        anchors={"top_target": menu_buttons["med_cat_den"]},
+    )
+
+    if "clearing" in menu_buttons:
+        menu_buttons["clearing"].kill()
+
+    if game_mode != "classic":
+        if not left_align:
+            x_pos = 694
+        menu_buttons["clearing"] = UISurfaceImageButton(
+            ui_scale(pygame.Rect((x_pos, 10), (81, 28))),
+            "screens.core.clearing",
+            get_button_dict(ButtonStyles.ROUNDED_RECT, (81, 28)),
+            visible=False,
+            manager=MANAGER,
+            object_id="@buttonstyles_rounded_rect",
+            starting_height=6,
+            anchors={"top_target": menu_buttons["warrior_den"]},
+        )
 
 
 def rebuild_mute(location: str):


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
Med den hover was being blocked by layering images, which happened due to the pygui update. I've just switched those layers over to our subclass that fixes hover blocking.

Den dropdown is back!! This was a goddamn beast to wrestle.  I've set up a function for updating the positioning of the dropdown depending on if the moons+seasons widget is up.  It seems like the code we used to have doing this was what killed the button in the first place.  There was some wack stuff going on with size and positioning.  I'm not super happy with the function cus it isn't very efficient when it comes to aligning to the right, but it works and it *is* better and more readable than what we had.

Chosen cat list now persists correctly!  It was broken because I wasn't starting the group dropdown off correctly and it was defaulting to `your_clan`, then forcing the rest of the screen to conform.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
Fixes #3631 
Fixes #3632
Fixes #3644 
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
<img width="785" height="681" alt="image" src="https://github.com/user-attachments/assets/d9953e58-0a31-489f-9b5c-79edb0fd5b35" />

Med den!

<img width="798" height="685" alt="image" src="https://github.com/user-attachments/assets/f3e07b0b-50d1-4a6a-a0dc-d7c2beb1b0a7" />

Behold her splendor

<img width="786" height="689" alt="image" src="https://github.com/user-attachments/assets/35c6c3d8-04c5-4919-979a-645e185d1728" />

And here she is when the other widget is up!
I did also test in fullscreen, it works fine there as well.

https://github.com/user-attachments/assets/ebf360ed-aa13-4e53-9e8e-a80b9891fe24

List works!

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Med den hover info is back
- Dens dropdown button is back
- Returning to the list screen after viewing a cat profile no longer defaults to your clan list, instead it returns you to the last list you were viewing
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
