### PR TITLE
Add displayname to Clan save data

### DIFF
--- a/resources/lang/en/screens/switch_clan.en.json
+++ b/resources/lang/en/screens/switch_clan.en.json
@@ -2,7 +2,7 @@
     "en": {
         "current_clan": {
             "zero": "There is no Clan currently loaded.",
-            "one": "The currently loaded Clan is %{clan}Clan."
+            "one": "The currently loaded Clan is %{clan}Clan\n(id: %{clan_id})."
         }
     }
 }

--- a/scripts/clan.py
+++ b/scripts/clan.py
@@ -241,7 +241,7 @@ class Clan:
         save_cats(game.clan.name, Cat, game)
         number_other_clans = randint(3, 5)
         for _ in range(number_other_clans):
-            other_clan_names = [str(i.name) for i in self.all_clans] + [game.clan.name]
+            other_clan_names = [str(i.name) for i in self.all_clans] + [game.clan.displayname]
             other_clan_name = choice(
                 names.names_dict["normal_prefixes"] + names.names_dict["clan_prefixes"]
             )

--- a/scripts/clan.py
+++ b/scripts/clan.py
@@ -76,6 +76,7 @@ class Clan:
         starting_members=None,
         starting_season="Newleaf",
         self_run_init_functions=True,
+        displayname=""
     ):
         if name == "":
             return
@@ -83,7 +84,13 @@ class Clan:
         if starting_members is None:
             starting_members = []
 
+        # name is the unique id of the clan. i'm sorry if this is confusing...
         self.name = name
+        # displayname is the name you should use whenever displaying the clan name in UI
+        if not displayname:
+            self.displayname = name
+        else:
+            self.displayname = displayname
         self.leader = leader
         self.leader_lives = 9
         self.leader_predecessors = 0
@@ -385,6 +392,7 @@ class Clan:
 
         clan_data = {
             "clanname": self.name,
+            "displayname": self.displayname,
             "clanage": self.age,
             "biome": self.biome,
             "camp_bg": self.camp_bg,
@@ -701,8 +709,14 @@ class Clan:
         else:
             med_cat = None
 
+        if "displayname" in clan_data:
+            displayname = clan_data["displayname"]
+        else:
+            displayname = clan_data["clanname"]
+
         game.clan = Clan(
             name=clan_data["clanname"],
+            displayname=displayname,
             leader=leader,
             deputy=deputy,
             medicine_cat=med_cat,

--- a/scripts/clan.py
+++ b/scripts/clan.py
@@ -76,7 +76,7 @@ class Clan:
         starting_members=None,
         starting_season="Newleaf",
         self_run_init_functions=True,
-        displayname=""
+        displayname="",
     ):
         if name == "":
             return
@@ -241,7 +241,9 @@ class Clan:
         save_cats(game.clan.name, Cat, game)
         number_other_clans = randint(3, 5)
         for _ in range(number_other_clans):
-            other_clan_names = [str(i.name) for i in self.all_clans] + [game.clan.displayname]
+            other_clan_names = [str(i.name) for i in self.all_clans] + [
+                game.clan.displayname
+            ]
             other_clan_name = choice(
                 names.names_dict["normal_prefixes"] + names.names_dict["clan_prefixes"]
             )

--- a/scripts/clan.py
+++ b/scripts/clan.py
@@ -85,6 +85,7 @@ class Clan:
             starting_members = []
 
         # name is the unique id of the clan. i'm sorry if this is confusing...
+        # TODO: change to better name like clan_id
         self.name = name
         # displayname is the name you should use whenever displaying the clan name in UI
         if not displayname:

--- a/scripts/events_module/ongoing/disaster_events.py
+++ b/scripts/events_module/ongoing/disaster_events.py
@@ -69,7 +69,7 @@ class DisasterEvents:
 
         # display trigger event
         event = self.disaster_text(chosen_disaster.trigger_events)
-        event.replace("c_n", f"{game.clan.name}Clan")
+        event.replace("c_n", f"{game.clan.displayname}Clan")
         game.cur_events_list.append(Single_Event(event, "misc"))
 
     def handle_current_primary_disaster(self):
@@ -208,6 +208,6 @@ class DisasterEvents:
         text = text.replace("lead_name", str(leader.name))
         text = text.replace("dep_name", str(deputy.name))
         text = text.replace("med_name", str(random.choice(med_cats).name))
-        text = text.replace("c_n", f"{game.clan.name}Clan")
+        text = text.replace("c_n", f"{game.clan.displayname}Clan")
 
         return text

--- a/scripts/events_module/patrol/patrol.py
+++ b/scripts/events_module/patrol/patrol.py
@@ -1135,7 +1135,7 @@ class Patrol:
 
         text = text.replace("o_c_n", str(other_clan_name) + "Clan")
 
-        clan_name = game.clan.name
+        clan_name = game.clan.displayname
         s = 0
         pos = 0
         for x in range(text.count("c_n")):
@@ -1155,7 +1155,7 @@ class Patrol:
                         text = " ".join(modify)
                         break
 
-        text = text.replace("c_n", str(game.clan.name) + "Clan")
+        text = text.replace("c_n", str(game.clan.displayname) + "Clan")
 
         text, senses, list_type, _ = find_special_list_types(text)
         if list_type:

--- a/scripts/events_module/short/condition_events.py
+++ b/scripts/events_module/short/condition_events.py
@@ -1046,7 +1046,7 @@ class Condition_Events:
                     if cat.age == CatAge.ADOLESCENT:
                         event += i18n.t(
                             "hardcoded.condition_retire_adolescent_ceremony",
-                            clan=game.clan.name,
+                            clan=game.clan.displayname,
                             newname=cat.name.prefix + cat.name.suffix,
                         )
 

--- a/scripts/game_structure/discord_rpc.py
+++ b/scripts/game_structure/discord_rpc.py
@@ -114,7 +114,7 @@ class _DiscordRPC(threading.Thread):
             # Example: beach_greenleaf_camp1_dark
 
             if game.clan:
-                clan_name = f"{game.clan.name}Clan"
+                clan_name = f"{game.clan.displayname}Clan"
                 cats_amount = len(game.clan.clan_cats)
                 clan_age = game.clan.age
             else:

--- a/scripts/game_structure/windows.py
+++ b/scripts/game_structure/windows.py
@@ -559,7 +559,7 @@ class GameOver(UIWindow):
             resizable=False,
         )
         self.set_blocking(True)
