### PR TITLE
[CONTENT] Relationship Logs - Forest Summer/Fall Border

### DIFF
--- a/resources/lang/en/patrols/forest/border/greenleaf.json
+++ b/resources/lang/en/patrols/forest/border/greenleaf.json
@@ -37,7 +37,19 @@
             {
                 "text": "{PRONOUN/r_c/subject/CAP} {VERB/r_c/get/gets} distracted while splashing in the water. r_c swears {PRONOUN/r_c/subject} saw a fish, but it derails {PRONOUN/r_c/poss} border patrol completely, and {PRONOUN/r_c/subject} {VERB/r_c/get/gets} nothing done.",
                 "exp": 0,
-                "weight": 20
+                "weight": 20,
+                "relationships": [
+                    {
+                        "cats_from": ["some_clan"],
+                        "cats_to": ["r_c"],
+                        "values": ["respect"],
+                        "mutual": false,
+                        "amount": -5,
+                        "log": {
+                            "cats_from": "from_cat saw to_cat return from patrol with soggy paws and nothing to show for an afternoon of work."
+                        }
+                    }
+                ]
             }
         ]
     }

--- a/resources/lang/en/patrols/forest/border/leaf-fall.json
+++ b/resources/lang/en/patrols/forest/border/leaf-fall.json
@@ -29,14 +29,50 @@
                 "bold", 
                 "shameless"
             ],
-            "can_have_stat": ["r_c"]
+            "can_have_stat": ["r_c"],
+            "relationships": [
+                {
+                    "cats_from": ["patrol"],
+                    "cats_to": ["s_c"],
+                    "values": ["respect"],
+                    "mutual": false,
+                    "amount": 3,
+                    "log":
+                    {
+                        "cats_from": "from_cat was impressed by to_cat's boldness in tasting a Twoleg object."
+                    }
+                },
+                {
+                    "cats_from": ["p_l"],
+                    "cats_to": ["s_c"],
+                    "values": ["trust", "like"],
+                    "mutual": false,
+                    "amount": -5,
+                    "log":
+                    {
+                        "cats_from": "Bold or not, from_cat thinks to_cat was mouse-brained to taste the Twoleg object."
+                    }
+                }
+            ]
         }
     ],
     "fail_outcomes": [
         {
             "text": "As p_l creeps closer to get a better look, the sound of crashing and chattering fills the air. p_l freezes and watches a pack of Twolegs stumble through the trees. The cats scatter, leaving behind whatever that weird thing was in the grass.",
             "exp": 0,
-            "weight": 20
+            "weight": 20,
+            "relationships": [
+                {
+                    "cats_from": ["patrol"],
+                    "cats_to": ["p_l"],
+                    "values": ["respect", "trust"],
+                    "mutual": false,
+                    "amount": -5,
+                    "log": {
+                        "cats_from": "from_cat watched to_cat freeze up on a patrol {PRONOUN/to_cat/subject} {VERB/to_cat/were/was} leading."
+                    }
+                }
+            ]
         }
     ]
 }]


### PR DESCRIPTION
## About The Pull Request

These files are tiny. Two new relationship blocks, with logs to go with them.

## Why This Is Good For ClanGen

Relationship logging project.

## Proof of Testing

<img width="693" height="130" alt="image" src="https://github.com/user-attachments/assets/3e85f124-4142-4e6b-90a9-31db4db5cef9" />