### PR TITLE
[ENHANCEMENT] Relationship debug command and debug console QOL

### DIFF
--- a/resources/theme/master_screen_scale.json
+++ b/resources/theme/master_screen_scale.json
@@ -580,20 +580,60 @@
             "border_width": "3",
             "shadow_width": "0",
             "enable_title_bar": "1",
-            "enable_close_button": "0"
+            "enable_close_button": "1"
         },
         "colours": {"normal_border": "#2F2918", "dark_bg": "#AC9D72"}
     },
     "window.#title_bar": {
         "colours": {
             "normal_text": "#EFE5CE",
+            "hovered_text": "#EFE5CE",
+            "normal_border": "#2F2918", 
+            "dark_bg": "#AC9D72"
+        },
+        "misc":
+        {
+            "shape": "rounded_rectangle",
+            "shape_corner_radius": "8,0,0,0",
+            "shadow_width": "0",
+            "border_width": "1",
+            "text_horiz_alignment": "center",
+            "text_horiz_alignment_padding": "5"
+        }
+    },
+    "window.#close_button": {
+        "prototype": "window.#title_bar",
+        "misc":
+        {
+            "shape_corner_radius": "0,8,0,0"
+        }
+    },
+    "window.#title_button": {
+        "prototype": "window.#close_button",
+        "misc":
+        {
+            "shape": "rectangle"
+        }
+    },
+    "window.#command_line": {
+        "prototype": "text_entry_line",
+        "misc": {
+            "shape": "rounded_rectangle",
+            "shape_corner_radius": "6,0,6,0",
+            "shadow_width": "0",
+            "padding": "(0,0)"
+        }
+    },
+    "window.#submit_command": {
+        "colours": {
+            "normal_text": "#EFE5CE",
             "hovered_text": "#EFE5CE"
         },
         "misc":
         {
-            "shape": "rectangle",
+            "shape": "rounded_rectangle",
+            "shape_corner_radius": "0,6,0,6",
             "shadow_width": "0",
-            "border_width": "1",
             "text_horiz_alignment": "center",
             "text_horiz_alignment_padding": "5"
         }

--- a/scripts/debug_commands/__init__.py
+++ b/scripts/debug_commands/__init__.py
@@ -2,16 +2,13 @@ from typing import List
 
 from scripts.debug_commands.cat import CatsCommand
 from scripts.debug_commands.cat_pregnancy import PregnanciesCommand
+from scripts.debug_commands.cat_relationship import RelationshipsCommand
 from scripts.debug_commands.command import Command
-from scripts.debug_commands.eval import EvalCommand, UnderstandRisksCommand
+from scripts.debug_commands.eval import EvalCommand
 from scripts.debug_commands.fps import FpsCommand
 from scripts.debug_commands.help import HelpCommand
 from scripts.debug_commands.settings import ToggleCommand, SetCommand, GetCommand
-from scripts.debug_commands.cat_pregnancy import PregnanciesCommand
 from scripts.debug_commands.clan import ClanCommand
-
-arbitrary_assignation = "to prevent optimizers from moving BiomeCommand to the top of the list and crashing the game"
-# for some reason if this is at the top of the list, it crashes.
 from scripts.debug_commands.biome import BiomeCommand
 
 commandList: List[Command] = [
@@ -24,6 +21,7 @@ commandList: List[Command] = [
     CatsCommand(),
     ClanCommand(),
     PregnanciesCommand(),
+    RelationshipsCommand()
 ]
 
 helpCommand = HelpCommand(commandList)

--- a/scripts/debug_commands/__init__.py
+++ b/scripts/debug_commands/__init__.py
@@ -21,7 +21,7 @@ commandList: List[Command] = [
     CatsCommand(),
     ClanCommand(),
     PregnanciesCommand(),
-    RelationshipsCommand()
+    RelationshipsCommand(),
 ]
 
 helpCommand = HelpCommand(commandList)

--- a/scripts/debug_commands/biome.py
+++ b/scripts/debug_commands/biome.py
@@ -1,8 +1,8 @@
 from typing import List
 
+from scripts.game_structure import constants
 from scripts.debug_commands import Command
 from scripts.debug_commands.utils import add_output_line_to_log
-from scripts.game_structure import constants
 from scripts.game_structure import game
 
 

--- a/scripts/debug_commands/cat.py
+++ b/scripts/debug_commands/cat.py
@@ -70,7 +70,6 @@ class AgeCatsCommand(Command):
                         cat.moons = int(args[1])
                     add_output_line_to_log(f"{cat.name} is now {cat.moons} moons old")
 
-
 class CatsCommand(Command):
     name = "cats"
     description = "Manage Cats"
@@ -80,7 +79,7 @@ class CatsCommand(Command):
         AddCatCommand(),
         RemoveCatCommand(),
         ListCatsCommand(),
-        AgeCatsCommand(),
+        AgeCatsCommand()
     ]
 
     def callback(self, args: List[str]):

--- a/scripts/debug_commands/cat.py
+++ b/scripts/debug_commands/cat.py
@@ -70,6 +70,7 @@ class AgeCatsCommand(Command):
                         cat.moons = int(args[1])
                     add_output_line_to_log(f"{cat.name} is now {cat.moons} moons old")
 
+
 class CatsCommand(Command):
     name = "cats"
     description = "Manage Cats"
@@ -79,7 +80,7 @@ class CatsCommand(Command):
         AddCatCommand(),
         RemoveCatCommand(),
         ListCatsCommand(),
-        AgeCatsCommand()
+        AgeCatsCommand(),
     ]
 
     def callback(self, args: List[str]):

