### PR TITLE
[BUGFIX] Lost kids returning with inappropriate statuses

### DIFF
--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -924,7 +924,7 @@ class Cat:
                 and child.moons < 12
             ):
                 child.status.add_to_group(
-                    new_group_ID=CatGroup.PLAYER_CLAN_ID, age=self.age
+                    new_group_ID=CatGroup.PLAYER_CLAN_ID, age=child.age
                 )
                 child.add_to_clan()
                 child.history.add_beginning()

--- a/scripts/cat/status.py
+++ b/scripts/cat/status.py
@@ -384,14 +384,18 @@ class Status:
                         CatRank.APPRENTICE,
                         CatRank.MEDIATOR_APPRENTICE,
                         CatRank.MEDICINE_APPRENTICE,
-                    ], weights=[6, 1, 2]
+                    ],
+                    weights=[6, 1, 2],
                 )[0]
             )
         elif age in (CatAge.YOUNG_ADULT, CatAge.ADULT, CatAge.SENIOR_ADULT):
             return (
                 CatRank.WARRIOR
                 if disable_random
-                else choices([CatRank.WARRIOR, CatRank.MEDICINE_CAT, CatRank.MEDIATOR], weights=[6, 2, 1])[0]
+                else choices(
+                    [CatRank.WARRIOR, CatRank.MEDICINE_CAT, CatRank.MEDIATOR],
+                    weights=[6, 2, 1],
+                )[0]
             )
         else:
             return CatRank.ELDER

--- a/scripts/cat/status.py
+++ b/scripts/cat/status.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from itertools import groupby
-from random import choice
+from random import choice, choices
 from typing import TypedDict, Optional, List, Dict
 
 from scripts.cat.enums import CatRank, CatSocial, CatStanding, CatAge, CatGroup
@@ -379,19 +379,19 @@ class Status:
             return (
                 CatRank.APPRENTICE
                 if disable_random
-                else choice(
+                else choices(
                     [
                         CatRank.APPRENTICE,
                         CatRank.MEDIATOR_APPRENTICE,
                         CatRank.MEDICINE_APPRENTICE,
-                    ]
-                )
+                    ], weights=[6, 1, 2]
+                )[0]
             )
         elif age in (CatAge.YOUNG_ADULT, CatAge.ADULT, CatAge.SENIOR_ADULT):
             return (
                 CatRank.WARRIOR
                 if disable_random
-                else choice([CatRank.WARRIOR, CatRank.MEDICINE_CAT, CatRank.MEDIATOR])
+                else choices([CatRank.WARRIOR, CatRank.MEDICINE_CAT, CatRank.MEDIATOR], weights=[6, 2, 1])[0]
             )
         else:
             return CatRank.ELDER


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
Just a mistake `self.age` which needed to be `child.age`. We were essentially choosing the child's rank based off their parent's age, instead of the child's age.

Also added weighting to the random rank choice, which I've wanted to do for a while. This way warriors and warrior apps are more common than meddies and mediators.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
fixes #4326
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
<img width="550" height="151" alt="image" src="https://github.com/user-attachments/assets/e07067ba-f605-4a70-9030-57f1d9711edc" />
<img width="667" height="305" alt="image" src="https://github.com/user-attachments/assets/643c4d00-6dfa-46a4-a06e-2fe2545c7120" />

Previously the kid would have become an elder like their mom.

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- When a lost parent returns to the Clan and brings their children with them, the kids will now take a new status appropriate for their age, rather than for their parent's age.
- Random status choices have now been weighted to prefer warriors and warrior apps over mediators and meddies
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
