### PR TITLE
Americanization - "A Herb"

### DIFF
--- a/resources/lang/en/conditions/risk_strings/injuries_risk_strings.json
+++ b/resources/lang/en/conditions/risk_strings/injuries_risk_strings.json
@@ -52,7 +52,7 @@
     },
     "broken jaw": {
         "an infected wound": [
-            "A meat paste for getting food and water into m_c's stomach, a herb paste to fight the infection growing in {PRONOUN/m_c/poss} broken jaw... r_c wracks {PRONOUN/r_c/poss} brain for anything else that might help {PRONOUN/r_c/poss} patient.",
+            "A meat paste for getting food and water into m_c's stomach, an herb paste to fight the infection growing in {PRONOUN/m_c/poss} broken jaw... r_c wracks {PRONOUN/r_c/poss} brain for anything else that might help {PRONOUN/r_c/poss} patient.",
             "m_c drifts in and out of consciousness as an infection grows in {PRONOUN/m_c/poss} broken jaw."
         ]
     },

--- a/resources/lang/en/conditions/risk_strings/permanent_condition_risk_strings.json
+++ b/resources/lang/en/conditions/risk_strings/permanent_condition_risk_strings.json
@@ -48,7 +48,7 @@
     },
     "lost their tail": {
         "an infected wound": [
-            "r_c drags m_c into the medicine cat den to apply a herbal salve despite m_c's protests - {PRONOUN/r_c/subject}{VERB/r_c/'ve/'s} begun to smell infection in the tail stump.",
+            "r_c drags m_c into the medicine cat den to apply an herbal salve despite m_c's protests - {PRONOUN/r_c/subject}{VERB/r_c/'ve/'s} begun to smell infection in the tail stump.",
             "The stump where m_c's tail used to be has become infected."
         ],
         "phantom pain": [

--- a/resources/lang/en/events/relationship_events/normal_interactions/respect/increase.json
+++ b/resources/lang/en/events/relationship_events/normal_interactions/respect/increase.json
@@ -203,7 +203,7 @@
 		"id": "admire_med_inc_med2",
 		"interactions": [
 			"m_c escorted r_c so {PRONOUN/r_c/subject} could gather herbs.",
-			"m_c thought of r_c on the last patrol and brought a herb back with {PRONOUN/m_c/object}.",
+			"m_c thought of r_c on the last patrol and brought an herb back with {PRONOUN/m_c/object}.",
 			"m_c notices that r_c is trying really hard to be a great medicine cat.",
 			"m_c is suddenly struck by the thought of how much r_c does to keep the Clan healthy.",
 			"m_c thanks r_c for keeping the Clan healthy.",

--- a/resources/lang/en/patrols/beach/med/greenleaf.json
+++ b/resources/lang/en/patrols/beach/med/greenleaf.json
@@ -7906,7 +7906,7 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c was scarred from bramble thorns on a herb gathering patrol.",
+                    "scar": "m_c was scarred from bramble thorns on an herb gathering patrol.",
                     "death": "Bramble thorns scratched up m_c, and the wounds eventually festered and killed {PRONOUN/m_c/object}."
                 },
                 "relationships": [

--- a/resources/lang/en/patrols/beach/med/leaf-fall.json
+++ b/resources/lang/en/patrols/beach/med/leaf-fall.json
@@ -7566,7 +7566,7 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c was scarred from bramble thorns on a herb gathering patrol.",
+                    "scar": "m_c was scarred from bramble thorns on an herb gathering patrol.",
                     "death": "Bramble thorns scratched up m_c, and the wounds eventually festered and killed {PRONOUN/m_c/object}."
                 },
                 "relationships": [

--- a/resources/lang/en/patrols/beach/med/newleaf.json
+++ b/resources/lang/en/patrols/beach/med/newleaf.json
@@ -7604,7 +7604,7 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c was scarred from bramble thorns on a herb gathering patrol.",
+                    "scar": "m_c was scarred from bramble thorns on an herb gathering patrol.",
                     "death": "Bramble thorns scratched up m_c, and the wounds eventually festered and killed {PRONOUN/m_c/object}."
                 },
                 "relationships": [

--- a/resources/lang/en/patrols/desert/med/leaf-bare.json
+++ b/resources/lang/en/patrols/desert/med/leaf-bare.json
@@ -1138,7 +1138,7 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c was scarred from bramble thorns on a herb gathering patrol.",
+                    "scar": "m_c was scarred from bramble thorns on an herb gathering patrol.",
                     "death": "Bramble thorns scratched up m_c, and the wounds eventually festered and killed {PRONOUN/m_c/object}."
                 },
                 "relationships": [

--- a/resources/lang/en/patrols/desert/med/leaf-fall.json
+++ b/resources/lang/en/patrols/desert/med/leaf-fall.json
@@ -1147,7 +1147,7 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c was scarred from bramble thorns on a herb gathering patrol.",
+                    "scar": "m_c was scarred from bramble thorns on an herb gathering patrol.",
                     "death": "Bramble thorns scratched up m_c, and the wounds eventually festered and killed {PRONOUN/m_c/object}."
                 },
                 "relationships": [

--- a/resources/lang/en/patrols/desert/med/newleaf.json
+++ b/resources/lang/en/patrols/desert/med/newleaf.json
@@ -1147,7 +1147,7 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c was scarred from bramble thorns on a herb gathering patrol.",
+                    "scar": "m_c was scarred from bramble thorns on an herb gathering patrol.",
                     "death": "Bramble thorns scratched up m_c, and the wounds eventually festered and killed {PRONOUN/m_c/object}."
                 },
                 "relationships": [

--- a/resources/lang/en/patrols/forest/med/greenleaf.json
+++ b/resources/lang/en/patrols/forest/med/greenleaf.json
@@ -942,7 +942,7 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c was scarred from bramble thorns on a herb gathering patrol.",
+                    "scar": "m_c was scarred from bramble thorns on an herb gathering patrol.",
                     "death": "Bramble thorns scratched up m_c, and the wounds eventually festered and killed {PRONOUN/m_c/object}."
                 },
                 "relationships": [

--- a/resources/lang/en/patrols/forest/med/leaf-fall.json
+++ b/resources/lang/en/patrols/forest/med/leaf-fall.json
@@ -8294,7 +8294,7 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c was scarred from bramble thorns on a herb gathering patrol.",
+                    "scar": "m_c was scarred from bramble thorns on an herb gathering patrol.",
                     "death": "Bramble thorns scratched up m_c, and the wounds eventually festered and killed {PRONOUN/m_c/object}."
                 },
                 "relationships": [

--- a/resources/lang/en/patrols/forest/med/newleaf.json
+++ b/resources/lang/en/patrols/forest/med/newleaf.json
@@ -8452,7 +8452,7 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c was scarred from bramble thorns on a herb gathering patrol.",
+                    "scar": "m_c was scarred from bramble thorns on an herb gathering patrol.",
                     "death": "Bramble thorns scratched up m_c, and the wounds eventually festered and killed {PRONOUN/m_c/object}."
                 },
                 "relationships": [

--- a/resources/lang/en/patrols/general/medcat.json
+++ b/resources/lang/en/patrols/general/medcat.json
@@ -5657,7 +5657,7 @@
                 "frequency": 4
             },
             {
-                "text": "Fine, s_c tells app1. Medicine cats had to work hard to learn the skills they needed - if app1 didn't want to spend moons memorising herbs, trying {PRONOUN/app1/poss} best and making mistakes, then {PRONOUN/app1/subject} should go find an easier role. Walking away from app1, s_c is pleased to hear the apprentice eagerly bounding after {PRONOUN/s_c/object}.",
+                "text": "Fine, s_c tells app1. Medicine cats had to work hard to learn the skills they needed - if app1 didn't want to spend moons memorizing herbs, trying {PRONOUN/app1/poss} best and making mistakes, then {PRONOUN/app1/subject} should go find an easier role. Walking away from app1, s_c is pleased to hear the apprentice eagerly bounding after {PRONOUN/s_c/object}.",
                 "exp": 20,
                 "stat_trait": [
                     "ambitious",

--- a/resources/lang/en/patrols/general/medcat.json
+++ b/resources/lang/en/patrols/general/medcat.json
@@ -5980,7 +5980,7 @@
                 "frequency": 4
             },
             {
-                "text": "s_c suddenly pauses, brightly suggesting a game for them to play - every time they see an herb, p_l had to teach s_c it's uses, and, at the end of the patrol, p_l could give {PRONOUN/s_c/object} a quiz. If s_c got more than half the questions right, {PRONOUN/s_c/subject} {VERB/s_c/win/wins}! Pleased at the opportunity to both impart {PRONOUN/p_l/poss} herbal knowledge and spend time with {PRONOUN/p_l/poss} parent, the patrol seems to fly by all too quickly, with both cats having a great time.",
+                "text": "s_c suddenly pauses, brightly suggesting a game for them to play - every time they see an herb, p_l had to teach s_c its uses, and, at the end of the patrol, p_l could give {PRONOUN/s_c/object} a quiz. If s_c got more than half the questions right, {PRONOUN/s_c/subject} {VERB/s_c/win/wins}! Pleased at the opportunity to both impart {PRONOUN/p_l/poss} herbal knowledge and spend time with {PRONOUN/p_l/poss} parent, the patrol seems to fly by all too quickly, with both cats having a great time.",
                 "exp": 20,
                 "stat_trait": [
                     "childish",

--- a/resources/lang/en/patrols/general/medcat.json
+++ b/resources/lang/en/patrols/general/medcat.json
@@ -5980,7 +5980,7 @@
                 "frequency": 4
             },
             {
-                "text": "s_c suddenly pauses, brightly suggesting a game for them to play - every time they see a herb, p_l had to teach s_c it's uses, and, at the end of the patrol, p_l could give {PRONOUN/s_c/object} a quiz. If s_c got more than half the questions right, {PRONOUN/s_c/subject} {VERB/s_c/win/wins}! Pleased at the opportunity to both impart {PRONOUN/p_l/poss} herbal knowledge and spend time with {PRONOUN/p_l/poss} parent, the patrol seems to fly by all too quickly, with both cats having a great time.",
+                "text": "s_c suddenly pauses, brightly suggesting a game for them to play - every time they see an herb, p_l had to teach s_c it's uses, and, at the end of the patrol, p_l could give {PRONOUN/s_c/object} a quiz. If s_c got more than half the questions right, {PRONOUN/s_c/subject} {VERB/s_c/win/wins}! Pleased at the opportunity to both impart {PRONOUN/p_l/poss} herbal knowledge and spend time with {PRONOUN/p_l/poss} parent, the patrol seems to fly by all too quickly, with both cats having a great time.",
                 "exp": 20,
                 "stat_trait": [
                     "childish",

--- a/resources/lang/en/patrols/mountainous/med/greenleaf.json
+++ b/resources/lang/en/patrols/mountainous/med/greenleaf.json
@@ -5616,7 +5616,7 @@
                 "frequency": 4
             },
             {
-                "text": "Suitable for soothing throat and pelt irritation, and with a welcome - albeit weird - habit of consistently sprouting up on well-trodden paths, plantain is a basic but valuable herb to keep stocks of, and always taught early in the herbal lore each medicine cat must memorise. p_l finds today's harvest growing overshadowed by a big mullein plant, and takes that too.",
+                "text": "Suitable for soothing throat and pelt irritation, and with a welcome - albeit weird - habit of consistently sprouting up on well-trodden paths, plantain is a basic but valuable herb to keep stocks of, and always taught early in the herbal lore each medicine cat must memorize. p_l finds today's harvest growing overshadowed by a big mullein plant, and takes that too.",
                 "exp": 20,
                 "herbs": [
                     "many_herbs",

--- a/resources/lang/en/patrols/mountainous/med/greenleaf.json
+++ b/resources/lang/en/patrols/mountainous/med/greenleaf.json
@@ -8628,7 +8628,7 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c was scarred from bramble thorns on a herb gathering patrol.",
+                    "scar": "m_c was scarred from bramble thorns on an herb gathering patrol.",
                     "death": "Bramble thorns scratched up m_c, and the wounds eventually festered and killed {PRONOUN/m_c/object}."
                 },
                 "relationships": [

--- a/resources/lang/en/patrols/mountainous/med/leaf-fall.json
+++ b/resources/lang/en/patrols/mountainous/med/leaf-fall.json
@@ -8817,7 +8817,7 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c was scarred from bramble thorns on a herb gathering patrol.",
+                    "scar": "m_c was scarred from bramble thorns on an herb gathering patrol.",
                     "death": "Bramble thorns scratched up m_c, and the wounds eventually festered and killed {PRONOUN/m_c/object}."
                 },
                 "relationships": [

--- a/resources/lang/en/patrols/mountainous/med/newleaf.json
+++ b/resources/lang/en/patrols/mountainous/med/newleaf.json
@@ -6824,7 +6824,7 @@
         ],
         "fail_outcomes": [
             {
-                "text": "Try as {PRONOUN/p_l/subject} might, p_l can't quite remember the exact shape of the tansy leaves, and {PRONOUN/p_l/subject} {VERB/p_l/are/is}n't going to harvest from plants {PRONOUN/p_l/subject} {VERB/p_l/have/has}n't confidently identified. Better safe than sorry, as they say. app1 is secretly thankful not to go gathering today, as {PRONOUN/app1/subject} {VERB/app1/don't/doesn't} believe {PRONOUN/app1/subject}{VERB/app1/'re/'s} quite ready to safely gather a herb like tansy.",
+                "text": "Try as {PRONOUN/p_l/subject} might, p_l can't quite remember the exact shape of the tansy leaves, and {PRONOUN/p_l/subject} {VERB/p_l/are/is}n't going to harvest from plants {PRONOUN/p_l/subject} {VERB/p_l/have/has}n't confidently identified. Better safe than sorry, as they say. app1 is secretly thankful not to go gathering today, as {PRONOUN/app1/subject} {VERB/app1/don't/doesn't} believe {PRONOUN/app1/subject}{VERB/app1/'re/'s} quite ready to safely gather an herb like tansy.",
                 "exp": 0,
                 "relationships": [
                     {
@@ -8685,7 +8685,7 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c was scarred from bramble thorns on a herb gathering patrol.",
+                    "scar": "m_c was scarred from bramble thorns on an herb gathering patrol.",
                     "death": "Bramble thorns scratched up m_c, and the wounds eventually festered and killed {PRONOUN/m_c/object}."
                 },
                 "relationships": [

--- a/resources/lang/en/patrols/plains/med/greenleaf.json
+++ b/resources/lang/en/patrols/plains/med/greenleaf.json
@@ -9142,7 +9142,7 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c was scarred from bramble thorns on a herb gathering patrol.",
+                    "scar": "m_c was scarred from bramble thorns on an herb gathering patrol.",
                     "death": "Bramble thorns scratched up m_c, and the wounds eventually festered and killed {PRONOUN/m_c/object}."
                 },
                 "relationships": [

--- a/resources/lang/en/patrols/plains/med/leaf-fall.json
+++ b/resources/lang/en/patrols/plains/med/leaf-fall.json
@@ -8555,7 +8555,7 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c was scarred from bramble thorns on a herb gathering patrol.",
+                    "scar": "m_c was scarred from bramble thorns on an herb gathering patrol.",
                     "death": "Bramble thorns scratched up m_c, and the wounds eventually festered and killed {PRONOUN/m_c/object}."
                 },
                 "relationships": [

--- a/resources/lang/en/patrols/plains/med/newleaf.json
+++ b/resources/lang/en/patrols/plains/med/newleaf.json
@@ -8694,7 +8694,7 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c was scarred from bramble thorns on a herb gathering patrol.",
+                    "scar": "m_c was scarred from bramble thorns on an herb gathering patrol.",
                     "death": "Bramble thorns scratched up m_c, and the wounds eventually festered and killed {PRONOUN/m_c/object}."
                 },
                 "relationships": [

--- a/resources/lang/en/patrols/wetlands/med/greenleaf.json
+++ b/resources/lang/en/patrols/wetlands/med/greenleaf.json
@@ -1001,7 +1001,7 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c was scarred from bramble thorns on a herb gathering patrol.",
+                    "scar": "m_c was scarred from bramble thorns on an herb gathering patrol.",
                     "death": "Bramble thorns scratched up m_c, and the wounds eventually festered and killed {PRONOUN/m_c/object}."
                 },
                 "relationships": [

--- a/resources/lang/en/patrols/wetlands/med/leaf-fall.json
+++ b/resources/lang/en/patrols/wetlands/med/leaf-fall.json
@@ -988,7 +988,7 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c was scarred from bramble thorns on a herb gathering patrol.",
+                    "scar": "m_c was scarred from bramble thorns on an herb gathering patrol.",
                     "death": "Bramble thorns scratched up m_c, and the wounds eventually festered and killed {PRONOUN/m_c/object}."
                 },
                 "relationships": [

--- a/resources/lang/en/patrols/wetlands/med/newleaf.json
+++ b/resources/lang/en/patrols/wetlands/med/newleaf.json
@@ -1001,7 +1001,7 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c was scarred from bramble thorns on a herb gathering patrol.",
+                    "scar": "m_c was scarred from bramble thorns on an herb gathering patrol.",
                     "death": "Bramble thorns scratched up m_c, and the wounds eventually festered and killed {PRONOUN/m_c/object}."
                 },
                 "relationships": [

--- a/resources/lang/en/screens/med_den_messages.json
+++ b/resources/lang/en/screens/med_den_messages.json
@@ -6,7 +6,7 @@
             "m_c couldn't even treat a thorn in a paw with so little supplies. The herb stores need replenishing.",
             "Seeing the empty herb stores makes m_c shiver slightly and puff out {PRONOUN/m_c/poss} fur.",
             "Without any herbs m_c feels helpless.",
-            "c_n needs a herb gathering patrol <i>yesterday</i>, the herb stores are entirely empty and m_c feels like {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} going to vibrate out of {PRONOUN/m_c/poss} skin."
+            "c_n needs an herb gathering patrol <i>yesterday</i>, the herb stores are entirely empty and m_c feels like {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} going to vibrate out of {PRONOUN/m_c/poss} skin."
         ],
         "low": [
             "m_c worries over the herb stores, there isn't nearly enough for the whole Clan.",
@@ -29,7 +29,7 @@
             "Though the supply is decent, m_c knows there aren't enough herbs to face an outbreak if one occurs.",
             "The herb stores aren't critically low, but m_c would feel safer if {PRONOUN/m_c/subject} had a little more.",
             "The herb stores could be better stocked. Could be worse though, this isn't too bad.",
-            "Hmm. Time to go on a herb gathering patrol, m_c thinks. A pawful of prevention is worth a cat's weight of cure.",
+            "Hmm. Time to go on an herb gathering patrol, m_c thinks. A pawful of prevention is worth a cat's weight of cure.",
             "As m_c mentally reviews the day's tasks, {PRONOUN/m_c/subject} {VERB/m_c/put/puts} herb gathering on the list, though it's not the most important.",
             "Maybe m_c should search for some of the rarer herbs, just to round out c_n's supplies fully."
         ],

--- a/scripts/clan_resources/herb/herb_supply.py
+++ b/scripts/clan_resources/herb/herb_supply.py
@@ -499,7 +499,7 @@ class HerbSupply:
             ):
                 continue
 
-            # chance to find a herb is based on it's rarity
+            # chance to find an herb is based on it's rarity
             if (
                 randint(
                     1,

--- a/scripts/events_module/short/short_event.py
+++ b/scripts/events_module/short/short_event.py
@@ -344,7 +344,7 @@ class ShortEvent:
                     self.types.append("misc")
                 if block["type"] == "freshkill":
                     self.handle_freshkill_supply(block)
-                else:  # if freshkill isn't being adjusted, then it must be a herb supply
+                else:  # if freshkill isn't being adjusted, then it must be an herb supply
                     self.handle_herb_supply(block)
 
         # adjust text again to account for info that wasn't available when we do rel changes

--- a/scripts/events_module/short/short_event_generation.py
+++ b/scripts/events_module/short/short_event_generation.py
@@ -497,7 +497,7 @@ def filter_events(
                     else:
                         discard = False
 
-                else:  # if supply type wasn't freshkill, then it must be a herb type
+                else:  # if supply type wasn't freshkill, then it must be an herb type
                     if not event_for_herb_supply(trigger, supply_type, clan_size):
                         discard = True
                         break


### PR DESCRIPTION
## About The Pull Request

I noticed that there was a lot of both "an herb" and "a herb." Turns out "an herb" is the american version, so I've regularized it across all files.

## Why This Is Good For ClanGen

Just the usual. Making it consistent and American.

## Proof of Testing

<img width="1145" height="1005" alt="image" src="https://github.com/user-attachments/assets/4e65a51d-98f1-466e-8eba-04a4d3cd13cd" />
i didn't bork anything