--- a/scripts/debug_commands/cat_relationship.py
+++ b/scripts/debug_commands/cat_relationship.py
@@ -1,0 +1,101 @@
+from typing import List
+
+from scripts.cat.cats import Cat
+from scripts.cat_relations.relationship import Relationship, RelType
+from scripts.debug_commands.command import Command
+from scripts.debug_commands.utils import add_output_line_to_log
+
+def set_cat_relationship_to_cat(cat_a: Cat, rel_type: str, cat_b: Cat, rel_value: int):
+    """
+    Sets the specified relationship type (rel_type) 
+    of cat_a towards cat_b to a specified value (rel_value)
+    """
+    from_cat_relationship: Relationship = cat_a.relationships.get(cat_b.ID)
+    if not from_cat_relationship:
+        return
+
+    if rel_type == RelType.ROMANCE:
+        from_cat_relationship.romance = rel_value
+    elif rel_type == RelType.COMFORT:
+        from_cat_relationship.comfort = rel_value
+    elif rel_type == RelType.LIKE:
+        from_cat_relationship.like = rel_value
+    elif rel_type == RelType.RESPECT:
+        from_cat_relationship.respect = rel_value
+    elif rel_type == RelType.TRUST:
+        from_cat_relationship.trust = rel_value
+
+    add_output_line_to_log(
+        f"Successfully set {str(cat_a.name)}'s {rel_type} towards {str(cat_b.name)} to {rel_value}"
+    )
+
+class SetRelationshipCommand(Command):
+    name = "set"
+    description = "Set the relationship values of a cat towards another cat."
+    usage = "<from_cat name|id> <romance|like|respect|trust|comfort> <to_cat name|id> [number] <mutual>"
+    aliases = ["s"]
+
+    def callback(self, args):
+        if len(args) == 0:
+            add_output_line_to_log("Please specify a cat name or ID")
+            return
+        
+        if len(args) < 4:
+            add_output_line_to_log("Missing required arguments")
+            return
+
+        from_cat = None
+        to_cat = None
+        rel_type = args[1].lower()
+
+        if not args[3].isdigit():
+            add_output_line_to_log("rel_value is not an integer")
+            return
+        
+        rel_value = int(args[3])
+
+        if (
+            not rel_type
+            in RelType._value2member_map_  # pylint: disable=protected-access
+        ):
+            add_output_line_to_log(f"Invalid relationship type '{rel_type}'")
+            return
+
+        for cat in Cat.all_cats_list:
+            if from_cat and to_cat:
+                break
+            cat_name = str(cat.name).lower()
+            if cat_name == args[0].lower() or cat.ID == args[0]:
+                from_cat = cat
+                continue
+            if cat_name == args[2].lower() or cat.ID == args[2]:
+                to_cat = cat
+                continue
+
+        if not from_cat:
+            add_output_line_to_log(
+                "Failed to retrieve from_cat, did you specify a valid cat name or ID?"
+            )
+            return
+        if not to_cat:
+            add_output_line_to_log(
+                "Failed to retrieve to_cat, did you specify a valid cat name or ID?"
+            )
+            return
+
+        set_cat_relationship_to_cat(from_cat, rel_type, to_cat, rel_value)
+        if len(args) == 5:
+            set_cat_relationship_to_cat(to_cat, rel_type, from_cat, rel_value)
+
+
+class RelationshipsCommand(Command):
+    name = "relationship"
+    description = "Manage cats' relationships"
+    aliases = ["relation", "rel", "r"]
+
+    sub_commands = [
+        SetRelationshipCommand(),
+    ]
+
+    def callback(self, args: List[str]):
+        add_output_line_to_log("Please specify a subcommand")

