### PR TITLE
UI bug fixes

### DIFF
--- a/scripts/events_module/short/handle_short_events.py
+++ b/scripts/events_module/short/handle_short_events.py
@@ -496,6 +496,8 @@ class HandleShortEvents:
         else:
             self.main_cat.pelt.accessory = [choice(acc_list)]
 
+        self.main_cat.pelt.rebuild_sprite = True
+
     def handle_transition(self):
         """
         handles updating gender_align and pronouns

--- a/scripts/game_structure/ui_elements.py
+++ b/scripts/game_structure/ui_elements.py
@@ -502,6 +502,8 @@ class UIModifiedScrollingContainer(
         should_grow_automatically=True,
         anchors=None,
     ):
+        self.scroll_bar_starting_height = 1
+
         super().__init__(
             relative_rect=relative_rect,
             manager=manager,
@@ -514,7 +516,7 @@ class UIModifiedScrollingContainer(
             should_grow_automatically=should_grow_automatically,
             anchors=anchors,
         )
-
+        self.scroll_bar_starting_height = self.get_top_layer()
         if self.allow_scroll_y:
             self.vert_scroll_bar.kill()
             self.vert_scroll_bar = None
@@ -533,7 +535,7 @@ class UIModifiedScrollingContainer(
                 manager=self.ui_manager,
                 container=self._root_container,
                 parent_element=self,
-                starting_height=10,
+                starting_height=self.scroll_bar_starting_height,
                 anchors={
                     "left": "right",
                     "right": "right",
@@ -573,7 +575,7 @@ class UIModifiedScrollingContainer(
                     "bottom": "bottom",
                 },
                 visible=True,
-                starting_height=10,
+                starting_height=self.scroll_bar_starting_height,
             )
             self.horiz_scroll_bar.set_dimensions((self.relative_rect.width, 0))
             self.horiz_scroll_bar.set_relative_position((0, 0))
@@ -607,11 +609,11 @@ class UIModifiedScrollingContainer(
         super()._sort_out_element_container_scroll_bars()
 
         if self.vert_scroll_bar:
-            self.vert_scroll_bar.change_layer(9)
+            self.vert_scroll_bar.change_layer(self.scroll_bar_starting_height)
             self.vert_scroll_bar.show()
 
         if self.horiz_scroll_bar:
-            self.horiz_scroll_bar.change_layer(9)
+            self.horiz_scroll_bar.change_layer(self.scroll_bar_starting_height)
             self.horiz_scroll_bar.show()
 
     def _check_scroll_bars(self) -> Tuple[bool, bool]:

--- a/scripts/game_structure/windows.py
+++ b/scripts/game_structure/windows.py
@@ -2244,7 +2244,7 @@ class ConfirmDisplayChanges(UIMessageWindow):
             ui_scale_offset((0, 22)),
             (
                 self.get_container().get_size()[0],
-                self.get_container().get_size()[1] - button_vertical_space,
+                -1,
             ),
         )
         self.text_block = pygame_gui.elements.UITextBox(
@@ -2261,6 +2261,7 @@ class ConfirmDisplayChanges(UIMessageWindow):
             },
             text_kwargs={"count": 10},
         )
+        self.text_block.disable()
         self.text_block.rebuild_from_changed_theme_data()
 
         # make a timeout that will call in 10 seconds - if this window isn't closed,

--- a/scripts/game_structure/windows.py
+++ b/scripts/game_structure/windows.py
@@ -276,9 +276,10 @@ class SaveCheck(UIWindow):
             container=self,
         )
         save_buttons = get_button_dict(ButtonStyles.SQUOVAL, (114, 30))
-        save_buttons["normal"] = pygame.transform.scale(image_cache.load_image(
-            "resources/images/buttons/save_clan.png"
-        ), ui_scale_dimensions((114, 30)))
+        save_buttons["normal"] = pygame.transform.scale(
+            image_cache.load_image("resources/images/buttons/save_clan.png"),
+            ui_scale_dimensions((114, 30)),
+        )
 
         self.save_button = UISurfaceImageButton(
             ui_scale(pygame.Rect((0, 115), (114, 30))),

--- a/scripts/game_structure/windows.py
+++ b/scripts/game_structure/windows.py
@@ -276,9 +276,10 @@ class SaveCheck(UIWindow):
             container=self,
         )
         save_buttons = get_button_dict(ButtonStyles.SQUOVAL, (114, 30))
-        save_buttons["normal"] = image_cache.load_image(
+        save_buttons["normal"] = pygame.transform.scale(image_cache.load_image(
             "resources/images/buttons/save_clan.png"
-        )
+        ), ui_scale_dimensions((114, 30)))
+
         self.save_button = UISurfaceImageButton(
             ui_scale(pygame.Rect((0, 115), (114, 30))),
             "buttons.save_clan",

--- a/scripts/game_structure/windows.py
+++ b/scripts/game_structure/windows.py
@@ -41,6 +41,7 @@ from scripts.game_structure.ui_elements import (
     UITextBoxTweaked,
     UISurfaceImageButton,
     UIDropDown,
+    UIModifiedScrollingContainer,
 )
 from scripts.housekeeping.datadir import (
     get_save_dir,
@@ -76,7 +77,7 @@ if TYPE_CHECKING:
 class SymbolFilterWindow(UIWindow):
     def __init__(self):
         super().__init__(
-            ui_scale(pygame.Rect((250, 175), (300, 450))),
+            ui_scale(pygame.Rect((250, 125), (300, 450))),
             window_display_title="windows.symbol_filters",
             object_id="#filter_window",
         )
@@ -104,12 +105,12 @@ class SymbolFilterWindow(UIWindow):
             object_id="#text_box_40",
             container=self,
         )
-        self.filter_container = pygame_gui.elements.UIScrollingContainer(
-            ui_scale(pygame.Rect((5, 45), (285, 310))),
+        self.filter_container = UIModifiedScrollingContainer(
+            ui_scale(pygame.Rect((5, 45), (285, 400))),
             manager=MANAGER,
             starting_height=1,
-            object_id="#filter_container",
             allow_scroll_x=False,
+            allow_scroll_y=True,
             container=self,
         )
         self.checkbox = {}

--- a/scripts/screens/ClanScreen.py
+++ b/scripts/screens/ClanScreen.py
@@ -274,9 +274,9 @@ class ClanScreen(Screens):
         )
 
         save_buttons = get_button_dict(ButtonStyles.SQUOVAL, (114, 30))
-        save_buttons["normal"] = image_cache.load_image(
+        save_buttons["normal"] = pygame.transform.scale(image_cache.load_image(
             "resources/images/buttons/save_clan.png"
-        )
+        ), ui_scale_dimensions((114, 30)))
         self.save_button = UISurfaceImageButton(
             ui_scale(pygame.Rect(((343, 643), (114, 30)))),
             "buttons.save_clan",

--- a/scripts/screens/ClanScreen.py
+++ b/scripts/screens/ClanScreen.py
@@ -274,9 +274,10 @@ class ClanScreen(Screens):
         )
 
         save_buttons = get_button_dict(ButtonStyles.SQUOVAL, (114, 30))
-        save_buttons["normal"] = pygame.transform.scale(image_cache.load_image(
-            "resources/images/buttons/save_clan.png"
-        ), ui_scale_dimensions((114, 30)))
+        save_buttons["normal"] = pygame.transform.scale(
+            image_cache.load_image("resources/images/buttons/save_clan.png"),
+            ui_scale_dimensions((114, 30)),
+        )
         self.save_button = UISurfaceImageButton(
             ui_scale(pygame.Rect(((343, 643), (114, 30)))),
             "buttons.save_clan",

--- a/scripts/screens/ClearingScreen.py
+++ b/scripts/screens/ClearingScreen.py
@@ -13,6 +13,7 @@ from scripts.game_structure.ui_elements import (
     UITextBoxTweaked,
     UISurfaceImageButton,
     UIModifiedImage,
+    UIModifiedScrollingContainer,
 )
 from scripts.utility import (
     get_text_box_theme,
@@ -720,11 +721,10 @@ class ClearingScreen(Screens):
     def create_checkboxes(self):
         self.delete_checkboxes()
 
-        self.tactic_text[
-            "container_general"
-        ] = pygame_gui.elements.UIScrollingContainer(
+        self.tactic_text["container_general"] = UIModifiedScrollingContainer(
             ui_scale(pygame.Rect((140, 450), (230, 175))),
             allow_scroll_x=False,
+            allow_scroll_y=True,
             manager=MANAGER,
         )
 
@@ -745,15 +745,10 @@ class ClearingScreen(Screens):
             )
             n += 1
 
-        self.tactic_text["container_general"].set_scrollable_area_dimensions(
-            ui_scale_dimensions((200, (n * 30 + x_val + 20)))
-        )
-
-        self.additional_text[
-            "container_general"
-        ] = pygame_gui.elements.UIScrollingContainer(
+        self.additional_text["container_general"] = UIModifiedScrollingContainer(
             ui_scale(pygame.Rect((360, 450), (327, 175))),
             allow_scroll_x=False,
+            allow_scroll_y=True,
             manager=MANAGER,
         )
 
@@ -812,10 +807,6 @@ class ClearingScreen(Screens):
                 },
             )
             n += 1
-
-        self.additional_text["container_general"].set_scrollable_area_dimensions(
-            ui_scale_dimensions((305, (n * 30)))
-        )
 
         self.refresh_checkboxes("general")
 

--- a/scripts/screens/ClearingScreen.py
+++ b/scripts/screens/ClearingScreen.py
@@ -19,7 +19,6 @@ from scripts.utility import (
     get_text_box_theme,
     ui_scale,
     shorten_text_to_fit,
-    ui_scale_dimensions,
 )
 from .Screens import Screens
 from ..clan_package.settings import get_clan_setting, switch_clan_setting


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
- Save clan button just wasn't utilizing pygame.transform
- Fullscreen confirm was the overlapping text box issue we've been having
- Freshkill pile tactics were just being... created weirdly.  Now they aren't created weirdly.
- Sprite just needed to be rebuilt after acc receiving
- Filters scroll just needed the `allow_scroll_y` true, another victim of pygui updating

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
Fixes #3469 
Fixes #3709 
Fixes #3755 
Fixes #3738 
Fixes #3663 

<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
<img width="1918" height="1079" alt="image" src="https://github.com/user-attachments/assets/3ccbd565-e2bd-4890-bccf-7783892b0416" />

Save clan looks normal

<img width="546" height="342" alt="image" src="https://github.com/user-attachments/assets/75b5a979-4fe9-46cc-8a25-2aedb2387591" />

Button is hoverable again

<img width="980" height="382" alt="image" src="https://github.com/user-attachments/assets/f899e508-47f8-476f-ae12-2016f8590873" />

Tactics scroll to the bottom

<img width="315" height="278" alt="image" src="https://github.com/user-attachments/assets/643ae23b-4f32-4bbf-8672-a50be59c0290" />

Lichenstripe is showing their acc after their event

<img width="349" height="515" alt="image" src="https://github.com/user-attachments/assets/25383496-cf78-44a6-b8f8-540b738b3513" />

Scrolling once more
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Save clan button is now the normal size while in fullscreen mode
- Fullscreen confirm changes buttons can be clicked again
- Freshkill tactics now scroll all the way to the bottom
- Cat sprites now update to display new accessories received
- Symbol filter window scrolls once more
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