-        self.clan_name = str(game.clan.name + "Clan")
+        self.clan_name = str(game.clan.displayname + "Clan")
         self.last_screen = last_screen
         self.game_over_message = UITextBoxTweaked(
             "windows.game_over_message",

--- a/scripts/screens/AllegiancesScreen.py
+++ b/scripts/screens/AllegiancesScreen.py
@@ -42,7 +42,7 @@ class AllegiancesScreen(Screens):
         self.heading = pygame_gui.elements.UITextBox(
             "screens.allegiances.heading",
             ui_scale(pygame.Rect((0, 115), (400, 40))),
-            text_kwargs={"clan_name": game.clan.name},
+            text_kwargs={"clan_name": game.clan.displayname},
             object_id=get_text_box_theme("#text_box_34_horizcenter_vertcenter"),
             manager=MANAGER,
             anchors={"centerx": "centerx"},
@@ -52,7 +52,7 @@ class AllegiancesScreen(Screens):
         self.show_menu_buttons()
         self.show_mute_buttons()
         self.set_disabled_menu_buttons(["allegiances"])
-        self.update_heading_text(f"{game.clan.name}Clan")
+        self.update_heading_text(f"{game.clan.displayname}Clan")
         allegiance_list = self.get_allegiances_text()
 
         self.scroll_container = UIModifiedScrollingContainer(

--- a/scripts/screens/ClanScreen.py
+++ b/scripts/screens/ClanScreen.py
@@ -129,7 +129,7 @@ class ClanScreen(Screens):
         self.choose_cat_positions()
 
         self.set_disabled_menu_buttons(["camp_screen"])
-        self.update_heading_text(f"{game.clan.name}Clan")
+        self.update_heading_text(f"{game.clan.displayname}Clan")
         self.show_menu_buttons()
 
         # Creates and places the cat sprites.

--- a/scripts/screens/EventsScreen.py
+++ b/scripts/screens/EventsScreen.py
@@ -353,7 +353,7 @@ class EventsScreen(Screens):
 
         # Draw and disable the correct menu buttons.
         self.set_disabled_menu_buttons(["events_screen"])
-        self.update_heading_text(f"{game.clan.name}Clan")
+        self.update_heading_text(f"{game.clan.displayname}Clan")
         self.show_menu_buttons()
 
     def display_change_save(self) -> Dict:

--- a/scripts/screens/LeaderDenScreen.py
+++ b/scripts/screens/LeaderDenScreen.py
@@ -337,7 +337,7 @@ class LeaderDenScreen(Screens):
             manager=MANAGER,
             text_kwargs={
                 "temper": i18n.t(f"screens.leader_den.{self.clan_temper}"),
-                "clan": game.clan.name,
+                "clan": game.clan.displayname,
             },
         )
 

--- a/scripts/screens/LeaderDenScreen.py
+++ b/scripts/screens/LeaderDenScreen.py
@@ -432,7 +432,7 @@ class LeaderDenScreen(Screens):
             manager=MANAGER,
         )
         for i, other_clan in enumerate(game.clan.all_clans):
-            if other_clan.name == game.clan.name:
+            if other_clan.name == game.clan.displayname:
                 continue
             x_pos = 128
             self.other_clan_selection_elements[f"container{i}"] = UIContainer(

--- a/scripts/screens/ListScreen.py
+++ b/scripts/screens/ListScreen.py
@@ -242,7 +242,7 @@ class ListScreen(Screens):
     def screen_switches(self):
         super().screen_switches()
         self.show_mute_buttons()
-        self.clan_name = game.clan.name + "Clan"
+        self.clan_name = game.clan.displayname + "Clan"
 
         self.set_disabled_menu_buttons(["catlist_screen"])
         self.show_menu_buttons()

--- a/scripts/screens/MakeClanScreen.py
+++ b/scripts/screens/MakeClanScreen.py
@@ -1,6 +1,7 @@
 from random import choice, randrange
 from re import sub
 from typing import Optional
+from uuid import uuid4
 
 import i18n
 import pygame
@@ -2223,13 +2224,7 @@ class MakeClanScreen(Screens):
             )
     
     def _generate_unique_clan_name(self, new_clan_name: str):
-        existing_clan_names = (clan.casefold() for clan in switch_get_value(Switch.clan_list))
-        i = 0
-        new_unique_clan_name = f"{new_clan_name}_{i}"
-        while new_unique_clan_name.casefold() in existing_clan_names:
-            i += 1
-            new_unique_clan_name = f"{new_clan_name}_{i}"
-        return new_unique_clan_name
+        return f"{new_clan_name}_{uuid4()}"
 
 
 make_clan_screen = MakeClanScreen()

--- a/scripts/screens/MakeClanScreen.py
+++ b/scripts/screens/MakeClanScreen.py
@@ -269,9 +269,7 @@ class MakeClanScreen(Screens):
                 self.elements["error"].set_text("Your Clan's name cannot be empty")
                 self.elements["error"].show()
                 return
-            if new_name.casefold() in (
-                clan.casefold() for clan in switch_get_value(Switch.clan_list)
-            ):
+            if self._clan_name_exists(new_name):
                 self.elements["error"].set_text("A Clan with that name already exists.")
                 self.elements["error"].show()
                 return
@@ -297,9 +295,7 @@ class MakeClanScreen(Screens):
                     self.elements["error"].set_text("Your Clan's name cannot be empty")
                     self.elements["error"].show()
                     return
-                if new_name.casefold() in (
-                    clan.casefold() for clan in switch_get_value(Switch.clan_list)
-                ):
+                if self._clan_name_exists(new_name):
                     self.elements["error"].set_text(
                         "A Clan with that name already exists."
                     )
@@ -315,9 +311,7 @@ class MakeClanScreen(Screens):
                 self.elements["error"].set_text("Your Clan's name cannot be empty")
                 self.elements["error"].show()
                 return
-            if new_name.casefold() in (
-                clan.casefold() for clan in switch_get_value(Switch.clan_list)
-            ):
+            if self._clan_name_exists(new_name):
                 self.elements["error"].set_text("A Clan with that name already exists.")
                 self.elements["error"].show()
                 return
@@ -587,9 +581,7 @@ class MakeClanScreen(Screens):
                 )
                 self.elements["error"].show()
                 self.elements["next_step"].disable()