--- a/scripts/debug_commands/cat_relationship.py
+++ b/scripts/debug_commands/cat_relationship.py
@@ -15,16 +15,7 @@ def set_cat_relationship_to_cat(cat_a: Cat, rel_type: str, cat_b: Cat, rel_value
     if not from_cat_relationship:
         return
 
-    if rel_type == RelType.ROMANCE:
-        from_cat_relationship.romance = rel_value
-    elif rel_type == RelType.COMFORT:
-        from_cat_relationship.comfort = rel_value
-    elif rel_type == RelType.LIKE:
-        from_cat_relationship.like = rel_value
-    elif rel_type == RelType.RESPECT:
-        from_cat_relationship.respect = rel_value
-    elif rel_type == RelType.TRUST:
-        from_cat_relationship.trust = rel_value
+    setattr(from_cat_relationship, rel_type, rel_value)
 
     add_output_line_to_log(
         f"Successfully set {str(cat_a.name)}'s {rel_type} towards {str(cat_b.name)} to {rel_value}"
@@ -43,7 +34,7 @@ class SetRelationshipCommand(Command):
             return
 
         if len(args) < 4:
-            add_output_line_to_log("Missing required arguments")
+            add_output_line_to_log("Missing more than one required argument")
             return
 
         from_cat = None

--- a/scripts/debug_commands/cat_relationship.py
+++ b/scripts/debug_commands/cat_relationship.py
@@ -5,9 +5,10 @@ from scripts.cat_relations.relationship import Relationship, RelType
 from scripts.debug_commands.command import Command
 from scripts.debug_commands.utils import add_output_line_to_log
 
+
 def set_cat_relationship_to_cat(cat_a: Cat, rel_type: str, cat_b: Cat, rel_value: int):
     """
-    Sets the specified relationship type (rel_type) 
+    Sets the specified relationship type (rel_type)
     of cat_a towards cat_b to a specified value (rel_value)
     """
     from_cat_relationship: Relationship = cat_a.relationships.get(cat_b.ID)
@@ -29,6 +30,7 @@ def set_cat_relationship_to_cat(cat_a: Cat, rel_type: str, cat_b: Cat, rel_value
         f"Successfully set {str(cat_a.name)}'s {rel_type} towards {str(cat_b.name)} to {rel_value}"
     )
 
+
 class SetRelationshipCommand(Command):
     name = "set"
     description = "Set the relationship values of a cat towards another cat."
@@ -39,7 +41,7 @@ class SetRelationshipCommand(Command):
         if len(args) == 0:
             add_output_line_to_log("Please specify a cat name or ID")
             return
-        
+
         if len(args) < 4:
             add_output_line_to_log("Missing required arguments")
             return
@@ -51,7 +53,7 @@ class SetRelationshipCommand(Command):
         if not args[3].isdigit():
             add_output_line_to_log("rel_value is not an integer")
             return
-        
+
         rel_value = int(args[3])
 
         if (

--- a/scripts/debug_commands/cat_relationship.py
+++ b/scripts/debug_commands/cat_relationship.py
@@ -89,9 +89,9 @@ class SetRelationshipCommand(Command):
 
 
 class RelationshipsCommand(Command):
-    name = "relationship"
+    name = "relationships"
     description = "Manage cats' relationships"
-    aliases = ["relation", "rel", "r"]
+    aliases = ["relationship", "relation", "rel", "r"]
 
     sub_commands = [
         SetRelationshipCommand(),

--- a/scripts/debug_console.py
+++ b/scripts/debug_console.py
@@ -6,10 +6,10 @@ import pygame
 import pygame_gui
 import html
 
-from pygame_gui.elements import UIWindow, UITextBox, UITextEntryLine
+from pygame_gui.elements import UIWindow, UITextBox, UITextEntryLine, UIButton
 from scripts.ui.scale import ui_scale
 from scripts.debug_commands import commandList
-from scripts.debug_commands.utils import set_debug_class
+from scripts.debug_commands.utils import set_debug_class, add_output_line_to_log
 from scripts.game_structure import game
 from scripts.game_structure.screen_settings import MANAGER, offset, screen_scale
 from scripts.ui.theme import get_text_box_theme
@@ -51,15 +51,26 @@ class DebugMenu(UIWindow):
 
         self.command_line = UITextEntryLine(
             relative_rect=ui_scale(
-                pygame.Rect((2, -32), (self.get_container().get_size()[0] - 4, 30))
+                pygame.Rect((2, -32), (self.get_container().get_size()[0] - 32, 30))
             ),
             container=self,
+            object_id="#command_line",
             anchors={"top": "bottom"},
         )
 
-        # self.submit_command = UIButton(
+        self.submit_command = UIButton(
+            ui_scale(pygame.Rect((-32, -32), (30, 30))),
+            ">>",
+            manager=MANAGER,
+            container=self,
+            object_id="#submit_command",
+            anchors={
+                "top": "bottom",
+                "left": "right"
+            }
+        )
 
-        # )
+        self.previous_command = ""
 
         self.change_layer(1000)
 
@@ -122,16 +133,25 @@ class DebugMenu(UIWindow):
 
     def process_event(self, event: pygame.Event):
         if (
-            event.type == pygame_gui.UI_TEXT_ENTRY_FINISHED
-            and event.ui_element == self.command_line
+            (event.type == pygame_gui.UI_TEXT_ENTRY_FINISHED
+            and event.ui_element == self.command_line)
+            or (event.type == pygame_gui.UI_BUTTON_PRESSED
+            and event.ui_element == self.submit_command)
         ):
+            add_output_line_to_log(f"> {self.command_line.get_text()}")
             pygame.event.post(
                 pygame.Event(
                     pygame_gui.UI_CONSOLE_COMMAND_ENTERED,
                     {"command": self.command_line.get_text()},
                 )
             )
+            self.previous_command = self.command_line.get_text()
             self.command_line.clear()
+        
+        if event.type == pygame.KEYDOWN:
+            if event.key == pygame.K_UP:
+                self.command_line.set_text(self.previous_command)
+
         if event.type == pygame_gui.UI_CONSOLE_COMMAND_ENTERED:
             self.process_command(event.command)
         return super().process_event(event)
@@ -148,6 +168,9 @@ class DebugMenu(UIWindow):
         """
         for line in lines.split("\n"):
             self.push_line(line)
+
+    def on_close_window_button_pressed(self):
+        self.hide()
 
 
 class DebugMode:
@@ -262,6 +285,5 @@ class DebugMode:
                     pygame.draw.rect(screen, (0, 255, 0), rect, 1)
                 else:
                     pygame.draw.rect(screen, (255, 0, 0), rect, 1)
-
 
 debug_mode = DebugMode()

--- a/scripts/debug_console.py
+++ b/scripts/debug_console.py
@@ -64,10 +64,7 @@ class DebugMenu(UIWindow):
             manager=MANAGER,
             container=self,
             object_id="#submit_command",
-            anchors={
-                "top": "bottom",
-                "left": "right"
-            }
+            anchors={"top": "bottom", "left": "right"},
         )
 
         self.previous_command = ""
@@ -133,10 +130,11 @@ class DebugMenu(UIWindow):
 
     def process_event(self, event: pygame.Event):
         if (
-            (event.type == pygame_gui.UI_TEXT_ENTRY_FINISHED
-            and event.ui_element == self.command_line)
-            or (event.type == pygame_gui.UI_BUTTON_PRESSED
-            and event.ui_element == self.submit_command)
+            event.type == pygame_gui.UI_TEXT_ENTRY_FINISHED
+            and event.ui_element == self.command_line
+        ) or (
+            event.type == pygame_gui.UI_BUTTON_PRESSED
+            and event.ui_element == self.submit_command
         ):
             add_output_line_to_log(f"> {self.command_line.get_text()}")
             pygame.event.post(
@@ -147,7 +145,7 @@ class DebugMenu(UIWindow):
             )
             self.previous_command = self.command_line.get_text()
             self.command_line.clear()
-        
+
         if event.type == pygame.KEYDOWN:
             if event.key == pygame.K_UP:
                 self.command_line.set_text(self.previous_command)
@@ -285,5 +283,6 @@ class DebugMode:
                     pygame.draw.rect(screen, (0, 255, 0), rect, 1)
                 else:
                     pygame.draw.rect(screen, (255, 0, 0), rect, 1)
+
 
 debug_mode = DebugMode()


### PR DESCRIPTION
## About The Pull Request
Adds the "relationships" command to the debug console. Current it only has one sub-command which is setting a specific relationship value (as requested by #4345). 
I also went through and did some quality-of-life stuff for the debug console, added a button that runs the currently typed command and added a way to recall the previous command by pressing the up arrow key.

I'm not too well-versed in the relationship code but a quick read and I gathered that this *should* be enough to satisfy #4345, though I could have also missed something.

## Why This Is Good For ClanGen
The relationship command adds a way to modify relationship values in game, which removes the need to either wait for the values to occur naturally or to have to edit the values manually.

## Linked Issues
fixes: #4345 

## Proof of Testing
https://github.com/user-attachments/assets/4d17f90e-52ca-4211-8325-d95e7f6998e7

