### PR TITLE
[CONTENT] - New Wetland and Desert Events

### DIFF
--- a/resources/lang/en/events/death/desert.json
+++ b/resources/lang/en/events/death/desert.json
@@ -24,7 +24,7 @@
           "season": ["any"],
           "tags": [],
           "weight": 20,
-          "event_text": "m_c chased a kangaroo rat into a burrow, only to run right into the fangs of a surprised rattlesnake.",
+          "event_text": "m_c chased a kangaroo rat into a burrow, only to run right into the fatal fangs of a surprised rattlesnake.",
           "m_c": {
               "status": ["apprentice", "warrior", "deputy", "leader"],
               "dies": true

--- a/resources/lang/en/events/death/desert.json
+++ b/resources/lang/en/events/death/desert.json
@@ -71,7 +71,7 @@
               {
               "cats": ["m_c"],
               "reg_death": "m_c was mislead by a mirage, thinking it was water.",
-              "lead_death": "{VERB/m_c/were/was} mislead by a mirage thinking it was water."
+              "lead_death": "{VERB/m_c/were/was} mislead by a mirage, thinking it was water."
               }
           ]
   },

--- a/resources/lang/en/events/death/desert.json
+++ b/resources/lang/en/events/death/desert.json
@@ -1,1 +1,117 @@
-[]
+[
+  {
+          "event_id": "dst_death_any_rattlesnake1",
+          "location": ["desert"],
+          "season": ["any"],
+          "tags": [],
+          "weight": 20,
+          "event_text": "m_c was killed by a rattlesnake out in the territory.",
+          "m_c": {
+              "status": ["apprentice", "warrior", "deputy", "leader"],
+              "dies": true
+          },
+          "history": [
+              {
+              "cats": ["m_c"],
+              "reg_death": "m_c was killed by a rattlesnake.",
+              "lead_death": "{VERB/m_c/were/was} killed by a rattlesnake."
+              }
+          ]
+  },
+  {
+          "event_id": "dst_death_any_rattlesnake2",
+          "location": ["desert"],
+          "season": ["any"],
+          "tags": [],
+          "weight": 20,
+          "event_text": "m_c chased a kangaroo rat into a burrow, only to run right into the fangs of a surprised rattlesnake.",
+          "m_c": {
+              "status": ["apprentice", "warrior", "deputy", "leader"],
+              "dies": true
+          },
+          "history": [
+              {
+              "cats": ["m_c"],
+              "reg_death": "m_c was killed by a rattlesnake.",
+              "lead_death": "{VERB/m_c/were/was} killed by a rattlesnake."
+              }
+          ]
+  },
+  {
+          "event_id": "dst_death_app_rattlesnake3",
+          "location": ["desert"],
+          "season": ["any"],
+          "tags": [],
+          "weight": 20,
+          "event_text": "m_c jumped on top of a rattlesnake by mistake and was killed by the ensuing bite.",
+          "m_c": {
+              "status": ["apprentice"],
+              "dies": true
+          },
+          "history": [
+              {
+              "cats": ["m_c"],
+              "reg_death": "m_c was killed by a rattlesnake.",
+              "lead_death": "{VERB/m_c/were/was} killed by a rattlesnake."
+              }
+          ]
+  },
+  {
+          "event_id": "dst_death_any_mirage1",
+          "location": ["desert"],
+          "season": ["greenleaf", "newleaf"],
+          "tags": [],
+          "weight": 20,
+          "event_text": "m_c died of dehydration after mistakenly following a mirage.",
+          "m_c": {
+              "status": ["apprentice", "warrior", "deputy", "leader"],
+              "dies": true
+          },
+          "history": [
+              {
+              "cats": ["m_c"],
+              "reg_death": "m_c was mislead by a mirage thinking it was water.",
+              "lead_death": "{VERB/m_c/were/was} mislead by a mirage thinking it was water."
+              }
+          ]
+  },
+  {
+          "event_id": "dst_death_any_scorpion1",
+          "location": ["desert"],
+          "season": ["any"],
+          "tags": [],
+          "weight": 20,
+          "event_text": "m_c was killed after being stung by a scorpion.",
+          "m_c": {
+              "status": ["apprentice", "warrior", "deputy", "leader"],
+              "dies": true
+          },
+          "history": [
+              {
+              "cats": ["m_c"],
+              "reg_death": "m_c was killed by a scorpion.",
+              "lead_death": "{VERB/m_c/were/was} killed by a scorpion."
+              }
+          ]
+  },
+  {
+          "event_id": "dst_death_any_multitraitscorpion2",
+          "location": ["desert"],
+          "season": ["any"],
+          "tags": [],
+          "weight": 20,
+          "event_text": "m_c was mistakenly stung by a scorpion during a hunt and succumbed to the venom.",
+          "m_c": {
+              "status": ["apprentice", "warrior", "deputy", "leader"],
+              "trait": ["ambitious", "bold", "charismatic", "competitive", "daring", "flamboyant", "insecure", "strange", "troublesome"],
+              "dies": true
+          },
+          "history": [
+              {
+              "cats": ["m_c"],
+              "reg_death": "m_c was killed by a scorpion.",
+              "lead_death": "{VERB/m_c/were/was} killed by a scorpion."
+              }
+          ]
+  }
+]

