### PR TITLE
[BUGFIX] Clan name appearing incorrectly in history

### DIFF
--- a/scripts/utility.py
+++ b/scripts/utility.py
@@ -1952,7 +1952,7 @@ def history_text_adjust(text, other_clan_name, clan, other_cat_rc=None):
         text = text.replace("o_c_n", str(other_clan_name))
 
     if "c_n" in text:
-        text = text.replace("c_n", clan.displayname)
+        text = text.replace("c_n", clan.displayname + "Clan")
     if "r_c" in text and other_cat_rc:
         text = selective_replace(text, "r_c", str(other_cat_rc.name))
     return text


### PR DESCRIPTION
## About The Pull Request

Fixes issue where Clan names weren't displaying correctly in history text.

## Linked Issues

Fixes: #4059

## Proof of Testing

Displays full name of Clan after being hunted down:
<img width="1454" height="190" alt="image" src="https://github.com/user-attachments/assets/2aa164f7-329d-4b8b-afa6-ef47a0fe1976" />


## Changelog/Credits

* Fixes issue where Clan names weren't displaying correctly in history text