### PR TITLE
[BUGFIX] Dislike-locked patrol generating for non-dislike cats

### DIFF
--- a/resources/lang/en/patrols/general/training.json
+++ b/resources/lang/en/patrols/general/training.json
@@ -10550,7 +10550,7 @@
             "normal adult": [2, 2]
         },
         "frequency": 4,
-        "relationship_status": ["dislikes"],
+        "relationship_constraint": ["dislikes"],
         "intro_text": "p_l pulls r_c aside during training to discuss a recent disagreement between the two of them, hoping to clear the air.",
         "decline_text": "r_c cuts the training short, not interested in hearing p_l out.",
         "chance_of_success": 40,


### PR DESCRIPTION
## About The Pull Request

I didn't actually file the bugfix but I mentioned this one discord

## Linked Issues

https://discord.com/channels/1003759225522110524/1101276997751164948/1459043432147189831
Here is my "report" of the issue

## Proof of Testing

<img width="1048" height="677" alt="image" src="https://github.com/user-attachments/assets/0fdd48d0-008d-4fbf-a31a-23a3531bf284" />
<img width="1450" height="39" alt="image" src="https://github.com/user-attachments/assets/9d32c52b-2271-4cbb-a742-d0587a5658bb" />
Proof of generating it and also proof that it didn't generate when I sent out two warriors who did not have dislike toward each other.