### PR TITLE
[BUGFIX] Elders going on patrol when they shouldn't be

### DIFF
--- a/resources/lang/en/events/relationship_events/normal_interactions/like/increase.json
+++ b/resources/lang/en/events/relationship_events/normal_interactions/like/increase.json
@@ -789,10 +789,7 @@
 		"intensity": "high",
 		"interactions": [
 			"m_c and r_c heckled another Clan at the Gathering together.",
-			"m_c and r_c worked well together on a patrol.",
-			"When they return from a patrol, m_c and r_c seem more at peace with each other than usual.",
-			"m_c and r_c defended their Clan at the Gathering together.",
-			"m_c and r_c had a great time on a patrol."
+			"m_c and r_c defended their Clan at the Gathering together."
 		],
 		"reaction_random_cat": {
 			"like": "increase"
@@ -816,6 +813,30 @@
 			"mediator",
 			"medicine cat apprentice",
 			"medicine cat",
+			"deputy",
+			"leader"
+		]
+	},
+	{
+		"id": "dislike_de_high3",
+		"intensity": "high",
+		"interactions": [
+			"m_c and r_c worked well together on a patrol.",
+			"When they return from a patrol, m_c and r_c seem more at peace with each other than usual.",
+			"m_c and r_c had a great time on a patrol."
+		],
+		"reaction_random_cat": {
+			"like": "increase"
+		},
+		"main_status_constraint": [
+			"apprentice",
+			"warrior",
+			"deputy",
+			"leader"
+		],
+		"random_status_constraint": [
+			"apprentice",
+			"warrior",
 			"deputy",
 			"leader"
 		]

--- a/resources/lang/en/events/relationship_events/normal_interactions/like/increase.json
+++ b/resources/lang/en/events/relationship_events/normal_interactions/like/increase.json
@@ -832,13 +832,17 @@
 			"apprentice",
 			"warrior",
 			"deputy",
-			"leader"
+			"leader",
+			"medicine cat apprentice",
+			"medicine cat"
 		],
 		"random_status_constraint": [
 			"apprentice",
 			"warrior",
 			"deputy",
-			"leader"
+			"leader",
+			"medicine cat apprentice",
+			"medicine cat"
 		]
 	}
 ]

--- a/resources/lang/en/events/relationship_events/normal_interactions/romance/increase.json
+++ b/resources/lang/en/events/relationship_events/normal_interactions/romance/increase.json
@@ -234,7 +234,15 @@
             		"m_c and r_c got so into playing around that they got separated from the rest of the patrol, earning themselves an earful back at camp.",
 			"m_c feels giddy about getting on the same patrol as r_c."
 		],
