### PR TITLE
[ENHANCEMENT] min_max_status on outcomes and a few other things

### DIFF
--- a/docs/dev/writing/patrols.md
+++ b/docs/dev/writing/patrols.md
@@ -516,7 +516,7 @@ Please have a look at the [full biome differences list](index.md#clangen-biomes)
 ***
 
 #### relationship_constraint: List[str]
->Optional. Only allows the patrol if the cats meet relationship constraints. You can include any tags in [Relationship Levels](reference/tag-lists.md#relationship-levels) and [Relationship Types](reference/tag-lists.md#relationship-types).
+>Optional. Only allows the patrol if the cats meet relationship constraints. You can include any tags in [Relationship Levels](reference/tag-lists.md#relationship-tiers) and [Relationship Types](reference/tag-lists.md#relationship-tiers).
 
 ***
 
@@ -545,6 +545,7 @@ This is a good starting point for writing your own outcomes.
 
 ```json
 {
+    "min_max_status": {},
     "text": "The raw displayed outcome text.",
     "exp": 0,
     "frequency": 4,
@@ -589,6 +590,14 @@ This is a good starting point for writing your own outcomes.
 ### By-Parameter - Outcome
 What each parameter does, and what the options are for outcomes.
 
+***
+
+#### min_max_status: Dict[str, List[int]]
+>Optional. Allows specification of the minimum and maximum number of specific types of cats that are allowed on this outcome. Utlizes the exact same format and options as the overall [min_max_status](#min_max_status-dictstr-listint) parameter.
+
+!!! caution
+    Use this sparingly and always ensure at least one of every outcome type is possible for *any* combination of cats allowed on this patrol. Ideally there should always be outcomes that *do not use* this parameter. If you've utilized this parameter on every outcome, it should be in a simple and easy-to-follow manner (i.e. all outcomes are either for 1-3 warriors or 4-6 warriors) rather than overly convoluted (i.e. every outcome has a different `min_max_status`: some disallow leaders, some allow medicine cats, some disallow all apps except medicine apps, others only allow medicine apps, ect.) ***If it starts to get insane, you are better off separating this patrol into multiple patrols instead of cramming all those outcomes together.***
+ 
 ***
 
 #### text: str

--- a/docs/dev/writing/patrols.md
+++ b/docs/dev/writing/patrols.md
@@ -549,6 +549,7 @@ This is a good starting point for writing your own outcomes.
     "text": "The raw displayed outcome text.",
     "exp": 0,
     "frequency": 4,
+    "relationship_constraint": [],
     "stat_skill": [],
     "stat_trait": [],
     "can_have_stat": [],
@@ -628,6 +629,11 @@ What each parameter does, and what the options are for outcomes.
 !!! warning
     Don't try to boost an outcome's frequency to make up for it being heavily constrained! While we used to do that with our old system, the new code automatically decides how to weight an outcome according to its constraints in a way that is completely divorced from the frequency. We decide outcome rarities and the code decides if outcomes should be prioritized in specific instances.
 
+
+***
+
+#### relationship_constraint: List[str]
+>Optional. Only allows the outcome if the cats meet relationship constraints. You can include any tags in [Relationship Levels](reference/tag-lists.md#relationship-tiers) and [Relationship Types](reference/tag-lists.md#relationship-tiers).
 
 ***
 

--- a/docs/dev/writing/patrols.md
+++ b/docs/dev/writing/patrols.md
@@ -516,7 +516,7 @@ Please have a look at the [full biome differences list](index.md#clangen-biomes)
 ***
 
 #### relationship_constraint: List[str]
->Optional. Only allows the patrol if the cats meet relationship constraints. You can include any tags in [Relationship Levels](reference/tag-lists.md#relationship-tiers) and [Relationship Types](reference/tag-lists.md#relationship-tiers).
+>Optional. Only allows the patrol if the cats meet relationship constraints. You can include any tags in [Relationship Tiers](reference/tag-lists.md#relationship-tiers) and [Interpersonal Relationships](reference/tag-lists.md#interpersonal-relationships).
 
 ***
 
@@ -633,7 +633,7 @@ What each parameter does, and what the options are for outcomes.
 ***
 
 #### relationship_constraint: List[str]
->Optional. Only allows the outcome if the cats meet relationship constraints. You can include any tags in [Relationship Levels](reference/tag-lists.md#relationship-tiers) and [Relationship Types](reference/tag-lists.md#relationship-tiers).
+>Optional. Only allows the outcome if the cats meet relationship constraints. You can include any tags in [Relationship Tiers](reference/tag-lists.md#relationship-tiers) and [Interpersonal Relationships](reference/tag-lists.md#interpersonal-relationships).
 
 ***
 

--- a/docs/dev/writing/shortevents.md
+++ b/docs/dev/writing/shortevents.md
@@ -258,7 +258,7 @@ lowercase season names + "any"
 
     However, remember the wide range of ages and statuses we have and how they can overlap with each other.  It's possible to have warriors who graduate early and are still adolescent age.  It's also possible for apps to train longer than usual and become young adults without becoming warriors.  Elders, likewise, can be both young and old cats as it's possible for cats to retire to the elder den at any age.
 
->**relationship_status:[list]** : dictates what relationships m_c must have towards r_c.  Do not use this section if there is no r_c in the event. You can include any tags in [Relationship Levels](reference/tag-lists.md#relationship-levels) and [Relationship Types](reference/tag-lists.md#relationship-types).
+>**relationship_status:[list]** : dictates what relationships m_c must have towards r_c.  Do not use this section if there is no r_c in the event. You can include any tags in [Relationship Levels](reference/tag-lists.md#relationship-tiers) and [Relationship Types](reference/tag-lists.md#relationship-tiers).
 
 >**skill[list]** : m_c must possess at least one skill from this list. if they can be anything, use "any"
 >
@@ -283,7 +283,7 @@ lowercase season names + "any"
 >
 >**status:[list]** : a list of statuses r_c can be. if they can be anything, use "any"
 >
->**relationship_status:[list]** : dictates what relationships the r_c must have towards m_c. You can include any tags in [Relationship Levels](reference/tag-lists.md#relationship-levels).
+>**relationship_status:[list]** : dictates what relationships the r_c must have towards m_c. You can include any tags in [Relationship Levels](reference/tag-lists.md#relationship-tiers).
 > 
 >**skill[list]** : r_c must possess at least one skill from this list. if they can be anything, remove parameter or leave list empty.
 >

--- a/docs/dev/writing/shortevents.md
+++ b/docs/dev/writing/shortevents.md
@@ -258,7 +258,7 @@ lowercase season names + "any"
 
     However, remember the wide range of ages and statuses we have and how they can overlap with each other.  It's possible to have warriors who graduate early and are still adolescent age.  It's also possible for apps to train longer than usual and become young adults without becoming warriors.  Elders, likewise, can be both young and old cats as it's possible for cats to retire to the elder den at any age.
 
->**relationship_status:[list]** : dictates what relationships m_c must have towards r_c.  Do not use this section if there is no r_c in the event. You can include any tags in [Relationship Levels](reference/tag-lists.md#relationship-tiers) and [Relationship Types](reference/tag-lists.md#relationship-tiers).
+>**relationship_status:[list]** : dictates what relationships m_c must have towards r_c.  Do not use this section if there is no r_c in the event. [Relationship Tiers](reference/tag-lists.md#relationship-tiers) and [Interpersonal Relationships](reference/tag-lists.md#interpersonal-relationships).
 
 >**skill[list]** : m_c must possess at least one skill from this list. if they can be anything, use "any"
 >

--- a/docs/dev/writing/thoughts.md
+++ b/docs/dev/writing/thoughts.md
@@ -114,7 +114,7 @@ The additional constraint `born_with` allows you to constrain whether this thoug
     Be careful when specifying `born_with`. If you force a condition to be congenital when it can never generate as such, the thought will never trigger! The same also applies for forcing a condition to be non-congenital when it is always generated as such.
 
 **RELATIONSHIP_CONSTRAINT:**
-Constrains the thought to only occur if m_c and r_c fulfill the tags requirements. You can include any tags in [Relationship Levels](reference/tag-lists.md#relationship-tiers) and [Relationship Types](reference/tag-lists.md#relationship-tiers).
+Constrains the thought to only occur if m_c and r_c fulfill the tags requirements. You can include any tags in [Relationship Tiers](reference/tag-lists.md#relationship-tiers) and [Interpersonal Relationships](reference/tag-lists.md#interpersonal-relationships).
 
 
 BACKSTORY_CONSTRAINT:

--- a/docs/dev/writing/thoughts.md
+++ b/docs/dev/writing/thoughts.md
@@ -114,7 +114,7 @@ The additional constraint `born_with` allows you to constrain whether this thoug
     Be careful when specifying `born_with`. If you force a condition to be congenital when it can never generate as such, the thought will never trigger! The same also applies for forcing a condition to be non-congenital when it is always generated as such.
 
 **RELATIONSHIP_CONSTRAINT:**
-Constrains the thought to only occur if m_c and r_c fulfill the tags requirements. You can include any tags in [Relationship Levels](reference/tag-lists.md#relationship-levels) and [Relationship Types](reference/tag-lists.md#relationship-types).
+Constrains the thought to only occur if m_c and r_c fulfill the tags requirements. You can include any tags in [Relationship Levels](reference/tag-lists.md#relationship-tiers) and [Relationship Types](reference/tag-lists.md#relationship-tiers).
 
 
 BACKSTORY_CONSTRAINT:

--- a/resources/lang/en/patrols/other_clan.json
+++ b/resources/lang/en/patrols/other_clan.json
@@ -897,15 +897,14 @@
         "types": [
             "border"
         ],
-        "tags": [],
+        "tags": ["clan:deputy"],
         "patrol_art": "gen_warrior_crouching",
         "min_cats": 1,
         "max_cats": 1,
         "min_max_status": {
-            "all apprentices": [ -1, -1 ],
-            "deputy": [
-                -1,
-                -1
+            "normal adult": [
+                1,
+                1
             ]
         },
         "frequency": 4,
@@ -1366,11 +1365,16 @@
         "types": [
             "border"
         ],
-        "tags": [],
+        "tags": ["clan:deputy"],
         "patrol_art": "gen_warrior_crouching",
         "min_cats": 1,
         "max_cats": 1,
-        "min_max_status": {},
+        "min_max_status": {
+            "normal adult": [
+                1,
+                1
+            ]
+        },
         "frequency": 4,
         "intro_text": "r_c heads out into the desert alone, wanting to make a quick check on the border.",
         "decline_text": "r_c turns back to camp, deciding that {PRONOUN/r_c/poss} other duties have to come first.",
@@ -1829,12 +1833,15 @@
         "types": [
             "border"
         ],
-        "tags": [],
+        "tags": ["clan:deputy"],
         "patrol_art": "gen_warrior_crouching",
         "min_cats": 1,
         "max_cats": 1,
         "min_max_status": {
-            "all apprentices": [ -1, -1 ]
+            "normal adult": [
+                1,
+                1
+            ]
         },
         "frequency": 4,
         "intro_text": "r_c heads out into the forest alone, wanting to make a quick check on the border.",
@@ -2294,7 +2301,7 @@
         "types": [
             "border"
         ],
-        "tags": [],
+        "tags": ["clan:deputy"],
         "patrol_art": "gen_warrior_crouching",
         "min_cats": 1,
         "max_cats": 1,
@@ -2762,11 +2769,16 @@
         "types": [
             "border"
         ],
-        "tags": [],
+        "tags": ["clan:deputy"],
         "patrol_art": "gen_warrior_crouching",
         "min_cats": 1,
         "max_cats": 1,
-        "min_max_status": {},
+        "min_max_status": {
+            "normal adult": [
+                1,
+                1
+            ]
+        },
         "frequency": 4,
         "intro_text": "r_c heads out into the grasslands alone, wanting to make a quick check on the border.",
         "decline_text": "r_c turns back to camp, deciding that {PRONOUN/r_c/poss} other duties have to come first.",

--- a/resources/lang/en/patrols/other_clan.json
+++ b/resources/lang/en/patrols/other_clan.json
@@ -940,7 +940,7 @@
                 "min_max_status": {
                     "warrior": [-1,-1]
                 },
-                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to them, led by their deputy. They strike up a friendly conversation, and eventually the o_c_n warriors drift away. The unexpected opportunity turns into the perfect chance to casually but purposefully keep each other informed on an ongoing problem in the territories.",
+                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to them, led by their deputy. {PRONOUN/s_c/subject/CAP} {VERB/s_c/strike/strikes} up a friendly conversation, and eventually the o_c_n warriors drift away. The unexpected opportunity turns into the perfect chance to casually but purposefully keep each other informed on an ongoing problem in the territories.",
                 "exp": 20,
                 "stat_skill": [
                     "SPEAKER,1"
@@ -953,7 +953,7 @@
                 "min_max_status": {
                     "warrior": [-1,-1]
                 },
-                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to s_c with their leader. They strike up a friendly conversation, and eventually the o_c_n warriors drift away. The unexpected opportunity turns into the perfect chance to casually but purposefully keep each other informed on an ongoing problem in the territories.",
+                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to s_c with their leader. {PRONOUN/s_c/subject/CAP} {VERB/s_c/strike/strikes} up a friendly conversation, and eventually the o_c_n warriors drift away. The unexpected opportunity turns into the perfect chance to casually but purposefully keep each other informed on an ongoing problem in the territories.",
                 "exp": 20,
                 "stat_skill": [
                     "SPEAKER,1"
@@ -1363,7 +1363,7 @@
                 "min_max_status": {
                     "warrior": [-1,-1]
                 },
-                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to them, led by their deputy. They strike up a friendly conversation, and eventually the o_c_n warriors drift away. The unexpected opportunity turns into the perfect chance to casually but purposefully keep each other informed on an ongoing problem in the territories.",
+                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to them, led by their deputy. {PRONOUN/s_c/subject/CAP} {VERB/s_c/strike/strikes} up a friendly conversation, and eventually the o_c_n warriors drift away. The unexpected opportunity turns into the perfect chance to casually but purposefully keep each other informed on an ongoing problem in the territories.",
                 "exp": 20,
                 "stat_skill": [
                     "SPEAKER,1"
@@ -1376,7 +1376,7 @@
                 "min_max_status": {
                     "warrior": [-1,-1]
                 },
-                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to s_c with their leader. They strike up a friendly conversation, and eventually the o_c_n warriors drift away. The unexpected opportunity turns into the perfect chance to casually but purposefully keep each other informed on an ongoing problem in the territories.",
+                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to s_c with their leader. {PRONOUN/s_c/subject/CAP} {VERB/s_c/strike/strikes} up a friendly conversation, and eventually the o_c_n warriors drift away. The unexpected opportunity turns into the perfect chance to casually but purposefully keep each other informed on an ongoing problem in the territories.",
                 "exp": 20,
                 "stat_skill": [
                     "SPEAKER,1"
@@ -1425,7 +1425,7 @@
                 "art": "gen_angry_cat_warrior"
             },
             {
-                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to {PRONOUN/s_c/object}, and turns to follow the same marking path as them. {PRONOUN/s_c/subject/CAP} strike up a friendly conversation, and while s_c doesn't give anything away about c_n, {PRONOUN/s_c/subject}{VERB/s_c/'re/'s} able to pick up on a lot of gossip about o_c_n through careful conversation. It's always worth keeping an eye on their neighbors. Trust, but verify.",
+                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to {PRONOUN/s_c/object}, and turns to follow the same marking path as them. {PRONOUN/s_c/subject/CAP} {VERB/s_c/strike/strikes} up a friendly conversation, and while s_c doesn't give anything away about c_n, {PRONOUN/s_c/subject}{VERB/s_c/'re/'s} able to pick up on a lot of gossip about o_c_n through careful conversation. It's always worth keeping an eye on their neighbors. Trust, but verify.",
                 "exp": 20,
                 "stat_skill": [
                     "SPEAKER,1"
@@ -1788,7 +1788,7 @@
                 "min_max_status": {
                     "warrior": [-1,-1]
                 },
-                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to them, led by their deputy. They strike up a friendly conversation, and eventually the o_c_n warriors drift away. The unexpected opportunity turns into the perfect chance to casually but purposefully keep each other informed on an ongoing problem in the territories.",
+                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to them, led by their deputy. {PRONOUN/s_c/subject/CAP} {VERB/s_c/strike/strikes} up a friendly conversation, and eventually the o_c_n warriors drift away. The unexpected opportunity turns into the perfect chance to casually but purposefully keep each other informed on an ongoing problem in the territories.",
                 "exp": 20,
                 "stat_skill": [
                     "SPEAKER,1"
@@ -1801,7 +1801,7 @@
                 "min_max_status": {
                     "warrior": [-1,-1]
                 },
-                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to s_c with their leader. They strike up a friendly conversation, and eventually the o_c_n warriors drift away. The unexpected opportunity turns into the perfect chance to casually but purposefully keep each other informed on an ongoing problem in the territories.",
+                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to s_c with their leader. {PRONOUN/s_c/subject/CAP} {VERB/s_c/strike/strikes} up a friendly conversation, and eventually the o_c_n warriors drift away. The unexpected opportunity turns into the perfect chance to casually but purposefully keep each other informed on an ongoing problem in the territories.",
                 "exp": 20,
                 "stat_skill": [
                     "SPEAKER,1"
@@ -1850,7 +1850,7 @@
                 "art": "gen_angry_cat_warrior"
             },
             {
-                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to {PRONOUN/s_c/object}, and turns to follow the same marking path as them. {PRONOUN/s_c/subject/CAP} strike up a friendly conversation, and while s_c doesn't give anything away about c_n, {PRONOUN/s_c/subject}{VERB/s_c/'re/'s} able to pick up on a lot of gossip about o_c_n through careful conversation. It's always worth keeping an eye on their neighbors. Trust, but verify.",
+                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to {PRONOUN/s_c/object}, and turns to follow the same marking path as them. {PRONOUN/s_c/subject/CAP} {VERB/s_c/strike/strikes} up a friendly conversation, and while s_c doesn't give anything away about c_n, {PRONOUN/s_c/subject}{VERB/s_c/'re/'s} able to pick up on a lot of gossip about o_c_n through careful conversation. It's always worth keeping an eye on their neighbors. Trust, but verify.",
                 "exp": 20,
                 "stat_skill": [
                     "SPEAKER,1"
@@ -2216,7 +2216,7 @@
                 "min_max_status": {
                     "warrior": [-1,-1]
                 },
-                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to them, led by their deputy. They strike up a friendly conversation, and eventually the o_c_n warriors drift away. The unexpected opportunity turns into the perfect chance to casually but purposefully keep each other informed on an ongoing problem in the territories.",
+                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to them, led by their deputy. {PRONOUN/s_c/subject/CAP} {VERB/s_c/strike/strikes} up a friendly conversation, and eventually the o_c_n warriors drift away. The unexpected opportunity turns into the perfect chance to casually but purposefully keep each other informed on an ongoing problem in the territories.",
                 "exp": 20,
                 "stat_skill": [
                     "SPEAKER,1"
@@ -2229,7 +2229,7 @@
                 "min_max_status": {
                     "warrior": [-1,-1]
                 },
-                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to s_c with their leader. They strike up a friendly conversation, and eventually the o_c_n warriors drift away. The unexpected opportunity turns into the perfect chance to casually but purposefully keep each other informed on an ongoing problem in the territories.",
+                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to s_c with their leader. {PRONOUN/s_c/subject/CAP} {VERB/s_c/strike/strikes} up a friendly conversation, and eventually the o_c_n warriors drift away. The unexpected opportunity turns into the perfect chance to casually but purposefully keep each other informed on an ongoing problem in the territories.",
                 "exp": 20,
                 "stat_skill": [
                     "SPEAKER,1"
@@ -2278,7 +2278,7 @@
                 "art": "gen_angry_cat_warrior"
             },
             {
-                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to {PRONOUN/s_c/object}, and turns to follow the same marking path as them. {PRONOUN/s_c/subject/CAP} strike up a friendly conversation, and while s_c doesn't give anything away about c_n, {PRONOUN/s_c/subject}{VERB/s_c/'re/'s} able to pick up on a lot of gossip about o_c_n through careful conversation. It's always worth keeping an eye on their neighbors. Trust, but verify.",
+                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to {PRONOUN/s_c/object}, and turns to follow the same marking path as them. {PRONOUN/s_c/subject/CAP} {VERB/s_c/strike/strikes} up a friendly conversation, and while s_c doesn't give anything away about c_n, {PRONOUN/s_c/subject}{VERB/s_c/'re/'s} able to pick up on a lot of gossip about o_c_n through careful conversation. It's always worth keeping an eye on their neighbors. Trust, but verify.",
                 "exp": 20,
                 "stat_skill": [
                     "SPEAKER,1"
@@ -2639,7 +2639,7 @@
                 "min_max_status": {
                     "warrior": [-1,-1]
                 },
-                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to them, led by their deputy. They strike up a friendly conversation, and eventually the o_c_n warriors drift away. The unexpected opportunity turns into the perfect chance to casually but purposefully keep each other informed on an ongoing problem in the territories.",
+                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to them, led by their deputy. {PRONOUN/s_c/subject/CAP} {VERB/s_c/strike/strikes} up a friendly conversation, and eventually the o_c_n warriors drift away. The unexpected opportunity turns into the perfect chance to casually but purposefully keep each other informed on an ongoing problem in the territories.",
                 "exp": 20,
                 "stat_skill": [
                     "SPEAKER,1"
@@ -2652,7 +2652,7 @@
                 "min_max_status": {
                     "warrior": [-1,-1]
                 },
-                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to s_c with their leader. They strike up a friendly conversation, and eventually the o_c_n warriors drift away. The unexpected opportunity turns into the perfect chance to casually but purposefully keep each other informed on an ongoing problem in the territories.",
+                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to s_c with their leader. {PRONOUN/s_c/subject/CAP} {VERB/s_c/strike/strikes} up a friendly conversation, and eventually the o_c_n warriors drift away. The unexpected opportunity turns into the perfect chance to casually but purposefully keep each other informed on an ongoing problem in the territories.",
                 "exp": 20,
                 "stat_skill": [
                     "SPEAKER,1"
@@ -2701,7 +2701,7 @@
                 "art": "gen_angry_cat_warrior"
             },
             {
-                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to {PRONOUN/s_c/object}, and turns to follow the same marking path as them. {PRONOUN/s_c/subject/CAP} strike up a friendly conversation, and while s_c doesn't give anything away about c_n, {PRONOUN/s_c/subject}{VERB/s_c/'re/'s} able to pick up on a lot of gossip about o_c_n through careful conversation. It's always worth keeping an eye on their neighbors. Trust, but verify.",
+                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to {PRONOUN/s_c/object}, and turns to follow the same marking path as them. {PRONOUN/s_c/subject/CAP} {VERB/s_c/strike/strikes} up a friendly conversation, and while s_c doesn't give anything away about c_n, {PRONOUN/s_c/subject}{VERB/s_c/'re/'s} able to pick up on a lot of gossip about o_c_n through careful conversation. It's always worth keeping an eye on their neighbors. Trust, but verify.",
                 "exp": 20,
                 "stat_skill": [
                     "SPEAKER,1"

--- a/resources/lang/en/patrols/other_clan.json
+++ b/resources/lang/en/patrols/other_clan.json
@@ -32,7 +32,7 @@
                 "frequency": 4
             },
             {
-                "text": "p_l approaches the other Clan patrol, striking up a conversation about the weather. After talking for a short time, the two patrols part ways. p_l remarks to the leader on the o_c_n cats' kindness once the patrol has returned to camp.",
+                "text": "p_l approaches the other Clan patrol, striking up a conversation about the weather. After talking for a short time, the two patrols part ways. p_l re-marks to the leader on the o_c_n cats' kindness once the patrol has returned to camp.",
                 "exp": 10,
                 "other_clan_rep": 2,
                 "frequency": 1
@@ -130,7 +130,7 @@
                 "frequency": 4
             },
             {
-                "text": "p_l approaches the other Clan patrol, striking up a conversation about the weather. After talking for a short time, the two patrols part ways. p_l remarks to the leader on the o_c_n cats' kindness once the patrol has returned to camp.",
+                "text": "p_l approaches the other Clan patrol, striking up a conversation about the weather. After talking for a short time, the two patrols part ways. p_l re-marks to the leader on the o_c_n cats' kindness once the patrol has returned to camp.",
                 "exp": 10,
                 "other_clan_rep": 2,
                 "frequency": 1
@@ -898,7 +898,7 @@
             "border"
         ],
         "tags": [],
-        "patrol_art": "bord_general_intro",
+        "patrol_art": "gen_warrior_crouching",
         "min_cats": 1,
         "max_cats": 1,
         "min_max_status": {
@@ -920,22 +920,99 @@
                 "frequency": 4
             },
             {
-                "text": "r_c comes across a o_c_n apprentice on the wrong side of the border with a mouthful of prey. {PRONOUN/r_c/subject/CAP} {VERB/r_c/see/sees} the younger cat off with a furious yowl, claiming the prey for c_n. Impressed by the catch but not by the antics, r_c feels a begrudging respect for o_c_n as {PRONOUN/r_c/subject} {VERB/r_c/return/returns} home to report this to the deputy.",
+                "text": "r_c comes upon a o_c_n patrol and exchanges pleasantries before continuing along the border.",
                 "exp": 20,
                 "other_clan_rep": 2,
-                "frequency": 1
+                "frequency": 4,
+                "art": "gen_train_talkingOCWW"
             },
             {
-                "text": "s_c comes across a o_c_n patrol, out on a similar mission, and decides to follow the same marking path as them. s_c strikes up a friendly conversation - while they don't give anything away about c_n, they're able to pick up on a lot of gossip about o_c_n through careful conversation.",
+                "min_max_status": {
+                    "warrior": [-1,-1]
+                },
+                "text": "r_c heads out to clarify a portion of the border that there's been confusion over recently and encounters {PRONOUN/r_c/poss} o_c_n counterpart out doing the same thing. They commiserate over the incompetence of the apprentices on both sides that caused the issue and walk away with a greater respect for one another.",
+                "exp": 20,
+                "other_clan_rep": 2,
+                "frequency": 2,
+                "art": "gen_train_talkingOCWW"
+            },
+            {
+                "min_max_status": {
+                    "warrior": [-1,-1]
+                },
+                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to them, led by their deputy. They strike up a friendly conversation, and eventually the o_c_n warriors drift away. The unexpected opportunity turns into the perfect chance to casually but purposefully keep each other informed on an ongoing problem in the territories.",
                 "exp": 20,
                 "stat_skill": [
                     "SPEAKER,1"
                 ],
                 "other_clan_rep": 2,
-                "frequency": 4
+                "frequency": 3,
+                "art": "gen_train_talkingOCWW"
             },
             {
-                "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} a o_c_n border patrol. It even includes a young apprentice, who goes round-eyed and fluffy at encountering a real c_n cat! s_c plays along, acting very impressed with the hardworking apprentice, and the apprentice's mentor purrs gratefully.",
+                "min_max_status": {
+                    "warrior": [-1,-1]
+                },
+                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to s_c with their leader. They strike up a friendly conversation, and eventually the o_c_n warriors drift away. The unexpected opportunity turns into the perfect chance to casually but purposefully keep each other informed on an ongoing problem in the territories.",
+                "exp": 20,
+                "stat_skill": [
+                    "SPEAKER,1"
+                ],
+                "other_clan_rep": 2,
+                "frequency": 3,
+                "art": "gen_train_talkingOCWW"
+            },
+            {
+                "text": "r_c comes across a o_c_n apprentice on the wrong side of the border and holding prey. The young cat seems distraught when they realize their mistake and apologizes profusely. r_c escorts them back to the o_c_n camp and explains the situation to their deputy, who thanks {PRONOUN/r_c/object} for {PRONOUN/r_c/poss} restraint.",
+                "exp": 20,
+                "other_clan_rep": 2,
+                "frequency": 1,
+                "art": "gen_bord_otherclan_app_allies"
+            },
+            {
+                "text": "r_c comes across a o_c_n apprentice on the wrong side of the border, holding prey. Calmly, they tell the apprentice they're on the wrong side of the territory and lead them back to their mentor and rightful side, where the apprentice scampers and is scolded by the o_c_n warrior.",
+                "stat_trait": [
+                    "calm",
+                    "responsible",
+                    "thoughtful",
+                    "careful",
+                    "sincere",
+                    "compassionate"
+                ],
+                "exp": 20,
+                "other_clan_rep": 2,
+                "frequency": 1,
+                "art": "gen_bord_otherclan_app_allies"
+            },
+            {
+                "min_max_status": {
+                    "deputy": [1,1]
+                },
+                "text": "r_c comes across a o_c_n apprentice on the wrong side of the border and holding prey. Furious, {PRONOUN/r_c/subject} {VERB/r_c/snarl/snarls} {PRONOUN/r_c/poss} anger. The apprentice turns tail and flees with r_c hot on their trail, and when the apprentice crosses the border to hide behind their mentor, the o_c_n warrior's face goes slack with horror to see c_n's deputy.",
+                "stat_trait": [
+                    "fierce",
+                    "bloodthirsty",
+                    "insecure",
+                    "arrogant",
+                    "grumpy"
+                ],
+                "exp": 20,
+                "other_clan_rep": 2,
+                "frequency": 1,
+                "art": "gen_angry_cat_warrior"
+            },
+            {
+                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to {PRONOUN/s_c/object}, and turns to follow the same marking path as them. {PRONOUN/s_c/subject/CAP} strike up a friendly conversation, and while s_c doesn't give anything away about c_n, {PRONOUN/s_c/subject}{VERB/s_c/'re/'s} able to pick up on a lot of gossip about o_c_n through careful conversation. It's always worth keeping an eye on their neighbors. Trust, but verify.",
+                "exp": 20,
+                "stat_skill": [
+                    "SPEAKER,1"
+                ],
+                "other_clan_rep": 2,
+                "frequency": 4,
+                "art": "gen_speaking_cat_other1"
+            },
+            {
+                "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} a o_c_n border patrol. It even includes a young apprentice, whose eyes go round and fur fluffs up at encountering a real c_n cat! s_c plays along, acting very impressed with the hardworking apprentice, and the apprentice's mentor purrs gratefully.",
                 "exp": 20,
                 "stat_trait": [
                     "compassionate",
@@ -943,21 +1020,184 @@
                     "loving",
                     "responsible",
                     "thoughtful",
-                    "wise"
+                    "wise",
+                    "confident"
                 ],
                 "other_clan_rep": 2,
-                "frequency": 4
+                "frequency": 3,
+                "art": "gen_train_app_otherclan"
+            },
+            {
+                "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} a o_c_n border patrol. It even includes a young apprentice, whose eyes go round and fur fluffs up at encountering a real c_n cat! Tactlessly, the apprentice immediately turns to their mentor and begins loudly asking <i>why</i> the c_n cat smells like <i>that</i>? s_c laughs good-naturedly and launches into a silly story about rolling in all manner of strange-smelling things in order to trick nasty dogs. The two patrols part in good spirits.",
+                "exp": 0,
+                "stat_trait": [
+                    "strange",
+                    "playful",
+                    "childish",
+                    "flamboyant",
+                    "oblivious",
+                    "shameless"
+                ],
+                "other_clan_rep": 2,
+                "frequency": 3,
+                "art": "gen_train_app_otherclan"
+            },
+            {
+                "min_max_status": {
+                    "deputy": [1,1]
+                },
+                "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} a o_c_n border patrol, which includes a young apprentice. Their eyes go round and they tuck their paws together neatly, sitting pretty for inspection. s_c plays along, acting very impressed with the hardworking apprentice, and the apprentice's mentor purrs gratefully at the c_n deputy's kindness.",
+                "exp": 20,
+                "stat_trait": [
+                    "compassionate",
+                    "faithful",
+                    "loving",
+                    "responsible",
+                    "thoughtful",
+                    "wise",
+                    "confident"
+                ],
+                "other_clan_rep": 2,
+                "frequency": 3,
+                "art": "gen_train_app_otherclan"
+            },
+            {
+                "min_max_status": {
+                    "leader": [1,1]
+                },
+                "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} a o_c_n border patrol, which includes a young apprentice. Their eyes go round and they hide behind their mentor, but s_c manages to coax them out, praising the little apprentice to their mentor, who purrs gratefully at the c_n leader's kindness.",
+                "exp": 20,
+                "stat_trait": [
+                    "compassionate",
+                    "faithful",
+                    "loving",
+                    "responsible",
+                    "thoughtful",
+                    "wise",
+                    "confident"
+                ],
+                "other_clan_rep": 2,
+                "frequency": 3,
+                "art": "gen_train_app_otherclan"
+            },
+            {
+                "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} a o_c_n cat out with their new apprentice. The cat encourages their apprentice to ask s_c any questions they have, and s_c compliments them both on how the young cat's training is progressing.",
+                "exp": 20,
+                "stat_trait": [
+                    "compassionate",
+                    "faithful",
+                    "loving",
+                    "responsible",
+                    "thoughtful",
+                    "wise",
+                    "confident"
+                ],
+                "other_clan_rep": 2,
+                "frequency": 3,
+                "art": "gen_train_app_otherclan"
             }
         ],
         "fail_outcomes": [
             {
-                "text": "r_c marks a little, but {PRONOUN/r_c/subject} {VERB/r_c/reach/reaches} a section of border that is too muddled to make sense of and {VERB/r_c/have/has} to give up and go home.",
+                "text": "r_c comes upon a o_c_n patrol and, in a fit of panic at their unexpected appearance, attempts to hide behind a rock to avoid a conversation. Judging by the puzzled whispers, it didn't quite work. r_c ends up awkwardly squatting there until the patrol finally leaves.",
+                "stat_trait": ["nervous", "gloomy", "lonesome"],
+                "exp": 0,
+                "other_clan_rep": -1,
+                "frequency": 4,
+                "art": "gen_bord_otherclan_allies"
+            },
+            {
+                "text": "r_c marks a little, but {PRONOUN/r_c/subject} {VERB/r_c/reach/reaches} a section where the border is muddled and {VERB/r_c/have/has} to give up and go home. Unclear borders won't make o_c_n too happy, though...",
                 "exp": 0,
                 "other_clan_rep": -1,
                 "frequency": 4
             },
             {
-                "text": "s_c is marking along the territory line when {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} a o_c_n patrol, out on a similar mission. They stare at the other Clan's patrol challengingly, following their every move until the shared border ends. Though no words are exchanged, the tension is palpable.",
+                "min_max_status": {
+                    "deputy": [-1,-1]
+                },
+                "text": "r_c comes across a o_c_n apprentice on the wrong side of the border and holding prey. {PRONOUN/r_c/subject/CAP} {VERB/r_c/see/sees} the young cat off with a furious yowl and then {VERB/r_c/bring/brings} the prey back to c_n camp to report the incident to the deputy.",
+                "prey": ["small"],
+                "exp": 0,
+                "other_clan_rep": -1,
+                "frequency": 2,
+                "art": "gen_angry_cat_warrior"
+            },
+            {
+                "min_max_status": {
+                    "deputy": [1,1]
+                },
+                "text": "r_c heads out to clarify a portion of the border that there's been confusion over recently and encounters the deputy of o_c_n out doing the same thing. Both deputies find a point where they can't agree on the right border path and return to their respective camps to discuss with their leaders.",
+                "exp": 0,
+                "other_clan_rep": -1,
+                "frequency": 2,
+                "art": "gen_train_talkingOCWW"
+            },
+            {
+                "min_max_status": {
+                    "deputy": [1,1]
+                },
+                "text": "s_c heads out to clarify a portion of the border that there's been confusion over recently and encounters the deputy of o_c_n out doing the same thing. s_c insists on {PRONOUN/s_c/poss} idea of the correct border line, despite the other deputy's protests. The two eventually leave to consult with their own leaders, tails whipping and hisses hanging in the air.",
+                "stat_trait": [
+                    "troublesome",
+                    "ambitious",
+                    "fierce",
+                    "bloodthirsty",
+                    "childish",
+                    "bold",
+                    "daring",
+                    "insecure",
+                    "responsible",
+                    "vengeful",
+                    "arrogant",
+                    "competitive",
+                    "grumpy",
+                    "oblivious",
+                    "rebellious"
+                ],
+                "exp": 0,
+                "other_clan_rep": -2,
+                "frequency": 2,
+                "art": "gen_angry_cat_warrior"
+            },
+            {
+                "min_max_status": {
+                    "leader": [1,1]
+                },
+                "text": "r_c heads out to clarify a portion of the border that there's been confusion over recently and encounters the leader of o_c_n out doing the same thing. Both cats find a point where they can't agree on the right border path and agree to bring the subject up at the next Gathering instead.",
+                "exp": 0,
+                "frequency": 2,
+                "art": "gen_train_talkingOCWW"
+            },
+            {
+                "min_max_status": {
+                    "leader": [1,1]
+                },
+                "text": "s_c heads out to clarify a portion of the border that there's been confusion over recently and encounters the leader of o_c_n out doing the same thing. s_c insists on {PRONOUN/s_c/poss} idea of the correct border line, despite the other leader's protests. Hissed promises are made to bring this up at the next Gathering.",
+                "stat_trait": [
+                    "troublesome",
+                    "ambitious",
+                    "fierce",
+                    "bloodthirsty",
+                    "childish",
+                    "bold",
+                    "daring",
+                    "insecure",
+                    "responsible",
+                    "vengeful",
+                    "arrogant",
+                    "competitive",
+                    "grumpy",
+                    "oblivious",
+                    "rebellious"
+                ],
+                "exp": 0,
+                "other_clan_rep": -2,
+                "frequency": 2,
+                "art": "gen_angry_cat_warrior"
+            },
+            {
+                "text": "s_c is marking along the territory line when they encounter a patrol from o_c_n, out on a similar mission. {PRONOUN/s_c/subject/CAP} {VERB/s_c/stare/stares} at the other Clan's patrol challengingly, following their every move until the shared border ends, and though no words are exchanged, it's very tense.",
                 "exp": 0,
                 "stat_trait": [
                     "ambitious",
@@ -967,13 +1207,65 @@
                     "shameless",
                     "strict",
                     "troublesome",
-                    "vengeful"
+                    "vengeful",
+                    "insecure"
                 ],
                 "other_clan_rep": -1,
-                "frequency": 4
+                "frequency": 4,
+                "art": "gen_bord_otherclan_hostile"
             },
             {
-                "text": "r_c is having trouble focusing today and puts a mark in the wrong place - and at the worst possible moment, because a o_c_n patrol sees {PRONOUN/r_c/object} doing it! {PRONOUN/r_c/subject/CAP} {VERB/r_c/return/returns} to camp scratched up and embarrassed, and immediately {VERB/r_c/apologize/apologizes} to the deputy for the diplomatic incident {PRONOUN/r_c/subject}{VERB/r_c/'ve/'s} inadvertently caused.",
+                "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} a o_c_n border patrol. It even includes a young apprentice, whose eyes go round and fur fluffs up at encountering a real c_n cat! Tactlessly, the apprentice immediately turns to their mentor and begins loudly asking <i>why</i> the c_n cat smells like <i>that</i>? s_c bristles and stomps away while the apprentice's mentor stutters apologies behind {PRONOUN/s_c/object}.",
+                "exp": 0,
+                "stat_trait": [
+                    "fierce",
+                    "childish",
+                    "insecure",
+                    "vengeful"
+                ],
+                "other_clan_rep": -2,
+                "frequency": 3,
+                "art": "gen_angry_cat_warrior"
+            },
+            {
+                "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} a o_c_n cat out with their new apprentice. The cat encourages their apprentice to ask s_c any questions they have. The apprentice peppers {PRONOUN/s_c/object} with questions. Some of them are, perhaps, probing a bit too far into c_n's personal affairs, but s_c answers everything enthusiastically. The apprentice's mentor seems surprised at {PRONOUN/s_c/poss} candor... and perhaps a bit concerned at some of the answers.",
+                "exp": 0,
+                "stat_trait": [
+                    "sincere",
+                    "oblivious",
+                    "flamboyant",
+                    "strange",
+                    "competitive",
+                    "childish",
+                    "playful"
+                ],
+                "other_clan_rep": -1,
+                "frequency": 3,
+                "art": "gen_bord_otherclan_app_allies"
+            },
+            {
+                "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} a o_c_n cat out with their new apprentice. The cat encourages their apprentice to ask s_c any questions they have, but s_c interrupts and tersely informs the pair that s_c doesn't have time for questions. s_c leaves the two stunned cats behind to continue {PRONOUN/s_c/poss} patrol.",
+                "exp": 0,
+                "stat_trait": [
+                    "fierce",
+                    "cold",
+                    "strict",
+                    "ambitious",
+                    "responsible",
+                    "loyal",
+                    "competitive",
+                    "arrogant",
+                    "insecure"
+                ],
+                "other_clan_rep": -1,
+                "frequency": 3,
+                "art": "gen_bord_otherclan_app_allies"
+            },
+            {
+                "min_max_status": {
+                    "deputy": [-1,-1]
+                },
+                "text": "r_c is having trouble focusing today and puts a mark in the wrong place - and at the worst possible moment, because a o_c_n patrol sees {PRONOUN/r_c/object} doing it! {PRONOUN/r_c/subject/CAP} {VERB/r_c/come/comes} back to camp scratched up, and immediately {VERB/r_c/apologize/apologizes} to the deputy for the diplomatic incident {PRONOUN/r_c/subject}{VERB/r_c/'ve/'s} inadvertently caused.",
                 "exp": 0,
                 "injury": [
                     {
@@ -989,237 +1281,17 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c was injured by an enemy patrol while marking the border."
+                    "scar": "m_c got injured patrolling on the border."
                 },
                 "other_clan_rep": -1,
-                "frequency": 3
-            }
-        ]
-    },
-    {
-        "patrol_id": "bch_bord_soloneutral2",
-        "biome": [
-            "beach"
-        ],
-        "season": [
-            "any"
-        ],
-        "types": [
-            "border"
-        ],
-        "tags": [],
-        "patrol_art": "bord_general_intro",
-        "min_cats": 1,
-        "max_cats": 1,
-        "min_max_status": {
-            "deputy": [
-                1,
-                1
-            ]
-        },
-        "frequency": 4,
-        "intro_text": "r_c heads out onto the beach alone to check on the border.",
-        "decline_text": "r_c reconsiders and turns back to camp, deciding that {PRONOUN/r_c/poss} other duties have to come first.",
-        "chance_of_success": 30,
-        "success_outcomes": [
-            {
-                "text": "The border with o_c_n extends all the way to the coast, with all the pitfalls that come with that. The spray from the ocean has once again wiped away the border markings. r_c re-marks and heads home, a simple but necessary task completed.",
-                "exp": 20,
-                "other_clan_rep": 2,
-                "frequency": 4
+                "frequency": 2,
+                "art": "gen_battle_warrior_other_clan"
             },
             {
-                "text": "r_c comes across a o_c_n apprentice on the wrong side of the border with a mouthful of prey. Furious, they snarl {PRONOUN/r_c/poss} anger. The young cat turns tail and flees, r_c hot on their tail. When they dart back across the border to hide behind their mentor, the o_c_n warrior's face goes slack with horror to see c_n's deputy.",
-                "exp": 20,
-                "other_clan_rep": 2,
-                "frequency": 1
-            },
-            {
-                "text": "s_c comes across a o_c_n patrol, out on a similar mission. They strike up a friendly conversation, and while s_c doesn't give anything away about c_n, they're able to pick up on a lot of gossip about o_c_n through careful conversation. It's always worth keeping an eye on the neighbors.",
-                "exp": 20,
-                "stat_skill": [
-                    "SPEAKER,1"
-                ],
-                "other_clan_rep": 2,
-                "frequency": 4
-            },
-            {
-                "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} a o_c_n border patrol, which includes a young apprentice. Their eyes go round and they tuck their paws together neatly, sitting pretty for inspection. s_c plays along, acting very impressed with the hardworking apprentice, and the apprentice's mentor purrs gratefully at the c_n deputy's kindness.",
-                "exp": 20,
-                "stat_trait": [
-                    "compassionate",
-                    "faithful",
-                    "loving",
-                    "responsible",
-                    "thoughtful",
-                    "wise"
-                ],
-                "other_clan_rep": 2,
-                "frequency": 4
-            }
-        ],
-        "fail_outcomes": [
-            {
-                "text": "r_c marks a little, but {PRONOUN/r_c/subject} {VERB/r_c/reach/reaches} a section of border that is too muddled to make sense of and {VERB/r_c/have/has} to give up and go home.",
-                "exp": 0,
-                "other_clan_rep": -1,
-                "frequency": 4
-            },
-            {
-                "text": "s_c is marking along the territory line when {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} a o_c_n patrol, out on a similar mission. {PRONOUN/s_c/subject/CAP} {VERB/s_c/stare/stares} at the other Clan's patrol challengingly, following their every move until the shared border ends. Though no words are exchanged, the tension is palpable.",
-                "exp": 0,
-                "stat_trait": [
-                    "ambitious",
-                    "bloodthirsty",
-                    "cold",
-                    "fierce",
-                    "shameless",
-                    "strict",
-                    "troublesome",
-                    "vengeful"
-                ],
-                "other_clan_rep": -1,
-                "frequency": 4
-            },
-            {
-                "text": "r_c encounters a patrol from o_c_n on the border and greets them politely, but there's something different here. Something dangerous. . . r_c never returns to camp.",
-                "exp": 0,
-                "dead_cats": [
-                    "r_c"
-                ],
-                "history_text": {
-                    "scar": "m_c was injured by an enemy patrol while marking the border.",
-                    "reg_death": "m_c lost {PRONOUN/m_c/poss} life in an ambush on the border.",
-                    "lead_death": "{VERB/m_c/were/was} killed in a border ambush"
+                "min_max_status": {
+                    "warrior": [-1,-1]
                 },
-                "other_clan_rep": -1,
-                "frequency": 3
-            },
-            {
-                "text": "r_c is having trouble focusing today and puts a mark in the wrong place - and at the worst possible moment, because a o_c_n patrol sees them doing it! The diplomatic incident spirals into a full-blown conflict, and r_c hauls themselves back to camp, wounded and bleeding.",
-                "exp": 0,
-                "injury": [
-                    {
-                        "cats": [
-                            "r_c"
-                        ],
-                        "injuries": [
-                            "battle_injury"
-                        ],
-                        "scars": []
-                    }
-                ],
-                "history_text": {
-                    "scar": "m_c was injured by an enemy patrol while marking the border.",
-                    "reg_death": "m_c lost {PRONOUN/m_c/poss} life in an ambush on the border.",
-                    "lead_death": "{VERB/m_c/were/was} killed in a border ambush"
-                },
-                "other_clan_rep": -1,
-                "frequency": 3
-            }
-        ]
-    },
-    {
-        "patrol_id": "bch_bord_soloneutral3",
-        "biome": [
-            "beach"
-        ],
-        "season": [
-            "any"
-        ],
-        "types": [
-            "border"
-        ],
-        "tags": [],
-        "patrol_art": "bord_general_intro",
-        "min_cats": 1,
-        "max_cats": 1,
-        "min_max_status": {
-            "leader": [
-                1,
-                1
-            ]
-        },
-        "frequency": 4,
-        "intro_text": "r_c heads out onto the beach alone to check on the border.",
-        "decline_text": "r_c reconsiders and turns back to camp, deciding that their other duties have to come first.",
-        "chance_of_success": 30,
-        "success_outcomes": [
-            {
-                "text": "The border with o_c_n extends all the way to the coast, with all the pitfalls that come with that. The spray from the ocean has once again wiped away the border markings. r_c re-marks and heads home, a simple but necessary task completed.",
-                "exp": 20,
-                "other_clan_rep": 2,
-                "frequency": 4
-            },
-            {
-                "text": "r_c comes across a o_c_n apprentice on the wrong side of the border with a mouthful of prey. Furious, they snarl their anger. The young cat turns tail and flees, r_c hot on their tail. When they dart back across the border to hide behind their mentor, the o_c_n warrior's tail tucks at the sight of c_n's outraged leader.",
-                "exp": 20,
-                "other_clan_rep": 2,
-                "frequency": 1
-            },
-            {
-                "text": "s_c comes across a o_c_n patrol, out on a similar mission. They strike up a friendly conversation, and while s_c doesn't give anything away about c_n, they're able to pick up on a lot of gossip about o_c_n through careful conversation. It's always worth keeping an eye on the neighbors. Trust, but verify.",
-                "exp": 20,
-                "stat_skill": [
-                    "SPEAKER,1"
-                ],
-                "other_clan_rep": 2,
-                "frequency": 4
-            },
-            {
-                "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} a o_c_n border patrol, which includes a young apprentice. Their eyes go round and they hide behind their mentor, but s_c gently coaxes them out. s_c praises the little apprentice to their mentor, who purrs gratefully at the c_n leader's kindness.",
-                "exp": 20,
-                "stat_trait": [
-                    "compassionate",
-                    "faithful",
-                    "loving",
-                    "responsible",
-                    "thoughtful",
-                    "wise"
-                ],
-                "other_clan_rep": 2,
-                "frequency": 4
-            }
-        ],
-        "fail_outcomes": [
-            {
-                "text": "r_c marks a little, but {PRONOUN/r_c/subject} {VERB/r_c/reach/reaches} a section of border that is too muddled to make sense of and {VERB/r_c/have/has} to give up and go home.",
-                "exp": 0,
-                "other_clan_rep": -1,
-                "frequency": 4
-            },
-            {
-                "text": "s_c is marking along the territory line when {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} a o_c_n patrol, out on a similar mission. {PRONOUN/s_c/subject/CAP} {VERB/s_c/stare/stares} at the other Clan's patrol challengingly, following their every move until the shared border ends. Though no words are exchanged, the tension is palpable.",
-                "exp": 0,
-                "stat_trait": [
-                    "ambitious",
-                    "bloodthirsty",
-                    "cold",
-                    "fierce",
-                    "shameless",
-                    "strict",
-                    "troublesome",
-                    "vengeful"
-                ],
-                "other_clan_rep": -1,
-                "frequency": 4
-            },
-            {
-                "text": "r_c encounters a patrol from o_c_n on the border and greets them politely, but there's something different here. Something dangerous. . . r_c returns to camp late, blood soaked through their fur and a new hardness in their heart.",
-                "exp": 0,
-                "dead_cats": [
-                    "r_c"
-                ],
-                "history_text": {
-                    "scar": "m_c was injured by an enemy patrol while marking the border.",
-                    "reg_death": "m_c lost a life in an ambush on the border.",
-                    "lead_death": "{VERB/m_c/were/was} killed in a border ambush"
-                },
-                "other_clan_rep": -1,
-                "frequency": 3
-            },
-            {
-                "text": "r_c is having trouble focusing today and puts a mark in the wrong place - and at the worst possible moment, because a o_c_n patrol sees them doing it! The diplomatic incident spirals into a full-blown conflict, and r_c hauls themselves back to camp, wounded and bleeding.",
+                "text": "r_c is having trouble focusing today and puts a mark in the wrong place - and at the worst possible moment, because a o_c_n patrol sees them doing it! The diplomatic incident spirals into a full blown conflict, and r_c hauls themselves back to camp wounded and bleeding.",
                 "exp": 0,
                 "injury": [
                     {
@@ -1230,203 +1302,16 @@
                             "battle_injury"
                         ],
                         "scars": [
-                            "CHEEK"
+                            "SIDE"
                         ]
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c was injured by an enemy patrol while marking the border.",
-                    "reg_death": "m_c lost a life in an ambush on the border.",
-                    "lead_death": "{VERB/m_c/were/was} killed in a border ambush"
+                    "scar": "m_c got injured patrolling on the border."
                 },
                 "other_clan_rep": -1,
-                "frequency": 3
-            }
-        ]
-    },
-    {
-        "patrol_id": "bch_bord_soloneutral4",
-        "biome": [
-            "beach"
-        ],
-        "season": [
-            "any"
-        ],
-        "types": [
-            "border"
-        ],
-        "tags": [],
-        "patrol_art": "bord_general_intro",
-        "min_cats": 1,
-        "max_cats": 1,
-        "min_max_status": {
-            "deputy": [
-                1,
-                6
-            ]
-        },
-        "frequency": 4,
-        "intro_text": "r_c heads out onto the beach alone to check on the border.",
-        "decline_text": "r_c reconsiders and turns back to camp, deciding that their other duties have to come first.",
-        "chance_of_success": 30,
-        "success_outcomes": [
-            {
-                "text": "The border with o_c_n extends all the way to the coast, with all the pitfalls that come with that. The spray from the ocean has once again wiped away the border markings. r_c re-marks and heads home, a simple but necessary task completed.",
-                "exp": 20,
-                "other_clan_rep": 2,
-                "frequency": 4
-            },
-            {
-                "text": "r_c heads out to clarify a portion of the border that there's been confusion over recently and encounters the o_c_n deputy out doing the same thing. They commiserate over the incompetence of the apprentices on both sides that caused the issue, and walk away with greater respect for one another.",
-                "exp": 20,
-                "other_clan_rep": 2,
-                "frequency": 1
-            },
-            {
-                "text": "s_c comes across a o_c_n patrol, out on a similar mission and being led by their deputy. The deputies strike up a conversation, and the o_c_n warriors eventually wander off. The unexpected opportunity gives the two a chance to privately exchange news about an ongoing problem on the coast.",
-                "exp": 20,
-                "stat_skill": [
-                    "SPEAKER,1"
-                ],
-                "other_clan_rep": 2,
-                "frequency": 4
-            },
-            {
-                "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} the o_c_n deputy out with their new apprentice. The fellow deputy greets s_c and encourages their apprentice to quiz them. s_c plays along and compliments them both on how the young cat's training is progressing before parting ways.",
-                "exp": 20,
-                "stat_trait": [
-                    "compassionate",
-                    "faithful",
-                    "loving",
-                    "responsible",
-                    "thoughtful",
-                    "wise"
-                ],
-                "other_clan_rep": 2,
-                "frequency": 4
-            }
-        ],
-        "fail_outcomes": [
-            {
-                "text": "r_c heads out to clarify a portion of the border that there's been confusion over recently and encounters the o_c_n deputy out doing the same thing. Unable to agree on exactly where the borders are meant to lie, both deputies must return to camp and raise the issue with their leaders.",
-                "exp": 0,
-                "other_clan_rep": -1,
-                "frequency": 4
-            },
-            {
-                "text": "r_c is having trouble focusing today and puts a mark in the wrong place - and at the worst possible moment, because a o_c_n patrol sees them doing it! The diplomatic incident spirals into a full-blown conflict, and r_c hauls themselves back to camp, wounded and bleeding.",
-                "exp": 0,
-                "injury": [
-                    {
-                        "cats": [
-                            "r_c"
-                        ],
-                        "injuries": [
-                            "battle_injury"
-                        ],
-                        "scars": [
-                            "CHEEK"
-                        ]
-                    }
-                ],
-                "history_text": {
-                    "scar": "m_c was injured by an enemy patrol while marking the border."
-                },
-                "other_clan_rep": -1,
-                "frequency": 3
-            }
-        ]
-    },
-    {
-        "patrol_id": "bch_bord_soloneutral5",
-        "biome": [
-            "beach"
-        ],
-        "season": [
-            "any"
-        ],
-        "types": [
-            "border"
-        ],
-        "tags": [],
-        "patrol_art": "bord_general_intro",
-        "min_cats": 1,
-        "max_cats": 1,
-        "min_max_status": {
-            "leader": [
-                1,
-                6
-            ]
-        },
-        "frequency": 4,
-        "intro_text": "r_c heads out onto the beach alone to check on the border.",
-        "decline_text": "r_c reconsiders and turns back to camp, deciding that their other duties have to come first.",
-        "chance_of_success": 30,
-        "success_outcomes": [
-            {
-                "text": "The border with o_c_n extends all the way to the coast, with all the pitfalls that come with that. The spray from the ocean has once again wiped away the border markings. r_c re-marks and heads home, a simple but necessary task completed.",
-                "exp": 20,
-                "other_clan_rep": 2,
-                "frequency": 4
-            },
-            {
-                "text": "r_c heads out to clarify a portion of the border that there's been confusion over recently and encounters the o_c_n leader out doing the same thing. They commiserate over the incompetence of the apprentices on both sides that caused the issue, and walk away with greater respect for one another.",
-                "exp": 20,
-                "other_clan_rep": 2,
-                "frequency": 1
-            },
-            {
-                "text": "s_c comes across a o_c_n patrol, out on a similar mission and being led by their deputy. The leaders strike up a conversation, and the o_c_n warriors eventually wander off. The unexpected opportunity gives the two a chance to privately exchange news about an ongoing problem on the coast.",
-                "exp": 20,
-                "stat_skill": [
-                    "SPEAKER,1"
-                ],
-                "other_clan_rep": 2,
-                "frequency": 4
-            },
-            {
-                "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} the o_c_n leader out with their new apprentice. The fellow deputy greets s_c and encourages their apprentice to quiz them. s_c plays along and compliments them both on how the young cat's training is progressing before parting ways.",
-                "exp": 20,
-                "stat_trait": [
-                    "compassionate",
-                    "faithful",
-                    "loving",
-                    "responsible",
-                    "thoughtful",
-                    "wise"
-                ],
-                "other_clan_rep": 2,
-                "frequency": 4
-            }
-        ],
-        "fail_outcomes": [
-            {
-                "text": "r_c heads out to clarify a portion of the border that there's been confusion over recently and encounters the o_c_n leader out doing the same thing. Unable to agree on exactly where the borders are meant to lie, both leaders agree to raise it at the next Gathering instead.",
-                "exp": 0,
-                "other_clan_rep": -1,
-                "frequency": 4
-            },
-            {
-                "text": "r_c is having trouble focusing today and puts a mark in the wrong place - and at the worst possible moment, because a o_c_n patrol sees them doing it! The diplomatic incident spirals into a full-blown conflict, and r_c hauls themselves back to camp, wounded and bleeding.",
-                "exp": 0,
-                "injury": [
-                    {
-                        "cats": [
-                            "r_c"
-                        ],
-                        "injuries": [
-                            "battle_injury"
-                        ],
-                        "scars": [
-                            "SNOUT"
-                        ]
-                    }
-                ],
-                "history_text": {
-                    "scar": "m_c was injured by an enemy patrol while marking the border."
-                },
-                "other_clan_rep": -1,
-                "frequency": 3
+                "frequency": 2,
+                "art": "gen_battle_warrior_other_clan"
             }
         ]
     },
@@ -1442,7 +1327,7 @@
             "border"
         ],
         "tags": [],
-        "patrol_art": "bord_general_intro",
+        "patrol_art": "gen_warrior_crouching",
         "min_cats": 1,
         "max_cats": 1,
         "min_max_status": {},
@@ -1452,25 +1337,102 @@
         "chance_of_success": 30,
         "success_outcomes": [
             {
-                "text": "A section of their border with o_c_n has had the border markings wiped off the map by a duststorm. Not that seeing any sign of o_c_n other than their scent is very common, but r_c remarks it and heads home, a simple but necessary mission completed.",
+                "text": "A section of their border with o_c_n has had the border markings wiped off the map by a duststorm. Not that seeing any sign of o_c_n other than their scent is very common, but r_c re-marks it and heads home, a simple but necessary mission completed.",
                 "exp": 20,
                 "other_clan_rep": 2,
                 "frequency": 4
             },
             {
-                "text": "r_c comes across a o_c_n apprentice on the wrong side of the border and holding precious prey. {PRONOUN/r_c/subject/CAP} {VERB/r_c/see/sees} the young cat off with a furious yowl and then {VERB/r_c/bring/brings} the prey back to c_n camp to report the incident to the deputy.",
+                "text": "r_c comes upon a o_c_n patrol and exchanges pleasantries before continuing along the border.",
                 "exp": 20,
                 "other_clan_rep": 2,
-                "frequency": 1
+                "frequency": 4,
+                "art": "gen_train_talkingOCWW"
             },
             {
-                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to them. How unusual to meet a patrol in person! They strike up a friendly conversation, and while s_c doesn't give anything away about c_n, they're able to pick up on a lot of gossip about o_c_n through careful conversation.",
+                "min_max_status": {
+                    "warrior": [-1,-1]
+                },
+                "text": "r_c heads out to clarify a portion of the border that there's been confusion over recently and encounters {PRONOUN/r_c/poss} o_c_n counterpart out doing the same thing. They commiserate over the incompetence of the apprentices on both sides that caused the issue and walk away with a greater respect for one another.",
+                "exp": 20,
+                "other_clan_rep": 2,
+                "frequency": 2,
+                "art": "gen_train_talkingOCWW"
+            },
+            {
+                "min_max_status": {
+                    "warrior": [-1,-1]
+                },
+                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to them, led by their deputy. They strike up a friendly conversation, and eventually the o_c_n warriors drift away. The unexpected opportunity turns into the perfect chance to casually but purposefully keep each other informed on an ongoing problem in the territories.",
                 "exp": 20,
                 "stat_skill": [
                     "SPEAKER,1"
                 ],
                 "other_clan_rep": 2,
-                "frequency": 4
+                "frequency": 3,
+                "art": "gen_train_talkingOCWW"
+            },
+            {
+                "min_max_status": {
+                    "warrior": [-1,-1]
+                },
+                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to s_c with their leader. They strike up a friendly conversation, and eventually the o_c_n warriors drift away. The unexpected opportunity turns into the perfect chance to casually but purposefully keep each other informed on an ongoing problem in the territories.",
+                "exp": 20,
+                "stat_skill": [
+                    "SPEAKER,1"
+                ],
+                "other_clan_rep": 2,
+                "frequency": 3,
+                "art": "gen_train_talkingOCWW"
+            },
+            {
+                "text": "r_c comes across a o_c_n apprentice on the wrong side of the border and holding prey. The young cat seems distraught when they realize their mistake and apologizes profusely. r_c escorts them back to the o_c_n camp and explains the situation to their deputy, who thanks {PRONOUN/r_c/object} for {PRONOUN/r_c/poss} restraint.",
+                "exp": 20,
+                "other_clan_rep": 2,
+                "frequency": 1,
+                "art": "gen_bord_otherclan_app_allies"
+            },
+            {
+                "text": "r_c comes across a o_c_n apprentice on the wrong side of the border, holding prey. Calmly, they tell the apprentice they're on the wrong side of the territory and lead them back to their mentor and rightful side, where the apprentice scampers and is scolded by the o_c_n warrior.",
+                "stat_trait": [
+                    "calm",
+                    "responsible",
+                    "thoughtful",
+                    "careful",
+                    "sincere",
+                    "compassionate"
+                ],
+                "exp": 20,
+                "other_clan_rep": 2,
+                "frequency": 1,
+                "art": "gen_bord_otherclan_app_allies"
+            },
+            {
+                "min_max_status": {
+                    "deputy": [1,1]
+                },
+                "text": "r_c comes across a o_c_n apprentice on the wrong side of the border and holding prey. Furious, {PRONOUN/r_c/subject} {VERB/r_c/snarl/snarls} {PRONOUN/r_c/poss} anger. The apprentice turns tail and flees with r_c hot on their trail, and when the apprentice crosses the border to hide behind their mentor, the o_c_n warrior's face goes slack with horror to see c_n's deputy.",
+                "stat_trait": [
+                    "fierce",
+                    "bloodthirsty",
+                    "insecure",
+                    "arrogant",
+                    "grumpy"
+                ],
+                "exp": 20,
+                "other_clan_rep": 2,
+                "frequency": 1,
+                "art": "gen_angry_cat_warrior"
+            },
+            {
+                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to {PRONOUN/s_c/object}, and turns to follow the same marking path as them. {PRONOUN/s_c/subject/CAP} strike up a friendly conversation, and while s_c doesn't give anything away about c_n, {PRONOUN/s_c/subject}{VERB/s_c/'re/'s} able to pick up on a lot of gossip about o_c_n through careful conversation. It's always worth keeping an eye on their neighbors. Trust, but verify.",
+                "exp": 20,
+                "stat_skill": [
+                    "SPEAKER,1"
+                ],
+                "other_clan_rep": 2,
+                "frequency": 4,
+                "art": "gen_speaking_cat_other1"
             },
             {
                 "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} a o_c_n border patrol. It even includes a young apprentice, whose eyes go round and fur fluffs up at encountering a real c_n cat! s_c plays along, acting very impressed with the hardworking apprentice, and the apprentice's mentor purrs gratefully.",
@@ -1481,85 +1443,32 @@
                     "loving",
                     "responsible",
                     "thoughtful",
-                    "wise"
+                    "wise",
+                    "confident"
                 ],
                 "other_clan_rep": 2,
-                "frequency": 4
-            }
-        ],
-        "fail_outcomes": [
-            {
-                "text": "r_c marks a little, but {PRONOUN/r_c/subject} {VERB/r_c/reach/reaches} a section where the border is muddled and {VERB/r_c/have/has} to give up and go home.",
-                "exp": 0,
-                "other_clan_rep": -1,
-                "frequency": 4
+                "frequency": 3,
+                "art": "gen_train_app_otherclan"
             },
             {
-                "text": "s_c is marking along the territory line when they encounter a patrol from o_c_n, out on a similar mission. {PRONOUN/s_c/subject/CAP} {VERB/s_c/stare/stares} at the other Clan's patrol challengingly, following their every move until the shared border ends, and though no words are exchanged, it's very tense.",
+                "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} a o_c_n border patrol. It even includes a young apprentice, whose eyes go round and fur fluffs up at encountering a real c_n cat! Tactlessly, the apprentice immediately turns to their mentor and begins loudly asking <i>why</i> the c_n cat smells like <i>that</i>? s_c laughs good-naturedly and launches into a silly story about rolling in all manner of strange-smelling things in order to trick nasty dogs. The two patrols part in good spirits.",
                 "exp": 0,
                 "stat_trait": [
-                    "ambitious",
-                    "bloodthirsty",
-                    "cold",
-                    "fierce",
-                    "shameless",
-                    "strict",
-                    "troublesome",
-                    "vengeful"
-                ],
-                "other_clan_rep": -1,
-                "frequency": 4
-            }
-        ]
-    },
-    {
-        "patrol_id": "dst_bord_soloneutral2",
-        "biome": [
-            "desert"
-        ],
-        "season": [
-            "any"
-        ],
-        "types": [
-            "border"
-        ],
-        "tags": [],
-        "patrol_art": "bord_general_intro",
-        "min_cats": 1,
-        "max_cats": 1,
-        "min_max_status": {
-            "deputy": [
-                1,
-                6
-            ]
-        },
-        "frequency": 4,
-        "intro_text": "r_c heads out into the desert alone, wanting to make a quick check on the border.",
-        "decline_text": "r_c turns back to camp, deciding that {PRONOUN/r_c/poss} other duties have to come first.",
-        "chance_of_success": 30,
-        "success_outcomes": [
-            {
-                "text": "A section of their border with o_c_n has had the border markings wiped off the map by a duststorm. Not that seeing any sign of o_c_n other than their scent is very common, but r_c remarks it and heads home, a simple but necessary mission completed.",
-                "exp": 20,
-                "other_clan_rep": 2,
-                "frequency": 4
-            },
-            {
-                "text": "r_c comes across a o_c_n apprentice on the wrong side of the border and holding precious prey. Furious, they snarl their anger. The apprentice turns tail and flees with r_c hot on their trail, and when the apprentice crosses the border to hide behind their mentor, the o_c_n warrior's face goes slack with horror to see c_n's deputy.",
-                "exp": 20,
-                "other_clan_rep": 2,
-                "frequency": 1
-            },
-            {
-                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to them. How unusual to meet a patrol in person! They strike up a friendly conversation, and while s_c doesn't give anything away about c_n, they're able to pick up on a lot of gossip about o_c_n through careful conversation. It's always worth keeping an eye on their neighbors.",
-                "exp": 20,
-                "stat_skill": [
-                    "SPEAKER,1"
+                    "strange",
+                    "playful",
+                    "childish",
+                    "flamboyant",
+                    "oblivious",
+                    "shameless"
                 ],
                 "other_clan_rep": 2,
-                "frequency": 4
+                "frequency": 3,
+                "art": "gen_train_app_otherclan"
             },
             {
+                "min_max_status": {
+                    "deputy": [1,1]
+                },
                 "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} a o_c_n border patrol, which includes a young apprentice. Their eyes go round and they tuck their paws together neatly, sitting pretty for inspection. s_c plays along, acting very impressed with the hardworking apprentice, and the apprentice's mentor purrs gratefully at the c_n deputy's kindness.",
                 "exp": 20,
                 "stat_trait": [
@@ -1568,107 +1477,17 @@
                     "loving",
                     "responsible",
                     "thoughtful",
-                    "wise"
+                    "wise",
+                    "confident"
                 ],
                 "other_clan_rep": 2,
-                "frequency": 4
-            }
-        ],
-        "fail_outcomes": [
-            {
-                "text": "r_c marks a little, but {PRONOUN/r_c/subject} {VERB/r_c/reach/reaches} a section where the border is muddled and {VERB/r_c/have/has} to give up and go home.",
-                "exp": 0,
-                "other_clan_rep": -1,
-                "frequency": 4
+                "frequency": 3,
+                "art": "gen_train_app_otherclan"
             },
             {
-                "text": "s_c is marking along the territory line when they encounter a patrol from o_c_n, out on a similar mission. {PRONOUN/s_c/subject/CAP} {VERB/s_c/stare/stares} at the other Clan's patrol challengingly, following their every move until the shared border ends, and though no words are exchanged, it's very tense.",
-                "exp": 0,
-                "stat_trait": [
-                    "ambitious",
-                    "bloodthirsty",
-                    "cold",
-                    "fierce",
-                    "shameless",
-                    "strict",
-                    "troublesome",
-                    "vengeful"
-                ],
-                "other_clan_rep": -1,
-                "frequency": 4
-            },
-            {
-                "text": "r_c is having trouble focusing today and puts a mark in the wrong place - and at the worst possible moment, because a o_c_n patrol sees them doing it! The diplomatic incident spirals into a full blown conflict, and r_c hauls themselves back to camp wounded and bleeding.",
-                "exp": 0,
-                "injury": [
-                    {
-                        "cats": [
-                            "r_c"
-                        ],
-                        "injuries": [
-                            "battle_injury"
-                        ],
-                        "scars": [
-                            "CHEEK"
-                        ]
-                    }
-                ],
-                "history_text": {
-                    "scar": "m_c got injured patrolling on the border."
+                "min_max_status": {
+                    "leader": [1,1]
                 },
-                "other_clan_rep": -1,
-                "frequency": 3
-            }
-        ]
-    },
-    {
-        "patrol_id": "dst_bord_soloneutral3",
-        "biome": [
-            "desert"
-        ],
-        "season": [
-            "any"
-        ],
-        "types": [
-            "border"
-        ],
-        "tags": [],
-        "patrol_art": "bord_general_intro",
-        "min_cats": 1,
-        "max_cats": 1,
-        "min_max_status": {
-            "leader": [
-                1,
-                6
-            ]
-        },
-        "frequency": 4,
-        "intro_text": "r_c heads out into the desert alone, wanting to make a quick check on the border.",
-        "decline_text": "r_c turns back to camp, deciding that {PRONOUN/r_c/poss} other duties have to come first.",
-        "chance_of_success": 30,
-        "success_outcomes": [
-            {
-                "text": "A section of their border with o_c_n has had the border markings wiped off the map by a duststorm. Not that seeing any sign of o_c_n other than their scent is very common, but r_c remarks it and heads home, a simple but necessary mission completed.",
-                "exp": 20,
-                "other_clan_rep": 2,
-                "frequency": 4
-            },
-            {
-                "text": "r_c comes across a o_c_n apprentice on the wrong side of the border and holding prey. Furious, {PRONOUN/r_c/subject} {VERB/r_c/snarl/snarls} {PRONOUN/r_c/poss} anger. The apprentice turns tail and flees with r_c hot on their trail, and when the apprentice crosses the border to hide behind their mentor, the o_c_n warrior's tail tucks at the sight of c_n's outraged leader.",
-                "exp": 20,
-                "other_clan_rep": 2,
-                "frequency": 1
-            },
-            {
-                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to them. How unusual to meet a patrol in person! They strike up a friendly conversation, and while s_c doesn't give anything away about c_n, they're able to pick up on a lot of gossip about o_c_n through careful conversation. Trust, but verify.",
-                "exp": 20,
-                "stat_skill": [
-                    "SPEAKER,1"
-                ],
-                "other_clan_rep": 2,
-                "frequency": 4
-            },
-            {
                 "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} a o_c_n border patrol, which includes a young apprentice. Their eyes go round and they hide behind their mentor, but s_c manages to coax them out, praising the little apprentice to their mentor, who purrs gratefully at the c_n leader's kindness.",
                 "exp": 20,
                 "stat_trait": [
@@ -1677,18 +1496,128 @@
                     "loving",
                     "responsible",
                     "thoughtful",
-                    "wise"
+                    "wise",
+                    "confident"
                 ],
                 "other_clan_rep": 2,
-                "frequency": 4
+                "frequency": 3,
+                "art": "gen_train_app_otherclan"
+            },
+            {
+                "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} a o_c_n cat out with their new apprentice. The cat encourages their apprentice to ask s_c any questions they have, and s_c compliments them both on how the young cat's training is progressing.",
+                "exp": 20,
+                "stat_trait": [
+                    "compassionate",
+                    "faithful",
+                    "loving",
+                    "responsible",
+                    "thoughtful",
+                    "wise",
+                    "confident"
+                ],
+                "other_clan_rep": 2,
+                "frequency": 3,
+                "art": "gen_train_app_otherclan"
             }
         ],
         "fail_outcomes": [
             {
-                "text": "r_c marks a little, but {PRONOUN/r_c/subject} {VERB/r_c/reach/reaches} a section where the border is muddled and {VERB/r_c/have/has} to give up and go home.",
+                "text": "r_c comes upon a o_c_n patrol and, in a fit of panic at their unexpected appearance, attempts to hide behind a rock to avoid a conversation. Judging by the puzzled whispers, it didn't quite work. r_c ends up awkwardly squatting there until the patrol finally leaves.",
+                "stat_trait": ["nervous", "gloomy", "lonesome"],
+                "exp": 0,
+                "other_clan_rep": -1,
+                "frequency": 4,
+                "art": "gen_bord_otherclan_allies"
+            },
+            {
+                "text": "r_c marks a little, but {PRONOUN/r_c/subject} {VERB/r_c/reach/reaches} a section where the border is muddled and {VERB/r_c/have/has} to give up and go home. Unclear borders won't make o_c_n too happy, though...",
                 "exp": 0,
                 "other_clan_rep": -1,
                 "frequency": 4
+            },
+            {
+                "min_max_status": {
+                    "deputy": [-1,-1]
+                },
+                "text": "r_c comes across a o_c_n apprentice on the wrong side of the border and holding prey. {PRONOUN/r_c/subject/CAP} {VERB/r_c/see/sees} the young cat off with a furious yowl and then {VERB/r_c/bring/brings} the prey back to c_n camp to report the incident to the deputy.",
+                "prey": ["small"],
+                "exp": 0,
+                "other_clan_rep": -1,
+                "frequency": 2,
+                "art": "gen_angry_cat_warrior"
+            },
+            {
+                "min_max_status": {
+                    "deputy": [1,1]
+                },
+                "text": "r_c heads out to clarify a portion of the border that there's been confusion over recently and encounters the deputy of o_c_n out doing the same thing. Both deputies find a point where they can't agree on the right border path and return to their respective camps to discuss with their leaders.",
+                "exp": 0,
+                "other_clan_rep": -1,
+                "frequency": 2,
+                "art": "gen_train_talkingOCWW"
+            },
+            {
+                "min_max_status": {
+                    "deputy": [1,1]
+                },
+                "text": "s_c heads out to clarify a portion of the border that there's been confusion over recently and encounters the deputy of o_c_n out doing the same thing. s_c insists on {PRONOUN/s_c/poss} idea of the correct border line, despite the other deputy's protests. The two eventually leave to consult with their own leaders, tails whipping and hisses hanging in the air.",
+                "stat_trait": [
+                    "troublesome",
+                    "ambitious",
+                    "fierce",
+                    "bloodthirsty",
+                    "childish",
+                    "bold",
+                    "daring",
+                    "insecure",
+                    "responsible",
+                    "vengeful",
+                    "arrogant",
+                    "competitive",
+                    "grumpy",
+                    "oblivious",
+                    "rebellious"
+                ],
+                "exp": 0,
+                "other_clan_rep": -2,
+                "frequency": 2,
+                "art": "gen_angry_cat_warrior"
+            },
+            {
+                "min_max_status": {
+                    "leader": [1,1]
+                },
+                "text": "r_c heads out to clarify a portion of the border that there's been confusion over recently and encounters the leader of o_c_n out doing the same thing. Both cats find a point where they can't agree on the right border path and agree to bring the subject up at the next Gathering instead.",
+                "exp": 0,
+                "frequency": 2,
+                "art": "gen_train_talkingOCWW"
+            },
+            {
+                "min_max_status": {
+                    "leader": [1,1]
+                },
+                "text": "s_c heads out to clarify a portion of the border that there's been confusion over recently and encounters the leader of o_c_n out doing the same thing. s_c insists on {PRONOUN/s_c/poss} idea of the correct border line, despite the other leader's protests. Hissed promises are made to bring this up at the next Gathering.",
+                "stat_trait": [
+                    "troublesome",
+                    "ambitious",
+                    "fierce",
+                    "bloodthirsty",
+                    "childish",
+                    "bold",
+                    "daring",
+                    "insecure",
+                    "responsible",
+                    "vengeful",
+                    "arrogant",
+                    "competitive",
+                    "grumpy",
+                    "oblivious",
+                    "rebellious"
+                ],
+                "exp": 0,
+                "other_clan_rep": -2,
+                "frequency": 2,
+                "art": "gen_angry_cat_warrior"
             },
             {
                 "text": "s_c is marking along the territory line when they encounter a patrol from o_c_n, out on a similar mission. {PRONOUN/s_c/subject/CAP} {VERB/s_c/stare/stares} at the other Clan's patrol challengingly, following their every move until the shared border ends, and though no words are exchanged, it's very tense.",
@@ -1701,12 +1630,90 @@
                     "shameless",
                     "strict",
                     "troublesome",
-                    "vengeful"
+                    "vengeful",
+                    "insecure"
                 ],
                 "other_clan_rep": -1,
-                "frequency": 4
+                "frequency": 4,
+                "art": "gen_bord_otherclan_hostile"
             },
             {
+                "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} a o_c_n border patrol. It even includes a young apprentice, whose eyes go round and fur fluffs up at encountering a real c_n cat! Tactlessly, the apprentice immediately turns to their mentor and begins loudly asking <i>why</i> the c_n cat smells like <i>that</i>? s_c bristles and stomps away while the apprentice's mentor stutters apologies behind {PRONOUN/s_c/object}.",
+                "exp": 0,
+                "stat_trait": [
+                    "fierce",
+                    "childish",
+                    "insecure",
+                    "vengeful"
+                ],
+                "other_clan_rep": -2,
+                "frequency": 3,
+                "art": "gen_angry_cat_warrior"
+            },
+            {
+                "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} a o_c_n cat out with their new apprentice. The cat encourages their apprentice to ask s_c any questions they have. The apprentice peppers {PRONOUN/s_c/object} with questions. Some of them are, perhaps, probing a bit too far into c_n's personal affairs, but s_c answers everything enthusiastically. The apprentice's mentor seems surprised at {PRONOUN/s_c/poss} candor... and perhaps a bit concerned at some of the answers.",
+                "exp": 0,
+                "stat_trait": [
+                    "sincere",
+                    "oblivious",
+                    "flamboyant",
+                    "strange",
+                    "competitive",
+                    "childish",
+                    "playful"
+                ],
+                "other_clan_rep": -1,
+                "frequency": 3,
+                "art": "gen_bord_otherclan_app_allies"
+            },
+            {
+                "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} a o_c_n cat out with their new apprentice. The cat encourages their apprentice to ask s_c any questions they have, but s_c interrupts and tersely informs the pair that s_c doesn't have time for questions. s_c leaves the two stunned cats behind to continue {PRONOUN/s_c/poss} patrol.",
+                "exp": 0,
+                "stat_trait": [
+                    "fierce",
+                    "cold",
+                    "strict",
+                    "ambitious",
+                    "responsible",
+                    "loyal",
+                    "competitive",
+                    "arrogant",
+                    "insecure"
+                ],
+                "other_clan_rep": -1,
+                "frequency": 3,
+                "art": "gen_bord_otherclan_app_allies"
+            },
+            {
+                "min_max_status": {
+                    "deputy": [-1,-1]
+                },
+                "text": "r_c is having trouble focusing today and puts a mark in the wrong place - and at the worst possible moment, because a o_c_n patrol sees {PRONOUN/r_c/object} doing it! {PRONOUN/r_c/subject/CAP} {VERB/r_c/come/comes} back to camp scratched up, and immediately {VERB/r_c/apologize/apologizes} to the deputy for the diplomatic incident {PRONOUN/r_c/subject}{VERB/r_c/'ve/'s} inadvertently caused.",
+                "exp": 0,
+                "injury": [
+                    {
+                        "cats": [
+                            "r_c"
+                        ],
+                        "injuries": [
+                            "battle_injury"
+                        ],
+                        "scars": [
+                            "BRIDGE"
+                        ]
+                    }
+                ],
+                "history_text": {
+                    "scar": "m_c got injured patrolling on the border."
+                },
+                "other_clan_rep": -1,
+                "frequency": 2,
+                "art": "gen_battle_warrior_other_clan"
+            },
+            {
+                "min_max_status": {
+                    "warrior": [-1,-1]
+                },
                 "text": "r_c is having trouble focusing today and puts a mark in the wrong place - and at the worst possible moment, because a o_c_n patrol sees them doing it! The diplomatic incident spirals into a full blown conflict, and r_c hauls themselves back to camp wounded and bleeding.",
                 "exp": 0,
                 "injury": [
@@ -1718,7 +1725,7 @@
                             "battle_injury"
                         ],
                         "scars": [
-                            "TWO"
+                            "SIDE"
                         ]
                     }
                 ],
@@ -1726,149 +1733,8 @@
                     "scar": "m_c got injured patrolling on the border."
                 },
                 "other_clan_rep": -1,
-                "frequency": 3
-            }
-        ]
-    },
-    {
-        "patrol_id": "dst_bord_soloneutral4",
-        "biome": [
-            "desert"
-        ],
-        "season": [
-            "any"
-        ],
-        "types": [
-            "border"
-        ],
-        "tags": [],
-        "patrol_art": "bord_general_intro",
-        "min_cats": 1,
-        "max_cats": 1,
-        "min_max_status": {
-            "deputy": [
-                1,
-                6
-            ]
-        },
-        "frequency": 4,
-        "intro_text": "r_c heads out into the desert alone, wanting to make a quick check on the border.",
-        "decline_text": "r_c turns back to camp, deciding that {PRONOUN/r_c/poss} other duties have to come first.",
-        "chance_of_success": 30,
-        "success_outcomes": [
-            {
-                "text": "A section of their border with o_c_n has had the border markings wiped off the map by a duststorm. Not that seeing any sign of o_c_n other than their scent is very common, but r_c remarks it and heads home, a simple but necessary mission completed.",
-                "exp": 20,
-                "other_clan_rep": 2,
-                "frequency": 4
-            },
-            {
-                "text": "r_c heads out to clarify a portion of the border that there's been confusion over recently and encounters the deputy of o_c_n out doing the same thing. They commiserate over the incompetence of the apprentices on both sides that caused the issue and walk away with a greater respect for one another.",
-                "exp": 20,
-                "other_clan_rep": 2,
-                "frequency": 1
-            },
-            {
-                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to them, led by their deputy. How unusual to meet a patrol in person! They strike up a friendly conversation. The unexpected opportunity turns into the perfect chance to casually but purposefully keep each other informed on an ongoing problem in the desert.",
-                "exp": 20,
-                "stat_skill": [
-                    "SPEAKER,1"
-                ],
-                "other_clan_rep": 2,
-                "frequency": 4
-            },
-            {
-                "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} the o_c_n deputy out with their new apprentice. Their fellow deputy encourages their apprentice to quiz s_c, and s_c compliments them both on how the young cat's training is progressing.",
-                "exp": 20,
-                "stat_trait": [
-                    "compassionate",
-                    "faithful",
-                    "loving",
-                    "responsible",
-                    "thoughtful",
-                    "wise"
-                ],
-                "other_clan_rep": 2,
-                "frequency": 4
-            }
-        ],
-        "fail_outcomes": [
-            {
-                "text": "r_c heads out to clarify a portion of the border that there's been confusion over recently and encounters the deputy of o_c_n out doing the same thing. Both deputies find a point where they can't agree on the right border path and return to their respective camps to discuss with their leaders.",
-                "exp": 0,
-                "other_clan_rep": -1,
-                "frequency": 4
-            }
-        ]
-    },
-    {
-        "patrol_id": "dst_bord_soloneutral5",
-        "biome": [
-            "desert"
-        ],
-        "season": [
-            "any"
-        ],
-        "types": [
-            "border"
-        ],
-        "tags": [],
-        "patrol_art": "bord_general_intro",
-        "min_cats": 1,
-        "max_cats": 1,
-        "min_max_status": {
-            "leader": [
-                1,
-                6
-            ]
-        },
-        "frequency": 4,
-        "intro_text": "r_c heads out into the desert alone, wanting to make a quick check on the border.",
-        "decline_text": "r_c turns back to camp, deciding that {PRONOUN/r_c/poss} other duties have to come first.",
-        "chance_of_success": 30,
-        "success_outcomes": [
-            {
-                "text": "A section of their border with o_c_n has had the border markings wiped off the map by a duststorm. Not that seeing any sign of o_c_n other than their scent is very common, but r_c remarks it and heads home, a simple but necessary mission completed.",
-                "exp": 20,
-                "other_clan_rep": 2,
-                "frequency": 4
-            },
-            {
-                "text": "r_c heads out to clarify a portion of the border that there's been confusion over recently and encounters the leader of o_c_n out doing the same thing. They commiserate over the incompetence of the apprentices on both sides that caused the issue and walk away with a greater respect for one another.",
-                "exp": 20,
-                "other_clan_rep": 2,
-                "frequency": 1
-            },
-            {
-                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to s_c with their leader. How unusual to meet a patrol in person! They strike up a friendly conversation. The unexpected opportunity turns into the perfect chance to casually but purposefully keep each other informed on an ongoing problem in the desert.",
-                "exp": 20,
-                "stat_skill": [
-                    "SPEAKER,1"
-                ],
-                "other_clan_rep": 2,
-                "frequency": 4
-            },
-            {
-                "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} the o_c_n leader out with their new apprentice. Their fellow leader encourages their apprentice to quiz s_c, and s_c compliments them both on how the young cat's training is progressing.",
-                "exp": 20,
-                "stat_trait": [
-                    "compassionate",
-                    "faithful",
-                    "loving",
-                    "responsible",
-                    "thoughtful",
-                    "wise"
-                ],
-                "other_clan_rep": 2,
-                "frequency": 4
-            }
-        ],
-        "fail_outcomes": [
-            {
-                "text": "r_c heads out to clarify a portion of the border that there's been confusion over recently and encounters the leader of o_c_n out doing the same thing. Both leaders find a point where they can't agree on the right border path and agree to bring the subject up at the next Gathering instead.",
-                "exp": 0,
-                "other_clan_rep": -1,
-                "frequency": 4
+                "frequency": 2,
+                "art": "gen_battle_warrior_other_clan"
             }
         ]
     },
@@ -1884,7 +1750,7 @@
             "border"
         ],
         "tags": [],
-        "patrol_art": "bord_general_intro",
+        "patrol_art": "gen_warrior_crouching",
         "min_cats": 1,
         "max_cats": 1,
         "min_max_status": {
@@ -1896,28 +1762,102 @@
         "chance_of_success": 30,
         "success_outcomes": [
             {
-                "text": "There's a particular spot where a stream crosses from c_n's forest to o_c_n where the spray from the stream's little tumbling rapids wipes the territory marks particularly quickly. r_c remarks it and heads home, a simple but necessary mission completed.",
+                "text": "There's a particular spot where a stream crosses from c_n's forest to o_c_n where the spray from the stream's little tumbling rapids wipes the territory marks particularly quickly. r_c re-marks it and heads home, a simple but necessary mission completed.",
                 "exp": 20,
                 "other_clan_rep": 2,
                 "frequency": 4
             },
             {
-                "text": "r_c comes across a o_c_n apprentice on the wrong side of the border and holding prey. {PRONOUN/r_c/subject/CAP} {VERB/r_c/see/sees} the young cat off with a furious yowl and then {VERB/r_c/bring/brings} the prey back to c_n camp to report the incident to the deputy.",
+                "text": "r_c comes upon a o_c_n patrol and exchanges pleasantries before continuing along the border.",
                 "exp": 20,
-                "prey": [
-                    "small"
-                ],
-                "other_clan_rep": -1,
-                "frequency": 1
+                "other_clan_rep": 2,
+                "frequency": 4,
+                "art": "gen_train_talkingOCWW"
             },
             {
-                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to them, and turns to follow the same marking path as them. They strike up a friendly conversation, and while s_c doesn't give anything away about c_n, they're able to pick up on a lot of gossip about o_c_n through careful conversation.",
+                "min_max_status": {
+                    "warrior": [-1,-1]
+                },
+                "text": "r_c heads out to clarify a portion of the border that there's been confusion over recently and encounters {PRONOUN/r_c/poss} o_c_n counterpart out doing the same thing. They commiserate over the incompetence of the apprentices on both sides that caused the issue and walk away with a greater respect for one another.",
+                "exp": 20,
+                "other_clan_rep": 2,
+                "frequency": 2,
+                "art": "gen_train_talkingOCWW"
+            },
+            {
+                "min_max_status": {
+                    "warrior": [-1,-1]
+                },
+                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to them, led by their deputy. They strike up a friendly conversation, and eventually the o_c_n warriors drift away. The unexpected opportunity turns into the perfect chance to casually but purposefully keep each other informed on an ongoing problem in the territories.",
                 "exp": 20,
                 "stat_skill": [
                     "SPEAKER,1"
                 ],
                 "other_clan_rep": 2,
-                "frequency": 4
+                "frequency": 3,
+                "art": "gen_train_talkingOCWW"
+            },
+            {
+                "min_max_status": {
+                    "warrior": [-1,-1]
+                },
+                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to s_c with their leader. They strike up a friendly conversation, and eventually the o_c_n warriors drift away. The unexpected opportunity turns into the perfect chance to casually but purposefully keep each other informed on an ongoing problem in the territories.",
+                "exp": 20,
+                "stat_skill": [
+                    "SPEAKER,1"
+                ],
+                "other_clan_rep": 2,
+                "frequency": 3,
+                "art": "gen_train_talkingOCWW"
+            },
+            {
+                "text": "r_c comes across a o_c_n apprentice on the wrong side of the border and holding prey. The young cat seems distraught when they realize their mistake and apologizes profusely. r_c escorts them back to the o_c_n camp and explains the situation to their deputy, who thanks {PRONOUN/r_c/object} for {PRONOUN/r_c/poss} restraint.",
+                "exp": 20,
+                "other_clan_rep": 2,
+                "frequency": 1,
+                "art": "gen_bord_otherclan_app_allies"
+            },
+            {
+                "text": "r_c comes across a o_c_n apprentice on the wrong side of the border, holding prey. Calmly, they tell the apprentice they're on the wrong side of the territory and lead them back to their mentor and rightful side, where the apprentice scampers and is scolded by the o_c_n warrior.",
+                "stat_trait": [
+                    "calm",
+                    "responsible",
+                    "thoughtful",
+                    "careful",
+                    "sincere",
+                    "compassionate"
+                ],
+                "exp": 20,
+                "other_clan_rep": 2,
+                "frequency": 1,
+                "art": "gen_bord_otherclan_app_allies"
+            },
+            {
+                "min_max_status": {
+                    "deputy": [1,1]
+                },
+                "text": "r_c comes across a o_c_n apprentice on the wrong side of the border and holding prey. Furious, {PRONOUN/r_c/subject} {VERB/r_c/snarl/snarls} {PRONOUN/r_c/poss} anger. The apprentice turns tail and flees with r_c hot on their trail, and when the apprentice crosses the border to hide behind their mentor, the o_c_n warrior's face goes slack with horror to see c_n's deputy.",
+                "stat_trait": [
+                    "fierce",
+                    "bloodthirsty",
+                    "insecure",
+                    "arrogant",
+                    "grumpy"
+                ],
+                "exp": 20,
+                "other_clan_rep": 2,
+                "frequency": 1,
+                "art": "gen_angry_cat_warrior"
+            },
+            {
+                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to {PRONOUN/s_c/object}, and turns to follow the same marking path as them. {PRONOUN/s_c/subject/CAP} strike up a friendly conversation, and while s_c doesn't give anything away about c_n, {PRONOUN/s_c/subject}{VERB/s_c/'re/'s} able to pick up on a lot of gossip about o_c_n through careful conversation. It's always worth keeping an eye on their neighbors. Trust, but verify.",
+                "exp": 20,
+                "stat_skill": [
+                    "SPEAKER,1"
+                ],
+                "other_clan_rep": 2,
+                "frequency": 4,
+                "art": "gen_speaking_cat_other1"
             },
             {
                 "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} a o_c_n border patrol. It even includes a young apprentice, whose eyes go round and fur fluffs up at encountering a real c_n cat! s_c plays along, acting very impressed with the hardworking apprentice, and the apprentice's mentor purrs gratefully.",
@@ -1928,18 +1868,181 @@
                     "loving",
                     "responsible",
                     "thoughtful",
-                    "wise"
+                    "wise",
+                    "confident"
                 ],
                 "other_clan_rep": 2,
-                "frequency": 4
+                "frequency": 3,
+                "art": "gen_train_app_otherclan"
+            },
+            {
+                "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} a o_c_n border patrol. It even includes a young apprentice, whose eyes go round and fur fluffs up at encountering a real c_n cat! Tactlessly, the apprentice immediately turns to their mentor and begins loudly asking <i>why</i> the c_n cat smells like <i>that</i>? s_c laughs good-naturedly and launches into a silly story about rolling in all manner of strange-smelling things in order to trick nasty dogs. The two patrols part in good spirits.",
+                "exp": 0,
+                "stat_trait": [
+                    "strange",
+                    "playful",
+                    "childish",
+                    "flamboyant",
+                    "oblivious",
+                    "shameless"
+                ],
+                "other_clan_rep": 2,
+                "frequency": 3,
+                "art": "gen_train_app_otherclan"
+            },
+            {
+                "min_max_status": {
+                    "deputy": [1,1]
+                },
+                "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} a o_c_n border patrol, which includes a young apprentice. Their eyes go round and they tuck their paws together neatly, sitting pretty for inspection. s_c plays along, acting very impressed with the hardworking apprentice, and the apprentice's mentor purrs gratefully at the c_n deputy's kindness.",
+                "exp": 20,
+                "stat_trait": [
+                    "compassionate",
+                    "faithful",
+                    "loving",
+                    "responsible",
+                    "thoughtful",
+                    "wise",
+                    "confident"
+                ],
+                "other_clan_rep": 2,
+                "frequency": 3,
+                "art": "gen_train_app_otherclan"
+            },
+            {
+                "min_max_status": {
+                    "leader": [1,1]
+                },
+                "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} a o_c_n border patrol, which includes a young apprentice. Their eyes go round and they hide behind their mentor, but s_c manages to coax them out, praising the little apprentice to their mentor, who purrs gratefully at the c_n leader's kindness.",
+                "exp": 20,
+                "stat_trait": [
+                    "compassionate",
+                    "faithful",
+                    "loving",
+                    "responsible",
+                    "thoughtful",
+                    "wise",
+                    "confident"
+                ],
+                "other_clan_rep": 2,
+                "frequency": 3,
+                "art": "gen_train_app_otherclan"
+            },
+            {
+                "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} a o_c_n cat out with their new apprentice. The cat encourages their apprentice to ask s_c any questions they have, and s_c compliments them both on how the young cat's training is progressing.",
+                "exp": 20,
+                "stat_trait": [
+                    "compassionate",
+                    "faithful",
+                    "loving",
+                    "responsible",
+                    "thoughtful",
+                    "wise",
+                    "confident"
+                ],
+                "other_clan_rep": 2,
+                "frequency": 3,
+                "art": "gen_train_app_otherclan"
             }
         ],
         "fail_outcomes": [
             {
-                "text": "r_c marks a little, but {PRONOUN/r_c/subject} {VERB/r_c/reach/reaches} a section where the border is muddled and {VERB/r_c/have/has} to give up and go home.",
+                "text": "r_c comes upon a o_c_n patrol and, in a fit of panic at their unexpected appearance, attempts to hide behind a rock to avoid a conversation. Judging by the puzzled whispers, it didn't quite work. r_c ends up awkwardly squatting there until the patrol finally leaves.",
+                "stat_trait": ["nervous", "gloomy", "lonesome"],
+                "exp": 0,
+                "other_clan_rep": -1,
+                "frequency": 4,
+                "art": "gen_bord_otherclan_allies"
+            },
+            {
+                "text": "r_c marks a little, but {PRONOUN/r_c/subject} {VERB/r_c/reach/reaches} a section where the border is muddled and {VERB/r_c/have/has} to give up and go home. Unclear borders won't make o_c_n too happy, though...",
                 "exp": 0,
                 "other_clan_rep": -1,
                 "frequency": 4
+            },
+            {
+                "min_max_status": {
+                    "deputy": [-1,-1]
+                },
+                "text": "r_c comes across a o_c_n apprentice on the wrong side of the border and holding prey. {PRONOUN/r_c/subject/CAP} {VERB/r_c/see/sees} the young cat off with a furious yowl and then {VERB/r_c/bring/brings} the prey back to c_n camp to report the incident to the deputy.",
+                "prey": ["small"],
+                "exp": 0,
+                "other_clan_rep": -1,
+                "frequency": 2,
+                "art": "gen_angry_cat_warrior"
+            },
+            {
+                "min_max_status": {
+                    "deputy": [1,1]
+                },
+                "text": "r_c heads out to clarify a portion of the border that there's been confusion over recently and encounters the deputy of o_c_n out doing the same thing. Both deputies find a point where they can't agree on the right border path and return to their respective camps to discuss with their leaders.",
+                "exp": 0,
+                "other_clan_rep": -1,
+                "frequency": 2,
+                "art": "gen_train_talkingOCWW"
+            },
+            {
+                "min_max_status": {
+                    "deputy": [1,1]
+                },
+                "text": "s_c heads out to clarify a portion of the border that there's been confusion over recently and encounters the deputy of o_c_n out doing the same thing. s_c insists on {PRONOUN/s_c/poss} idea of the correct border line, despite the other deputy's protests. The two eventually leave to consult with their own leaders, tails whipping and hisses hanging in the air.",
+                "stat_trait": [
+                    "troublesome",
+                    "ambitious",
+                    "fierce",
+                    "bloodthirsty",
+                    "childish",
+                    "bold",
+                    "daring",
+                    "insecure",
+                    "responsible",
+                    "vengeful",
+                    "arrogant",
+                    "competitive",
+                    "grumpy",
+                    "oblivious",
+                    "rebellious"
+                ],
+                "exp": 0,
+                "other_clan_rep": -2,
+                "frequency": 2,
+                "art": "gen_angry_cat_warrior"
+            },
+            {
+                "min_max_status": {
+                    "leader": [1,1]
+                },
+                "text": "r_c heads out to clarify a portion of the border that there's been confusion over recently and encounters the leader of o_c_n out doing the same thing. Both cats find a point where they can't agree on the right border path and agree to bring the subject up at the next Gathering instead.",
+                "exp": 0,
+                "frequency": 2,
+                "art": "gen_train_talkingOCWW"
+            },
+            {
+                "min_max_status": {
+                    "leader": [1,1]
+                },
+                "text": "s_c heads out to clarify a portion of the border that there's been confusion over recently and encounters the leader of o_c_n out doing the same thing. s_c insists on {PRONOUN/s_c/poss} idea of the correct border line, despite the other leader's protests. Hissed promises are made to bring this up at the next Gathering.",
+                "stat_trait": [
+                    "troublesome",
+                    "ambitious",
+                    "fierce",
+                    "bloodthirsty",
+                    "childish",
+                    "bold",
+                    "daring",
+                    "insecure",
+                    "responsible",
+                    "vengeful",
+                    "arrogant",
+                    "competitive",
+                    "grumpy",
+                    "oblivious",
+                    "rebellious"
+                ],
+                "exp": 0,
+                "other_clan_rep": -2,
+                "frequency": 2,
+                "art": "gen_angry_cat_warrior"
             },
             {
                 "text": "s_c is marking along the territory line when they encounter a patrol from o_c_n, out on a similar mission. {PRONOUN/s_c/subject/CAP} {VERB/s_c/stare/stares} at the other Clan's patrol challengingly, following their every move until the shared border ends, and though no words are exchanged, it's very tense.",
@@ -1952,12 +2055,64 @@
                     "shameless",
                     "strict",
                     "troublesome",
-                    "vengeful"
+                    "vengeful",
+                    "insecure"
                 ],
                 "other_clan_rep": -1,
-                "frequency": 4
+                "frequency": 4,
+                "art": "gen_bord_otherclan_hostile"
             },
             {
+                "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} a o_c_n border patrol. It even includes a young apprentice, whose eyes go round and fur fluffs up at encountering a real c_n cat! Tactlessly, the apprentice immediately turns to their mentor and begins loudly asking <i>why</i> the c_n cat smells like <i>that</i>? s_c bristles and stomps away while the apprentice's mentor stutters apologies behind {PRONOUN/s_c/object}.",
+                "exp": 0,
+                "stat_trait": [
+                    "fierce",
+                    "childish",
+                    "insecure",
+                    "vengeful"
+                ],
+                "other_clan_rep": -2,
+                "frequency": 3,
+                "art": "gen_angry_cat_warrior"
+            },
+            {
+                "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} a o_c_n cat out with their new apprentice. The cat encourages their apprentice to ask s_c any questions they have. The apprentice peppers {PRONOUN/s_c/object} with questions. Some of them are, perhaps, probing a bit too far into c_n's personal affairs, but s_c answers everything enthusiastically. The apprentice's mentor seems surprised at {PRONOUN/s_c/poss} candor... and perhaps a bit concerned at some of the answers.",
+                "exp": 0,
+                "stat_trait": [
+                    "sincere",
+                    "oblivious",
+                    "flamboyant",
+                    "strange",
+                    "competitive",
+                    "childish",
+                    "playful"
+                ],
+                "other_clan_rep": -1,
+                "frequency": 3,
+                "art": "gen_bord_otherclan_app_allies"
+            },
+            {
+                "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} a o_c_n cat out with their new apprentice. The cat encourages their apprentice to ask s_c any questions they have, but s_c interrupts and tersely informs the pair that s_c doesn't have time for questions. s_c leaves the two stunned cats behind to continue {PRONOUN/s_c/poss} patrol.",
+                "exp": 0,
+                "stat_trait": [
+                    "fierce",
+                    "cold",
+                    "strict",
+                    "ambitious",
+                    "responsible",
+                    "loyal",
+                    "competitive",
+                    "arrogant",
+                    "insecure"
+                ],
+                "other_clan_rep": -1,
+                "frequency": 3,
+                "art": "gen_bord_otherclan_app_allies"
+            },
+            {
+                "min_max_status": {
+                    "deputy": [-1,-1]
+                },
                 "text": "r_c is having trouble focusing today and puts a mark in the wrong place - and at the worst possible moment, because a o_c_n patrol sees {PRONOUN/r_c/object} doing it! {PRONOUN/r_c/subject/CAP} {VERB/r_c/come/comes} back to camp scratched up, and immediately {VERB/r_c/apologize/apologizes} to the deputy for the diplomatic incident {PRONOUN/r_c/subject}{VERB/r_c/'ve/'s} inadvertently caused.",
                 "exp": 0,
                 "injury": [
@@ -1969,121 +2124,21 @@
                             "battle_injury"
                         ],
                         "scars": [
-                            "ONE"
+                            "BRIDGE"
                         ]
                     }
                 ],
                 "history_text": {
                     "scar": "m_c got injured patrolling on the border."
                 },
-                "prey": [
-                    "very_small"
-                ],
                 "other_clan_rep": -1,
-                "frequency": 3
-            }
-        ]
-    },
-    {
-        "patrol_id": "fst_bord_soloneutral2",
-        "biome": [
-            "forest"
-        ],
-        "season": [
-            "any"
-        ],
-        "types": [
-            "border"
-        ],
-        "tags": [],
-        "patrol_art": "bord_general_intro",
-        "min_cats": 1,
-        "max_cats": 1,
-        "min_max_status": {
-            "deputy": [
-                1,
-                6
-            ]
-        },
-        "frequency": 4,
-        "intro_text": "r_c heads out into the forest alone, wanting to make a quick check on the border.",
-        "decline_text": "r_c turns back to camp, deciding that {PRONOUN/r_c/poss} other duties have to come first.",
-        "chance_of_success": 30,
-        "success_outcomes": [
-            {
-                "text": "There's a particular spot where a stream crosses from c_n's forest to o_c_n where the spray from the stream's little tumbling rapids wipes the territory marks particularly quickly. r_c remarks it and heads home, a simple but necessary mission completed.",
-                "exp": 20,
-                "other_clan_rep": 2,
-                "frequency": 4
+                "frequency": 2,
+                "art": "gen_battle_warrior_other_clan"
             },
             {
-                "text": "r_c comes across a o_c_n apprentice on the wrong side of the border and holding prey. Furious, {PRONOUN/r_c/subject} {VERB/r_c/snarl/snarls} {PRONOUN/r_c/poss} anger. The apprentice turns tail and flees with r_c hot on their trail, and when the apprentice crosses the border to hide behind their mentor, the o_c_n warrior's face goes slack with horror to see c_n's deputy.",
-                "exp": 20,
-                "other_clan_rep": 2,
-                "frequency": 1
-            },
-            {
-                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to them. They strike up a friendly conversation, and while s_c doesn't give anything away about c_n, they're able to pick up on a lot of gossip about o_c_n through careful conversation. It's always worth keeping an eye on their neighbors.",
-                "exp": 20,
-                "stat_skill": [
-                    "SPEAKER,1"
-                ],
-                "other_clan_rep": 2,
-                "frequency": 4
-            },
-            {
-                "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} a o_c_n border patrol, which includes a young apprentice. Their eyes go round and they tuck their paws together neatly, sitting pretty for inspection. s_c plays along, acting very impressed with the hardworking apprentice, and the apprentice's mentor purrs gratefully at the c_n deputy's kindness.",
-                "exp": 20,
-                "stat_trait": [
-                    "compassionate",
-                    "faithful",
-                    "loving",
-                    "responsible",
-                    "thoughtful",
-                    "wise"
-                ],
-                "other_clan_rep": 2,
-                "frequency": 4
-            }
-        ],
-        "fail_outcomes": [
-            {
-                "text": "r_c marks a little, but {PRONOUN/r_c/subject} {VERB/r_c/reach/reaches} a section where the border is muddled and {VERB/r_c/have/has} to give up and go home.",
-                "exp": 0,
-                "other_clan_rep": -1,
-                "frequency": 4
-            },
-            {
-                "text": "s_c is marking along the territory line when they encounter a patrol from o_c_n, out on a similar mission. {PRONOUN/s_c/subject/CAP} {VERB/s_c/stare/stares} at the other Clan's patrol challengingly, following their every move until the shared border ends, and though no words are exchanged, it's very tense.",
-                "exp": 0,
-                "stat_trait": [
-                    "ambitious",
-                    "bloodthirsty",
-                    "cold",
-                    "fierce",
-                    "shameless",
-                    "strict",
-                    "troublesome",
-                    "vengeful"
-                ],
-                "other_clan_rep": -1,
-                "frequency": 4
-            },
-            {
-                "text": "r_c encounters a patrol from o_c_n on the border and greets them politely, but there's something different here. Something dangerous. {PRONOUN/r_c/subject/CAP} {VERB/r_c/do/does}'t make it back to camp.",
-                "exp": 0,
-                "dead_cats": [
-                    "r_c"
-                ],
-                "history_text": {
-                    "scar": "m_c got injured patrolling on the border.",
-                    "reg_death": "m_c lost their life in an ambush on the border.",
-                    "lead_death": "{VERB/m_c/were/was} killed in a border ambush"
+                "min_max_status": {
+                    "warrior": [-1,-1]
                 },
-                "other_clan_rep": -1,
-                "frequency": 3
-            },
-            {
                 "text": "r_c is having trouble focusing today and puts a mark in the wrong place - and at the worst possible moment, because a o_c_n patrol sees them doing it! The diplomatic incident spirals into a full blown conflict, and r_c hauls themselves back to camp wounded and bleeding.",
                 "exp": 0,
                 "injury": [
@@ -2100,323 +2155,11 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c got injured patrolling on the border.",
-                    "reg_death": "m_c lost their life in an ambush on the border.",
-                    "lead_death": "{VERB/m_c/were/was} killed in a border ambush"
-                },
-                "other_clan_rep": -1,
-                "frequency": 3
-            }
-        ]
-    },
-    {
-        "patrol_id": "fst_bord_soloneutral3",
-        "biome": [
-            "forest"
-        ],
-        "season": [
-            "any"
-        ],
-        "types": [
-            "border"
-        ],
-        "tags": [],
-        "patrol_art": "bord_general_intro",
-        "min_cats": 1,
-        "max_cats": 1,
-        "min_max_status": {
-            "leader": [
-                1,
-                6
-            ]
-        },
-        "frequency": 4,
-        "intro_text": "r_c heads out into the forest alone, wanting to make a quick check on the border.",
-        "decline_text": "r_c turns back to camp, deciding that {PRONOUN/r_c/poss} other duties have to come first.",
-        "chance_of_success": 30,
-        "success_outcomes": [
-            {
-                "text": "There's a particular spot where a stream crosses from c_n's forest to o_c_n where the spray from the stream's little tumbling rapids wipes the territory marks particularly quickly. r_c remarks it and heads home, a simple but necessary mission completed.",
-                "exp": 20,
-                "other_clan_rep": 2,
-                "frequency": 4
-            },
-            {
-                "text": "r_c comes across a o_c_n apprentice on the wrong side of the border and holding prey. Furious, {PRONOUN/r_c/subject} {VERB/r_c/snarl/snarls} {PRONOUN/r_c/poss} anger. The apprentice turns tail and flees with r_c hot on their trail, and when the apprentice crosses the border to hide behind their mentor, the o_c_n warrior's tail tucks at the sight of c_n's outraged leader.",
-                "exp": 20,
-                "other_clan_rep": 2,
-                "frequency": 1
-            },
-            {
-                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to them. They strike up a friendly conversation, and while s_c doesn't give anything away about c_n, they're able to pick up on a lot of gossip about o_c_n through careful conversation. It's always worth keeping an eye on their neighbors. Trust, but verify.",
-                "exp": 20,
-                "stat_skill": [
-                    "SPEAKER,1"
-                ],
-                "other_clan_rep": 2,
-                "frequency": 4
-            },
-            {
-                "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} a o_c_n border patrol, which includes a young apprentice. Their eyes go round and they hide behind their mentor, but s_c manages to coax them out, praising the little apprentice to their mentor, who purrs gratefully at the c_n leader's kindness.",
-                "exp": 20,
-                "stat_trait": [
-                    "compassionate",
-                    "faithful",
-                    "loving",
-                    "responsible",
-                    "thoughtful",
-                    "wise"
-                ],
-                "other_clan_rep": 2,
-                "frequency": 4
-            }
-        ],
-        "fail_outcomes": [
-            {
-                "text": "r_c marks a little, but {PRONOUN/r_c/subject} {VERB/r_c/reach/reaches} a section where the border is muddled and {VERB/r_c/have/has} to give up and go home.",
-                "exp": 0,
-                "other_clan_rep": -1,
-                "frequency": 4
-            },
-            {
-                "text": "s_c is marking along the territory line when they encounter a patrol from o_c_n, out on a similar mission. {PRONOUN/s_c/subject/CAP} {VERB/s_c/stare/stares} at the other Clan's patrol challengingly, following their every move until the shared border ends, and though no words are exchanged, it's very tense.",
-                "exp": 0,
-                "stat_trait": [
-                    "ambitious",
-                    "bloodthirsty",
-                    "cold",
-                    "fierce",
-                    "shameless",
-                    "strict",
-                    "troublesome",
-                    "vengeful"
-                ],
-                "other_clan_rep": -1,
-                "frequency": 4
-            },
-            {
-                "text": "r_c encounters a patrol from o_c_n on the border and greets them politely, but there's something different here. Something dangerous. {PRONOUN/r_c/subject/CAP} {VERB/r_c/return/returns} to camp, blood soaked through {PRONOUN/r_c/poss} fur and a new hardness in {PRONOUN/r_c/poss} heart.",
-                "exp": 0,
-                "dead_cats": [
-                    "r_c"
-                ],
-                "history_text": {
-                    "scar": "m_c got injured patrolling on the border.",
-                    "reg_death": "m_c lost a life in an ambush on the border.",
-                    "lead_death": "{VERB/m_c/were/was} killed in a border ambush"
-                },
-                "other_clan_rep": -1,
-                "frequency": 3
-            },
-            {
-                "text": "r_c is having trouble focusing today and puts a mark in the wrong place - and at the worst possible moment, because a o_c_n patrol sees them doing it! The diplomatic incident spirals into a full blown conflict, and r_c hauls themselves back to camp wounded and bleeding.",
-                "exp": 0,
-                "injury": [
-                    {
-                        "cats": [
-                            "r_c"
-                        ],
-                        "injuries": [
-                            "battle_injury"
-                        ],
-                        "scars": [
-                            "CHEEK"
-                        ]
-                    }
-                ],
-                "history_text": {
-                    "scar": "m_c got injured patrolling on the border.",
-                    "reg_death": "m_c lost a life in an ambush on the border.",
-                    "lead_death": "{VERB/m_c/were/was} killed in a border ambush"
-                },
-                "other_clan_rep": -1,
-                "frequency": 3
-            }
-        ]
-    },
-    {
-        "patrol_id": "fst_bord_soloneutral4",
-        "biome": [
-            "forest"
-        ],
-        "season": [
-            "any"
-        ],
-        "types": [
-            "border"
-        ],
-        "tags": [],
-        "patrol_art": "bord_general_intro",
-        "min_cats": 1,
-        "max_cats": 1,
-        "min_max_status": {
-            "deputy": [
-                1,
-                6
-            ]
-        },
-        "frequency": 4,
-        "intro_text": "r_c heads out into the forest alone, wanting to make a quick check on the border.",
-        "decline_text": "r_c turns back to camp, deciding that {PRONOUN/r_c/poss} other duties have to come first.",
-        "chance_of_success": 30,
-        "success_outcomes": [
-            {
-                "text": "There's a particular spot where a stream crosses from c_n's forest to o_c_n where the spray from the stream's little tumbling rapids wipes the territory marks particularly quickly. r_c remarks it and heads home, a simple but necessary mission completed.",
-                "exp": 20,
-                "other_clan_rep": 2,
-                "frequency": 4
-            },
-            {
-                "text": "r_c heads out to clarify a portion of the border that there's been confusion over recently and encounters the deputy of o_c_n out doing the same thing. They commiserate over the incompetence of the apprentices on both sides that caused the issue and walk away with a greater respect for one another.",
-                "exp": 20,
-                "other_clan_rep": 2,
-                "frequency": 1
-            },
-            {
-                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to them, led by their deputy. They strike up a friendly conversation, and eventually the o_c_n warriors drift away. The unexpected opportunity turns into the perfect chance to casually but purposefully keep each other informed on an ongoing problem in the forest.",
-                "exp": 20,
-                "stat_skill": [
-                    "SPEAKER,1"
-                ],
-                "other_clan_rep": 2,
-                "frequency": 4
-            },
-            {
-                "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} the o_c_n deputy out with their new apprentice. Their fellow deputy encourages their apprentice to quiz s_c, and s_c compliments them both on how the young cat's training is progressing.",
-                "exp": 20,
-                "stat_trait": [
-                    "compassionate",
-                    "faithful",
-                    "loving",
-                    "responsible",
-                    "thoughtful",
-                    "wise"
-                ],
-                "other_clan_rep": 2,
-                "frequency": 4
-            }
-        ],
-        "fail_outcomes": [
-            {
-                "text": "r_c heads out to clarify a portion of the border that there's been confusion over recently and encounters the deputy of o_c_n out doing the same thing. Both deputies find a point where they can't agree on the right border path and return to their respective camps to discuss with their leaders.",
-                "exp": 0,
-                "other_clan_rep": -1,
-                "frequency": 4
-            },
-            {
-                "text": "r_c is having trouble focusing today and puts a mark in the wrong place - and at the worst possible moment, because a o_c_n patrol sees them doing it! The diplomatic incident spirals into a full blown conflict, and r_c hauls themselves back to camp wounded and bleeding.",
-                "exp": 0,
-                "injury": [
-                    {
-                        "cats": [
-                            "r_c"
-                        ],
-                        "injuries": [
-                            "battle_injury"
-                        ],
-                        "scars": [
-                            "SNOUT"
-                        ]
-                    }
-                ],
-                "history_text": {
                     "scar": "m_c got injured patrolling on the border."
                 },
                 "other_clan_rep": -1,
-                "frequency": 3
-            }
-        ]
-    },
-    {
-        "patrol_id": "fst_bord_soloneutral5",
-        "biome": [
-            "forest"
-        ],
-        "season": [
-            "any"
-        ],
-        "types": [
-            "border"
-        ],
-        "tags": [],
-        "patrol_art": "bord_general_intro",
-        "min_cats": 1,
-        "max_cats": 1,
-        "min_max_status": {
-            "leader": [
-                1,
-                6
-            ]
-        },
-        "frequency": 4,
-        "intro_text": "r_c heads out into the forest alone, wanting to make a quick check on the border.",
-        "decline_text": "r_c turns back to camp, deciding that {PRONOUN/r_c/poss} other duties have to come first.",
-        "chance_of_success": 30,
-        "success_outcomes": [
-            {
-                "text": "There's a particular spot where a stream crosses from c_n's forest to o_c_n where the spray from the stream's little tumbling rapids wipes the territory marks particularly quickly. r_c remarks it and heads home, a simple but necessary mission completed.",
-                "exp": 20,
-                "other_clan_rep": 2,
-                "frequency": 4
-            },
-            {
-                "text": "r_c heads out to clarify a portion of the border that there's been confusion over recently and encounters the leader of o_c_n out doing the same thing. They commiserate over the incompetence of the apprentices on both sides that caused the issue and walk away with a greater respect for one another.",
-                "exp": 20,
-                "other_clan_rep": 2,
-                "frequency": 1
-            },
-            {
-                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to s_c with their leader. They strike up a friendly conversation, and eventually the o_c_n warriors drift away. The unexpected opportunity turns into the perfect chance to casually but purposefully keep each other informed on an ongoing problem in the forest.",
-                "exp": 20,
-                "stat_skill": [
-                    "SPEAKER,1"
-                ],
-                "other_clan_rep": 2,
-                "frequency": 4
-            },
-            {
-                "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} the o_c_n leader out with their new apprentice. Their fellow leader encourages their apprentice to quiz s_c, and s_c compliments them both on how the young cat's training is progressing.",
-                "exp": 20,
-                "stat_trait": [
-                    "compassionate",
-                    "faithful",
-                    "loving",
-                    "responsible",
-                    "thoughtful",
-                    "wise"
-                ],
-                "other_clan_rep": 2,
-                "frequency": 4
-            }
-        ],
-        "fail_outcomes": [
-            {
-                "text": "r_c heads out to clarify a portion of the border that there's been confusion over recently and encounters the leader of o_c_n out doing the same thing. Both leaders find a point where they can't agree on the right border path and agree to bring the subject up at the next Gathering instead.",
-                "exp": 0,
-                "other_clan_rep": -1,
-                "frequency": 4
-            },
-            {
-                "text": "r_c is having trouble focusing today and puts a mark in the wrong place - and at the worst possible moment, because a o_c_n patrol sees them doing it! The diplomatic incident spirals into a full blown conflict, and r_c hauls themselves back to camp wounded and bleeding.",
-                "exp": 0,
-                "injury": [
-                    {
-                        "cats": [
-                            "r_c"
-                        ],
-                        "injuries": [
-                            "battle_injury"
-                        ],
-                        "scars": [
-                            "CHEEK"
-                        ]
-                    }
-                ],
-                "history_text": {
-                    "scar": "m_c got injured patrolling on the border."
-                },
-                "other_clan_rep": -1,
-                "frequency": 3
+                "frequency": 2,
+                "art": "gen_battle_warrior_other_clan"
             }
         ]
     },
@@ -2432,13 +2175,13 @@
             "border"
         ],
         "tags": [],
-        "patrol_art": "bord_general_intro",
+        "patrol_art": "gen_warrior_crouching",
         "min_cats": 1,
         "max_cats": 1,
         "min_max_status": {
-            "deputy": [
-                -1,
-                -1
+            "normal adult": [
+                1,
+                1
             ]
         },
         "frequency": 4,
@@ -2447,25 +2190,102 @@
         "chance_of_success": 30,
         "success_outcomes": [
             {
-                "text": "There's a particular spot where the ground is prone to slipping along the border with o_c_n, dirt falling away from under the trails - not dangerous, but wiping the border markings off the map. r_c remarks it and heads home, a simple but necessary mission completed.",
+                "text": "There's a particular spot where the ground is prone to slipping along the border with o_c_n, dirt falling away from under the trails - not dangerous, but wiping the border markings off the map. r_c re-marks it and heads home, a simple but necessary mission completed.",
                 "exp": 20,
                 "other_clan_rep": 2,
                 "frequency": 4
             },
             {
-                "text": "r_c comes across a o_c_n apprentice on the wrong side of the border and holding prey. The young cat seems distraught when they realize their mistake and apologizes profusely. r_c escorts them back to the o_c_n camp and explains the situation to their deputy, who thanks them for their restraint.",
+                "text": "r_c comes upon a o_c_n patrol and exchanges pleasantries before continuing along the border.",
                 "exp": 20,
                 "other_clan_rep": 2,
-                "frequency": 1
+                "frequency": 4,
+                "art": "gen_train_talkingOCWW"
             },
             {
-                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to them, and turns to follow the same marking path as them. They strike up a friendly conversation, and while s_c doesn't give anything away about c_n, they're able to pick up on a lot of gossip about o_c_n through careful conversation.",
+                "min_max_status": {
+                    "warrior": [-1,-1]
+                },
+                "text": "r_c heads out to clarify a portion of the border that there's been confusion over recently and encounters {PRONOUN/r_c/poss} o_c_n counterpart out doing the same thing. They commiserate over the incompetence of the apprentices on both sides that caused the issue and walk away with a greater respect for one another.",
+                "exp": 20,
+                "other_clan_rep": 2,
+                "frequency": 2,
+                "art": "gen_train_talkingOCWW"
+            },
+            {
+                "min_max_status": {
+                    "warrior": [-1,-1]
+                },
+                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to them, led by their deputy. They strike up a friendly conversation, and eventually the o_c_n warriors drift away. The unexpected opportunity turns into the perfect chance to casually but purposefully keep each other informed on an ongoing problem in the territories.",
                 "exp": 20,
                 "stat_skill": [
                     "SPEAKER,1"
                 ],
                 "other_clan_rep": 2,
-                "frequency": 4
+                "frequency": 3,
+                "art": "gen_train_talkingOCWW"
+            },
+            {
+                "min_max_status": {
+                    "warrior": [-1,-1]
+                },
+                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to s_c with their leader. They strike up a friendly conversation, and eventually the o_c_n warriors drift away. The unexpected opportunity turns into the perfect chance to casually but purposefully keep each other informed on an ongoing problem in the territories.",
+                "exp": 20,
+                "stat_skill": [
+                    "SPEAKER,1"
+                ],
+                "other_clan_rep": 2,
+                "frequency": 3,
+                "art": "gen_train_talkingOCWW"
+            },
+            {
+                "text": "r_c comes across a o_c_n apprentice on the wrong side of the border and holding prey. The young cat seems distraught when they realize their mistake and apologizes profusely. r_c escorts them back to the o_c_n camp and explains the situation to their deputy, who thanks {PRONOUN/r_c/object} for {PRONOUN/r_c/poss} restraint.",
+                "exp": 20,
+                "other_clan_rep": 2,
+                "frequency": 1,
+                "art": "gen_bord_otherclan_app_allies"
+            },
+            {
+                "text": "r_c comes across a o_c_n apprentice on the wrong side of the border, holding prey. Calmly, they tell the apprentice they're on the wrong side of the territory and lead them back to their mentor and rightful side, where the apprentice scampers and is scolded by the o_c_n warrior.",
+                "stat_trait": [
+                    "calm",
+                    "responsible",
+                    "thoughtful",
+                    "careful",
+                    "sincere",
+                    "compassionate"
+                ],
+                "exp": 20,
+                "other_clan_rep": 2,
+                "frequency": 1,
+                "art": "gen_bord_otherclan_app_allies"
+            },
+            {
+                "min_max_status": {
+                    "deputy": [1,1]
+                },
+                "text": "r_c comes across a o_c_n apprentice on the wrong side of the border and holding prey. Furious, {PRONOUN/r_c/subject} {VERB/r_c/snarl/snarls} {PRONOUN/r_c/poss} anger. The apprentice turns tail and flees with r_c hot on their trail, and when the apprentice crosses the border to hide behind their mentor, the o_c_n warrior's face goes slack with horror to see c_n's deputy.",
+                "stat_trait": [
+                    "fierce",
+                    "bloodthirsty",
+                    "insecure",
+                    "arrogant",
+                    "grumpy"
+                ],
+                "exp": 20,
+                "other_clan_rep": 2,
+                "frequency": 1,
+                "art": "gen_angry_cat_warrior"
+            },
+            {
+                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to {PRONOUN/s_c/object}, and turns to follow the same marking path as them. {PRONOUN/s_c/subject/CAP} strike up a friendly conversation, and while s_c doesn't give anything away about c_n, {PRONOUN/s_c/subject}{VERB/s_c/'re/'s} able to pick up on a lot of gossip about o_c_n through careful conversation. It's always worth keeping an eye on their neighbors. Trust, but verify.",
+                "exp": 20,
+                "stat_skill": [
+                    "SPEAKER,1"
+                ],
+                "other_clan_rep": 2,
+                "frequency": 4,
+                "art": "gen_speaking_cat_other1"
             },
             {
                 "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} a o_c_n border patrol. It even includes a young apprentice, whose eyes go round and fur fluffs up at encountering a real c_n cat! s_c plays along, acting very impressed with the hardworking apprentice, and the apprentice's mentor purrs gratefully.",
@@ -2476,13 +2296,92 @@
                     "loving",
                     "responsible",
                     "thoughtful",
-                    "wise"
+                    "wise",
+                    "confident"
                 ],
                 "other_clan_rep": 2,
-                "frequency": 4
+                "frequency": 3,
+                "art": "gen_train_app_otherclan"
+            },
+            {
+                "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} a o_c_n border patrol. It even includes a young apprentice, whose eyes go round and fur fluffs up at encountering a real c_n cat! Tactlessly, the apprentice immediately turns to their mentor and begins loudly asking <i>why</i> the c_n cat smells like <i>that</i>? s_c laughs good-naturedly and launches into a silly story about rolling in all manner of strange-smelling things in order to trick nasty dogs. The two patrols part in good spirits.",
+                "exp": 0,
+                "stat_trait": [
+                    "strange",
+                    "playful",
+                    "childish",
+                    "flamboyant",
+                    "oblivious",
+                    "shameless"
+                ],
+                "other_clan_rep": 2,
+                "frequency": 3,
+                "art": "gen_train_app_otherclan"
+            },
+            {
+                "min_max_status": {
+                    "deputy": [1,1]
+                },
+                "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} a o_c_n border patrol, which includes a young apprentice. Their eyes go round and they tuck their paws together neatly, sitting pretty for inspection. s_c plays along, acting very impressed with the hardworking apprentice, and the apprentice's mentor purrs gratefully at the c_n deputy's kindness.",
+                "exp": 20,
+                "stat_trait": [
+                    "compassionate",
+                    "faithful",
+                    "loving",
+                    "responsible",
+                    "thoughtful",
+                    "wise",
+                    "confident"
+                ],
+                "other_clan_rep": 2,
+                "frequency": 3,
+                "art": "gen_train_app_otherclan"
+            },
+            {
+                "min_max_status": {
+                    "leader": [1,1]
+                },
+                "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} a o_c_n border patrol, which includes a young apprentice. Their eyes go round and they hide behind their mentor, but s_c manages to coax them out, praising the little apprentice to their mentor, who purrs gratefully at the c_n leader's kindness.",
+                "exp": 20,
+                "stat_trait": [
+                    "compassionate",
+                    "faithful",
+                    "loving",
+                    "responsible",
+                    "thoughtful",
+                    "wise",
+                    "confident"
+                ],
+                "other_clan_rep": 2,
+                "frequency": 3,
+                "art": "gen_train_app_otherclan"
+            },
+            {
+                "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} a o_c_n cat out with their new apprentice. The cat encourages their apprentice to ask s_c any questions they have, and s_c compliments them both on how the young cat's training is progressing.",
+                "exp": 20,
+                "stat_trait": [
+                    "compassionate",
+                    "faithful",
+                    "loving",
+                    "responsible",
+                    "thoughtful",
+                    "wise",
+                    "confident"
+                ],
+                "other_clan_rep": 2,
+                "frequency": 3,
+                "art": "gen_train_app_otherclan"
             }
         ],
         "fail_outcomes": [
+            {
+                "text": "r_c comes upon a o_c_n patrol and, in a fit of panic at their unexpected appearance, attempts to hide behind a rock to avoid a conversation. Judging by the puzzled whispers, it didn't quite work. r_c ends up awkwardly squatting there until the patrol finally leaves.",
+                "stat_trait": ["nervous", "gloomy", "lonesome"],
+                "exp": 0,
+                "other_clan_rep": -1,
+                "frequency": 4,
+                "art": "gen_bord_otherclan_allies"
+            },
             {
                 "text": "r_c marks a little, but {PRONOUN/r_c/subject} {VERB/r_c/reach/reaches} a section where the border is muddled and {VERB/r_c/have/has} to give up and go home. Unclear borders won't make o_c_n too happy, though...",
                 "exp": 0,
@@ -2490,10 +2389,88 @@
                 "frequency": 4
             },
             {
+                "min_max_status": {
+                    "deputy": [-1,-1]
+                },
                 "text": "r_c comes across a o_c_n apprentice on the wrong side of the border and holding prey. {PRONOUN/r_c/subject/CAP} {VERB/r_c/see/sees} the young cat off with a furious yowl and then {VERB/r_c/bring/brings} the prey back to c_n camp to report the incident to the deputy.",
+                "prey": ["small"],
                 "exp": 0,
                 "other_clan_rep": -1,
-                "frequency": 2
+                "frequency": 2,
+                "art": "gen_angry_cat_warrior"
+            },
+            {
+                "min_max_status": {
+                    "deputy": [1,1]
+                },
+                "text": "r_c heads out to clarify a portion of the border that there's been confusion over recently and encounters the deputy of o_c_n out doing the same thing. Both deputies find a point where they can't agree on the right border path and return to their respective camps to discuss with their leaders.",
+                "exp": 0,
+                "other_clan_rep": -1,
+                "frequency": 2,
+                "art": "gen_train_talkingOCWW"
+            },
+            {
+                "min_max_status": {
+                    "deputy": [1,1]
+                },
+                "text": "s_c heads out to clarify a portion of the border that there's been confusion over recently and encounters the deputy of o_c_n out doing the same thing. s_c insists on {PRONOUN/s_c/poss} idea of the correct border line, despite the other deputy's protests. The two eventually leave to consult with their own leaders, tails whipping and hisses hanging in the air.",
+                "stat_trait": [
+                    "troublesome",
+                    "ambitious",
+                    "fierce",
+                    "bloodthirsty",
+                    "childish",
+                    "bold",
+                    "daring",
+                    "insecure",
+                    "responsible",
+                    "vengeful",
+                    "arrogant",
+                    "competitive",
+                    "grumpy",
+                    "oblivious",
+                    "rebellious"
+                ],
+                "exp": 0,
+                "other_clan_rep": -2,
+                "frequency": 2,
+                "art": "gen_angry_cat_warrior"
+            },
+            {
+                "min_max_status": {
+                    "leader": [1,1]
+                },
+                "text": "r_c heads out to clarify a portion of the border that there's been confusion over recently and encounters the leader of o_c_n out doing the same thing. Both cats find a point where they can't agree on the right border path and agree to bring the subject up at the next Gathering instead.",
+                "exp": 0,
+                "frequency": 2,
+                "art": "gen_train_talkingOCWW"
+            },
+            {
+                "min_max_status": {
+                    "leader": [1,1]
+                },
+                "text": "s_c heads out to clarify a portion of the border that there's been confusion over recently and encounters the leader of o_c_n out doing the same thing. s_c insists on {PRONOUN/s_c/poss} idea of the correct border line, despite the other leader's protests. Hissed promises are made to bring this up at the next Gathering.",
+                "stat_trait": [
+                    "troublesome",
+                    "ambitious",
+                    "fierce",
+                    "bloodthirsty",
+                    "childish",
+                    "bold",
+                    "daring",
+                    "insecure",
+                    "responsible",
+                    "vengeful",
+                    "arrogant",
+                    "competitive",
+                    "grumpy",
+                    "oblivious",
+                    "rebellious"
+                ],
+                "exp": 0,
+                "other_clan_rep": -2,
+                "frequency": 2,
+                "art": "gen_angry_cat_warrior"
             },
             {
                 "text": "s_c is marking along the territory line when they encounter a patrol from o_c_n, out on a similar mission. {PRONOUN/s_c/subject/CAP} {VERB/s_c/stare/stares} at the other Clan's patrol challengingly, following their every move until the shared border ends, and though no words are exchanged, it's very tense.",
@@ -2506,12 +2483,64 @@
                     "shameless",
                     "strict",
                     "troublesome",
-                    "vengeful"
+                    "vengeful",
+                    "insecure"
                 ],
                 "other_clan_rep": -1,
-                "frequency": 4
+                "frequency": 4,
+                "art": "gen_bord_otherclan_hostile"
             },
             {
+                "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} a o_c_n border patrol. It even includes a young apprentice, whose eyes go round and fur fluffs up at encountering a real c_n cat! Tactlessly, the apprentice immediately turns to their mentor and begins loudly asking <i>why</i> the c_n cat smells like <i>that</i>? s_c bristles and stomps away while the apprentice's mentor stutters apologies behind {PRONOUN/s_c/object}.",
+                "exp": 0,
+                "stat_trait": [
+                    "fierce",
+                    "childish",
+                    "insecure",
+                    "vengeful"
+                ],
+                "other_clan_rep": -2,
+                "frequency": 3,
+                "art": "gen_angry_cat_warrior"
+            },
+            {
+                "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} a o_c_n cat out with their new apprentice. The cat encourages their apprentice to ask s_c any questions they have. The apprentice peppers {PRONOUN/s_c/object} with questions. Some of them are, perhaps, probing a bit too far into c_n's personal affairs, but s_c answers everything enthusiastically. The apprentice's mentor seems surprised at {PRONOUN/s_c/poss} candor... and perhaps a bit concerned at some of the answers.",
+                "exp": 0,
+                "stat_trait": [
+                    "sincere",
+                    "oblivious",
+                    "flamboyant",
+                    "strange",
+                    "competitive",
+                    "childish",
+                    "playful"
+                ],
+                "other_clan_rep": -1,
+                "frequency": 3,
+                "art": "gen_bord_otherclan_app_allies"
+            },
+            {
+                "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} a o_c_n cat out with their new apprentice. The cat encourages their apprentice to ask s_c any questions they have, but s_c interrupts and tersely informs the pair that s_c doesn't have time for questions. s_c leaves the two stunned cats behind to continue {PRONOUN/s_c/poss} patrol.",
+                "exp": 0,
+                "stat_trait": [
+                    "fierce",
+                    "cold",
+                    "strict",
+                    "ambitious",
+                    "responsible",
+                    "loyal",
+                    "competitive",
+                    "arrogant",
+                    "insecure"
+                ],
+                "other_clan_rep": -1,
+                "frequency": 3,
+                "art": "gen_bord_otherclan_app_allies"
+            },
+            {
+                "min_max_status": {
+                    "deputy": [-1,-1]
+                },
                 "text": "r_c is having trouble focusing today and puts a mark in the wrong place - and at the worst possible moment, because a o_c_n patrol sees {PRONOUN/r_c/object} doing it! {PRONOUN/r_c/subject/CAP} {VERB/r_c/come/comes} back to camp scratched up, and immediately {VERB/r_c/apologize/apologizes} to the deputy for the diplomatic incident {PRONOUN/r_c/subject}{VERB/r_c/'ve/'s} inadvertently caused.",
                 "exp": 0,
                 "injury": [
@@ -2531,96 +2560,13 @@
                     "scar": "m_c got injured patrolling on the border."
                 },
                 "other_clan_rep": -1,
-                "frequency": 4
-            }
-        ]
-    },
-    {
-        "patrol_id": "mtn_bord_soloneutral2",
-        "biome": [
-            "mountainous"
-        ],
-        "season": [
-            "any"
-        ],
-        "types": [
-            "border"
-        ],
-        "tags": [],
-        "patrol_art": "bord_general_intro",
-        "min_cats": 1,
-        "max_cats": 1,
-        "min_max_status": {
-            "deputy": [
-                1,
-                6
-            ]
-        },
-        "frequency": 4,
-        "intro_text": "r_c heads out into the mountains alone, wanting to make a quick check on the border.",
-        "decline_text": "r_c turns back to camp, deciding that {PRONOUN/r_c/poss} other duties have to come first.",
-        "chance_of_success": 30,
-        "success_outcomes": [
-            {
-                "text": "There's a particular spot where the ground is prone to slipping along the border with o_c_n, dirt falling away from under the trails - not dangerous, but wiping the border markings off the map. r_c remarks it and heads home, a simple but necessary mission completed.",
-                "exp": 20,
-                "other_clan_rep": 2,
-                "frequency": 4
+                "frequency": 2,
+                "art": "gen_battle_warrior_other_clan"
             },
             {
-                "text": "r_c comes across a o_c_n apprentice on the wrong side of the border and holding prey. Furious, {PRONOUN/r_c/subject} {VERB/r_c/snarl/snarls} {PRONOUN/r_c/poss} anger. The apprentice turns tail and flees with r_c hot on their trail, and when the apprentice crosses the border to hide behind their mentor, the o_c_n warrior's face goes slack with horror to see c_n's deputy.",
-                "exp": 20,
-                "other_clan_rep": 2,
-                "frequency": 1
-            },
-            {
-                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to them. They strike up a friendly conversation, and while s_c doesn't give anything away about c_n, they're able to pick up on a lot of gossip about o_c_n through careful conversation. It's always worth keeping an eye on their neighbors.",
-                "exp": 20,
-                "stat_skill": [
-                    "SPEAKER,1"
-                ],
-                "other_clan_rep": 2,
-                "frequency": 4
-            },
-            {
-                "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} a o_c_n border patrol, which includes a young apprentice. Their eyes go round and they tuck their paws together neatly, sitting pretty for inspection. s_c plays along, acting very impressed with the hardworking apprentice, and the apprentice's mentor purrs gratefully at the c_n deputy's kindness.",
-                "exp": 20,
-                "stat_trait": [
-                    "compassionate",
-                    "faithful",
-                    "loving",
-                    "responsible",
-                    "thoughtful",
-                    "wise"
-                ],
-                "other_clan_rep": 2,
-                "frequency": 4
-            }
-        ],
-        "fail_outcomes": [
-            {
-                "text": "r_c marks a little, but {PRONOUN/r_c/subject} {VERB/r_c/reach/reaches} a section where the border is muddled and {VERB/r_c/have/has} to give up and go home.",
-                "exp": 0,
-                "other_clan_rep": -1,
-                "frequency": 4
-            },
-            {
-                "text": "s_c is marking along the territory line when they encounter a patrol from o_c_n, out on a similar mission. {PRONOUN/s_c/subject/CAP} {VERB/s_c/stare/stares} at the other Clan's patrol challengingly, following their every move until the shared border ends, and though no words are exchanged, it's very tense.",
-                "exp": 0,
-                "stat_trait": [
-                    "ambitious",
-                    "bloodthirsty",
-                    "cold",
-                    "fierce",
-                    "shameless",
-                    "strict",
-                    "troublesome",
-                    "vengeful"
-                ],
-                "other_clan_rep": -1,
-                "frequency": 4
-            },
-            {
+                "min_max_status": {
+                    "warrior": [-1,-1]
+                },
                 "text": "r_c is having trouble focusing today and puts a mark in the wrong place - and at the worst possible moment, because a o_c_n patrol sees them doing it! The diplomatic incident spirals into a full blown conflict, and r_c hauls themselves back to camp wounded and bleeding.",
                 "exp": 0,
                 "injury": [
@@ -2640,257 +2586,8 @@
                     "scar": "m_c got injured patrolling on the border."
                 },
                 "other_clan_rep": -1,
-                "frequency": 3
-            }
-        ]
-    },
-    {
-        "patrol_id": "mtn_bord_soloneutral3",
-        "biome": [
-            "mountainous"
-        ],
-        "season": [
-            "any"
-        ],
-        "types": [
-            "border"
-        ],
-        "tags": [],
-        "patrol_art": "bord_general_intro",
-        "min_cats": 1,
-        "max_cats": 1,
-        "min_max_status": {
-            "leader": [
-                1,
-                6
-            ]
-        },
-        "frequency": 4,
-        "intro_text": "r_c heads out into the mountains alone, wanting to make a quick check on the border.",
-        "decline_text": "r_c turns back to camp, deciding that {PRONOUN/r_c/poss} other duties have to come first.",
-        "chance_of_success": 30,
-        "success_outcomes": [
-            {
-                "text": "There's a particular spot where the ground is prone to slipping along the border with o_c_n, dirt falling away from under the trails - not dangerous, but wiping the border markings off the map. r_c remarks it and heads home, a simple but necessary mission completed.",
-                "exp": 20,
-                "other_clan_rep": 2,
-                "frequency": 4
-            },
-            {
-                "text": "r_c comes across a o_c_n apprentice on the wrong side of the border, holding prey. Calmly, they tell the apprentice they're on the wrong side of the territory and lead them back to their mentor and rightful side, where the apprentice scampers and is scolded by the o_c_n warrior.",
-                "exp": 20,
-                "other_clan_rep": 2,
-                "frequency": 1
-            },
-            {
-                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to them. They strike up a friendly conversation, and while s_c doesn't give anything away about c_n, they're able to pick up on a lot of gossip about o_c_n through careful conversation. It's always worth keeping an eye on their neighbors. Trust, but verify.",
-                "exp": 20,
-                "stat_skill": [
-                    "SPEAKER,1"
-                ],
-                "other_clan_rep": 2,
-                "frequency": 4
-            },
-            {
-                "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} a o_c_n border patrol, which includes a young apprentice. Their eyes go round and they hide behind their mentor, but s_c manages to coax them out, praising the little apprentice to their mentor, who purrs gratefully at the c_n leader's kindness.",
-                "exp": 20,
-                "stat_trait": [
-                    "compassionate",
-                    "faithful",
-                    "loving",
-                    "responsible",
-                    "thoughtful",
-                    "wise"
-                ],
-                "other_clan_rep": 2,
-                "frequency": 4
-            }
-        ],
-        "fail_outcomes": [
-            {
-                "text": "r_c marks a little, but {PRONOUN/r_c/subject} {VERB/r_c/reach/reaches} a section where the border is muddled and {VERB/r_c/have/has} to give up and go home.",
-                "exp": 0,
-                "other_clan_rep": -1,
-                "frequency": 4
-            },
-            {
-                "text": "s_c is marking along the territory line when they encounter a patrol from o_c_n, out on a similar mission. {PRONOUN/s_c/subject/CAP} {VERB/s_c/stare/stares} at the other Clan's patrol challengingly, following their every move until the shared border ends, and though no words are exchanged, it's very tense.",
-                "exp": 0,
-                "stat_trait": [
-                    "ambitious",
-                    "bloodthirsty",
-                    "cold",
-                    "fierce",
-                    "shameless",
-                    "strict",
-                    "troublesome",
-                    "vengeful"
-                ],
-                "other_clan_rep": -1,
-                "frequency": 4
-            },
-            {
-                "text": "r_c is having trouble focusing today and puts a mark in the wrong place - and at the worst possible moment, because a o_c_n patrol sees them doing it! The diplomatic incident spirals into a full blown conflict, and r_c hauls themselves back to camp wounded and bleeding.",
-                "exp": 0,
-                "injury": [
-                    {
-                        "cats": [
-                            "r_c"
-                        ],
-                        "injuries": [
-                            "battle_injury"
-                        ],
-                        "scars": [
-                            "ONE"
-                        ]
-                    }
-                ],
-                "history_text": {
-                    "scar": "m_c got injured patrolling on the border."
-                },
-                "other_clan_rep": -1,
-                "frequency": 3
-            }
-        ]
-    },
-    {
-        "patrol_id": "mtn_bord_soloneutral4",
-        "biome": [
-            "mountainous"
-        ],
-        "season": [
-            "any"
-        ],
-        "types": [
-            "border"
-        ],
-        "tags": [],
-        "patrol_art": "bord_general_intro",
-        "min_cats": 1,
-        "max_cats": 1,
-        "min_max_status": {
-            "deputy": [
-                1,
-                6
-            ]
-        },
-        "frequency": 4,
-        "intro_text": "r_c heads out into the mountains alone, wanting to make a quick check on the border.",
-        "decline_text": "r_c turns back to camp, deciding that {PRONOUN/r_c/poss} other duties have to come first.",
-        "chance_of_success": 30,
-        "success_outcomes": [
-            {
-                "text": "There's a particular spot where the ground is prone to slipping along the border with o_c_n, dirt falling away from under the trails - not dangerous, but wiping the border markings off the map. r_c remarks it and heads home, a simple but necessary mission completed.",
-                "exp": 20,
-                "other_clan_rep": 2,
-                "frequency": 4
-            },
-            {
-                "text": "r_c heads out to clarify a portion of the border that there's been confusion over recently and encounters the deputy of o_c_n out doing the same thing. They commiserate over the incompetence of the apprentices on both sides that caused the issue and walk away with a greater respect for one another.",
-                "exp": 20,
-                "other_clan_rep": 2,
-                "frequency": 1
-            },
-            {
-                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to them, led by their deputy. They strike up a friendly conversation, and eventually the o_c_n warriors drift away. The unexpected opportunity turns into the perfect chance to casually but purposefully keep each other informed on an ongoing problem in the mountains.",
-                "exp": 20,
-                "stat_skill": [
-                    "SPEAKER,1"
-                ],
-                "other_clan_rep": 2,
-                "frequency": 4
-            },
-            {
-                "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} the o_c_n deputy out with their new apprentice. Their fellow deputy encourages their apprentice to quiz s_c, and s_c compliments them both on how the young cat's training is progressing.",
-                "exp": 20,
-                "stat_trait": [
-                    "compassionate",
-                    "faithful",
-                    "loving",
-                    "responsible",
-                    "thoughtful",
-                    "wise"
-                ],
-                "other_clan_rep": 2,
-                "frequency": 4
-            }
-        ],
-        "fail_outcomes": [
-            {
-                "text": "r_c heads out to clarify a portion of the border that there's been confusion over recently and encounters the deputy of o_c_n out doing the same thing. Both deputies find a point where they can't agree on the right border path and return to their respective camps to discuss with their leaders.",
-                "exp": 0,
-                "other_clan_rep": -1,
-                "frequency": 4
-            }
-        ]
-    },
-    {
-        "patrol_id": "mtn_bord_soloneutral5",
-        "biome": [
-            "mountainous"
-        ],
-        "season": [
-            "any"
-        ],
-        "types": [
-            "border"
-        ],
-        "tags": [],
-        "patrol_art": "bord_general_intro",
-        "min_cats": 1,
-        "max_cats": 1,
-        "min_max_status": {
-            "leader": [
-                1,
-                6
-            ]
-        },
-        "frequency": 4,
-        "intro_text": "r_c heads out into the mountains alone, wanting to make a quick check on the border.",
-        "decline_text": "r_c turns back to camp, deciding that {PRONOUN/r_c/poss} other duties have to come first.",
-        "chance_of_success": 30,
-        "success_outcomes": [
-            {
-                "text": "There's a particular spot where the ground is prone to slipping along the border with o_c_n, dirt falling away from under the trails - not dangerous, but wiping the border markings off the map. r_c remarks it and heads home, a simple but necessary mission completed.",
-                "exp": 20,
-                "other_clan_rep": 2,
-                "frequency": 4
-            },
-            {
-                "text": "r_c heads out to clarify a portion of the border that there's been confusion over recently and encounters the leader of o_c_n out doing the same thing. They commiserate over the incompetence of the apprentices on both sides that caused the issue and walk away with a greater respect for one another.",
-                "exp": 20,
-                "other_clan_rep": 2,
-                "frequency": 1
-            },
-            {
-                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to s_c with their leader. They strike up a friendly conversation, and eventually the o_c_n warriors drift away. The unexpected opportunity turns into the perfect chance to casually but purposefully keep each other informed on an ongoing problem in the mountains.",
-                "exp": 20,
-                "stat_skill": [
-                    "SPEAKER,1"
-                ],
-                "other_clan_rep": 2,
-                "frequency": 4
-            },
-            {
-                "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} the o_c_n leader out with their new apprentice. Their fellow leader encourages their apprentice to quiz s_c, and s_c compliments them both on how the young cat's training is progressing.",
-                "exp": 20,
-                "stat_trait": [
-                    "compassionate",
-                    "faithful",
-                    "loving",
-                    "responsible",
-                    "thoughtful",
-                    "wise"
-                ],
-                "other_clan_rep": 2,
-                "frequency": 4
-            }
-        ],
-        "fail_outcomes": [
-            {
-                "text": "r_c heads out to clarify a portion of the border that there's been confusion over recently and encounters the leader of o_c_n out doing the same thing. Both leaders find a point where they can't agree on the right border path and agree to bring the subject up at the next Gathering instead.",
-                "exp": 0,
-                "frequency": 4
+                "frequency": 2,
+                "art": "gen_battle_warrior_other_clan"
             }
         ]
     },
@@ -2906,7 +2603,7 @@
             "border"
         ],
         "tags": [],
-        "patrol_art": "bord_general_intro",
+        "patrol_art": "gen_warrior_crouching",
         "min_cats": 1,
         "max_cats": 1,
         "min_max_status": {},
@@ -2916,25 +2613,102 @@
         "chance_of_success": 30,
         "success_outcomes": [
             {
-                "text": "There's a particular spot where a herd of buffalo have wandered recently along the border with o_c_n, churning the grass into mud and wiping the border markings off the map. r_c remarks it and heads home, a simple but necessary mission completed.",
+                "text": "There's a particular spot where a herd of buffalo have wandered recently along the border with o_c_n, churning the grass into mud and wiping the border markings off the map. r_c re-marks it and heads home, a simple but necessary mission completed.",
                 "exp": 20,
                 "other_clan_rep": 2,
                 "frequency": 4
             },
             {
-                "text": "r_c comes across a o_c_n apprentice on the wrong side of the border and holding prey. {PRONOUN/r_c/subject/CAP} {VERB/r_c/see/sees} the young cat off with a furious yowl and then {VERB/r_c/bring/brings} the prey back to c_n camp to report the incident to the deputy.",
+                "text": "r_c comes upon a o_c_n patrol and exchanges pleasantries before continuing along the border.",
                 "exp": 20,
                 "other_clan_rep": 2,
-                "frequency": 1
+                "frequency": 4,
+                "art": "gen_train_talkingOCWW"
             },
             {
-                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to them, and turns to follow the same marking path as them. They strike up a friendly conversation, and while s_c doesn't give anything away about c_n, they're able to pick up on a lot of gossip about o_c_n through careful conversation.",
+                "min_max_status": {
+                    "warrior": [-1,-1]
+                },
+                "text": "r_c heads out to clarify a portion of the border that there's been confusion over recently and encounters {PRONOUN/r_c/poss} o_c_n counterpart out doing the same thing. They commiserate over the incompetence of the apprentices on both sides that caused the issue and walk away with a greater respect for one another.",
+                "exp": 20,
+                "other_clan_rep": 2,
+                "frequency": 2,
+                "art": "gen_train_talkingOCWW"
+            },
+            {
+                "min_max_status": {
+                    "warrior": [-1,-1]
+                },
+                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to them, led by their deputy. They strike up a friendly conversation, and eventually the o_c_n warriors drift away. The unexpected opportunity turns into the perfect chance to casually but purposefully keep each other informed on an ongoing problem in the territories.",
                 "exp": 20,
                 "stat_skill": [
                     "SPEAKER,1"
                 ],
                 "other_clan_rep": 2,
-                "frequency": 4
+                "frequency": 3,
+                "art": "gen_train_talkingOCWW"
+            },
+            {
+                "min_max_status": {
+                    "warrior": [-1,-1]
+                },
+                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to s_c with their leader. They strike up a friendly conversation, and eventually the o_c_n warriors drift away. The unexpected opportunity turns into the perfect chance to casually but purposefully keep each other informed on an ongoing problem in the territories.",
+                "exp": 20,
+                "stat_skill": [
+                    "SPEAKER,1"
+                ],
+                "other_clan_rep": 2,
+                "frequency": 3,
+                "art": "gen_train_talkingOCWW"
+            },
+            {
+                "text": "r_c comes across a o_c_n apprentice on the wrong side of the border and holding prey. The young cat seems distraught when they realize their mistake and apologizes profusely. r_c escorts them back to the o_c_n camp and explains the situation to their deputy, who thanks {PRONOUN/r_c/object} for {PRONOUN/r_c/poss} restraint.",
+                "exp": 20,
+                "other_clan_rep": 2,
+                "frequency": 1,
+                "art": "gen_bord_otherclan_app_allies"
+            },
+            {
+                "text": "r_c comes across a o_c_n apprentice on the wrong side of the border, holding prey. Calmly, they tell the apprentice they're on the wrong side of the territory and lead them back to their mentor and rightful side, where the apprentice scampers and is scolded by the o_c_n warrior.",
+                "stat_trait": [
+                    "calm",
+                    "responsible",
+                    "thoughtful",
+                    "careful",
+                    "sincere",
+                    "compassionate"
+                ],
+                "exp": 20,
+                "other_clan_rep": 2,
+                "frequency": 1,
+                "art": "gen_bord_otherclan_app_allies"
+            },
+            {
+                "min_max_status": {
+                    "deputy": [1,1]
+                },
+                "text": "r_c comes across a o_c_n apprentice on the wrong side of the border and holding prey. Furious, {PRONOUN/r_c/subject} {VERB/r_c/snarl/snarls} {PRONOUN/r_c/poss} anger. The apprentice turns tail and flees with r_c hot on their trail, and when the apprentice crosses the border to hide behind their mentor, the o_c_n warrior's face goes slack with horror to see c_n's deputy.",
+                "stat_trait": [
+                    "fierce",
+                    "bloodthirsty",
+                    "insecure",
+                    "arrogant",
+                    "grumpy"
+                ],
+                "exp": 20,
+                "other_clan_rep": 2,
+                "frequency": 1,
+                "art": "gen_angry_cat_warrior"
+            },
+            {
+                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to {PRONOUN/s_c/object}, and turns to follow the same marking path as them. {PRONOUN/s_c/subject/CAP} strike up a friendly conversation, and while s_c doesn't give anything away about c_n, {PRONOUN/s_c/subject}{VERB/s_c/'re/'s} able to pick up on a lot of gossip about o_c_n through careful conversation. It's always worth keeping an eye on their neighbors. Trust, but verify.",
+                "exp": 20,
+                "stat_skill": [
+                    "SPEAKER,1"
+                ],
+                "other_clan_rep": 2,
+                "frequency": 4,
+                "art": "gen_speaking_cat_other1"
             },
             {
                 "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} a o_c_n border patrol. It even includes a young apprentice, whose eyes go round and fur fluffs up at encountering a real c_n cat! s_c plays along, acting very impressed with the hardworking apprentice, and the apprentice's mentor purrs gratefully.",
@@ -2945,107 +2719,32 @@
                     "loving",
                     "responsible",
                     "thoughtful",
-                    "wise"
+                    "wise",
+                    "confident"
                 ],
                 "other_clan_rep": 2,
-                "frequency": 4
-            }
-        ],
-        "fail_outcomes": [
-            {
-                "text": "r_c marks a little, but {PRONOUN/r_c/subject} {VERB/r_c/reach/reaches} a section where the border is muddled and {VERB/r_c/have/has} to give up and go home.",
-                "exp": 0,
-                "other_clan_rep": -1,
-                "frequency": 4
+                "frequency": 3,
+                "art": "gen_train_app_otherclan"
             },
             {
-                "text": "s_c is marking along the territory line when they encounter a patrol from o_c_n, out on a similar mission. {PRONOUN/s_c/subject/CAP} {VERB/s_c/stare/stares} at the other Clan's patrol challengingly, following their every move until the shared border ends, and though no words are exchanged, it's very tense.",
+                "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} a o_c_n border patrol. It even includes a young apprentice, whose eyes go round and fur fluffs up at encountering a real c_n cat! Tactlessly, the apprentice immediately turns to their mentor and begins loudly asking <i>why</i> the c_n cat smells like <i>that</i>? s_c laughs good-naturedly and launches into a silly story about rolling in all manner of strange-smelling things in order to trick nasty dogs. The two patrols part in good spirits.",
                 "exp": 0,
                 "stat_trait": [
-                    "ambitious",
-                    "bloodthirsty",
-                    "cold",
-                    "fierce",
-                    "shameless",
-                    "strict",
-                    "troublesome",
-                    "vengeful"
+                    "strange",
+                    "playful",
+                    "childish",
+                    "flamboyant",
+                    "oblivious",
+                    "shameless"
                 ],
-                "other_clan_rep": -1,
-                "frequency": 4
+                "other_clan_rep": 2,
+                "frequency": 3,
+                "art": "gen_train_app_otherclan"
             },
             {
-                "text": "r_c is having trouble focusing today and puts a mark in the wrong place - and at the worst possible moment, because a o_c_n patrol sees {PRONOUN/r_c/object} doing it! {PRONOUN/r_c/subject/CAP} {VERB/r_c/come/comes} back to camp scratched up, and immediately {VERB/r_c/apologize/apologizes} to the deputy for the diplomatic incident {PRONOUN/r_c/subject}{VERB/r_c/'ve/'s} inadvertently caused.",
-                "exp": 0,
-                "injury": [
-                    {
-                        "cats": [
-                            "r_c"
-                        ],
-                        "injuries": [
-                            "battle_injury"
-                        ],
-                        "scars": [
-                            "TWO"
-                        ]
-                    }
-                ],
-                "history_text": {
-                    "scar": "m_c got injured patrolling on the border."
+                "min_max_status": {
+                    "deputy": [1,1]
                 },
-                "other_clan_rep": -1,
-                "frequency": 3
-            }
-        ]
-    },
-    {
-        "patrol_id": "pln_bord_soloneutral2",
-        "biome": [
-            "plains"
-        ],
-        "season": [
-            "any"
-        ],
-        "types": [
-            "border"
-        ],
-        "tags": [],
-        "patrol_art": "bord_general_intro",
-        "min_cats": 1,
-        "max_cats": 1,
-        "min_max_status": {
-            "deputy": [
-                1,
-                6
-            ]
-        },
-        "frequency": 4,
-        "intro_text": "r_c heads out into the grasslands alone, wanting to make a quick check on the border.",
-        "decline_text": "r_c turns back to camp, deciding that {PRONOUN/r_c/poss} other duties have to come first.",
-        "chance_of_success": 30,
-        "success_outcomes": [
-            {
-                "text": "There's a particular spot where a herd of buffalo have wandered recently along the border with o_c_n, churning the grass into mud and wiping the border markings off the map. r_c remarks it and heads home, a simple but necessary mission completed.",
-                "exp": 20,
-                "other_clan_rep": 2,
-                "frequency": 4
-            },
-            {
-                "text": "r_c comes across a o_c_n apprentice on the wrong side of the border and holding prey. Furious, {PRONOUN/r_c/subject} {VERB/r_c/snarl/snarls} {PRONOUN/r_c/poss} anger. The apprentice turns tail and flees with r_c hot on their trail, and when the apprentice crosses the border to hide behind their mentor, the o_c_n warrior's face goes slack with horror to see c_n's deputy.",
-                "exp": 20,
-                "other_clan_rep": 2,
-                "frequency": 1
-            },
-            {
-                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to them. They strike up a friendly conversation, and while s_c doesn't give anything away about c_n, they're able to pick up on a lot of gossip about o_c_n through careful conversation. It's always worth keeping an eye on their neighbors.",
-                "exp": 20,
-                "stat_skill": [
-                    "SPEAKER,1"
-                ],
-                "other_clan_rep": 2,
-                "frequency": 4
-            },
-            {
                 "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} a o_c_n border patrol, which includes a young apprentice. Their eyes go round and they tuck their paws together neatly, sitting pretty for inspection. s_c plays along, acting very impressed with the hardworking apprentice, and the apprentice's mentor purrs gratefully at the c_n deputy's kindness.",
                 "exp": 20,
                 "stat_trait": [
@@ -3054,123 +2753,17 @@
                     "loving",
                     "responsible",
                     "thoughtful",
-                    "wise"
+                    "wise",
+                    "confident"
                 ],
                 "other_clan_rep": 2,
-                "frequency": 4
-            }
-        ],
-        "fail_outcomes": [
-            {
-                "text": "r_c marks a little, but {PRONOUN/r_c/subject} {VERB/r_c/reach/reaches} a section where the border is muddled and {VERB/r_c/have/has} to give up and go home.",
-                "exp": 0,
-                "other_clan_rep": -1,
-                "frequency": 4
+                "frequency": 3,
+                "art": "gen_train_app_otherclan"
             },
             {
-                "text": "s_c is marking along the territory line when they encounter a patrol from o_c_n, out on a similar mission. {PRONOUN/s_c/subject/CAP} {VERB/s_c/stare/stares} at the other Clan's patrol challengingly, following their every move until the shared border ends, and though no words are exchanged, it's very tense.",
-                "exp": 0,
-                "stat_trait": [
-                    "ambitious",
-                    "bloodthirsty",
-                    "cold",
-                    "fierce",
-                    "shameless",
-                    "strict",
-                    "troublesome",
-                    "vengeful"
-                ],
-                "other_clan_rep": -1,
-                "frequency": 4
-            },
-            {
-                "text": "r_c encounters a patrol from o_c_n on the border and greets them politely, but there's something different here. Something dangerous. {PRONOUN/r_c/subject/CAP} {VERB/r_c/do/does}'t make it back to camp.",
-                "exp": 0,
-                "dead_cats": [
-                    "r_c"
-                ],
-                "history_text": {
-                    "scar": "m_c got injured patrolling on the border.",
-                    "reg_death": "m_c lost their life in an ambush on the border.",
-                    "lead_death": "{VERB/m_c/were/was} killed in a border ambush"
+                "min_max_status": {
+                    "leader": [1,1]
                 },
-                "other_clan_rep": -1,
-                "frequency": 3
-            },
-            {
-                "text": "r_c is having trouble focusing today and puts a mark in the wrong place - and at the worst possible moment, because a o_c_n patrol sees them doing it! The diplomatic incident spirals into a full blown conflict, and r_c hauls themselves back to camp wounded and bleeding.",
-                "exp": 0,
-                "injury": [
-                    {
-                        "cats": [
-                            "r_c"
-                        ],
-                        "injuries": [
-                            "battle_injury"
-                        ],
-                        "scars": [
-                            "CHEEK"
-                        ]
-                    }
-                ],
-                "history_text": {
-                    "scar": "m_c got injured patrolling on the border.",
-                    "reg_death": "m_c lost their life in an ambush on the border.",
-                    "lead_death": "{VERB/m_c/were/was} killed in a border ambush"
-                },
-                "other_clan_rep": -1,
-                "frequency": 3
-            }
-        ]
-    },
-    {
-        "patrol_id": "pln_bord_soloneutral3",
-        "biome": [
-            "plains"
-        ],
-        "season": [
-            "any"
-        ],
-        "types": [
-            "border"
-        ],
-        "tags": [],
-        "patrol_art": "bord_general_intro",
-        "min_cats": 1,
-        "max_cats": 1,
-        "min_max_status": {
-            "leader": [
-                1,
-                6
-            ]
-        },
-        "frequency": 4,
-        "intro_text": "r_c heads out into the grasslands alone, wanting to make a quick check on the border.",
-        "decline_text": "r_c turns back to camp, deciding that {PRONOUN/r_c/poss} other duties have to come first.",
-        "chance_of_success": 30,
-        "success_outcomes": [
-            {
-                "text": "There's a particular spot where a herd of buffalo have wandered recently along the border with o_c_n, churning the grass into mud and wiping the border markings off the map. r_c remarks it and heads home, a simple but necessary mission completed.",
-                "exp": 20,
-                "other_clan_rep": 2,
-                "frequency": 4
-            },
-            {
-                "text": "r_c comes across a o_c_n apprentice on the wrong side of the border and holding prey. Furious, {PRONOUN/r_c/subject} {VERB/r_c/snarl/snarls} {PRONOUN/r_c/poss} anger. The apprentice turns tail and flees with r_c hot on their trail, and when the apprentice crosses the border to hide behind their mentor, the o_c_n warrior's tail tucks at the sight of c_n's outraged leader.",
-                "exp": 20,
-                "other_clan_rep": 2,
-                "frequency": 1
-            },
-            {
-                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to them. They strike up a friendly conversation, and while s_c doesn't give anything away about c_n, they're able to pick up on a lot of gossip about o_c_n through careful conversation. It's always worth keeping an eye on their neighbors. Trust, but verify.",
-                "exp": 20,
-                "stat_skill": [
-                    "SPEAKER,1"
-                ],
-                "other_clan_rep": 2,
-                "frequency": 4
-            },
-            {
                 "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} a o_c_n border patrol, which includes a young apprentice. Their eyes go round and they hide behind their mentor, but s_c manages to coax them out, praising the little apprentice to their mentor, who purrs gratefully at the c_n leader's kindness.",
                 "exp": 20,
                 "stat_trait": [
@@ -3179,18 +2772,128 @@
                     "loving",
                     "responsible",
                     "thoughtful",
-                    "wise"
+                    "wise",
+                    "confident"
                 ],
                 "other_clan_rep": 2,
-                "frequency": 4
+                "frequency": 3,
+                "art": "gen_train_app_otherclan"
+            },
+            {
+                "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} a o_c_n cat out with their new apprentice. The cat encourages their apprentice to ask s_c any questions they have, and s_c compliments them both on how the young cat's training is progressing.",
+                "exp": 20,
+                "stat_trait": [
+                    "compassionate",
+                    "faithful",
+                    "loving",
+                    "responsible",
+                    "thoughtful",
+                    "wise",
+                    "confident"
+                ],
+                "other_clan_rep": 2,
+                "frequency": 3,
+                "art": "gen_train_app_otherclan"
             }
         ],
         "fail_outcomes": [
             {
-                "text": "r_c marks a little, but {PRONOUN/r_c/subject} {VERB/r_c/reach/reaches} a section where the border is muddled and {VERB/r_c/have/has} to give up and go home.",
+                "text": "r_c comes upon a o_c_n patrol and, in a fit of panic at their unexpected appearance, attempts to hide behind a rock to avoid a conversation. Judging by the puzzled whispers, it didn't quite work. r_c ends up awkwardly squatting there until the patrol finally leaves.",
+                "stat_trait": ["nervous", "gloomy", "lonesome"],
+                "exp": 0,
+                "other_clan_rep": -1,
+                "frequency": 4,
+                "art": "gen_bord_otherclan_allies"
+            },
+            {
+                "text": "r_c marks a little, but {PRONOUN/r_c/subject} {VERB/r_c/reach/reaches} a section where the border is muddled and {VERB/r_c/have/has} to give up and go home. Unclear borders won't make o_c_n too happy, though...",
                 "exp": 0,
                 "other_clan_rep": -1,
                 "frequency": 4
+            },
+            {
+                "min_max_status": {
+                    "deputy": [-1,-1]
+                },
+                "text": "r_c comes across a o_c_n apprentice on the wrong side of the border and holding prey. {PRONOUN/r_c/subject/CAP} {VERB/r_c/see/sees} the young cat off with a furious yowl and then {VERB/r_c/bring/brings} the prey back to c_n camp to report the incident to the deputy.",
+                "prey": ["small"],
+                "exp": 0,
+                "other_clan_rep": -1,
+                "frequency": 2,
+                "art": "gen_angry_cat_warrior"
+            },
+            {
+                "min_max_status": {
+                    "deputy": [1,1]
+                },
+                "text": "r_c heads out to clarify a portion of the border that there's been confusion over recently and encounters the deputy of o_c_n out doing the same thing. Both deputies find a point where they can't agree on the right border path and return to their respective camps to discuss with their leaders.",
+                "exp": 0,
+                "other_clan_rep": -1,
+                "frequency": 2,
+                "art": "gen_train_talkingOCWW"
+            },
+            {
+                "min_max_status": {
+                    "deputy": [1,1]
+                },
+                "text": "s_c heads out to clarify a portion of the border that there's been confusion over recently and encounters the deputy of o_c_n out doing the same thing. s_c insists on {PRONOUN/s_c/poss} idea of the correct border line, despite the other deputy's protests. The two eventually leave to consult with their own leaders, tails whipping and hisses hanging in the air.",
+                "stat_trait": [
+                    "troublesome",
+                    "ambitious",
+                    "fierce",
+                    "bloodthirsty",
+                    "childish",
+                    "bold",
+                    "daring",
+                    "insecure",
+                    "responsible",
+                    "vengeful",
+                    "arrogant",
+                    "competitive",
+                    "grumpy",
+                    "oblivious",
+                    "rebellious"
+                ],
+                "exp": 0,
+                "other_clan_rep": -2,
+                "frequency": 2,
+                "art": "gen_angry_cat_warrior"
+            },
+            {
+                "min_max_status": {
+                    "leader": [1,1]
+                },
+                "text": "r_c heads out to clarify a portion of the border that there's been confusion over recently and encounters the leader of o_c_n out doing the same thing. Both cats find a point where they can't agree on the right border path and agree to bring the subject up at the next Gathering instead.",
+                "exp": 0,
+                "frequency": 2,
+                "art": "gen_train_talkingOCWW"
+            },
+            {
+                "min_max_status": {
+                    "leader": [1,1]
+                },
+                "text": "s_c heads out to clarify a portion of the border that there's been confusion over recently and encounters the leader of o_c_n out doing the same thing. s_c insists on {PRONOUN/s_c/poss} idea of the correct border line, despite the other leader's protests. Hissed promises are made to bring this up at the next Gathering.",
+                "stat_trait": [
+                    "troublesome",
+                    "ambitious",
+                    "fierce",
+                    "bloodthirsty",
+                    "childish",
+                    "bold",
+                    "daring",
+                    "insecure",
+                    "responsible",
+                    "vengeful",
+                    "arrogant",
+                    "competitive",
+                    "grumpy",
+                    "oblivious",
+                    "rebellious"
+                ],
+                "exp": 0,
+                "other_clan_rep": -2,
+                "frequency": 2,
+                "art": "gen_angry_cat_warrior"
             },
             {
                 "text": "s_c is marking along the territory line when they encounter a patrol from o_c_n, out on a similar mission. {PRONOUN/s_c/subject/CAP} {VERB/s_c/stare/stares} at the other Clan's patrol challengingly, following their every move until the shared border ends, and though no words are exchanged, it's very tense.",
@@ -3203,27 +2906,65 @@
                     "shameless",
                     "strict",
                     "troublesome",
+                    "vengeful",
+                    "insecure"
+                ],
+                "other_clan_rep": -1,
+                "frequency": 4,
+                "art": "gen_bord_otherclan_hostile"
+            },
+            {
+                "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} a o_c_n border patrol. It even includes a young apprentice, whose eyes go round and fur fluffs up at encountering a real c_n cat! Tactlessly, the apprentice immediately turns to their mentor and begins loudly asking <i>why</i> the c_n cat smells like <i>that</i>? s_c bristles and stomps away while the apprentice's mentor stutters apologies behind {PRONOUN/s_c/object}.",
+                "exp": 0,
+                "stat_trait": [
+                    "fierce",
+                    "childish",
+                    "insecure",
                     "vengeful"
                 ],
-                "other_clan_rep": -1,
-                "frequency": 4
+                "other_clan_rep": -2,
+                "frequency": 3,
+                "art": "gen_angry_cat_warrior"
             },
             {
-                "text": "r_c encounters a patrol from o_c_n on the border and greets them politely, but there's something different here. Something dangerous. {PRONOUN/r_c/subject/CAP} {VERB/r_c/return/returns} to camp, blood soaked through {PRONOUN/r_c/poss} fur and a new hardness in {PRONOUN/r_c/poss} heart.",
+                "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} a o_c_n cat out with their new apprentice. The cat encourages their apprentice to ask s_c any questions they have. The apprentice peppers {PRONOUN/s_c/object} with questions. Some of them are, perhaps, probing a bit too far into c_n's personal affairs, but s_c answers everything enthusiastically. The apprentice's mentor seems surprised at {PRONOUN/s_c/poss} candor... and perhaps a bit concerned at some of the answers.",
                 "exp": 0,
-                "dead_cats": [
-                    "r_c"
+                "stat_trait": [
+                    "sincere",
+                    "oblivious",
+                    "flamboyant",
+                    "strange",
+                    "competitive",
+                    "childish",
+                    "playful"
                 ],
-                "history_text": {
-                    "scar": "m_c got injured patrolling on the border.",
-                    "reg_death": "m_c lost a life in an ambush on the border.",
-                    "lead_death": "{VERB/m_c/were/was} killed in a border ambush"
-                },
                 "other_clan_rep": -1,
-                "frequency": 3
+                "frequency": 3,
+                "art": "gen_bord_otherclan_app_allies"
             },
             {
-                "text": "r_c is having trouble focusing today and puts a mark in the wrong place - and at the worst possible moment, because a o_c_n patrol sees them doing it! The diplomatic incident spirals into a full blown conflict, and r_c hauls themselves back to camp wounded and bleeding.",
+                "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} a o_c_n cat out with their new apprentice. The cat encourages their apprentice to ask s_c any questions they have, but s_c interrupts and tersely informs the pair that s_c doesn't have time for questions. s_c leaves the two stunned cats behind to continue {PRONOUN/s_c/poss} patrol.",
+                "exp": 0,
+                "stat_trait": [
+                    "fierce",
+                    "cold",
+                    "strict",
+                    "ambitious",
+                    "responsible",
+                    "loyal",
+                    "competitive",
+                    "arrogant",
+                    "insecure"
+                ],
+                "other_clan_rep": -1,
+                "frequency": 3,
+                "art": "gen_bord_otherclan_app_allies"
+            },
+            {
+                "min_max_status": {
+                    "deputy": [-1,-1]
+                },
+                "text": "r_c is having trouble focusing today and puts a mark in the wrong place - and at the worst possible moment, because a o_c_n patrol sees {PRONOUN/r_c/object} doing it! {PRONOUN/r_c/subject/CAP} {VERB/r_c/come/comes} back to camp scratched up, and immediately {VERB/r_c/apologize/apologizes} to the deputy for the diplomatic incident {PRONOUN/r_c/subject}{VERB/r_c/'ve/'s} inadvertently caused.",
                 "exp": 0,
                 "injury": [
                     {
@@ -3239,85 +2980,16 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c got injured patrolling on the border.",
-                    "reg_death": "m_c lost a life in an ambush on the border.",
-                    "lead_death": "{VERB/m_c/were/was} killed in a border ambush"
+                    "scar": "m_c got injured patrolling on the border."
                 },
                 "other_clan_rep": -1,
-                "frequency": 3
-            }
-        ]
-    },
-    {
-        "patrol_id": "pln_bord_soloneutral4",
-        "biome": [
-            "plains"
-        ],
-        "season": [
-            "any"
-        ],
-        "types": [
-            "border"
-        ],
-        "tags": [],
-        "patrol_art": "bord_general_intro",
-        "min_cats": 1,
-        "max_cats": 1,
-        "min_max_status": {
-            "deputy": [
-                1,
-                6
-            ]
-        },
-        "frequency": 4,
-        "intro_text": "r_c heads out into the grasslands alone, wanting to make a quick check on the border.",
-        "decline_text": "r_c turns back to camp, deciding that {PRONOUN/r_c/poss} other duties have to come first.",
-        "chance_of_success": 30,
-        "success_outcomes": [
-            {
-                "text": "There's a particular spot where a herd of buffalo have wandered recently along the border with o_c_n, churning the grass into mud and wiping the border markings off the map. r_c remarks it and heads home, a simple but necessary mission completed.",
-                "exp": 20,
-                "other_clan_rep": 2,
-                "frequency": 4
+                "frequency": 2,
+                "art": "gen_battle_warrior_other_clan"
             },
             {
-                "text": "r_c heads out to clarify a portion of the border that there's been confusion over recently and encounters the deputy of o_c_n out doing the same thing. They commiserate over the incompetence of the apprentices on both sides that caused the issue and walk away with a greater respect for one another.",
-                "exp": 20,
-                "other_clan_rep": 2,
-                "frequency": 1
-            },
-            {
-                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to them, led by their deputy. They strike up a friendly conversation, and eventually the o_c_n warriors drift away. The unexpected opportunity turns into the perfect chance to casually but purposefully keep each other informed on an ongoing problem in the grasslands.",
-                "exp": 20,
-                "stat_skill": [
-                    "SPEAKER,1"
-                ],
-                "other_clan_rep": 2,
-                "frequency": 4
-            },
-            {
-                "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} the o_c_n deputy out with their new apprentice. Their fellow deputy encourages their apprentice to quiz s_c, and s_c compliments them both on how the young cat's training is progressing.",
-                "exp": 20,
-                "stat_trait": [
-                    "compassionate",
-                    "faithful",
-                    "loving",
-                    "responsible",
-                    "thoughtful",
-                    "wise"
-                ],
-                "other_clan_rep": 2,
-                "frequency": 4
-            }
-        ],
-        "fail_outcomes": [
-            {
-                "text": "r_c heads out to clarify a portion of the border that there's been confusion over recently and encounters the deputy of o_c_n out doing the same thing. Both deputies find a point where they can't agree on the right border path and return to their respective camps to discuss with their leaders.",
-                "exp": 0,
-                "other_clan_rep": -1,
-                "frequency": 4
-            },
-            {
+                "min_max_status": {
+                    "warrior": [-1,-1]
+                },
                 "text": "r_c is having trouble focusing today and puts a mark in the wrong place - and at the worst possible moment, because a o_c_n patrol sees them doing it! The diplomatic incident spirals into a full blown conflict, and r_c hauls themselves back to camp wounded and bleeding.",
                 "exp": 0,
                 "injury": [
@@ -3329,7 +3001,7 @@
                             "battle_injury"
                         ],
                         "scars": [
-                            "ONE"
+                            "SIDE"
                         ]
                     }
                 ],
@@ -3337,100 +3009,8 @@
                     "scar": "m_c got injured patrolling on the border."
                 },
                 "other_clan_rep": -1,
-                "frequency": 3
-            }
-        ]
-    },
-    {
-        "patrol_id": "pln_bord_soloneutral5",
-        "biome": [
-            "plains"
-        ],
-        "season": [
-            "any"
-        ],
-        "types": [
-            "border"
-        ],
-        "tags": [],
-        "patrol_art": "bord_general_intro",
-        "min_cats": 1,
-        "max_cats": 1,
-        "min_max_status": {
-            "leader": [
-                1,
-                6
-            ]
-        },
-        "frequency": 4,
-        "intro_text": "r_c heads out into the grasslands alone, wanting to make a quick check on the border.",
-        "decline_text": "r_c turns back to camp, deciding that {PRONOUN/r_c/poss} other duties have to come first.",
-        "chance_of_success": 30,
-        "success_outcomes": [
-            {
-                "text": "There's a particular spot where a herd of buffalo have wandered recently along the border with o_c_n, churning the grass into mud and wiping the border markings off the map. r_c remarks it and heads home, a simple but necessary mission completed.",
-                "exp": 20,
-                "other_clan_rep": 2,
-                "frequency": 4
-            },
-            {
-                "text": "r_c heads out to clarify a portion of the border that there's been confusion over recently and encounters the leader of o_c_n out doing the same thing. They commiserate over the incompetence of the apprentices on both sides that caused the issue and walk away with a greater respect for one another.",
-                "exp": 20,
-                "other_clan_rep": 2,
-                "frequency": 1
-            },
-            {
-                "text": "s_c comes across a patrol from o_c_n, out on a similar mission to s_c with their leader. They strike up a friendly conversation, and eventually the o_c_n warriors drift away. The unexpected opportunity turns into the perfect chance to casually but purposefully keep each other informed on an ongoing problem in the grasslands.",
-                "exp": 20,
-                "stat_skill": [
-                    "SPEAKER,1"
-                ],
-                "other_clan_rep": 2,
-                "frequency": 4
-            },
-            {
-                "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} the o_c_n leader out with their new apprentice. Their fellow leader encourages their apprentice to quiz s_c, and s_c compliments them both on how the young cat's training is progressing.",
-                "exp": 20,
-                "stat_trait": [
-                    "compassionate",
-                    "faithful",
-                    "loving",
-                    "responsible",
-                    "thoughtful",
-                    "wise"
-                ],
-                "other_clan_rep": 2,
-                "frequency": 4
-            }
-        ],
-        "fail_outcomes": [
-            {
-                "text": "r_c heads out to clarify a portion of the border that there's been confusion over recently and encounters the leader of o_c_n out doing the same thing. Both leaders find a point where they can't agree on the right border path and agree to bring the subject up at the next Gathering instead.",
-                "exp": 0,
-                "other_clan_rep": -1,
-                "frequency": 4
-            },
-            {
-                "text": "r_c is having trouble focusing today and puts a mark in the wrong place - and at the worst possible moment, because a o_c_n patrol sees them doing it! The diplomatic incident spirals into a full blown conflict, and r_c hauls themselves back to camp wounded and bleeding.",
-                "exp": 0,
-                "injury": [
-                    {
-                        "cats": [
-                            "r_c"
-                        ],
-                        "injuries": [
-                            "battle_injury"
-                        ],
-                        "scars": [
-                            "TWO"
-                        ]
-                    }
-                ],
-                "history_text": {
-                    "scar": "m_c got injured patrolling on the border."
-                },
-                "other_clan_rep": -1,
-                "frequency": 3
+                "frequency": 2,
+                "art": "gen_battle_warrior_other_clan"
             }
         ]
     },

--- a/resources/lang/en/patrols/other_clan.json
+++ b/resources/lang/en/patrols/other_clan.json
@@ -1117,9 +1117,19 @@
                     "deputy": [-1,-1]
                 },
                 "text": "r_c comes across a o_c_n apprentice on the wrong side of the border and holding prey. {PRONOUN/r_c/subject/CAP} {VERB/r_c/see/sees} the young cat off with a furious yowl and then {VERB/r_c/bring/brings} the prey back to c_n camp to report the incident to the deputy.",
+                "relationship": {
+                    "cats_from": ["high_aggress"],
+                    "cats_to": ["r_c"],
+                    "mutual": false,
+                    "values": ["respect"],
+                    "amount": 5,
+                    "log": {
+                        "cats_from": "from_cat heard that to_cat chased off a thieving o_c_n apprentice!"
+                    }
+                },
                 "prey": ["small"],
                 "exp": 0,
-                "other_clan_rep": -1,
+                "other_clan_rep": -3,
                 "frequency": 2,
                 "art": "gen_angry_cat_warrior"
             },
@@ -1229,6 +1239,16 @@
             },
             {
                 "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} a o_c_n cat out with their new apprentice. The cat encourages their apprentice to ask s_c any questions they have. The apprentice peppers {PRONOUN/s_c/object} with questions. Some of them are, perhaps, probing a bit too far into c_n's personal affairs, but s_c answers everything enthusiastically. The apprentice's mentor seems surprised at {PRONOUN/s_c/poss} candor... and perhaps a bit concerned at some of the answers.",
+                "relationship": {
+                    "cats_from": ["low_social", "low_stable"],
+                    "cats_to": ["s_c"],
+                    "mutual": false,
+                    "values": ["trust"],
+                    "amount": -5,
+                    "log": {
+                        "cats_from": "from_cat heard that to_cat was gossiping about {PRONOUN/to_cat/poss} own Clanmates to a o_c_n cat!"
+                    }
+                },
                 "exp": 0,
                 "stat_trait": [
                     "sincere",
@@ -1266,6 +1286,16 @@
                     "deputy": [-1,-1]
                 },
                 "text": "r_c is having trouble focusing today and puts a mark in the wrong place - and at the worst possible moment, because a o_c_n patrol sees {PRONOUN/r_c/object} doing it! {PRONOUN/r_c/subject/CAP} {VERB/r_c/come/comes} back to camp scratched up, and immediately {VERB/r_c/apologize/apologizes} to the deputy for the diplomatic incident {PRONOUN/r_c/subject}{VERB/r_c/'ve/'s} inadvertently caused.",
+                "relationship": {
+                    "cats_from": ["some_clan"],
+                    "cats_to": ["r_c"],
+                    "mutual": false,
+                    "values": ["trust"],
+                    "amount": -5,
+                    "log": {
+                        "cats_from": "from_cat heard about to_cat starting accidentally starting a fight with a misplaced border marking."
+                    }
+                },
                 "exp": 0,
                 "injury": [
                     {
@@ -1292,6 +1322,16 @@
                     "warrior": [-1,-1]
                 },
                 "text": "r_c is having trouble focusing today and puts a mark in the wrong place - and at the worst possible moment, because a o_c_n patrol sees them doing it! The diplomatic incident spirals into a full blown conflict, and r_c hauls themselves back to camp wounded and bleeding.",
+                "relationship": {
+                    "cats_from": ["some_clan"],
+                    "cats_to": ["r_c"],
+                    "mutual": false,
+                    "values": ["trust"],
+                    "amount": -5,
+                    "log": {
+                        "cats_from": "from_cat heard about to_cat starting accidentally starting a fight with a misplaced border marking."
+                    }
+                },
                 "exp": 0,
                 "injury": [
                     {
@@ -1540,9 +1580,19 @@
                     "deputy": [-1,-1]
                 },
                 "text": "r_c comes across a o_c_n apprentice on the wrong side of the border and holding prey. {PRONOUN/r_c/subject/CAP} {VERB/r_c/see/sees} the young cat off with a furious yowl and then {VERB/r_c/bring/brings} the prey back to c_n camp to report the incident to the deputy.",
+                "relationship": {
+                    "cats_from": ["high_aggress"],
+                    "cats_to": ["r_c"],
+                    "mutual": false,
+                    "values": ["respect"],
+                    "amount": 5,
+                    "log": {
+                        "cats_from": "from_cat heard that to_cat chased off a thieving o_c_n apprentice!"
+                    }
+                },
                 "prey": ["small"],
                 "exp": 0,
-                "other_clan_rep": -1,
+                "other_clan_rep": -3,
                 "frequency": 2,
                 "art": "gen_angry_cat_warrior"
             },
@@ -1652,6 +1702,16 @@
             },
             {
                 "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} a o_c_n cat out with their new apprentice. The cat encourages their apprentice to ask s_c any questions they have. The apprentice peppers {PRONOUN/s_c/object} with questions. Some of them are, perhaps, probing a bit too far into c_n's personal affairs, but s_c answers everything enthusiastically. The apprentice's mentor seems surprised at {PRONOUN/s_c/poss} candor... and perhaps a bit concerned at some of the answers.",
+                "relationship": {
+                    "cats_from": ["low_social", "low_stable"],
+                    "cats_to": ["s_c"],
+                    "mutual": false,
+                    "values": ["trust"],
+                    "amount": -5,
+                    "log": {
+                        "cats_from": "from_cat heard that to_cat was gossiping about {PRONOUN/to_cat/poss} own Clanmates to a o_c_n cat!"
+                    }
+                },
                 "exp": 0,
                 "stat_trait": [
                     "sincere",
@@ -1689,6 +1749,16 @@
                     "deputy": [-1,-1]
                 },
                 "text": "r_c is having trouble focusing today and puts a mark in the wrong place - and at the worst possible moment, because a o_c_n patrol sees {PRONOUN/r_c/object} doing it! {PRONOUN/r_c/subject/CAP} {VERB/r_c/come/comes} back to camp scratched up, and immediately {VERB/r_c/apologize/apologizes} to the deputy for the diplomatic incident {PRONOUN/r_c/subject}{VERB/r_c/'ve/'s} inadvertently caused.",
+                "relationship": {
+                    "cats_from": ["some_clan"],
+                    "cats_to": ["r_c"],
+                    "mutual": false,
+                    "values": ["trust"],
+                    "amount": -5,
+                    "log": {
+                        "cats_from": "from_cat heard about to_cat starting accidentally starting a fight with a misplaced border marking."
+                    }
+                },
                 "exp": 0,
                 "injury": [
                     {
@@ -1715,6 +1785,16 @@
                     "warrior": [-1,-1]
                 },
                 "text": "r_c is having trouble focusing today and puts a mark in the wrong place - and at the worst possible moment, because a o_c_n patrol sees them doing it! The diplomatic incident spirals into a full blown conflict, and r_c hauls themselves back to camp wounded and bleeding.",
+                "relationship": {
+                    "cats_from": ["some_clan"],
+                    "cats_to": ["r_c"],
+                    "mutual": false,
+                    "values": ["trust"],
+                    "amount": -5,
+                    "log": {
+                        "cats_from": "from_cat heard about to_cat starting accidentally starting a fight with a misplaced border marking."
+                    }
+                },
                 "exp": 0,
                 "injury": [
                     {
@@ -1965,9 +2045,19 @@
                     "deputy": [-1,-1]
                 },
                 "text": "r_c comes across a o_c_n apprentice on the wrong side of the border and holding prey. {PRONOUN/r_c/subject/CAP} {VERB/r_c/see/sees} the young cat off with a furious yowl and then {VERB/r_c/bring/brings} the prey back to c_n camp to report the incident to the deputy.",
+                "relationship": {
+                    "cats_from": ["high_aggress"],
+                    "cats_to": ["r_c"],
+                    "mutual": false,
+                    "values": ["respect"],
+                    "amount": 5,
+                    "log": {
+                        "cats_from": "from_cat heard that to_cat chased off a thieving o_c_n apprentice!"
+                    }
+                },
                 "prey": ["small"],
                 "exp": 0,
-                "other_clan_rep": -1,
+                "other_clan_rep": -3,
                 "frequency": 2,
                 "art": "gen_angry_cat_warrior"
             },
@@ -2077,6 +2167,16 @@
             },
             {
                 "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} a o_c_n cat out with their new apprentice. The cat encourages their apprentice to ask s_c any questions they have. The apprentice peppers {PRONOUN/s_c/object} with questions. Some of them are, perhaps, probing a bit too far into c_n's personal affairs, but s_c answers everything enthusiastically. The apprentice's mentor seems surprised at {PRONOUN/s_c/poss} candor... and perhaps a bit concerned at some of the answers.",
+                "relationship": {
+                    "cats_from": ["low_social", "low_stable"],
+                    "cats_to": ["s_c"],
+                    "mutual": false,
+                    "values": ["trust"],
+                    "amount": -5,
+                    "log": {
+                        "cats_from": "from_cat heard that to_cat was gossiping about {PRONOUN/to_cat/poss} own Clanmates to a o_c_n cat!"
+                    }
+                },
                 "exp": 0,
                 "stat_trait": [
                     "sincere",
@@ -2114,6 +2214,16 @@
                     "deputy": [-1,-1]
                 },
                 "text": "r_c is having trouble focusing today and puts a mark in the wrong place - and at the worst possible moment, because a o_c_n patrol sees {PRONOUN/r_c/object} doing it! {PRONOUN/r_c/subject/CAP} {VERB/r_c/come/comes} back to camp scratched up, and immediately {VERB/r_c/apologize/apologizes} to the deputy for the diplomatic incident {PRONOUN/r_c/subject}{VERB/r_c/'ve/'s} inadvertently caused.",
+                "relationship": {
+                    "cats_from": ["some_clan"],
+                    "cats_to": ["r_c"],
+                    "mutual": false,
+                    "values": ["trust"],
+                    "amount": -5,
+                    "log": {
+                        "cats_from": "from_cat heard about to_cat starting accidentally starting a fight with a misplaced border marking."
+                    }
+                },
                 "exp": 0,
                 "injury": [
                     {
@@ -2140,6 +2250,16 @@
                     "warrior": [-1,-1]
                 },
                 "text": "r_c is having trouble focusing today and puts a mark in the wrong place - and at the worst possible moment, because a o_c_n patrol sees them doing it! The diplomatic incident spirals into a full blown conflict, and r_c hauls themselves back to camp wounded and bleeding.",
+                "relationship": {
+                    "cats_from": ["some_clan"],
+                    "cats_to": ["r_c"],
+                    "mutual": false,
+                    "values": ["trust"],
+                    "amount": -5,
+                    "log": {
+                        "cats_from": "from_cat heard about to_cat starting accidentally starting a fight with a misplaced border marking."
+                    }
+                },
                 "exp": 0,
                 "injury": [
                     {
@@ -2393,9 +2513,19 @@
                     "deputy": [-1,-1]
                 },
                 "text": "r_c comes across a o_c_n apprentice on the wrong side of the border and holding prey. {PRONOUN/r_c/subject/CAP} {VERB/r_c/see/sees} the young cat off with a furious yowl and then {VERB/r_c/bring/brings} the prey back to c_n camp to report the incident to the deputy.",
+                "relationship": {
+                    "cats_from": ["high_aggress"],
+                    "cats_to": ["r_c"],
+                    "mutual": false,
+                    "values": ["respect"],
+                    "amount": 5,
+                    "log": {
+                        "cats_from": "from_cat heard that to_cat chased off a thieving o_c_n apprentice!"
+                    }
+                },
                 "prey": ["small"],
                 "exp": 0,
-                "other_clan_rep": -1,
+                "other_clan_rep": -3,
                 "frequency": 2,
                 "art": "gen_angry_cat_warrior"
             },
@@ -2505,6 +2635,16 @@
             },
             {
                 "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} a o_c_n cat out with their new apprentice. The cat encourages their apprentice to ask s_c any questions they have. The apprentice peppers {PRONOUN/s_c/object} with questions. Some of them are, perhaps, probing a bit too far into c_n's personal affairs, but s_c answers everything enthusiastically. The apprentice's mentor seems surprised at {PRONOUN/s_c/poss} candor... and perhaps a bit concerned at some of the answers.",
+                "relationship": {
+                    "cats_from": ["low_social", "low_stable"],
+                    "cats_to": ["s_c"],
+                    "mutual": false,
+                    "values": ["trust"],
+                    "amount": -5,
+                    "log": {
+                        "cats_from": "from_cat heard that to_cat was gossiping about {PRONOUN/to_cat/poss} own Clanmates to a o_c_n cat!"
+                    }
+                },
                 "exp": 0,
                 "stat_trait": [
                     "sincere",
@@ -2542,6 +2682,16 @@
                     "deputy": [-1,-1]
                 },
                 "text": "r_c is having trouble focusing today and puts a mark in the wrong place - and at the worst possible moment, because a o_c_n patrol sees {PRONOUN/r_c/object} doing it! {PRONOUN/r_c/subject/CAP} {VERB/r_c/come/comes} back to camp scratched up, and immediately {VERB/r_c/apologize/apologizes} to the deputy for the diplomatic incident {PRONOUN/r_c/subject}{VERB/r_c/'ve/'s} inadvertently caused.",
+                "relationship": {
+                    "cats_from": ["some_clan"],
+                    "cats_to": ["r_c"],
+                    "mutual": false,
+                    "values": ["trust"],
+                    "amount": -5,
+                    "log": {
+                        "cats_from": "from_cat heard about to_cat starting accidentally starting a fight with a misplaced border marking."
+                    }
+                },
                 "exp": 0,
                 "injury": [
                     {
@@ -2568,6 +2718,16 @@
                     "warrior": [-1,-1]
                 },
                 "text": "r_c is having trouble focusing today and puts a mark in the wrong place - and at the worst possible moment, because a o_c_n patrol sees them doing it! The diplomatic incident spirals into a full blown conflict, and r_c hauls themselves back to camp wounded and bleeding.",
+                "relationship": {
+                    "cats_from": ["some_clan"],
+                    "cats_to": ["r_c"],
+                    "mutual": false,
+                    "values": ["trust"],
+                    "amount": -5,
+                    "log": {
+                        "cats_from": "from_cat heard about to_cat starting accidentally starting a fight with a misplaced border marking."
+                    }
+                },
                 "exp": 0,
                 "injury": [
                     {
@@ -2816,9 +2976,19 @@
                     "deputy": [-1,-1]
                 },
                 "text": "r_c comes across a o_c_n apprentice on the wrong side of the border and holding prey. {PRONOUN/r_c/subject/CAP} {VERB/r_c/see/sees} the young cat off with a furious yowl and then {VERB/r_c/bring/brings} the prey back to c_n camp to report the incident to the deputy.",
+                "relationship": {
+                    "cats_from": ["high_aggress"],
+                    "cats_to": ["r_c"],
+                    "mutual": false,
+                    "values": ["respect"],
+                    "amount": 5,
+                    "log": {
+                        "cats_from": "from_cat heard that to_cat chased off a thieving o_c_n apprentice!"
+                    }
+                },
                 "prey": ["small"],
                 "exp": 0,
-                "other_clan_rep": -1,
+                "other_clan_rep": -3,
                 "frequency": 2,
                 "art": "gen_angry_cat_warrior"
             },
@@ -2928,6 +3098,16 @@
             },
             {
                 "text": "As s_c marks the border, {PRONOUN/s_c/subject} {VERB/s_c/encounter/encounters} a o_c_n cat out with their new apprentice. The cat encourages their apprentice to ask s_c any questions they have. The apprentice peppers {PRONOUN/s_c/object} with questions. Some of them are, perhaps, probing a bit too far into c_n's personal affairs, but s_c answers everything enthusiastically. The apprentice's mentor seems surprised at {PRONOUN/s_c/poss} candor... and perhaps a bit concerned at some of the answers.",
+                "relationship": {
+                    "cats_from": ["low_social", "low_stable"],
+                    "cats_to": ["r_c"],
+                    "mutual": false,
+                    "values": ["trust"],
+                    "amount": -5,
+                    "log": {
+                        "cats_from": "from_cat heard that to_cat was gossiping about {PRONOUN/to_cat/poss} own Clanmates to a o_c_n cat!"
+                    }
+                },
                 "exp": 0,
                 "stat_trait": [
                     "sincere",
@@ -2991,6 +3171,16 @@
                     "warrior": [-1,-1]
                 },
                 "text": "r_c is having trouble focusing today and puts a mark in the wrong place - and at the worst possible moment, because a o_c_n patrol sees them doing it! The diplomatic incident spirals into a full blown conflict, and r_c hauls themselves back to camp wounded and bleeding.",
+                "relationship": {
+                    "cats_from": ["some_clan"],
+                    "cats_to": ["r_c"],
+                    "mutual": false,
+                    "values": ["trust"],
+                    "amount": -5,
+                    "log": {
+                        "cats_from": "from_cat heard about to_cat starting accidentally starting a fight with a misplaced border marking."
+                    }
+                },
                 "exp": 0,
                 "injury": [
                     {

--- a/resources/lang/en/patrols/other_clan.json
+++ b/resources/lang/en/patrols/other_clan.json
@@ -32,7 +32,7 @@
                 "frequency": 4
             },
             {
-                "text": "p_l approaches the other Clan patrol, striking up a conversation about the weather. After talking for a short time, the two patrols part ways. p_l re-marks to the leader on the o_c_n cats' kindness once the patrol has returned to camp.",
+                "text": "p_l approaches the other Clan patrol, striking up a conversation about the weather. After talking for a short time, the two patrols part ways. p_l remarks to the leader on the o_c_n cats' kindness once the patrol has returned to camp.",
                 "exp": 10,
                 "other_clan_rep": 2,
                 "frequency": 1
@@ -130,7 +130,7 @@
                 "frequency": 4
             },
             {
-                "text": "p_l approaches the other Clan patrol, striking up a conversation about the weather. After talking for a short time, the two patrols part ways. p_l re-marks to the leader on the o_c_n cats' kindness once the patrol has returned to camp.",
+                "text": "p_l approaches the other Clan patrol, striking up a conversation about the weather. After talking for a short time, the two patrols part ways. p_l remarks to the leader on the o_c_n cats' kindness once the patrol has returned to camp.",
                 "exp": 10,
                 "other_clan_rep": 2,
                 "frequency": 1

--- a/schemas/patrol.schema.json
+++ b/schemas/patrol.schema.json
@@ -7,6 +7,31 @@
     "outcome": {
       "type": "object",
       "properties": {
+        "min_max_status": {
+          "description": "Allows specification of the minimum and maximum number of specific types of cats that are allowed on this outcome.",
+          "type": "object",
+          "propertyNames": {
+            "enum": [
+              "medicine cat",
+              "warrior",
+              "leader",
+              "deputy",
+              "apprentice",
+              "medicine cat apprentice",
+              "healer cats",
+              "normal adult",
+              "all apprentices"
+            ]
+          },
+          "additionalProperties": {
+            "type": "array",
+            "minItems": 2,
+            "maxItems": 2,
+            "items": {
+              "type": "integer"
+            }
+          }
+        },
         "text": {
           "description": "Displayed outcome text.",
           "type": "string"

--- a/scripts/events_module/patrol/patrol_outcome.py
+++ b/scripts/events_module/patrol/patrol_outcome.py
@@ -25,6 +25,7 @@ from scripts.utility import (
     create_new_cat_block,
     gather_cat_objects,
     adjust_list_text,
+    filter_relationship_type,
 )
 from scripts.game_structure import game
 from scripts.cat.skills import SkillPath
@@ -76,6 +77,7 @@ class PatrolOutcome:
         outcome_art_clean: Union[str, None] = None,
         stat_cat: Cat = None,
         future_event: Dict = None,
+        min_max_status: Dict = None,
     ):
         self.weight = 1
 
@@ -84,6 +86,9 @@ class PatrolOutcome:
         self.text = text if text else ""
         self.frequency = frequency
         self.exp = exp
+
+        self.min_max_status = min_max_status if min_max_status else {}
+        self.weight += len(self.min_max_status) * 2
 
         self.relationship_constraints = (
             relationship_constraints if relationship_constraints else []
@@ -133,47 +138,49 @@ class PatrolOutcome:
 
     @staticmethod
     def prepare_allowed_outcomes(
-        outcomes: List["PatrolOutcome"], patrol: "Patrol"
+        possible_outcomes: List["PatrolOutcome"], patrol: "Patrol"
     ) -> List["PatrolOutcome"]:
-        """Takes a list of patrol outcomes, and returns those which are possible. If "special" events, gated
-        by stat cats or relationships, are possible, this function returns only those. Stat cats are also determined here.
-        """
+        """Takes a list of patrol outcomes, and returns those which are possible"""
 
         # Determine which outcomes are possible
-        reg_outcomes = []
-        special_outcomes = []
-        for out in outcomes:
-            # We want to gather special (ie, gated with stat or relationship constaints)
-            # outcomes seperatly, so we can ensure that those occur if possible.
-            special = False
-
-            if out.stat_skill or out.stat_trait:
-                special = True
-                out._get_stat_cat(patrol)
-                if not isinstance(out.stat_cat, Cat):
+        allowed_outcomes = []
+        for outcome in possible_outcomes:
+            if outcome.stat_skill or outcome.stat_trait:
+                outcome._get_stat_cat(patrol)
+                if not isinstance(outcome.stat_cat, Cat):
                     continue
 
-            # TODO: outcome relationship constraints
-            # if not patrol._satify_relationship_constaints(patrol, out.relationship_constaints):
-            #    continue
-            # elif out.relationship_constaints:
-            #    special = True
+                if not filter_relationship_type(
+                    group=patrol.patrol_cats,
+                    filter_types=outcome.relationship_constraints,
+                    event_id=patrol.patrol_event.patrol_id,
+                    patrol_leader=patrol.patrol_leader,
+                ):
+                    continue
 
-            if special:
-                special_outcomes.append(out)
-            else:
-                reg_outcomes.append(out)
+                for status, allowed_range in outcome.min_max_status.items():
+                    if len(allowed_range) != 2:
+                        raise Exception(
+                            f'{patrol.patrol_event.patrol_id} has an outcome with status limits that lists limit range incorrectly. Status limits should be formatted: "status_type": [min_value, max_value]'
+                        )
+
+                    if not (
+                        allowed_range[0]
+                        <= patrol.patrol_statuses.get(status, -1)
+                        <= allowed_range[1]
+                    ):
+                        break
+
+                allowed_outcomes.append(outcome)
 
         # If there are somehow no possible outcomes, add a single default
         # outcome. Patrols should be written so this never has to occur
-        if not (special_outcomes or reg_outcomes):
-            reg_outcomes.append(
-                PatrolOutcome(
-                    text="There's nothing here, and that's a problem. Please report! ",
-                )
+        if not allowed_outcomes:
+            raise Exception(
+                f"{patrol.patrol_event.patrol_id} somehow has no possible outcomes! Ensure at least one unconstrained outcome is present."
             )
 
-        return special_outcomes if special_outcomes else reg_outcomes
+        return allowed_outcomes
 
     @staticmethod
     def generate_from_info(
@@ -232,7 +239,7 @@ class PatrolOutcome:
 
     def execute_outcome(self, patrol: "Patrol") -> Tuple[str, str, Optional[str]]:
         """
-        Excutes the outcome. Returns a tuple with the final outcome text, the results text, and any outcome art
+        Executes the outcome. Returns a tuple with the final outcome text, the results text, and any outcome art
         format: (Outcome text, results text, outcome art (might be None))
         """
         # This must be done before text processing so that the new cat's pronouns are generated first

--- a/scripts/events_module/patrol/patrol_outcome.py
+++ b/scripts/events_module/patrol/patrol_outcome.py
@@ -150,28 +150,32 @@ class PatrolOutcome:
                 if not isinstance(outcome.stat_cat, Cat):
                     continue
 
-                if not filter_relationship_type(
-                    group=patrol.patrol_cats,
-                    filter_types=outcome.relationship_constraints,
-                    event_id=patrol.patrol_event.patrol_id,
-                    patrol_leader=patrol.patrol_leader,
+            if not filter_relationship_type(
+                group=patrol.patrol_cats,
+                filter_types=outcome.relationship_constraints,
+                event_id=patrol.patrol_event.patrol_id,
+                patrol_leader=patrol.patrol_leader,
+            ):
+                continue
+
+            allowed = True
+            for status, allowed_range in outcome.min_max_status.items():
+                if len(allowed_range) != 2:
+                    raise Exception(
+                        f'{patrol.patrol_event.patrol_id} has an outcome with status limits that lists limit range incorrectly. Status limits should be formatted: "status_type": [min_value, max_value]'
+                    )
+
+                if not (
+                    allowed_range[0]
+                    <= patrol.patrol_statuses.get(status, -1)
+                    <= allowed_range[1]
                 ):
-                    continue
+                    allowed = False
+                    break
+            if not allowed:
+                continue
 
-                for status, allowed_range in outcome.min_max_status.items():
-                    if len(allowed_range) != 2:
-                        raise Exception(
-                            f'{patrol.patrol_event.patrol_id} has an outcome with status limits that lists limit range incorrectly. Status limits should be formatted: "status_type": [min_value, max_value]'
-                        )
-
-                    if not (
-                        allowed_range[0]
-                        <= patrol.patrol_statuses.get(status, -1)
-                        <= allowed_range[1]
-                    ):
-                        break
-
-                allowed_outcomes.append(outcome)
+            allowed_outcomes.append(outcome)
 
         # If there are somehow no possible outcomes, add a single default
         # outcome. Patrols should be written so this never has to occur
@@ -232,6 +236,7 @@ class PatrolOutcome:
                     outcome_art=_d.get("art"),
                     outcome_art_clean=_d.get("art_clean"),
                     future_event=_d.get("future_event"),
+                    min_max_status=_d.get("min_max_status"),
                 )
             )
 

--- a/scripts/utility.py
+++ b/scripts/utility.py
@@ -1370,7 +1370,7 @@ def filter_relationship_type(
                         allowed_levels = rel_type_tiers[rel_type][index:]
                     # if it's a neg tier, we allow that index and lower
                     elif rel_tier.is_any_neg:
-                        allowed_levels = rel_type_tiers[rel_type][0:index]
+                        allowed_levels = rel_type_tiers[rel_type][0 : index + 1]
 
                     discard = True
                     for l in tier_list:


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
This covers a few things:
- Added a `min_max_status` parameter to patrol *outcomes*. This behaves the same way as the main `min_max_status` parameter, just on an outcome level. 
- Fixed the relationship constraint filter for patrol outcomes. Somehow, this was *never* working, the func has been commented out since 2023 and i don't? think it was ever not commented.
- In the `filter_relationship_type` I made a teeny little edit to the indexing in one line. This `+1` is bc I realized that index slicing stops *before* the second index, not *at* the second index while I was debugging. The `+1` makes this work as intended.
- In working on the outcome filtering, I decided to reduce some of it's complexity. Previously we would create two lists of possible outcomes: regular and special. Special was all the outcomes with extra constraints (stat and relationship). The intention was to ensure special outcomes always had priority when possible. However, our new frequency and auto-weighting system does the exact same thing in a more elegant manner. There's no reason to keep this outdated redundancy, so I removed it.
- To demonstrate the use of outcome `min_max_status`, I condense the solo other_clan patrols that had been making me feel insane. These were sets of 5 patrols (one set for each biome) where the only differences between patrols were whether or not the cat was a leader or deputy. Utilizing the new parameter, I could make 5 patrols into 1 patrol.
- I also couldn't resist adding some new outcomes to these patrols. These are pretty much all trait specific, but I think I actually covered all or most traits! I also updated the chosen art.  Each biome variant of this patrol is identical *except* for the intro and *first* outcome (which i *did not* change), so if you reviewed one patrol, you've essentially reviewed them all.
- ctrl+r'd "remark" into "re-mark" bc that's more grammatically correct.
- Updated the documentation with new `min_max_status`! I also fixed a few broken links that I noticed.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Why This Is Good For ClanGen
Allows us to further condense mostly-duplicate patrols, reducing unnecessary repetition.
<!-- If this is a bug fix, you can remove this section. -->
<!-- Please add a short description of why you think these changes would benefit the game. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->
<!-- If you have multiple features that can stand on their own, or unrelated bugfixes, please create separate PRs for them. -->

## Proof of Testing
<img width="854" height="444" alt="image" src="https://github.com/user-attachments/assets/7c022ef6-ea9c-4f9b-adee-123b6b178fc1" />

Documentation

<img width="709" height="409" alt="image" src="https://github.com/user-attachments/assets/973fa179-25e7-4885-be89-f7607985e6b8" />
<img width="717" height="450" alt="image" src="https://github.com/user-attachments/assets/f0d2f54f-7bb2-4efc-b274-08f4e7bc10c8" />
<img width="701" height="482" alt="image" src="https://github.com/user-attachments/assets/e10ecc34-7822-4627-a1b4-a9578effb851" />
<img width="714" height="481" alt="image" src="https://github.com/user-attachments/assets/6dbf7f5e-d3f7-42cc-bc3f-5a485375b2fd" />

(notably, Posyhare *isn't* the deputy. this is an outcome that is only allowed for warriors)

<img width="711" height="453" alt="image" src="https://github.com/user-attachments/assets/dc8bd1c6-e3ab-47cb-811a-9a2fda6f6e5c" />
<img width="716" height="518" alt="image" src="https://github.com/user-attachments/assets/40fe8304-c486-428b-91ed-84670766c25b" />

(once again, this is an outcome only allowed for warriors, which Mulberry is!)

<img width="704" height="457" alt="image" src="https://github.com/user-attachments/assets/316470a6-fd3c-486a-9b7b-017cfe97396f" />
<img width="681" height="451" alt="image" src="https://github.com/user-attachments/assets/4e6d6d10-f895-4a8e-9791-72eefcb9b091" />
<img width="713" height="468" alt="image" src="https://github.com/user-attachments/assets/620257aa-085f-450e-b81c-a04960316e5a" />

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Added a `min_max_status` parameter to patrol *outcomes*. This behaves the same way as the main `min_max_status` parameter, just on an outcome level. 
- Fixed the relationship constraint filter for patrol outcomes. Somehow, this was *never* working, the func has been commented out since 2023 and i don't? think it was ever not commented.
- Removed the extra bit of outcome logic that prioritized "special" outcomes, as this is now redundant due to the new auto-weighting.
- Updated the documentation with new `min_max_status`! I also fixed a few broken links that I noticed.
- Added *a lot* of new outcomes to the solo other_clan border patrol! featuring tactless apprentices, accidental over-sharing, border spats, and more!
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
