### PR TITLE
[CONTENT] Apprentice New_Cat Events.

### DIFF
--- a/resources/lang/en/events/new_cat/general.json
+++ b/resources/lang/en/events/new_cat/general.json
@@ -957,7 +957,62 @@
             }
         ]
     },
-
+        {
+    "event_id": "gen_new_cat_rogueapp1",
+    "location": ["any"],
+    "season": ["any"],
+    "frequency": 4,
+    "event_text": "m_c finds a young cat who asks to join the Clan. The rogue is welcomed into the Clan, and renamed n_c:0.",
+    "m_c": {
+        "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+        "status": ["any"]
+    },
+    "new_cat": [
+        ["new_name",
+        "rogue",
+        "status:apprentice"]
+    ],
+    "relationships": [
+        {
+            "cats_from": ["m_c"],
+            "cats_to": ["n_c:0"],
+            "mutual": false,
+            "values": ["trust", "respect"],
+            "amount": 20,
+            "log": {
+                    "cats_from": "m_c found n_c:0 and brought {PRONOUN/n_c:0/object} into the Clan."
+                }
+        }
+    ]
+},
+    {
+    "event_id": "gen_new_cat_rogueapp2",
+    "location": ["any"],
+    "season": ["any"],
+    "frequency": 3,
+    "event_text": "m_c couldn't keep {PRONOUN/m_c/poss} new friend a secret forever. The two quietly came back into camp one day, and the young rogue asked to join the Clan, officially becoming n_c:0.",
+    "m_c": {
+        "age": ["adolescent"],
+        "status": ["any"]
+    },
+    "new_cat": [
+        ["new_name",
+        "rogue",
+        "status:apprentice"]
+    ],
+    "relationships": [
+        {
+            "cats_from": ["m_c"],
+            "cats_to": ["n_c:0"],
+            "mutual": false,
+            "values": ["trust", "respect"],
+            "amount": 30,
+            "log": {
+                    "cats_from": "m_c and n_c:0 became friends over the border before the latter joined the Clan."
+                }
+        }
+    ]
+},
     {
         "event_id": "gen_new_cat_anyotherclancat1",
         "location": ["any"],

--- a/resources/lang/en/events/new_cat/general.json
+++ b/resources/lang/en/events/new_cat/general.json
@@ -600,7 +600,7 @@
     "location": ["any"],
     "season": ["any"],
     "frequency": 3,
-    "event_text": "m_c couldn't keep {PRONOUN/m_c/poss} new friend a secret forever. The two quietly came back into camp one day, the young loner agreeing to be trained in the ways of c_n. m_c cheers the loudest when n_c:0 is made an apprentice",
+    "event_text": "m_c couldn't keep {PRONOUN/m_c/poss} new loner friend a secret forever. The two quietly came back to camp one day, m_c cheering the loudest when n_c:0 is welcomed as an apprentice of c_n.",
     "m_c": {
         "age": ["adolescent"],
         "status": ["any"]
@@ -618,7 +618,7 @@
             "values": ["trust", "respect"],
             "amount": 30,
             "log": {
-                    "cats_from": "m_c and n_c:0 became friends over the border before the latter joined the Clan."
+                    "cats_from": "m_c and n_c:0 became friends along the border before the latter joined the Clan."
                 }
         }
     ]
@@ -796,7 +796,7 @@
     "location": ["any"],
     "season": ["any"],
     "frequency": 3,
-    "event_text": "m_c couldn't keep {PRONOUN/m_c/poss} new friend a secret forever. The two quietly came back into camp one day, the young kittypet agreeing to be trained in the ways of c_n. m_c cheers the loudest when n_c:0 is made an apprentice",
+    "event_text": "m_c couldn't keep {PRONOUN/m_c/poss} new kittypet friend a secret forever. The two quietly came back to camp one day, m_c cheering the loudest when n_c:0 is welcomed as an apprentice of c_n",
     "m_c": {
         "age": ["adolescent"],
         "status": ["any"]
@@ -814,7 +814,7 @@
             "values": ["trust", "respect"],
             "amount": 30,
             "log": {
-                    "cats_from": "m_c and n_c:0 became friends over the border before the latter joined the Clan."
+                    "cats_from": "m_c and n_c:0 became friends along the border before the latter joined the Clan."
                 }
         }
     ]
@@ -990,7 +990,7 @@
     "location": ["any"],
     "season": ["any"],
     "frequency": 3,
-    "event_text": "m_c couldn't keep {PRONOUN/m_c/poss} new friend a secret forever. The two quietly came back into camp one day, the young rogue agreeing to be trained in the ways of c_n. m_c cheers the loudest when n_c:0 is made an apprentice.",
+    "event_text": "m_c couldn't keep {PRONOUN/m_c/poss} new rogue friend a secret forever. The two quietly came back to camp one day, m_c cheering the loudest when n_c:0 is welcomed as an apprentice of c_n",
     "m_c": {
         "age": ["adolescent"],
         "status": ["any"]
@@ -1008,7 +1008,7 @@
             "values": ["trust", "respect"],
             "amount": 30,
             "log": {
-                    "cats_from": "m_c and n_c:0 became friends over the border before the latter joined the Clan."
+                    "cats_from": "m_c and n_c:0 became friends along the border before the latter joined the Clan."
                 }
         }
     ]

