### PR TITLE
[CLEANUP] Combining Solo Warrior/Deputy/Leader Patrols

### DIFF
--- a/resources/lang/en/patrols/beach/training/any.json
+++ b/resources/lang/en/patrols/beach/training/any.json
@@ -1000,10 +1000,7 @@
         "min_cats": 1,
         "max_cats": 1,
         "min_max_status": {
-            "apprentice": [
-                1,
-                6
-            ]
+            "apprentice": [1, 1]
         },
         "frequency": 4,
         "intro_text": "r_c heads out along the coast alone, but maybe an apprentice shouldn't try to do a solo patrol.",
@@ -1097,10 +1094,7 @@
         "min_cats": 1,
         "max_cats": 1,
         "min_max_status": {
-            "normal adult": [
-                1,
-                6
-            ]
+            "normal adult": [ 1, 1 ]
         },
         "frequency": 4,
         "intro_text": "r_c heads out along the coast alone, wanting to explore and have some time to {PRONOUN/r_c/self}.",
@@ -1108,7 +1102,7 @@
         "chance_of_success": 60,
         "success_outcomes": [
             {
-                "text": "r_c heads off to map out a field of sand dunes {PRONOUN/r_c/subject}{VERB/r_c/'ve/'s} always found confusing. Hunting, fighting, driving off predators - it all requires knowledge of {PRONOUN/r_c/poss} home turf. It's always worth making sure {PRONOUN/r_c/poss} mental map is up to date.",
+                "text": "r_c heads off to map out a field of sand dunes {PRONOUN/r_c/subject}{VERB/r_c/'ve/'s} always found confusing. Hunting, fighting, driving off predators - it all requires knowledge of {PRONOUN/r_c/poss} home turf. It's always worth making sure {PRONOUN/r_c/poss} mental map is up to date. It feels like work though, and it isn't the peaceful break {PRONOUN/r_c/subject} hoped for.",
                 "exp": 20,
                 "frequency": 4
             },
@@ -1121,7 +1115,28 @@
                 "text": "s_c rounds a corner and stumbles across a tiny, sparkling waterfall! Further investigation shows that it emerges from an equally tiny spring, and s_c purrs. This reliable source of fresh water could be important during times of drought.",
                 "exp": 20,
                 "stat_skill": [
-                    "CLEVER,1"
+                    "CLEVER,1",
+                    "INSIGHTFUL,1"
+                ],
+                "frequency": 4
+            },
+            {
+                "min_max_status": {"deputy": [1, 1]},
+                "text": "s_c rounds a corner and stumbles across a tiny, sparkling waterfall! Further investigation shows its origin is an equally tiny spring, and s_c purrs. This reliable source of fresh water could be important during times of drought, and its discovery helps to ease one of the many worries on the deputy's mind.",
+                "exp": 20,
+                "stat_skill": [
+                    "CLEVER,1",
+                    "INSIGHTFUL,1"
+                ],
+                "frequency": 4
+            },
+            {
+                "min_max_status": {"leader": [1, 1]},
+                "text": "s_c rounds a corner and stumbles across a tiny, sparkling waterfall! Further investigation shows its origin is an equally tiny spring, and s_c purrs. This reliable source of fresh water could be important during times of drought, and its discovery helps to ease one of the many worries on the leader's mind.",
+                "exp": 20,
+                "stat_skill": [
+                    "CLEVER,1",
+                    "INSIGHTFUL,1"
                 ],
                 "frequency": 4
             },
@@ -1156,76 +1171,14 @@
                     "nervous"
                 ],
                 "frequency": 4