-            elif self.elements["name_entry"].get_text().casefold() in (
-                clan.casefold() for clan in switch_get_value(Switch.clan_list)
-            ):
+            elif self._clan_name_exists(self.elements["name_entry"].get_text()):
                 self.elements["error"].set_text(
                     "screens.make_clan.error_clan_name_duplicate"
                 )
@@ -2237,6 +2229,11 @@ class MakeClanScreen(Screens):
             object_id=get_text_box_theme("#text_box_26_horizcenter"),
             manager=MANAGER,
         )
+
+    def _clan_name_exists(self, new_clan_name: str):
+        return new_clan_name.casefold() in (
+                clan.casefold() for clan in switch_get_value(Switch.clan_list)
+            )
 
 
 make_clan_screen = MakeClanScreen()

--- a/scripts/screens/MakeClanScreen.py
+++ b/scripts/screens/MakeClanScreen.py
@@ -2140,7 +2140,7 @@ class MakeClanScreen(Screens):
         convert_camp = {1: "camp1", 2: "camp2", 3: "camp3", 4: "camp4"}
         displayname = self.clan_name
         if self._clan_name_exists(self.clan_name):
-            clan_name = self.clan_name
+            clan_name = self._generate_unique_clan_name(self.clan_name)
         else:
             clan_name = self.clan_name
 
