### PR TITLE
[CONTENT] New Mate Makeup Events

### DIFF
--- a/resources/lang/en/events/relationship_events/become_mates.json
+++ b/resources/lang/en/events/relationship_events/become_mates.json
@@ -68,7 +68,7 @@
 		"Still having lots of love for r_c even after their break up, m_c asked {PRONOUN/r_c/poss} if they can make up and try again, r_c accepts and they've become mates again.",
 		"Realizing how much they missed being with each other, m_c and r_c have gotten back together.",
 		"Despite their prior misgivings, m_c and r_c decided to try their romantic relationship again and got back together, promising to do better with each other than ever before.",
-		"Even though they broke up, m_c loves r_c too much and wants to start things over with {PRONOUN/r_c/object}. Turns out, r_c feels the same way and they got back together, starting anew.",
+		"Even though they broke up, m_c loves r_c too much and wants to start things over with {PRONOUN/r_c/object}. Turns out, r_c feels the same way and they have gotten back together, starting anew.",
 		"m_c regrets breaking up with r_c, realizing how much they actually loved each other. m_c asks r_c to be {PRONOUN/m_c/poss} mate again and r_c accepts.",
 		"m_c and r_c have been seen all love-dovey with each other again lately - it seems they've gotten back together!",
 		"m_c and r_c announced that they have gotten back together! Though the Clan's not really surprised as everyone knew m_c and r_c's love could never truly die.",

--- a/resources/lang/en/events/relationship_events/become_mates.json
+++ b/resources/lang/en/events/relationship_events/become_mates.json
@@ -65,7 +65,7 @@
 	],
 	"high_romantic_makeup":[
 		"m_c really wants to get back with r_c, so {PRONOUN/m_c/subject} confessed {PRONOUN/m_c/poss} feelings to r_c and they've become mates again.",
-		"Still having lots of love for r_c even after their break up, m_c asked {PRONOUN/r_c/poss} if they can make up and try again, r_c accepts and they've become mates again.",
+		"Still having lots of love for r_c even after their break up, m_c asked {PRONOUN/r_c/object} if they can make up and try again, r_c accepts and they've become mates again.",
 		"Realizing how much they missed being with each other, m_c and r_c have gotten back together.",
 		"Despite their prior misgivings, m_c and r_c decided to try their romantic relationship again and got back together, promising to do better with each other than ever before.",
 		"Even though they broke up, m_c loves r_c too much and wants to start things over with {PRONOUN/r_c/object}. Turns out, r_c feels the same way and they have gotten back together, starting anew.",

--- a/resources/lang/en/events/relationship_events/become_mates.json
+++ b/resources/lang/en/events/relationship_events/become_mates.json
@@ -80,7 +80,7 @@
 		"m_c wants to get back with r_c, so {PRONOUN/m_c/subject} confessed {PRONOUN/m_c/poss} feelings to r_c and they've become mates again.",
 		"Despite their prior misgivings, m_c and r_c decided to try their romantic relationship again and got back together.",
 		"m_c and r_c announced that they have made up and gotten back together, much to the Clan's surprise, but they congratulated them anyway.",
-		"m_c and r_c realized they still have some feelings for each other and got back together.",
+		"m_c and r_c realized they still have some feelings for each other. They decided to try their relationship again and got back together.",
 		"Even though they broke up, m_c wants to try to start things over with r_c and asks {PRONOUN/r_c/object} to be {PRONOUN/m_c/poss} mate again. Though r_c was reluctant at first, {PRONOUN/r_c/subject} eventually {VERB/r_c/accept/accepts} and they've become mates again."
 	]
 }

--- a/resources/lang/en/events/relationship_events/become_mates.json
+++ b/resources/lang/en/events/relationship_events/become_mates.json
@@ -79,7 +79,7 @@
 	"low_romantic_makeup":[
 		"m_c wants to get back with r_c, so {PRONOUN/m_c/subject} confessed {PRONOUN/m_c/poss} feelings to r_c and they've become mates again.",
 		"Despite their prior misgivings, m_c and r_c decided to try their romantic relationship again and got back together.",
-		"m_c and r_c announced that they have made up and gotten back together, much to the Clan's surprise, but they congratulated them regardless.",
+		"m_c and r_c announced that they have made up and gotten back together, much to the Clan's surprise, but they congratulated them anyways.",
 		"Even though they broke up, m_c wants to try to start things over with r_c and asks {PRONOUN/r_c/object} to be {PRONOUN/m_c/poss} mate again. Though r_c was reluctant at first, {PRONOUN/r_c/subject} eventually {VERB/r_c/accept/accepts}."
 	]
 }

--- a/resources/lang/en/events/relationship_events/become_mates.json
+++ b/resources/lang/en/events/relationship_events/become_mates.json
@@ -81,6 +81,6 @@
 		"Despite their prior misgivings, m_c and r_c decided to try their romantic relationship again and got back together.",
 		"m_c and r_c announced that they have made up and gotten back together, much to the Clan's surprise, but they congratulated them anyway.",
 		"m_c and r_c realized they still have some feelings for each other and got back together.",
-		"Even though they broke up, m_c wants to try to start things over with r_c and asks {PRONOUN/r_c/object} to be {PRONOUN/m_c/poss} mate again. Though r_c was reluctant at first, {PRONOUN/r_c/subject} eventually {VERB/r_c/accept/accepts}."
+		"Even though they broke up, m_c wants to try to start things over with r_c and asks {PRONOUN/r_c/object} to be {PRONOUN/m_c/poss} mate again. Though r_c was reluctant at first, {PRONOUN/r_c/subject} eventually {VERB/r_c/accept/accepts} and they've become mates again."
 	]
 }

--- a/resources/lang/en/events/relationship_events/become_mates.json
+++ b/resources/lang/en/events/relationship_events/become_mates.json
@@ -70,9 +70,9 @@
 		"Despite their prior misgivings, m_c and r_c decided to try their romantic relationship again and got back together, promising to do better with each other than ever before.",
 		"Even though they broke up, m_c loves r_c too much and wants to start things over with {PRONOUN/r_c/object}. Turns out, r_c feels the same way and they have gotten back together, starting anew.",
 		"m_c regrets breaking up with r_c, realizing how much they actually loved each other. m_c asks r_c to be {PRONOUN/m_c/poss} mate again and r_c accepts.",
-		"m_c and r_c have been seen all love-dovey with each other again lately - it seems they've gotten back together!",
+		"m_c and r_c have been seen all love-dovey with each other again lately - it seems that they've gotten back together!",
 		"m_c and r_c announced that they have gotten back together! Though the Clan's not really surprised as everyone knew m_c and r_c's love could never truly die.",
-		"Some cats may say it is wrong to get back with your ex-mate, but for m_c and r_c, it feels so right - they have made amends and got back together.",
+		"Some cats may say it is wrong to get back with your ex-mate, but for m_c and r_c, it feels so right - they have made amends and gotten back together.",
 		"After discussing their feelings and the reason why they broke up in the first place, m_c and r_c decided to start over and become mates again."
 	],
 	"low_romantic_makeup":[

--- a/resources/lang/en/events/relationship_events/become_mates.json
+++ b/resources/lang/en/events/relationship_events/become_mates.json
@@ -51,5 +51,34 @@
 		"m_c confesses {PRONOUN/m_c/poss} feelings to r_c, asking to be mates. And the answer, well, it's not yes.",
 		"Look, r_c is sorry, but {PRONOUN/r_c/subject} just {VERB/r_c/don't/doesn't} see m_c that way. m_c slinks off, rejected.",
 		"m_c's confession of love to r_c could've gone better. Actually, anything would've been better than the rejection {PRONOUN/m_c/subject} got."
+	],
+	"makeup_fail":[
+		"m_c wants to get back with r_c, so {PRONOUN/m_c/subject} confessed {PRONOUN/m_c/poss} feelings to r_c but got rejected.",
+		"<i>Seriously?</i> m_c wants to get back with r_c after what they've said to each other? Sorry, but no thanks, r_c rejects {PRONOUN/m_c/object}.",
+		"Even though they broke up, m_c wants to start things over with r_c. Unfortunatley, r_c doesn't feel the same and rejects {PRONOUN/m_c/object}.",
+		"m_c asked r_c if they could get back together again. r_c sighs and tries to calmly explain that {PRONOUN/r_c/subject}{VERB/r_c/'re/'s} already in the process of moving on and that m_c should move on too.",
+		"Realizing how much m_c misses being with r_c, {PRONOUN/m_c/subject} asked {PRONOUN/r_c/poss} if they can get back together again, but unfortunatley r_c said no.",
+		"m_c asked r_c if they could become mates again. The answer is no - they broke up for a reason.",
+		"m_c regrets breaking up with r_c, so {PRONOUN/m_c/subject} asks r_c to be {PRONOUN/m_c/poss} mate again but r_c rejects {PRONOUN/m_c/object}.",
+		"Some cats may say it is wrong to get back with your ex-mate, but m_c just can't ignore these leftover feelings any longer! So {PRONOUN/m_c/subject} confessed to r_c, but got rejected. Perhaps those cats were right?",
+        "m_c still has feelings for r_c and wants {PRONOUN/r_c/object} back. {PRONOUN/m_c/subject/CAP} {VERB/m_c/plead/pleads} r_c to get back with {PRONOUN/m_c/object} in the middle of the clearing. Weirded out and embarrassed, r_c had to reject {PRONOUN/m_c/object}... publicly."
+	],
+	"high_romantic_makeup":[
+		"m_c really wants to get back with r_c, so {PRONOUN/m_c/subject} confessed {PRONOUN/m_c/poss} feelings to r_c and they've become mates again.",
+		"Still having lots of love for r_c even after their break up, m_c asked {PRONOUN/r_c/poss} if they can make up and try again, r_c accepts and they've become mates again.",
+		"Realizing how much they missed being with each other, m_c and r_c have gotten back together.",
+		"Despite their prior misgivings, m_c and r_c decided to try their romantic relationship again and got back together, promising to do better with eachother than ever before.",
+		"Even though they broke up, m_c loves r_c too much and wants to start things over with {PRONOUN/r_c/object}. Turns out, r_c feels the same way and they got back together, starting anew.",
+		"m_c regrets breaking up with r_c, realizing how much they actually loved each other. m_c asks r_c to be {PRONOUN/m_c/poss} mate again and r_c accepts.",
+		"m_c and r_c were seen being all love-dovey with each other again lately - it seems they've gotten back together!",
+		"m_c and r_c announced that they have gotten back together! Though, the Clan's not really surpised as everyone knew m_c and r_c's love could never truly die.",
+		"Some cats may say it is wrong to get back with your ex-mate, but for m_c and r_c, it feels so right - they have made amends and got back together.",
+		"After disscusing their feelings and the reason why they broke up in the first place, m_c and r_c decided to start over and become mates again."
+	],
+	"low_romantic_makeup":[
+		"m_c wants to get back with r_c, so {PRONOUN/m_c/subject} confessed {PRONOUN/m_c/poss} feelings to r_c and they've become mates again.",
+		"Despite their prior misgivings, m_c and r_c decided to try their romantic relationship again and got back together.",
+		"m_c and r_c announced that they have made up and gotten back together, much to the Clan's surpise, but they congratulated them regardless.",
+		"Even though they broke up, m_c wants to try to start things over with r_c an asks {PRONOUN/r_c/object} to be {PRONOUN/m_c/poss} mate again. Though r_c was reluctant at first, {PRONOUN/r_c/subject} eventually {VERB/r_c/accept/accepts}."
 	]
 }

--- a/resources/lang/en/events/relationship_events/become_mates.json
+++ b/resources/lang/en/events/relationship_events/become_mates.json
@@ -80,6 +80,7 @@
 		"m_c wants to get back with r_c, so {PRONOUN/m_c/subject} confessed {PRONOUN/m_c/poss} feelings to r_c and they've become mates again.",
 		"Despite their prior misgivings, m_c and r_c decided to try their romantic relationship again and got back together.",
 		"m_c and r_c announced that they have made up and gotten back together, much to the Clan's surprise, but they congratulated them anyway.",
+		"m_c and r_c realized they still have some feelings for each other and got back together.",
 		"Even though they broke up, m_c wants to try to start things over with r_c and asks {PRONOUN/r_c/object} to be {PRONOUN/m_c/poss} mate again. Though r_c was reluctant at first, {PRONOUN/r_c/subject} eventually {VERB/r_c/accept/accepts}."
 	]
 }

--- a/resources/lang/en/events/relationship_events/become_mates.json
+++ b/resources/lang/en/events/relationship_events/become_mates.json
@@ -59,7 +59,7 @@
 		"m_c asked r_c if they could get back together again. r_c sighs and tries to calmly explain that {PRONOUN/r_c/subject}{VERB/r_c/'re/'s} already in the process of moving on and that m_c should move on too.",
 		"Realizing how much m_c misses being with r_c, {PRONOUN/m_c/subject} asked {PRONOUN/r_c/poss} if they can get back together again, but unfortunatley r_c said no.",
 		"m_c asked r_c if they could become mates again. The answer is no - they broke up for a reason.",
