### PR TITLE
[ENHANCEMENT] Event tab pagination

### DIFF
--- a/scripts/game_structure/constants.py
+++ b/scripts/game_structure/constants.py
@@ -18,6 +18,8 @@ MENU_SCREENS = [
     GameScreen.MAKE_CLAN,
 ]
 
+EVENTS_PER_PAGE = 10
+
 BIOME_TYPES = ["Forest", "Plains", "Mountainous", "Beach", "Wetlands", "Desert"]
 
 SEASONS = ["Newleaf", "Greenleaf", "Leaf-fall", "Leaf-bare"]

--- a/scripts/game_structure/game/switches/game_switches.py
+++ b/scripts/game_structure/game/switches/game_switches.py
@@ -31,6 +31,7 @@ class Switch(StrEnum):
     war_rel_change_type = auto()
     disallowed_symbol_tags = auto()
     saved_scroll_positions = auto()
+    saved_page_positions = auto()
     moon_and_seasons_open = auto()
     sort_type = auto()
     no_able_left = auto()
@@ -57,6 +58,7 @@ _switches: Dict[str, Union[str, int, bool, list, dict, None]] = {
     "war_rel_change_type": "neutral",
     "disallowed_symbol_tags": [],
     "saved_scroll_positions": {},
+    "saved_page_positions": {},
     "moon_and_seasons_open": False,
     "sort_type": "rank",
     "no_able_left": False,

--- a/scripts/screens/EventsScreen.py
+++ b/scripts/screens/EventsScreen.py
@@ -382,6 +382,7 @@ class EventsScreen(Screens):
     def reset_page_buttons(self, is_page_update=False):
         """
         Resets page button and page counter states
+        :param is_page_update: Set True if page buttons do not need to be recreated.
         """
         if self.page_control and not is_page_update:
             for ele in self.page_control.values():

--- a/scripts/screens/EventsScreen.py
+++ b/scripts/screens/EventsScreen.py
@@ -1,16 +1,14 @@
 from math import ceil
-from opcode import is_pseudo
 from typing import Dict
 
 import i18n
 import pygame
 import pygame_gui
-from pygame_gui.core import ObjectID
 
 from scripts.cat.cats import Cat
 from scripts import events
 from scripts.events import Single_Event
-from scripts.game_structure import image_cache
+from scripts.game_structure import image_cache, constants
 from scripts.game_structure.game.settings import game_setting_get
 from scripts.game_structure.game.switches import (
     Switch,
@@ -48,7 +46,6 @@ class EventsScreen(Screens):
     current_display = "all events"
     selected_display = "all events"
 
-    EVENTS_PER_PAGE = 10
     current_page = 1
     current_page_amount = 0
     page_chunks = []
@@ -708,7 +705,7 @@ class EventsScreen(Screens):
         # SET UP PAGES
         if not is_page_update:
             self.current_page_amount = (
-                int(ceil(len(self.display_events) / self.EVENTS_PER_PAGE))
+                int(ceil(len(self.display_events) / constants.EVENTS_PER_PAGE))
                 if len(self.display_events)
                 else 1
             )
@@ -724,8 +721,8 @@ class EventsScreen(Screens):
                 self.current_page = 1
 
             self.page_chunks = [
-                self.display_events[x : x + self.EVENTS_PER_PAGE]
-                for x in range(0, len(self.display_events), self.EVENTS_PER_PAGE)
+                self.display_events[x : x + constants.EVENTS_PER_PAGE]
+                for x in range(0, len(self.display_events), constants.EVENTS_PER_PAGE)
             ]
         else:
             switch_set_value(Switch.saved_scroll_positions, {})


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
This adds pagination to the Events screen tabs. Honestly it turned out to be relatively simple to set up.

I've added a new switch for saving page positions that essentially matches the switch we already had for saving scroll positions. This ensures that the player can flip between tabs or screens and still return to a tab on the same page they left it.

The page buttons themselves are created and recreated as needed to ensure anchoring stays centered; when possible I've limited this so that we aren't recreating the elements when we don't need to.

For now I have it set up to chunk events into pages of 10 events. This number is saved as a constant in the events script, so pretty easy for us to adjust without fiddling with the code.  I think 10 is pretty reasonable though, it gets through a good number of events without making scrolling through them feel like an ordeal.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Why This Is Good For ClanGen
The rel tab especially has always struggled when you get to a certain number of cats. It just gets overwhelmed; it lags and the scrolling breaks. Breaking this up into pages eliminates the issue.
<!-- If this is a bug fix, you can remove this section. -->
<!-- Please add a short description of why you think these changes would benefit the game. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->
<!-- If you have multiple features that can stand on their own, or unrelated bugfixes, please create separate PRs for them. -->

## Linked Issues
#2816 shows off the scrolling issues we have with the rel events. While this PR doesn't fix *scrolling* (i think this is something we just. can't really fix. it's more of a pygui limitation), it does address the core of the problem: the tab being overwhelmed by too many events.
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing

https://github.com/user-attachments/assets/75b67548-c134-449c-916e-111560f73681

<img width="229" height="122" alt="image" src="https://github.com/user-attachments/assets/0f18776f-7586-4d45-b91f-9f28d2356e44" />

Also stress tested this with a massive Clan from a community member (Vicki) that has around 800 cats (600-ish of which are alive). Rel tab loaded instantly without any problem, whereas it would reportedly crash before.
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Events on the Event screen now get separated into pages, with 10 events per page.
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