--- a/resources/lang/en/events/new_cat/general.json
+++ b/resources/lang/en/events/new_cat/general.json
@@ -567,6 +567,62 @@
             }
         ]
     },
+        {
+    "event_id": "gen_new_cat_lonerapp1",
+    "location": ["any"],
+    "season": ["any"],
+    "frequency": 4,
+    "event_text": "m_c finds a young cat who asks to join the Clan. The loner is welcomed into the Clan, and renamed n_c:0.",
+    "m_c": {
+        "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+        "status": ["any"]
+    },
+    "new_cat": [
+        ["new_name",
+        "loner",
+        "status:apprentice"]
+    ],
+    "relationships": [
+        {
+            "cats_from": ["m_c"],
+            "cats_to": ["n_c:0"],
+            "mutual": false,
+            "values": ["trust", "respect"],
+            "amount": 20,
+            "log": {
+                    "cats_from": "m_c found n_c:0 and brought {PRONOUN/n_c:0/object} into the Clan."
+                }
+        }
+    ]
+},
+    {
+    "event_id": "gen_new_cat_lonerapp2",
+    "location": ["any"],
+    "season": ["any"],
+    "frequency": 3,
+    "event_text": "m_c couldn't keep {PRONOUN/m_c/poss} new friend a secret forever. The two quietly came back into camp one day, and the young loner asked to join the Clan, officially becoming n_c:0.",
+    "m_c": {
+        "age": ["adolescent"],
+        "status": ["any"]
+    },
+    "new_cat": [
+        ["new_name",
+        "loner",
+        "status:apprentice"]
+    ],
+    "relationships": [
+        {
+            "cats_from": ["m_c"],
+            "cats_to": ["n_c:0"],
+            "mutual": false,
+            "values": ["trust", "respect"],
+            "amount": 30,
+            "log": {
+                    "cats_from": "m_c and n_c:0 became friends over the border before the latter joined the Clan."
+                }
+        }
+    ]
+},
     {
         "event_id": "gen_new_cat_anykittypet1",
         "location": ["any"],

--- a/resources/lang/en/events/new_cat/general.json
+++ b/resources/lang/en/events/new_cat/general.json
@@ -763,6 +763,62 @@
             }
         ]
     },
