### PR TITLE
[BUGFIX] Remove random_cat None assignment

### DIFF
--- a/scripts/events.py
+++ b/scripts/events.py
@@ -2111,8 +2111,6 @@ def handle_murder(cat):
             )
 
         elif kill_chance <= 20:
-            print(cat.name, "TARGET CHOSEN", Cat.fetch_cat(chosen_target.cat_to).name)
-            print("FAILED")
             create_short_event(
                 event_type="misc",
                 main_cat=cat,

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -2050,8 +2050,7 @@ def handle_murder(cat):
     if random.getrandbits(murder_capable) != 1:
         return
 
-    # If random murder is not triggered, targets can only be those they have some dislike for
-    # If random murder is not triggered, targets can only be those they have extreme negativity for
+    # If random murder is not triggered, targets can only be those they have some mid/extreme neg for
     negative_relation = [
         i
         for i in relationships
@@ -2112,6 +2111,8 @@ def handle_murder(cat):
             )
 
         elif kill_chance <= 20:
+            print(cat.name, "TARGET CHOSEN", Cat.fetch_cat(chosen_target.cat_to).name)
+            print("FAILED")
             create_short_event(
                 event_type="misc",
                 main_cat=cat,

--- a/scripts/events_module/short/short_event_generation.py
+++ b/scripts/events_module/short/short_event_generation.py
@@ -508,7 +508,7 @@ def filter_events(
         final_events.extend([event] * event.weight)
 
     if not final_events:
-        return None, None
+        return None, random_cat
 
     cat_list = [
         c

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -67,7 +67,7 @@ class TestEvents(unittest.TestCase):
         """
         main_cat = choice(Cat.all_cats_list)
         random_cat = None
-        while random_cat != main_cat:
+        while random_cat == main_cat:
             random_cat = choice(Cat.all_cats_list)
 
         chosen_event, new_random_cat = filter_events(

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -2,6 +2,7 @@ import unittest
 from random import choice
 from uuid import uuid4
 
+from scripts.cat import save_load
 from scripts.cat.cats import create_cat, Cat
 from scripts.cat.enums import CatRank
 from scripts.cat.sprites import sprites
@@ -50,6 +51,7 @@ class TestEvents(unittest.TestCase):
             ],
             starting_season="Newleaf",
         )
+        save_load.cat_to_fade.clear()
         game.clan.create_clan()
         game.cur_events_list.clear()
         game.herb_events_list.clear()

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -8,12 +8,16 @@ from scripts.cat.sprites import sprites
 from scripts.clan import Clan, Afterlife
 from scripts.clan_package.settings import switch_clan_setting, set_clan_setting
 from scripts import events
+from scripts.events_module.short.short_event_generation import (
+    find_needed_events,
+    filter_events,
+)
 from scripts.game_structure import game
 from scripts.utility import get_living_cat_count
 
 
 class TestEvents(unittest.TestCase):
-    def test_bulk_skip(self):
+    def setUp(self):
         # load in the spritesheets
         # we have to do this to prevent a crash, even though we won't be displaying anything
         sprites.load_all()
@@ -57,6 +61,30 @@ class TestEvents(unittest.TestCase):
         set_clan_setting("business as usual", False)
         set_clan_setting("hunting", True)
 
+    def test_random_cat_assignment(self):
+        """
+        Testing if random_cat is incorrectly reassigned to None when no events are available.
+        """
+        main_cat = choice(Cat.all_cats_list)
+        random_cat = None
+        while random_cat != main_cat:
+            random_cat = choice(Cat.all_cats_list)
+
+        chosen_event, new_random_cat = filter_events(
+            possible_events=[],
+            main_cat=main_cat,
+            random_cat=random_cat,
+            other_clan=game.clan.all_other_clans[0],
+            sub_types=[],
+            allowed_events=None,
+            excluded_events=None,
+            ignore_subtyping=False,
+            reduction_avoidance_chance=1,
+        )
+
+        self.assertEqual(random_cat, new_random_cat)
+
+    def test_bulk_skip(self):
         with self.subTest(
             "Timeskip Failed",
         ):

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -66,7 +66,7 @@ class TestEvents(unittest.TestCase):
         Testing if random_cat is incorrectly reassigned to None when no events are available.
         """
         main_cat = choice(Cat.all_cats_list)
-        random_cat = None
+        random_cat = choice(Cat.all_cats_list)
         while random_cat == main_cat:
             random_cat = choice(Cat.all_cats_list)
 


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
This was discovered via failed murder fuckery, but has likely been silently affecting many events. When we returned from the `filter_events` func (due to failing to find any events) we were incorrectly assigning `random_cat` as `None`, even when a `random_cat` did already exist.

Easy fix, we just make sure it always returns it's `random_cat` variable, which will be whatever was passed to it in the first place (either `None` or the appropriate cat object). This way we're not losing our `random_cat` to the filter.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
Fixes #4173 
This was not, in fact, a problem caused by the murder code. The murders just made it more visible since they were clearly losing their initial targets.
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
<img width="554" height="255" alt="image" src="https://github.com/user-attachments/assets/d1d322a6-c474-47f4-a06c-4f2532dd7ec8" />

Failed murder triggered

<img width="554" height="136" alt="image" src="https://github.com/user-attachments/assets/0238ae91-3d16-47a6-a1d3-65ccccf2ca88" />

While Brinicle isn't mentioned, the important cat here is Jattematt, as he's the random_cat. As you can see, he's been correctly assigned to the event, which wouldn't have happened before my fix.

<img width="370" height="91" alt="image" src="https://github.com/user-attachments/assets/02b65bfb-f547-4940-8ef9-c3d8cd1e9007" />

And another instance

<img width="532" height="115" alt="image" src="https://github.com/user-attachments/assets/c104f369-b1a3-41c0-b969-a36f280eaf54" />

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- random_cats no longer get detached from events when the event filter fails to find an event
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