-		"m_c regrets breaking up with r_c, so {PRONOUN/m_c/subject} asks r_c to be {PRONOUN/m_c/poss} mate again but r_c rejects {PRONOUN/m_c/object}.",
+		"m_c regrets breaking up with r_c, so {PRONOUN/m_c/subject} {VERB/m_c/ask/asks} r_c to be {PRONOUN/m_c/poss} mate again but r_c rejects {PRONOUN/m_c/object}.",
 		"Some cats may say it is wrong to get back with your ex-mate, but m_c just can't ignore these leftover feelings any longer! So {PRONOUN/m_c/subject} confessed to r_c, but got rejected. Perhaps those cats were right?",
         "m_c still has feelings for r_c and wants {PRONOUN/r_c/object} back. {PRONOUN/m_c/subject/CAP} {VERB/m_c/plead/pleads} r_c to get back with {PRONOUN/m_c/object} in the middle of the clearing. Weirded out and embarrassed, r_c had to reject {PRONOUN/m_c/object} ...publicly."
 	],

--- a/resources/lang/en/events/relationship_events/become_mates.json
+++ b/resources/lang/en/events/relationship_events/become_mates.json
@@ -61,24 +61,24 @@
 		"m_c asked r_c if they could become mates again. The answer is no - they broke up for a reason.",
 		"m_c regrets breaking up with r_c, so {PRONOUN/m_c/subject} asks r_c to be {PRONOUN/m_c/poss} mate again but r_c rejects {PRONOUN/m_c/object}.",
 		"Some cats may say it is wrong to get back with your ex-mate, but m_c just can't ignore these leftover feelings any longer! So {PRONOUN/m_c/subject} confessed to r_c, but got rejected. Perhaps those cats were right?",
-        "m_c still has feelings for r_c and wants {PRONOUN/r_c/object} back. {PRONOUN/m_c/subject/CAP} {VERB/m_c/plead/pleads} r_c to get back with {PRONOUN/m_c/object} in the middle of the clearing. Weirded out and embarrassed, r_c had to reject {PRONOUN/m_c/object}... publicly."
+        "m_c still has feelings for r_c and wants {PRONOUN/r_c/object} back. {PRONOUN/m_c/subject/CAP} {VERB/m_c/plead/pleads} r_c to get back with {PRONOUN/m_c/object} in the middle of the clearing. Weirded out and embarrassed, r_c had to reject {PRONOUN/m_c/object} ...publicly."
 	],
 	"high_romantic_makeup":[
 		"m_c really wants to get back with r_c, so {PRONOUN/m_c/subject} confessed {PRONOUN/m_c/poss} feelings to r_c and they've become mates again.",
 		"Still having lots of love for r_c even after their break up, m_c asked {PRONOUN/r_c/poss} if they can make up and try again, r_c accepts and they've become mates again.",
 		"Realizing how much they missed being with each other, m_c and r_c have gotten back together.",
-		"Despite their prior misgivings, m_c and r_c decided to try their romantic relationship again and got back together, promising to do better with eachother than ever before.",
+		"Despite their prior misgivings, m_c and r_c decided to try their romantic relationship again and got back together, promising to do better with each other than ever before.",
 		"Even though they broke up, m_c loves r_c too much and wants to start things over with {PRONOUN/r_c/object}. Turns out, r_c feels the same way and they got back together, starting anew.",
 		"m_c regrets breaking up with r_c, realizing how much they actually loved each other. m_c asks r_c to be {PRONOUN/m_c/poss} mate again and r_c accepts.",
-		"m_c and r_c were seen being all love-dovey with each other again lately - it seems they've gotten back together!",
-		"m_c and r_c announced that they have gotten back together! Though, the Clan's not really surpised as everyone knew m_c and r_c's love could never truly die.",
+		"m_c and r_c have been seen all love-dovey with each other again lately - it seems they've gotten back together!",
+		"m_c and r_c announced that they have gotten back together! Though the Clan's not really surprised as everyone knew m_c and r_c's love could never truly die.",
 		"Some cats may say it is wrong to get back with your ex-mate, but for m_c and r_c, it feels so right - they have made amends and got back together.",
-		"After disscusing their feelings and the reason why they broke up in the first place, m_c and r_c decided to start over and become mates again."
+		"After discussing their feelings and the reason why they broke up in the first place, m_c and r_c decided to start over and become mates again."
 	],
 	"low_romantic_makeup":[
 		"m_c wants to get back with r_c, so {PRONOUN/m_c/subject} confessed {PRONOUN/m_c/poss} feelings to r_c and they've become mates again.",
 		"Despite their prior misgivings, m_c and r_c decided to try their romantic relationship again and got back together.",
-		"m_c and r_c announced that they have made up and gotten back together, much to the Clan's surpise, but they congratulated them regardless.",
-		"Even though they broke up, m_c wants to try to start things over with r_c an asks {PRONOUN/r_c/object} to be {PRONOUN/m_c/poss} mate again. Though r_c was reluctant at first, {PRONOUN/r_c/subject} eventually {VERB/r_c/accept/accepts}."
+		"m_c and r_c announced that they have made up and gotten back together, much to the Clan's surprise, but they congratulated them regardless.",
+		"Even though they broke up, m_c wants to try to start things over with r_c and asks {PRONOUN/r_c/object} to be {PRONOUN/m_c/poss} mate again. Though r_c was reluctant at first, {PRONOUN/r_c/subject} eventually {VERB/r_c/accept/accepts}."
 	]
 }

--- a/resources/lang/en/events/relationship_events/become_mates.json
+++ b/resources/lang/en/events/relationship_events/become_mates.json
@@ -73,7 +73,7 @@
 		"m_c and r_c have been seen all lovey-dovey with each other again lately - it seems that they've gotten back together!",
 		"m_c and r_c announced that they have gotten back together! Though the Clan's not really surprised as everyone knew m_c and r_c's love could never truly die.",
 		"Some cats may say it is wrong to get back with your ex-mate, but for m_c and r_c, it feels so right - they have made amends and gotten back together.",
-		"m_c and r_c relized that their reason for breaking up just wasn't worth it. They've made up decided to try again.",
+		"m_c and r_c realized that their reason for breaking up just wasn't worth it. They've made up decided to try again.",
 		"After discussing their feelings and the reason why they broke up in the first place, m_c and r_c decided to start over and become mates again."
 	],
 	"low_romantic_makeup":[

--- a/resources/lang/en/events/relationship_events/become_mates.json
+++ b/resources/lang/en/events/relationship_events/become_mates.json
@@ -71,7 +71,7 @@
 		"Even though they broke up, m_c loves r_c too much and wants to start things over with {PRONOUN/r_c/object}. Turns out, r_c feels the same way and they have gotten back together, starting anew.",
 		"m_c regrets breaking up with r_c, realizing how much they actually loved each other. m_c asks r_c to be {PRONOUN/m_c/poss} mate again and r_c accepts.",
 		"m_c and r_c have been seen all lovey-dovey with each other again lately - it seems that they've gotten back together!",
-		"m_c and r_c announced that they have gotten back together! Though the Clan's not really surprised as everyone knew m_c and r_c's love could never truly die.",
+		"m_c and r_c announced that they have gotten back together! Though the Clan's not really surprised, everyone knew m_c and r_c's love could never truly die.",
 		"Some cats may say it is wrong to get back with your ex-mate, but for m_c and r_c, it feels so right - they have made amends and gotten back together.",
 		"m_c and r_c realized that their reason for breaking up just wasn't worth it. They've made up and decided to try again.",
 		"After discussing their feelings and the reason why they broke up in the first place, m_c and r_c decided to start over and become mates again."

--- a/resources/lang/en/events/relationship_events/become_mates.json
+++ b/resources/lang/en/events/relationship_events/become_mates.json
@@ -1,3 +1,57 @@
+{
+	"high_romantic": [
+		"m_c confessed {PRONOUN/m_c/poss} feelings to r_c and they have become mates.",
+		"This has been a long time coming - m_c and r_c have become mates.",
+		"m_c and r_c really think the Clan hasn't noticed how they feel about each other? Everyone carefully hides their smiles as they announce becoming mates.",
+		"m_c and r_c have been practically floating on air since announcing their commitment as mates before c_n.",
+		"Some of the less sympathetic cats of c_n would prefer to try to hack up a hairball, rather than watch m_c and r_c melt in each others' direction. New mates can be insufferable.",
+		"The more romantic members of the Clan sigh, watching the new mates m_c and r_c, who're too caught up in each other to notice.",
+		"In a bright spot this moon, m_c and r_c have finally announced their commitment as mates.",
+		"Their love has been a slow basking warmth, not a wildfire, and m_c wouldn't change it for the world. {PRONOUN/m_c/subject/CAP}{VERB/m_c/'re/'s} so excited to commit to padding at r_c's side forever.",
+        "It's neither a mystery nor a surprise, but c_n is happy to celebrate m_c and r_c becoming mates regardless.",
+		"m_c and r_c announce they've become mates in the least showy way possible, by combining their nests into one.",
+		"There's such happiness in the promises they make to each other. m_c and r_c leap into their new life as mates without question or hesitation.",
+		"For just this one perfect moment, heads pressed together and speaking their commitment in front of the Clan, there's nothing in m_c and r_c's worlds but love.",
+		"m_c and r_c are very proud to announce their new status as mates - it's quite cute."
+	],
+	"low_romantic":[
+		"m_c and r_c have become mates.",
+		"It's funny how quickly love takes flight - m_c and r_c have become mates.",
+		"The Clan gathers to celebrate a new pair of mates, m_c and r_c.",
+		"In a bright spot this moon, m_c and r_c have announced their commitment as mates.",
+        "m_c puts {PRONOUN/m_c/poss} paw over r_c's, as they announce they've become mates.",
+		"m_c bunts {PRONOUN/m_c/poss} head against r_c's as c_n celebrates the new mates.",
+		"It's funny how love has worked for m_c and r_c. Slowly at first, like a little trip or tumble, and then suddenly falling all at once.",
+		"Maybe it's surprising to some cats. It doesn't feel like it should be, m_c is so sure {PRONOUN/m_c/subject} {VERB/m_c/want/wants} r_c as {PRONOUN/m_c/poss} mate, and r_c loves {PRONOUN/m_c/object} just as much in return.",
+		"This moon marks the beginning of the rest of their lives together for m_c and r_c.",
+		"Tails twined together, m_c and r_c announce that love has blossomed between them. They've become mates.",
+        "It's endearing how embarrassed m_c is, with {PRONOUN/m_c/object} and r_c briefly becoming the center of attention as new mates.",
+        "No one is going to blame m_c for the pride {PRONOUN/m_c/subject} {VERB/m_c/display/displays} in successfully asking r_c to become {PRONOUN/m_c/poss} mate. It's a wonderful life event to celebrate, and something to rightfully congratulate the couple on."
+	],
+	"like_to_romance":[
+		"m_c and r_c see each other in a different light and have become mates.",
+		"It's like- like shedding fur to find a new colour underneath, m_c explains. r_c has been such an important friend, is it so surprising that both their feelings have evolved in this new direction to become mates?",
+		"It surprised them, too. But m_c and r_c are sure of this. So sure. The new mates celebrate with c_n.",
+		"Closeness can bring new aspects to any relationship. m_c glows with contentment, flushed the thrill of {PRONOUN/m_c/poss} new romance with r_c.",
+		"Tails twined together, m_c and r_c announce that love has blossomed between them. They've become mates.",
+		"In a bright spot this moon, m_c and r_c announce that their friendship has had romance added to the mix - they're now mates.",
+		"Sometimes one form of love can grow into another - m_c and r_c no longer only think of each other platonically.",
+		"Love blooms from platonic to romantic, and m_c is now mates with r_c.",
+        "m_c and r_c don't make any big announcements. But when they combine their nests, the Clan realizes that their relationship isn't so platonic anymore."
+	],
+	"rejected":[
+		"m_c confessed {PRONOUN/m_c/poss} feelings to r_c but {PRONOUN/m_c/subject} got rejected.",
+		"m_c confessed to r_c. Everyone tiptoes around {PRONOUN/m_c/object}, not wanting to disturb {PRONOUN/m_c/object} as m_c processes the rejection.",
+		"This, them, together? It wouldn't work out. r_c rejects m_c.",
+		"It stings. m_c is going to be nursing the hurt from r_c rejecting {PRONOUN/m_c/object} for a while.",
+		"m_c was so confident that r_c felt the same. But {PRONOUN/r_c/subject} {VERB/r_c/don't/doesn't}. m_c <i>really</i> doesn't want to talk about it.",
+		"r_c's rejection of m_c was very... public. Everyone's still feeling awkward about it.",
+		"m_c's dreams of romance and love have been crushed by r_c's rejection.",
+        "After being rejected by r_c, m_c's barely been visible round camp. {PRONOUN/m_c/subject/CAP}{VERB/m_c/'re/'s} good at hiding when {PRONOUN/m_c/subject} {VERB/m_c/want/wants} to be.",
+		"m_c confesses {PRONOUN/m_c/poss} feelings to r_c, asking to be mates. And the answer, well, it's not yes.",
+		"Look, r_c is sorry, but {PRONOUN/r_c/subject} just {VERB/r_c/don't/doesn't} see m_c that way. m_c slinks off, rejected.",
+		"m_c's confession of love to r_c could've gone better. Actually, anything would've been better than the rejection {PRONOUN/m_c/subject} got."
+	],
 	"makeup_fail":[
 		"m_c wants to get back with r_c, so {PRONOUN/m_c/subject} confessed {PRONOUN/m_c/poss} feelings to r_c but got rejected.",
 		"<i>Seriously?</i> m_c wants to get back with r_c after what they've said to each other? Sorry, but no thanks, r_c rejects {PRONOUN/m_c/object}.",
@@ -7,23 +61,24 @@
 		"m_c asked r_c if they could become mates again. The answer is no - they broke up for a reason.",
 		"m_c regrets breaking up with r_c, so {PRONOUN/m_c/subject} asks r_c to be {PRONOUN/m_c/poss} mate again but r_c rejects {PRONOUN/m_c/object}.",
 		"Some cats may say it is wrong to get back with your ex-mate, but m_c just can't ignore these leftover feelings any longer! So {PRONOUN/m_c/subject} confessed to r_c, but got rejected. Perhaps those cats were right?",
-        "m_c still has feelings for r_c and wants {PRONOUN/r_c/object} back. {PRONOUN/m_c/subject/CAP} {VERB/m_c/plead/pleads} r_c to get back with {PRONOUN/m_c/object} in the middle of the clearing. Weirded out and embarrassed, r_c had to reject {PRONOUN/m_c/object} ...publicly."
+        "m_c still has feelings for r_c and wants {PRONOUN/r_c/object} back. {PRONOUN/m_c/subject/CAP} {VERB/m_c/plead/pleads} r_c to get back with {PRONOUN/m_c/object} in the middle of the clearing. Weirded out and embarrassed, r_c had to reject {PRONOUN/m_c/object}... publicly."
 	],
 	"high_romantic_makeup":[
 		"m_c really wants to get back with r_c, so {PRONOUN/m_c/subject} confessed {PRONOUN/m_c/poss} feelings to r_c and they've become mates again.",
 		"Still having lots of love for r_c even after their break up, m_c asked {PRONOUN/r_c/poss} if they can make up and try again, r_c accepts and they've become mates again.",
 		"Realizing how much they missed being with each other, m_c and r_c have gotten back together.",
-		"Despite their prior misgivings, m_c and r_c decided to try their romantic relationship again and got back together, promising to do better with each other than ever before.",
+		"Despite their prior misgivings, m_c and r_c decided to try their romantic relationship again and got back together, promising to do better with eachother than ever before.",
 		"Even though they broke up, m_c loves r_c too much and wants to start things over with {PRONOUN/r_c/object}. Turns out, r_c feels the same way and they got back together, starting anew.",
 		"m_c regrets breaking up with r_c, realizing how much they actually loved each other. m_c asks r_c to be {PRONOUN/m_c/poss} mate again and r_c accepts.",
-		"m_c and r_c have been seen all love-dovey with each other again lately - it seems they've gotten back together!",
-		"m_c and r_c announced that they have gotten back together! Though the Clan's not really surprised as everyone knew m_c and r_c's love could never truly die.",
+		"m_c and r_c were seen being all love-dovey with each other again lately - it seems they've gotten back together!",
+		"m_c and r_c announced that they have gotten back together! Though, the Clan's not really surpised as everyone knew m_c and r_c's love could never truly die.",
 		"Some cats may say it is wrong to get back with your ex-mate, but for m_c and r_c, it feels so right - they have made amends and got back together.",
-		"After discussing their feelings and the reason why they broke up in the first place, m_c and r_c decided to start over and become mates again."
+		"After disscusing their feelings and the reason why they broke up in the first place, m_c and r_c decided to start over and become mates again."
 	],
 	"low_romantic_makeup":[
 		"m_c wants to get back with r_c, so {PRONOUN/m_c/subject} confessed {PRONOUN/m_c/poss} feelings to r_c and they've become mates again.",
 		"Despite their prior misgivings, m_c and r_c decided to try their romantic relationship again and got back together.",
-		"m_c and r_c announced that they have made up and gotten back together, much to the Clan's surprise, but they congratulated them regardless.",
-		"Even though they broke up, m_c wants to try to start things over with r_c and asks {PRONOUN/r_c/object} to be {PRONOUN/m_c/poss} mate again. Though r_c was reluctant at first, {PRONOUN/r_c/subject} eventually {VERB/r_c/accept/accepts}."
+		"m_c and r_c announced that they have made up and gotten back together, much to the Clan's surpise, but they congratulated them regardless.",
+		"Even though they broke up, m_c wants to try to start things over with r_c an asks {PRONOUN/r_c/object} to be {PRONOUN/m_c/poss} mate again. Though r_c was reluctant at first, {PRONOUN/r_c/subject} eventually {VERB/r_c/accept/accepts}."
 	]
+}

--- a/resources/lang/en/events/relationship_events/become_mates.json
+++ b/resources/lang/en/events/relationship_events/become_mates.json
@@ -73,13 +73,13 @@
 		"m_c and r_c have been seen all lovey-dovey with each other again lately - it seems that they've gotten back together!",
 		"m_c and r_c announced that they have gotten back together! Though the Clan's not really surprised as everyone knew m_c and r_c's love could never truly die.",
 		"Some cats may say it is wrong to get back with your ex-mate, but for m_c and r_c, it feels so right - they have made amends and gotten back together.",
-		"m_c and r_c realized that their reason for breaking up just wasn't worth it. They've made up decided to try again.",
+		"m_c and r_c realized that their reason for breaking up just wasn't worth it. They've made up and decided to try again.",
 		"After discussing their feelings and the reason why they broke up in the first place, m_c and r_c decided to start over and become mates again."
 	],
 	"low_romantic_makeup":[
 		"m_c wants to get back with r_c, so {PRONOUN/m_c/subject} confessed {PRONOUN/m_c/poss} feelings to r_c and they've become mates again.",
 		"Despite their prior misgivings, m_c and r_c decided to try their romantic relationship again and got back together.",
-		"m_c and r_c announced that they have made up and gotten back together, much to the Clan's surprise, but they congratulated them anyways.",
+		"m_c and r_c announced that they have made up and gotten back together, much to the Clan's surprise, but they congratulated them anyway.",
 		"Even though they broke up, m_c wants to try to start things over with r_c and asks {PRONOUN/r_c/object} to be {PRONOUN/m_c/poss} mate again. Though r_c was reluctant at first, {PRONOUN/r_c/subject} eventually {VERB/r_c/accept/accepts}."
 	]
 }

