### PR TITLE
[BUGFIX] Lost deputies can no longer help in the leader's den

### DIFF
--- a/scripts/screens/LeaderDenScreen.py
+++ b/scripts/screens/LeaderDenScreen.py
@@ -194,7 +194,7 @@ class LeaderDenScreen(Screens):
         self.helper_cat = None
         if self.no_leader or game.clan.leader.not_working():
             if game.clan.deputy:
-                if not game.clan.deputy.not_working() and not game.clan.deputy.dead:
+                if not game.clan.deputy.not_working() and game.clan.deputy.status.alive_in_player_clan:
                     self.helper_cat = game.clan.deputy  # if lead is sick, dep helps
             if not self.helper_cat:  # if dep is sick, med cat helps
                 meds = find_alive_cats_with_rank(

--- a/scripts/screens/LeaderDenScreen.py
+++ b/scripts/screens/LeaderDenScreen.py
@@ -194,7 +194,10 @@ class LeaderDenScreen(Screens):
         self.helper_cat = None
         if self.no_leader or game.clan.leader.not_working():
             if game.clan.deputy:
-                if not game.clan.deputy.not_working() and game.clan.deputy.status.alive_in_player_clan:
+                if (
+                    not game.clan.deputy.not_working()
+                    and game.clan.deputy.status.alive_in_player_clan
+                ):
                     self.helper_cat = game.clan.deputy  # if lead is sick, dep helps
             if not self.helper_cat:  # if dep is sick, med cat helps
                 meds = find_alive_cats_with_rank(


### PR DESCRIPTION
## About The Pull Request
Switches the requirement for a deputy to be a helper cat from 'not being dead' to 'being alive and in the clan', so lost deputies can't help anymore.

## Proof of Testing
(Before fix) Morningpath, TestClan's lost deputy, can search for himself while Buzzardstar is injured.
<img width="949" height="785" alt="Screenshot 2025-09-16 134413" src="https://github.com/user-attachments/assets/2f11edae-7a60-4b7c-a814-1ae39c05e6bd" />

(After fix) Later on, Morningstar is sick, but his lost deputy Haillight isn't available to help - he's got to rely on his medicine cat, Wikipedia.
<img width="948" height="541" alt="Screenshot 2025-09-16 141030" src="https://github.com/user-attachments/assets/34184b4c-d47e-452f-8962-e20e9054a4c2" />