### PR TITLE
[BALANCING] Herb improvements

### DIFF
--- a/resources/dicts/herb_info.json
+++ b/resources/dicts/herb_info.json
@@ -3,28 +3,28 @@
         "expiration": 12,
         "rarity": {
             "forest": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 3,
+                "greenleaf": 2,
+                "leaf-fall": 4,
+                "leaf-bare": 6
             },
             "mountainous": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 3,
+                "greenleaf": 2,
+                "leaf-fall": 4,
+                "leaf-bare": 6
             },
             "plains": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 3,
+                "greenleaf": 2,
+                "leaf-fall": 5,
+                "leaf-bare": 6
             },
             "beach": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 4,
+                "greenleaf": 3,
+                "leaf-fall": 5,
+                "leaf-bare": 6
             }
         }
     },
@@ -58,83 +58,83 @@
         }
     },
     "daisy": {
-        "expiration": 12,
+        "expiration": 8,
         "rarity": {
             "forest": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 3,
+                "greenleaf": 2,
+                "leaf-fall": 3,
+                "leaf-bare": 5
             },
             "mountainous": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 3,
+                "greenleaf": 2,
+                "leaf-fall": 3,
+                "leaf-bare": 5
             },
             "plains": {
-                "newleaf": 1,
+                "newleaf": 2,
                 "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "leaf-fall": 2,
+                "leaf-bare": 4
             },
             "beach": {
-                "newleaf": 1,
+                "newleaf": 2,
                 "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "leaf-fall": 2,
+                "leaf-bare": 4
             }
         }
     },
     "horsetail": {
-        "expiration": 12,
+        "expiration": 8,
         "rarity": {
             "forest": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 3,
+                "greenleaf": 2,
+                "leaf-fall": 3,
+                "leaf-bare": 4
             },
             "mountainous": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 3,
+                "greenleaf": 2,
+                "leaf-fall": 3,
+                "leaf-bare": 4
             },
             "plains": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 3,
+                "greenleaf": 2,
+                "leaf-fall": 3,
+                "leaf-bare": 4
             },
             "beach": {
-                "newleaf": 1,
+                "newleaf": 2,
                 "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "leaf-fall": 2,
+                "leaf-bare": 3
             }
         }
     },
     "juniper": {
-        "expiration": 12,
+        "expiration": 6,
         "rarity": {
             "forest": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 3,
+                "greenleaf": 3,
+                "leaf-fall": 3,
+                "leaf-bare": 3
             },
             "mountainous": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 2,
+                "greenleaf": 2,
+                "leaf-fall": 2,
+                "leaf-bare": 2
             },
             "plains": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 2,
+                "greenleaf": 2,
+                "leaf-fall": 2,
+                "leaf-bare": 2
             },
             "beach": {
                 "newleaf": 1,
@@ -148,28 +148,28 @@
         "expiration": 12,
         "rarity": {
             "forest": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 5,
+                "greenleaf": 4,
+                "leaf-fall": 5,
+                "leaf-bare": 6
             },
             "mountainous": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 4,
+                "greenleaf": 3,
+                "leaf-fall": 4,
+                "leaf-bare": 5
             },
             "plains": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 5,
+                "greenleaf": 4,
+                "leaf-fall": 5,
+                "leaf-bare": 6
             },
             "beach": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 5,
+                "greenleaf": 4,
+                "leaf-fall": 5,
+                "leaf-bare": 6
             }
         }
     },
@@ -177,144 +177,144 @@
         "expiration": 12,
         "rarity": {
             "forest": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 3,
+                "greenleaf": 2,
+                "leaf-fall": 2,
+                "leaf-bare": 5
             },
             "mountainous": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 3,
+                "greenleaf": 2,
+                "leaf-fall": 2,
+                "leaf-bare": 5
             },
             "plains": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 3,
+                "greenleaf": 2,
+                "leaf-fall": 2,
+                "leaf-bare": 5
             },
             "beach": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 3,
