### PR TITLE
[BUGFIX] Mediator Fixes

### DIFF
--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -2853,13 +2853,8 @@ class Cat:
         if allow_romantic and (mates or cat1.is_potential_mate(cat2)):
             rel_values.append(RelType.ROMANCE)
 
-        # Determine the number of positive traits to effect, and choose the traits
-        chosen_pos = sample(rel_values, k=randint(2, len(rel_values)))
-
-        # Determine negative trains effected
-        chosen_neg = sample(
-            [v for v in rel_values if v not in chosen_pos], k=randint(1, 2)
-        )
+        # Determine the number of traits to effect, and choose the traits
+        chosen_rel = sample(rel_values, k=randint(2, len(rel_values)))
 
         if compat is True:
             personality_bonus = 2
@@ -2869,7 +2864,7 @@ class Cat:
             personality_bonus = 0
 
         # Effects on traits
-        for rel_type in chosen_pos + chosen_neg:
+        for rel_type in chosen_rel:
             # The EX bonus in not applied upon a fail.
             if apply_bonus:
                 if mediator.experience_level == "very low":
@@ -2888,10 +2883,7 @@ class Cat:
             else:
                 bonus = 0
 
-            if sabotage or rel_type in chosen_neg:
-                decrease = True
-            else:
-                decrease = sabotage or rel_type in chosen_neg
+            decrease = sabotage
 
             ran = (5, 10) if rel_type == RelType.ROMANCE and mates else (4, 6)
 
@@ -2899,8 +2891,21 @@ class Cat:
                 -1 if sabotage else 1
             )
 
-            setattr(rel1, rel_type, amount)
-            setattr(rel2, rel_type, amount)
+            if rel_type == RelType.ROMANCE:
+                setattr(rel1, "romance", rel1.romance + amount)
+                setattr(rel2, "romance", rel2.romance + amount)
+            if rel_type == RelType.LIKE:
+                setattr(rel1, "like", rel1.like + amount)
+                setattr(rel2, "like", rel2.like + amount)
+            if rel_type == RelType.RESPECT:
+                setattr(rel1, "respect", rel1.respect + amount)
+                setattr(rel2, "respect", rel2.respect + amount)
+            if rel_type == RelType.COMFORT:
+                setattr(rel1, "comfort", rel1.comfort + amount)
+                setattr(rel2, "comfort", rel2.comfort + amount)
+            if rel_type == RelType.TRUST:
+                setattr(rel1, "trust", rel1.trust + amount)
+                setattr(rel2, "trust", rel2.trust + amount)
 
             output += i18n.t(
                 f"screens.mediation.output_{'decrease' if decrease else 'increase'}",

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -2883,32 +2883,17 @@ class Cat:
             else:
                 bonus = 0
 
-            decrease = sabotage
-
             ran = (5, 10) if rel_type == RelType.ROMANCE and mates else (4, 6)
 
             amount = ((randint(ran[0], ran[1]) + bonus) + personality_bonus) * (
                 -1 if sabotage else 1
             )
 
-            if rel_type == RelType.ROMANCE:
-                setattr(rel1, "romance", rel1.romance + amount)
-                setattr(rel2, "romance", rel2.romance + amount)
-            if rel_type == RelType.LIKE:
-                setattr(rel1, "like", rel1.like + amount)
-                setattr(rel2, "like", rel2.like + amount)
-            if rel_type == RelType.RESPECT:
-                setattr(rel1, "respect", rel1.respect + amount)
-                setattr(rel2, "respect", rel2.respect + amount)
-            if rel_type == RelType.COMFORT:
-                setattr(rel1, "comfort", rel1.comfort + amount)
-                setattr(rel2, "comfort", rel2.comfort + amount)
-            if rel_type == RelType.TRUST:
-                setattr(rel1, "trust", rel1.trust + amount)
-                setattr(rel2, "trust", rel2.trust + amount)
+            setattr(rel1, rel_type, getattr(rel1, rel_type) + amount)
+            setattr(rel2, rel_type, getattr(rel2, rel_type) + amount)
 
             output += i18n.t(
-                f"screens.mediation.output_{'decrease' if decrease else 'increase'}",
+                f"screens.mediation.output_{'decrease' if sabotage else 'increase'}",
                 trait=i18n.t(f"screens.mediation.{rel_type}"),
             )
 


### PR DESCRIPTION
## About The Pull Request
Bug 3939 occurred because the mediator function would assign some RelTypes to "chosen_pos", and then attempt to assign a few more traits to "chosen_neg". This would either result in a crash (if all RelTypes had already been assigned to "chosen_pos") or some RelTypes would be increased while others would be decreased (unintended behavior for mediator).
Since we no longer have the negative RelTypes (dislike, jealousy) that "chosen_neg" was used for, I removed "chosen_neg" and renamed "chosen_pos" to "chosen_rel".

This revealed a second bug, as the 'setattr' function was simply setting the rel_type value to the 'amount' variable instead of adding 'amount' to the relationship. All mediated cats were being assigned relationship values of around 4-6.

The code could find the correct 'rel_type' attribute in 'setattr(rel1, rel_type...), but couldn't call it when trying to set rel1.rel_type (at least not with anything I did), so instead of just doing setattr(rel1, rel_type, rel1.rel_type + amount), I had it identify the relationship type and then call the associated attribute by name. The way I did this might be less than smooth. I can fix it if needed.

Also removed an if/else statement and set decreased = sabotage directly. Can return if/else statement if needed for testing or catching unintended values.

## Linked Issues
Fixes: #3939 

## Proof of Testing
The exact difference is hard to see, but Lightcrest can both mediate and sabotage relationships without issue, including larger relationship values. 
<img width="929" height="505" alt="Screenshot 2025-08-12 013916" src="https://github.com/user-attachments/assets/1c612a6d-04f3-4897-8bcb-e7349abce420" />
<img width="942" height="568" alt="Screenshot 2025-08-12 013929" src="https://github.com/user-attachments/assets/9e070854-d3e1-414c-9a66-18eb3e65b3c6" />
<img width="948" height="564" alt="Screenshot 2025-08-12 014114" src="https://github.com/user-attachments/assets/2858a428-1380-41a9-94c9-17389d5c0205" />
<img width="934" height="570" alt="Screenshot 2025-08-12 014130" src="https://github.com/user-attachments/assets/6bb36800-1e2a-4d2a-b699-ebcc64ae50cb" />
