### PR TITLE
[BUGFIX] Herb amount not detected properly

### DIFF
--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -766,7 +766,7 @@ class Cat:
                 if (
                     body
                     and not body_treated
-                    and game.clan.herb_supply.entire_supply["rosemary"] > 0
+                    and game.clan.herb_supply.entire_supply["rosemary"]
                 ):
                     body_treated = True
                     game.clan.herb_supply.remove_herb("rosemary", -1)

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -2030,8 +2030,8 @@ class Cat:
             ):
                 clan_herbs = {
                     herb
-                    for herb, herb_count in game.clan.herb_supply.entire_supply.items()
-                    if herb_count > 0
+                    for herb, clan_has_herb in game.clan.herb_supply.entire_supply.items()
+                    if clan_has_herb
                 }
                 needed_herbs = {"horsetail", "raspberry", "marigold", "cobwebs"}
                 usable_herbs = list(needed_herbs.intersection(clan_herbs))

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -766,7 +766,7 @@ class Cat:
                 if (
                     body
                     and not body_treated
-                    and "rosemary" in game.clan.herb_supply.entire_supply
+                    and game.clan.herb_supply.entire_supply["rosemary"] > 0
                 ):
                     body_treated = True
                     game.clan.herb_supply.remove_herb("rosemary", -1)

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -2028,7 +2028,11 @@ class Cat:
                 )
                 != 0
             ):
-                clan_herbs = set(game.clan.herb_supply.entire_supply.keys())
+                clan_herbs = {
+                    herb
+                    for herb, herb_count in game.clan.herb_supply.entire_supply.items()
+                    if herb_count > 0
+                }
                 needed_herbs = {"horsetail", "raspberry", "marigold", "cobwebs"}
                 usable_herbs = list(needed_herbs.intersection(clan_herbs))
 

--- a/scripts/clan_resources/herb/herb_supply.py
+++ b/scripts/clan_resources/herb/herb_supply.py
@@ -277,7 +277,7 @@ class HerbSupply:
         """
         returns the rating of given supply, aka how "full" the supply is compared to clan size
         """
-        if not self.entire_supply:
+        if not self.total:
             return Supply.EMPTY
 
         lowest_herb = self.sorted_by_lowest[0]

--- a/scripts/clan_resources/herb/herb_supply.py
+++ b/scripts/clan_resources/herb/herb_supply.py
@@ -277,7 +277,7 @@ class HerbSupply:
         """
         returns the rating of given supply, aka how "full" the supply is compared to clan size
         """
-        if not self.total:
+        if self.total <= 0:
             return Supply.EMPTY
 
         lowest_herb = self.sorted_by_lowest[0]

--- a/scripts/events_module/event_filters.py
+++ b/scripts/events_module/event_filters.py
@@ -222,7 +222,7 @@ def event_for_herb_supply(trigger, supply_type, clan_size) -> bool:
 
     herb_supply = game.clan.herb_supply
 
-    if not herb_supply.total and "empty" in trigger:
+    if herb_supply.total <= 0 and "empty" in trigger:
         return True
 
     if supply_type == "all_herb":

--- a/scripts/events_module/event_filters.py
+++ b/scripts/events_module/event_filters.py
@@ -222,7 +222,7 @@ def event_for_herb_supply(trigger, supply_type, clan_size) -> bool:
 
     herb_supply = game.clan.herb_supply
 
-    if not herb_supply.entire_supply and "empty" in trigger:
+    if not herb_supply.total and "empty" in trigger:
         return True
 
     if supply_type == "all_herb":

--- a/scripts/screens/MedDenScreen.py
+++ b/scripts/screens/MedDenScreen.py
@@ -593,7 +593,7 @@ class MedDenScreen(Screens):
         herb_list = []
         herb_supply = game.clan.herb_supply
 
-        if not herb_supply.total:
+        if herb_supply.total <= 0:
             herb_list = ["Empty"]
 
         elif game.clan.game_mode != "classic":


### PR DESCRIPTION
## About The Pull Request

`herb_supply.entire_supply` returns a dictionary where all the herbs in the game are the keys, and the amounts of herbs owned by the player are the values. However, some checks worked under the assumption that the dictionary only contained herbs that the player owned, and were not functioning correctly as a result. 

This adjusts the checks to work with the actual structure of the dictionary.

## Proof of Testing
* Have no rosemary in Clan
* Kill cat
* No rosemary treatment in log

## Changelog/Credits

* Fixes issue where cats were using herbs that they didn't actually have for some treatments
* Fixes issue where events that were supposed to occur when cats had no herbs weren't able to be triggered (though, none exist)