### PR TITLE
[ENHANCEMENT] Access to full game settings while playing

### DIFF
--- a/resources/lang/en/screens/clan_settings.en.json
+++ b/resources/lang/en/screens/clan_settings.en.json
@@ -1,5 +1,7 @@
 {
     "en": {
+        "full_settings": "Open Game Settings",
+        "full_settings_info": "Change the overall game and audio settings",
         "general": "general settings",
         "general_info": "Change the general Clan-specific settings",
         "relation": "relation settings",

--- a/scripts/screens/ClanSettingsScreen.py
+++ b/scripts/screens/ClanSettingsScreen.py
@@ -25,6 +25,7 @@ from scripts.utility import (
     ui_scale_offset,
 )  # pylint: disable=redefined-builtin
 from .Screens import Screens
+from .enums import GameScreen
 from .screens_core.screens_core import rebuild_den_dropdown
 from ..cat import save_load
 from ..clan_package.settings import get_clan_setting, switch_clan_setting
@@ -86,6 +87,8 @@ class ClanSettingsScreen(Screens):
             elif event.ui_element == self.open_data_directory_button:
                 open_data_dir()
                 return
+            elif event.ui_element == self.game_settings_button:
+                self.change_screen(GameScreen.SETTINGS)
             elif event.ui_element == self.relation_settings_button:
                 self.open_relation_settings()
                 return
@@ -174,6 +177,15 @@ class ClanSettingsScreen(Screens):
             anchors={"left_target": self.role_settings_button},
         )
 
+        self.game_settings_button = UISurfaceImageButton(
+            ui_scale(pygame.Rect((25, 600), (175, 30))),
+            "screens.clan_settings.full_settings",
+            get_button_dict(ButtonStyles.SQUOVAL, (175, 30)),
+            tool_tip_text="screens.clan_settings.full_settings_info",
+            object_id="@buttonstyles_squoval",
+            manager=MANAGER,
+        )
+
         self.open_data_directory_button = UISurfaceImageButton(
             ui_scale(pygame.Rect((25, 645), (178, 30))),
             "buttons.open_data_directory",
@@ -249,6 +261,8 @@ class ClanSettingsScreen(Screens):
         self.hide_menu_buttons()
         self.fullscreen_toggle.kill()
         del self.fullscreen_toggle
+        self.game_settings_button.kill()
+        del self.game_settings_button
 
     def open_general_settings(self):
         """Opens and draws general_settings"""

--- a/scripts/screens/SettingsScreen.py
+++ b/scripts/screens/SettingsScreen.py
@@ -144,8 +144,8 @@ class SettingsScreen(Screens):
         if event.type == pygame_gui.UI_BUTTON_START_PRESS:
             self.mute_button_pressed(event)
 
-            if event.ui_element == self.main_menu_button:
-                self.change_screen(GameScreen.START)
+            if event.ui_element == self.back_button:
+                self.change_screen(game.last_screen_forupdate)
                 return
             if event.ui_element == self.fullscreen_toggle:
                 game_setting_toggle("fullscreen")
@@ -320,10 +320,10 @@ class SettingsScreen(Screens):
             self.open_data_directory_button.hide()
 
         self.update_save_button()
-        self.main_menu_button = UISurfaceImageButton(
-            ui_scale(pygame.Rect((25, 25), (152, 30))),
-            "buttons.main_menu",
-            get_button_dict(ButtonStyles.SQUOVAL, (152, 30)),
+        self.back_button = UISurfaceImageButton(
+            ui_scale(pygame.Rect((25, 25), (105, 30))),
+            "buttons.back",
+            get_button_dict(ButtonStyles.SQUOVAL, (105, 30)),
             manager=MANAGER,
             object_id="@buttonstyles_squoval",
             starting_height=1,
@@ -363,8 +363,8 @@ class SettingsScreen(Screens):
         del self.language_button
         self.save_settings_button.kill()
         del self.save_settings_button
-        self.main_menu_button.kill()
-        del self.main_menu_button
+        self.back_button.kill()
+        del self.back_button
         self.fullscreen_toggle.kill()
         del self.fullscreen_toggle
         self.open_data_directory_button.kill()


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
Allows access to the full game settings via the clan settings menu. Surprisingly simple. The 'main menu' button in the settings screen has been changed to a 'back' button that returns the previous screen. This means it's behavior is unaltered when accessing from the main menu, but when accessed from clan settings it'll return straight to clan settings.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Why This Is Good For ClanGen
QoL! It sucks to try and change a setting only available in game settings as you have to completely back out of gameplay. It's especially detrimental that the audio settings are only accessible from game settings, especially with the upcoming update to integrate music/ambiance into regular gameplay.  
<!-- If this is a bug fix, you can remove this section. -->
<!-- Please add a short description of why you think these changes would benefit the game. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->
<!-- If you have multiple features that can stand on their own, or unrelated bugfixes, please create separate PRs for them. -->
## Proof of Testing

https://github.com/user-attachments/assets/bc06af32-098e-4964-ac92-87dd57c62113


<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- An 'Open Game Settings' button has been added to the Clan Settings screen, allowing players to access *all* settings in the game without having to back out to the main menu.
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