@@ -2221,6 +2221,15 @@ class MakeClanScreen(Screens):
         return new_clan_name.casefold() in (
                 clan.casefold() for clan in switch_get_value(Switch.clan_list)
             )
+    
+    def _generate_unique_clan_name(self, new_clan_name: str):
+        existing_clan_names = (clan.casefold() for clan in switch_get_value(Switch.clan_list))
+        i = 0
+        new_unique_clan_name = f"{new_clan_name}_{i}"
+        while new_unique_clan_name.casefold() in existing_clan_names:
+            i += 1
+            new_unique_clan_name = f"{new_clan_name}_{i}"
+        return new_unique_clan_name
 
 
 make_clan_screen = MakeClanScreen()

--- a/scripts/screens/MakeClanScreen.py
+++ b/scripts/screens/MakeClanScreen.py
@@ -2220,9 +2220,9 @@ class MakeClanScreen(Screens):
 
     def _clan_name_exists(self, new_clan_name: str):
         return new_clan_name.casefold() in (
-                clan.casefold() for clan in switch_get_value(Switch.clan_list)
-            )
-    
+            clan.casefold() for clan in switch_get_value(Switch.clan_list)
+        )
+
     def _generate_unique_clan_name(self, new_clan_name: str):
         return f"{new_clan_name}_{uuid4()}"
 

--- a/scripts/screens/MakeClanScreen.py
+++ b/scripts/screens/MakeClanScreen.py
@@ -269,10 +269,6 @@ class MakeClanScreen(Screens):
                 self.elements["error"].set_text("Your Clan's name cannot be empty")
                 self.elements["error"].show()
                 return
-            if self._clan_name_exists(new_name):
-                self.elements["error"].set_text("A Clan with that name already exists.")
-                self.elements["error"].show()
-                return
             self.clan_name = new_name
             self.open_choose_leader()
         elif event.ui_element == self.elements["previous_step"]:
@@ -295,12 +291,6 @@ class MakeClanScreen(Screens):
                     self.elements["error"].set_text("Your Clan's name cannot be empty")
                     self.elements["error"].show()
                     return
-                if self._clan_name_exists(new_name):
-                    self.elements["error"].set_text(
-                        "A Clan with that name already exists."
-                    )
-                    self.elements["error"].show()
-                    return
                 self.clan_name = new_name
                 self.open_choose_leader()
         elif event.key == pygame.K_RETURN:
@@ -309,10 +299,6 @@ class MakeClanScreen(Screens):
             ).strip()
             if not new_name:
                 self.elements["error"].set_text("Your Clan's name cannot be empty")
-                self.elements["error"].show()
-                return
-            if self._clan_name_exists(new_name):
-                self.elements["error"].set_text("A Clan with that name already exists.")
                 self.elements["error"].show()
                 return
             self.clan_name = new_name
@@ -578,12 +564,6 @@ class MakeClanScreen(Screens):
             elif self.elements["name_entry"].get_text().startswith(" "):
                 self.elements["error"].set_text(
                     "screens.make_clan.error_clan_name_space"
-                )
-                self.elements["error"].show()
-                self.elements["next_step"].disable()
-            elif self._clan_name_exists(self.elements["name_entry"].get_text()):
-                self.elements["error"].set_text(
-                    "screens.make_clan.error_clan_name_duplicate"
                 )
                 self.elements["error"].show()
                 self.elements["next_step"].disable()
@@ -2158,8 +2138,15 @@ class MakeClanScreen(Screens):
         Cat.outside_cats.clear()
         Patrol.used_patrols.clear()
         convert_camp = {1: "camp1", 2: "camp2", 3: "camp3", 4: "camp4"}
