### PR TITLE
Skill display fix

### DIFF
--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -459,7 +459,7 @@ class Cat:
             self.experience = 0
 
         if not skill_dict:
-            self.skills = CatSkills.generate_new_catskills(self.status.rank, self.moons)
+            self.skills = CatSkills.generate_new_catskills(self.status.rank, self.age)
 
     def __repr__(self):
         return "CAT OBJECT:" + self.ID

--- a/scripts/cat/skills.py
+++ b/scripts/cat/skills.py
@@ -270,8 +270,8 @@ class Skill:
         print("Can't set tier directly")
 
     def set_points_to_tier(self, tier: int):
-        """This is seperate from the tier setter, since it will booonly allow you
-        to set points to tier 1, 2, or 3, and never 0. Tier 0 is retricted to interest_only
+        """This is separate from the tier setter, since it will only allow you
+        to set points to tier 1, 2, or 3, and never 0. Tier 0 is restricted to interest_only
         skills"""
 
         # Make sure it in the right range. If not, return.
@@ -361,21 +361,21 @@ class CatSkills:
         return f"<CatSkills: Primary: |{self.primary}|, Secondary: |{self.secondary}|, Hidden: |{self.hidden}|>"
 
     @staticmethod
-    def generate_new_catskills(rank, moons, hidden_skill: HiddenSkillEnum = None):
+    def generate_new_catskills(rank, age, hidden_skill: HiddenSkillEnum = None):
         """Generates a new skill"""
         new_skill = CatSkills()
 
         new_skill.hidden = hidden_skill
 
-        if rank == CatRank.NEWBORN or moons <= 0:
+        if rank == CatRank.NEWBORN or CatAge.NEWBORN:
             pass
-        elif rank == CatRank.KITTEN or moons < 6:
+        elif rank == CatRank.KITTEN or CatAge.KITTEN:
             new_skill.primary = Skill.get_random_skill(points=0, interest_only=True)
         elif rank in [
             CatRank.APPRENTICE,
             CatRank.MEDICINE_APPRENTICE,
             CatRank.MEDIATOR_APPRENTICE,
-        ]:
+        ] or CatAge.ADOLESCENT:
             new_skill.primary = Skill.get_random_skill(point_tier=1, interest_only=True)
             if random.randint(1, 3) == 1:
                 new_skill.secondary = Skill.get_random_skill(
@@ -384,13 +384,13 @@ class CatSkills:
         else:
             primary_tier = 1
             secondary_tier = 1
-            if moons < 50:
+            if age < 50:
                 primary_tier += random.randint(0, 1)
                 secondary_tier += random.randint(0, 1)
-            elif moons < 100:
+            elif age < 100:
                 primary_tier += random.randint(0, 2)
                 secondary_tier += random.randint(0, 1)
-            elif moons < 150:
+            elif age < 150:
                 primary_tier += random.randint(1, 2)
                 secondary_tier += random.randint(0, 1)
             new_skill.primary = Skill.get_random_skill(point_tier=primary_tier)
@@ -500,14 +500,14 @@ class CatSkills:
                 self.primary = Skill(
                     random.choice(parental_paths),
                     points=0,
-                    interest_only=the_cat.status.rank
-                    in (CatRank.APPRENTICE, CatRank.KITTEN),
+                    interest_only=the_cat.status.rank.is_any_apprentice_rank()
+                    or the_cat.status.rank == CatRank.KITTEN,
                 )
             else:
                 self.primary = Skill.get_random_skill(
                     points=0,
-                    interest_only=the_cat.status.rank
-                    in (CatRank.APPRENTICE, CatRank.KITTEN),
+                    interest_only=the_cat.status.rank.is_any_apprentice_rank()
+                    or the_cat.status.rank == CatRank.KITTEN,
                 )
 
         if the_cat.status.is_clancat:

--- a/scripts/cat/skills.py
+++ b/scripts/cat/skills.py
@@ -371,11 +371,15 @@ class CatSkills:
             pass
         elif rank == CatRank.KITTEN or CatAge.KITTEN:
             new_skill.primary = Skill.get_random_skill(points=0, interest_only=True)
-        elif rank in [
-            CatRank.APPRENTICE,
-            CatRank.MEDICINE_APPRENTICE,
-            CatRank.MEDIATOR_APPRENTICE,
-        ] or CatAge.ADOLESCENT:
+        elif (
+            rank
+            in [
+                CatRank.APPRENTICE,
+                CatRank.MEDICINE_APPRENTICE,
+                CatRank.MEDIATOR_APPRENTICE,
+            ]
+            or CatAge.ADOLESCENT
+        ):
             new_skill.primary = Skill.get_random_skill(point_tier=1, interest_only=True)
             if random.randint(1, 3) == 1:
                 new_skill.secondary = Skill.get_random_skill(

--- a/scripts/cat/skills.py
+++ b/scripts/cat/skills.py
@@ -361,7 +361,9 @@ class CatSkills:
         return f"<CatSkills: Primary: |{self.primary}|, Secondary: |{self.secondary}|, Hidden: |{self.hidden}|>"
 
     @staticmethod
-    def generate_new_catskills(rank: CatRank, age: CatAge, hidden_skill: HiddenSkillEnum = None):
+    def generate_new_catskills(
+        rank: CatRank, age: CatAge, hidden_skill: HiddenSkillEnum = None
+    ):
         """Generates a new skill"""
         new_skill = CatSkills()
 
@@ -388,15 +390,18 @@ class CatSkills:
         else:
             primary_tier = 1
             secondary_tier = 1
-            if age < 50:
+            if age == CatAge.YOUNG_ADULT:
                 primary_tier += random.randint(0, 1)
                 secondary_tier += random.randint(0, 1)
-            elif age < 100:
+            elif age == CatAge.ADULT:
                 primary_tier += random.randint(0, 2)
                 secondary_tier += random.randint(0, 1)
-            elif age < 150:
+            elif age == CatAge.SENIOR_ADULT:
                 primary_tier += random.randint(1, 2)
                 secondary_tier += random.randint(0, 1)
+            elif age == CatAge.SENIOR:
+                primary_tier -= random.randint(0, 1),
+
             new_skill.primary = Skill.get_random_skill(point_tier=primary_tier)
             if random.randint(1, 2) == 1:
                 new_skill.secondary = Skill.get_random_skill(

--- a/scripts/cat/skills.py
+++ b/scripts/cat/skills.py
@@ -369,11 +369,11 @@ class CatSkills:
 
         new_skill.hidden = hidden_skill
 
-        if rank == CatRank.NEWBORN or CatAge.NEWBORN:
+        if rank == CatRank.NEWBORN or age == CatAge.NEWBORN:
             pass
-        elif rank == CatRank.KITTEN or CatAge.KITTEN:
+        elif rank == CatRank.KITTEN or age == CatAge.KITTEN:
             new_skill.primary = Skill.get_random_skill(points=0, interest_only=True)
-        elif rank.is_any_apprentice_rank() or CatAge.ADOLESCENT:
+        elif rank.is_any_apprentice_rank() or age == CatAge.ADOLESCENT:
             new_skill.primary = Skill.get_random_skill(point_tier=1, interest_only=True)
             if random.randint(1, 3) == 1:
                 new_skill.secondary = Skill.get_random_skill(

--- a/scripts/cat/skills.py
+++ b/scripts/cat/skills.py
@@ -361,7 +361,7 @@ class CatSkills:
         return f"<CatSkills: Primary: |{self.primary}|, Secondary: |{self.secondary}|, Hidden: |{self.hidden}|>"
 
     @staticmethod
-    def generate_new_catskills(rank, age, hidden_skill: HiddenSkillEnum = None):
+    def generate_new_catskills(rank: CatRank, age: CatAge, hidden_skill: HiddenSkillEnum = None):
         """Generates a new skill"""
         new_skill = CatSkills()
 
@@ -665,7 +665,7 @@ class CatSkills:
         return skills_meet
 
     @staticmethod
-    def get_skills_from_old(old_skill, rank, moons):
+    def get_skills_from_old(old_skill, rank: CatRank, age: CatAge):
         """Generates a CatSkill object"""
         new_skill = CatSkills()
         conversion = {
@@ -715,6 +715,6 @@ class CatSkills:
             new_skill.primary = Skill(conversion[old_skill][0])
             new_skill.primary.set_points_to_tier(conversion[old_skill][1])
         else:
-            new_skill = CatSkills.generate_new_catskills(rank, moons)
+            new_skill = CatSkills.generate_new_catskills(rank, age)
 
         return new_skill

--- a/scripts/cat/skills.py
+++ b/scripts/cat/skills.py
@@ -392,7 +392,7 @@ class CatSkills:
                 primary_tier += random.randint(1, 2)
                 secondary_tier += random.randint(0, 1)
             elif age == CatAge.SENIOR:
-                primary_tier -= random.randint(0, 1),
+                primary_tier -= random.randint(0, 1)
 
             new_skill.primary = Skill.get_random_skill(point_tier=primary_tier)
             if random.randint(1, 2) == 1:

--- a/scripts/cat/skills.py
+++ b/scripts/cat/skills.py
@@ -373,15 +373,7 @@ class CatSkills:
             pass
         elif rank == CatRank.KITTEN or CatAge.KITTEN:
             new_skill.primary = Skill.get_random_skill(points=0, interest_only=True)
-        elif (
-            rank
-            in [
-                CatRank.APPRENTICE,
-                CatRank.MEDICINE_APPRENTICE,
-                CatRank.MEDIATOR_APPRENTICE,
-            ]
-            or CatAge.ADOLESCENT
-        ):
+        elif rank.is_any_apprentice_rank() or CatAge.ADOLESCENT:
             new_skill.primary = Skill.get_random_skill(point_tier=1, interest_only=True)
             if random.randint(1, 3) == 1:
                 new_skill.secondary = Skill.get_random_skill(

--- a/scripts/game_structure/load_cat.py
+++ b/scripts/game_structure/load_cat.py
@@ -227,7 +227,7 @@ def json_load():
                     else:
                         new_cat.backstory = "clanborn"
                 new_cat.skills = CatSkills.get_skills_from_old(
-                    cat["skill"], new_cat.status.rank, new_cat.moons
+                    cat["skill"], new_cat.status.rank, new_cat.age
                 )
 
             new_cat.mate = cat["mate"] if type(cat["mate"]) is list else [cat["mate"]]

--- a/scripts/utility.py
+++ b/scripts/utility.py
@@ -838,12 +838,12 @@ def create_new_cat(
             if new_cat.status.rank != rank:
                 new_cat.status._change_rank(CatRank(rank))
             # give apprentice aged cat a mentor
-            if new_cat.status.rank in (
-                CatRank.APPRENTICE,
-                CatRank.MEDICINE_APPRENTICE,
-                CatRank.MEDIATOR_APPRENTICE,
-            ):
+            if new_cat.status.rank.is_any_apprentice_rank():
                 new_cat.update_mentor()
+                # ensuring that any cats joining as an apprentice will display the correct skills
+                new_cat.skills.primary.interest_only = True
+                if new_cat.skills.secondary:
+                    new_cat.skills.secondary.interest_only = True
 
         # NAMES and accs
         # clancat adults should have already generated with a clan-ish name, thus they skip all of this re-naming


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
Essentially, now that we first create new cats as their "old" social *then* add them to the Clan, adolescents joining as apprentices weren't having their interest set correctly.  `generate_new_catskills()` was only checking for an apprentice rank, not adolescent age, which meant loner adolescents wouldn't have their `interest_only` set correctly.

I've adjusted `generate_new_catskills()` to, firstly, utilize CatRank instead of moons (this makes it more readable and less dependent on magic nums) and, secondly, checking for adolescents alongside apprentice ranks.

Additionally, when new cats join as an apprentice, I've added some redundancy just to make *certain* those interest_only bools are set how we want them.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
Fixes #3823
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
<img width="716" height="366" alt="image" src="https://github.com/user-attachments/assets/9865e012-1d75-46c8-a57c-579af547d238" />

Forced a patrol to get this cat.  She joined at 11 moons old, going from a loner to an apprentice, just like the cat in the bug report.  She then aged up into an adult over timeskip, but is still displaying the interest skill as intended.
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Cats who join the Clan as an apprentice now only have skill interests, instead of gaining higher tiers before promotion.
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
