### PR TITLE
[BUGFIX] Apprentice odds for "very old med" will never trigger

### DIFF
--- a/scripts/events.py
+++ b/scripts/events.py
@@ -1302,18 +1302,18 @@ def perform_ceremonies(cat):
 
                 # assign chance to become med app depending on current med cat and traits
                 chance = constants.CONFIG["roles"]["base_medicine_app_chance"]
-                if has_elder_med == med_cat_list:
+                if very_old_med == med_cat_list:
+                    # These chances apply if all the current medicine cats are very old.
+                    if has_med:
+                        chance = int(chance / 3)
+                    else:
+                        chance = int(chance / 14)
+                elif has_elder_med == med_cat_list:
                     # These chances apply if all the current medicine cats are elders.
                     if has_med:
                         chance = int(chance / 2.22)
                     else:
                         chance = int(chance / 13.67)
-                elif very_old_med == med_cat_list:
-                    # These chances apply is all the current medicine cats are very old.
-                    if has_med:
-                        chance = int(chance / 3)
-                    else:
-                        chance = int(chance / 14)
                 # These chances will only be reached if the
                 # Clan has at least one non-elder medicine cat.
                 elif not has_med:


### PR DESCRIPTION

## About The Pull Request
Switches the very old med conditonal with the senior med conditional, giving higher chance for a med apprentice if all med cats are over 150 moons as intended.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

<!-- If you have multiple features that can stand on their own, or unrelated bugfixes, please create separate PRs for them. -->

## Linked Issues
Fixes #4198

## Proof of Testing
<img width="1419" height="296" alt="image" src="https://github.com/user-attachments/assets/766c303c-2c09-4ff4-871f-c8128ccfa2c8" />
<img width="777" height="402" alt="image" src="https://github.com/user-attachments/assets/50acf4d8-4dc9-4c84-a741-62e47b23ed0a" />

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

