### PR TITLE
[ENHANCEMENT] Prevent return to neutral relationships

### DIFF
--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -2776,7 +2776,7 @@ class Cat:
                             respect=rel["respect"] or 0,
                             comfort=rel["comfort"] or 0,
                             trust=rel["trust"] or 0,
-                            log=rel["log"]
+                            log=rel["log"],
                         )
                         self.relationships[rel["cat_to_id"]] = new_rel
 

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -2777,6 +2777,7 @@ class Cat:
                             comfort=rel["comfort"] or 0,
                             trust=rel["trust"] or 0,
                             log=rel["log"],
+                            no_longer_neutral=rel.get("no_longer_neutral", []),
                         )
                         self.relationships[rel["cat_to_id"]] = new_rel
 

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -2776,8 +2776,7 @@ class Cat:
                             respect=rel["respect"] or 0,
                             comfort=rel["comfort"] or 0,
                             trust=rel["trust"] or 0,
-                            log=rel["log"],
-                            no_longer_neutral=rel.get("no_longer_neutral", []),
+                            log=rel["log"]
                         )
                         self.relationships[rel["cat_to_id"]] = new_rel
 

--- a/scripts/cat_relations/relationship.py
+++ b/scripts/cat_relations/relationship.py
@@ -43,6 +43,7 @@ class Relationship:
         trust: int = 0,
         comfort: int = 0,
         log: list = None,
+        no_longer_neutral: list = None,
     ) -> None:
         self.chosen_interaction = None
         self.cat_from = cat_from
@@ -58,6 +59,11 @@ class Relationship:
             self.log = log
         else:
             self.log = []
+
+        self.no_longer_neutral = no_longer_neutral if no_longer_neutral else []
+        """
+        List of rel types that made it out of the neutral tier (ROMANCE is not included). This list is used to indicate which types should not return to a neutral state.
+        """
 
         # romance operates on a 0-100 scale, 0 is no romantic interest and 100 is full romantic interest
         self.romance = romance
@@ -81,6 +87,7 @@ class Relationship:
             "comfort": self.comfort,
             "trust": self.trust,
             "log": self.log,
+            "no_longer_neutral": self.no_longer_neutral,
         }
 
     def link_relationship(self):
@@ -606,7 +613,14 @@ class Relationship:
             value = 100
         elif value < -100:
             value = -100
+
         self._like = value
+
+        if RelType.LIKE in self.no_longer_neutral and self.like_tier.is_neutral:
+            self._like = self._get_neutral_adjusted_value(self._like)
+
+        if RelType.LIKE not in self.no_longer_neutral and not self.like_tier.is_neutral:
+            self.no_longer_neutral.append(RelType.LIKE)
 
     @property
     def like_tier(self) -> Optional[RelTier]:
@@ -639,6 +653,15 @@ class Relationship:
             value = -100
         self._respect = value
 
+        if RelType.RESPECT in self.no_longer_neutral and self.respect_tier.is_neutral:
+            self._respect = self._get_neutral_adjusted_value(self._respect)
+
+        if (
+            RelType.RESPECT not in self.no_longer_neutral
+            and not self.respect_tier.is_neutral
+        ):
+            self.no_longer_neutral.append(RelType.RESPECT)
+
     @property
     def respect_tier(self) -> Optional[RelTier]:
         group = self._get_tier_group(self.respect)
@@ -669,6 +692,15 @@ class Relationship:
         elif value < -100:
             value = -100
         self._comfort = value
+
+        if RelType.COMFORT in self.no_longer_neutral and self.comfort_tier.is_neutral:
+            self._comfort = self._get_neutral_adjusted_value(self._comfort)
+
+        if (
+            RelType.COMFORT not in self.no_longer_neutral
+            and not self.comfort_tier.is_neutral
+        ):
+            self.no_longer_neutral.append(RelType.COMFORT)
 
     @property
     def comfort_tier(self) -> Optional[RelTier]:
@@ -701,6 +733,15 @@ class Relationship:
             value = -100
         self._trust = value
 
+        if RelType.TRUST in self.no_longer_neutral and self.trust_tier.is_neutral:
+            self._trust = self._get_neutral_adjusted_value(self._trust)
+
+        if (
+            RelType.TRUST not in self.no_longer_neutral
+            and not self.trust_tier.is_neutral
+        ):
+            self.no_longer_neutral.append(RelType.TRUST)
+
     @property
     def trust_tier(self) -> Optional[RelTier]:
         group = self._get_tier_group(self.trust)
