### PR TITLE
[BUGFIX] Outsider afterlife history

### DIFF
--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -499,7 +499,8 @@ class Cat:
                 )
                 return
 
-            if self.status.get_default_afterlife_id() == CatGroup.UNKNOWN_RESIDENCE_ID:
+            cat_default_afterlife_id = self.status.get_default_afterlife_id()
+            if cat_default_afterlife_id == CatGroup.UNKNOWN_RESIDENCE_ID:
                 pass
             # kits are auto-accepted
             elif self.age in (CatAge.KITTEN, CatAge.NEWBORN):
@@ -508,7 +509,7 @@ class Cat:
                     is_kit=True,
                 )
             else:
-                if game.clan.instructor.status.group == CatGroup.STARCLAN:
+                if cat_default_afterlife_id == CatGroup.STARCLAN_ID:
                     affinity = self.starclan_affinity
                     afterlife_group = CatGroup.STARCLAN
                     rejected_ID = CatGroup.DARK_FOREST_ID

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -499,8 +499,10 @@ class Cat:
                 )
                 return
 
+            if self.status.get_default_afterlife_id() == CatGroup.UNKNOWN_RESIDENCE_ID:
+                pass
             # kits are auto-accepted
-            if self.age in (CatAge.KITTEN, CatAge.NEWBORN):
+            elif self.age in (CatAge.KITTEN, CatAge.NEWBORN):
                 self.history.add_afterlife_acceptance(
                     game.clan.instructor.status.group,
                     is_kit=True,

--- a/scripts/cat/status.py
+++ b/scripts/cat/status.py
@@ -555,7 +555,7 @@ class Status:
             )
             return
 
-        self.add_to_group(self.get_default_afterlife_id())
+        self.add_to_group(new_group_ID=self.get_default_afterlife_id())
 
     def _change_rank(self, new_rank: CatRank):
         """

--- a/scripts/cat/status.py
+++ b/scripts/cat/status.py
@@ -524,6 +524,24 @@ class Status:
             new_group_ID=new_group_ID,
         )
 
+    def get_default_afterlife_id(self):
+        """
+        Gets default afterlife id of cat.
+
+        Clancats and former Clancats go to their guide's afterlife, while outsiders
+        go to the unknown residence.
+        """
+        # if we have an outsider who has never been a clancat, they go to the unknown residence
+        if self.is_outsider and (
+            self.is_exiled(CatGroup.PLAYER_CLAN_ID) or not self.is_former_clancat
+        ):
+            return CatGroup.UNKNOWN_RESIDENCE_ID
+
+        # meanwhile clan cats go wherever their guide points them
+        if game.clan:
+            return game.clan.instructor.status.group_ID
+        return CatGroup.STARCLAN_ID
+
     def send_to_afterlife(self, target_ID: str = None):
         """
         Changes a cat's group into the appropriate afterlife
@@ -537,18 +555,7 @@ class Status:
             )
             return
 
-        # if we have an outsider who has never been a clancat, they go to the unknown residence
-        if self.is_outsider and (
-            self.is_exiled(CatGroup.PLAYER_CLAN_ID) or not self.is_former_clancat
-        ):
-            self.add_to_group(new_group_ID=CatGroup.UNKNOWN_RESIDENCE_ID)
-            return
-
-        # meanwhile clan cats go wherever their guide points them
-        if game.clan:
-            self.add_to_group(new_group_ID=game.clan.instructor.status.group_ID)
-        else:
-            self.add_to_group(new_group_ID=CatGroup.STARCLAN_ID)
+        self.add_to_group(self.get_default_afterlife_id())
 
     def _change_rank(self, new_rank: CatRank):
         """


### PR DESCRIPTION
## About The Pull Request

Fixes issue where cats sent to unknown residence would have incorrect afterlife acceptance text. 

## Linked Issues

Fixes: #4070

## Proof of Testing

Hunting down a loner:
<img width="1578" height="1382" alt="image" src="https://github.com/user-attachments/assets/a79f327e-1987-4f26-b7d4-8da0a01097b5" />

No afterlife acceptance text:
<img width="1588" height="1378" alt="image" src="https://github.com/user-attachments/assets/28b50950-7708-45b4-a9bc-73115ed6b2eb" />


## Changelog/Credits

* Fixes issue where cats sent to unknown residence would have incorrect afterlife acceptance text