+        displayname = self.clan_name
+        if self._clan_name_exists(self.clan_name):
+            clan_name = self.clan_name
+        else:
+            clan_name = self.clan_name
+
         game.clan = Clan(
-            name=self.clan_name,
+            name=clan_name,
+            displayname=displayname,
             leader=self.leader,
             deputy=self.deputy,
             medicine_cat=self.med_cat,

--- a/scripts/screens/PatrolScreen.py
+++ b/scripts/screens/PatrolScreen.py
@@ -297,7 +297,7 @@ class PatrolScreen(Screens):
     def screen_switches(self):
         super().screen_switches()
         self.set_disabled_menu_buttons(["patrol_screen"])
-        self.update_heading_text(f"{game.clan.name}Clan")
+        self.update_heading_text(f"{game.clan.displayname}Clan")
         self.show_mute_buttons()
         self.show_menu_buttons()
 

--- a/scripts/screens/ProfileScreen.py
+++ b/scripts/screens/ProfileScreen.py
@@ -313,7 +313,7 @@ class ProfileScreen(Screens):
                                 new_group=CatGroup.STARCLAN
                             )
                             self.the_cat.thought = i18n.t(
-                                "screens.profile.guide_thought_sc", clan=game.clan.name
+                                "screens.profile.guide_thought_sc", clan=game.clan.displayname
                             )
                         # SC -> DF
                         else:
@@ -322,7 +322,7 @@ class ProfileScreen(Screens):
                             )
 
                             self.the_cat.thought = i18n.t(
-                                "screens.profile.guide_thought_df", clan=game.clan.name
+                                "screens.profile.guide_thought_df", clan=game.clan.displayname
                             )
                         self.the_cat.pelt.rebuild_sprite = True
                     else:
@@ -564,11 +564,11 @@ class ProfileScreen(Screens):
         if self.the_cat.dead and game.clan.instructor is self.the_cat:
             if self.the_cat.status.group == CatGroup.STARCLAN:  # StarClan
                 self.the_cat.thought = i18n.t(
-                    "screens.profile.guide_thought_sc", clan=game.clan.name
+                    "screens.profile.guide_thought_sc", clan=game.clan.displayname
                 )
             elif self.the_cat.status.group == CatGroup.DARK_FOREST:  # Dark Forest
                 self.the_cat.thought = i18n.t(
-                    "screens.profile.guide_thought_df", clan=game.clan.name
+                    "screens.profile.guide_thought_df", clan=game.clan.displayname
                 )
 
         self.profile_elements["cat_name"] = pygame_gui.elements.UITextBox(

--- a/scripts/screens/ProfileScreen.py
+++ b/scripts/screens/ProfileScreen.py
@@ -313,7 +313,8 @@ class ProfileScreen(Screens):
                                 new_group=CatGroup.STARCLAN
                             )
                             self.the_cat.thought = i18n.t(
-                                "screens.profile.guide_thought_sc", clan=game.clan.displayname
+                                "screens.profile.guide_thought_sc",
+                                clan=game.clan.displayname,
                             )
                         # SC -> DF
                         else:
@@ -322,7 +323,8 @@ class ProfileScreen(Screens):
                             )
 
                             self.the_cat.thought = i18n.t(
-                                "screens.profile.guide_thought_df", clan=game.clan.displayname
+                                "screens.profile.guide_thought_df",
+                                clan=game.clan.displayname,
                             )
                         self.the_cat.pelt.rebuild_sprite = True
                     else:

--- a/scripts/screens/RoleScreen.py
+++ b/scripts/screens/RoleScreen.py
@@ -533,7 +533,7 @@ class RoleScreen(Screens):
         else:
             output = "screens.role.blurb_unknown"
 
-        return i18n.t(output, name=self.the_cat.name, clan=game.clan.name)
+        return i18n.t(output, name=self.the_cat.name, clan=game.clan.displayname)
 
     def exit_screen(self):
         self.back_button.kill()

--- a/scripts/screens/Screens.py
+++ b/scripts/screens/Screens.py
@@ -201,7 +201,7 @@ class Screens:
         Screens.menu_buttons = scripts.screens.screens_core.screens_core.menu_buttons
         Screens.game_frame = scripts.screens.screens_core.screens_core.game_frame
         try:
