### PR TITLE
[CRASHFIX] Logs missing their {}s

### DIFF
--- a/resources/lang/en/events/misc/mountainous.json
+++ b/resources/lang/en/events/misc/mountainous.json
@@ -152,7 +152,7 @@
                         "like"
                     ],
                     "amount": 5,
-                    "log": "r_c gave a gift to m_c that {PRONOUN/m_c/subject} {VERB/m_c/have/has} worn on {PRONOUN/m_c/poss} pelt ever since."
+                    "log": {"cats_from": "r_c gave a gift to m_c that {PRONOUN/m_c/subject} {VERB/m_c/have/has} worn on {PRONOUN/m_c/poss} pelt ever since."}
                 }
             ]
     },

--- a/resources/lang/en/patrols/beach/hunting/any.json
+++ b/resources/lang/en/patrols/beach/hunting/any.json
@@ -6012,7 +6012,7 @@
                         "mutual": false,
                         "values": ["like", "comfort"],
                         "amount": 5,
-                        "log": "to_cat and from_cat reminisced on old funny memories while hunting together."
+                        "log": {"cats_from": "to_cat and from_cat reminisced on old funny memories while hunting together."}
                     }
                 ]
             },
@@ -6427,7 +6427,7 @@
                         "mutual": false,
                         "values": ["like", "comfort"],
                         "amount": 5,
-                        "log": "to_cat and from_cat reminisced on old funny memories while hunting together."
+                        "log": {"cats_from": "to_cat and from_cat reminisced on old funny memories while hunting together."}
                     }
                 ]
             },

--- a/resources/lang/en/patrols/desert/hunting/any.json
+++ b/resources/lang/en/patrols/desert/hunting/any.json
@@ -3859,7 +3859,7 @@
                         "mutual": false,
                         "values": ["like", "comfort"],
                         "amount": 5,
-                        "log": "to_cat and from_cat reminisced on old funny memories while hunting together."
+                        "log": {"cats_from": "to_cat and from_cat reminisced on old funny memories while hunting together."}
                     }
                 ]
             },
@@ -4274,7 +4274,7 @@
                         "mutual": false,
                         "values": ["like", "comfort"],
                         "amount": 5,
-                        "log": "to_cat and from_cat reminisced on old funny memories while hunting together."
+                        "log": {"cats_from": "to_cat and from_cat reminisced on old funny memories while hunting together."}
                     }
                 ]
             },

--- a/resources/lang/en/patrols/forest/hunting/any.json
+++ b/resources/lang/en/patrols/forest/hunting/any.json
@@ -7272,7 +7272,7 @@
                         "mutual": false,
                         "values": ["like", "comfort"],
                         "amount": 5,
-                        "log": "to_cat and from_cat reminisced on old funny memories while hunting together."
+                        "log": {"cats_from": "to_cat and from_cat reminisced on old funny memories while hunting together."}
                     }
                 ]
             },
@@ -7687,7 +7687,7 @@
                         "mutual": false,
                         "values": ["like", "comfort"],
                         "amount": 5,
-                        "log": "to_cat and from_cat reminisced on old funny memories while hunting together."
+                        "log": {"cats_from": "to_cat and from_cat reminisced on old funny memories while hunting together."}
                     }
                 ]
             },

--- a/resources/lang/en/patrols/forest/hunting/greenleaf.json
+++ b/resources/lang/en/patrols/forest/hunting/greenleaf.json
@@ -461,7 +461,7 @@
                         "mutual": false,
                         "values": ["comfort"],
                         "amount": -5,