-		"m_c":[
+		"main_status_constraint":[
+			"warrior",
+			"deputy",
+			"leader",
+			"apprentice",
+			"medicine cat apprentice",
+			"medicine cat"
+		],
+		"random_status_constraint":[
 			"warrior",
 			"deputy",
 			"leader",
@@ -375,7 +383,13 @@
 			"m_c compliments r_c on {PRONOUN/r_c/poss} catch during a hunting patrol, which causes {PRONOUN/r_c/object} to purr."
 		],
 		"relationship_constraint": ["adores"],
-		"m_c": [
+		"main_status_constraint": [
+			"apprentice",
+			"deputy",
+			"leader",
+			"warrior"
+		],
+		"random_status_constraint": [
 			"apprentice",
 			"deputy",
 			"leader",

--- a/resources/lang/en/events/relationship_events/normal_interactions/romance/increase.json
+++ b/resources/lang/en/events/relationship_events/normal_interactions/romance/increase.json
@@ -184,7 +184,6 @@
 		"interactions": [
 			"m_c thinks r_c is the most beautiful cat in the Clan.",
 			"m_c can't stop thinking about r_c.",
-			"m_c feels giddy about getting on the same patrol as r_c.",
 			"m_c wants r_c to understand how crazy {PRONOUN/m_c/subject} {VERB/m_c/are/is} about {PRONOUN/r_c/object}.",
 			"m_c thinks r_c has a lovely sense of humor.",
 			"If you were to ask m_c, no other cat is anywhere near as fun or interesting as r_c.",
@@ -227,12 +226,19 @@
 		}
 	},
 	{
-		"id": "rom_inc_med9",
+		"id": "rom_inc_med_patrols9",
 		"intensity": "medium",
 		"interactions": [
             		"m_c and r_c played around during patrol and got in a bit of trouble, but still returned to camp smiling.",
             		"m_c just barely missed a mouse, but r_c caught it right after, handing it off to {PRONOUN/m_c/object}.",
-            		"m_c and r_c got so into playing around that they got separated from the rest of the patrol, earning themselves an earful back at camp."
+            		"m_c and r_c got so into playing around that they got separated from the rest of the patrol, earning themselves an earful back at camp.",
+			"m_c feels giddy about getting on the same patrol as r_c."
+		],
+		"m_c":[
+			"warrior",
+			"deputy",
+			"leader",
+			"apprentice"
 		],
 		"reaction_random_cat": {
 			"romance": "increase",

--- a/resources/lang/en/events/relationship_events/normal_interactions/romance/increase.json
+++ b/resources/lang/en/events/relationship_events/normal_interactions/romance/increase.json
@@ -238,7 +238,9 @@
 			"warrior",
 			"deputy",
 			"leader",
-			"apprentice"
+			"apprentice",
+			"medicine cat apprentice",
+			"medicine cat"
 		],
 		"reaction_random_cat": {
 			"romance": "increase",
@@ -259,14 +261,12 @@
 			"m_c saves a piece of prey for r_c because {PRONOUN/m_c/subject} {VERB/m_c/know/knows} it's {PRONOUN/r_c/poss} favorite.",
 			"m_c brings r_c some fresh-kill, hoping that {PRONOUN/m_c/subject} remembered what r_c's favorite was.",
 			"m_c got stuck in the same tree with r_c for hours and realized how much they have in common.",
-			"m_c asks r_c to help {PRONOUN/m_c/object} freshen up on some battle moves, complementing {PRONOUN/r_c/object} constantly throughout.",
 			"m_c asks r_c to go fishing with {PRONOUN/m_c/object}, but they keep on getting distracted by each other.",
 			"m_c gives r_c a beautiful feather {PRONOUN/m_c/subject} found, and hides behind {PRONOUN/m_c/poss} whiskers when thanked.",
 			"m_c gives r_c a wonderfully colored pebble {PRONOUN/m_c/subject} found, and hides behind {PRONOUN/m_c/poss} whiskers when thanked.",
 			"m_c gives r_c a circular Twoleg object {PRONOUN/m_c/subject} found, and hides behind {PRONOUN/m_c/poss} whiskers when thanked.",
 			"m_c compliments r_c on how well groomed {PRONOUN/r_c/poss} pelt is today.",
-			"m_c compliments r_c on how sharp {PRONOUN/r_c/poss} claws are today.",
-			"m_c compliments r_c on {PRONOUN/r_c/poss} catch during a hunting patrol, which causes {PRONOUN/r_c/object} to purr."
+			"m_c compliments r_c on how sharp {PRONOUN/r_c/poss} claws are today."
 		],
 		"reaction_random_cat": {
 			"romance": "increase",
@@ -319,9 +319,9 @@
 			"m_c was caught enjoying a moonlit stroll with r_c last night...",
 			"m_c sneaks out at night to sleep in r_c's nest.",
 			"m_c and r_c were heard discussing kits.",
-            		"m_c and r_c have been sickeningly lovey-dovey all day.",
-            		"m_c and r_c snuck out of camp together.",
-            		"m_c promises r_c to always be there to protect {PRONOUN/r_c/object} with {PRONOUN/m_c/poss} life."
+            "m_c and r_c have been sickeningly lovey-dovey all day.",
+        	"m_c and r_c snuck out of camp together.",
+            "m_c promises r_c to always be there to protect {PRONOUN/r_c/object} with {PRONOUN/m_c/poss} life."
 		],
 		"relationship_constraint": [
 			"adores",
@@ -338,9 +338,7 @@
 		"intensity": "high",
 		"interactions": [
 			"m_c purrs for a long time at one of r_c's lame jokes.",
-			"m_c can't stop gushing over r_c.",
-            		"m_c came back to camp sulking after failing to catch r_c's favorite prey for {PRONOUN/r_c/object} but {PRONOUN/r_c/subject} {VERB/r_c/doesn't/didn't} seem to care, nuzzling into m_c's neck, {PRONOUN/r_c/subject} {VERB/r_c/were/was} just happy m_c was back.",
-            		"m_c goes out of {PRONOUN/m_c/poss} way to catch r_c's favorite prey."
+			"m_c can't stop gushing over r_c."
 		],
 		"relationship_constraint": [
 			"mates"
@@ -360,6 +358,28 @@
 		],
 		"main_skill_constraint": [
 			"STORY,3"
+		],
+		"reaction_random_cat": {
+			"romance": "increase",
+			"like": "increase",
+			"comfort": "increase"
+		}
+	},
+	{
+		"id": "rom_inc_high_warrior7",
+		"intensity": "high",
+		"interactions": [
+            "m_c came back to camp sulking after failing to catch r_c's favorite prey for {PRONOUN/r_c/object} but {PRONOUN/r_c/subject} {VERB/r_c/doesn't/didn't} seem to care, nuzzling into m_c's neck.",
+            "m_c goes out of {PRONOUN/m_c/poss} way to catch r_c's favorite prey.",
+			"m_c asks r_c to help {PRONOUN/m_c/object} freshen up on some battle moves, complimenting {PRONOUN/r_c/object} constantly throughout.",
+			"m_c compliments r_c on {PRONOUN/r_c/poss} catch during a hunting patrol, which causes {PRONOUN/r_c/object} to purr."
+		],
+		"relationship_constraint": ["adores"],
+		"m_c": [
+			"apprentice",
+			"deputy",
+			"leader",
+			"warrior"
 		],
 		"reaction_random_cat": {
 			"romance": "increase",


### PR DESCRIPTION
## About The Pull Request

Moving a few events that describe going on patrol into their own event categories that are restricted to leaders, deputies, warriors, and apprentices (ie. cats that regularly go on patrol).

## Linked Issues

#4128 

## Proof of Testing
still possible to generate the patrol:
<img width="686" height="100" alt="image" src="https://github.com/user-attachments/assets/9576410d-ca4b-4ec2-bf46-5081dfa56930" />
