### PR TITLE
[CRASHFIX] Leaders dying crashing the game

### DIFF
--- a/scripts/events_module/short/handle_short_events.py
+++ b/scripts/events_module/short/handle_short_events.py
@@ -564,7 +564,7 @@ class HandleShortEvents:
                 if "all_lives" in self.chosen_event.tags:
                     game.clan.leader_lives -= 10
                 elif "some_lives" in self.chosen_event.tags:
-                    game.clan.leader_lives -= randrange(2, self.current_lives - 1)
+                    game.clan.leader_lives -= randrange(2, self.current_lives)
                 else:
                     game.clan.leader_lives -= 1
 


### PR DESCRIPTION
## About The Pull Request

* Fixes issue where leaders with exactly three lives would cause the game to crash if killed during a `some_lives` short event
* Fixes issue where leaders killed via `some_lives` events would never be cut down to just one life

Note: `randrange(a, b)` has range [a, b), not [a, b]

## Proof of Testing

* Created a Clan
* Killed every cat except the leader
* Edited leader to have exactly 3 lives
* Forced `some_lives` death via game config
* No crash

## Changelog/Credits

* Fixes issue where leaders with exactly three lives could occasionally crash the game
* Fixes issue where some events weren't allowed to take enough lives 