### PR TITLE
[FEATURE] Add status history constraint for thoughts

### DIFF
--- a/docs/dev/writing/thoughts.md
+++ b/docs/dev/writing/thoughts.md
@@ -43,6 +43,8 @@ It's essential to know how thoughts are formatted when adding or altering them s
     },
     "main_status_constraint": [],
     "random_status_constraint": [],
+    "main_status_history": [],
+    "random_status_history": [],
     "main_age_constraint": [],
     "random_age_constraint": [],
     "main_trait_constraint": [],
@@ -128,6 +130,11 @@ Constrains the thought to only happen if m_c or r_c are in a certain role. You c
 > [Status Tag List](reference/tag-lists.md#__tabbed_2_2)
 > 
 > You can also use the tag "any" to allow the thought to occur for all roles except "newborns", who shouldn't get any general thoughts, just the ones placed in their specific JSON.
+
+STATUS_HISTORY:
+Constrains the thought to only happen if m_c or r_c used to have a certain role. You can utilize [exclusionary values](reference/index.md#exclusionary-values).
+
+> [Status Tag List](reference/tag-lists.md#__tabbed_2_2)
 
 AGE_CONSTRAINT:
 Constrains the thought to only occur if m_c or r_c are within a certain age group. You can utilize [exclusionary values](reference/index.md#exclusionary-values).

--- a/scripts/events_module/event_filters.py
+++ b/scripts/events_module/event_filters.py
@@ -335,6 +335,7 @@ def event_for_cat(
     func_lookup = {
         "age": _check_cat_age,
         "status": _check_cat_status,
+        "status_history": _check_cat_status_history,
         "trait": _check_cat_trait,
         "skill": _check_cat_skills,
         "backstory": _check_cat_backstory,
@@ -423,6 +424,28 @@ def _check_cat_status(cat, statuses: list) -> bool:
 
     if (cat.status.rank in statuses) or ("lost" in statuses and cat.status.is_lost()):
         return False
+
+    return is_exclusionary
+
+
+def _check_cat_status_history(cat, statuses: list) -> bool:
+    """
+    Checks if cat's group_history contains any status within statuses list.
+    """
+    if not statuses or "any" in statuses:
+        return True
+
+    is_exclusionary = _check_for_exclusionary_value(statuses)
+
+    if is_exclusionary:
+        statuses = [x.replace("-", "") for x in statuses]
+
+    for i in cat.status.group_history:
+        if i["rank"] in statuses and i["rank"] != cat.status.rank:
+            if is_exclusionary:
+                return False
+            else:
+                return True
 
     return is_exclusionary
 

--- a/scripts/events_module/event_filters.py
+++ b/scripts/events_module/event_filters.py
@@ -440,8 +440,8 @@ def _check_cat_status_history(cat, statuses: list) -> bool:
     if is_exclusionary:
         statuses = [x.replace("-", "") for x in statuses]
 
-    for i in cat.status.group_history:
-        if i["rank"] in statuses and i["rank"] != cat.status.rank:
+    for _rank in cat.status.all_ranks.keys():
+        if _rank in statuses and _rank != cat.status.rank:
             if is_exclusionary:
                 return False
             else:

--- a/scripts/events_module/thoughts/generate_thoughts.py
+++ b/scripts/events_module/thoughts/generate_thoughts.py
@@ -227,6 +227,12 @@ def _constraints_fulfilled(
     if "random_status_constraint" in thought and random_cat:
         random_info_dict["status"] = thought["random_status_constraint"]
 
+    if "main_status_history" in thought:
+        main_info_dict["status_history"] = thought["main_status_history"]
+
+    if "random_status_history" in thought and random_cat:
+        random_info_dict["status_history"] = thought["random_status_history"]
+
     if "main_age_constraint" in thought:
         main_info_dict["age"] = thought["main_age_constraint"]
 


### PR DESCRIPTION

## About The Pull Request
Adds a new constraint for thoughts that checks if any of the provided statuses are in the cat's group_history.

New event_filters function `_check_cat_status_history` to perform this check. It does not return True if a matching status is also the cat's current rank.

## Why This Is Good For ClanGen
Allows writers to refer more specifically to the cat's past within the clan, as well as write new thoughts based on the cat's previous status. Removes the awkward limitations of elders specifically.
Can later be extended to ShortEvents and Patrols as well.

## Linked Issues
Closes #4117

## Proof of Testing

<img width="400" height="381" alt="Zrzut ekranu 2026-02-07 114052" src="https://github.com/user-attachments/assets/e44cc3e7-81a5-487f-a425-1d5dfb5ba3b4" /> <img width="400" height="600" alt="Zrzut ekranu 2026-02-07 114109" src="https://github.com/user-attachments/assets/bc533cb2-56d8-4214-a3dc-cdf5d6e6c2f9" />
<img width="400" height="352" alt="Zrzut ekranu 2026-02-07 120815" src="https://github.com/user-attachments/assets/048326cf-6330-4a0d-ba38-dd375f9ec86e" /><img width="400" height="600" alt="Zrzut ekranu 2026-02-07 120838" src="https://github.com/user-attachments/assets/be257eee-1dfd-4d90-a755-cd01e5d5d464" />
<img width="400" height="310" alt="Zrzut ekranu 2026-02-07 122208" src="https://github.com/user-attachments/assets/cd8e1ace-9818-42bb-be38-dc5d5f44989b" /> <img width="400" height="600" alt="Zrzut ekranu 2026-02-07 122220" src="https://github.com/user-attachments/assets/8caf892e-b01b-49ca-9635-9db25d2c94b6" />
