### PR TITLE
[BUGFIX] Rel log pronouns

### DIFF
--- a/scripts/events_module/text_adjust.py
+++ b/scripts/events_module/text_adjust.py
@@ -49,6 +49,12 @@ def pronoun_repl(m, cat_pronouns_dict, raise_exception=False):
     inner_details = m.group(1).split("/")
     out = None
 
+    # if the cat that the pronoun is assigned to wasn't passed with the dict, then we just return
+    # it's assumed that the text is going to be processed at some other point with that cat's info
+    # (for example, this is required for rel log processing to be done correctly)
+    if inner_details[1] not in cat_pronouns_dict:
+        return m.group(0)
+
     try:
         if inner_details[1].upper() == "PLURAL":
             inner_details.pop(1)  # remove plural tag so it can be processed as normal

--- a/scripts/events_module/text_adjust.py
+++ b/scripts/events_module/text_adjust.py
@@ -52,7 +52,7 @@ def pronoun_repl(m, cat_pronouns_dict, raise_exception=False):
     # if the cat that the pronoun is assigned to wasn't passed with the dict, then we just return
     # it's assumed that the text is going to be processed at some other point with that cat's info
     # (for example, this is required for rel log processing to be done correctly)
-    if inner_details[1] not in cat_pronouns_dict:
+    if inner_details[1] != "PLURAL" and inner_details[1] not in cat_pronouns_dict:
         return m.group(0)
 
     try:


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
This fixes the pesky from_cat and to_cat pronoun defaulting. What was happening was that the first round of text adjust was getting confused at the presence of pronoun tags that didn't come with a matching replace_dict entry.

I've added a catch to the pronoun replacement func that returns if the pronoun tag is for a cat that isn't included in the replacement dict.  This does mean that if we have any spots in our text where a pronoun is tagged in an unhandled way, then it won't smoothly default to pronouns. However, I think that if that's happening, I'd rather it be obvious so that we can fix it.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Proof of Testing
<img width="482" height="114" alt="image" src="https://github.com/user-attachments/assets/565a56cf-ab6f-4707-bd56-047a5c018228" />

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Rel logs now include the correct pronouns for mentioned cats
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
