### PR TITLE
[BUGFIX] skill test failure

### DIFF
--- a/tests/test_group_interaction.py
+++ b/tests/test_group_interaction.py
@@ -125,6 +125,7 @@ class MainCatFiltering(unittest.TestCase):
         group_events = GroupEvents()
         main_cat = Cat(moons=40)
         main_cat.skills.primary = Skill(SkillPath.HUNTER, points=9)
+        main_cat.skills.secondary = Skill(SkillPath.SWIMMER, points=9)
         group_events.abbreviations_cat_id = {"m_c": main_cat.ID}
 
         interaction1 = GroupInteraction("1")
@@ -138,6 +139,9 @@ class MainCatFiltering(unittest.TestCase):
         filtered_interactions = group_events.get_main_cat_interactions(
             all_interactions, {"m_c": main_cat.ID}
         )
+
+        if len(filtered_interactions) == 2:
+            pass
 
         # then
         self.assertNotEqual(len(filtered_interactions), len(all_interactions))

--- a/tests/test_group_interaction.py
+++ b/tests/test_group_interaction.py
@@ -140,9 +140,6 @@ class MainCatFiltering(unittest.TestCase):
             all_interactions, {"m_c": main_cat.ID}
         )
 
-        if len(filtered_interactions) == 2:
-            pass
-
         # then
         self.assertNotEqual(len(filtered_interactions), len(all_interactions))
         self.assertIn(interaction1, filtered_interactions)


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
So the reason this test would fail once in a blue moon is bc sometimes the main_cat would randomly be assigned the HUNTER skill as their secondary, leading to inconsistent results. I've prevented this by assigning a specific secondary skill.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Proof of Testing
<img width="631" height="270" alt="image" src="https://github.com/user-attachments/assets/4f765054-4c21-4af4-a9cc-c197a55c39ec" />

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- `test_main_cat_skill_one` should no longer fail out of the blue
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