-            }
-        ]
-    },
-    {
-        "patrol_id": "bch_train_solo3",
-        "biome": [
-            "beach"
-        ],
-        "season": [
-            "any"
-        ],
-        "types": [
-            "training"
-        ],
-        "tags": [],
-        "patrol_art": "gen_train_solo",
-        "min_cats": 1,
-        "max_cats": 1,
-                "min_max_status": {
-            "deputy": [
-                1,
-                1
-            ]
-        },
-        "frequency": 4,
-        "intro_text": "r_c heads out along the coast alone, wanting to explore and have some time to {PRONOUN/r_c/self}.",
-        "decline_text": "r_c turns back to camp after getting some fresh sea air, deciding that {PRONOUN/r_c/poss} duties have to come first.",
-        "chance_of_success": 60,
-        "success_outcomes": [
-            {
-                "text": "r_c heads off to map out a field of sand dunes {PRONOUN/r_c/subject}{VERB/r_c/'ve/'s} always found confusing. Hunting, fighting, driving off predators - it all requires knowledge of {PRONOUN/r_c/poss} home turf. It's always worth making sure {PRONOUN/r_c/poss} mental map is up to date. It feels like work though, and it isn't the peaceful break {PRONOUN/r_c/subject} hoped for.",
-                "exp": 20,
-                "frequency": 4
             },
-            {
-                "text": "r_c rounds a corner and stumbles across a tiny, sparkling waterfall! Purring, {PRONOUN/r_c/subject} {VERB/r_c/take/takes} the opportunity for a moment of peace, relaxing and enjoying the view.",
-                "exp": 20,
-                "frequency": 1
-            },
-            {
-                "text": "s_c rounds a corner and stumbles across a tiny, sparkling waterfall! Further investigation shows its origin is an equally tiny spring, and s_c purrs. This reliable source of fresh water could be important during times of drought, and its discovery helps to ease one of the many worries on the deputy's mind.",
-                "exp": 20,
-                "stat_skill": [
-                    "CLEVER,1"
-                ],
-                "frequency": 4
-            },
-            {
-                "text": "s_c pads confidently through c_n territory. There's a particular peace in exploring {PRONOUN/s_c/poss} beloved home, {PRONOUN/s_c/poss} ears pricked up curiously whenever {PRONOUN/s_c/subject} {VERB/s_c/spot/spots} how the seasons and weather have reshaped it since {PRONOUN/s_c/subject} last passed this way.",
-                "exp": 20,
-                "stat_trait": [
-                    "adventurous",
-                    "bold",
-                    "charismatic",
-                    "childish",
-                    "confident",
-                    "daring",
-                    "playful",
-                    "righteous"
-                ],
-                "frequency": 4
-            }
-        ],
-        "fail_outcomes": [
             {
                 "text": "r_c gets lost in the territory. Somehow. {PRONOUN/r_c/poss/CAP} pelt is burning with shame by the time {PRONOUN/r_c/subject} finally {VERB/r_c/return/returns}, sneaking back to {PRONOUN/r_c/poss} den to avoid any embarrassing questions.",
                 "exp": 0,
                 "frequency": 4
             },
             {
+                "min_max_status": {"deputy": [1, 1]},
                 "text": "s_c wavers in {PRONOUN/s_c/poss} decision. {PRONOUN/s_c/subject/CAP} {VERB/s_c/have/has} so much work to do and so many other things demanding {PRONOUN/s_c/poss} time... No, definitely not. {PRONOUN/s_c/subject/CAP} {VERB/s_c/turn/turns} around and {VERB/s_c/march/marches} straight back to camp.",
                 "exp": 0,
                 "stat_trait": [
@@ -1234,76 +1187,9 @@
                     "nervous"
                 ],
                 "frequency": 4
-            }
-        ]
-    },
-    {
-        "patrol_id": "bch_train_solo4",
-        "biome": [
-            "beach"
-        ],
-        "season": [
-            "any"
-        ],
-        "types": [
-            "training"
-        ],
-        "tags": [],
-        "patrol_art": "gen_train_solo",
-        "min_cats": 1,
-        "max_cats": 1,
-        "min_max_status": {
-            "leader": [
-                1,
-                1
-            ]
-        },
-        "frequency": 4,
-        "intro_text": "r_c heads out along the coast alone, wanting to explore and have some time to {PRONOUN/r_c/self}.",
-        "decline_text": "r_c turns back to camp after getting some fresh sea air, deciding that {PRONOUN/r_c/poss} duties have to come first.",
-        "chance_of_success": 60,
-        "success_outcomes": [
-            {
-                "text": "r_c heads off to map out a field of sand dunes {PRONOUN/r_c/subject}{VERB/r_c/'ve/'s} always found confusing. Hunting, fighting, driving off predators - it all requires knowledge of {PRONOUN/r_c/poss} home turf. It's always worth making sure {PRONOUN/r_c/poss} mental map is up to date. It feels like work though, and it isn't the peaceful break {PRONOUN/r_c/subject} hoped for.",
-                "exp": 20,
-                "frequency": 4
             },
             {
-                "text": "r_c rounds a corner and stumbles across a tiny, sparkling waterfall! Purring, {PRONOUN/r_c/subject} {VERB/r_c/take/takes} the opportunity for a moment of peace, relaxing and enjoying the view.",
-                "exp": 20,
-                "frequency": 1
-            },
-            {
-                "text": "s_c rounds a corner and stumbles across a tiny, sparkling waterfall! Further investigation shows its origin is an equally tiny spring, and s_c purrs. This reliable source of fresh water could be important during times of drought, and its discovery helps to ease one of the many worries on the leader's mind.",
-                "exp": 20,
-                "stat_skill": [
-                    "CLEVER,1"
-                ],
-                "frequency": 4
-            },
-            {
-                "text": "s_c pads confidently through c_n territory. There's a particular peace in exploring {PRONOUN/s_c/poss} beloved home, {PRONOUN/s_c/poss} ears pricked up curiously whenever {PRONOUN/s_c/subject} {VERB/s_c/spot/spots} how the seasons and weather have reshaped it since {PRONOUN/s_c/subject} last passed this way.",
-                "exp": 20,
-                "stat_trait": [
-                    "adventurous",
-                    "bold",
-                    "charismatic",
-                    "childish",
-                    "confident",
-                    "daring",
-                    "playful",
-                    "righteous"
-                ],
-                "frequency": 4
-            }
-        ],
-        "fail_outcomes": [
-            {
-                "text": "r_c gets lost in the territory. Somehow. {PRONOUN/r_c/poss/CAP} pelt is burning with shame by the time {PRONOUN/r_c/subject} finally {VERB/r_c/return/returns}, sneaking back to {PRONOUN/r_c/poss} den to avoid any embarrassing questions.",
-                "exp": 0,
-                "frequency": 4
-            },
-            {
+                "min_max_status": {"leader": [1, 1]},
                 "text": "s_c wavers in {PRONOUN/s_c/poss} decision. {PRONOUN/s_c/subject/CAP} {VERB/s_c/have/has} so much work to do and so many other things demanding {PRONOUN/s_c/poss} time... No, definitely not. {PRONOUN/s_c/subject/CAP} {VERB/s_c/turn/turns} around and {VERB/s_c/march/marches} straight back to camp.",
                 "exp": 0,
                 "stat_trait": [

--- a/resources/lang/en/patrols/beach/training/any.json
+++ b/resources/lang/en/patrols/beach/training/any.json
@@ -1048,7 +1048,8 @@
                 "stat_trait": [
                     "insecure",
                     "lonesome",
-                    "nervous"
+                    "nervous",
+                    "careful"
                 ],
                 "can_have_stat": [
                     "app"
@@ -1168,7 +1169,9 @@
                 "stat_trait": [
                     "insecure",
                     "lonesome",
-                    "nervous"
+                    "nervous",
+                    "careful",
+                    "responsible"
                 ],
                 "frequency": 4
             },
@@ -1178,24 +1181,15 @@
                 "frequency": 4
             },
             {
-                "min_max_status": {"deputy": [1, 1]},
+                "min_max_status": {"warrior": [-1, -1]},
                 "text": "s_c wavers in {PRONOUN/s_c/poss} decision. {PRONOUN/s_c/subject/CAP} {VERB/s_c/have/has} so much work to do and so many other things demanding {PRONOUN/s_c/poss} time... No, definitely not. {PRONOUN/s_c/subject/CAP} {VERB/s_c/turn/turns} around and {VERB/s_c/march/marches} straight back to camp.",
                 "exp": 0,
                 "stat_trait": [
                     "insecure",
                     "lonesome",
-                    "nervous"
-                ],
-                "frequency": 4
-            },
-            {
-                "min_max_status": {"leader": [1, 1]},
-                "text": "s_c wavers in {PRONOUN/s_c/poss} decision. {PRONOUN/s_c/subject/CAP} {VERB/s_c/have/has} so much work to do and so many other things demanding {PRONOUN/s_c/poss} time... No, definitely not. {PRONOUN/s_c/subject/CAP} {VERB/s_c/turn/turns} around and {VERB/s_c/march/marches} straight back to camp.",
-                "exp": 0,
-                "stat_trait": [
-                    "insecure",
-                    "lonesome",
-                    "nervous"
+                    "nervous",
+                    "careful",
+                    "responsible"
                 ],
                 "frequency": 4
             }

--- a/resources/lang/en/patrols/desert/training/any.json
+++ b/resources/lang/en/patrols/desert/training/any.json
@@ -828,24 +828,15 @@
                 "frequency": 4
             },
             {
-                "min_max_status": {"deputy": [1, 1]},
-                "text": "s_c wavers in their decision. They have so much work to do, so many other things pulling on their time... no, definitely not. They turn around and go straight back to camp.",
+                "min_max_status": {"warrior": [-1, -1]},
+                "text": "s_c wavers in {PRONOUN/s_c/poss} decision. {PRONOUN/s_c/subject/CAP} {VERB/s_c/have/has} so much work to do, so many other things demanding {PRONOUN/s_c/poss} time... No, definitely not. {PRONOUN/s_c/subject/CAP} {VERB/s_c/turn/turns} around and {VERB/s_c/march/marches} straight back to camp.",
                 "exp": 0,
                 "stat_trait": [
                     "insecure",
                     "lonesome",
-                    "nervous"
-                ],
-                "frequency": 4
-            },
-            {
-                "min_max_status": {"leader": [1, 1]},
-                "text": "s_c wavers in their decision. They have so much work to do, so many other things pulling on their time... no, definitely not. They turn around and go straight back to camp.",
-                "exp": 0,
-                "stat_trait": [
-                    "insecure",
-                    "lonesome",
-                    "nervous"
+                    "nervous",
+                    "careful", 
+                    "responsible"
                 ],
                 "frequency": 4
             }

--- a/resources/lang/en/patrols/desert/training/any.json
+++ b/resources/lang/en/patrols/desert/training/any.json
@@ -702,10 +702,7 @@
         "min_cats": 1,
         "max_cats": 1,
         "min_max_status": {
-            "apprentice": [
-                1,
-                6
-            ]
+            "apprentice": [1, 1]
         },
         "frequency": 2,
         "intro_text": "r_c heads out into the desert alone, but maybe an apprentice shouldn't try to do a solo patrol.",
@@ -771,14 +768,16 @@
         "patrol_art": "train_general_intro",
         "min_cats": 1,
         "max_cats": 1,
-        "min_max_status": {},
+        "min_max_status": {
+            "normal adult": [1, 1]
+        },
         "frequency": 2,
         "intro_text": "r_c heads out into the desert alone, wanting to explore and have some time to {PRONOUN/r_c/self}.",
         "decline_text": "r_c turns back to camp, deciding that {PRONOUN/r_c/poss} duties have to come first.",
         "chance_of_success": 30,
         "success_outcomes": [
             {
-                "text": "r_c heads off to map out the paths through a rocky maze {PRONOUN/r_c/subject}{VERB/r_c/'ve/'s} always found confusing. Hunting, fighting, driving off predators - it all requires knowledge of {PRONOUN/r_c/poss} home turf, and it's always worth making sure {PRONOUN/r_c/poss} mental map is up to date.",
+                "text": "r_c heads off to map out the paths through a rocky maze {PRONOUN/r_c/subject}{VERB/r_c/'ve/'s} always found confusing. Hunting, fighting, driving off predators - it all requires knowledge of {PRONOUN/r_c/poss} home turf, and it's always worth making sure {PRONOUN/r_c/poss} mental map is up to date. It feels a little like more work though and isn't exactly the peaceful break {PRONOUN/r_c/subject} hoped for.",
                 "exp": 20,
                 "frequency": 4
             },
@@ -791,7 +790,8 @@
                 "text": "r_c squeezes through a tight gap between two massive rock pillars and stumbles across a tiny pool of water hidden in their shadow! Further investigation shows it's springfed, and s_c purrs. This reliable water source will be important during baking hot greenleaf.",
                 "exp": 20,
                 "stat_skill": [
-                    "CLEVER,1"
+                    "CLEVER,1",
+                    "INSIGHTFUL,1"
                 ],
                 "frequency": 4
             },
@@ -826,76 +826,9 @@
                     "nervous"
                 ],
                 "frequency": 4
-            }
-        ]
-    },
-    {
-        "patrol_id": "desert_train_solo3",
-        "biome": [
-            "desert"
-        ],
-        "season": [
-            "any"
-        ],
-        "types": [
-            "training"
-        ],
-        "tags": [],
-        "patrol_art": "train_general_intro",
-        "min_cats": 1,
-        "max_cats": 1,
-                "min_max_status": {
-            "deputy": [
-                1,
-                1
-            ]
-        },
-        "frequency": 2,
-        "intro_text": "r_c heads out into the desert alone, wanting to explore and have some time to {PRONOUN/r_c/self}.",
-        "decline_text": "r_c turns back to camp, deciding that {PRONOUN/r_c/poss} duties have to come first.",
-        "chance_of_success": 30,
-        "success_outcomes": [
-            {
-                "text": "r_c heads off to map out the paths through a rocky maze {PRONOUN/r_c/subject}{VERB/r_c/'ve/'s} always found confusing. Hunting, fighting, driving off predators - it all requires knowledge of {PRONOUN/r_c/poss} home turf, and it's always worth making sure {PRONOUN/r_c/poss} mental map is up to date. It feels a little like more work though and isn't exactly the peaceful break {PRONOUN/r_c/subject} hoped for.",
-                "exp": 20,
-                "frequency": 4
             },
             {
-                "text": "r_c squeezes through a tight gap between two massive rock pillars and stumbles across a tiny pool of water hidden in their shadow! Purring, {PRONOUN/r_c/subject} {VERB/r_c/take/takes} the opportunity for a moment of peace, relaxing and enjoying the view.",
-                "exp": 20,
-                "frequency": 1
-            },
-            {
-                "text": "r_c squeezes through a tight gap between two massive rock pillars and stumbles across a tiny pool of water hidden in their shadow! Further investigation shows it's springfed, and s_c purrs. This reliable water source will be important during baking hot greenleaf; there's a relief to the discovery.",
-                "exp": 20,
-                "stat_skill": [
-                    "CLEVER,1"
-                ],
-                "frequency": 4
-            },
-            {
-                "text": "s_c pads confidently through c_n territory. There's a particular peace in exploring {PRONOUN/s_c/poss} beloved home, ears pricked up curiously whenever {PRONOUN/s_c/subject} {VERB/s_c/spot/spots} how the seasons and weather have reshaped it since {PRONOUN/s_c/subject} last passed this way.",
-                "exp": 20,
-                "stat_trait": [
-                    "adventurous",
-                    "bold",
-                    "charismatic",
-                    "childish",
-                    "confident",
-                    "daring",
-                    "playful",
-                    "righteous"
-                ],
-                "frequency": 4
-            }
-        ],
-        "fail_outcomes": [
-            {
-                "text": "r_c gets lost in the territory. Somehow.",
-                "exp": 0,
-                "frequency": 4
-            },
-            {
+                "min_max_status": {"deputy": [1, 1]},
                 "text": "s_c wavers in their decision. They have so much work to do, so many other things pulling on their time... no, definitely not. They turn around and go straight back to camp.",
                 "exp": 0,
                 "stat_trait": [
@@ -904,76 +837,9 @@
                     "nervous"
                 ],
                 "frequency": 4
-            }
-        ]
-    },
-    {
-        "patrol_id": "dst_train_solo4",
-        "biome": [
-            "desert"
-        ],
-        "season": [
-            "any"
-        ],
-        "types": [
-            "training"
-        ],
-        "tags": [],
-        "patrol_art": "train_general_intro",
-        "min_cats": 1,
-        "max_cats": 1,
-        "min_max_status": {
-            "leader": [
-                1,
-                1
-            ]
-        },
-        "frequency": 2,
-        "intro_text": "r_c heads out into the desert alone, wanting to explore and have some time to {PRONOUN/r_c/self}.",
-        "decline_text": "r_c turns back to camp, deciding that {PRONOUN/r_c/poss} duties have to come first.",
-        "chance_of_success": 30,
-        "success_outcomes": [
-            {
-                "text": "r_c heads off to map out the paths through a rocky maze {PRONOUN/r_c/subject}{VERB/r_c/'ve/'s} always found confusing. Hunting, fighting, driving off predators - it all requires knowledge of {PRONOUN/r_c/poss} home turf, and it's always worth making sure {PRONOUN/r_c/poss} mental map is up to date. It feels a little like more work though and isn't exactly the peaceful break {PRONOUN/r_c/subject} hoped for.",
-                "exp": 20,
-                "frequency": 4
             },
             {
-                "text": "r_c squeezes through a tight gap between two massive rock pillars and stumbles across a tiny pool of water hidden in their shadow! Purring, {PRONOUN/r_c/subject} {VERB/r_c/take/takes} the opportunity for a moment of peace, relaxing and enjoying the view.",
-                "exp": 20,
-                "frequency": 1
-            },
-            {
-                "text": "r_c squeezes through a tight gap between two massive rock pillars and stumbles across a tiny pool of water hidden in their shadow! Further investigation shows it's springfed, and s_c purrs. This reliable water source will be important during baking hot greenleaf; there's a relief to the discovery.",
-                "exp": 20,
-                "stat_skill": [
-                    "CLEVER,1"
-                ],
-                "frequency": 4
-            },
-            {
-                "text": "s_c pads confidently through c_n territory. There's a particular peace in exploring {PRONOUN/s_c/poss} beloved home, ears pricked up curiously whenever {PRONOUN/s_c/subject} {VERB/s_c/spot/spots} how the seasons and weather have reshaped it since {PRONOUN/s_c/subject} last passed this way.",
-                "exp": 20,
-                "stat_trait": [
-                    "adventurous",
-                    "bold",
-                    "charismatic",
-                    "childish",
-                    "confident",
-                    "daring",
-                    "playful",
-                    "righteous"
-                ],
-                "frequency": 4
-            }
-        ],
-        "fail_outcomes": [
-            {
-                "text": "r_c gets lost in the territory. Somehow.",
-                "exp": 0,
-                "frequency": 4
-            },
-            {
+                "min_max_status": {"leader": [1, 1]},
                 "text": "s_c wavers in their decision. They have so much work to do, so many other things pulling on their time... no, definitely not. They turn around and go straight back to camp.",
                 "exp": 0,
                 "stat_trait": [

--- a/resources/lang/en/patrols/forest/training/any.json
+++ b/resources/lang/en/patrols/forest/training/any.json
@@ -1676,7 +1676,8 @@
                 "stat_trait": [
                     "insecure",
                     "lonesome",
-                    "nervous"
+                    "nervous",
+                    "careful"
                 ],
                 "can_have_stat": [
                     "app"
@@ -1801,29 +1802,22 @@
                 "stat_trait": [
                     "insecure",
                     "lonesome",
-                    "nervous"
+                    "nervous",
+                    "careful",
+                    "responsible"
                 ],
                 "frequency": 4
             },
             {
-                "min_max_status": {"deputy": [1, 1]},
+                "min_max_status": {"warrior": [-1, -1]},
                 "text": "s_c wavers in {PRONOUN/s_c/poss} decision. {PRONOUN/s_c/subject/CAP} {VERB/s_c/have/has} so much work to do, so many other things demanding {PRONOUN/s_c/poss} time... No, definitely not. {PRONOUN/s_c/subject/CAP} {VERB/s_c/turn/turns} around and {VERB/s_c/march/marches} straight back to camp.",
                 "exp": 0,
                 "stat_trait": [
                     "insecure",
                     "lonesome",
-                    "nervous"
-                ],
-                "frequency": 4
-            },
-            {
-                "min_max_status": {"leader": [1, 1]},
-                "text": "s_c wavers in {PRONOUN/s_c/poss} decision. {PRONOUN/s_c/subject/CAP} {VERB/s_c/have/has} so much work to do, so many other things demanding {PRONOUN/s_c/poss} time... No, definitely not. {PRONOUN/s_c/subject/CAP} {VERB/s_c/turn/turns} around and {VERB/s_c/march/marches} straight back to camp.",
-                "exp": 0,
-                "stat_trait": [
-                    "insecure",
-                    "lonesome",
-                    "nervous"
+                    "nervous",
+                    "careful",
+                    "responsible"
                 ],
                 "frequency": 4
             }

--- a/resources/lang/en/patrols/forest/training/any.json
+++ b/resources/lang/en/patrols/forest/training/any.json
@@ -1628,10 +1628,7 @@
         "min_cats": 1,
         "max_cats": 1,
         "min_max_status": {
-            "apprentice": [
-                1,
-                6
-            ]
+            "apprentice": [1, 1]
         },
         "frequency": 4,
         "intro_text": "r_c heads out into the forest alone, but maybe an apprentice shouldn't try to do a solo patrol.",
@@ -1725,10 +1722,7 @@
         "min_cats": 1,
         "max_cats": 1,
         "min_max_status": {
-            "normal adult": [
-                1,
-                6
-            ]
+            "normal adult": [ 1, 1 ]
         },
         "frequency": 4,
         "intro_text": "r_c heads out into the forest alone, wanting to explore and have some time to {PRONOUN/r_c/self}.",
@@ -1736,7 +1730,7 @@
         "chance_of_success": 60,
         "success_outcomes": [
             {
-                "text": "r_c heads off to map out a thicket {PRONOUN/r_c/subject}{VERB/r_c/'ve/'s} always found confusing. Hunting, fighting, driving off predators - it all requires knowledge of {PRONOUN/r_c/poss} home turf. It's always worth making sure {PRONOUN/r_c/poss} mental map is up to date.",
+                "text": "r_c heads off to map out a thicket {PRONOUN/r_c/subject}{VERB/r_c/'ve/'s} always found confusing. Hunting, fighting, driving off predators - it all requires knowledge of {PRONOUN/r_c/poss} home turf. It's always worth making sure {PRONOUN/r_c/poss} mental map is up to date. It feels a little like more work though, and isn't exactly the peaceful break {PRONOUN/r_c/subject} hoped for.",
                 "exp": 20,
                 "frequency": 4
             },
@@ -1749,7 +1743,28 @@
                 "text": "s_c rounds a corner and stumbles across a tiny, sparkling waterfall! Further investigation shows that it emerges from an equally tiny spring, and s_c purrs. This reliable water source could be important during times of drought.",
                 "exp": 20,
                 "stat_skill": [
-                    "CLEVER,1"
+                    "CLEVER,1",
+                    "INSIGHTFUL,1"
+                ],
+                "frequency": 4
+            },
+            {
+                "min_max_status": {"deputy": [1, 1]},
+                "text": "s_c rounds a corner and stumbles across a tiny, sparkling waterfall! Further investigation shows that it emerges from an equally tiny spring, and s_c purrs. This reliable water source could be important during times of drought, and its discovery helps to ease one of the many worries on the deputy's mind.",
+                "exp": 20,
+                "stat_skill": [
+                    "CLEVER,1",
+                    "INSIGHTFUL,1"
+                ],
+                "frequency": 4
+            },
+            {
+                "min_max_status": {"leader": [1, 1]},
+                "text": "s_c rounds a corner and stumbles across a tiny, sparkling waterfall! Further investigation shows that it emerges from an equally tiny spring, and s_c purrs. This reliable water source could be important during times of drought, and its discovery helps to ease one of the many worries on the leader's mind.",
+                "exp": 20,
+                "stat_skill": [
+                    "CLEVER,1",
+                    "INSIGHTFUL,1"
                 ],
                 "frequency": 4
             },
@@ -1776,6 +1791,11 @@
                 "frequency": 4
             },
             {
+                "text": "r_c gets lost in the territory. Somehow. {PRONOUN/r_c/poss/CAP} pelt is burning with shame by the time {PRONOUN/r_c/subject} finally {VERB/r_c/return/returns}, sneaking back to {PRONOUN/r_c/poss} den to avoid any embarrassing questions.",
+                "exp": 0,
+                "frequency": 4
+            },
+            {
                 "text": "s_c shivers a little, thinking of the dangers of solo patrols... No, definitely not. {PRONOUN/s_c/subject/CAP} {VERB/s_c/turn/turns} around and {VERB/s_c/slink/slinks} straight back to camp.",
                 "exp": 0,
                 "stat_trait": [
@@ -1784,76 +1804,9 @@
                     "nervous"
                 ],
                 "frequency": 4
-            }
-        ]
-    },
-    {
-        "patrol_id": "fst_train_solo3",
-        "biome": [
-            "forest"
-        ],
-        "season": [
-            "any"
-        ],
-        "types": [
-            "training"
-        ],
-        "tags": [],
-        "patrol_art": "gen_train_solo",
-        "min_cats": 1,
-        "max_cats": 1,
-                "min_max_status": {
-            "deputy": [
-                1,
-                1
-            ]
-        },
-        "frequency": 4,
-        "intro_text": "r_c heads out into the forest alone, wanting to explore and have some time to {PRONOUN/r_c/self}.",
-        "decline_text": "r_c turns back to camp, deciding that {PRONOUN/r_c/poss} duties have to come first.",
-        "chance_of_success": 60,
-        "success_outcomes": [
-            {
-                "text": "r_c heads off to map out a thicket {PRONOUN/r_c/subject}{VERB/r_c/'ve/'s} always found confusing. Hunting, fighting, driving off predators - it all requires knowledge of {PRONOUN/r_c/poss} home turf. It's always worth making sure {PRONOUN/r_c/poss} mental map is up to date. It feels a little like more work though, and isn't exactly the peaceful break {PRONOUN/r_c/subject} hoped for.",
-                "exp": 20,
-                "frequency": 4
             },
             {
-                "text": "r_c rounds a corner and stumbles across a tiny, sparkling waterfall! Purring, {PRONOUN/r_c/subject} {VERB/r_c/take/takes} the opportunity for a moment of peace, relaxing and enjoying the view.",
-                "exp": 20,
-                "frequency": 1
-            },
-            {
-                "text": "s_c rounds a corner and stumbles across a tiny, sparkling waterfall! Further investigation shows that it emerges from an equally tiny spring, and s_c purrs. This reliable water source could be important during times of drought, and its discovery helps to ease one of the many worries on the deputy's mind.",
-                "exp": 20,
-                "stat_skill": [
-                    "CLEVER,1"
-                ],
-                "frequency": 4
-            },
-            {
-                "text": "s_c pads confidently through c_n territory. There's a particular peace in exploring {PRONOUN/s_c/poss} beloved home, ears pricked up curiously whenever {PRONOUN/s_c/subject} {VERB/s_c/spot/spots} how the seasons and weather have reshaped it since {PRONOUN/s_c/subject} last passed this way.",
-                "exp": 20,
-                "stat_trait": [
-                    "adventurous",
-                    "bold",
-                    "charismatic",
-                    "childish",
-                    "confident",
-                    "daring",
-                    "playful",
-                    "righteous"
-                ],
-                "frequency": 4
-            }
-        ],
-        "fail_outcomes": [
-            {
-                "text": "r_c gets lost in the territory. Somehow. {PRONOUN/r_c/poss/CAP} pelt is burning with shame by the time {PRONOUN/r_c/subject} finally {VERB/r_c/return/returns}, sneaking back to {PRONOUN/r_c/poss} den to avoid any embarrassing questions.",
-                "exp": 0,
-                "frequency": 4
-            },
-            {
+                "min_max_status": {"deputy": [1, 1]},
                 "text": "s_c wavers in {PRONOUN/s_c/poss} decision. {PRONOUN/s_c/subject/CAP} {VERB/s_c/have/has} so much work to do, so many other things demanding {PRONOUN/s_c/poss} time... No, definitely not. {PRONOUN/s_c/subject/CAP} {VERB/s_c/turn/turns} around and {VERB/s_c/march/marches} straight back to camp.",
                 "exp": 0,
                 "stat_trait": [
@@ -1862,76 +1815,9 @@
                     "nervous"
                 ],
                 "frequency": 4
-            }
-        ]
-    },
-    {
-        "patrol_id": "fst_train_solo4",
-        "biome": [
-            "forest"
-        ],
-        "season": [
-            "any"
-        ],
-        "types": [
-            "training"
-        ],
-        "tags": [],
-        "patrol_art": "gen_train_solo",
-        "min_cats": 1,
-        "max_cats": 1,
-        "min_max_status": {
-            "leader": [
-                1,
-                1
-            ]
-        },
-        "frequency": 4,
-        "intro_text": "r_c heads out into the forest alone, wanting to explore and have some time to {PRONOUN/r_c/self}.",
-        "decline_text": "r_c turns back to camp, deciding that {PRONOUN/r_c/poss} duties have to come first.",
-        "chance_of_success": 60,
-        "success_outcomes": [
-            {
-                "text": "r_c heads off to map out a thicket {PRONOUN/r_c/subject}{VERB/r_c/'ve/'s} always found confusing. Hunting, fighting, driving off predators - it all requires knowledge of {PRONOUN/r_c/poss} home turf. It's always worth making sure {PRONOUN/r_c/poss} mental map is up to date. It feels a little like more work though, and isn't exactly the peaceful break {PRONOUN/r_c/subject} hoped for.",
-                "exp": 20,
-                "frequency": 4
             },
             {
-                "text": "r_c rounds a corner and stumbles across a tiny, sparkling waterfall! Purring, {PRONOUN/r_c/subject} {VERB/r_c/take/takes} the opportunity for a moment of peace, relaxing and enjoying the view.",
-                "exp": 20,
-                "frequency": 1
-            },
-            {
-                "text": "s_c rounds a corner and stumbles across a tiny, sparkling waterfall! Further investigation shows that it emerges from an equally tiny spring, and s_c purrs. This reliable water source could be important during times of drought, and its discovery helps to ease one of the many worries on the leader's mind.",
-                "exp": 20,
-                "stat_skill": [
-                    "CLEVER,1"
-                ],
-                "frequency": 4
-            },
-            {
-                "text": "s_c pads confidently through c_n territory. There's a particular peace in exploring {PRONOUN/s_c/poss} beloved home, ears pricked up curiously whenever {PRONOUN/s_c/subject} {VERB/s_c/spot/spots} how the seasons and weather have reshaped it since {PRONOUN/s_c/subject} last passed this way.",
-                "exp": 20,
-                "stat_trait": [
-                    "adventurous",
-                    "bold",
-                    "charismatic",
-                    "childish",
-                    "confident",
-                    "daring",
-                    "playful",
-                    "righteous"
-                ],
-                "frequency": 4
-            }
-        ],
-        "fail_outcomes": [
-            {
-                "text": "r_c gets lost in the territory. Somehow. {PRONOUN/r_c/poss/CAP} pelt is burning with shame by the time {PRONOUN/r_c/subject} finally {VERB/r_c/return/returns}, sneaking back to {PRONOUN/r_c/poss} den to avoid any embarrassing questions.",
-                "exp": 0,
-                "frequency": 4
-            },
-            {
+                "min_max_status": {"leader": [1, 1]},
                 "text": "s_c wavers in {PRONOUN/s_c/poss} decision. {PRONOUN/s_c/subject/CAP} {VERB/s_c/have/has} so much work to do, so many other things demanding {PRONOUN/s_c/poss} time... No, definitely not. {PRONOUN/s_c/subject/CAP} {VERB/s_c/turn/turns} around and {VERB/s_c/march/marches} straight back to camp.",
                 "exp": 0,
                 "stat_trait": [

--- a/resources/lang/en/patrols/mountainous/training/any.json
+++ b/resources/lang/en/patrols/mountainous/training/any.json
@@ -1584,7 +1584,8 @@
                 "stat_trait": [
                     "insecure",
                     "lonesome",
-                    "nervous"
+                    "nervous",
+                    "careful"
                 ],
                 "can_have_stat": [
                     "app"
@@ -1704,7 +1705,9 @@
                 "stat_trait": [
                     "insecure",
                     "lonesome",
-                    "nervous"
+                    "nervous",
+                    "careful",
+                    "responsible"
                 ],
                 "frequency": 4
             },
@@ -1714,24 +1717,15 @@
                 "frequency": 4
             },
             {
-                "min_max_status": {"deputy": [1, 1]},
+                "min_max_status": {"warrior": [-1, -1]},
                 "text": "s_c wavers in {PRONOUN/s_c/poss} decision. {PRONOUN/s_c/subject/CAP} {VERB/s_c/have/has} so much work to do, so many other things demanding {PRONOUN/s_c/poss} time... No, definitely not. {PRONOUN/s_c/subject/CAP} {VERB/s_c/turn/turns} around and {VERB/s_c/go/goes} straight back to camp.",
                 "exp": 0,
                 "stat_trait": [
                     "insecure",
                     "lonesome",
-                    "nervous"
-                ],
-                "frequency": 4
-            },
-            {
-                "min_max_status": {"leader": [1, 1]},
-                "text": "s_c wavers in {PRONOUN/s_c/poss} decision. {PRONOUN/s_c/subject/CAP} {VERB/s_c/have/has} so much work to do, so many other things demanding {PRONOUN/s_c/poss} time... No, definitely not. {PRONOUN/s_c/subject/CAP} {VERB/s_c/turn/turns} around and {VERB/s_c/go/goes} straight back to camp.",
-                "exp": 0,
-                "stat_trait": [
-                    "insecure",
-                    "lonesome",
-                    "nervous"
+                    "nervous",
+                    "careful",
+                    "responsible"
                 ],
                 "frequency": 4
             }

--- a/resources/lang/en/patrols/mountainous/training/any.json
+++ b/resources/lang/en/patrols/mountainous/training/any.json
@@ -1536,10 +1536,7 @@
         "min_cats": 1,
         "max_cats": 1,
         "min_max_status": {
-            "apprentice": [
-                1,
-                6
-            ]
+            "apprentice": [ 1, 1 ]
         },
         "frequency": 4,
         "intro_text": "r_c heads out into the mountains alone, but maybe an apprentice shouldn't try to do a solo patrol.",
@@ -1633,10 +1630,7 @@
         "min_cats": 1,
         "max_cats": 1,
         "min_max_status": {
-            "normal adult": [
-                1,
-                6
-            ]
+            "normal adult": [1, 1]
         },
         "frequency": 4,
         "intro_text": "r_c heads out into the mountains alone, wanting to explore and have some time to {PRONOUN/r_c/self}.",
@@ -1644,12 +1638,12 @@
         "chance_of_success": 60,
         "success_outcomes": [
             {
-                "text": "r_c heads off to map out a field of boulders {PRONOUN/r_c/subject}{VERB/r_c/'ve/'s} always found confusing. Hunting, fighting, driving off predators - it all requires knowledge of {PRONOUN/r_c/poss} home turf. It's always worth making sure {PRONOUN/r_c/poss} mental map is up to date.",
+                "text": "r_c heads off to map out a field of boulders {PRONOUN/r_c/subject}{VERB/r_c/'ve/'s} always found confusing. Hunting, fighting, driving off predators - it all requires knowledge of {PRONOUN/r_c/poss} home turf. It's always worth making sure {PRONOUN/r_c/poss} mental map is up to date. It feels a little like more work though and isn't exactly the peaceful break {PRONOUN/r_c/subject} hoped for.",
                 "exp": 20,
                 "frequency": 4
             },
             {
-                "text": "r_c rounds a corner and stumbles across a tiny, perfect, sheltered gully, thick with bushes and prey scent.",
+                "text": "r_c rounds a corner and stumbles across a tiny, perfect, sheltered gully, thick with bushes and prey scent. Purring, {PRONOUN/r_c/subject} {VERB/r_c/take/takes} the opportunity for a moment of peace, stretching out in the shade to relax.",
                 "exp": 20,
                 "frequency": 1
             },
@@ -1657,7 +1651,28 @@
                 "text": "s_c rounds a corner and stumbles across a tiny, perfect, sheltered gully, thick with bushes and prey scent. Further investigation shows it will be sheltered from almost all wind directions, and s_c purrs. This reliable prey source will be important during leaf-bare.",
                 "exp": 20,
                 "stat_skill": [
-                    "CLEVER,1"
+                    "CLEVER,1",
+                    "INSIGHTFUL,1"
+                ],
+                "frequency": 4
+            },
+            {
+                "min_max_status": {"deputy": [1, 1]},
+                "text": "s_c rounds a corner and stumbles across a tiny, perfect, sheltered gully, thick with bushes and prey scent. Further investigation shows it will be sheltered from almost all wind directions, and s_c purrs. This reliable prey source will be important during leaf-bare, and its discovery helps to ease one of the many worries on the deputy's mind.",
+                "exp": 20,
+                "stat_skill": [
+                    "CLEVER,1",
+                    "INSIGHTFUL,1"
+                ],
+                "frequency": 4
+            },
+            {
+                "min_max_status": {"leader": [1, 1]},
+                "text": "s_c rounds a corner and stumbles across a tiny, perfect, sheltered gully, thick with bushes and prey scent. Further investigation shows it will be sheltered from almost all wind directions, and s_c purrs. This reliable prey source will be important during leaf-bare, and its discovery helps to ease one of the many worries on the leader's mind.",
+                "exp": 20,
+                "stat_skill": [
+                    "CLEVER,1",
+                    "INSIGHTFUL,1"
                 ],
                 "frequency": 4
             },
@@ -1692,76 +1707,14 @@
                     "nervous"
                 ],
                 "frequency": 4
-            }
-        ]
-    },
-    {
-        "patrol_id": "mtn_train_solo3",
-        "biome": [
-            "mountainous"
-        ],
-        "season": [
-            "any"
-        ],
-        "types": [
-            "training"
-        ],
-        "tags": [],
-        "patrol_art": "gen_train_solo",
-        "min_cats": 1,
-        "max_cats": 1,
-                "min_max_status": {
-            "deputy": [
-                1,
-                1
-            ]
-        },
-        "frequency": 4,
-        "intro_text": "r_c heads out into the mountains alone, wanting to explore and have some time to {PRONOUN/r_c/self}.",
-        "decline_text": "r_c turns back to camp, deciding that {PRONOUN/r_c/poss} duties have to come first.",
-        "chance_of_success": 70,
-        "success_outcomes": [
-            {
-                "text": "r_c heads off to map out a field of boulders {PRONOUN/r_c/subject}{VERB/r_c/'ve/'s} always found confusing. Hunting, fighting, driving off predators - it all requires knowledge of {PRONOUN/r_c/poss} home turf. It's always worth making sure {PRONOUN/r_c/poss} mental map is up to date. It feels a little like more work though and isn't exactly the peaceful break {PRONOUN/r_c/subject} hoped for.",
-                "exp": 20,
-                "frequency": 4
             },
-            {
-                "text": "r_c rounds a corner and stumbles across a tiny, perfect, sheltered gully, thick with bushes and prey scent. Purring, {PRONOUN/r_c/subject} {VERB/r_c/take/takes} the opportunity for a moment of peace, stretching out in the shade to relax.",
-                "exp": 20,
-                "frequency": 1
-            },
-            {
-                "text": "s_c rounds a corner and stumbles across a tiny, perfect, sheltered gully, thick with bushes and prey scent. Further investigation shows it will be sheltered from almost all wind directions, and s_c purrs. This reliable prey source will be important during leaf-bare, and its discovery helps to ease one of the many worries on the deputy's mind.",
-                "exp": 20,
-                "stat_skill": [
-                    "CLEVER,1"
-                ],
-                "frequency": 4
-            },
-            {
-                "text": "s_c pads confidently through c_n territory. There's a particular peace in exploring {PRONOUN/s_c/poss} beloved home, ears pricked up curiously whenever {PRONOUN/s_c/subject} {VERB/s_c/spot/spots} how the seasons and weather have reshaped it since {PRONOUN/s_c/subject} last passed this way.",
-                "exp": 20,
-                "stat_trait": [
-                    "adventurous",
-                    "bold",
-                    "charismatic",
-                    "childish",
-                    "confident",
-                    "daring",
-                    "playful",
-                    "righteous"
-                ],
-                "frequency": 4
-            }
-        ],
-        "fail_outcomes": [
             {
                 "text": "r_c gets lost in the territory. Somehow. {PRONOUN/r_c/poss/CAP} pelt is burning with shame by the time {PRONOUN/r_c/subject} finally {VERB/r_c/return/returns}, sneaking back to {PRONOUN/r_c/poss} den to avoid any embarrassing questions.",
                 "exp": 0,
                 "frequency": 4
             },
             {
+                "min_max_status": {"deputy": [1, 1]},
                 "text": "s_c wavers in {PRONOUN/s_c/poss} decision. {PRONOUN/s_c/subject/CAP} {VERB/s_c/have/has} so much work to do, so many other things demanding {PRONOUN/s_c/poss} time... No, definitely not. {PRONOUN/s_c/subject/CAP} {VERB/s_c/turn/turns} around and {VERB/s_c/go/goes} straight back to camp.",
                 "exp": 0,
                 "stat_trait": [
@@ -1770,76 +1723,9 @@
                     "nervous"
                 ],
                 "frequency": 4
-            }
-        ]
-    },
-    {
-        "patrol_id": "mtn_train_solo4",
-        "biome": [
-            "mountainous"
-        ],
-        "season": [
-            "any"
-        ],
-        "types": [
-            "training"
-        ],
-        "tags": [],
-        "patrol_art": "gen_train_solo",
-        "min_cats": 1,
-        "max_cats": 1,
-        "min_max_status": {
-            "leader": [
-                1,
-                1
-            ]
-        },
-        "frequency": 4,
-        "intro_text": "r_c heads out into the mountains alone, wanting to explore and have some time to {PRONOUN/r_c/self}.",
-        "decline_text": "r_c turns back to camp, deciding that {PRONOUN/r_c/poss} duties have to come first.",
-        "chance_of_success": 70,
-        "success_outcomes": [
-            {
-                "text": "r_c heads off to map out a field of boulders {PRONOUN/r_c/subject}{VERB/r_c/'ve/'s} always found confusing. Hunting, fighting, driving off predators - it all requires knowledge of {PRONOUN/r_c/poss} home turf. It's always worth making sure {PRONOUN/r_c/poss} mental map is up to date. It feels a little like more work though and isn't exactly the peaceful break {PRONOUN/r_c/subject} hoped for.",
-                "exp": 20,
-                "frequency": 4
             },
             {
-                "text": "r_c rounds a corner and stumbles across a tiny, perfect, sheltered gully, thick with bushes and prey scent. Purring, {PRONOUN/r_c/subject} {VERB/r_c/take/takes} the opportunity for a moment of peace, stretching out in the shade to relax.",
-                "exp": 20,
-                "frequency": 1
-            },
-            {
-                "text": "s_c rounds a corner and stumbles across a tiny, perfect, sheltered gully, thick with bushes and prey scent. Further investigation shows it will be sheltered from almost all wind directions, and s_c purrs. This reliable prey source will be important during leaf-bare, and its discovery helps to ease one of the many worries on the leader's mind.",
-                "exp": 20,
-                "stat_skill": [
-                    "CLEVER,1"
-                ],
-                "frequency": 4
-            },
-            {
-                "text": "s_c pads confidently through c_n territory. There's a particular peace in exploring {PRONOUN/s_c/poss} beloved home, ears pricked up curiously whenever {PRONOUN/s_c/subject} {VERB/s_c/spot/spots} how the seasons and weather have reshaped it since {PRONOUN/s_c/subject} last passed this way.",
-                "exp": 20,
-                "stat_trait": [
-                    "adventurous",
-                    "bold",
-                    "charismatic",
-                    "childish",
-                    "confident",
-                    "daring",
-                    "playful",
-                    "righteous"
-                ],
-                "frequency": 4
-            }
-        ],
-        "fail_outcomes": [
-            {
-                "text": "r_c gets lost in the territory. Somehow. {PRONOUN/r_c/poss/CAP} pelt is burning with shame by the time {PRONOUN/r_c/subject} finally {VERB/r_c/return/returns}, sneaking back to {PRONOUN/r_c/poss} den to avoid any embarrassing questions.",
-                "exp": 0,
-                "frequency": 4
-            },
-            {
+                "min_max_status": {"leader": [1, 1]},
                 "text": "s_c wavers in {PRONOUN/s_c/poss} decision. {PRONOUN/s_c/subject/CAP} {VERB/s_c/have/has} so much work to do, so many other things demanding {PRONOUN/s_c/poss} time... No, definitely not. {PRONOUN/s_c/subject/CAP} {VERB/s_c/turn/turns} around and {VERB/s_c/go/goes} straight back to camp.",
                 "exp": 0,
                 "stat_trait": [

--- a/resources/lang/en/patrols/plains/training/any.json
+++ b/resources/lang/en/patrols/plains/training/any.json
@@ -1739,26 +1739,16 @@
                 "frequency": 4
             },
             {
-                "min_max_status": {"deputy": [1, 1]},
+                "min_max_status": {"warrior": [-1, -1]},
                 "text": "s_c wavers in {PRONOUN/s_c/poss} decision. {PRONOUN/s_c/subject/CAP} {VERB/s_c/have/has} so much work to do, so many other things demanding {PRONOUN/s_c/poss} time... No, definitely not. {PRONOUN/s_c/subject/CAP} {VERB/s_c/turn/turns} around and {VERB/s_c/march/marches} straight back to camp.",
                 "exp": 0,
                 "art": "gen_hunt_sneakprey",
                 "stat_trait": [
                     "insecure",
                     "lonesome",
-                    "nervous"
-                ],
-                "frequency": 4
-            },
-            {
-                "min_max_status": {"leader": [1, 1]},
-                "text": "s_c wavers in {PRONOUN/s_c/poss} decision. {PRONOUN/s_c/subject/CAP} {VERB/s_c/have/has} so much work to do, so many other things demanding {PRONOUN/s_c/poss} time... No, definitely not. {PRONOUN/s_c/subject/CAP} {VERB/s_c/turn/turns} around and {VERB/s_c/march/marches} straight back to camp.",
-                "exp": 0,
-                "art": "gen_hunt_sneakprey",
-                "stat_trait": [
-                    "insecure",
-                    "lonesome",
-                    "nervous"
+                    "nervous",
+                    "careful",
+                    "responsible"
                 ],
                 "frequency": 4
             }

--- a/resources/lang/en/patrols/plains/training/any.json
+++ b/resources/lang/en/patrols/plains/training/any.json
@@ -1548,10 +1548,7 @@
         "min_cats": 1,
         "max_cats": 1,
         "min_max_status": {
-            "apprentice": [
-                1,
-                6
-            ]
+            "apprentice": [ 1, 1 ]
         },
         "frequency": 4,
         "intro_text": "app1 heads out into the grasslands alone, but maybe an apprentice shouldn't try to do a solo patrol.",
@@ -1651,10 +1648,7 @@
         "min_cats": 1,
         "max_cats": 1,
         "min_max_status": {
-            "normal adult": [
-                1,
-                6
-            ]
+            "normal adult": [ 1, 1 ]
         },
         "frequency": 4,
         "intro_text": "r_c heads out into the grasslands alone, wanting to explore and have some time to {PRONOUN/r_c/self}.",
@@ -1662,13 +1656,13 @@
         "chance_of_success": 60,
         "success_outcomes": [
             {
-                "text": "r_c heads off to map out a thick field of tall grass {PRONOUN/r_c/subject}{VERB/r_c/'ve/'s} always found confusing. Hunting, fighting, driving off predators - it all requires knowledge of {PRONOUN/r_c/poss} home turf. It's always worth making sure {PRONOUN/r_c/poss} mental map is up to date.",
+                "text": "r_c heads off to map out a thick field of tall grass {PRONOUN/r_c/subject}{VERB/r_c/'ve/'s} always found confusing. Hunting, fighting, driving off predators - it all requires knowledge of {PRONOUN/r_c/poss} home turf. It's always worth making sure {PRONOUN/r_c/poss} mental map is up to date. It feels a little like more work though, and isn't exactly the peaceful break {PRONOUN/r_c/subject} hoped for.",
                 "exp": 20,
                 "art": "fst_hunt_fun1",
                 "frequency": 4
             },
             {
-                "text": "r_c rounds a corner and stumbles across a tiny, perfect pond!",
+                "text": "r_c rounds a corner and stumbles across a tiny, perfect pond! Purring, {PRONOUN/r_c/subject} {VERB/r_c/take/takes} the opportunity for a moment of peace, relaxing and enjoying the view.",
                 "exp": 20,
                 "art": "gen_happy_cat",
                 "frequency": 1
@@ -1679,6 +1673,28 @@
                 "art": "gen_happy_cat",
                 "stat_skill": [
                     "CLEVER,1"
+                ],
+                "frequency": 4
+            },
+            {
+                "min_max_status": {"deputy": [1, 1]},
+                "text": "s_c rounds a corner and stumbles across a tiny, perfect pond! Further investigation shows that it emerges from an equally tiny spring, and s_c purrs. This reliable water source could be important during times of drought, and its discovery helps to ease one of the many worries on the deputy's mind.",
+                "exp": 20,
+                "art": "gen_warrior_crouching",
+                "stat_skill": [
+                    "CLEVER,1",
+                    "INSIGHTFUL,1"
+                ],
+                "frequency": 4
+            },
+            {
+                "min_max_status": {"leader": [1, 1]},
+                "text": "s_c rounds a corner and stumbles across a tiny, perfect pond! Further investigation shows that it emerges from an equally tiny spring, and s_c purrs. This reliable water source could be important during times of drought, and its discovery helps to ease one of the many worries on the leader's mind.",
+                "exp": 20,
+                "art": "gen_warrior_crouching",
+                "stat_skill": [
+                    "CLEVER,1",
+                    "INSIGHTFUL,1"
                 ],
                 "frequency": 4
             },
@@ -1715,75 +1731,7 @@
                     "nervous"
                 ],
                 "frequency": 4
-            }
-        ]
-    },
-    {
-        "patrol_id": "pln_train_solo3",
-        "biome": [
-            "plains"
-        ],
-        "season": [
-            "any"
-        ],
-        "types": [
-            "training"
-        ],
-        "tags": [],
-        "patrol_art": "gen_train_solo",
-        "min_cats": 1,
-        "max_cats": 1,
-                "min_max_status": {
-            "deputy": [
-                1,
-                1
-            ]
-        },
-        "frequency": 4,
-        "intro_text": "r_c heads out into the grasslands alone, wanting to explore and have some time to {PRONOUN/r_c/self}.",
-        "decline_text": "r_c turns back to camp, deciding that {PRONOUN/r_c/poss} duties have to come first.",
-        "chance_of_success": 60,
-        "success_outcomes": [
-            {
-                "text": "r_c heads off to map out a thick field of tall grass {PRONOUN/r_c/subject}{VERB/r_c/'ve/'s} always found confusing. Hunting, fighting, driving off predators - it all requires knowledge of {PRONOUN/r_c/poss} home turf. It's always worth making sure {PRONOUN/r_c/poss} mental map is up to date. It feels a little like more work though, and isn't exactly the peaceful break {PRONOUN/r_c/subject} hoped for.",
-                "exp": 20,
-                "art": "fst_hunt_fun1",
-                "frequency": 4
             },
-            {
-                "text": "r_c rounds a corner and stumbles across a tiny, perfect pond! Purring, {PRONOUN/r_c/subject} {VERB/r_c/take/takes} the opportunity for a moment of peace, relaxing and enjoying the view.",
-                "exp": 20,
-                "art": "gen_train_sunny",
-                "frequency": 1
-            },
-            {
-                "text": "s_c rounds a corner and stumbles across a tiny, perfect pond! Further investigation shows that it emerges from an equally tiny spring, and s_c purrs. This reliable water source could be important during times of drought, and its discovery helps to ease one of the many worries on the deputy's mind.",
-                "exp": 20,
-                "art": "gen_warrior_crouching",
-                "stat_skill": [
-                    "CLEVER,1",
-                    "INSIGHTFUL,1"
-                ],
-                "frequency": 4
-            },
-            {
-                "text": "s_c pads confidently through c_n territory. There's a particular peace in exploring {PRONOUN/s_c/poss} beloved home, ears pricked up curiously whenever {PRONOUN/s_c/subject} {VERB/s_c/spot/spots} how the seasons and weather have reshaped it since {PRONOUN/s_c/subject} last passed this way.",
-                "exp": 20,
-                "art": "gen_happy_cat",
-                "stat_trait": [
-                    "adventurous",
-                    "bold",
-                    "charismatic",
-                    "childish",
-                    "confident",
-                    "daring",
-                    "playful",
-                    "righteous"
-                ],
-                "frequency": 4
-            }
-        ],
-        "fail_outcomes": [
             {
                 "text": "r_c gets lost in the territory. Somehow. {PRONOUN/r_c/poss/CAP} pelt is burning with shame by the time {PRONOUN/r_c/subject} finally {VERB/r_c/return/returns}, sneaking back to {PRONOUN/r_c/poss} den to avoid any embarrassing questions.",
                 "exp": 0,
@@ -1791,6 +1739,7 @@
                 "frequency": 4
             },
             {
+                "min_max_status": {"deputy": [1, 1]},
                 "text": "s_c wavers in {PRONOUN/s_c/poss} decision. {PRONOUN/s_c/subject/CAP} {VERB/s_c/have/has} so much work to do, so many other things demanding {PRONOUN/s_c/poss} time... No, definitely not. {PRONOUN/s_c/subject/CAP} {VERB/s_c/turn/turns} around and {VERB/s_c/march/marches} straight back to camp.",
                 "exp": 0,
                 "art": "gen_hunt_sneakprey",
@@ -1800,82 +1749,9 @@
                     "nervous"
                 ],
                 "frequency": 4
-            }
-        ]
-    },
-    {
-        "patrol_id": "pln_train_solo4",
-        "biome": [
-            "plains"
-        ],
-        "season": [
-            "any"
-        ],
-        "types": [
-            "training"
-        ],
-        "tags": [],
-        "patrol_art": "gen_train_solo",
-        "min_cats": 1,
-        "max_cats": 1,
-        "min_max_status": {
-            "leader": [
-                1,
-                1
-            ]
-        },
-        "frequency": 4,
-        "intro_text": "r_c heads out into the grasslands alone, wanting to explore and have some time to {PRONOUN/r_c/self}.",
-        "decline_text": "r_c turns back to camp, deciding that {PRONOUN/r_c/poss} duties have to come first.",
-        "chance_of_success": 60,
-        "success_outcomes": [
-            {
-                "text": "r_c heads off to map out a thick field of tall grass {PRONOUN/r_c/subject}{VERB/r_c/'ve/'s} always found confusing. Hunting, fighting, driving off predators - it all requires knowledge of {PRONOUN/r_c/poss} home turf. It's always worth making sure {PRONOUN/r_c/poss} mental map is up to date. It feels a little like more work though, and isn't exactly the peaceful break {PRONOUN/r_c/subject} hoped for.",
-                "exp": 20,
-                "art": "fst_hunt_fun1",
-                "frequency": 4
             },
             {
-                "text": "r_c rounds a corner and stumbles across a tiny, perfect pond! Purring, {PRONOUN/r_c/subject} {VERB/r_c/take/takes} the opportunity for a moment of peace, relaxing and enjoying the view.",
-                "exp": 20,
-                "art": "gen_train_sunny",
-                "frequency": 1
-            },
-            {
-                "text": "s_c rounds a corner and stumbles across a tiny, perfect pond! Further investigation shows that it emerges from an equally tiny spring, and s_c purrs. This reliable water source could be important during times of drought, and its discovery helps to ease one of the many worries on the leader's mind.",
-                "exp": 20,
-                "art": "gen_warrior_crouching",
-                "stat_skill": [
-                    "CLEVER,1",
-                    "INSIGHTFUL,1"
-                ],
-                "frequency": 4
-            },
-            {
-                "text": "s_c pads confidently through c_n territory. There's a particular peace in exploring {PRONOUN/s_c/poss} beloved home, ears pricked up curiously whenever {PRONOUN/s_c/subject} {VERB/s_c/spot/spots} how the seasons and weather have reshaped it since {PRONOUN/s_c/subject} last passed this way.",
-                "exp": 20,
-                "art": "gen_happy_cat",
-                "stat_trait": [
-                    "adventurous",
-                    "bold",
-                    "charismatic",
-                    "childish",
-                    "confident",
-                    "daring",
-                    "playful",
-                    "righteous"
-                ],
-                "frequency": 4
-            }
-        ],
-        "fail_outcomes": [
-            {
-                "text": "r_c gets lost in the territory. Somehow. {PRONOUN/r_c/poss/CAP} pelt is burning with shame by the time {PRONOUN/r_c/subject} finally {VERB/r_c/return/returns}, sneaking back to {PRONOUN/r_c/poss} den to avoid any embarrassing questions.",
-                "exp": 0,
-                "art": "gen_hunt_sneakprey",
-                "frequency": 4
-            },
-            {
+                "min_max_status": {"leader": [1, 1]},
                 "text": "s_c wavers in {PRONOUN/s_c/poss} decision. {PRONOUN/s_c/subject/CAP} {VERB/s_c/have/has} so much work to do, so many other things demanding {PRONOUN/s_c/poss} time... No, definitely not. {PRONOUN/s_c/subject/CAP} {VERB/s_c/turn/turns} around and {VERB/s_c/march/marches} straight back to camp.",
                 "exp": 0,
                 "art": "gen_hunt_sneakprey",

--- a/resources/lang/en/patrols/wetlands/training/any.json
+++ b/resources/lang/en/patrols/wetlands/training/any.json
@@ -677,24 +677,15 @@
                 "frequency": 4
             },
             {
-                "min_max_status": {"deputy": [1, 1]},
+                "min_max_status": {"warrior": [-1, -1]},
                 "text": "s_c wavers in their decision. {PRONOUN/s_c/subject/CAP} {VERB/s_c/have/has} so much work to do, so many other things pulling on {PRONOUN/s_c/poss} time... No, definitely not. {PRONOUN/s_c/subject/CAP} {VERB/s_c/turn/turns} around and {VERB/s_c/go/goes} straight back to camp.",
                 "exp": 0,
                 "stat_trait": [
                     "insecure",
                     "lonesome",
-                    "nervous"
-                ],
-                "frequency": 4
-            },
-            {
-                "min_max_status": {"leader": [1, 1]},
-                "text": "s_c wavers in their decision. {PRONOUN/s_c/subject/CAP} {VERB/s_c/have/has} so much work to do, so many other things pulling on {PRONOUN/s_c/poss} time... No, definitely not. {PRONOUN/s_c/subject/CAP} {VERB/s_c/turn/turns} around and {VERB/s_c/go/goes} straight back to camp.",
-                "exp": 0,
-                "stat_trait": [
-                    "insecure",
-                    "lonesome",
-                    "nervous"
+                    "nervous",
+                    "careful",
+                    "responsible"
                 ],
                 "frequency": 4
             }

--- a/resources/lang/en/patrols/wetlands/training/any.json
+++ b/resources/lang/en/patrols/wetlands/training/any.json
@@ -531,10 +531,7 @@
         "min_cats": 1,
         "max_cats": 1,
         "min_max_status": {
-            "apprentice": [
-                1,
-                6
-            ]
+            "apprentice": [ 1, 1 ]
         },
         "frequency": 2,
         "intro_text": "r_c heads out into the swamps alone, but maybe an apprentice shouldn't try to do a solo patrol.",
@@ -600,19 +597,21 @@
         "patrol_art": "train_general_intro",
         "min_cats": 1,
         "max_cats": 1,
-        "min_max_status": {},
+        "min_max_status": {
+            "normal adult": [1, 1]
+        },
         "frequency": 2,
         "intro_text": "r_c heads out into the swamps alone, wanting to explore and have some time to {PRONOUN/r_c/self}.",
         "decline_text": "r_c turns back to camp, deciding that {PRONOUN/r_c/poss} duties have to come first.",
         "chance_of_success": 30,
         "success_outcomes": [
             {
-                "text": "r_c heads off to map out the paths of solid ground through a boggy area {PRONOUN/r_c/subject}{VERB/r_c/'ve/s} always found confusing. Hunting, fighting, driving off predators - it all requires knowledge of {PRONOUN/r_c/poss} home turf, and it's always worth making sure {PRONOUN/r_c/poss} mental map is up to date.",
+                "text": "r_c heads off to map out the paths of solid ground through a boggy area {PRONOUN/r_c/subject}{VERB/r_c/'ve/'s} always found confusing. Hunting, fighting, driving off predators - it all requires knowledge of {PRONOUN/r_c/poss} home turf, and it's always worth making sure {PRONOUN/r_c/poss} mental map is up to date. It feels a little like more work though and isn't exactly the peaceful break {PRONOUN/r_c/subject} hoped for.",
                 "exp": 20,
                 "frequency": 4
             },
             {
-                "text": "r_c clambers through a muddy area and stumbles across a tiny island rising from the swamp.",
+                "text": "r_c rounds a corner and stumbles across a tiny island rising from the swamp. Purring, {PRONOUN/r_c/subject} {VERB/r_c/take/takes} the opportunity for a moment of peace, relaxing and enjoying the view.",
                 "exp": 20,
                 "frequency": 1
             },
@@ -620,7 +619,28 @@
                 "text": "s_c rounds a corner and stumbles across a tiny island rising from the swamp. Further investigation shows it's dry and lush, and s_c purrs. This reliable prey hunting ground could be important during times of scarcity.",
                 "exp": 20,
                 "stat_skill": [
-                    "CLEVER,1"
+                    "CLEVER,1",
+                    "INSIGHTFUL,1"
+                ],
+                "frequency": 4
+            },
+            {
+                "min_max_status": {"deputy": [1, 1]},
+                "text": "s_c rounds a corner and stumbles across a tiny island rising from the swamp. Further investigation shows it's dry and lush, and s_c purrs. This reliable prey hunting ground could be important during times of scarcity, and its discovery helps to ease one of the many worries on the deputy's mind.",
+                "exp": 20,
+                "stat_skill": [
+                    "CLEVER,1",
+                    "INSIGHTFUL,1"
+                ],
+                "frequency": 4
+            },
+            {
+                "min_max_status": {"leader": [1, 1]},
+                "text": "s_c rounds a corner and stumbles across a tiny island rising from the swamp. Further investigation shows it's dry and lush, and s_c purrs. This reliable prey hunting ground could be important during times of scarcity, and its discovery helps to ease one of the many worries on the leader's mind.",
+                "exp": 20,
+                "stat_skill": [
+                    "CLEVER,1",
+                    "INSIGHTFUL,1"
                 ],
                 "frequency": 4
             },
@@ -655,77 +675,10 @@
                     "nervous"
                 ],
                 "frequency": 4
-            }
-        ]
-    },
-    {
-        "patrol_id": "wtlnd_train_solo3",
-        "biome": [
-            "wetlands"
-        ],
-        "season": [
-            "any"
-        ],
-        "types": [
-            "training"
-        ],
-        "tags": [],
-        "patrol_art": "train_general_intro",
-        "min_cats": 1,
-        "max_cats": 1,
-                "min_max_status": {
-            "deputy": [
-                1,
-                1
-            ]
-        },
-        "frequency": 2,
-        "intro_text": "r_c heads out into the swamps alone, wanting to explore and have some time to {PRONOUN/r_c/self}.",
-        "decline_text": "r_c turns back to camp, deciding that {PRONOUN/r_c/poss} duties have to come first.",
-        "chance_of_success": 30,
-        "success_outcomes": [
-            {
-                "text": "r_c heads off to map out the paths of solid ground through a boggy area {PRONOUN/r_c/subject}{VERB/r_c/'ve/'s} always found confusing. Hunting, fighting, driving off predators - it all requires knowledge of {PRONOUN/r_c/poss} home turf, and it's always worth making sure {PRONOUN/r_c/poss} mental map is up to date. It feels a little like more work though and isn't exactly the peaceful break {PRONOUN/r_c/subject} hoped for.",
-                "exp": 20,
-                "frequency": 4
             },
             {
-                "text": "r_c rounds a corner and stumbles across a tiny island rising from the swamp. Purring, {PRONOUN/r_c/subject} {VERB/r_c/take/takes} the opportunity for a moment of peace, relaxing and enjoying the view.",
-                "exp": 20,
-                "frequency": 1
-            },
-            {
-                "text": "s_c rounds a corner and stumbles across a tiny island rising from the swamp. Further investigation shows it's dry and lush, and s_c purrs. This reliable prey hunting ground could be important during times of scarcity; there's a relief to the discovery.",
-                "exp": 20,
-                "stat_skill": [
-                    "CLEVER,1"
-                ],
-                "frequency": 4
-            },
-            {
-                "text": "s_c pads confidently through c_n territory. There's a particular peace in exploring {PRONOUN/s_c/poss} beloved home, ears pricked up curiously whenever {PRONOUN/s_c/subject} {VERB/s_c/spot/spots} how the seasons and weather have reshaped it since {PRONOUN/s_c/subject} last passed this way.",
-                "exp": 20,
-                "stat_trait": [
-                    "adventurous",
-                    "bold",
-                    "charismatic",
-                    "childish",
-                    "confident",
-                    "daring",
-                    "playful",
-                    "righteous"
-                ],
-                "frequency": 4
-            }
-        ],
-        "fail_outcomes": [
-            {
-                "text": "r_c gets lost in the territory. Somehow.",
-                "exp": 0,
-                "frequency": 4
-            },
-            {
-                "text": "s_c wavers in their decision. {PRONOUN/s_c/subject/CAP} {VERB/s_c/have/has} so much work to do, so many other things pulling on {PRONOUN/s_c/poss} time. . . No, definitely not. {PRONOUN/s_c/subject/CAP} {VERB/s_c/turn/turns} around and {VERB/s_c/go/goes} straight back to camp.",
+                "min_max_status": {"deputy": [1, 1]},
+                "text": "s_c wavers in their decision. {PRONOUN/s_c/subject/CAP} {VERB/s_c/have/has} so much work to do, so many other things pulling on {PRONOUN/s_c/poss} time... No, definitely not. {PRONOUN/s_c/subject/CAP} {VERB/s_c/turn/turns} around and {VERB/s_c/go/goes} straight back to camp.",
                 "exp": 0,
                 "stat_trait": [
                     "insecure",
@@ -733,77 +686,10 @@
                     "nervous"
                 ],
                 "frequency": 4
-            }
-        ]
-    },
-    {
-        "patrol_id": "wtlnd_train_solo4",
-        "biome": [
-            "wetlands"
-        ],
-        "season": [
-            "any"
-        ],
-        "types": [
-            "training"
-        ],
-        "tags": [],
-        "patrol_art": "train_general_intro",
-        "min_cats": 1,
-        "max_cats": 1,
-        "min_max_status": {
-            "leader": [
-                1,
-                1
-            ]
-        },
-        "frequency": 2,
-        "intro_text": "r_c heads out into the swamps alone, wanting to explore and have some time to {PRONOUN/r_c/self}.",
-        "decline_text": "r_c turns back to camp, deciding that {PRONOUN/r_c/poss} duties have to come first.",
-        "chance_of_success": 30,
-        "success_outcomes": [
-            {
-                "text": "r_c heads off to map out the paths of solid ground through a boggy area {PRONOUN/r_c/subject}{VERB/r_c/'ve/'s} always found confusing. Hunting, fighting, driving off predators - it all requires knowledge of {PRONOUN/r_c/poss} home turf, and it's always worth making sure {PRONOUN/r_c/poss} mental map is up to date. It feels a little like more work though and isn't exactly the peaceful break {PRONOUN/r_c/subject} hoped for.",
-                "exp": 20,
-                "frequency": 4
             },
             {
-                "text": "r_c rounds a corner and stumbles across a tiny island rising from the swamp. Purring, {PRONOUN/r_c/subject} {VERB/r_c/take/takes} the opportunity for a moment of peace, relaxing and enjoying the view.",
-                "exp": 20,
-                "frequency": 1
-            },
-            {
-                "text": "s_c rounds a corner and stumbles across a tiny island rising from the swamp. Further investigation shows it's dry and lush, and s_c purrs. This reliable prey hunting ground could be important during times of scarcity; there's a relief to the discovery.",
-                "exp": 20,
-                "stat_skill": [
-                    "CLEVER,1"
-                ],
-                "frequency": 4
-            },
-            {
-                "text": "s_c pads confidently through c_n territory. There's a particular peace in exploring {PRONOUN/s_c/poss} beloved home, ears pricked up curiously whenever {PRONOUN/s_c/subject} {VERB/s_c/spot/spots} how the seasons and weather have reshaped it since {PRONOUN/s_c/subject} last passed this way.",
-                "exp": 20,
-                "stat_trait": [
-                    "adventurous",
-                    "bold",
-                    "charismatic",
-                    "childish",
-                    "confident",
-                    "daring",
-                    "playful",
-                    "righteous"
-                ],
-                "frequency": 4
-            }
-        ],
-        "fail_outcomes": [
-            {
-                "text": "r_c gets lost in the territory. Somehow.",
-                "exp": 0,
-                "frequency": 4
-            },
-            {
-                "text": "s_c wavers in their decision. {PRONOUN/s_c/subject/CAP} {VERB/s_c/have/has} so much work to do, so many other things pulling on {PRONOUN/s_c/poss} time. . . No, definitely not. {PRONOUN/s_c/subject/CAP} {VERB/s_c/turn/turns} around and {VERB/s_c/go/goes} straight back to camp.",
+                "min_max_status": {"leader": [1, 1]},
+                "text": "s_c wavers in their decision. {PRONOUN/s_c/subject/CAP} {VERB/s_c/have/has} so much work to do, so many other things pulling on {PRONOUN/s_c/poss} time... No, definitely not. {PRONOUN/s_c/subject/CAP} {VERB/s_c/turn/turns} around and {VERB/s_c/go/goes} straight back to camp.",
                 "exp": 0,
                 "stat_trait": [
                     "insecure",


### PR DESCRIPTION
## About The Pull Request

Each training/any file has four solo patrols: app, warrior, deputy, and leader. There are only a couple of differences in outcome for the latter three, so I've combined them using the min max status feature for outcomes.

## Why This Is Good For ClanGen

Less redundancy.

## Proof of Testing

<img width="1030" height="640" alt="image" src="https://github.com/user-attachments/assets/a6cdeb70-24c8-41d0-b7d0-597b5e9cff80" />
Patrol still generating as expected. (the line about "feels like more work" actually used to be unique to leader/deputy patrols, but there's no reason for that to be the case, so I joined it up with the warrior outcomes.)