### PR TITLE
[ENHANCEMENT] Reestablish functionality for 'scars' block in events by adding potential_scars to Injury

### DIFF
--- a/docs/dev/writing/patrols.md
+++ b/docs/dev/writing/patrols.md
@@ -726,7 +726,7 @@ What each parameter does, and what the options are for outcomes.
 ***
 
 #### injury: List[Dict[str, various]]
->Optional. Indicates which cats get injured, and how. In classic mode, there are no conditions, so you can include a "scars" line to scar the cat instead. You can include as many of the following blocks (in a list) as you want. 
+>Optional. Indicates which cats get injured, and how. You can include as many of the following blocks (in a list) as you want. 
 >
 >```json
 >{
@@ -758,7 +758,7 @@ What each parameter does, and what the options are for outcomes.
 >The above list includes both singular injuries and injury pools.  Adding an injury pool will allow for any of the injuries within that pool to be possible.  One will be chosen at random.  You don't have to pick just one injury or injury pool, you can include as many as you like!
 
 >**scars: List[str]:** 
->Optional. If in classic mode, a scar is chosen from this pool to be given instead of an injury.  If in expanded mode, a scar is chosen from this pool to possibly be given upon healing their injury.
+>Optional. This replaces the standard scar pool for the given injury.
 >
 >[Scar List](reference/tag-lists.md#__tabbed_1_5)
 

--- a/docs/dev/writing/shortevents.md
+++ b/docs/dev/writing/shortevents.md
@@ -343,7 +343,7 @@ lowercase season names + "any"
 ***
 
 ### injury:list[dict[str, various]]
->Optional. Indicates which cats get injured, and how. In classic mode, there are no conditions, so you can include a "scars" line to scar the cat instead. You can include as many of the blocks as you like within the list. 
+>Optional. Indicates which cats get injured, and how. You can include as many of the blocks as you like within the list. 
 >
 >```json
 >    {
@@ -370,7 +370,7 @@ lowercase season names + "any"
 >The above list includes both singular injuries and injury pools.  Adding an injury pool will allow for any of the injuries within that pool to be possible.  One will be chosen at random.  You don't have to pick just one injury or injury pool, you can include as many as you like!
 
 >**scars: List[str]:** 
->Optional. A scar is chosen from this pool to possibly be given upon healing their injury.
+>Optional. This replaces the standard scar pool for the given injury.
 >
 >[Scar List](reference/tag-lists.md#__tabbed_1_5)
 

--- a/resources/lang/en/events/injury/desert.json
+++ b/resources/lang/en/events/injury/desert.json
@@ -1178,7 +1178,7 @@
                 "injuries": [
                     "small cut"
                 ],
-                "scar": [
+                "scars": [
                     "QUILLSIDE"
                 ]
             },

--- a/resources/lang/en/events/injury/general.json
+++ b/resources/lang/en/events/injury/general.json
@@ -826,7 +826,7 @@
                 "injuries": [
                     "claw-wound"
                 ],
-                "scar": [
+                "scars": [
                     "TWO"
                 ]
             }
@@ -935,7 +935,7 @@
                 "injuries": [
                     "bite-wound"
                 ],
-                "scar": [
+                "scars": [
                     "LEGBITE"
                 ]
             }

--- a/resources/lang/en/patrols/other_clan.json
+++ b/resources/lang/en/patrols/other_clan.json
@@ -4128,7 +4128,7 @@
                         "injuries": [
                             "small_bite_injury"
                         ],
-                        "scar": [
+                        "scars": [
                             "LEGBITE"
                         ]
                     }
@@ -4184,7 +4184,7 @@
                         "injuries": [
                             "battle_injury"
                         ],
-                        "scar": [
+                        "scars": [
                             "NECKBITE",
                             "SNOUT"
                         ]

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -1904,7 +1904,7 @@ class Cat:
                 "event_triggered": new_illness.new,
             }
 
-    def get_injured(self, name, event_triggered=False, lethal=True, severity="default"):
+    def get_injured(self, name, event_triggered=False, lethal=True, potential_scars=None, severity="default"):
         """Add an injury to this cat.
 
         :param name: The injury to add
@@ -1913,6 +1913,8 @@ class Cat:
         :type event_triggered: bool, optional
         :param lethal: _description_, defaults to True
         :type lethal: bool, optional
+        :param potential_scars: List of possible scars to get upon healing, defaults to None
+        :type potential_scars: array, optional
         :param severity: _description_, defaults to 'default'
         :type severity: str, optional
         """
@@ -1962,6 +1964,7 @@ class Cat:
             also_got=injury["also_got"],
             cause_permanent=injury["cause_permanent"],
             event_triggered=event_triggered,
+            potential_scars=potential_scars,
         )
 
         if new_injury.name not in self.injuries:
@@ -1975,6 +1978,7 @@ class Cat:
                 "complication": None,
                 "cause_permanent": new_injury.cause_permanent,
                 "event_triggered": new_injury.new,
+                "potential_scars": new_injury.potential_scars,
             }
 
         if len(new_injury.also_got) > 0 and not int(random() * 5):

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -1904,7 +1904,14 @@ class Cat:
                 "event_triggered": new_illness.new,
             }
 
