### PR TITLE
[BUGFIX] Negative Rel Events

### DIFF
--- a/scripts/cat_relations/relationship.py
+++ b/scripts/cat_relations/relationship.py
@@ -244,12 +244,12 @@ class Relationship:
 
         return process_text(string, cat_dict)
 
-    def get_value_change_amount(self, value_change: bool, intensity: str) -> int:
+    def get_value_change_amount(self, is_positive: bool, intensity: str) -> int:
         """Finds and returns the int amount that the relationship type will change by according to given intensity and additional modifiers
 
         Parameters
         ----------
-        value_change : bool
+        is_positive : bool
             True if the relationship value is positive, False if negative.
         intensity : str
             the intensity of the affect
@@ -261,7 +261,7 @@ class Relationship:
         """
         # get the normal amount
         amount = constants.CONFIG["relationship"]["value_change_amount"][intensity]
-        if value_change == "decrease":
+        if not is_positive:
             amount = amount * -1
 
         # take compatibility into account
@@ -278,13 +278,13 @@ class Relationship:
         return amount
 
     def interaction_affect_relationships(
-        self, value_change: bool, intensity: str, rel_type: str
+        self, is_positive: bool, intensity: str, rel_type: str
     ) -> None:
         """Affects the relationship according to the chosen types.
 
         Parameters
         ----------
-        value_change : str
+        is_positive : str
             if the relationship value is positive
         intensity : str
             the intensity of the affect
@@ -294,7 +294,7 @@ class Relationship:
         Returns
         -------
         """
-        amount = self.get_value_change_amount(value_change, intensity)
+        amount = self.get_value_change_amount(is_positive, intensity)
 
         # only high intensity gives passive buffs
         if intensity == "high":

--- a/scripts/cat_relations/relationship.py
+++ b/scripts/cat_relations/relationship.py
@@ -350,7 +350,10 @@ class Relationship:
         for key, value in dictionary.items():
             if value == "neutral":
                 continue
-            amount = self.get_value_change_amount(value, "low")
+
+            amount = self.get_value_change_amount(
+                is_positive=True if value == "positive" else False, intensity="low"
+            )
 
             setattr(self, key, getattr(self, key) + amount)
 

--- a/scripts/cat_relations/relationship.py
+++ b/scripts/cat_relations/relationship.py
@@ -284,7 +284,7 @@ class Relationship:
 
         Parameters
         ----------
-        is_positive : str
+        is_positive : bool
             if the relationship value is positive
         intensity : str
             the intensity of the affect
@@ -352,7 +352,7 @@ class Relationship:
                 continue
 
             amount = self.get_value_change_amount(
-                is_positive=True if value == "positive" else False, intensity="low"
+                is_positive=value == "positive", intensity="low"
             )
 
             setattr(self, key, getattr(self, key) + amount)

--- a/scripts/events_module/relationship/romantic_events.py
+++ b/scripts/events_module/relationship/romantic_events.py
@@ -203,11 +203,11 @@ class RomanticEvents:
         relationship.used_interaction_ids.append(chosen_interaction.id)
 
         # affect relationship - it should always be in a romantic way
-        value_change = True if positive else False
+        value_change = "increase" if positive else "decrease"
         rel_type = RelType.ROMANCE
         relationship.chosen_interaction = chosen_interaction
         relationship.interaction_affect_relationships(
-            value_change, chosen_interaction.intensity, rel_type
+            positive, chosen_interaction.intensity, rel_type
         )
 
         # give cats injuries

--- a/scripts/events_module/relationship/romantic_events.py
+++ b/scripts/events_module/relationship/romantic_events.py
@@ -203,7 +203,7 @@ class RomanticEvents:
         relationship.used_interaction_ids.append(chosen_interaction.id)
 
         # affect relationship - it should always be in a romantic way
-        value_change = "increase" if positive else "decrease"
+        value_change = True if positive else False
         rel_type = RelType.ROMANCE
         relationship.chosen_interaction = chosen_interaction
         relationship.interaction_affect_relationships(

--- a/scripts/screens/RelationshipScreen.py
+++ b/scripts/screens/RelationshipScreen.py
@@ -415,7 +415,7 @@ class RelationshipScreen(Screens):
         if constants.CONFIG["sorting"]["sort_by_rel_total"]:
             self.all_relations = sorted(
                 self.the_cat.relationships.values(),
-                key=lambda x: x.total_relationship_value,
+                key=lambda x: abs(x.total_relationship_value),
                 reverse=True,
             )
         else:


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
There was an old magic string still hanging about preventing a bool value from working as intended, leading to negative events not having a negative impact on relationship values.  This fixes that and renames an attribute to make it's use clearer.

I also realized that relationships on the rel screen weren't sorted by absolute value, meaning that cats with negative rels were always at the end of the list (after cats with empty/low relationships).  Fixed that as a little QoL thing.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Proof of Testing
<img width="601" height="90" alt="image" src="https://github.com/user-attachments/assets/2f372ed6-90f5-4d63-9bdf-e30cc493db72" />

Meant to be a positive change, returns a positive value to change rels by

<img width="652" height="94" alt="image" src="https://github.com/user-attachments/assets/48a9a819-0f98-4501-b943-35b8c8cbe04b" />

Meant to be a negative change, returns a negative value to change rels by

<img width="513" height="512" alt="image" src="https://github.com/user-attachments/assets/b9e56ab9-8e9f-4565-9f93-60a1038ef6e2" />

Sungale no longer at the end of the line
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Negative relationship events now affect relationships negatively instead of positively
- On the relationship screen, cats with negative relationships are no longer sorted at the end of the list. Instead, cats are sorted by absolute total rel value, meaning that negative rel values are treated and sorted like positive ones.
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
