### PR TITLE
[BUGFIX] Exiled deputies

### DIFF
--- a/scripts/clan.py
+++ b/scripts/clan.py
@@ -145,15 +145,15 @@ class Clan:
     # The clan couldn't save itself in time due to issues arising, for example, from this function: "if deputy is not
     # None: self.deputy.status_change('deputy') -> game.clan.remove_med_cat(self)"
     def post_initialization_functions(self):
-        if self.deputy is not None:
+        if self.deputy and self.deputy.status.alive_in_player_clan:
             self.deputy.rank_change(CatRank.DEPUTY)
             self.clan_cats.append(self.deputy.ID)
 
-        if self.leader:
+        if self.leader and self.leader.status.alive_in_player_clan:
             self.leader.rank_change(CatRank.LEADER)
             self.clan_cats.append(self.leader.ID)
 
-        if self.medicine_cat is not None:
+        if self.medicine_cat and self.medicine_cat.status.alive_in_player_clan:
             self.clan_cats.append(self.medicine_cat.ID)
             self.med_cat_list.append(self.medicine_cat.ID)
             if self.medicine_cat.status.rank != CatRank.MEDICINE_CAT:


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
So turns out, if you exiled a deputy (or any "leadership" role), then saved and closed before a new deputy was chosen, that exiled deputy would just become deputy again when the save was reloaded.  This was due to our post initialization functions not checking if the still-listed deputy was *still* fit for being deputy.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
Fixes #3821
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
<img width="698" height="320" alt="image" src="https://github.com/user-attachments/assets/f059306a-43b1-42c5-9d3e-dfb45b85cfc6" />

The cat I'd been testing with.  With my fix, he's now stayed an exiled loner rather than returning to be deputy.

I also tested if new deputies could still be assigned after save load, and they can:
<img width="561" height="157" alt="image" src="https://github.com/user-attachments/assets/9d916a13-1008-4996-8ea4-c27c3d9c1fce" />

Then I saved again and reloaded once more to check all the deputies were where they're supposed to be, and they are!
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Exiled deputies no longer sneak back into their deputy position when a save is reloaded.
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