--- a/resources/lang/en/events/relationship_events/become_mates.json
+++ b/resources/lang/en/events/relationship_events/become_mates.json
@@ -79,7 +79,7 @@
 	"low_romantic_makeup":[
 		"m_c wants to get back with r_c, so {PRONOUN/m_c/subject} confessed {PRONOUN/m_c/poss} feelings to r_c and they've become mates again.",
 		"Despite their prior misgivings, m_c and r_c decided to try their romantic relationship again and got back together.",
-		"m_c and r_c announced that they have made up and gotten back together, much to the Clan's surprise, but they congratulated them anyway.",
+		"m_c and r_c announced that they have made up and gotten back together, much to the Clan's surprise. Everyone still congratulates them.",
 		"m_c and r_c realized they still have some feelings for each other. They decided to try their relationship again and got back together.",
 		"Even though they broke up, m_c wants to try to start things over with r_c and asks {PRONOUN/r_c/object} to be {PRONOUN/m_c/poss} mate again. Though r_c was reluctant at first, {PRONOUN/r_c/subject} eventually {VERB/r_c/accept/accepts} and they've become mates again."
 	]

--- a/resources/lang/en/events/relationship_events/become_mates.json
+++ b/resources/lang/en/events/relationship_events/become_mates.json
@@ -57,7 +57,7 @@
 		"<i>Seriously?</i> m_c wants to get back with r_c after what they've said to each other? Sorry, but no thanks, r_c rejects {PRONOUN/m_c/object}.",
 		"Even though they broke up, m_c wants to start things over with r_c. Unfortunately, r_c doesn't feel the same and rejects {PRONOUN/m_c/object}.",
 		"m_c asked r_c if they could get back together again. r_c sighs and tries to calmly explain that {PRONOUN/r_c/subject}{VERB/r_c/'re/'s} already in the process of moving on and that m_c should move on too.",
-		"Realizing how much m_c misses being with r_c, {PRONOUN/m_c/subject} asked {PRONOUN/r_c/poss} if they can get back together again, but unfortunatley r_c said no.",
+		"Realizing how much m_c misses being with r_c, {PRONOUN/m_c/subject} asked {PRONOUN/r_c/poss} if they could get back together again. Unfortunately r_c said no.",
 		"m_c asked r_c if they could become mates again. The answer is no - they broke up for a reason.",
 		"m_c regrets breaking up with r_c, so {PRONOUN/m_c/subject} {VERB/m_c/ask/asks} r_c to be {PRONOUN/m_c/poss} mate again but r_c rejects {PRONOUN/m_c/object}.",
 		"Some cats may say it is wrong to get back with your ex-mate, but m_c just can't ignore these leftover feelings any longer! So {PRONOUN/m_c/subject} confessed to r_c, but got rejected. Perhaps those cats were right?",

--- a/resources/lang/en/events/relationship_events/become_mates.json
+++ b/resources/lang/en/events/relationship_events/become_mates.json
@@ -73,6 +73,7 @@
 		"m_c and r_c have been seen all love-dovey with each other again lately - it seems that they've gotten back together!",
 		"m_c and r_c announced that they have gotten back together! Though the Clan's not really surprised as everyone knew m_c and r_c's love could never truly die.",
 		"Some cats may say it is wrong to get back with your ex-mate, but for m_c and r_c, it feels so right - they have made amends and gotten back together.",
