### PR TITLE
[FEATURE] New Thought Tags to Exclude Conditions

### DIFF
--- a/resources/lang/en/thoughts/alive/apprentice.json
+++ b/resources/lang/en/thoughts/alive/apprentice.json
@@ -39,7 +39,6 @@
             "Insists on sharpening {PRONOUN/m_c/poss} claws on a specific surface",
             "Is jumpy after battle practice",
             "Whirls around and bares {PRONOUN/m_c/poss} fangs, only to realize training is over",
-            "Was overzealous during battle training and got a stern lecture",
             "Hopes {PRONOUN/m_c/subject}'ll be remembered as a mighty warrior",
             "Wonders if there would ever be a story about {PRONOUN/m_c/poss} deeds",
             "Puffs out {PRONOUN/m_c/poss} chest after hearing someone praise {PRONOUN/m_c/object}",
@@ -70,6 +69,15 @@
             "Is struggling to come to terms with what 'being a warrior' entails",
             "Feels {PRONOUN/m_c/poss} kithood admiration of warriors waning"
         ]
+    },
+    {
+        "id": "working_apprentice_gen",
+        "thoughts": [
+            "Was overzealous during battle training and got a stern lecture"
+        ],
+        "has_injuries": {
+            "m_c": ["not_major", "not_severe"]
+        }
     },
     {
         "id": "warrior_apprentice_to_alive_leader_or_deputy",

--- a/resources/lang/en/thoughts/alive/general.json
+++ b/resources/lang/en/thoughts/alive/general.json
@@ -1604,6 +1604,9 @@
             "Went out to hunt by {PRONOUN/m_c/self}",
             "Is feeling a bit anxious after having been around so many cats at the last Gathering"
         ],
+        "has_injuries": {
+            "m_c": ["not_severe", "not_major"]
+        },
         "main_status_constraint": [
             "apprentice",
             "warrior",
@@ -1791,6 +1794,9 @@
             "Acted bravely on a recent patrol, despite {PRONOUN/m_c/poss} anxieties",
             "Got scared by a mouse while hunting"
         ],
+        "has_injuries": {
+            "m_c": ["not_severe", "not_major"]
+        },
         "main_status_constraint": [
             "apprentice",
             "warrior",
@@ -2289,6 +2295,9 @@
             "Spends some time helping out the medicine cat today",
             "Tidies the area in front of the medicine cat den"
         ],
+        "has_injuries": {
+            "m_c": ["not_severe", "not_major"]
+        },
         "main_status_constraint": [
             "warrior",
             "deputy",
@@ -3148,6 +3157,9 @@
             "Found something odd on patrol",
             "Is smug after a spectacular catch on patrol"
         ],
+        "has_injuries": {
+            "m_c": ["not_severe", "not_major"]
+        },
         "main_status_constraint": [
             "apprentice",
             "warrior",

--- a/resources/lang/en/thoughts/alive/warrior.json
+++ b/resources/lang/en/thoughts/alive/warrior.json
@@ -330,6 +330,9 @@
         "thoughts": [
             "Ate a mouse while out on patrol"
         ],
+        "has_injuries": {
+            "m_c": ["not_major", "not_severe"]
+        },
         "main_trait_constraint": [
             "troublesome"
         ]

--- a/schemas/thought.schema.json
+++ b/schemas/thought.schema.json
@@ -16,14 +16,30 @@
     },
     "illness_injury_any": {
       "anyOf": [
-        {
-          "$ref": "common.schema.json#/definitions/illness"
+        { 
+          "$ref": "common.schema.json#/definitions/illness" 
+        },
+        { 
+          "$ref": "common.schema.json#/definitions/injury" 
+        },
+        { 
+          "const": "any" 
+        },
+        { 
+          "const": "not_minor" 
+        },
+        { 
+          "const": "not_major" 
+        },
+        { 
+          "const": "not_severe" 
+        },
+        { 
+          "const": "not_any" 
         },
         {
-          "$ref": "common.schema.json#/definitions/injury"
-        },
-        {
-          "const": "any"
+          "type": "string",
+          "pattern": "^not_[a-zA-Z0-9_]+$"
         }
       ]
     },

--- a/scripts/cat/thoughts.py
+++ b/scripts/cat/thoughts.py
@@ -184,8 +184,34 @@ class Thoughts:
                         and "any" not in thought["has_injuries"]["m_c"]
                     ):
                         return False