--- a/resources/lang/en/events/death/desert.json
+++ b/resources/lang/en/events/death/desert.json
@@ -70,7 +70,7 @@
           "history": [
               {
               "cats": ["m_c"],
-              "reg_death": "m_c was mislead by a mirage thinking it was water.",
+              "reg_death": "m_c was mislead by a mirage, thinking it was water.",
               "lead_death": "{VERB/m_c/were/was} mislead by a mirage thinking it was water."
               }
           ]

--- a/resources/lang/en/events/death/wetlands.json
+++ b/resources/lang/en/events/death/wetlands.json
@@ -1,1 +1,40 @@
-[]
+[
+  {
+        "event_id": "wtlnd_death_any_quicksand",
+        "location": ["wetlands"],
+        "season": ["any"],
+        "tags": [],
+        "weight": 10,
+        "event_text": "m_c got stuck in quicksand and wasn't found in time.",
+        "m_c": {
+            "status": ["apprentice", "warrior", "deputy", "leader"],
+            "dies": true
+        },
+        "history": [
+            {
+            "cats": ["m_c"],
+            "reg_death": "m_c died after getting trapped in quicksand.",
+            "lead_death": "{VERB/m_c/were/was} stuck in quicksand."
+            }
+        ]
+  },
+  {
+        "event_id": "wtlnd_death_app_cottonmouth",
+        "location": ["wetlands"],
+        "season": ["greenleaf", "newleaf", "leaf-fall"],
+        "tags": [],
+        "weight": 20,
+        "event_text": "m_c was killed by a snake with a strikingly white mouth.",
+        "m_c": {
+            "status": ["apprentice"],
+            "dies": true
+        },
+        "history": [
+            {
+            "cats": ["m_c"],
+            "reg_death": "m_c was killed by a cottonmouth snake.",
+            "lead_death": "{VERB/m_c/were/was} killed by a cottonmouth snake."
+            }
+        ]
+  }
+]

