### PR TITLE
[BUGFIX] Relationships slightly broken

### DIFF
--- a/scripts/cat_relations/interaction.py
+++ b/scripts/cat_relations/interaction.py
@@ -119,7 +119,7 @@ def cats_fulfill_single_interaction_constraints(
         "status": interaction.main_status_constraint,
         "trait": interaction.main_trait_constraint,
         "backstory": interaction.backstory_constraint.get("m_c"),
-        "skills": interaction.main_skill_constraint,
+        "skill": interaction.main_skill_constraint,
         "relationship_status": interaction.relationship_constraint,
     }
     random_constraint_dict = {

--- a/scripts/cat_relations/relationship.py
+++ b/scripts/cat_relations/relationship.py
@@ -352,7 +352,7 @@ class Relationship:
                 continue
 
             amount = self.get_value_change_amount(
-                is_positive=value == "positive", intensity="low"
+                is_positive=value == "increase", intensity="low"
             )
 
             setattr(self, key, getattr(self, key) + amount)


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
increase/positive bullshit strikes again! We just needed to be using the right magic string (ugh). All reactionary relationship changes were being made negative because we were checking for the wrong string. Fixing this has fixed the issue.

The issue with skill filtering was also due to an incorrect string (goddammit).  
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
Fixes #4137
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
This is easiest to view via the debugger, so bear with me.

<img width="860" height="267" alt="image" src="https://github.com/user-attachments/assets/59afcb7a-5187-4427-be41-f884ece55bd0" />
<img width="386" height="72" alt="image" src="https://github.com/user-attachments/assets/445967e1-bb0b-49f3-9e2e-064285ffae50" />

We've found an event that has a reactionary relationship change.  We should increase like (prior, the bug would have decreased it instead).  Our current Like is 40.

<img width="369" height="52" alt="image" src="https://github.com/user-attachments/assets/8fe2a8e8-5a87-4fa7-b0c5-a9b521897641" />

After the reactionary change is applied, our Like has increased to 48, as intended!


For the Skill filtering bug:
<img width="836" height="279" alt="image" src="https://github.com/user-attachments/assets/fddfa3fd-39e3-4192-bca9-0418598c91cf" />

here we have an event that wants to filter for STORY cats

<img width="534" height="117" alt="image" src="https://github.com/user-attachments/assets/47439982-acb5-4f7a-8e87-090ce9068df9" />

And here we have correctly ascertained that the cat does not have that skill and thus returned False for this cat qualifying, as intended.

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Reactionary relationship changes (how the opposite cat responds to relationship events) were defaulting to negative effects even when they should have been positive. This is fixed.
- Main cat skills are now correctly filtered for relationship events.
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
