### PR TITLE
[BALANCE] change mid_neg grief assignment

### DIFF
--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -753,7 +753,9 @@ class Cat:
                         high_types.extend(rel_type)
                 elif tier.is_low_pos:
                     high_types.extend(rel_type)
-                elif tier.is_extreme_neg or tier.is_mid_neg:
+                elif tier.is_extreme_neg:
+                    very_low_types.extend(rel_type)
+                elif tier.is_mid_neg and randint(1, 4) == 1:
                     very_low_types.extend(rel_type)
                 continue
 


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
I've shifted things so that extreme_neg relationships continue to always allow neg grief events, but mid_neg relationships now only have a 1/4 chance to produce a neg grief event. ed the same as cats with 50 dislike.  The new system breaks that up a bit and should feel more variable.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Why This Is Good For ClanGen
 Previously, extreme_neg and mid_neg were treated this same, this made things feel a bit too reactionary, since the mid-range of relationship tiers is actually the largest of all the ranges. This means that cats with 20 dislike, for example, were treat
<!-- If this is a bug fix, you can remove this section. -->
<!-- Please add a short description of why you think these changes would benefit the game. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->
<!-- If you have multiple features that can stand on their own, or unrelated bugfixes, please create separate PRs for them. -->

## Linked Issues
Fixes #4103
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
<img width="607" height="184" alt="image" src="https://github.com/user-attachments/assets/d115d57e-598c-4fce-a143-7ddcb9ea61d5" />
<img width="140" height="263" alt="image" src="https://github.com/user-attachments/assets/5eceba73-8e12-4be6-aa9a-da023c488723" />

We can see that Swiftzoom loathes Nightspeck, and has an accompanying "grief" message.

However, another cat also felt negatively toward Nightspeck, but didn't have a grief message. This is because their negativity was a mid_neg tier instead of an extreme_neg tier:
<img width="155" height="291" alt="image" src="https://github.com/user-attachments/assets/8cdaf1d6-fe1e-4725-be98-87f868c315c8" />

When it came to cats who only had mid_neg tiers, there was a definite decrease in neg grief events. Admittedly I had a hard time getting good testing on this, since I didn't have many cats with numerous negative relationships, but I had a few cats with 2-3 neg relationships that would usually only see 1 (or no) neg grief events.  I think this is an improvement as far as frequency goes.

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Negative death reaction events should be less frequent for mid-range negative relationships.
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