+                "greenleaf": 2,
+                "leaf-fall": 2,
+                "leaf-bare": 5
             }
         }
     },
     "marigold": {
-        "expiration": 12,
+        "expiration": 6,
         "rarity": {
             "forest": {
-                "newleaf": 1,
+                "newleaf": 2,
                 "greenleaf": 1,
                 "leaf-fall": 1,
-                "leaf-bare": 1
+                "leaf-bare": 5
             },
             "mountainous": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 3,
+                "greenleaf": 2,
+                "leaf-fall": 2,
+                "leaf-bare": 6
             },
             "plains": {
-                "newleaf": 1,
+                "newleaf": 2,
                 "greenleaf": 1,
                 "leaf-fall": 1,
-                "leaf-bare": 1
+                "leaf-bare": 5
             },
             "beach": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 4,
+                "greenleaf": 3,
+                "leaf-fall": 3,
+                "leaf-bare": 6
             }
         }
     },
     "moss": {
-        "expiration": 24,
+        "expiration": 12,
         "rarity": {
             "forest": {
-                "newleaf": 1,
+                "newleaf": 2,
                 "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "leaf-fall": 2,
+                "leaf-bare": 3
             },
             "mountainous": {
-                "newleaf": 1,
+                "newleaf": 2,
                 "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "leaf-fall": 2,
+                "leaf-bare": 3
             },
             "plains": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 3,
+                "greenleaf": 2,
+                "leaf-fall": 3,
+                "leaf-bare": 4
             },
             "beach": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 3,
+                "greenleaf": 2,
+                "leaf-fall": 3,
+                "leaf-bare": 4
             }
         }
     },
     "oak_leaves": {
-        "expiration": 12,
+        "expiration": 6,
         "rarity": {
             "forest": {
-                "newleaf": 1,
+                "newleaf": 2,
                 "greenleaf": 1,
                 "leaf-fall": 1,
-                "leaf-bare": 1
+                "leaf-bare": 5
             },
             "mountainous": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 3,
+                "greenleaf": 2,
+                "leaf-fall": 2,
+                "leaf-bare": 5
             },
             "plains": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 4,
+                "greenleaf": 3,
+                "leaf-fall": 3,
+                "leaf-bare": 6
             },
             "beach": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 4,
+                "greenleaf": 3,
+                "leaf-fall": 3,
+                "leaf-bare": 6
             }
         }
     },
     "ragwort": {
-        "expiration": 12,
+        "expiration": 4,
         "rarity": {
             "forest": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 3,
+                "greenleaf": 2,
+                "leaf-fall": 2,
+                "leaf-bare": 6
             },
             "mountainous": {
-                "newleaf": 1,
+                "newleaf": 2,
                 "greenleaf": 1,
                 "leaf-fall": 1,
-                "leaf-bare": 1
+                "leaf-bare": 5
             },
             "plains": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 3,
+                "greenleaf": 2,
+                "leaf-fall": 2,
+                "leaf-bare": 6
             },
             "beach": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 3,
+                "greenleaf": 2,
+                "leaf-fall": 2,
+                "leaf-bare": 6
             }
         }
     },
@@ -322,173 +322,173 @@
         "expiration": 12,
         "rarity": {
             "forest": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 4,
+                "greenleaf": 2,
+                "leaf-fall": 2,
+                "leaf-bare": 6
             },
             "mountainous": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 4,
+                "greenleaf": 2,
+                "leaf-fall": 2,
+                "leaf-bare": 6
             },
             "plains": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 4,
+                "greenleaf": 2,
+                "leaf-fall": 2,
+                "leaf-bare": 5
             },
             "beach": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 3,
+                "greenleaf": 2,
+                "leaf-fall": 2,
+                "leaf-bare": 5
             }
         }
     },
     "tansy": {
-        "expiration": 12,
+        "expiration": 8,
         "rarity": {
             "forest": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 3,
+                "greenleaf": 2,
+                "leaf-fall": 3,
+                "leaf-bare": 5
             },
             "mountainous": {
-                "newleaf": 1,
+                "newleaf": 2,
                 "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "leaf-fall": 2,
+                "leaf-bare": 4
             },
             "plains": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 3,
+                "greenleaf": 2,
+                "leaf-fall": 3,
+                "leaf-bare": 5
             },
             "beach": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 4,
