### PR TITLE
[BUGFIX] No Possible Outcomes

### DIFF
--- a/resources/lang/en/patrols/forest/hunting/any.json
+++ b/resources/lang/en/patrols/forest/hunting/any.json
@@ -5924,6 +5924,40 @@
         "chance_of_success": 70,
         "success_outcomes": [
             {
+                "text": "A gray fox is bigger than them, yes... but only just, and that carcass smells divine. The cats creep up on the fox, using the bushes for cover, and wait until the fox has its head buried in the carcass to attack. The ambush sends the competing predator fleeing and leaves the cats to claim the fawn.",
+                "exp": 20,
+                "prey": [
+                    "large"
+                ],
+                "relationships": [
+                    {
+                        "cats_to": [
+                            "patrol"
+                        ],
+                        "cats_from": [
+                            "patrol"
+                        ],
+                        "mutual": false,
+                        "values": ["trust"],
+                        "amount": 5,
+                        "log": {
+                            "cats_from": "to_cat and from_cat drove off a scavenging fox together."
+                        }
+                    },
+                    {
+                        "cats_to": ["patrol"],
+                        "cats_from": ["some_clan"],
+                        "mutual": false,
+                        "values": ["respect"],
+                        "amount": 5,
+                        "log": {
+                            "cats_from": "from_cat heard about how to_cat's patrol drove off a scavenging fox."
+                        }
+                    }
+                ],
+                "frequency": 1
+            },
+            {
                 "min_max_status": {
                     "normal adult": [2, 3]
                 },

--- a/resources/lang/en/patrols/forest/hunting/any.json
+++ b/resources/lang/en/patrols/forest/hunting/any.json
@@ -3354,6 +3354,14 @@
                         }
                     }
                 ]
+            },
+            {
+                "text": "r_c is caught in a trap hidden in the sand and taken by Twolegs shortly after.",
+                "exp": 0,
+                "lost_cats": [
+                    "r_c"
+                ],
+                "frequency": 3
             }
         ],
         "fail_outcomes": [

--- a/resources/lang/en/patrols/forest/hunting/any.json
+++ b/resources/lang/en/patrols/forest/hunting/any.json
@@ -3354,14 +3354,6 @@
                         }
                     }
                 ]
-            },
-            {
-                "text": "r_c is caught in a trap hidden in the sand and taken by Twolegs shortly after.",
-                "exp": 0,
-                "lost_cats": [
-                    "r_c"
-                ],
-                "frequency": 3
             }
         ],
         "fail_outcomes": [
@@ -3376,6 +3368,14 @@
                     "playful"
                 ],
                 "frequency": 4
+            },
+            {
+                "text": "r_c is caught in a trap hidden in the sand and taken by Twolegs shortly after.",
+                "exp": 0,
+                "lost_cats": [
+                    "r_c"
+                ],
+                "frequency": 3
             }
         ]
     },


### PR DESCRIPTION
## About The Pull Request

Two bugs I reported relating to patrols that had no possible outcomes. Chinch Bug did me a favour and found the problem. For some reason, these two forest patrols were missing outcomes that other biomes' versions contained, so I've added those back in.

## Linked Issues

Fixes #4327 
Fixes #4273 

## Proof of Testing

<img width="1022" height="780" alt="image" src="https://github.com/user-attachments/assets/f7f0c41e-828e-4168-86b6-022119e839c5" />

Patrol generating with 4 cats (With the new success outcome)