### PR TITLE
[BUGFIX] Wrong cat referenced as mentor in events

### DIFF
--- a/scripts/events_module/event_filters.py
+++ b/scripts/events_module/event_filters.py
@@ -555,7 +555,7 @@ def _get_cats_with_rel_status(
         cat_list = [c for c in cat_list if c.ID in cat.apprentice]
         rel_status_list.remove("mentor/app")
     elif "app/mentor" in rel_status_list:
-        cat_list = [c for c in cat_list if c.ID in cat.mentor]
+        cat_list = [c for c in cat_list if c.ID == cat.mentor]
         rel_status_list.remove("app/mentor")
 
     return cat_list, rel_status_list


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
SO, what I *think* was happening, is that we were treating the cat's mentor attribute as a list instead of a string.  The list comprehension to filter for current mentor was `[c for c in cat_list if c.ID in cat.mentor]`.  Most of the time, this did work! But If one of the cats in `cat_list` had an ID that matched a single number within `cat.mentor`, then it would be treated like a mentor.  For example, let's say we're looking for a mentor with the ID `64`.  One of the cats in the `cat_list` has the ID `6`. As `6` is *in* `64`, cat 6 is added to the list of current mentors.

The solution is just to switch from `in` to `==`
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->


## Linked Issues
Fixes #4097
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
<img width="536" height="135" alt="image" src="https://github.com/user-attachments/assets/8dda051f-729e-453e-8593-36fa605d64e4" />
<img width="462" height="160" alt="image" src="https://github.com/user-attachments/assets/93cc70b7-94e4-4ed9-832e-661235f7185b" />

Not the exact event from the bug report, but it has the same tag for relationship filtering.
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Cats who are *not* the mentor no longer sneak into app/mentor events
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
