### PR TITLE
[BUGFIX] rel status constraints removed from original object list

### DIFF
--- a/scripts/events.py
+++ b/scripts/events.py
@@ -1812,6 +1812,13 @@ class Events:
         """
         new cats
         """
+        if constants.CONFIG["event_generation"]["debug_type_override"] == "new_cat":
+            create_short_event(
+                event_type="new_cat",
+                main_cat=cat,
+            )
+            return
+
         chance = 200
 
         alive_cats = list(
@@ -1853,13 +1860,6 @@ class Events:
             chance = base_chance - reputation
 
         chance = max(chance, 1)
-
-        if constants.CONFIG["event_generation"]["debug_type_override"] == "new_cat":
-            create_short_event(
-                event_type="new_cat",
-                main_cat=cat,
-            )
-            return
 
         if (
             not int(random.random() * chance)

--- a/scripts/events_module/event_filters.py
+++ b/scripts/events_module/event_filters.py
@@ -498,8 +498,6 @@ def cat_for_event(
 
     # rel status check
     if comparison_cat_rel_status or constraint_dict.get("relationship_status"):
-        # copying this so that we don't modify the original list
-        comparison_cat_rel_status = comparison_cat_rel_status.copy()
         # preliminary check to see if we can just skip to gathering certain rel groups
         allowed_cats, comparison_cat_rel_status = _get_cats_with_rel_status(
             allowed_cats, comparison_cat, comparison_cat_rel_status

--- a/scripts/events_module/event_filters.py
+++ b/scripts/events_module/event_filters.py
@@ -498,6 +498,8 @@ def cat_for_event(
 
     # rel status check
     if comparison_cat_rel_status or constraint_dict.get("relationship_status"):
+        # copying this so that we don't modify the original list
+        comparison_cat_rel_status = comparison_cat_rel_status.copy()
         # preliminary check to see if we can just skip to gathering certain rel groups
         allowed_cats, comparison_cat_rel_status = _get_cats_with_rel_status(
             allowed_cats, comparison_cat, comparison_cat_rel_status

--- a/scripts/events_module/short/short_event_generation.py
+++ b/scripts/events_module/short/short_event_generation.py
@@ -547,6 +547,7 @@ def filter_events(
             != chosen_event.event_id
         ):
             final_events.remove(chosen_event)
+            failed_ids.append(chosen_event.event_id)
             chosen_event = None
             continue
 

--- a/scripts/events_module/short/short_event_generation.py
+++ b/scripts/events_module/short/short_event_generation.py
@@ -566,10 +566,12 @@ def filter_events(
             r_c_injuries.extend(block["injuries"] if "r_c" in block["cats"] else [])
 
         chosen_cat = cat_for_event(
-            constraint_dict=chosen_event.r_c,
+            constraint_dict=chosen_event.r_c.copy(),
             possible_cats=cat_list,
             comparison_cat=main_cat,
-            comparison_cat_rel_status=chosen_event.m_c.get("relationship_status", []),
+            comparison_cat_rel_status=chosen_event.m_c.get(
+                "relationship_status", []
+            ).copy(),
             injuries=r_c_injuries,
             return_id=False,
         )


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
This was so annoying to track down.  So during the relationship tag filtering, we remove tags from the constraint list as we filter for them, this cuts down on how many tags we have to for loop over, since there can end up being a ton of for looping in this part of the filtering.  However, we were actually removing these tags from the event object's list, instead of a copy. This meant that once an event went through the filter, any subsequent filtering of that event *wouldn't* have any relationship tags, leading to events being given to improper cats.  Solution is just to be sending a list copy through the filter func.

The other two changes (moving "new_cat" type override and adding filtered ids to `failed_ids` list) were just done to further optimize the event debug code. Minor changes. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
Fixes #4101
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
<img width="348" height="210" alt="image" src="https://github.com/user-attachments/assets/f669cad2-69bd-4d76-a772-b8a00c407f8f" />

Debug view of the m_c constraints prior to filtering.

<img width="445" height="139" alt="image" src="https://github.com/user-attachments/assets/51531e1e-e263-4ce3-afa1-459846650153" />

Debug view of the m_c onstraints after filtering. This is where, previously, the "mates" tag would have been absent, as it was being removed during filtering.

<img width="559" height="379" alt="image" src="https://github.com/user-attachments/assets/ed4c30cd-d4dd-4511-a2a0-c01864719a11" />

Same event from the bug report, all of these are using the appropriate cats.

This testing was done using the debug_ensure configs, also displaying that my minor changes to the debug code hasn't broken it (else this testing would have been much harder)
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Events requiring certain types of relationships (mates, siblings, parents, ect.) are once again filtered correctly
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