+            {
+    "event_id": "gen_new_cat_kittypetapp1",
+    "location": ["any"],
+    "season": ["any"],
+    "frequency": 4,
+    "event_text": "m_c finds a young cat who asks to join the Clan. The kittypet is welcomed into the Clan, and renamed n_c:0.",
+    "m_c": {
+        "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+        "status": ["any"]
+    },
+    "new_cat": [
+        ["new_name",
+        "kittypet",
+        "status:apprentice"]
+    ],
+    "relationships": [
+        {
+            "cats_from": ["m_c"],
+            "cats_to": ["n_c:0"],
+            "mutual": false,
+            "values": ["trust", "respect"],
+            "amount": 20,
+            "log": {
+                    "cats_from": "m_c found n_c:0 and brought {PRONOUN/n_c:0/object} into the Clan."
+                }
+        }
+    ]
+},
+    {
+    "event_id": "gen_new_cat_kittypetapp2",
+    "location": ["any"],
+    "season": ["any"],
+    "frequency": 3,
+    "event_text": "m_c couldn't keep {PRONOUN/m_c/poss} new friend a secret forever. The two quietly came back into camp one day, and the young kittypet asked to join the Clan, officially becoming n_c:0.",
+    "m_c": {
+        "age": ["adolescent"],
+        "status": ["any"]
+    },
+    "new_cat": [
+        ["new_name",
+        "kittypet",
+        "status:apprentice"]
+    ],
+    "relationships": [
+        {
+            "cats_from": ["m_c"],
+            "cats_to": ["n_c:0"],
+            "mutual": false,
+            "values": ["trust", "respect"],
+            "amount": 30,
+            "log": {
+                    "cats_from": "m_c and n_c:0 became friends over the border before the latter joined the Clan."
+                }
+        }
+    ]
+},
     {
         "event_id": "gen_new_cat_anyrogue1",
         "location": ["any"],

--- a/resources/lang/en/events/new_cat/general.json
+++ b/resources/lang/en/events/new_cat/general.json
@@ -600,7 +600,7 @@
     "location": ["any"],
     "season": ["any"],
     "frequency": 3,
-    "event_text": "m_c couldn't keep {PRONOUN/m_c/poss} new friend a secret forever. The two quietly came back into camp one day, and the young loner asked to join the Clan, officially becoming n_c:0.",
+    "event_text": "m_c couldn't keep {PRONOUN/m_c/poss} new friend a secret forever. The two quietly came back into camp one day, the young loner agreeing to be trained in the ways of c_n. m_c cheers the loudest when n_c:0 is made an apprentice",
     "m_c": {
         "age": ["adolescent"],
         "status": ["any"]
@@ -796,7 +796,7 @@
     "location": ["any"],
     "season": ["any"],
     "frequency": 3,
-    "event_text": "m_c couldn't keep {PRONOUN/m_c/poss} new friend a secret forever. The two quietly came back into camp one day, and the young kittypet asked to join the Clan, officially becoming n_c:0.",
+    "event_text": "m_c couldn't keep {PRONOUN/m_c/poss} new friend a secret forever. The two quietly came back into camp one day, the young kittypet agreeing to be trained in the ways of c_n. m_c cheers the loudest when n_c:0 is made an apprentice",
     "m_c": {
         "age": ["adolescent"],
         "status": ["any"]
@@ -990,7 +990,7 @@
     "location": ["any"],
     "season": ["any"],
     "frequency": 3,
-    "event_text": "m_c couldn't keep {PRONOUN/m_c/poss} new friend a secret forever. The two quietly came back into camp one day, and the young rogue asked to join the Clan, officially becoming n_c:0.",
+    "event_text": "m_c couldn't keep {PRONOUN/m_c/poss} new friend a secret forever. The two quietly came back into camp one day, the young rogue agreeing to be trained in the ways of c_n. m_c cheers the loudest when n_c:0 is made an apprentice.",
     "m_c": {
         "age": ["adolescent"],
         "status": ["any"]

--- a/resources/lang/en/events/new_cat/general.json
+++ b/resources/lang/en/events/new_cat/general.json
@@ -572,7 +572,7 @@
     "location": ["any"],
     "season": ["any"],
     "frequency": 4,
-    "event_text": "m_c finds a young cat who asks to join the Clan. The loner is welcomed into the Clan, and renamed n_c:0.",
+    "event_text": "m_c finds a young cat who asks to join the Clan. The loner is welcomed into the Clan and renamed n_c:0.",
     "m_c": {
         "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
         "status": ["any"]
@@ -768,7 +768,7 @@
     "location": ["any"],
     "season": ["any"],
     "frequency": 4,
-    "event_text": "m_c finds a young cat who asks to join the Clan. The kittypet is welcomed into the Clan, and renamed n_c:0.",
+    "event_text": "m_c finds a young cat who asks to join the Clan. The kittypet is welcomed into the Clan and renamed n_c:0.",
     "m_c": {
         "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
         "status": ["any"]
@@ -962,7 +962,7 @@
     "location": ["any"],
     "season": ["any"],
     "frequency": 4,
-    "event_text": "m_c finds a young cat who asks to join the Clan. The rogue is welcomed into the Clan, and renamed n_c:0.",
+    "event_text": "m_c finds a young cat who asks to join the Clan. The rogue is welcomed into the Clan and renamed n_c:0.",
     "m_c": {
         "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
         "status": ["any"]

--- a/resources/lang/en/events/new_cat/general.json
+++ b/resources/lang/en/events/new_cat/general.json
@@ -614,7 +614,7 @@
         {
             "cats_from": ["m_c"],
             "cats_to": ["n_c:0"],
-            "mutual": false,
+            "mutual": true,
             "values": ["trust", "respect"],
             "amount": 30,
             "log": {
@@ -810,7 +810,7 @@
         {
             "cats_from": ["m_c"],
             "cats_to": ["n_c:0"],
-            "mutual": false,
+            "mutual": true,
             "values": ["trust", "respect"],
             "amount": 30,
             "log": {
@@ -1004,7 +1004,7 @@
         {
             "cats_from": ["m_c"],
             "cats_to": ["n_c:0"],
-            "mutual": false,
+            "mutual": true,
             "values": ["trust", "respect"],
             "amount": 30,
             "log": {


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
 - Adds 6 Gen_New_Cat events involving apprentices.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Why This Is Good For ClanGen
 - A majority of the new_cat events have only had kits or adults generated. These events allow for apprentices to be generated as well, reminiscent of Firepaw and Russetpaw.
<!-- If this is a bug fix, you can remove this section. -->
<!-- Please add a short description of why you think these changes would benefit the game. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->
<!-- If you have multiple features that can stand on their own, or unrelated bugfixes, please create separate PRs for them. -->

## Proof of Testing
<img width="507" height="61" alt="image" src="https://github.com/user-attachments/assets/32e940ea-423e-45a4-bed1-9f8c7514d9e9" />
<img width="504" height="89" alt="image" src="https://github.com/user-attachments/assets/74552433-fa2a-42f2-b322-e2695d4c1d1e" />

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->
