### PR TITLE
[CI] Fix Build Job Failure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -188,6 +188,7 @@ jobs:
             -F "fileBundle=@${BUNDLE_NAME}.sig" \
             --http1.1
       - name: Set up butler
+        if: startsWith(github.ref, 'refs/tags/')
         uses: jdno/setup-butler@v1
       - name: Upload build to itch.io
         env:


### PR DESCRIPTION
## About The Pull Request

Currently, the build job is failing because broth on itch.io is returning invalid 404s. There isn't really anything we can do about that, since it's an issue on itch.io's end. However, we can at least stop the job from failing by not trying to download butler when we're not using it.

## Why This Is Good For ClanGen

More green checkmarks are nice.