### PR TITLE
[BUGFIX] Menu screen crash

### DIFF
--- a/scripts/game_structure/constants.py
+++ b/scripts/game_structure/constants.py
@@ -2,6 +2,15 @@ from pygame import Cursor, image, SYSTEM_CURSOR_ARROW
 import ujson
 import tomllib
 
+# this is just to make referencing main menu screens as a whole easier,
+# note that the clan creation screen is included and the clan settings screen is excluded. this is intended.
+MENU_SCREENS = [
+    "settings screen",
+    "start screen",
+    "switch clan screen",
+    "make clan screen",
+]
+
 BIOME_TYPES = ["Forest", "Plains", "Mountainous", "Beach", "Wetlands", "Desert"]
 
 SEASONS = ["Newleaf", "Greenleaf", "Leaf-fall", "Leaf-bare"]

--- a/scripts/screens/Screens.py
+++ b/scripts/screens/Screens.py
@@ -88,15 +88,13 @@ class Screens:
         game.switch_screens = True
         game.rpc.update_rpc.set()
 
-        if game.last_screen_forupdate == "start screen":
-            if game.clan:
-                game_mode = game.clan.game_mode
-            else:
-                game_mode = None
-                
+        if (
+            game.last_screen_forupdate == "start screen"
+            and switch_get_value(Switch.cur_screen) not in constants.MENU_SCREENS
+        ):
             rebuild_den_dropdown(
                 left_align=not get_clan_setting("moons and seasons"),
-                game_mode=game_mode,
+                game_mode=game.clan.game_mode,
             )
 
     def __init__(self, name=None):

--- a/scripts/screens/Screens.py
+++ b/scripts/screens/Screens.py
@@ -89,9 +89,14 @@ class Screens:
         game.rpc.update_rpc.set()
 
         if game.last_screen_forupdate == "start screen":
+            if game.clan:
+                game_mode = game.clan.game_mode
+            else:
+                game_mode = None
+                
             rebuild_den_dropdown(
                 left_align=not get_clan_setting("moons and seasons"),
-                game_mode=game.clan.game_mode,
+                game_mode=game_mode,
             )
 
     def __init__(self, name=None):


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
game.clan is the bane of my existence.  Anyways, I've added a check so that we don't try to rebuild the dens dropdown at all if we aren't in the game proper.  I've added the `MENU_SCREENS` constant that I actually have in #3789 as it is also perfectly suited for this scenario.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Proof of Testing

https://github.com/user-attachments/assets/3437d109-9ae7-4247-bf5d-40db745346e0


<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- No longer crashes when navigating the main menus without any saved clans
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