+                "greenleaf": 2,
+                "leaf-fall": 4,
+                "leaf-bare": 5
             }
         }
     },
     "thyme": {
-        "expiration": 12,
+        "expiration": 8,
         "rarity": {
             "forest": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 3,
+                "greenleaf": 2,
+                "leaf-fall": 3,
+                "leaf-bare": 5
             },
             "mountainous": {
-                "newleaf": 1,
+                "newleaf": 2,
                 "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "leaf-fall": 2,
+                "leaf-bare": 4
             },
             "plains": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 3,
+                "greenleaf": 2,
+                "leaf-fall": 3,
+                "leaf-bare": 5
             },
             "beach": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 4,
+                "greenleaf": 3,
+                "leaf-fall": 4,
+                "leaf-bare": 5
             }
         }
     },
     "wild_garlic": {
-        "expiration": 12,
+        "expiration": 8,
         "rarity": {
             "forest": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 3,
+                "greenleaf": 2,
+                "leaf-fall": 2,
+                "leaf-bare": 4
             },
             "mountainous": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 3,
+                "greenleaf": 2,
+                "leaf-fall": 2,
+                "leaf-bare": 5
             },
             "plains": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 4,
+                "greenleaf": 3,
+                "leaf-fall": 3,
+                "leaf-bare": 6
             },
             "beach": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 4,
+                "greenleaf": 3,
+                "leaf-fall": 3,
+                "leaf-bare": 6
             }
         }
     },
     "dandelion": {
-        "expiration": 12,
+        "expiration": 8,
         "rarity": {
             "forest": {
-                "newleaf": 1,
+                "newleaf": 2,
                 "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "leaf-fall": 2,
+                "leaf-bare": 5
             },
             "mountainous": {
-                "newleaf": 1,
+                "newleaf": 2,
                 "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "leaf-fall": 2,
+                "leaf-bare": 5
             },
             "plains": {
-                "newleaf": 1,
+                "newleaf": 2,
                 "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "leaf-fall": 2,
+                "leaf-bare": 4
             },
             "beach": {
-                "newleaf": 1,
+                "newleaf": 2,
                 "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "leaf-fall": 2,
+                "leaf-bare": 4
             }
         }
     },
     "mullein": {
-        "expiration": 12,
+        "expiration": 10,
         "rarity": {
             "forest": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 3,
+                "greenleaf": 2,
+                "leaf-fall": 2,
+                "leaf-bare": 5
             },
             "mountainous": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 4,
+                "greenleaf": 3,
+                "leaf-fall": 3,
+                "leaf-bare": 6
             },
             "plains": {
-                "newleaf": 1,
+                "newleaf": 2,
                 "greenleaf": 1,
                 "leaf-fall": 1,
-                "leaf-bare": 1
+                "leaf-bare": 5
             },
             "beach": {
-                "newleaf": 1,
+                "newleaf": 2,
                 "greenleaf": 1,
                 "leaf-fall": 1,
-                "leaf-bare": 1
+                "leaf-bare": 5
             }
         }
     },
@@ -496,28 +496,28 @@
         "expiration": 12,
         "rarity": {
             "forest": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 3,
+                "greenleaf": 2,
+                "leaf-fall": 2,
+                "leaf-bare": 5
             },
             "mountainous": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 4,
+                "greenleaf": 3,
+                "leaf-fall": 3,
+                "leaf-bare": 6
             },
             "plains": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 3,
+                "greenleaf": 2,
+                "leaf-fall": 2,
+                "leaf-bare": 5
             },
             "beach": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 3,
+                "greenleaf": 2,
+                "leaf-fall": 2,
+                "leaf-bare": 6
             }
         }
     },
@@ -525,28 +525,28 @@
         "expiration": 12,
         "rarity": {
             "forest": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 3,
+                "greenleaf": 2,
+                "leaf-fall": 3,
+                "leaf-bare": 4
             },
             "mountainous": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 3,
+                "greenleaf": 2,
+                "leaf-fall": 3,
+                "leaf-bare": 4
             },
             "plains": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 3,
+                "greenleaf": 2,
+                "leaf-fall": 3,
+                "leaf-bare": 4
             },
             "beach": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 3,
+                "greenleaf": 2,
+                "leaf-fall": 3,
+                "leaf-bare": 4
             }
         }
     },
@@ -554,144 +554,144 @@
         "expiration": 12,
         "rarity": {
             "forest": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 4,
+                "greenleaf": 3,
+                "leaf-fall": 3,
+                "leaf-bare": 6
             },
             "mountainous": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 4,