-                        "log": "from_cat and to_cat avoided each other after a disastrous squirrel hunting patrol."
+                        "log": {"cats_from": "from_cat and to_cat avoided each other after a disastrous squirrel hunting patrol."}
                     }
                 ],
                 "prey": [

--- a/resources/lang/en/patrols/forest/hunting/leaf-bare.json
+++ b/resources/lang/en/patrols/forest/hunting/leaf-bare.json
@@ -1472,7 +1472,9 @@
                         "mutual": false,
                         "values": ["comfort"],
                         "amount": -5,
-                        "log": "from_cat and to_cat avoided each other after a disastrous squirrel hunting patrol."
+                        "log": {
+                            "cats_from": "from_cat and to_cat avoided each other after a disastrous squirrel hunting patrol."
+                        }
                     }
                 ],
                 "prey": [

--- a/resources/lang/en/patrols/forest/hunting/leaf-fall.json
+++ b/resources/lang/en/patrols/forest/hunting/leaf-fall.json
@@ -449,7 +449,7 @@
                         "mutual": false,
                         "values": ["comfort"],
                         "amount": -5,
-                        "log": "from_cat and to_cat avoided each other after a disastrous squirrel hunting patrol."
+                        "log": {"cats_from": "from_cat and to_cat avoided each other after a disastrous squirrel hunting patrol."}
                     }
                 ],
                 "prey": [

--- a/resources/lang/en/patrols/forest/hunting/newleaf.json
+++ b/resources/lang/en/patrols/forest/hunting/newleaf.json
@@ -445,7 +445,7 @@
                         "mutual": false,
                         "values": ["comfort"],
                         "amount": -5,
-                        "log": "from_cat and to_cat avoided each other after a disastrous squirrel hunting patrol."
+                        "log": {"cats_from": "from_cat and to_cat avoided each other after a disastrous squirrel hunting patrol."}
                     }
                 ],
                 "prey": [

--- a/resources/lang/en/patrols/mountainous/hunting/any.json
+++ b/resources/lang/en/patrols/mountainous/hunting/any.json
@@ -3842,7 +3842,7 @@
                         "mutual": false,
                         "values": ["like", "comfort"],
                         "amount": 5,
-                        "log": "to_cat and from_cat reminisced on old funny memories while hunting together."
+                        "log": {"cats_from": "to_cat and from_cat reminisced on old funny memories while hunting together."}
                     }
                 ]
             },
@@ -4257,7 +4257,7 @@
                         "mutual": false,
                         "values": ["like", "comfort"],
                         "amount": 5,
-                        "log": "to_cat and from_cat reminisced on old funny memories while hunting together."
+                        "log": {"cats_from": "to_cat and from_cat reminisced on old funny memories while hunting together."}
                     }
                 ]
             },

--- a/resources/lang/en/patrols/mountainous/hunting/greenleaf.json
+++ b/resources/lang/en/patrols/mountainous/hunting/greenleaf.json
@@ -560,7 +560,7 @@
                         "mutual": false,
                         "values": ["comfort"],
                         "amount": -5,
-                        "log": "from_cat and to_cat avoided each other after a disastrous squirrel hunting patrol."
+                        "log": {"cats_from": "from_cat and to_cat avoided each other after a disastrous squirrel hunting patrol."}
                     }
                 ],
                 "prey": [

--- a/resources/lang/en/patrols/mountainous/hunting/leaf-bare.json
+++ b/resources/lang/en/patrols/mountainous/hunting/leaf-bare.json
@@ -1334,7 +1334,7 @@
                         "mutual": false,
                         "values": ["comfort"],
                         "amount": -5,
-                        "log": "from_cat and to_cat avoided each other after a disastrous squirrel hunting patrol."
+                        "log": {"cats_from": "from_cat and to_cat avoided each other after a disastrous squirrel hunting patrol."}
                     }
                 ],
                 "prey": [

--- a/resources/lang/en/patrols/mountainous/hunting/leaf-fall.json
+++ b/resources/lang/en/patrols/mountainous/hunting/leaf-fall.json
@@ -1199,7 +1199,7 @@
                         "mutual": false,
                         "values": ["comfort"],
                         "amount": -5,
-                        "log": "from_cat and to_cat avoided each other after a disastrous squirrel hunting patrol."
+                        "log": {"cats_from": "from_cat and to_cat avoided each other after a disastrous squirrel hunting patrol."}
                     }
                 ],
                 "prey": [

--- a/resources/lang/en/patrols/mountainous/hunting/newleaf.json
+++ b/resources/lang/en/patrols/mountainous/hunting/newleaf.json
@@ -864,7 +864,7 @@
                         "mutual": false,
                         "values": ["comfort"],
                         "amount": -5,
-                        "log": "from_cat and to_cat avoided each other after a disastrous squirrel hunting patrol."
+                        "log": {"cats_from": "from_cat and to_cat avoided each other after a disastrous squirrel hunting patrol."}
                     }
                 ],
                 "prey": [

--- a/resources/lang/en/patrols/plains/hunting/any.json
+++ b/resources/lang/en/patrols/plains/hunting/any.json
@@ -6956,7 +6956,7 @@
                         "mutual": false,
                         "values": ["like", "comfort"],
                         "amount": 5,
-                        "log": "to_cat and from_cat reminisced on old funny memories while hunting together."
+                        "log": {"cats_from": "to_cat and from_cat reminisced on old funny memories while hunting together."}
                     }
                 ]
             },