-            Screens.update_heading_text(game.clan.name + "Clan")
+            Screens.update_heading_text(game.clan.displayname + "Clan")
         except AttributeError:
             Screens.update_heading_text("DebugClan")
         if self.active_bg is None or "default" in self.active_bg:

--- a/scripts/screens/SwitchClanScreen.py
+++ b/scripts/screens/SwitchClanScreen.py
@@ -129,12 +129,13 @@ class SwitchClanScreen(Screens):
 
         self.current_clan = pygame_gui.elements.UITextBox(
             "screens.switch_clan.current_clan",
-            ui_scale(pygame.Rect((0, 100), (600, 40))),
+            ui_scale(pygame.Rect((0, 90), (600, 80))),
             object_id=get_text_box_theme("#text_box_30_horizcenter"),
             manager=MANAGER,
             anchors={"centerx": "centerx"},
             text_kwargs={
-                "clan": game.clan.name if game.clan else "",
+                "clan": game.clan.displayname if game.clan else "",
+                "clan_id": game.clan.name if game.clan else "",
                 "count": 1 if game.clan else 0,
             },
         )

--- a/scripts/utility.py
+++ b/scripts/utility.py
@@ -2089,7 +2089,7 @@ def history_text_adjust(text, other_clan_name, clan, other_cat_rc=None):
         text = text.replace("o_c_n", str(other_clan_name))
 
     if "c_n" in text:
-        text = text.replace("c_n", clan.name)
+        text = text.replace("c_n", clan.displayname)
     if "r_c" in text and other_cat_rc:
         text = selective_replace(text, "r_c", str(other_cat_rc.name))
     return text
@@ -2139,13 +2139,13 @@ def ongoing_event_text_adjust(Cat, text, clan=None, other_clan_name=None):
     if other_clan_name:
         text = text.replace("o_c_n", other_clan_name)
     if clan:
-        clan_name = str(clan.name)
+        clan_name = str(clan.displayname)
     else:
         if game.clan is None:
             # todo can this be Switch.clan_name ?
             clan_name = switch_get_value(Switch.clan_list)[0]
         else:
-            clan_name = str(game.clan.name)
+            clan_name = str(game.clan.displayname)
 
     text = text.replace("c_n", clan_name + "Clan")
 
@@ -2334,7 +2334,7 @@ def event_text_adjust(
     # clan_name
     if "c_n" in text:
         try:
-            clan_name = clan.name
+            clan_name = clan.displayname
         except AttributeError:
             # todo can this be Switch.clan_name ?
             clan_name = switch_get_value(Switch.clan_list)[0]
@@ -2433,7 +2433,7 @@ def ceremony_text_adjust(
     living_parents=(),
     dead_parents=(),
 ):
-    clanname = str(game.clan.name + "Clan")
+    clanname = str(game.clan.displayname + "Clan")
 
     random_honor = random_honor
     random_living_parent = None

--- a/scripts/utility.py
+++ b/scripts/utility.py
@@ -2416,7 +2416,7 @@ def leader_ceremony_text_adjust(
     if extra_lives:
         text = text.replace("[life_num]", str(extra_lives))
 
-    text = text.replace("c_n", str(game.clan.name) + "Clan")
+    text = text.replace("c_n", str(game.clan.displayname) + "Clan")
 
     return text
 


### PR DESCRIPTION
## About The Pull Request

* Adds `displayname` field to Clan save data and Clan objects.
* `displayname` is used in UI to refer to the Clan's name instead of `name` (which is now effectively a unique ID referring to the Clan)
* Removes check during Clan creation that a Clan name doesn't exist. Instead, it allows it, sets the `displayname` to the existing name, and generates a new Clan ID using a uuid. The new Clan ID includes the name of the Clan for help with locating it when looking through folders.

I wanted to keep this PR small so it's simpler to review.  I'm hoping that I (or someone who is good at UI) can make improvements with separate PRs in the future.

This PR does not:
* Add any UI for changing `displayname` in-game  (side-note: this hypothetical future UI might want to make sure that the player's Clan not be named the same as any neighbouring Clans to help avoid confusion?)
* Display the `displayname` in the list of Clans when switching
<img width="310" height="538" alt="image" src="https://github.com/user-attachments/assets/28a5e002-3a96-459e-b159-165de7b028b5" />

## Why This Is Good For ClanGen

* Makes it possible to rename Clans

## Proof of Testing
<img width="812" height="262" alt="image" src="https://github.com/user-attachments/assets/3969d7fd-5d1b-4943-ae98-52ffe11748e0" />

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits

<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