+                "greenleaf": 3,
+                "leaf-fall": 3,
+                "leaf-bare": 6
             },
             "plains": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 4,
+                "greenleaf": 2,
+                "leaf-fall": 2,
+                "leaf-bare": 5
             },
             "beach": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 3,
+                "greenleaf": 2,
+                "leaf-fall": 2,
+                "leaf-bare": 5
             }
         }
     },
     "betony": {
-        "expiration": 12,
+        "expiration": 10,
         "rarity": {
             "forest": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 3,
+                "greenleaf": 2,
+                "leaf-fall": 3,
+                "leaf-bare": 4
             },
             "mountainous": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 3,
+                "greenleaf": 2,
+                "leaf-fall": 3,
+                "leaf-bare": 4
             },
             "plains": {
-                "newleaf": 1,
+                "newleaf": 2,
                 "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "leaf-fall": 2,
+                "leaf-bare": 4
             },
             "beach": {
-                "newleaf": 1,
+                "newleaf": 2,
                 "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "leaf-fall": 2,
+                "leaf-bare": 4
             }
         }
     },
     "goldenrod": {
-        "expiration": 12,
+        "expiration": 8,
         "rarity": {
             "forest": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 3,
+                "greenleaf": 2,
+                "leaf-fall": 4,
+                "leaf-bare": 6
             },
             "mountainous": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 3,
+                "greenleaf": 2,
+                "leaf-fall": 4,
+                "leaf-bare": 6
             },
             "plains": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 3,
+                "greenleaf": 2,
+                "leaf-fall": 4,
+                "leaf-bare": 6
             },
             "beach": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 3,
+                "greenleaf": 2,
+                "leaf-fall": 4,
+                "leaf-bare": 6
             }
         }
     },
     "poppy": {
-        "expiration": 12,
+        "expiration": 6,
         "rarity": {
             "forest": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 3,
+                "greenleaf": 2,
+                "leaf-fall": 2,
+                "leaf-bare": 6
             },
             "mountainous": {
-                "newleaf": 1,
+                "newleaf": 2,
                 "greenleaf": 1,
                 "leaf-fall": 1,
-                "leaf-bare": 1
+                "leaf-bare": 5
             },
             "plains": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 3,
+                "greenleaf": 2,
+                "leaf-fall": 2,
+                "leaf-bare": 6
             },
             "beach": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 3,
+                "greenleaf": 2,
+                "leaf-fall": 2,
+                "leaf-bare": 6
             }
         }
     },
     "plantain": {
-        "expiration": 12,
+        "expiration": 10,
         "rarity": {
             "forest": {
-                "newleaf": 1,
+                "newleaf": 2,
                 "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "leaf-fall": 2,
+                "leaf-bare": 3
             },
             "mountainous": {
-                "newleaf": 1,
+                "newleaf": 2,
                 "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "leaf-fall": 2,
+                "leaf-bare": 3
             },
             "plains": {
-                "newleaf": 1,
+                "newleaf": 2,
                 "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "leaf-fall": 2,
+                "leaf-bare": 3
             },
             "beach": {
-                "newleaf": 1,
+                "newleaf": 2,
                 "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "leaf-fall": 2,
+                "leaf-bare": 3
             }
         }
     },
@@ -699,28 +699,28 @@
         "expiration": 12,
         "rarity": {
             "forest": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 4,
+                "greenleaf": 3,
+                "leaf-fall": 4,
+                "leaf-bare": 6
             },
             "mountainous": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 3,
+                "greenleaf": 2,
+                "leaf-fall": 4,
+                "leaf-bare": 6
             },
             "plains": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 4,
+                "greenleaf": 3,
+                "leaf-fall": 5,
+                "leaf-bare": 6
             },
             "beach": {
-                "newleaf": 1,
-                "greenleaf": 1,
-                "leaf-fall": 1,
-                "leaf-bare": 1
+                "newleaf": 3,
+                "greenleaf": 3,
+                "leaf-fall": 4,
+                "leaf-bare": 6
             }
         }
     }

