### PR TITLE
[BUGFIX] Wrong Rel Log in Murder Confession

### DIFF
--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -1307,7 +1307,7 @@
         "relationships": [
             {
                 "cats_from": [
-                    "r_c"
+                    "r_c", "high_lawful"
                 ],
                 "cats_to": [
                     "m_c"
@@ -1325,7 +1325,7 @@
                 }
             },
             {
-                "cats_from": ["clan", "low_lawful"
+                "cats_from": ["r_c", "low_lawful"
                 ],
                 "cats_to": [
                     "m_c"


### PR DESCRIPTION
## About The Pull Request

I noticed in my own save that when Cat A confessed murder to Cat B, Cat B's relationship logs were doubled up.

## Proof of Testing

<img width="663" height="130" alt="image" src="https://github.com/user-attachments/assets/b77fc1ec-5651-4969-ac5c-f5a3a95e698b" />
only the proper log. the from_cat bug is unrelated obviously