### PR TITLE
[ENHANCEMENT] Improves relationship bar display

### DIFF
--- a/scripts/game_structure/ui_elements.py
+++ b/scripts/game_structure/ui_elements.py
@@ -36,6 +36,7 @@ from scripts.utility import (
     shorten_text_to_fit,
     ui_scale_dimensions,
     ui_scale_value,
+    clamp
 )
 
 
@@ -1239,33 +1240,23 @@ class UIRelationStatusScaleBar(pygame_gui.elements.UIImage):
         self.overlay.tool_tip_delay = 0
 
         # pointer element
-        max_width = relative_rect.width - 10
-        scale_position = int((scale_position + 100) / 2)
-        percentage = ui_scale_value(scale_position) / max_width
-        self.scale_position = ui_scale_value(int(percentage * 100))
-
-        offset = ui_scale_value(14)
-        #clamp(self.scale_position, 0, max_width + offset)
-        if self.scale_position > max_width + offset:
-            self.scale_position = max_width + offset
-        elif self.scale_position < 0:
-            self.scale_position = 0
-
-        pointer_size = ui_scale_dimensions((14, 12))
-        x_pos = relative_rect.x - ui_scale_value(17) + self.scale_position
-        if x_pos < relative_rect.x:
-            x_pos = relative_rect.x
-        pointer_pos = (
-            x_pos,
-            relative_rect.y + ui_scale_value(4),
+        # -7 bc coords are top-left so we have to shift over so arrow points at middle
+        pointer_origin = (bar.width // 2 - ui_scale_value(7), 0)
+        # every "unit" is 1/200th of the width of the bar
+        pointer_offset = int(scale_position / 200 * bar.width)
+        # -15 so it doesn't go past the end of the bar
+        pointer_final_position = (
+            clamp(pointer_offset + pointer_origin[0], 0, bar.width - ui_scale_value(15)),
+            pointer_origin[1]
         )
+        pointer_size = ui_scale_dimensions((14, 12))
 
         pointer = pygame.transform.scale(
             image_cache.load_image("resources/images/rel_pointer.png").convert_alpha(),
             pointer_size,
         )
         self.pointer = pygame_gui.elements.UIImage(
-            pygame.Rect(pointer_pos, pointer_size),
+            pygame.Rect(pointer_final_position, pointer_size),
             pointer,
             manager=manager,
             container=container,

--- a/scripts/game_structure/ui_elements.py
+++ b/scripts/game_structure/ui_elements.py
@@ -1,4 +1,5 @@
 import html
+import math
 from functools import lru_cache
 from math import ceil
 from typing import (
@@ -1173,20 +1174,37 @@ class UIRelationStatusScaleBar(pygame_gui.elements.UIImage):
             image_cache.load_image(path),
             (relative_rect[2], relative_rect[3]),
         )
-        if tier.is_neutral:
-            bar.fill((130, 117, 82))
-        elif tier.is_low_pos:
-            bar.fill((182, 174, 51))
+
+        bar_center_offset = int(bar.width / 2)
+        num_sub_bars = math.ceil((abs(scale_position)) / 25)
+        sub_bar_width = bar.width // 8
+        bar_width = sub_bar_width * num_sub_bars
+
+        if scale_position < 0:
+            short_bar = pygame.Rect(bar_center_offset - bar_width, 0, bar_width, bar.height)
+        else:
+            short_bar = pygame.Rect(bar_center_offset, 0, bar_width, bar.height)
+        
+        surf = pygame.Surface((short_bar.width, short_bar.height))
+        
+        bar.fill((130, 117, 82))
+    
+        bar_colour = (130, 117, 82)
+        if tier.is_low_pos:
+            bar_colour = (182, 174, 51)
         elif tier.is_mid_pos:
-            bar.fill((150, 195, 49))
+            bar_colour = (150, 195, 49)
         elif tier.is_extreme_pos:
-            bar.fill((154, 241, 32))
+            bar_colour = (154, 241, 32)
         elif tier.is_low_neg:
-            bar.fill((186, 128, 60))
+            bar_colour = (186, 128, 60)
         elif tier.is_mid_neg:
-            bar.fill((214, 90, 53))
+            bar_colour = (214, 90, 53)
         elif tier.is_extreme_neg:
-            bar.fill((233, 38, 30))
+            bar_colour = (233, 38, 30)
+
+        surf.fill(bar_colour)
+        bar.blit(surf, (short_bar.left, short_bar.top))
 
         # bar element is the base of this entire element
         super().__init__(
@@ -1227,6 +1245,7 @@ class UIRelationStatusScaleBar(pygame_gui.elements.UIImage):
         self.scale_position = ui_scale_value(int(percentage * 100))
 
         offset = ui_scale_value(14)
+        #clamp(self.scale_position, 0, max_width + offset)
         if self.scale_position > max_width + offset:
             self.scale_position = max_width + offset
         elif self.scale_position < 0:

--- a/scripts/game_structure/ui_elements.py
+++ b/scripts/game_structure/ui_elements.py
@@ -36,7 +36,7 @@ from scripts.utility import (
     shorten_text_to_fit,
     ui_scale_dimensions,
     ui_scale_value,
-    clamp
+    clamp,
 )
 
 
@@ -1182,14 +1182,16 @@ class UIRelationStatusScaleBar(pygame_gui.elements.UIImage):
         bar_width = sub_bar_width * num_sub_bars
 
         if scale_position < 0:
-            short_bar = pygame.Rect(bar_center_offset - bar_width, 0, bar_width, bar.height)
+            short_bar = pygame.Rect(
+                bar_center_offset - bar_width, 0, bar_width, bar.height
+            )
         else:
             short_bar = pygame.Rect(bar_center_offset, 0, bar_width, bar.height)
-        
+
         surf = pygame.Surface((short_bar.width, short_bar.height))
-        
+
         bar.fill((130, 117, 82))
-    
+
         bar_colour = (130, 117, 82)
         if tier.is_low_pos:
             bar_colour = (182, 174, 51)
@@ -1246,8 +1248,10 @@ class UIRelationStatusScaleBar(pygame_gui.elements.UIImage):
         pointer_offset = int(scale_position / 200 * bar.width)
         # -15 so it doesn't go past the end of the bar
         pointer_final_position = (
-            clamp(pointer_offset + pointer_origin[0], 0, bar.width - ui_scale_value(15)),
-            pointer_origin[1]
+            clamp(
+                pointer_offset + pointer_origin[0], 0, bar.width - ui_scale_value(15)
+            ),
+            pointer_origin[1],
         )
         pointer_size = ui_scale_dimensions((14, 12))
 


### PR DESCRIPTION
## About The Pull Request

* Makes relationship bars only go up to the "sub-section" the arrow does. Applies the same colours as the full bars did previously
* Adjusts math used to determine arrow positions to be easier to read while more accurately reflecting the relationship values

## Why This Is Good For ClanGen

* Makes relationships easier to read at a glance

## Proof of Testing

**Windowed**:
<img width="1824" height="1680" alt="image" src="https://github.com/user-attachments/assets/bf86d99f-9dd2-4359-8304-0ff8c1fece90" />

**Fullscreen:**
<img width="1470" height="919" alt="image" src="https://github.com/user-attachments/assets/11196152-3b4d-43a8-9939-a05470cb3bc8" />