+		"m_c and r_c relized that their reason for breaking up just wasn't worth it. They've made up decided to try again.",
 		"After discussing their feelings and the reason why they broke up in the first place, m_c and r_c decided to start over and become mates again."
 	],
 	"low_romantic_makeup":[

--- a/resources/lang/en/events/relationship_events/become_mates.json
+++ b/resources/lang/en/events/relationship_events/become_mates.json
@@ -55,7 +55,7 @@
 	"makeup_fail":[
 		"m_c wants to get back with r_c, so {PRONOUN/m_c/subject} confessed {PRONOUN/m_c/poss} feelings to r_c but was rejected.",
 		"<i>Seriously?</i> m_c wants to get back with r_c after what they've said to each other? Sorry, but no thanks, r_c rejects {PRONOUN/m_c/object}.",
-		"Even though they broke up, m_c wants to start things over with r_c. Unfortunatley, r_c doesn't feel the same and rejects {PRONOUN/m_c/object}.",
+		"Even though they broke up, m_c wants to start things over with r_c. Unfortunately, r_c doesn't feel the same and rejects {PRONOUN/m_c/object}.",
 		"m_c asked r_c if they could get back together again. r_c sighs and tries to calmly explain that {PRONOUN/r_c/subject}{VERB/r_c/'re/'s} already in the process of moving on and that m_c should move on too.",
 		"Realizing how much m_c misses being with r_c, {PRONOUN/m_c/subject} asked {PRONOUN/r_c/poss} if they can get back together again, but unfortunatley r_c said no.",
 		"m_c asked r_c if they could become mates again. The answer is no - they broke up for a reason.",

--- a/resources/lang/en/events/relationship_events/become_mates.json
+++ b/resources/lang/en/events/relationship_events/become_mates.json
@@ -60,7 +60,7 @@
 		"Realizing how much m_c misses being with r_c, {PRONOUN/m_c/subject} asked {PRONOUN/r_c/poss} if they could get back together again. Unfortunately r_c said no.",
 		"m_c asked r_c if they could become mates again. The answer is no - they broke up for a reason.",
 		"m_c regrets breaking up with r_c, so {PRONOUN/m_c/subject} {VERB/m_c/ask/asks} r_c to be {PRONOUN/m_c/poss} mate again. r_c rejects {PRONOUN/m_c/object}.",
-		"Some cats may say it is wrong to get back with your ex-mate, but m_c just can't ignore these leftover feelings any longer! So {PRONOUN/m_c/subject} confessed to r_c, but got rejected. Perhaps those cats were right?",
+		"Some cats may say it is wrong to get back with your ex-mate, but m_c just can't ignore these leftover feelings any longer! So {PRONOUN/m_c/subject} confesses to r_c, but is rejected. Perhaps those cats were right?",
         "m_c still has feelings for r_c and wants {PRONOUN/r_c/object} back. {PRONOUN/m_c/subject/CAP} {VERB/m_c/plead/pleads} r_c to get back with {PRONOUN/m_c/object} in the middle of the clearing. Weirded out and embarrassed, r_c had to reject {PRONOUN/m_c/object} ...publicly."
 	],
 	"high_romantic_makeup":[

--- a/resources/lang/en/events/relationship_events/become_mates.json
+++ b/resources/lang/en/events/relationship_events/become_mates.json
@@ -61,7 +61,7 @@
 		"m_c asked r_c if they could become mates again. The answer is no - they broke up for a reason.",
 		"m_c regrets breaking up with r_c, so {PRONOUN/m_c/subject} {VERB/m_c/ask/asks} r_c to be {PRONOUN/m_c/poss} mate again. r_c rejects {PRONOUN/m_c/object}.",
 		"Some cats may say it is wrong to get back with your ex-mate, but m_c just can't ignore these leftover feelings any longer! So {PRONOUN/m_c/subject} confesses to r_c, but is rejected. Perhaps those cats were right?",
-        "m_c still has feelings for r_c and wants {PRONOUN/r_c/object} back. {PRONOUN/m_c/subject/CAP} {VERB/m_c/plead/pleads} r_c to get back with {PRONOUN/m_c/object} in the middle of the clearing. Weirded out and embarrassed, r_c had to reject {PRONOUN/m_c/object} ...publicly."
+        "m_c still has feelings for r_c and wants {PRONOUN/r_c/object} back. {PRONOUN/m_c/subject/CAP} {VERB/m_c/plead/pleads} with r_c to get back with {PRONOUN/m_c/object} in the middle of the clearing. Weirded out and embarrassed, r_c had to reject {PRONOUN/m_c/object} ...publicly."
 	],
 	"high_romantic_makeup":[
 		"m_c really wants to get back with r_c, so {PRONOUN/m_c/subject} confessed {PRONOUN/m_c/poss} feelings to r_c and they've become mates again.",

--- a/resources/lang/en/events/relationship_events/become_mates.json
+++ b/resources/lang/en/events/relationship_events/become_mates.json
@@ -64,7 +64,7 @@
         "m_c still has feelings for r_c and wants {PRONOUN/r_c/object} back. {PRONOUN/m_c/subject/CAP} {VERB/m_c/plead/pleads} with r_c to get back with {PRONOUN/m_c/object} in the middle of the clearing. Weirded out and embarrassed, r_c had to reject {PRONOUN/m_c/object} ...publicly."
 	],
 	"high_romantic_makeup":[
-		"m_c really wants to get back with r_c, so {PRONOUN/m_c/subject} confessed {PRONOUN/m_c/poss} feelings to r_c and they've become mates again.",
+		"m_c really wanted to get back with r_c, so {PRONOUN/m_c/subject} confessed {PRONOUN/m_c/poss} feelings to r_c and they've become mates again.",
 		"Still having lots of love for r_c even after their break up, m_c asked {PRONOUN/r_c/object} if they can make up and try again, r_c accepts and they've become mates again.",
 		"Realizing how much they missed being with each other, m_c and r_c have gotten back together.",
 		"Despite their prior misgivings, m_c and r_c decided to try their romantic relationship again and got back together, promising to do better with each other than ever before.",

--- a/resources/lang/en/events/relationship_events/become_mates.json
+++ b/resources/lang/en/events/relationship_events/become_mates.json
@@ -70,7 +70,7 @@
 		"Despite their prior misgivings, m_c and r_c decided to try their romantic relationship again and got back together, promising to do better with each other than ever before.",
 		"Even though they broke up, m_c loves r_c too much and wants to start things over with {PRONOUN/r_c/object}. Turns out, r_c feels the same way and they have gotten back together, starting anew.",
 		"m_c regrets breaking up with r_c, realizing how much they actually loved each other. m_c asks r_c to be {PRONOUN/m_c/poss} mate again and r_c accepts.",
-		"m_c and r_c have been seen all love-dovey with each other again lately - it seems that they've gotten back together!",
+		"m_c and r_c have been seen all lovey-dovey with each other again lately - it seems that they've gotten back together!",
 		"m_c and r_c announced that they have gotten back together! Though the Clan's not really surprised as everyone knew m_c and r_c's love could never truly die.",
 		"Some cats may say it is wrong to get back with your ex-mate, but for m_c and r_c, it feels so right - they have made amends and gotten back together.",
 		"m_c and r_c relized that their reason for breaking up just wasn't worth it. They've made up decided to try again.",

--- a/resources/lang/en/events/relationship_events/become_mates.json
+++ b/resources/lang/en/events/relationship_events/become_mates.json
@@ -1,57 +1,3 @@
-{
-	"high_romantic": [
-		"m_c confessed {PRONOUN/m_c/poss} feelings to r_c and they have become mates.",
-		"This has been a long time coming - m_c and r_c have become mates.",
-		"m_c and r_c really think the Clan hasn't noticed how they feel about each other? Everyone carefully hides their smiles as they announce becoming mates.",
-		"m_c and r_c have been practically floating on air since announcing their commitment as mates before c_n.",
-		"Some of the less sympathetic cats of c_n would prefer to try to hack up a hairball, rather than watch m_c and r_c melt in each others' direction. New mates can be insufferable.",
-		"The more romantic members of the Clan sigh, watching the new mates m_c and r_c, who're too caught up in each other to notice.",
-		"In a bright spot this moon, m_c and r_c have finally announced their commitment as mates.",
-		"Their love has been a slow basking warmth, not a wildfire, and m_c wouldn't change it for the world. {PRONOUN/m_c/subject/CAP}{VERB/m_c/'re/'s} so excited to commit to padding at r_c's side forever.",
-        "It's neither a mystery nor a surprise, but c_n is happy to celebrate m_c and r_c becoming mates regardless.",
-		"m_c and r_c announce they've become mates in the least showy way possible, by combining their nests into one.",
-		"There's such happiness in the promises they make to each other. m_c and r_c leap into their new life as mates without question or hesitation.",
-		"For just this one perfect moment, heads pressed together and speaking their commitment in front of the Clan, there's nothing in m_c and r_c's worlds but love.",
-		"m_c and r_c are very proud to announce their new status as mates - it's quite cute."
-	],
-	"low_romantic":[
-		"m_c and r_c have become mates.",
-		"It's funny how quickly love takes flight - m_c and r_c have become mates.",
-		"The Clan gathers to celebrate a new pair of mates, m_c and r_c.",
-		"In a bright spot this moon, m_c and r_c have announced their commitment as mates.",
-        "m_c puts {PRONOUN/m_c/poss} paw over r_c's, as they announce they've become mates.",
-		"m_c bunts {PRONOUN/m_c/poss} head against r_c's as c_n celebrates the new mates.",
-		"It's funny how love has worked for m_c and r_c. Slowly at first, like a little trip or tumble, and then suddenly falling all at once.",
-		"Maybe it's surprising to some cats. It doesn't feel like it should be, m_c is so sure {PRONOUN/m_c/subject} {VERB/m_c/want/wants} r_c as {PRONOUN/m_c/poss} mate, and r_c loves {PRONOUN/m_c/object} just as much in return.",
-		"This moon marks the beginning of the rest of their lives together for m_c and r_c.",
-		"Tails twined together, m_c and r_c announce that love has blossomed between them. They've become mates.",
-        "It's endearing how embarrassed m_c is, with {PRONOUN/m_c/object} and r_c briefly becoming the center of attention as new mates.",
-        "No one is going to blame m_c for the pride {PRONOUN/m_c/subject} {VERB/m_c/display/displays} in successfully asking r_c to become {PRONOUN/m_c/poss} mate. It's a wonderful life event to celebrate, and something to rightfully congratulate the couple on."
-	],
-	"like_to_romance":[
-		"m_c and r_c see each other in a different light and have become mates.",
-		"It's like- like shedding fur to find a new colour underneath, m_c explains. r_c has been such an important friend, is it so surprising that both their feelings have evolved in this new direction to become mates?",
-		"It surprised them, too. But m_c and r_c are sure of this. So sure. The new mates celebrate with c_n.",
-		"Closeness can bring new aspects to any relationship. m_c glows with contentment, flushed the thrill of {PRONOUN/m_c/poss} new romance with r_c.",
-		"Tails twined together, m_c and r_c announce that love has blossomed between them. They've become mates.",
-		"In a bright spot this moon, m_c and r_c announce that their friendship has had romance added to the mix - they're now mates.",
-		"Sometimes one form of love can grow into another - m_c and r_c no longer only think of each other platonically.",
-		"Love blooms from platonic to romantic, and m_c is now mates with r_c.",
-        "m_c and r_c don't make any big announcements. But when they combine their nests, the Clan realizes that their relationship isn't so platonic anymore."
-	],
-	"rejected":[
-		"m_c confessed {PRONOUN/m_c/poss} feelings to r_c but {PRONOUN/m_c/subject} got rejected.",
-		"m_c confessed to r_c. Everyone tiptoes around {PRONOUN/m_c/object}, not wanting to disturb {PRONOUN/m_c/object} as m_c processes the rejection.",
-		"This, them, together? It wouldn't work out. r_c rejects m_c.",
-		"It stings. m_c is going to be nursing the hurt from r_c rejecting {PRONOUN/m_c/object} for a while.",
-		"m_c was so confident that r_c felt the same. But {PRONOUN/r_c/subject} {VERB/r_c/don't/doesn't}. m_c <i>really</i> doesn't want to talk about it.",
-		"r_c's rejection of m_c was very... public. Everyone's still feeling awkward about it.",
-		"m_c's dreams of romance and love have been crushed by r_c's rejection.",
-        "After being rejected by r_c, m_c's barely been visible round camp. {PRONOUN/m_c/subject/CAP}{VERB/m_c/'re/'s} good at hiding when {PRONOUN/m_c/subject} {VERB/m_c/want/wants} to be.",
-		"m_c confesses {PRONOUN/m_c/poss} feelings to r_c, asking to be mates. And the answer, well, it's not yes.",
-		"Look, r_c is sorry, but {PRONOUN/r_c/subject} just {VERB/r_c/don't/doesn't} see m_c that way. m_c slinks off, rejected.",
-		"m_c's confession of love to r_c could've gone better. Actually, anything would've been better than the rejection {PRONOUN/m_c/subject} got."
-	],
 	"makeup_fail":[
 		"m_c wants to get back with r_c, so {PRONOUN/m_c/subject} confessed {PRONOUN/m_c/poss} feelings to r_c but got rejected.",
 		"<i>Seriously?</i> m_c wants to get back with r_c after what they've said to each other? Sorry, but no thanks, r_c rejects {PRONOUN/m_c/object}.",
@@ -61,24 +7,23 @@
 		"m_c asked r_c if they could become mates again. The answer is no - they broke up for a reason.",
 		"m_c regrets breaking up with r_c, so {PRONOUN/m_c/subject} asks r_c to be {PRONOUN/m_c/poss} mate again but r_c rejects {PRONOUN/m_c/object}.",
 		"Some cats may say it is wrong to get back with your ex-mate, but m_c just can't ignore these leftover feelings any longer! So {PRONOUN/m_c/subject} confessed to r_c, but got rejected. Perhaps those cats were right?",
-        "m_c still has feelings for r_c and wants {PRONOUN/r_c/object} back. {PRONOUN/m_c/subject/CAP} {VERB/m_c/plead/pleads} r_c to get back with {PRONOUN/m_c/object} in the middle of the clearing. Weirded out and embarrassed, r_c had to reject {PRONOUN/m_c/object}... publicly."
+        "m_c still has feelings for r_c and wants {PRONOUN/r_c/object} back. {PRONOUN/m_c/subject/CAP} {VERB/m_c/plead/pleads} r_c to get back with {PRONOUN/m_c/object} in the middle of the clearing. Weirded out and embarrassed, r_c had to reject {PRONOUN/m_c/object} ...publicly."
 	],
 	"high_romantic_makeup":[
 		"m_c really wants to get back with r_c, so {PRONOUN/m_c/subject} confessed {PRONOUN/m_c/poss} feelings to r_c and they've become mates again.",
 		"Still having lots of love for r_c even after their break up, m_c asked {PRONOUN/r_c/poss} if they can make up and try again, r_c accepts and they've become mates again.",
 		"Realizing how much they missed being with each other, m_c and r_c have gotten back together.",
-		"Despite their prior misgivings, m_c and r_c decided to try their romantic relationship again and got back together, promising to do better with eachother than ever before.",
+		"Despite their prior misgivings, m_c and r_c decided to try their romantic relationship again and got back together, promising to do better with each other than ever before.",
 		"Even though they broke up, m_c loves r_c too much and wants to start things over with {PRONOUN/r_c/object}. Turns out, r_c feels the same way and they got back together, starting anew.",
 		"m_c regrets breaking up with r_c, realizing how much they actually loved each other. m_c asks r_c to be {PRONOUN/m_c/poss} mate again and r_c accepts.",
-		"m_c and r_c were seen being all love-dovey with each other again lately - it seems they've gotten back together!",
-		"m_c and r_c announced that they have gotten back together! Though, the Clan's not really surpised as everyone knew m_c and r_c's love could never truly die.",
+		"m_c and r_c have been seen all love-dovey with each other again lately - it seems they've gotten back together!",
+		"m_c and r_c announced that they have gotten back together! Though the Clan's not really surprised as everyone knew m_c and r_c's love could never truly die.",
 		"Some cats may say it is wrong to get back with your ex-mate, but for m_c and r_c, it feels so right - they have made amends and got back together.",
-		"After disscusing their feelings and the reason why they broke up in the first place, m_c and r_c decided to start over and become mates again."
+		"After discussing their feelings and the reason why they broke up in the first place, m_c and r_c decided to start over and become mates again."
 	],
 	"low_romantic_makeup":[
 		"m_c wants to get back with r_c, so {PRONOUN/m_c/subject} confessed {PRONOUN/m_c/poss} feelings to r_c and they've become mates again.",
 		"Despite their prior misgivings, m_c and r_c decided to try their romantic relationship again and got back together.",
-		"m_c and r_c announced that they have made up and gotten back together, much to the Clan's surpise, but they congratulated them regardless.",
-		"Even though they broke up, m_c wants to try to start things over with r_c an asks {PRONOUN/r_c/object} to be {PRONOUN/m_c/poss} mate again. Though r_c was reluctant at first, {PRONOUN/r_c/subject} eventually {VERB/r_c/accept/accepts}."
+		"m_c and r_c announced that they have made up and gotten back together, much to the Clan's surprise, but they congratulated them regardless.",
+		"Even though they broke up, m_c wants to try to start things over with r_c and asks {PRONOUN/r_c/object} to be {PRONOUN/m_c/poss} mate again. Though r_c was reluctant at first, {PRONOUN/r_c/subject} eventually {VERB/r_c/accept/accepts}."
 	]
-}

--- a/resources/lang/en/events/relationship_events/become_mates.json
+++ b/resources/lang/en/events/relationship_events/become_mates.json
@@ -53,7 +53,7 @@
 		"m_c's confession of love to r_c could've gone better. Actually, anything would've been better than the rejection {PRONOUN/m_c/subject} got."
 	],
 	"makeup_fail":[
-		"m_c wants to get back with r_c, so {PRONOUN/m_c/subject} confessed {PRONOUN/m_c/poss} feelings to r_c but got rejected.",
+		"m_c wants to get back with r_c, so {PRONOUN/m_c/subject} confessed {PRONOUN/m_c/poss} feelings to r_c but was rejected.",
 		"<i>Seriously?</i> m_c wants to get back with r_c after what they've said to each other? Sorry, but no thanks, r_c rejects {PRONOUN/m_c/object}.",
 		"Even though they broke up, m_c wants to start things over with r_c. Unfortunatley, r_c doesn't feel the same and rejects {PRONOUN/m_c/object}.",
 		"m_c asked r_c if they could get back together again. r_c sighs and tries to calmly explain that {PRONOUN/r_c/subject}{VERB/r_c/'re/'s} already in the process of moving on and that m_c should move on too.",

--- a/resources/lang/en/events/relationship_events/become_mates.json
+++ b/resources/lang/en/events/relationship_events/become_mates.json
@@ -65,7 +65,7 @@
 	],
 	"high_romantic_makeup":[
 		"m_c really wanted to get back with r_c, so {PRONOUN/m_c/subject} confessed {PRONOUN/m_c/poss} feelings to r_c and they've become mates again.",
-		"Still having lots of love for r_c even after their break up, m_c asked {PRONOUN/r_c/object} if they can make up and try again, r_c accepts and they've become mates again.",
+		"Still having lots of love for r_c even after their break up, m_c asked {PRONOUN/r_c/object} if they can make up and try again, r_c accepted and they've become mates again.",
 		"Realizing how much they missed being with each other, m_c and r_c have gotten back together.",
 		"Despite their prior misgivings, m_c and r_c decided to try their romantic relationship again and got back together, promising to do better with each other than ever before.",
 		"Even though they broke up, m_c loves r_c too much and wants to start things over with {PRONOUN/r_c/object}. Turns out, r_c feels the same way and they have gotten back together, starting anew.",

--- a/resources/lang/en/events/relationship_events/become_mates.json
+++ b/resources/lang/en/events/relationship_events/become_mates.json
@@ -59,7 +59,7 @@
 		"m_c asked r_c if they could get back together again. r_c sighs and tries to calmly explain that {PRONOUN/r_c/subject}{VERB/r_c/'re/'s} already in the process of moving on and that m_c should move on too.",
 		"Realizing how much m_c misses being with r_c, {PRONOUN/m_c/subject} asked {PRONOUN/r_c/poss} if they could get back together again. Unfortunately r_c said no.",
 		"m_c asked r_c if they could become mates again. The answer is no - they broke up for a reason.",
-		"m_c regrets breaking up with r_c, so {PRONOUN/m_c/subject} {VERB/m_c/ask/asks} r_c to be {PRONOUN/m_c/poss} mate again but r_c rejects {PRONOUN/m_c/object}.",
+		"m_c regrets breaking up with r_c, so {PRONOUN/m_c/subject} {VERB/m_c/ask/asks} r_c to be {PRONOUN/m_c/poss} mate again. r_c rejects {PRONOUN/m_c/object}.",
 		"Some cats may say it is wrong to get back with your ex-mate, but m_c just can't ignore these leftover feelings any longer! So {PRONOUN/m_c/subject} confessed to r_c, but got rejected. Perhaps those cats were right?",
         "m_c still has feelings for r_c and wants {PRONOUN/r_c/object} back. {PRONOUN/m_c/subject/CAP} {VERB/m_c/plead/pleads} r_c to get back with {PRONOUN/m_c/object} in the middle of the clearing. Weirded out and embarrassed, r_c had to reject {PRONOUN/m_c/object} ...publicly."
 	],

--- a/resources/lang/en/events/relationship_events/become_mates_poly.json
+++ b/resources/lang/en/events/relationship_events/become_mates_poly.json
@@ -79,7 +79,7 @@
 	"makeup_fail":{
 		"m_c_mates": [
 			"m_c loves [m_c_mates], but {PRONOUN/m_c/subject} still has feelings for r_c, even after their break up. After a talk with [m_c_mates], m_c confessed {PRONOUN/m_c/poss} feelings to r_c, but got rejected.",
-			"After a talk with {PRONOUN/m_c/poss} (m_c_mate/mates), m_c confessed {PRONOUN/m_c/poss} feelings to r_c, but was turned down.",
+			"After a talk with {PRONOUN/m_c/poss} (m_c_mate/mates), m_c confessed {PRONOUN/m_c/poss} feelings to r_c, but was turned down."
 		],
 		"r_c_mates": [
 			"m_c wants to get back with r_c, so {PRONOUN/m_c/subject} confessed {PRONOUN/m_c/poss} feelings to r_c. After r_c consulted with {PRONOUN/r_c/poss} (r_c_mate/mates), r_c rejected {PRONOUN/m_c/object}."

--- a/resources/lang/en/events/relationship_events/become_mates_poly.json
+++ b/resources/lang/en/events/relationship_events/become_mates_poly.json
@@ -49,5 +49,43 @@
 		"both_mates": [
 			"m_c confessed {PRONOUN/m_c/poss} feelings to r_c, but was rejected."
 		]
+	},
+	"high_romantic_makeup": {
+		"m_c_mates": [
+			"m_c loves [m_c_mates], but {PRONOUN/m_c/subject} still has feelings for r_c, even after their break up. After a talk with [m_c_mates], m_c confessed {PRONOUN/m_c/poss} feelings to r_c, and they have become mates again.",
+			"After a talk with {PRONOUN/m_c/poss} (m_c_mate/mates), m_c asked r_c if they can become mates again, r_c accepted and they have gotten back together."
+		],
+		"r_c_mates": [
+            "m_c wants to start things over with r_c. After {PRONOUN/r_c/subject} talked with [r_c_mates], m_c and r_c have gotten back together.",
+            "m_c told r_c that {PRONOUN/m_c/subject} {VERB/m_c/want/wants} to get back with {PRONOUN/r_c/object}. After r_c talked with {PRONOUN/r_c/poss} (r_c_mate/mates), m_c and r_c have become mates again."
+		],
+		"both_mates": [
+			"m_c and r_c realized they still had feelings for each other and after talking with their mates, they got back together."
+		]
+	},
+	"low_romantic_makeup":{
+		"m_c_mates": [
+			"After m_c talked about {PRONOUN/m_c/poss} lingering feelings for r_c with [m_c_mates], m_c and r_c have gotten back together.",
+			"After m_c talked about {PRONOUN/m_c/poss} left over feelings for r_c with {PRONOUN/m_c/poss} (m_c_mate/mates), m_c and r_c have become mates again."
+		],
+		"r_c_mates": [
+            "After r_c talked with [r_c_mates] about {PRONOUN/r_c/poss} lingering feelings for m_c, m_c and r_c have become mates again.",
+            "After r_c talked with {PRONOUN/r_c/poss} (r_c_mate/mates) about {PRONOUN/r_c/poss} left over feelings for m_c, m_c and r_c have gotten back together."
+		],
+		"both_mates": [
+			"m_c and r_c realized they still had feelings for each other and after talking with their mates, they got back together."
+		]
+	},
+	"makeup_fail":{
+		"m_c_mates": [
+			"m_c loves [m_c_mates], but {PRONOUN/m_c/subject} still has feelings for r_c, even after their break up. After a talk with [m_c_mates], m_c confessed {PRONOUN/m_c/poss} feelings to r_c, but got rejected.",
+			"After a talk with {PRONOUN/m_c/poss} (m_c_mate/mates), m_c confessed {PRONOUN/m_c/poss} feelings to r_c, but was turned down.",
+		],
+		"r_c_mates": [
+			"m_c wants to get back with r_c, so {PRONOUN/m_c/subject} confessed {PRONOUN/m_c/poss} feelings to r_c. After r_c consulted with {PRONOUN/r_c/poss} (r_c_mate/mates), r_c rejected {PRONOUN/m_c/object}."
+		],
+		"both_mates": [
+			"Even though they broke up and have taken up new mates, m_c still wants to start things over with r_c. Unfortunatley, r_c doesn't feel the same and rejects {PRONOUN/m_c/object}, already content with {PRONOUN/r_c/poss} current (r_c_mate/mates)."
+		]
 	}
 }

--- a/resources/lang/en/events/relationship_events/become_mates_poly.json
+++ b/resources/lang/en/events/relationship_events/become_mates_poly.json
@@ -53,14 +53,14 @@
 	"high_romantic_makeup": {
 		"m_c_mates": [
 			"m_c loves [m_c_mates], but {PRONOUN/m_c/subject} still has feelings for r_c, even after their break up. After a talk with [m_c_mates], m_c confessed {PRONOUN/m_c/poss} feelings to r_c, and they have become mates again.",
-			"After a talk with {PRONOUN/m_c/poss} (m_c_mate/mates), m_c asked r_c if they can become mates again, r_c accepted and they have gotten back together."
+			"After a talk with {PRONOUN/m_c/poss} (m_c_mate/mates), m_c asked r_c if they could become mates again, r_c accepted, and they have gotten back together."
 		],
 		"r_c_mates": [
             "m_c wants to start things over with r_c. After {PRONOUN/r_c/subject} talked with [r_c_mates], m_c and r_c have gotten back together.",
             "m_c told r_c that {PRONOUN/m_c/subject} {VERB/m_c/want/wants} to get back with {PRONOUN/r_c/object}. After r_c talked with {PRONOUN/r_c/poss} (r_c_mate/mates), m_c and r_c have become mates again."
 		],
 		"both_mates": [
-			"m_c and r_c realized they still had feelings for each other and after talking with their mates, they got back together."
+			"m_c and r_c realized they still had feelings for each other, and after talking with their mates, they got back together."
 		]
 	},
 	"low_romantic_makeup":{
@@ -73,7 +73,7 @@
             "After r_c talked with {PRONOUN/r_c/poss} (r_c_mate/mates) about {PRONOUN/r_c/poss} left over feelings for m_c, m_c and r_c have gotten back together."
 		],
 		"both_mates": [
-			"m_c and r_c realized they still had feelings for each other and after talking with their mates, they got back together."
+			"m_c and r_c realized they still had feelings for each other, and after talking with their mates, they got back together."
 		]
 	},
 	"makeup_fail":{

--- a/resources/lang/en/events/relationship_events/become_mates_poly.json
+++ b/resources/lang/en/events/relationship_events/become_mates_poly.json
@@ -85,7 +85,7 @@
 			"m_c wants to get back with r_c, so {PRONOUN/m_c/subject} confessed {PRONOUN/m_c/poss} feelings to r_c. After r_c consulted with {PRONOUN/r_c/poss} (r_c_mate/mates), r_c rejected {PRONOUN/m_c/object}."
 		],
 		"both_mates": [
-			"Even though they broke up and have taken up new mates, m_c still wants to start things over with r_c. Unfortunatley, r_c doesn't feel the same and rejects {PRONOUN/m_c/object}, already content with {PRONOUN/r_c/poss} current (r_c_mate/mates)."
+			"Even though they broke up and have taken up new mates, m_c still wants to start things over with r_c. Unfortunately, r_c doesn't feel the same and rejects {PRONOUN/m_c/object}, already content with {PRONOUN/r_c/poss} current {VERB/r_c/mate/mates}."
 		]
 	}
 }

