### PR TITLE
[BUGFIX] Dead cat backstory display

### DIFF
--- a/scripts/cat/status.py
+++ b/scripts/cat/status.py
@@ -279,9 +279,9 @@ class Status:
         return self.group_history[-1]["group"]
 
     @property
-    def all_groups(self) -> list:
+    def all_groups(self) -> list[str]:
         """
-        Returns a list of all groups the cat has been a part of or is currently a part of.
+        Returns a list of IDs for all groups the cat has been a part of or is currently a part of.
         """
         groups = []
         for record in self.group_history:

--- a/scripts/screens/ProfileScreen.py
+++ b/scripts/screens/ProfileScreen.py
@@ -997,7 +997,7 @@ class ProfileScreen(Screens):
         # if cat has never been part of the player clan, then they get no backstory yet
         if (
             not the_cat.status.alive_in_player_clan
-            and CatGroup.PLAYER_CLAN not in the_cat.status.all_groups
+            and CatGroup.PLAYER_CLAN_ID not in the_cat.status.all_groups
         ):
             bs_text = the_cat.status.social
         else:
@@ -1404,7 +1404,7 @@ class ProfileScreen(Screens):
         """
         returns adjusted apprenticeship history text (mentor influence and app ceremony)
         """
-        if CatGroup.PLAYER_CLAN not in self.the_cat.status.all_groups:
+        if CatGroup.PLAYER_CLAN_ID not in self.the_cat.status.all_groups:
             return ""
 
         mentor_influence = self.the_cat.history.mentor_influence


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
`status.all_groups` now provides a list of group IDs instead of group enums, which was fucking up the backstory check on profiles.  I've adjusted the relevant checks and updated `all_groups` to better reflect what it returns.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
#3997
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
<img width="635" height="300" alt="image" src="https://github.com/user-attachments/assets/a815bc38-eae2-4d54-bbbb-9434fade5b61" />

Backstory is correct and no longer displays as 'clancat'
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Dead clancats no longer switch their backstory display to plain "clancat"
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