-                else:
-                    return False
+                    if [
+                        i
+                        for i in injuries_and_illnesses
+                        if f"not_{i}" in thought["has_injuries"]["m_c"]
+                        or (
+                            "not_any" in thought["has_injuries"]["m_c"]
+                            and injuries_and_illnesses
+                        )
+                    ]:
+                        return False
+
+                    for severity in ["minor", "major", "severe"]:
+                        if f"not_{severity}" in thought["has_injuries"]["m_c"]:
+                            if [
+                                i
+                                for i in injuries_and_illnesses
+                                if (
+                                    i in main_cat.injuries
+                                    and main_cat.injuries[i]["severity"] == severity
+                                )
+                                or (
+                                    i in main_cat.illnesses
+                                    and main_cat.illnesses[i]["severity"] == severity
+                                )
+                            ]:
+                                return False
+            else:
+                return False
 
             if "r_c" in thought["has_injuries"] and random_cat:
                 if random_cat.injuries or random_cat.illnesses:
@@ -201,6 +227,32 @@ class Thoughts:
                         and "any" not in thought["has_injuries"]["r_c"]
                     ):
                         return False
+                    if [
+                        i
+                        for i in injuries_and_illnesses
+                        if f"not_{i}" in thought["has_injuries"]["r_c"]
+                        or (
+                            "not_any" in thought["has_injuries"]["r_c"]
+                            and injuries_and_illnesses
+                        )
+                    ]:
+                        return False
+
+                    for severity in ["minor", "major", "severe"]:
+                        if f"not_{severity}" in thought["has_injuries"]["r_c"]:
+                            if [
+                                i
+                                for i in injuries_and_illnesses
+                                if (
+                                    i in random_cat.injuries
+                                    and random_cat.injuries[i]["severity"] == severity
+                                )
+                                or (
+                                    i in random_cat.illnesses
+                                    and random_cat.illnesses[i]["severity"] == severity
+                                )
+                            ]:
+                                return False
                 else:
                     return False
 

--- a/scripts/cat/thoughts.py
+++ b/scripts/cat/thoughts.py
@@ -210,8 +210,8 @@ class Thoughts:
                                 )
                             ]:
                                 return False
-            else:
-                return False
+                else:
+                    return False
 
             if "r_c" in thought["has_injuries"] and random_cat:
                 if random_cat.injuries or random_cat.illnesses:


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
Adds new tags/logic to thoughts in order to exclude thought from cats with certain conditions/severity of conditions. These tags are:
* "not_{condition}" - If the cat(s) have a illness/injury of {condition}, then the thought is removed from their possible pool of thoughts.
* "not_any" - If the cat(s) have at least one illness/injury, then the thought is removed from their possible pool of thoughts.
* "not_{severity}" - If the cat(s)' illness/injury has a severity of {severity}, then the thought is removed from their possible pool of thoughts

Tags previously reported thoughts which would indicate a cat is going on patrol or leaving the camp with not_{severity} tags, in order to prevent cats with major/serve injuries from receiving them.

## Why This Is Good For ClanGen
Removes the immersion breaking issue of cats with serious injuries, like head trauma or broken back, mentioning going on patrol or leaving camp. In theory, these cats wouldn't be going anywhere until their injury is healed and have been properly monitored. Also, allows writers to write more nuanced thoughts on injuries/illnesses; What if a cat has one condition but not another, what if the main cat has fleas but random cat doesn't, what if a cats grief stricken but the other isn't? 

## Linked Issues
#3724

## Proof of Testing
<img width="891" height="694" alt="image" src="https://github.com/user-attachments/assets/eeb3ef78-df55-4a27-87f0-a2591c3cfe34" />
<img width="897" height="701" alt="image" src="https://github.com/user-attachments/assets/0f3ce43a-c16a-45fd-b20f-6e491d227e23" />

## Changelog/Credits
- Adds new options to thoughts, allowing them to be excluded based on condition and severity
- Fix (Some) thoughts mentioning patrolling or going outside, when the cat has a serious illness/injury