--- a/resources/lang/en/events/relationship_events/become_mates_poly.json
+++ b/resources/lang/en/events/relationship_events/become_mates_poly.json
@@ -73,7 +73,7 @@
             "After r_c talked with {PRONOUN/r_c/poss} (r_c_mate/mates) about {PRONOUN/r_c/poss} left over feelings for m_c, m_c and r_c have gotten back together."
 		],
 		"both_mates": [
-			"m_c and r_c realized they still had feelings for each other, and after talking with their mates, they got back together."
+			"m_c and r_c realized they still have feelings for each other, and after talking with their mates, they got back together."
 		]
 	},
 	"makeup_fail":{

--- a/resources/lang/en/events/relationship_events/become_mates_poly.json
+++ b/resources/lang/en/events/relationship_events/become_mates_poly.json
@@ -56,7 +56,7 @@
 			"After a talk with {PRONOUN/m_c/poss} (m_c_mate/mates), m_c asked r_c if they could become mates again, r_c accepted, and they have gotten back together."
 		],
 		"r_c_mates": [
-            "m_c wants to start things over with r_c. After {PRONOUN/r_c/subject} talked with [r_c_mates], m_c and r_c have gotten back together.",
+            "m_c wants to start things over with r_c. After r_c talked with [r_c_mates], m_c and r_c have gotten back together.",
             "m_c told r_c that {PRONOUN/m_c/subject} {VERB/m_c/want/wants} to get back with {PRONOUN/r_c/object}. After r_c talked with {PRONOUN/r_c/poss} (r_c_mate/mates), m_c and r_c have become mates again."
 		],
 		"both_mates": [

--- a/resources/lang/en/events/relationship_events/become_mates_poly.json
+++ b/resources/lang/en/events/relationship_events/become_mates_poly.json
@@ -85,7 +85,7 @@
 			"m_c wants to get back with r_c, so {PRONOUN/m_c/subject} confessed {PRONOUN/m_c/poss} feelings to r_c. After r_c consulted with {PRONOUN/r_c/poss} (r_c_mate/mates), r_c rejected {PRONOUN/m_c/object}."
 		],
 		"both_mates": [
-			"Even though they broke up and have taken up new mates, m_c still wants to start things over with r_c. Unfortunately, r_c doesn't feel the same and rejects {PRONOUN/m_c/object}, already content with {PRONOUN/r_c/poss} current {VERB/r_c/mate/mates}."
+			"Even though they broke up and have taken up new mates, m_c still wants to start things over with r_c. Unfortunately, r_c doesn't feel the same and rejects {PRONOUN/m_c/object}, already content with {PRONOUN/r_c/poss} current (r_c_mate/mates)."
 		]
 	}
 }