@@ -732,3 +773,20 @@ class Relationship:
                 return group
 
         return None
+
+    @staticmethod
+    def _get_neutral_adjusted_value(value: int):
+        value_intervals = constants.CONFIG["relationship"]["value_intervals"]
+        neutral_start = value_intervals["low_neg"]
+        neutral_end = value_intervals["neutral"]
+
+        if neutral_start < value <= neutral_end:  # if value is neutral
+            # find which end of the neutral range we're closest too
+            if abs(value - neutral_start) < abs(neutral_end - value):
+                # if closest to neg side, return negative tier value
+                return neutral_start - 1
+            else:
+                # if closest to pos side, return positive tier value
+                return neutral_end + 1
+        else:
+            return value

--- a/scripts/cat_relations/relationship.py
+++ b/scripts/cat_relations/relationship.py
@@ -43,7 +43,6 @@ class Relationship:
         trust: int = 0,
         comfort: int = 0,
         log: list = None,
-        no_longer_neutral: list = None,
     ) -> None:
         self.chosen_interaction = None
         self.cat_from = cat_from
@@ -60,7 +59,7 @@ class Relationship:
         else:
             self.log = []
 
-        self.no_longer_neutral = no_longer_neutral if no_longer_neutral else []
+        self.no_longer_neutral = []
         """
         List of rel types that made it out of the neutral tier (ROMANCE is not included). This list is used to indicate which types should not return to a neutral state.
         """


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
This adds detection that prevents relationships returning to neutral.  I've done this by adding a list to the relationship object which tracks which rel_types are no longer neutral. When a rel_type tries to change it's value to a neutral one while it's part of that list, it'll be caught and the value reset to one which falls into a non-neutral range.  The value reset will set it to whichever side of the bar it was closest too: if it was closest to a pos value, it becomes a low_pos value; if it was closest to a neg value, it becomes a low_neg value.  This is all being compared to the interval values set up in game config, so if those are ever changed, we don't have to worry about adjusting this func.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Why This Is Good For ClanGen
We've had some player feedback about it feeling disappointing when cats improve (or worsen) their relationships to a degree that it "returns" them to a neutral tier. It feels like an odd erasure/reset of their relationship, rather than a development.  I also brought this up in the dev game talk and other devs thought it would be a good addition.

This change would prevent that from occurring, hopefully enriching the relationships cats create. It also has an interesting side-effect of effectively setting a "threshold" that cats need to jump over before a relationship can move from neg to pos and vice versa. It's a small threshold (5), so I don't think it's detrimental to allowing relationships to change and grow; instead I think it will add another aspect to how they change, requiring larger impact events to make those bigger degrees of change.

<!-- If this is a bug fix, you can remove this section. -->
<!-- Please add a short description of why you think these changes would benefit the game. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->
<!-- If you have multiple features that can stand on their own, or unrelated bugfixes, please create separate PRs for them. -->

## Proof of Testing
<img width="671" height="389" alt="image" src="https://github.com/user-attachments/assets/823544c0-a312-4f1d-b4b5-503097aafac5" />

debugging the method that handles value resetting! our prospective new value is -2

<img width="556" height="265" alt="image" src="https://github.com/user-attachments/assets/ea007dcb-fc95-47a7-a67d-5457ac84dab4" />

double check if -2 falls into the neutral range, and it does. Since it's -2, it falls closest to the negative side, so we *should* see the first return statement chosen

<img width="549" height="255" alt="image" src="https://github.com/user-attachments/assets/d75f15a3-d9de-41a8-954d-efaa1811bb1b" />

and it was! we'll see -7 returned as the new value

<img width="357" height="81" alt="image" src="https://github.com/user-attachments/assets/acae65ec-e8a7-4628-a5c1-2f2dd836bbf7" />

And after applying that value, we see that our tier is at DOUBTS, which *isn't* a neutral tier.

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- When a cat's relationship moves from negative to positive (or vice versa), it can no longer return to a neutral value. Instead, it will skip the neutral tier and become either low_positive or low_negative.  This means that once a relationship value moves out of the neutral tier, it will *never* return there, hopefully resulting in some interesting relationships.
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