@@ -7371,7 +7371,7 @@
                         "mutual": false,
                         "values": ["like", "comfort"],
                         "amount": 5,
-                        "log": "to_cat and from_cat reminisced on old funny memories while hunting together."
+                        "log": {"cats_from": "to_cat and from_cat reminisced on old funny memories while hunting together."}
                     }
                 ]
             },

--- a/resources/lang/en/patrols/wetlands/hunting/any.json
+++ b/resources/lang/en/patrols/wetlands/hunting/any.json
@@ -5660,7 +5660,7 @@
                         "mutual": false,
                         "values": ["like", "comfort"],
                         "amount": 5,
-                        "log": "to_cat and from_cat reminisced on old funny memories while hunting together."
+                        "log": {"cats_from": "to_cat and from_cat reminisced on old funny memories while hunting together."}
                     }
                 ]
             },
@@ -6075,7 +6075,7 @@
                         "mutual": false,
                         "values": ["like", "comfort"],
                         "amount": 5,
-                        "log": "to_cat and from_cat reminisced on old funny memories while hunting together."
+                        "log": {"cats_from": "to_cat and from_cat reminisced on old funny memories while hunting together."}
                     }
                 ]
             },

--- a/resources/lang/en/patrols/wetlands/training/any.json
+++ b/resources/lang/en/patrols/wetlands/training/any.json
@@ -1770,7 +1770,7 @@
                             "trust"
                         ],
                         "amount": 15,
-                        "log": "from_cat and to_cat snuck out of camp to investigate a glow. to_cat told from_cat about how it was a gift from passing spirits."
+                        "log": {"cats_from": "from_cat and to_cat snuck out of camp to investigate a glow. to_cat told from_cat about how it was a gift from passing spirits."}
                     },
                     {
                         "cats_to": [
@@ -1784,7 +1784,7 @@
                             "like", "comfort"
                         ],
                         "amount": 15,
-                        "log": "from_cat and to_cat snuck out of camp to investigate a glow. from_cat told to_cat about how it was a gift from passing spirits."
+                        "log": {"cats_from": "from_cat and to_cat snuck out of camp to investigate a glow. from_cat told to_cat about how it was a gift from passing spirits."}
                     }
                 ],
                 "frequency": 4
@@ -1813,7 +1813,7 @@
                             "trust"
                         ],
                         "amount": 15,
-                        "log": "from_cat and to_cat snuck out of camp to investigate a glow. to_cat told from_cat how StarClan once used it to guide their ancestors."
+                        "log": {"cats_from": "from_cat and to_cat snuck out of camp to investigate a glow. to_cat told from_cat how StarClan once used it to guide their ancestors."}
                     },
                     {
                         "cats_to": [
@@ -1827,7 +1827,7 @@
                             "like", "comfort"
                         ],
                         "amount": 15,
-                        "log": "from_cat and to_cat snuck out of camp to investigate a glow. from_cat told to_cat how StarClan once used it to guide their ancestors."
+                        "log": {"cats_from": "from_cat and to_cat snuck out of camp to investigate a glow. from_cat told to_cat how StarClan once used it to guide their ancestors."}
                     }
                 ],
                 "frequency": 4


### PR DESCRIPTION
## About The Pull Request

So it turns out I misformatted a TON of logs, and they were all causing crashes. So this will fix that

## Proof of Testing

behold a non-crashed game:
<img width="1168" height="982" alt="image" src="https://github.com/user-attachments/assets/8d5d72fd-b2ca-44f0-a191-a25db0bc0128" />