--- a/scripts/events_module/relationship/romantic_events.py
+++ b/scripts/events_module/relationship/romantic_events.py
@@ -589,7 +589,7 @@ class RomanticEvents:
                     "high_romantic", poly, cat_from, cat_to
                 )
         else:
-            if cat_from.ID in cat_to.previous_mates and cat_to.ID in cat_to.previous_mates:
+            if cat_from.ID in cat_to.previous_mates and cat_to.ID in cat_from.previous_mates:
                 mate_string = RomanticEvents.get_mate_string(
                     "makeup_fail", poly, cat_from, cat_to
                 )

--- a/scripts/events_module/relationship/romantic_events.py
+++ b/scripts/events_module/relationship/romantic_events.py
@@ -599,7 +599,7 @@ class RomanticEvents:
                 cat_to.relationships[cat_from.ID].respect -= 5
             else:
                 mate_string = RomanticEvents.get_mate_string(
-                "rejected", poly, cat_from, cat_to
+                    "rejected", poly, cat_from, cat_to
                 )
                 cat_from.relationships[cat_to.ID].romance -= 10
                 cat_to.relationships[cat_from.ID].comfort -= 10

--- a/scripts/events_module/relationship/romantic_events.py
+++ b/scripts/events_module/relationship/romantic_events.py
@@ -564,7 +564,7 @@ class RomanticEvents:
             if cat_from.ID in cat_to.previous_mates and cat_to.ID in cat_from.previous_mates:
                 become_mate = True
                 mate_string = RomanticEvents.get_mate_string(
-                "high_romantic_makeup", poly, cat_from, cat_to
+                    "high_romantic_makeup", poly, cat_from, cat_to
             )
             else:
                 become_mate = True
@@ -581,7 +581,7 @@ class RomanticEvents:
             if cat_from.ID in cat_to.previous_mates and cat_to.ID in cat_from.previous_mates:
                 become_mate = True
                 mate_string = RomanticEvents.get_mate_string(
-                "high_romantic_makeup", poly, cat_from, cat_to
+                    "high_romantic_makeup", poly, cat_from, cat_to
             )
             else:
                 become_mate = True
@@ -591,7 +591,7 @@ class RomanticEvents:
         else:
             if cat_from.ID in cat_to.previous_mates and cat_to.ID in cat_to.previous_mates:
                 mate_string = RomanticEvents.get_mate_string(
-                "makeup_fail", poly, cat_from, cat_to
+                    "makeup_fail", poly, cat_from, cat_to
             )
                 cat_from.relationships[cat_to.ID].romance -= 20
                 cat_to.relationships[cat_from.ID].comfort -= 20
@@ -710,7 +710,7 @@ class RomanticEvents:
             if cat_from.ID in cat_to.previous_mates and cat_to.ID in cat_from.previous_mates:
                 become_mate = True
                 mate_string = RomanticEvents.get_mate_string(
-                "low_romantic_makeup", poly, cat_from, cat_to
+                    "low_romantic_makeup", poly, cat_from, cat_to
             )
             else:
                 become_mates = True

--- a/scripts/events_module/relationship/romantic_events.py
+++ b/scripts/events_module/relationship/romantic_events.py
@@ -734,7 +734,7 @@ class RomanticEvents:
                 become_mate = True
                 mate_string = RomanticEvents.get_mate_string(
                     "low_romantic_makeup", poly, cat_from, cat_to
-            ) 
+                ) 
             else:
                 become_mates = True
                 mate_string = RomanticEvents.get_mate_string(

--- a/scripts/events_module/relationship/romantic_events.py
+++ b/scripts/events_module/relationship/romantic_events.py
@@ -715,7 +715,7 @@ class RomanticEvents:
             else:
                 become_mates = True
                 mate_string = RomanticEvents.get_mate_string(
-                    "low_romantic_makeup", poly, cat_from, cat_to
+                    "low_romantic", poly, cat_from, cat_to
                 )
         if (
             not random_hit

--- a/scripts/events_module/relationship/romantic_events.py
+++ b/scripts/events_module/relationship/romantic_events.py
@@ -592,7 +592,7 @@ class RomanticEvents:
             if cat_from.ID in cat_to.previous_mates and cat_to.ID in cat_to.previous_mates:
                 mate_string = RomanticEvents.get_mate_string(
                     "makeup_fail", poly, cat_from, cat_to
-            )
+                )
                 cat_from.relationships[cat_to.ID].romance -= 20
                 cat_to.relationships[cat_from.ID].comfort -= 20
                 cat_to.relationships[cat_from.ID].like -= 10

--- a/scripts/events_module/relationship/romantic_events.py
+++ b/scripts/events_module/relationship/romantic_events.py
@@ -561,10 +561,16 @@ class RomanticEvents:
             rel_to_check = highest_romantic_relation.opposite_relationship
 
         if RomanticEvents.relationship_fulfill_condition(rel_to_check, condition):
-            become_mate = True
-            mate_string = RomanticEvents.get_mate_string(
-                "high_romantic", poly, cat_from, cat_to
+            if cat_from.ID in cat_to.previous_mates and cat_to.ID in cat_from.previous_mates:
+                become_mate = True
+                mate_string = RomanticEvents.get_mate_string(
+                "high_romantic_makeup", poly, cat_from, cat_to
             )
+            else:
+                become_mate = True
+                mate_string = RomanticEvents.get_mate_string(
+                    "high_romantic", poly, cat_from, cat_to
+                )
         # second acceptance chance if the romantic is high enough
         elif (
             RelType.ROMANCE in condition
@@ -572,16 +578,31 @@ class RomanticEvents:
             and condition[RelType.ROMANCE] > 0
             and rel_to_check.romance >= condition[RelType.ROMANCE] * 1.5
         ):
-            become_mate = True
-            mate_string = RomanticEvents.get_mate_string(
-                "high_romantic", poly, cat_from, cat_to
+            if cat_from.ID in cat_to.previous_mates and cat_to.ID in cat_from.previous_mates:
+                become_mate = True
+                mate_string = RomanticEvents.get_mate_string(
+                "high_romantic_makeup", poly, cat_from, cat_to
             )
+            else:
+                become_mate = True
+                mate_string = RomanticEvents.get_mate_string(
+                    "high_romantic", poly, cat_from, cat_to
+                )
         else:
-            mate_string = RomanticEvents.get_mate_string(
-                "rejected", poly, cat_from, cat_to
+            if cat_from.ID in cat_to.previous_mates and cat_to.ID in cat_to.previous_mates:
+                mate_string = RomanticEvents.get_mate_string(
+                "makeup_fail", poly, cat_from, cat_to
             )
-            cat_from.relationships[cat_to.ID].romance -= 10
-            cat_to.relationships[cat_from.ID].comfort -= 10
+                cat_from.relationships[cat_to.ID].romance -= 20
+                cat_to.relationships[cat_from.ID].comfort -= 20
+                cat_to.relationships[cat_from.ID].like -= 10
+                cat_to.relationships[cat_from.ID].respect -= 5
+            else:
+                mate_string = RomanticEvents.get_mate_string(
+                "rejected", poly, cat_from, cat_to
+                )
+                cat_from.relationships[cat_to.ID].romance -= 10
+                cat_to.relationships[cat_from.ID].comfort -= 10
 
         mate_string = RomanticEvents.prepare_relationship_string(
             mate_string, cat_from, cat_to
@@ -686,10 +707,16 @@ class RomanticEvents:
                 relationship_to, constants.CONFIG["mates"]["mate_condition"]
             )
         ):
-            become_mates = True
-            mate_string = RomanticEvents.get_mate_string(
-                "low_romantic", poly, cat_from, cat_to
+            if cat_from.ID in cat_to.previous_mates and cat_to.ID in cat_from.previous_mates:
+                become_mate = True
+                mate_string = RomanticEvents.get_mate_string(
+                "low_romantic_makeup", poly, cat_from, cat_to
             )
+            else:
+                become_mates = True
+                mate_string = RomanticEvents.get_mate_string(
+                    "low_romantic_makeup", poly, cat_from, cat_to
+                )
         if (
             not random_hit
             and RomanticEvents.relationship_fulfill_condition(

--- a/scripts/events_module/relationship/romantic_events.py
+++ b/scripts/events_module/relationship/romantic_events.py
@@ -726,10 +726,20 @@ class RomanticEvents:
                 relationship_to, constants.CONFIG["mates"]["like_to_romance"]
             )
         ):
-            become_mates = True
-            mate_string = RomanticEvents.get_mate_string(
-                "like_to_romance", poly, cat_from, cat_to
-            )
+            # had to reuse the low_romantic_makeup thing for here just in case we have a scenario  
+            # where mates break up and both cats have no pink in their romance bar for each other 
+            # anymore, but get back together only because of the like_to_romance chance, plus I'd 
+            # imagine the conversations would go about the same if they do make up because of this
+            if cat_from.ID in cat_to.previous_mates and cat_to.ID in cat_from.previous_mates:
+                become_mate = True
+                mate_string = RomanticEvents.get_mate_string(
+                    "low_romantic_makeup", poly, cat_from, cat_to
+            ) 
+            else:
+                become_mates = True
+                mate_string = RomanticEvents.get_mate_string(
+                    "like_to_romance", poly, cat_from, cat_to
+                )
 
         if not become_mates:
             return False, None

--- a/scripts/events_module/relationship/romantic_events.py
+++ b/scripts/events_module/relationship/romantic_events.py
@@ -568,12 +568,12 @@ class RomanticEvents:
                 become_mate = True
                 mate_string = RomanticEvents.get_mate_string(
                     "high_romantic_makeup", poly, cat_from, cat_to
-                )
+            )
             else:
                 become_mate = True
                 mate_string = RomanticEvents.get_mate_string(
                     "high_romantic", poly, cat_from, cat_to
-                )
+            )
         # second acceptance chance if the romantic is high enough
         elif (
             RelType.ROMANCE in condition
@@ -588,12 +588,12 @@ class RomanticEvents:
                 become_mate = True
                 mate_string = RomanticEvents.get_mate_string(
                     "high_romantic_makeup", poly, cat_from, cat_to
-                )
+            )
             else:
                 become_mate = True
                 mate_string = RomanticEvents.get_mate_string(
                     "high_romantic", poly, cat_from, cat_to
-                )
+            )
         else:
             if (
                 cat_from.ID in cat_to.previous_mates 
@@ -601,7 +601,7 @@ class RomanticEvents:
             ):
                 mate_string = RomanticEvents.get_mate_string(
                     "makeup_fail", poly, cat_from, cat_to
-                )
+            )
                 cat_from.relationships[cat_to.ID].romance -= 20
                 cat_to.relationships[cat_from.ID].comfort -= 20
                 cat_to.relationships[cat_from.ID].like -= 10
@@ -609,7 +609,7 @@ class RomanticEvents:
             else:
                 mate_string = RomanticEvents.get_mate_string(
                     "rejected", poly, cat_from, cat_to
-                )
+            )
                 cat_from.relationships[cat_to.ID].romance -= 10
                 cat_to.relationships[cat_from.ID].comfort -= 10
 
@@ -749,12 +749,12 @@ class RomanticEvents:
                 become_mate = True
                 mate_string = RomanticEvents.get_mate_string(
                     "low_romantic_makeup", poly, cat_from, cat_to
-                ) 
+            ) 
             else:
                 become_mates = True
                 mate_string = RomanticEvents.get_mate_string(
                     "like_to_romance", poly, cat_from, cat_to
-                )
+            )
 
         if not become_mates:
             return False, None