-    def get_injured(self, name, event_triggered=False, lethal=True, potential_scars=None, severity="default"):
+    def get_injured(
+        self,
+        name,
+        event_triggered=False,
+        lethal=True,
+        potential_scars=None,
+        severity="default",
+    ):
         """Add an injury to this cat.
 
         :param name: The injury to add

--- a/scripts/conditions.py
+++ b/scripts/conditions.py
@@ -184,6 +184,7 @@ class Injury:
         cause_permanent=None,
         herbs=None,
         event_triggered=False,
+        potential_scars=None,
     ):
         self.name = name
         self.severity = severity
@@ -196,6 +197,7 @@ class Injury:
         self.cause_permanent = cause_permanent
         self.herbs = herbs if herbs else []
         self.new = event_triggered
+        self.potential_scars = potential_scars
 
         self.current_duration = duration
         self.current_mortality = mortality

--- a/scripts/events_module/patrol/patrol_outcome.py
+++ b/scripts/events_module/patrol/patrol_outcome.py
@@ -641,7 +641,7 @@ class PatrolOutcome:
                     give_injury = choice(possible_injuries)
 
                 if give_injury in INJURIES:
-                    _cat.get_injured(give_injury, lethal=lethal)
+                    _cat.get_injured(give_injury, lethal=lethal, potential_scars=scars)
                 elif give_injury in ILLNESSES:
                     _cat.get_ill(give_injury, lethal=lethal)
                 elif give_injury in PERMANENT:

--- a/scripts/events_module/short/scar_events.py
+++ b/scripts/events_module/short/scar_events.py
@@ -86,9 +86,11 @@ class Scar_Events:
         """
         This function handles the scars
         """
+        # Scars specified in event override standard scar pool
+        scar_pool = cat.injuries[injury_name]["potential_scars"]
 
-        # If the injury can't give a scar, move return None, None
-        if injury_name not in Scar_Events.scar_allowed:
+        # If the injury can't give a scar, return None, None
+        if not scar_pool and injury_name not in Scar_Events.scar_allowed:
             return None, None
 
         moons_with = game.clan.age - cat.injuries[injury_name]["moon_start"]
@@ -101,13 +103,12 @@ class Scar_Events:
             chance += 2
 
         if len(cat.pelt.scars) < 4 and not int(random.random() * chance):
-            # move potential scar text into displayed scar text
-
-            scar_pool = [
-                i
-                for i in Scar_Events.scar_allowed[injury_name]
-                if i not in cat.pelt.scars
-            ]
+            if not scar_pool:
+                scar_pool = [
+                    i
+                    for i in Scar_Events.scar_allowed[injury_name]
+                    if i not in cat.pelt.scars
+                ]
             if "NOPAW" in cat.pelt.scars:
                 scar_pool = [
                     i for i in scar_pool if i not in ("TOETRAP", "RATBITE", "FROSTSOCK")

--- a/scripts/events_module/short/short_event.py
+++ b/scripts/events_module/short/short_event.py
@@ -792,7 +792,9 @@ class ShortEvent:
                 elif "n_c" in abbr:
                     for i, new_cat_objects in enumerate(self.new_cats):
                         injury = choice(possible_injuries)
-                        new_cat_objects[i].get_injured(injury, potential_scars=potential_scars)
+                        new_cat_objects[i].get_injured(
+                            injury, potential_scars=potential_scars
+                        )
                         self.handle_injury_history(new_cat_objects[i], abbr, injury)
 
     def handle_injury_history(self, cat, cat_abbr, injury=None):

--- a/scripts/events_module/short/short_event.py
+++ b/scripts/events_module/short/short_event.py
@@ -751,8 +751,7 @@ class ShortEvent:
 
     def handle_injury(self):
         """