--- a/resources/dicts/herb_info.json
+++ b/resources/dicts/herb_info.json
@@ -319,7 +319,7 @@
         }
     },
     "raspberry": {
-        "expiration": 12,
+        "expiration": 6,
         "rarity": {
             "forest": {
                 "newleaf": 4,

--- a/resources/dicts/herb_info.json
+++ b/resources/dicts/herb_info.json
@@ -699,9 +699,9 @@
         "expiration": 12,
         "rarity": {
             "forest": {
-                "newleaf": 4,
-                "greenleaf": 3,
-                "leaf-fall": 4,
+                "newleaf": 5,
+                "greenleaf": 4,
+                "leaf-fall": 5,
                 "leaf-bare": 6
             },
             "mountainous": {
@@ -711,15 +711,15 @@
                 "leaf-bare": 6
             },
             "plains": {
-                "newleaf": 4,
-                "greenleaf": 3,
+                "newleaf": 5,
+                "greenleaf": 4,
                 "leaf-fall": 5,
                 "leaf-bare": 6
             },
             "beach": {
-                "newleaf": 3,
+                "newleaf": 4,
                 "greenleaf": 3,
-                "leaf-fall": 4,
+                "leaf-fall": 5,
                 "leaf-bare": 6
             }
         }

--- a/scripts/clan_resources/herb/herb_supply.py
+++ b/scripts/clan_resources/herb/herb_supply.py
@@ -383,7 +383,6 @@ class HerbSupply:
 
         # get herbs found
         herb_list = []
-        list_of_herb_strs = []
         for med in med_cats:
             if assistants:
                 list_of_herb_strs, found_herbs = game.clan.herb_supply.get_found_herbs(
@@ -508,10 +507,10 @@ class HerbSupply:
                     quantity_modifier -= 0.5
                 elif rarity in (1, 2):
                     quantity_modifier += 1
-                found_herbs[herb] = int(
+                found_herbs[herb] = max(1, int(
                     choices(population=[2, 3, 4], weights=weight, k=1)[0]
                     * quantity_modifier
-                )
+                ))
                 amount_of_herbs -= 1
 
         return self.handle_found_herbs_outcomes(found_herbs)

--- a/scripts/clan_resources/herb/herb_supply.py
+++ b/scripts/clan_resources/herb/herb_supply.py
@@ -507,10 +507,13 @@ class HerbSupply:
                     quantity_modifier -= 0.5
                 elif rarity in (1, 2):
                     quantity_modifier += 1
-                found_herbs[herb] = max(1, int(
-                    choices(population=[2, 3, 4], weights=weight, k=1)[0]
-                    * quantity_modifier
-                ))
+                found_herbs[herb] = max(
+                    1,
+                    int(
+                        choices(population=[2, 3, 4], weights=weight, k=1)[0]
+                        * quantity_modifier
+                    ),
+                )
                 amount_of_herbs -= 1
 
         return self.handle_found_herbs_outcomes(found_herbs)

--- a/scripts/clan_resources/herb/herb_supply.py
+++ b/scripts/clan_resources/herb/herb_supply.py
@@ -113,7 +113,7 @@ class HerbSupply:
     @property
     def low_qualifier(self) -> int:
         """
-        returns the lowest qualifier for a low supply (supply must be higher than this qualifier and lower than or equal to the adequate qualifier)
+        returns the lowest qualifier for a low supply
         """
         return 0
 
@@ -504,7 +504,7 @@ class HerbSupply:
             # chance to find an herb is based on its rarity
             if randint(1, rarity) == 1:
                 if rarity in (5, 6):
-                    quantity_modifier -= 0.5
+                    quantity_modifier = quantity_modifier / 2
                 elif rarity in (1, 2):
                     quantity_modifier += 1
                 found_herbs[herb] = max(

--- a/scripts/clan_resources/herb/herb_supply.py
+++ b/scripts/clan_resources/herb/herb_supply.py
@@ -501,7 +501,7 @@ class HerbSupply:
             if not rarity:
                 continue
 
-            # chance to find an herb is based on it's rarity
+            # chance to find an herb is based on its rarity
             if randint(1, rarity) == 1:
                 if rarity in (5, 6):
                     quantity_modifier -= 0.5

--- a/scripts/clan_resources/herb/herb_supply.py
+++ b/scripts/clan_resources/herb/herb_supply.py
@@ -112,7 +112,7 @@ class HerbSupply:
     @property
     def low_qualifier(self) -> int:
         """
-        returns the lowest qualifier for a low supply
+        returns the lowest qualifier for a low supply (supply must be higher than this qualifier and lower than or equal to the adequate qualifier)
         """
         return 0
 
@@ -155,7 +155,7 @@ class HerbSupply:
         """
         takes given clan_size and multiplies it by the required_herbs_per_cat from constants.CONFIG
         """
-        self.required_herb_count = (
+        self.required_herb_count = int(
             clan_size
             * constants.CONFIG["clan_resources"]["herbs"]["required_herbs_per_cat"]
         )
@@ -502,13 +502,7 @@ class HerbSupply:
                 continue
 
             # chance to find an herb is based on it's rarity
-            if (
-                randint(
-                    1,
-                    rarity,
-                )
-                == 1
-            ):
+            if randint(1, rarity) == 1:
                 found_herbs[herb] = int(
                     choices(population=[3, 4, 5], weights=weight, k=1)[0]
                     * quantity_modifier

--- a/scripts/clan_resources/herb/herb_supply.py
+++ b/scripts/clan_resources/herb/herb_supply.py
@@ -1,3 +1,4 @@
+import statistics
 from random import choice, randint, choices
 from typing import Optional
 
@@ -388,7 +389,7 @@ class HerbSupply:
                 list_of_herb_strs, found_herbs = game.clan.herb_supply.get_found_herbs(
                     med,
                     general_amount_bonus=True,
-                    specific_quantity_bonus=len(assistants),
+                    specific_quantity_bonus=2,
                 )
             else:
                 list_of_herb_strs, found_herbs = game.clan.herb_supply.get_found_herbs(
@@ -503,8 +504,12 @@ class HerbSupply:
 
             # chance to find an herb is based on it's rarity
             if randint(1, rarity) == 1:
+                if rarity in (5, 6):
+                    quantity_modifier -= 0.5
+                elif rarity in (1, 2):
+                    quantity_modifier += 1
                 found_herbs[herb] = int(
-                    choices(population=[3, 4, 5], weights=weight, k=1)[0]
+                    choices(population=[2, 3, 4], weights=weight, k=1)[0]
                     * quantity_modifier
                 )
                 amount_of_herbs -= 1

--- a/scripts/clan_resources/herb/herb_supply.py
+++ b/scripts/clan_resources/herb/herb_supply.py
@@ -1,4 +1,5 @@
 from random import choice, randint, choices
+from typing import Optional
 
 import i18n
 
@@ -430,8 +431,8 @@ class HerbSupply:
         :param specific_quantity_bonus: a specific float to multiply the gathered herb amount by
         """
         # meds with relevant skills will get a boost to the herbs they find
-        # SENSE finds larger amount of herbs
-        # CLEVER finds greater quantity of herbs
+        # SENSE finds wider types of herbs (3 moss, 1 lungwort, 2 catmint)
+        # CLEVER finds greater quantity of herbs (5 moss, 6 lungwort)
         primary = med_cat.skills.primary.path
         secondary = None
         if med_cat.skills.secondary:
@@ -491,24 +492,20 @@ class HerbSupply:
                 break
 
             # rarity is set to 0 if the herb can't be found in the current season
-            if not self.herb[herb].get_rarity(
+            rarity = self.herb[herb].get_rarity(
                 game.clan.biome
                 if not game.clan.override_biome
                 else game.clan.override_biome,
                 game.clan.current_season,
-            ):
+            )
+            if not rarity:
                 continue
 
             # chance to find an herb is based on it's rarity
             if (
                 randint(
                     1,
-                    self.herb[herb].get_rarity(
-                        game.clan.biome
-                        if not game.clan.override_biome
-                        else game.clan.override_biome,
-                        game.clan.current_season,
-                    ),
+                    rarity,
                 )
                 == 1
             ):
@@ -520,7 +517,7 @@ class HerbSupply:
 
         return self.handle_found_herbs_outcomes(found_herbs)
 
-    def handle_found_herbs_outcomes(self, found_herbs: dict = {}):
+    def handle_found_herbs_outcomes(self, found_herbs: dict = None):
         """
         Handles adding herbs to the collection and preparing outcome for patrols
         """
@@ -633,7 +630,12 @@ class HerbSupply:
                 return
 
             self.in_need_of.extend(
-                [x for x in required_herbs if x not in self.in_need_of]
+                [
+                    x
+                    for x in required_herbs
+                    if x not in self.in_need_of
+                    and self.get_herb_rating(x) in (Supply.EMPTY, Supply.LOW)
+                ]
             )
 
             # find the possible effects of herb for the condition
@@ -834,7 +836,7 @@ class HerbSupply:
                 con_info[effect] = 2
 
 
-MESSAGES = None
+MESSAGES: Optional[dict] = None
 message_lang = None
 
 

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -250,7 +250,7 @@ def one_moon():
     # handle the herb supply for the moon
     game.clan.herb_supply.handle_moon(
         clan_size=get_living_clan_cat_count(Cat),
-        clan_cats=Cat.all_cats_list,
+        clan_cats=[c for c in Cat.all_cats_list if c.status.alive_in_player_clan],
         med_cats=find_alive_cats_with_rank(
             Cat,
             ranks=[CatRank.MEDICINE_CAT, CatRank.MEDICINE_APPRENTICE],


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
This is focused on herb balancing and on implementing the herb rarities that have been sitting in the wings for a while.

- All herbs now have variable rarities within each biome/season combo
- All herbs now have tailored expiration times. This was focused on making the very commonly found + used herbs expire faster and the very rare + less used herbs expire slower.
- Herb gathering focus now provides a static buff to quantity, instead of basing the quantity buff off the number of warriors. This is to prevent the crazy insane numbers that felt rly unrealistic (like... literal 100s of herbs being gathered in a moon with an average sized clan).  The "benefit" of the gathering focus is now more about it providing an "extra" gathering round to each med cat, with the quantity effectively doubled.
- Rarity of the herb now plays into the quantity gathered. "Rare" herbs will be gathered in lower quantities, while "common" herbs will be gathered in larger quantities.
- Herbs are only added to the "in_need" list when they have low or empty supplies.  I suspect the absence of this qualifier is what was leading to wildly disproportional herb supplies ( 300 cobwebs and 1 tansy, for example). 
- We *might* have been applying herbs to any and all cats, rather than just the clan cats. Probably wasn't affecting anything, since outsiders and dead cats don't get conditions anyways, but this is a good thing to fix regardless. (actually this *was* breaking stuff lol, so this fixed #4158)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Why This Is Good For ClanGen
We love balancing.

Rarities have been in the works for a while, just no one wanted to sit down and figure out what all the numbers should be. So ur welcome, I finally did it.

<!-- If this is a bug fix, you can remove this section. -->
<!-- Please add a short description of why you think these changes would benefit the game. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->
<!-- If you have multiple features that can stand on their own, or unrelated bugfixes, please create separate PRs for them. -->

## Proof of Testing
I did a fair amount of testing in my own Clan, seeing how well meddies kept up with demand. It seemed like they held it together fairly well, even without me doing consistent gathering patrols. Med den was generally staying at "adequate" supply, with it dipping down to "low" during leafbare, which I think is good.  Gathering focus didn't feel too overpowered, just a helpful boost, esp in newleaf when the Clan is trying to recover the herb stores in the wake of leafbare.  I noticed the range of herb amounts staying relatively proportional, though you still had some outliers, of course.  But it's nowhere near some of the wack ones I've seen previously with differences of 200-400.

<img width="800" height="694" alt="image" src="https://github.com/user-attachments/assets/219a9df4-32da-4837-a6d8-d77d846a72dc" />

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- All herbs now have variable rarities within each biome/season combo
- All herbs now have tailored expiration times. This was focused on making the very commonly found + used herbs expire faster and the very rare + less used herbs expire slower.
- Herb gathering focus now provides a static buff to quantity, instead of basing the quantity buff off the number of warriors. This is to prevent the crazy insane numbers that felt rly unrealistic (like... literal 100s of herbs being gathered in a moon with an average sized clan).  The "benefit" of the gathering focus is now more about it providing an "extra" gathering round to each med cat, with the quantity effectively doubled.
- Rarity of the herb now plays into the quantity gathered. "Rare" herbs will be gathered in lower quantities, while "common" herbs will be gathered in larger quantities.
- Herbs are only added to the "in_need" list when they have low or empty supplies.  I suspect the absence of this qualifier is what was leading to wildly disproportional herb supplies ( 300 cobwebs and 1 tansy, for example). 
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
