### PR TITLE
fix: cat younger than 150 moons dies of old age

### DIFF
--- a/scripts/events_module/short/short_event_generation.py
+++ b/scripts/events_module/short/short_event_generation.py
@@ -398,6 +398,15 @@ def filter_events(
             < constants.CONFIG["death_related"]["old_age_death_start"]
         ):
             continue
+        # check for old age for r_c when they die
+        if (
+            random_cat
+            and "old_age" in event.sub_type
+            and event.r_c.get("dies", False)
+            and random_cat.moons
+            < constants.CONFIG["death_related"]["old_age_death_start"]
+        ):
+            continue
         # remove some non-old age events to encourage elders to die of old age more often
         if (
             "old_age" not in event.sub_type


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

Fixed a bug where cats younger than 150 moons could die of old age when paired with an older mate in death events. The issue occurred because the code only checked if the main cat (m_c) had reached the old age death threshold (150 moons), but did not verify that the relationship cat (r_c) also met this requirement when both cats died together in old age events.

Added a check in the `filter_events` function in `short_event_generation.py` to ensure that when a relationship cat (r_c) dies in an old age event, they must also be at least 150 moons old. This prevents situations where a younger leader or cat loses all their lives prematurely due to their older mate's death.

## Linked Issues

#3983

## Proof of Testing

- All existing tests passed: 20 tests in `test_handle_short_events.py` and `test_event_filters.py` passed successfully
- Pylint validation passed with 0 errors on the modified file
- The fix ensures both cats in the "gen_death_age_any5" event (and similar old age death events) meet the 150 moon threshold before the event can trigger

## Changelog/Credits

**The code in this pull request was generated by GitHub Copilot with the Claude Sonnet 4.5 model.**