### PR TITLE
[BUGFIX] Fixing a couple death histories

### DIFF
--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -4995,8 +4995,8 @@
                 "cats": [
                     "m_c"
                 ],
-                "reg_death": "m_c died while wandering the territory.",
-                "lead_death": "died while wandering the territory"
+                "reg_death": "m_c was killed by r_c while wandering the territory.",
+                "lead_death": "was killed by r_c while wandering the territory"
             }
         ],
         "future_event": [

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -4995,8 +4995,8 @@
                 "cats": [
                     "m_c"
                 ],
-                "reg_death": "m_c was killed by r_c while wandering the territory.",
-                "lead_death": "killed by r_c while wandering the territory"
+                "reg_death": "m_c was lead out into the territory and killed by r_c.",
+                "lead_death": "were lead away from camp by r_c and killed"
             }
         ],
         "future_event": [

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -4996,7 +4996,7 @@
                     "m_c"
                 ],
                 "reg_death": "m_c was killed by r_c while wandering the territory.",
-                "lead_death": "was killed by r_c while wandering the territory"
+                "lead_death": "killed by r_c while wandering the territory"
             }
         ],
         "future_event": [

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -2324,7 +2324,7 @@
                     "r_c"
                 ],
                 "reg_death": "This cat died from old age.",
-                "lead_death": "lost all remaining lives from old age."
+                "lead_death": "died from old age."
             }
         ]
     },


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
Adjusted the death history of wandering away death to be more clear that it was a murder.
Adjusted the death history for leaders dying of old age so that it wouldn't be redundant.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
Fixes #3862
Fixes #3886
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Changelog/Credits
- Death history of a hidden murder adjusted to be more clearly a murder.
- Leader death history for old age death reworded to reduce redundancy.
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