--- a/scripts/events_module/relationship/romantic_events.py
+++ b/scripts/events_module/relationship/romantic_events.py
@@ -516,7 +516,7 @@ class RomanticEvents:
         return: bool if event is triggered or not
         """
 
-        # get the highest romantic love relationships and
+        # get the highest romantic love relationships
         rel_list = cat_from.relationships.values()
         highest_romantic_relation = get_highest_romantic_relation(
             rel_list, exclude_mate=True
@@ -544,9 +544,7 @@ class RomanticEvents:
             mate for mate in cat_from.mate if cat_from.status.alive_in_player_clan
         ]
         alive_inclan_to_mates = [
-            mate
-            for mate in cat_to.mate
-            if cat_to.fetch_cat(mate).status.alive_in_player_clan
+            mate for mate in cat_to.mate if cat_to.fetch_cat(mate).status.alive_in_player_clan
         ]
         poly = len(alive_inclan_from_mates) > 0 or len(alive_inclan_to_mates) > 0
 
@@ -574,7 +572,6 @@ class RomanticEvents:
                 mate_string = RomanticEvents.get_mate_string(
                     "high_romantic", poly, cat_from, cat_to
                 )
-        # second acceptance chance if the romantic is high enough
         elif (
             RelType.ROMANCE in condition
             and condition[RelType.ROMANCE] != 0
@@ -613,9 +610,7 @@ class RomanticEvents:
                 cat_from.relationships[cat_to.ID].romance -= 10
                 cat_to.relationships[cat_from.ID].comfort -= 10
 
-        mate_string = RomanticEvents.prepare_relationship_string(
-            mate_string, cat_from, cat_to
-        )
+        mate_string = RomanticEvents.prepare_relationship_string(mate_string, cat_from, cat_to)
         game.cur_events_list.append(
             Single_Event(
                 mate_string,
@@ -684,23 +679,17 @@ class RomanticEvents:
         mate_chance = constants.CONFIG["mates"]["chance_fulfilled_condition"]
         hit = int(random.random() * mate_chance)
 
-        # has to be high because every moon this will be checked for each relationship in the game
         friends_to_lovers = constants.CONFIG["mates"]["chance_friends_to_lovers"]
         random_hit = int(random.random() * friends_to_lovers)
 
-        # already return if there is 'no' hit (everything above 0), other checks are not necessary
         if hit > 0 and random_hit > 0:
             return False, None
 
         alive_inclan_from_mates = [
-            mate
-            for mate in cat_from.mate
-            if cat_from.fetch_cat(mate).status.alive_in_player_clan
+            mate for mate in cat_from.mate if cat_from.fetch_cat(mate).status.alive_in_player_clan
         ]
         alive_inclan_to_mates = [
-            mate
-            for mate in cat_to.mate
-            if cat_to.fetch_cat(mate).status.alive_in_player_clan
+            mate for mate in cat_to.mate if cat_to.fetch_cat(mate).status.alive_in_player_clan
         ]
         poly = len(alive_inclan_from_mates) > 0 or len(alive_inclan_to_mates) > 0
 
@@ -723,12 +712,13 @@ class RomanticEvents:
                 become_mates = True
                 mate_string = RomanticEvents.get_mate_string(
                     "low_romantic_makeup", poly, cat_from, cat_to
-            )
+                )
             else:
                 become_mates = True
                 mate_string = RomanticEvents.get_mate_string(
                     "low_romantic", poly, cat_from, cat_to
                 )
+
         if (
             not random_hit
             and RomanticEvents.relationship_fulfill_condition(
@@ -738,10 +728,6 @@ class RomanticEvents:
                 relationship_to, constants.CONFIG["mates"]["like_to_romance"]
             )
         ):
-            # had to reuse the low_romantic_makeup thing for here just in case we have a scenario  
-            # where mates break up and both cats have no pink in their romance bar for each other 
-            # anymore, but get back together only because of the like_to_romance chance, plus I'd 
-            # imagine the conversations would go about the same if they do make up because of this
             if (
                 cat_from.ID in cat_to.previous_mates
                 and cat_to.ID in cat_from.previous_mates
@@ -749,7 +735,7 @@ class RomanticEvents:
                 become_mates = True
                 mate_string = RomanticEvents.get_mate_string(
                     "low_romantic_makeup", poly, cat_from, cat_to
-                ) 
+                )
             else:
                 become_mates = True
                 mate_string = RomanticEvents.get_mate_string(
@@ -764,12 +750,10 @@ class RomanticEvents:
             print(cat_from.mate)
             print(cat_to.mate)
 
-        mate_string = RomanticEvents.prepare_relationship_string(
-            mate_string, cat_from, cat_to
-        )
+        mate_string = RomanticEvents.prepare_relationship_string(mate_string, cat_from, cat_to)
 
         return become_mates, mate_string
-
+        
     @staticmethod
     def relationship_fulfill_condition(relationship, condition):
         """

--- a/scripts/events_module/relationship/romantic_events.py
+++ b/scripts/events_module/relationship/romantic_events.py
@@ -720,7 +720,7 @@ class RomanticEvents:
                 cat_from.ID in cat_to.previous_mates
                 and cat_to.ID in cat_from.previous_mates
             ):
-                become_mate = True
+                become_mates = True
                 mate_string = RomanticEvents.get_mate_string(
                     "low_romantic_makeup", poly, cat_from, cat_to
             )
@@ -746,7 +746,7 @@ class RomanticEvents:
                 cat_from.ID in cat_to.previous_mates
                 and cat_to.ID in cat_from.previous_mates
             ):
-                become_mate = True
+                become_mates = True
                 mate_string = RomanticEvents.get_mate_string(
                     "low_romantic_makeup", poly, cat_from, cat_to
                 ) 

--- a/scripts/events_module/relationship/romantic_events.py
+++ b/scripts/events_module/relationship/romantic_events.py
@@ -561,7 +561,9 @@ class RomanticEvents:
             rel_to_check = highest_romantic_relation.opposite_relationship
 
         if RomanticEvents.relationship_fulfill_condition(rel_to_check, condition):
-            if cat_from.ID in cat_to.previous_mates and cat_to.ID in cat_from.previous_mates:
+            if (
+                cat_from.ID in cat_to.previous_mates and cat_to.ID in cat_from.previous_mates
+            ):
                 become_mate = True
                 mate_string = RomanticEvents.get_mate_string(
                     "high_romantic_makeup", poly, cat_from, cat_to
@@ -578,7 +580,9 @@ class RomanticEvents:
             and condition[RelType.ROMANCE] > 0
             and rel_to_check.romance >= condition[RelType.ROMANCE] * 1.5
         ):
-            if cat_from.ID in cat_to.previous_mates and cat_to.ID in cat_from.previous_mates:
+            if (
+                cat_from.ID in cat_to.previous_mates and cat_to.ID in cat_from.previous_mates
+            ):
                 become_mate = True
                 mate_string = RomanticEvents.get_mate_string(
                     "high_romantic_makeup", poly, cat_from, cat_to
@@ -589,7 +593,9 @@ class RomanticEvents:
                     "high_romantic", poly, cat_from, cat_to
                 )
         else:
-            if cat_from.ID in cat_to.previous_mates and cat_to.ID in cat_from.previous_mates:
+            if (
+                cat_from.ID in cat_to.previous_mates and cat_to.ID in cat_from.previous_mates
+            ):
                 mate_string = RomanticEvents.get_mate_string(
                     "makeup_fail", poly, cat_from, cat_to
                 )

--- a/scripts/events_module/relationship/romantic_events.py
+++ b/scripts/events_module/relationship/romantic_events.py
@@ -582,7 +582,7 @@ class RomanticEvents:
             and rel_to_check.romance >= condition[RelType.ROMANCE] * 1.5
         ):
             if (
-                cat_from.ID in cat_to.previous_mates 
+                cat_from.ID in cat_to.previous_mates
                 and cat_to.ID in cat_from.previous_mates
             ):
                 become_mate = True
@@ -596,7 +596,7 @@ class RomanticEvents:
                 )
         else:
             if (
-                cat_from.ID in cat_to.previous_mates 
+                cat_from.ID in cat_to.previous_mates
                 and cat_to.ID in cat_from.previous_mates
             ):
                 mate_string = RomanticEvents.get_mate_string(
@@ -717,13 +717,13 @@ class RomanticEvents:
             )
         ):
             if (
-                cat_from.ID in cat_to.previous_mates 
+                cat_from.ID in cat_to.previous_mates
                 and cat_to.ID in cat_from.previous_mates
             ):
                 become_mate = True
                 mate_string = RomanticEvents.get_mate_string(
                     "low_romantic_makeup", poly, cat_from, cat_to
-                )
+            )
             else:
                 become_mates = True
                 mate_string = RomanticEvents.get_mate_string(
@@ -743,7 +743,7 @@ class RomanticEvents:
             # anymore, but get back together only because of the like_to_romance chance, plus I'd 
             # imagine the conversations would go about the same if they do make up because of this
             if (
-                cat_from.ID in cat_to.previous_mates 
+                cat_from.ID in cat_to.previous_mates
                 and cat_to.ID in cat_from.previous_mates
             ):
                 become_mate = True

--- a/scripts/events_module/relationship/romantic_events.py
+++ b/scripts/events_module/relationship/romantic_events.py
@@ -562,7 +562,8 @@ class RomanticEvents:
 
         if RomanticEvents.relationship_fulfill_condition(rel_to_check, condition):
             if (
-                cat_from.ID in cat_to.previous_mates and cat_to.ID in cat_from.previous_mates
+                cat_from.ID in cat_to.previous_mates 
+                and cat_to.ID in cat_from.previous_mates
             ):
                 become_mate = True
                 mate_string = RomanticEvents.get_mate_string(
@@ -581,7 +582,8 @@ class RomanticEvents:
             and rel_to_check.romance >= condition[RelType.ROMANCE] * 1.5
         ):
             if (
-                cat_from.ID in cat_to.previous_mates and cat_to.ID in cat_from.previous_mates
+                cat_from.ID in cat_to.previous_mates 
+                and cat_to.ID in cat_from.previous_mates
             ):
                 become_mate = True
                 mate_string = RomanticEvents.get_mate_string(
@@ -594,7 +596,8 @@ class RomanticEvents:
                 )
         else:
             if (
-                cat_from.ID in cat_to.previous_mates and cat_to.ID in cat_from.previous_mates
+                cat_from.ID in cat_to.previous_mates 
+                and cat_to.ID in cat_from.previous_mates
             ):
                 mate_string = RomanticEvents.get_mate_string(
                     "makeup_fail", poly, cat_from, cat_to
@@ -714,7 +717,8 @@ class RomanticEvents:
             )
         ):
             if (
-                cat_from.ID in cat_to.previous_mates and cat_to.ID in cat_from.previous_mates
+                cat_from.ID in cat_to.previous_mates 
+                and cat_to.ID in cat_from.previous_mates
             ):
                 become_mate = True
                 mate_string = RomanticEvents.get_mate_string(
@@ -739,7 +743,8 @@ class RomanticEvents:
             # anymore, but get back together only because of the like_to_romance chance, plus I'd 
             # imagine the conversations would go about the same if they do make up because of this
             if (
-                cat_from.ID in cat_to.previous_mates and cat_to.ID in cat_from.previous_mates
+                cat_from.ID in cat_to.previous_mates 
+                and cat_to.ID in cat_from.previous_mates
             ):
                 become_mate = True
                 mate_string = RomanticEvents.get_mate_string(

--- a/scripts/events_module/relationship/romantic_events.py
+++ b/scripts/events_module/relationship/romantic_events.py
@@ -561,16 +561,15 @@ class RomanticEvents:
             rel_to_check = highest_romantic_relation.opposite_relationship
 
         if RomanticEvents.relationship_fulfill_condition(rel_to_check, condition):
+            become_mate = True
             if (
                 cat_from.ID in cat_to.previous_mates
                 and cat_to.ID in cat_from.previous_mates
             ):
-                become_mate = True
                 mate_string = RomanticEvents.get_mate_string(
                     "high_romantic_makeup", poly, cat_from, cat_to
                 )
             else:
-                become_mate = True
                 mate_string = RomanticEvents.get_mate_string(
                     "high_romantic", poly, cat_from, cat_to
                 )

--- a/scripts/events_module/relationship/romantic_events.py
+++ b/scripts/events_module/relationship/romantic_events.py
@@ -745,7 +745,7 @@ class RomanticEvents:
                 become_mates = True
                 mate_string = RomanticEvents.get_mate_string(
                     "low_romantic_makeup", poly, cat_from, cat_to
-                ) 
+                )
             else:
                 become_mates = True
                 mate_string = RomanticEvents.get_mate_string(

--- a/scripts/events_module/relationship/romantic_events.py
+++ b/scripts/events_module/relationship/romantic_events.py
@@ -738,10 +738,6 @@ class RomanticEvents:
                 relationship_to, constants.CONFIG["mates"]["like_to_romance"]
             )
         ):