-        assigns an injury to involved cats and then assigns possible histories (if in classic, assigns scar and scar
-        history)
+        assigns an injury to involved cats and then assigns possible histories
         """
 
         # if no injury block, then no injury gets assigned
@@ -765,6 +764,7 @@ class ShortEvent:
         # now go through each injury block
         for block in self.injury:
             cats_affected = block["cats"]
+            potential_scars = block["scars"]
 
             # find all possible injuries
             possible_injuries = []
@@ -779,20 +779,20 @@ class ShortEvent:
                 # MAIN CAT
                 if abbr == "m_c":
                     injury = choice(possible_injuries)
-                    self.main_cat.get_injured(injury)
+                    self.main_cat.get_injured(injury, potential_scars=potential_scars)
                     self.handle_injury_history(self.main_cat, "m_c", injury)
 
                 # RANDOM CAT
                 elif abbr == "r_c":
                     injury = choice(possible_injuries)
-                    self.random_cat.get_injured(injury)
+                    self.random_cat.get_injured(injury, potential_scars=potential_scars)
                     self.handle_injury_history(self.random_cat, "r_c", injury)
 
                 # NEW CATS
                 elif "n_c" in abbr:
                     for i, new_cat_objects in enumerate(self.new_cats):
                         injury = choice(possible_injuries)
-                        new_cat_objects[i].get_injured(injury)
+                        new_cat_objects[i].get_injured(injury, potential_scars=potential_scars)
                         self.handle_injury_history(new_cat_objects[i], abbr, injury)
 
     def handle_injury_history(self, cat, cat_abbr, injury=None):

--- a/scripts/events_module/short/short_event.py
+++ b/scripts/events_module/short/short_event.py
@@ -764,7 +764,7 @@ class ShortEvent:
         # now go through each injury block
         for block in self.injury:
             cats_affected = block["cats"]
-            potential_scars = block["scars"]
+            potential_scars = block.get("scars", ())
 
             # find all possible injuries
             possible_injuries = []


### PR DESCRIPTION

## About The Pull Request
The 'scars' block of events and patrols is now saved as a potential_scars list in the Injury instance, allowing writers to override the standard scar pool for that injury. This also allows to scar for injuries that would not normally permit it.

## Why This Is Good For ClanGen
Since the condition system was added to Classic mode, the 'scars' block has no actual use.
This was supposedly intended behaviour that was never added.

## Linked Issues
Closes #3971 

## Proof of Testing
Patrol injury:

<img width="450" height="392" alt="Zrzut ekranu 2026-02-05 155150" src="https://github.com/user-attachments/assets/eec3d8be-13d9-446c-a52c-8d1023a894c3" />
<img width="450" height="351" alt="Zrzut ekranu 2026-02-05 155318" src="https://github.com/user-attachments/assets/a3cc5154-a559-41e9-8df4-7702021bb66a" />
<img width="450" height="142" alt="Zrzut ekranu 2026-02-05 155255" src="https://github.com/user-attachments/assets/890f7664-c336-4311-a45a-8dfdeba91d96" />

Event injury:

<img width="450" height="514" alt="Zrzut ekranu 2026-02-05 160715" src="https://github.com/user-attachments/assets/148c35f9-d1c3-452f-a6b5-c63d54675771" />
<img width="450" height="154" alt="Zrzut ekranu 2026-02-05 160646" src="https://github.com/user-attachments/assets/67b8a73c-e90d-412f-a7eb-2f26a8ad44d1" />
<img width="450" height="380" alt="Zrzut ekranu 2026-02-05 160705" src="https://github.com/user-attachments/assets/8527c6b8-7004-49a0-b33b-6e823bd00b25" />

_**Note that while testing a given scar may not appear on cat sprite until reload due to #4075.**_