### PR TITLE
[BUGFIX] snippet lists with no biome

### DIFF
--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -2741,6 +2741,8 @@ class Cat:
             if not os.path.exists(relation_cat_directory):
                 self.init_all_relationships()
                 for cat in Cat.all_cats.values():
+                    if cat == self:
+                        continue
                     cat.create_one_relationship(self)
                 return
             try:

--- a/scripts/events_module/text_adjust.py
+++ b/scripts/events_module/text_adjust.py
@@ -169,9 +169,14 @@ def get_special_snippet_list(
     (i.e. ["hate", "fear", "dread"] becomes "hate, fear, and dread") - Default is True
     :return: a list of the chosen items from chosen_list or a formatted string if format is True
     """
-    biome = (
-        game.clan.biome if not game.clan.override_biome else game.clan.override_biome
-    ).casefold()
+    if not game.clan:
+        biome = None
+    else:
+        biome = (
+            game.clan.biome
+            if not game.clan.override_biome
+            else game.clan.override_biome
+        ).casefold()
     global SNIPPETS
     if langs["snippet"] != i18n.config.get("locale"):
         langs["snippet"] = i18n.config.get("locale")
@@ -183,7 +188,8 @@ def get_special_snippet_list(
             chosen_list == "story_list"
         ):  # story list has some biome specific things to collect
             snippets = SNIPPETS[chosen_list]["general"]
-            snippets.extend(SNIPPETS[chosen_list][biome])
+            if biome:
+                snippets.extend(SNIPPETS[chosen_list][biome])
         elif (
             chosen_list == "clair_list"
         ):  # the clair list also pulls from the dream list
@@ -205,7 +211,8 @@ def get_special_snippet_list(
         for sense in sense_groups:
             snippet_group = SNIPPETS[chosen_list][sense]
             snippets.extend(snippet_group["general"])
-            snippets.extend(snippet_group[biome])
+            if biome:
+                snippets.extend(snippet_group[biome])
 
     # now choose a unique snippet from each snip list
     unique_snippets = []


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
Some of our thoughts newly utilize the snippet lists! Unfortunately the snippet list func wants a biome, and when the game loads it loads cats and assigns their thoughts before the clan is loaded (thus there is no biome). This caused the save to fail.  I solved this by just preventing the use of biome-specific snippets if no biome is provided.

Also made a little adjustment to relationship creation on load! When no rel info is provided, new relationships are created with all the cats in the clan. This would cause a little warning message to pop up bc there was no check to skip over creating a relationship with yourself. So I added that check.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
This bug was reported on the discord.
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
<img width="648" height="164" alt="image" src="https://github.com/user-attachments/assets/5ea0cf64-0ada-40b2-a389-67ae0ee48e8a" />

Kittycat loaded with a thought that required a snippet list! 
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Thoughts that require snippet lists no longer break the save load process
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