-            # had to reuse the low_romantic_makeup thing for here just in case we have a scenario  
-            # where mates break up and both cats have no pink in their romance bar for each other 
-            # anymore, but get back together only because of the like_to_romance chance, plus I'd 
-            # imagine the conversations would go about the same if they do make up because of this
             if (
                 cat_from.ID in cat_to.previous_mates
                 and cat_to.ID in cat_from.previous_mates

--- a/scripts/events_module/relationship/romantic_events.py
+++ b/scripts/events_module/relationship/romantic_events.py
@@ -516,7 +516,7 @@ class RomanticEvents:
         return: bool if event is triggered or not
         """
 
-        # get the highest romantic love relationships
+        # get the highest romantic love relationships and
         rel_list = cat_from.relationships.values()
         highest_romantic_relation = get_highest_romantic_relation(
             rel_list, exclude_mate=True
@@ -544,7 +544,9 @@ class RomanticEvents:
             mate for mate in cat_from.mate if cat_from.status.alive_in_player_clan
         ]
         alive_inclan_to_mates = [
-            mate for mate in cat_to.mate if cat_to.fetch_cat(mate).status.alive_in_player_clan
+            mate
+            for mate in cat_to.mate
+            if cat_to.fetch_cat(mate).status.alive_in_player_clan
         ]
         poly = len(alive_inclan_from_mates) > 0 or len(alive_inclan_to_mates) > 0
 
@@ -572,6 +574,7 @@ class RomanticEvents:
                 mate_string = RomanticEvents.get_mate_string(
                     "high_romantic", poly, cat_from, cat_to
                 )
+        # second acceptance chance if the romantic is high enough
         elif (
             RelType.ROMANCE in condition
             and condition[RelType.ROMANCE] != 0
@@ -610,7 +613,9 @@ class RomanticEvents:
                 cat_from.relationships[cat_to.ID].romance -= 10
                 cat_to.relationships[cat_from.ID].comfort -= 10
 
-        mate_string = RomanticEvents.prepare_relationship_string(mate_string, cat_from, cat_to)
+        mate_string = RomanticEvents.prepare_relationship_string(
+            mate_string, cat_from, cat_to
+        )
         game.cur_events_list.append(
             Single_Event(
                 mate_string,
@@ -679,17 +684,23 @@ class RomanticEvents:
         mate_chance = constants.CONFIG["mates"]["chance_fulfilled_condition"]
         hit = int(random.random() * mate_chance)
 
+        # has to be high because every moon this will be checked for each relationship in the game
         friends_to_lovers = constants.CONFIG["mates"]["chance_friends_to_lovers"]
         random_hit = int(random.random() * friends_to_lovers)
 
+        # already return if there is 'no' hit (everything above 0), other checks are not necessary
         if hit > 0 and random_hit > 0:
             return False, None
 
         alive_inclan_from_mates = [
-            mate for mate in cat_from.mate if cat_from.fetch_cat(mate).status.alive_in_player_clan
+            mate
+            for mate in cat_from.mate
+            if cat_from.fetch_cat(mate).status.alive_in_player_clan
         ]
         alive_inclan_to_mates = [
-            mate for mate in cat_to.mate if cat_to.fetch_cat(mate).status.alive_in_player_clan
+            mate
+            for mate in cat_to.mate
+            if cat_to.fetch_cat(mate).status.alive_in_player_clan
         ]
         poly = len(alive_inclan_from_mates) > 0 or len(alive_inclan_to_mates) > 0
 
@@ -718,7 +729,6 @@ class RomanticEvents:
                 mate_string = RomanticEvents.get_mate_string(
                     "low_romantic", poly, cat_from, cat_to
                 )
-
         if (
             not random_hit
             and RomanticEvents.relationship_fulfill_condition(
@@ -728,6 +738,10 @@ class RomanticEvents:
                 relationship_to, constants.CONFIG["mates"]["like_to_romance"]
             )
         ):
+            # had to reuse the low_romantic_makeup thing for here just in case we have a scenario  
+            # where mates break up and both cats have no pink in their romance bar for each other 
+            # anymore, but get back together only because of the like_to_romance chance, plus I'd 
+            # imagine the conversations would go about the same if they do make up because of this
             if (
                 cat_from.ID in cat_to.previous_mates
                 and cat_to.ID in cat_from.previous_mates
@@ -735,7 +749,7 @@ class RomanticEvents:
                 become_mates = True
                 mate_string = RomanticEvents.get_mate_string(
                     "low_romantic_makeup", poly, cat_from, cat_to
-                )
+                ) 
             else:
                 become_mates = True
                 mate_string = RomanticEvents.get_mate_string(
@@ -750,10 +764,12 @@ class RomanticEvents:
             print(cat_from.mate)
             print(cat_to.mate)
 
-        mate_string = RomanticEvents.prepare_relationship_string(mate_string, cat_from, cat_to)
+        mate_string = RomanticEvents.prepare_relationship_string(
+            mate_string, cat_from, cat_to
+        )
 
         return become_mates, mate_string
-        
+
     @staticmethod
     def relationship_fulfill_condition(relationship, condition):
         """

--- a/scripts/events_module/relationship/romantic_events.py
+++ b/scripts/events_module/relationship/romantic_events.py
@@ -562,18 +562,18 @@ class RomanticEvents:
 
         if RomanticEvents.relationship_fulfill_condition(rel_to_check, condition):
             if (
-                cat_from.ID in cat_to.previous_mates 
+                cat_from.ID in cat_to.previous_mates
                 and cat_to.ID in cat_from.previous_mates
             ):
                 become_mate = True
                 mate_string = RomanticEvents.get_mate_string(
                     "high_romantic_makeup", poly, cat_from, cat_to
-            )
+                )
             else:
                 become_mate = True
                 mate_string = RomanticEvents.get_mate_string(
                     "high_romantic", poly, cat_from, cat_to
-            )
+                )
         # second acceptance chance if the romantic is high enough
         elif (
             RelType.ROMANCE in condition
@@ -588,12 +588,12 @@ class RomanticEvents:
                 become_mate = True
                 mate_string = RomanticEvents.get_mate_string(
                     "high_romantic_makeup", poly, cat_from, cat_to
-            )
+                )
             else:
                 become_mate = True
                 mate_string = RomanticEvents.get_mate_string(
                     "high_romantic", poly, cat_from, cat_to
-            )
+                )
         else:
             if (
                 cat_from.ID in cat_to.previous_mates 
@@ -601,7 +601,7 @@ class RomanticEvents:
             ):
                 mate_string = RomanticEvents.get_mate_string(
                     "makeup_fail", poly, cat_from, cat_to
-            )
+                )
                 cat_from.relationships[cat_to.ID].romance -= 20
                 cat_to.relationships[cat_from.ID].comfort -= 20
                 cat_to.relationships[cat_from.ID].like -= 10
@@ -609,7 +609,7 @@ class RomanticEvents:
             else:
                 mate_string = RomanticEvents.get_mate_string(
                     "rejected", poly, cat_from, cat_to
-            )
+                )
                 cat_from.relationships[cat_to.ID].romance -= 10
                 cat_to.relationships[cat_from.ID].comfort -= 10
 
@@ -749,12 +749,12 @@ class RomanticEvents:
                 become_mate = True
                 mate_string = RomanticEvents.get_mate_string(
                     "low_romantic_makeup", poly, cat_from, cat_to
-            ) 
+                ) 
             else:
                 become_mates = True
                 mate_string = RomanticEvents.get_mate_string(
                     "like_to_romance", poly, cat_from, cat_to
-            )
+                )
 
         if not become_mates:
             return False, None

--- a/scripts/events_module/relationship/romantic_events.py
+++ b/scripts/events_module/relationship/romantic_events.py
@@ -713,7 +713,9 @@ class RomanticEvents:
                 relationship_to, constants.CONFIG["mates"]["mate_condition"]
             )
         ):
-            if cat_from.ID in cat_to.previous_mates and cat_to.ID in cat_from.previous_mates:
+            if (
+                cat_from.ID in cat_to.previous_mates and cat_to.ID in cat_from.previous_mates
+            ):
                 become_mate = True
                 mate_string = RomanticEvents.get_mate_string(
                     "low_romantic_makeup", poly, cat_from, cat_to
@@ -736,7 +738,9 @@ class RomanticEvents:
             # where mates break up and both cats have no pink in their romance bar for each other 
             # anymore, but get back together only because of the like_to_romance chance, plus I'd 
             # imagine the conversations would go about the same if they do make up because of this
-            if cat_from.ID in cat_to.previous_mates and cat_to.ID in cat_from.previous_mates:
+            if (
+                cat_from.ID in cat_to.previous_mates and cat_to.ID in cat_from.previous_mates
+            ):
                 become_mate = True
                 mate_string = RomanticEvents.get_mate_string(
                     "low_romantic_makeup", poly, cat_from, cat_to

--- a/scripts/events_module/relationship/romantic_events.py
+++ b/scripts/events_module/relationship/romantic_events.py
@@ -581,16 +581,15 @@ class RomanticEvents:
             and condition[RelType.ROMANCE] > 0
             and rel_to_check.romance >= condition[RelType.ROMANCE] * 1.5
         ):
+            become_mates = True
             if (
                 cat_from.ID in cat_to.previous_mates
                 and cat_to.ID in cat_from.previous_mates
             ):
-                become_mate = True
                 mate_string = RomanticEvents.get_mate_string(
                     "high_romantic_makeup", poly, cat_from, cat_to
                 )
             else:
-                become_mate = True
                 mate_string = RomanticEvents.get_mate_string(
                     "high_romantic", poly, cat_from, cat_to
                 )
@@ -716,16 +715,15 @@ class RomanticEvents:
                 relationship_to, constants.CONFIG["mates"]["mate_condition"]
             )
         ):
+            become_mates = True
             if (
                 cat_from.ID in cat_to.previous_mates
                 and cat_to.ID in cat_from.previous_mates
             ):
-                become_mates = True
                 mate_string = RomanticEvents.get_mate_string(
                     "low_romantic_makeup", poly, cat_from, cat_to
                 )
             else:
-                become_mates = True
                 mate_string = RomanticEvents.get_mate_string(
                     "low_romantic", poly, cat_from, cat_to
                 )
@@ -738,16 +736,15 @@ class RomanticEvents:
                 relationship_to, constants.CONFIG["mates"]["like_to_romance"]
             )
         ):
+            become_mates = True
             if (
                 cat_from.ID in cat_to.previous_mates
                 and cat_to.ID in cat_from.previous_mates
             ):
-                become_mates = True
                 mate_string = RomanticEvents.get_mate_string(
                     "low_romantic_makeup", poly, cat_from, cat_to
                 )
             else:
-                become_mates = True
                 mate_string = RomanticEvents.get_mate_string(
                     "like_to_romance", poly, cat_from, cat_to
                 )

--- a/scripts/events_module/relationship/romantic_events.py
+++ b/scripts/events_module/relationship/romantic_events.py
@@ -568,7 +568,7 @@ class RomanticEvents:
                 become_mate = True
                 mate_string = RomanticEvents.get_mate_string(
                     "high_romantic_makeup", poly, cat_from, cat_to
-            )
+                )
             else:
                 become_mate = True
                 mate_string = RomanticEvents.get_mate_string(
@@ -588,7 +588,7 @@ class RomanticEvents:
                 become_mate = True
                 mate_string = RomanticEvents.get_mate_string(
                     "high_romantic_makeup", poly, cat_from, cat_to
-            )
+                )
             else:
                 become_mate = True
                 mate_string = RomanticEvents.get_mate_string(
@@ -723,7 +723,7 @@ class RomanticEvents:
                 become_mate = True
                 mate_string = RomanticEvents.get_mate_string(
                     "low_romantic_makeup", poly, cat_from, cat_to
-            )
+                )
             else:
                 become_mates = True
                 mate_string = RomanticEvents.get_mate_string(


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
I know development has been kinda slow lately (sorry for breaking the no-PR streak 😭😅), and I haven't made a PR since February, but I've been working on this all week after I got tired of mates breaking up and getting back together in the same moon as if nothing happened! This PR introduces new makeup texts if mates decide to get back together without making it seem like they've only just been together for the first time. 

I know it doesn't solve #3989, but I hope these new events atleast bring _some_ logic to the game so break ups and mate events between the same cats don't seem so out of the blue. Though in the future, I'd like there to be a chance of some sort that prevents that from happening often.

This adds "makeup_fail" (same as rejection events but for cats who have been mates before), "high_romantic_makeup", and "low_romantic_makeup", both work the same as high_romantic and low_romantic mate events.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Why This Is Good For ClanGen
This adds realism so cats don't break up and get back together as if nothing ever happened between them. They can't just say they "had a fight and broke up" and immediately after say they've "now made their commitment to each other as mates" in the same moon, like you guys didn't just go through a break up!?

## Proof of Testing
<img width="1171" height="371" alt="Screenshot (1723)" src="https://github.com/user-attachments/assets/1f859f0e-871a-4f42-bc9b-b858519d121c" />

Once upon a time, these two were mates.

<img width="765" height="196" alt="Screenshot 2025-11-01 204109" src="https://github.com/user-attachments/assets/5def1053-5e8d-4fc4-8740-31d5bd7ad4f6" />

Then, they unfortunately break up moons later.

<img width="772" height="181" alt="Screenshot 2025-11-01 205250" src="https://github.com/user-attachments/assets/358c0c72-51ee-4b74-a8d3-4948ce1be3ef" />

But it turns out they still have high romance for one another and decide to get back together.

<img width="1173" height="394" alt="Screenshot 2025-11-01 205342" src="https://github.com/user-attachments/assets/5abf08ca-3a7b-424f-9acb-bf309260c40b" />

And they're mates again!

Here's some examples of a breakup + makeup happening in the same moon:
<img width="780" height="343" alt="Screenshot 2025-11-09 162108" src="https://github.com/user-attachments/assets/e148441f-776a-465a-affe-15eb597e4c37" />
<img width="779" height="305" alt="Screenshot 2025-11-09 162339" src="https://github.com/user-attachments/assets/c701edd2-4ca3-448e-8cc5-be131f8f025f" />

And if one cat wants to get back with their ex-mate, makeup_fail events can happen, works the same as regular rejection.
<img width="1198" height="398" alt="Screenshot 2025-11-12 165823" src="https://github.com/user-attachments/assets/01d62df8-561c-4eae-9767-e321fc7c4901" />
These guys were mates.

<img width="1179" height="388" alt="Screenshot 2025-11-12 165851" src="https://github.com/user-attachments/assets/8a740189-6d65-47af-9bfa-e1747f43d19d" />

They got broken up, but Barleyhiss regained his feelings for Burnetstripe over time and wants him back.

<img width="771" height="190" alt="Screenshot 2025-11-12 172204" src="https://github.com/user-attachments/assets/958e99f2-ae5b-4b0d-b5ca-10b95b20a0ae" />
<img width="1191" height="398" alt="Screenshot 2025-11-12 173450" src="https://github.com/user-attachments/assets/1faec9bb-7e20-4fee-af7e-9436dbe1f8e0" />

But Burnetstripe doesn't feel the same way.

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
New makeup events 
Arcticnightsky: Makeup events
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->