### PR TITLE
Enhancement: Rename clan attributes name -> uuid and displayname -> name 

### DIFF
--- a/scripts/clan.py
+++ b/scripts/clan.py
@@ -88,6 +88,13 @@ class Clan:
             self.displayname = name
         else:
             self.displayname = displayname
+        
+        # clearer aliases
+        # self.name and self.displayname are preserved for save compatibility
+        # uuid and ui_name are clearer aliases and can be used for internal use
+        self.uuid = self.name
+        self.ui_name = self.displayname
+
         self.leader = leader
         self.leader_lives = 9
         self.leader_predecessors = 0


### PR DESCRIPTION
## About The Pull Request

This PR refactors the clan class attributes to reduce confusion between internal ID and display names

- `Clan.name` is now `uuid`
- `Clan.displayname` is now `name`

## Why This Is Good For ClanGen

This name seperation prevents any accidental bugs when referencing clans in code & displaying them in UI.

## Linked Issues

Fixes #4293

## Proof of Testing

- Game runs on windows without errors after the change.
- The clan creation, display and save\load functions works correctly