### PR TITLE
[BUGFIX] app1 tag showing up in med cat patrol text 

### DIFF
--- a/resources/lang/en/patrols/forest/med/newleaf.json
+++ b/resources/lang/en/patrols/forest/med/newleaf.json
@@ -4308,7 +4308,7 @@
         "chance_of_success": 30,
         "success_outcomes": [
             {
-                "text": "The soft, rose-like scent of the mallow bushes drifts around p_l and app1 as they work. They snip off clumps of large, fuzzy, three-nubbed leaves, and the occasional pink flower, to be taken back to camp. The patrol chats as they work, exchanging gossip and news as the smell of cut stems wreathes around them.",
+                "text": "The soft, rose-like scent of the mallow bushes drifts around p_l and the patrol as they work. They snip off clumps of large, fuzzy, three-nubbed leaves, and the occasional pink flower, to be taken back to camp. The patrol chats as they work, exchanging gossip and news as the smell of cut stems wreathes around them.",
                 "exp": 10,
                 "herbs": [
                     "mallow"


### PR DESCRIPTION
## About The Pull Request

Tiny modification to patrol text. The patrol is not intended to be restricted to patrols that contain apps, so I decided it made more sense to edit the app1 mention than to edit the constraints.

## Linked Issues

closes #4272 

## Proof of Testing

<img width="1072" height="768" alt="image" src="https://github.com/user-attachments/assets/d962b271-2ec3-41ab-b992-0ff1c8c2eb19" />
<img width="1089" height="743" alt="image" src="https://github.com/user-attachments/assets/2b58be3b-0f07-4ac8-9583-33bbc7ebc1b3" />
patrol with corrected outcome