### PR TITLE
[BUGFIX] Fix status display on profiles

### DIFF
--- a/resources/lang/en/general.en.json
+++ b/resources/lang/en/general.en.json
@@ -14,8 +14,9 @@
         },
         "moon_date": "moon %{moon}",
         "guide": "guiding ghost",
-        "past_no_group": "past",
-        "past_group": "past %{group}",
+        "living_group": "%{group} %{rank}",
+        "past_no_group": "past %{rank}",
+        "past_group": "past %{group} %{rank}",
         "leader": {
             "one": "leader",
             "many": "leaders"

--- a/resources/lang/en/general.en.json
+++ b/resources/lang/en/general.en.json
@@ -13,6 +13,9 @@
             "many": "%{count} moons (in life)"
         },
         "moon_date": "moon %{moon}",
+        "guide": "guiding ghost",
+        "past_no_group": "past",
+        "past_group": "past %{group}",
         "leader": {
             "one": "leader",
             "many": "leaders"

--- a/scripts/cat/status.py
+++ b/scripts/cat/status.py
@@ -317,6 +317,9 @@ class Status:
 
     @property
     def is_other_clancat(self) -> bool:
+        """
+        Returns True if the cat is a clancat but isn't part of the player_clan. If the cat is a dead clancat, returns True if their last living Clan wasn't the player_clan.
+        """
         dead_player_clan = (
             self.group
             and self.group.is_afterlife()
@@ -581,7 +584,7 @@ class Status:
         history.reverse()
 
         for entry in history:
-            if not entry["group"] or not entry["group"].is_afterlife():
+            if entry["group"] and not entry["group"].is_afterlife():
                 return entry["group"]
 
         return None

--- a/scripts/screens/ProfileScreen.py
+++ b/scripts/screens/ProfileScreen.py
@@ -871,11 +871,30 @@ class ProfileScreen(Screens):
             # NEWLINE ----------
             output += "\n"
 
-        if the_cat.status.is_other_clancat:
+        if the_cat == game.clan.instructor:
+            output += i18n.t(f"general.guide")
+            output += "\n"
+
+        # add group name
+        if the_cat.dead and (
+            the_cat.status.is_clancat or the_cat.status.is_former_clancat
+        ):
+            if the_cat == game.clan.instructor:
+                # these guys are special, we won't name a group for them
+                output += f"{i18n.t(f'general.past_no_group')} "
+            else:
+                output += f"{i18n.t(f'general.past_group', group=cat_clan)} "
+        elif the_cat.status.is_clancat:
             output += f"{cat_clan} "
 
         if the_cat.status.is_outsider:
+            if the_cat.dead:
+                output += f"{i18n.t(f'general.past_no_group')} "
             output += i18n.t(f"general.{the_cat.status.social}", count=1)
+        elif the_cat.status.is_other_clancat:
+            if name:
+                # add rank
+                output += i18n.t(f"general.{the_cat.status.rank}", count=1)
         else:
             output += i18n.t(f"general.{the_cat.status.rank}", count=1)
 

--- a/scripts/screens/ProfileScreen.py
+++ b/scripts/screens/ProfileScreen.py
@@ -875,28 +875,26 @@ class ProfileScreen(Screens):
             output += i18n.t(f"general.guide")
             output += "\n"
 
-        # add group name
-        if the_cat.dead and (
-            the_cat.status.is_clancat or the_cat.status.is_former_clancat
-        ):
-            if the_cat == game.clan.instructor:
-                # these guys are special, we won't name a group for them
-                output += f"{i18n.t(f'general.past_no_group')} "
+        if the_cat.dead:
+            if the_cat == game.clan.instructor or the_cat.status.is_outsider:
+                output += i18n.t(
+                    f"general.past_no_group",
+                    rank=i18n.t(f"general.{the_cat.status.rank}", count=1),
+                )
             else:
-                output += f"{i18n.t(f'general.past_group', group=cat_clan)} "
-        elif the_cat.status.is_clancat:
-            output += f"{cat_clan} "
-
-        if the_cat.status.is_outsider:
-            if the_cat.dead:
-                output += f"{i18n.t(f'general.past_no_group')} "
-            output += i18n.t(f"general.{the_cat.status.social}", count=1)
-        elif the_cat.status.is_other_clancat:
-            if name:
-                # add rank
-                output += i18n.t(f"general.{the_cat.status.rank}", count=1)
-        else:
+                output += i18n.t(
+                    "general.past_group",
+                    group=cat_clan,
+                    rank=i18n.t(f"general.{the_cat.status.rank}", count=1),
+                )
+        elif the_cat.status.is_outsider:
             output += i18n.t(f"general.{the_cat.status.rank}", count=1)
+        else:
+            output += i18n.t(
+                "general.living_group",
+                group=cat_clan,
+                rank=i18n.t(f"general.{the_cat.status.rank}", count=1),
+            )
 
         # NEWLINE ----------
         output += "\n"


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
This reworks a how we handle the status display on profiles... again. This kinda kills me with how tangle-y it is, but there's just a lot of scenarios to try and work around (and i keep wanting to add more to it lmaoo, some of this is just self-inflicted)

- guide cats are now labeled as "guiding ghost" and will display their rank without a clan name attached
- dead cats in general now begin their status display with "past", creating such strings as "past loner" and "past GlintClan warrior"
- living player_clan cats now have the clan name included before their rank, because it's just easier man, one less thing to account for
- `get_last_living_group()` wasn't working as intended, leading to NoneClan cats

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
Fixes #3843 

<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
<img width="610" height="298" alt="image" src="https://github.com/user-attachments/assets/0d68a5b8-2a0e-4455-b484-727758976a32" />
<img width="614" height="290" alt="image" src="https://github.com/user-attachments/assets/4b3df376-4d85-44de-a01c-c609f8fd5ba6" />
<img width="666" height="310" alt="image" src="https://github.com/user-attachments/assets/ebeffd76-b8eb-42cc-84f5-f363fd91adc3" />
<img width="647" height="278" alt="image" src="https://github.com/user-attachments/assets/364693a8-b027-4f9f-bc4e-b8c71a69a5b7" />
<img width="671" height="305" alt="image" src="https://github.com/user-attachments/assets/569c4380-0f80-4f77-8218-0b4e58456adc" />
<img width="665" height="288" alt="image" src="https://github.com/user-attachments/assets/428e917d-9219-46a6-8d95-466cefe8f731" />
<img width="647" height="289" alt="image" src="https://github.com/user-attachments/assets/83e3a6e1-d9fd-48ce-be4d-356e26a99420" />

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- guide cats are now labeled as "guiding ghost" and will display their rank without a clan name attached
- dead cats in general now begin their status display with "past", creating such strings as "past loner" and "past GlintClan warrior"
- living player_clan cats now have the clan name included before their rank, because it's just easier man, one less thing to account for
- `get_last_living_group()` wasn't working as intended, leading to NoneClan cats

<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
