### PR TITLE
[BUGFIX] remove "none" tints

### DIFF
--- a/sprites/dicts/tint.json
+++ b/sprites/dicts/tint.json
@@ -22,7 +22,7 @@
     "CHOCOLATE": "brown"
   },
   "possible_tints": {
-    "basic": ["pink", "gray", "red", "orange", "none", "warmdilute"],
+    "basic": ["pink", "gray", "red", "orange", "warmdilute"],
     "warm": ["yellow", "purple", "dilute", "cooldilute"],
     "cool": ["purple", "black", "dilute"],
     "white": ["yellow"],

--- a/sprites/dicts/white_patches_tint.json
+++ b/sprites/dicts/white_patches_tint.json
@@ -22,7 +22,7 @@
     "CHOCOLATE": "brown"
   },
   "possible_tints": {
-    "basic": ["none", "offwhite", "offwhite"],
+    "basic": ["offwhite", "offwhite"],
     "black": ["gray", "darkcream", "cream"],
     "gray": ["gray"],
     "ginger": ["darkcream", "cream", "pink"],


### PR DESCRIPTION
## About The Pull Request

"none" options in the tint dict files were still available, which is no longer a valid option for tints due to #3059 . This PR simply deletes them from the files

## Linked Issues

Link to the point out on discord: https://discord.com/channels/1003759225522110524/1005158434469068820/1405076421709271151 

## Proof of Testing

Linked a video proving error cats were no longer generating naturally for basic type pelt kitties (bad quality so sorry 😭 )

https://github.com/user-attachments/assets/7c0e7739-1a87-4f5a-b9fe-e8f7fc67e53a



## Changelog/Credits

- remove "none" options from tint dicts