--- a/resources/lang/en/events/injury/desert.json
+++ b/resources/lang/en/events/injury/desert.json
@@ -315,6 +315,22 @@
         ]
     },
     {
+        "event_id": "dst_injury_bruisessore_anymultiage2",
+        "location": ["desert"],
+        "season": ["any"],
+        "weight": 20,
+        "event_text": "m_c took a bad tumble over a rock hidden by the dusty ground.",
+        "m_c": {
+            "age": ["adolescent", "young adult", "adult", "senior adult", "senior"]
+        },
+        "injury": [
+            {
+                "cats": ["m_c"],
+                "injuries": ["bruises", "sore"]
+            }
+        ]
+    },
+    {
         "event_id": "dst_injury_dehydrated_nonleafbare_anymultiage1",
         "location": [
             "desert"
@@ -3260,6 +3276,23 @@
         ]
     },
     {
+        "event_id": "dst_injury_scrapessmallcuts_appmultitrait1",
+        "location": ["desert"],
+        "season": ["any"],
+        "weight": 20,
+        "event_text": "m_c dashes off from {PRONOUN/m_c/poss} mentor and tumbles face first into a cactus, thankfully the medicine cat is able to remove the spines with little difficulty.",
+        "m_c": {
+            "age": ["adolescent"],
+            "trait": ["adventurous", "arrogant", "bold", "childish", "confident", "daring", "oblivious", "playful", "rebellious", "shameless", "troublesome"]
+        },
+        "injury": [
+            {
+                "cats": ["m_c"],
+                "injuries": ["scrapes", "small cut"]
+            }
+        ]
+    },
+    {
         "event_id": "dst_injury_soreapp_clankits",
         "location": [
             "desert"
@@ -3435,6 +3468,30 @@
                 "cats": [
                     "m_c"
                 ],
+                "scar": "m_c was scarred by a snake bite.",
+                "reg_death": "m_c died after {PRONOUN/m_c/subject} {VERB/m_c/were/was} bitten by a snake.",
+                "lead_death": "after {PRONOUN/m_c/subject} {VERB/m_c/were/was} bitten by a snake"
+            }
+        ]
+    },
+    {
+        "event_id": "dst_injury_snake_any1",
+        "location": ["desert"],
+        "season": ["any"],
+        "weight": 20,
+        "event_text": "A snake managed to slither into camp and bite m_c.",
+        "m_c": {
+            "age": ["any"]
+        },
+        "injury": [
+            {
+                "cats": ["m_c"],
+                "injuries": ["snake bite"]
+            }
+        ],
+        "history": [
+            {
+                "cats": ["m_c"],
                 "scar": "m_c was scarred by a snake bite.",
                 "reg_death": "m_c died after {PRONOUN/m_c/subject} {VERB/m_c/were/was} bitten by a snake.",
                 "lead_death": "after {PRONOUN/m_c/subject} {VERB/m_c/were/was} bitten by a snake"

--- a/resources/lang/en/events/injury/desert.json
+++ b/resources/lang/en/events/injury/desert.json
@@ -3280,7 +3280,7 @@
         "location": ["desert"],
         "season": ["any"],
         "weight": 20,
-        "event_text": "m_c dashes off from {PRONOUN/m_c/poss} mentor and tumbles face first into a cactus, thankfully r_c is able to remove the spines with little difficulty.",
+        "event_text": "m_c dashes off from {PRONOUN/m_c/poss} mentor and tumbles face first into a cactus! Thankfully r_c is able to remove the spines with little difficulty.",
         "m_c": {
             "status": ["apprentice", "mediator apprentice", "medicine cat apprentice"],
             "trait": ["adventurous", "arrogant", "bold", "childish", "confident", "daring", "oblivious", "playful", "rebellious", "shameless", "troublesome"],

--- a/resources/lang/en/events/injury/desert.json
+++ b/resources/lang/en/events/injury/desert.json
@@ -3280,10 +3280,14 @@
         "location": ["desert"],
         "season": ["any"],
         "weight": 20,
-        "event_text": "m_c dashes off from {PRONOUN/m_c/poss} mentor and tumbles face first into a cactus, thankfully the medicine cat is able to remove the spines with little difficulty.",
+        "event_text": "m_c dashes off from {PRONOUN/m_c/poss} mentor and tumbles face first into a cactus, thankfully r_c is able to remove the spines with little difficulty.",
         "m_c": {
-            "age": ["adolescent"],
-            "trait": ["adventurous", "arrogant", "bold", "childish", "confident", "daring", "oblivious", "playful", "rebellious", "shameless", "troublesome"]
+            "status": ["apprentice", "mediator apprentice", "medicine cat apprentice"],
+            "trait": ["adventurous", "arrogant", "bold", "childish", "confident", "daring", "oblivious", "playful", "rebellious", "shameless", "troublesome"],
+            "relationship_status": ["app/mentor"]
+        },
+        "r_c": {
+            "status": ["warrior", "mediator", "medicine cat"]
         },
         "injury": [
             {

--- a/resources/lang/en/events/injury/wetlands.json
+++ b/resources/lang/en/events/injury/wetlands.json
@@ -1,1 +1,70 @@
-[]
+[
+  {
+        "event_id": "wtlnd_injury_sore_anymultiage1",
+        "location": ["wetlands"],
+        "season": ["any"],
+        "weight": 20,
+        "event_text": "m_c woke up sore after walking through an especially muddy and dense part of the territory.",
+        "m_c": {
+            "age": ["adolescent", "young adult", "adult", "senior adult", "senior"]
+        },
+        "injury": [
+            {
+                "cats": ["m_c"],
+                "injuries": ["sore"]
+            }
+        ]
+    },
+  {
+        "event_id": "wtlnd_injury_poisoned_app1",
+        "location": ["wetlands"],
+        "season": ["any"],
+        "weight": 20,
+        "event_text": "m_c ate some red berries out in the territory and was rushed back to camp by r_c.",
+        "m_c": {
+            "age": ["adolescent"],
+            "not_skill": ["HEALER,1"]
+        },
+        "r_c": {
+          "age": ["young adult", "adult", "senior adult"]
+        },
+        "injury": [
+            {
+                "cats": ["m_c"],
+                "injuries": ["poisoned"]
+            }
+        ]
+    },
+  {
+        "event_id": "wtlnd_injury_smallcut_anymultiage1",
+        "location": ["wetlands"],
+        "season": ["any"],
+        "weight": 20,
+        "event_text": "m_c nicked {PRONOUN/m_c/self} on the low branches of a spiky tree.",
+        "m_c": {
+            "age": ["adolescent", "young adult", "adult", "senior adult"]
+        },
+        "injury": [
+            {
+                "cats": ["m_c"],
+                "injuries": ["small cut"]
+            }
+        ]
+    },
+  {
+        "event_id": "wtlnd_injury_snakebite_anymultiage1",
+        "location": ["wetlands"],
+        "season": ["any"],
+        "weight": 20,
+        "event_text": "m_c was bitten by a hidden snake whilst hunting in the marsh.",
+        "m_c": {
+            "age": ["adolescent", "young adult", "adult", "senior adult"]
+        },
+        "injury": [
+            {
+                "cats": ["m_c"],
+                "injuries": ["snake bite"]
+            }
+        ]
+    }
+]

--- a/resources/lang/en/events/misc/desert.json
+++ b/resources/lang/en/events/misc/desert.json
@@ -1006,7 +1006,6 @@
     },
     "new_gender": ["trans female", "nonbinary"]
   },
-  [
   {
     "event_id": "dst_misc_any_angrylizard",
     "location": ["desert"],

--- a/resources/lang/en/events/misc/desert.json
+++ b/resources/lang/en/events/misc/desert.json
@@ -1005,5 +1005,50 @@
       "gender": ["male"]
     },
     "new_gender": ["trans female", "nonbinary"]
+  },
+  [
+  {
+    "event_id": "dst_misc_any_angrylizard",
+    "location": ["desert"],
+    "season": ["newleaf", "greenleaf", "leaf-fall"],
+    "weight": 20,
+    "event_text": "m_c was nipped on the nose when {PRONOUN/m_c/subject} investigated an odd, lizard-shaped lump in the sand.",
+    "m_c": {
+      "status": ["warrior", "apprentice", "kitten", "elder"]
+    }
+  },
+  {
+    "event_id": "dst_misc_war_anyapps1",
+    "location": ["desert"],
+    "season": ["any"],
+    "sub_type": ["war"],
+    "tags": ["clan:apprentice"],
+    "weight": 15,
+    "event_text": "The apprentices of the Clan are taking special training to learn how to blind their enemies with dust from the ground.",
+    "m_c": {
+      "status": ["apprentice"]
+    }
+  },
+  {
+    "event_id": "dst_misc_multiprophecymedcatprophet1",
+    "location": ["desert"],
+    "season": ["newleaf", "greenleaf"],
+    "weight": 20,
+    "event_text": "While out gathering valuable herbs, m_c sees a vision of prophecy_list_sight/m_c.",
+    "m_c": {
+      "status": ["medicine cat", "medicine cat apprentice"],
+      "skill": ["PROPHET,2"]
+    }
+  },
+  {
+    "event_id": "dst_misc_multiomenmedcatomen1",
+    "location": ["desert"],
+    "season": ["newleaf", "greenleaf", "leaf-fall"],
+    "weight": 20,
+    "event_text": "The things {PRONOUN/m_c/subject} saw in the sand today, omen_list_sight/m_c... {PRONOUN/m_c/subject/CAP} {VERB/m_c/consider/considers} what these omens may entail for c_n.",
+    "m_c": {
+      "status": ["medicine cat", "medicine cat apprentice"],
+      "skill": ["OMEN,2"]
+    }
   }
 ]

--- a/resources/lang/en/events/misc/wetlands.json
+++ b/resources/lang/en/events/misc/wetlands.json
@@ -1,1 +1,44 @@
-[]
+[
+  {
+    "event_id": "wtlnd_misc_any_stingingnettleboop",
+    "location": ["wetlands"],
+    "season": ["newleaf", "greenleaf", "leaf-fall"],
+    "weight": 20,
+    "event_text": "Whilst m_c was poking around in the undergrowth, {PRONOUN/m_c/subject} ran nose first into a stinging nettle plant - Ouch!",
+    "m_c": {
+      "status": ["apprentice", "warrior", "elder", "kitten"]
+    }
+  },
+  {
+    "event_id": "wtlnd_misc_multiprophecymedcatprophet1",
+    "location": ["wetlands"],
+    "season": ["newleaf", "greenleaf", "leaf-fall"],
+    "weight": 20,
+    "event_text": "m_c keeps seeing prophecy_list_sight/m_c in the water underpaw... {PRONOUN/m_c/subject/CAP} continues wading forward with {PRONOUN/m_c/poss} mission, debating the vision.",
+    "m_c": {
+      "status": ["medicine cat", "medicine cat apprentice"],
+      "skill": ["PROPHET,2"]
+    }
+  },
+  {
+    "event_id": "wtlnd_misc_multiomenmedcatomen1",
+    "location": ["wetlands"],
+    "season": ["newleaf", "greenleaf", "leaf-fall"],
+    "weight": 20,
+    "event_text": "The things m_c saw in the ripples of the marsh today, omen_list_sight/m_c... {PRONOUN/m_c/subject/CAP} {VERB/m_c/consider/considers} what these omens may foretell.",
+    "m_c": {
+      "status": ["medicine cat", "medicine cat apprentice"],
+      "skill": ["OMEN,2"]
+    }
+  },
+  {
+    "event_id": "wtlnd_misc_multiage_blueheron",
+    "location": ["wetlands"],
+    "season": ["newleaf", "greenleaf", "leaf-fall"],
+    "weight": 10,
+    "event_text": "m_c took a walk out in the territory and saw a large blue heron fly close overhead! How lucky!",
+    "m_c": {
+      "age": ["adolescent", "young adult", "adult", "senior adult", "senior"]
+    }
+  }
+]

--- a/resources/lang/en/events/new_cat/wetlands.json
+++ b/resources/lang/en/events/new_cat/wetlands.json
@@ -1,1 +1,84 @@
-[]
+[
+  {
+        "event_id": "wtlnd_new_cat_lost_kitten1",
+        "location": ["wetlands"],
+        "season": ["any"],
+        "weight": 5,
+        "event_text": "m_c returned to camp carrying a muddy kitten, explaining that {PRONOUN/m_c/subject} found {PRONOUN/n_c:0/object} wandering around the marsh, no parent in sight.",
+        "m_c": {
+            "age": ["young adult", "adult", "senior adult", "senior"],
+            "status": ["any"]
+        },
+        "new_cat": [
+            ["backstory:abandoned1, abandoned4", "age:kitten"]
+        ],
+	"relationships": [
+          {
+            "cats_from": ["m_c"],
+            "cats_to": ["n_c:0"],
+            "mutual": true,
+            "values": ["comfort", "platonic"],
+            "amount": 10
+          }
+        ],
+        "outsider": {
+            "current_rep": ["welcoming"],
+            "changed": 1
+        }
+    },
+  {
+        "event_id": "wtlnd_new_cat_lost_kitten2",
+        "location": ["wetlands"],
+        "season": ["any"],
+        "weight": 5,
+        "event_text": "m_c found an abandoned kitten wandering around the marsh and carried {PRONOUN/n_c:0/object} back to camp. Though c_n isn't happy about it, m_c persuades them to let n_c:0 stay in the Clan.",
+        "m_c": {
+            "age": ["young adult", "adult", "senior adult", "senior"],
+            "status": ["any"],
+	    "trait": ["compassionate", "loving", "responsible", "thoughtful"]
+        },
+        "new_cat": [
+            ["backstory:abandoned1, abandoned4", "age:kitten"]
+        ],
+	"relationships": [
+          {
+            "cats_from": ["m_c"],
+            "cats_to": ["n_c:0"],
+            "mutual": true,
+            "values": ["comfort", "platonic"],
+            "amount": 10
+          },
+	  {
+            "cats_from": ["clan"],
+            "cats_to": ["m_c", "n_c:0"],
+            "values": ["dislike"],
+            "amount": 5
+	  }
+
+
+        ],
+        "outsider": {
+            "current_rep": ["hostile"],
+            "changed": 1
+        }
+    },
+    {
+        "event_id": "wtlnd_new_cat_abandoned_litter",
+        "location": ["wetlands"],
+        "season": ["any"],
+        "weight": 5,
+        "event_text": "m_c found an abandoned litter concealed in the reeds and rushed them back to camp. Such young kits were lucky that m_c found them before something else did.",
+        "m_c": {
+            "age": ["young adult", "adult", "senior adult", "senior"],
+            "status": ["leader", "deputy", "medicine cat", "warrior"]
+          },
+        "new_cat": [
+            ["age:has_kits", "meeting", "loner", "can_birth"],
+            ["new_name", "parent:0", "backstory:abandoned1", "litter"]
+        ],
+        "outsider": {
+              "current_rep": ["neutral", "welcoming"],
+              "changed": 1
+          }
+    }
+]


### PR DESCRIPTION
About The Pull Request
Adds the following events

6 Desert Deaths
2 Wetlands Deaths
3 Desert Injuries
4 Wetlands Injuries
4 Desert Misc
4 Wetlands Misc
3 Wetlands New Cat

Why This Is Good For ClanGen
Trade offer:
I give you, more wetlands and desert events
You give me, another thing to add onto things I contributed

Linked Issues
(Same PR as #3493 just updated to merge more cleanly)
Helps with lack of event content for the new biomes
Conversations correcting and rewriting the text

https://discord.com/channels/1003759225522110524/1261072298245619854/1357149595964018830
https://discord.com/channels/1003759225522110524/1101276997751164948/1354681729767571587
More in these channels, giant text walls? Probably me!

Proof of Testing
The game does run with these changes and passes all the required checks!

Changelog/Credits
Changelog || More desert and wetlands events! (Refer to earlier if you wish to include exact numbers)
Credits || flamedash - writing