### PR TITLE
[ENHANCEMENT] Constrained treatment of perm conditions

### DIFF
--- a/scripts/clan_resources/herb/herb_supply.py
+++ b/scripts/clan_resources/herb/herb_supply.py
@@ -669,10 +669,13 @@ class HerbSupply:
                     self.__apply_lack_of_herb(treatment_cat, name, chosen_effect)
                     return
                 # if chance of risk is already low, med cat doesn't treat
+                no_treatment = False
                 for risk in condition.get("risks", []):
                     if risk["chance"] > 20:
                         self.__apply_lack_of_herb(treatment_cat, name, chosen_effect)
-                        return
+                        no_treatment = True
+                if no_treatment:
+                    break
 
             if game.clan.game_mode == "classic":
                 # classic always applies basic treatment, regardless of herb supply

--- a/scripts/clan_resources/herb/herb_supply.py
+++ b/scripts/clan_resources/herb/herb_supply.py
@@ -674,7 +674,7 @@ class HerbSupply:
                         self.__apply_lack_of_herb(treatment_cat, name, chosen_effect)
                         no_treatment = True
                 if no_treatment:
-                    break
+                    return
 
             if game.clan.game_mode == "classic":
                 # classic always applies basic treatment, regardless of herb supply

--- a/scripts/clan_resources/herb/herb_supply.py
+++ b/scripts/clan_resources/herb/herb_supply.py
@@ -203,8 +203,25 @@ class HerbSupply:
             # a whole. also helps prevent death spiral when med cats aren't able to work.
             if not med_cats and not kitty.status.rank.is_any_medicine_rank():
                 break
+
             severities = []
-            conditions = kitty.permanent_condition.copy()
+
+            # we'll only add perm conditions if they seem likely to negatively affect the cat
+            conditions = {}
+            if kitty.is_disabled():
+                for condition in kitty.permanent_condition:
+                    condition_list = kitty.permanent_condition
+                    if (
+                        condition_list[condition]["mortality"]
+                        and condition_list[condition]["mortality"] < 20
+                    ):
+                        conditions.update(condition_list[condition])
+                        continue
+                    for risk in condition_list[condition]["risks"]:
+                        if risk["chance"] < 20:
+                            conditions.update(condition_list[condition])
+                            break
+
             conditions.update(kitty.injuries)
             conditions.update(kitty.illnesses)
             for con in conditions:

--- a/scripts/clan_resources/herb/herb_supply.py
+++ b/scripts/clan_resources/herb/herb_supply.py
@@ -209,21 +209,7 @@ class HerbSupply:
             severities = []
 
             # we'll only add perm conditions if they seem likely to negatively affect the cat
-            conditions = {}
-            if kitty.is_disabled():
-                for condition in kitty.permanent_condition:
-                    condition_list = kitty.permanent_condition
-                    if (
-                        condition_list[condition]["mortality"]
-                        and condition_list[condition]["mortality"] < 20
-                    ):
-                        conditions.update(condition_list[condition])
-                        continue
-                    for risk in condition_list[condition]["risks"]:
-                        if risk["chance"] < 20:
-                            conditions.update(condition_list[condition])
-                            break
-
+            conditions = kitty.permanent_condition.copy()
             conditions.update(kitty.injuries)
             conditions.update(kitty.illnesses)
             for con in conditions:
@@ -673,6 +659,20 @@ class HerbSupply:
                 return
 
             chosen_effect = choice(possible_effects)
+
+            if (
+                treatment_cat.is_disabled()
+                and name in treatment_cat.permanent_condition
+            ):
+                # if chance of death is already low, med cat doesn't treat
+                if condition.get("mortality") and condition.get("mortality", 0) > 20:
+                    self.__apply_lack_of_herb(treatment_cat, name, chosen_effect)
+                    return
+                # if chance of risk is already low, med cat doesn't treat
+                for risk in condition.get("risks", []):
+                    if risk["chance"] > 20:
+                        self.__apply_lack_of_herb(treatment_cat, name, chosen_effect)
+                        return
 
             if game.clan.game_mode == "classic":
                 # classic always applies basic treatment, regardless of herb supply

--- a/scripts/clan_resources/herb/herb_supply.py
+++ b/scripts/clan_resources/herb/herb_supply.py
@@ -208,7 +208,6 @@ class HerbSupply:
 
             severities = []
 
-            # we'll only add perm conditions if they seem likely to negatively affect the cat
             conditions = kitty.permanent_condition.copy()
             conditions.update(kitty.injuries)
             conditions.update(kitty.illnesses)


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
This constrains treatment of perm conditions to only occur if death or risks seem likely to occur, if not, the med cat conserves their herbs.  Note that untreated perm conditions still have "lack of herb" applied to them, which effectively increases their chance of death/risks.  Chances will now ping-pong a bit, essentially.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Why This Is Good For ClanGen
I noticed that perm conditions quickly became a permanent drain on herb supplies, even when cats had an incredibly low chance of the perm condition doing anything (due to how many times it had been treated prior, we're talking like a 1/400 chance of a risk triggering). Now we that we constrain the treatment, perm conditions can be managed but not entirely negated; and at the same time, won't become *such* a drain on the herb supply.
<!-- If this is a bug fix, you can remove this section. -->
<!-- Please add a short description of why you think these changes would benefit the game. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->
<!-- If you have multiple features that can stand on their own, or unrelated bugfixes, please create separate PRs for them. -->

## Proof of Testing
<img width="587" height="423" alt="image" src="https://github.com/user-attachments/assets/01f98115-2aae-489a-9222-4c4de00cd709" />

We've got lots of cats in this Clan who have perm conditions (esp weak legs), however none of them have been treated this moon.

<img width="526" height="136" alt="image" src="https://github.com/user-attachments/assets/7b461a22-e618-4938-bfe8-8f44a7f8dcc1" />

Here's one who has been treated upon skipping to a new moon!

I've also stepped through this stuff in debug mode, it all seems to work as expected.
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Perm conditions are now only treated if a med cat deems death/risks to be likely. Otherwise, herbs will be conserved for other uses.
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
