### PR TITLE
[CRASHFIX] Fixed "chance romance not mate" wrong spelling causing crash

### DIFF
--- a/scripts/events_module/relationship/relation_events.py
+++ b/scripts/events_module/relationship/relation_events.py
@@ -114,7 +114,7 @@ class Relation_Events:
         # that the cat interacts romantic with ANOTHER cat than their mate
         use_mate = False
         if cat.mate:
-            chance_number = constants.CONFIG["relationship"]["chance_romantic_not_mate"]
+            chance_number = constants.CONFIG["relationship"]["chance_romance_not_mate"]
 
             # the more mates the cat has, the less likely it will be that they interact with another cat romantically
             for mate_id in cat.mate:


### PR DESCRIPTION


<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
Changed spelling to match how it's written in game_config
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
Since it was a crash related to the latest PR, there was no issue opened yet, but I ran upon this crash and fixed it:
<img width="616" height="184" alt="image" src="https://github.com/user-attachments/assets/626bd298-adcd-4905-b7e8-140a6ec3986f" />

## Changelog/Credits
CRASHFIX: Fixed crash related to cats with mates
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
