### PR TITLE
[BALANCE] Patrol weighting

### DIFF
--- a/resources/lang/en/patrols/plains/border/any.json
+++ b/resources/lang/en/patrols/plains/border/any.json
@@ -2197,7 +2197,7 @@
             "normal adult": [2, 6],
             "apprentice": [-1, 2]
         },
-        "frequency": 4,
+        "frequency": 2,
         "intro_text": "The patrol catches the scent of a fox - but is it red or swift?",
         "decline_text": "The patrol decides not to pursue the fox.",
         "chance_of_success": 30,

--- a/scripts/events_module/patrol/patrol_outcome.py
+++ b/scripts/events_module/patrol/patrol_outcome.py
@@ -99,7 +99,7 @@ class PatrolOutcome:
                 self.weight += len(self.stat_trait)
             else:
                 # inclusionary values get inverse weighting
-                self.weight += int((self.NUM_OF_TRAITS - len(self.stat_trait)) / 10)
+                self.weight += int((self.NUM_OF_TRAITS - len(self.stat_trait)))
         self.stat_skill = stat_skill if stat_skill else []
         if self.stat_skill:
             # exclusionary values!
@@ -107,7 +107,7 @@ class PatrolOutcome:
                 self.weight += len(self.stat_skill)
             else:
                 # inclusionary values get inverse weighting
-                self.weight += int((self.NUM_OF_SKILLS - len(self.stat_skill)) / 5)
+                self.weight += int((self.NUM_OF_SKILLS - len(self.stat_skill)))
 
         self.can_have_stat = can_have_stat if can_have_stat else []
 

--- a/scripts/events_module/patrol/patrol_outcome.py
+++ b/scripts/events_module/patrol/patrol_outcome.py
@@ -85,19 +85,30 @@ class PatrolOutcome:
         self.exp = exp
 
         self.min_max_status = min_max_status if min_max_status else {}
-        self.weight += len(self.min_max_status) * 2
+        self.weight += len(self.min_max_status) * 4
 
         self.relationship_constraints = (
             relationship_constraints if relationship_constraints else []
         )
         if relationship_constraints:
-            self.weight += len(relationship_constraints) * 2
+            self.weight += len(relationship_constraints) * 8
         self.stat_trait = stat_trait if stat_trait else []
         if self.stat_trait:
-            self.weight += int((self.NUM_OF_TRAITS - len(self.stat_trait)) / 10)
+            # exclusionary values!
+            if "-" in self.stat_trait[0]:
+                self.weight += len(self.stat_trait)
+            else:
+                # inclusionary values get inverse weighting
+                self.weight += int((self.NUM_OF_TRAITS - len(self.stat_trait)) / 10)
         self.stat_skill = stat_skill if stat_skill else []
         if self.stat_skill:
-            self.weight += int((self.NUM_OF_SKILLS - len(self.stat_skill)) / 5)
+            # exclusionary values!
+            if "-" in self.stat_skill[0]:
+                self.weight += len(self.stat_skill)
+            else:
+                # inclusionary values get inverse weighting
+                self.weight += int((self.NUM_OF_SKILLS - len(self.stat_skill)) / 5)
+
         self.can_have_stat = can_have_stat if can_have_stat else []
 
         self.dead_cats = dead_cats if dead_cats else []


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
All the patrol rel log reviewing has me more aware of the breadth of patrols we have; and what sort of weighting might help them shine. 
- rel constraints now have a very big weight; this is cus they're relatively unused *and* they depend on the right cats being placed together. when it happens, we want them to have a good chance of appearing!
- skill and trait constraints for the patrol as a whole got a boost. once again, relatively unused and depend on certain cats. 
- skill and trait constraints for overall and outcome got some additional logic to deal with exclusionary values. when values are *in*clusionary, we want to give extra weight to smaller lists. however, when they're *ex*clusionary, we don't want to do that.
- made biome and season constraints weight on an inverse, just like skills and traits. this means smaller lists enjoy higher weight and vice versa.

- adjusted freq on a vixen patrol i came across while testing
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Why This Is Good For ClanGen
helps those higher constrained patrols shine! i especially wanted to see more biome-specific patrols being chosen, which I think I saw an improvement on while bug testing this.
<!-- If this is a bug fix, you can remove this section. -->
<!-- Please add a short description of why you think these changes would benefit the game. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->
<!-- If you have multiple features that can stand on their own, or unrelated bugfixes, please create separate PRs for them. -->

## Proof of Testing
<img width="395" height="90" alt="image" src="https://github.com/user-attachments/assets/8654b938-0515-436b-bc59-dbefdcc0a2c4" />
<img width="414" height="86" alt="image" src="https://github.com/user-attachments/assets/819b0015-843f-49e6-aa8b-5e72679d86b3" />
<img width="421" height="70" alt="image" src="https://github.com/user-attachments/assets/af4841bd-8d1f-4db3-b029-a472772c9827" />
<img width="340" height="73" alt="image" src="https://github.com/user-attachments/assets/157aa330-67f2-4b57-8278-8e8850555631" />
<img width="385" height="102" alt="image" src="https://github.com/user-attachments/assets/6484696c-5a0d-48be-a29e-41122e3bcf35" />

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- rel constraints now have a very big weight; this is cus they're relatively unused *and* they depend on the right cats being placed together. when it happens, we want them to have a good chance of appearing!
- skill and trait constraints for the patrol as a whole got a boost. once again, relatively unused and depend on certain cats. 
- skill and trait constraints for overall and outcome got some additional logic to deal with exclusionary values. when values are *in*clusionary, we want to give extra weight to smaller lists. however, when they're *ex*clusionary, we don't want to do that.
- made biome and season constraints weight on an inverse, just like skills and traits. this means smaller lists enjoy higher weight and vice versa.

- adjusted frequency on a vixen patrol
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
