### PR TITLE
[CRASHFIX] Herb supply crash

### DIFF
--- a/scripts/events_module/generate_events.py
+++ b/scripts/events_module/generate_events.py
@@ -439,12 +439,6 @@ class GenerateEvents:
                     trigger = supply["trigger"]
                     supply_type = supply["type"]
 
-                    if (
-                        supply["adjust"] in ["reduce_half", "reduce_full"]
-                        and random.randint(1, avoidance_chance) != 1
-                    ):
-                        continue
-
                     if supply_type == "freshkill":
                         if not freshkill_active:
                             continue
@@ -466,6 +460,13 @@ class GenerateEvents:
                             break
                         else:
                             discard = False
+
+                    if (
+                        supply["adjust"] in ["reduce_half", "reduce_full"]
+                        and random.randint(1, avoidance_chance) != 1
+                    ):
+                        discard = True
+                        break
 
                 if discard:
                     continue

--- a/scripts/events_module/generate_events.py
+++ b/scripts/events_module/generate_events.py
@@ -439,6 +439,13 @@ class GenerateEvents:
                     trigger = supply["trigger"]
                     supply_type = supply["type"]
 
+                    if (
+                        supply["adjust"] in ["reduce_half", "reduce_full"]
+                        and random.randint(1, avoidance_chance) != 1
+                    ):
+                        discard = True
+                        break
+
                     if supply_type == "freshkill":
                         if not freshkill_active:
                             continue
@@ -460,13 +467,6 @@ class GenerateEvents:
                             break
                         else:
                             discard = False
-
-                    if (
-                        supply["adjust"] in ["reduce_half", "reduce_full"]
-                        and random.randint(1, avoidance_chance) != 1
-                    ):
-                        discard = True
-                        break
 
                 if discard:
                     continue


### PR DESCRIPTION
## About The Pull Request

The camp skill protection was inadvertently skipping over some important checks that make sure Clans have adequate supplies for supply adjustment events. Also, I discovered that it was breaking out of the wrong loop and therefore not actually removing the event from the pool.

## Linked Issues

Fixes: #4036

## Proof of Testing

I don’t know how to prove a negative, but it didn't crash when I ran the timeskip test. Other than that... 
<img width="296" height="256" alt="image" src="https://github.com/user-attachments/assets/32e54884-3e11-4ae1-a4bb-11071dd287c6" />


## Changelog/Credits

* Fixes herb-related timeskip crash
* Fixes issue where CAMP skill protection wasn't working correctly
