### PR TITLE
[BUGFIX] Preserving death info

### DIFF
--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -72,7 +72,6 @@ if TYPE_CHECKING:
 class Cat:
     """The cat class."""
 
-    dead_cats = []
     used_screen = screen
     current_pronoun_lang = None
 
@@ -121,8 +120,6 @@ class Cat:
 
     all_cats_list: List[Cat] = []
     ordered_cat_list: List[Cat] = []
-
-    grief_strings = {}
 
     def __init__(
         self,
@@ -706,7 +703,7 @@ class Cat:
             and self.status.get_last_living_group() == CatGroup.PLAYER_CLAN_ID
         ):
             self.grief(body)
-            Cat.dead_cats.append(self)
+            game.dead_cats_to_grieve.append(self)
 
         # mark the sprite as outdated
         self.pelt.rebuild_sprite = True
@@ -826,10 +823,12 @@ class Cat:
 
             if grief_type:
                 # Generate the event:
-                if cat.ID not in Cat.grief_strings:
-                    Cat.grief_strings[cat.ID] = []
+                if cat.ID not in game.clan.grief_strings:
+                    game.clan.grief_strings[cat.ID] = []
 
-                Cat.grief_strings[cat.ID].append((text, (self.ID, cat.ID), grief_type))
+                game.clan.grief_strings[cat.ID].append(
+                    (text, (self.ID, cat.ID), grief_type)
+                )
                 continue
 
             # Negative "grief" messages are just for flavor.
@@ -847,10 +846,12 @@ class Cat:
                 text = event_text_adjust(
                     Cat, choice(possible_strings), main_cat=self, random_cat=cat
                 )
-                if cat.ID not in Cat.grief_strings:
-                    Cat.grief_strings[cat.ID] = []
+                if cat.ID not in game.clan.grief_strings:
+                    game.clan.grief_strings[cat.ID] = []
 
-                Cat.grief_strings[cat.ID].append((text, (self.ID, cat.ID), "negative"))
+                game.clan.grief_strings[cat.ID].append(
+                    (text, (self.ID, cat.ID), "negative")
+                )
 
     def familial_grief(self, living_cat: Cat):
         """

--- a/scripts/clan.py
+++ b/scripts/clan.py
@@ -11,9 +11,7 @@ TODO: Docs
 import os
 import statistics
 from random import choice, randint
-from typing import Optional
 
-import pygame
 import ujson
 
 from scripts.cat.cats import Cat, cat_class, BACKSTORIES
@@ -24,7 +22,6 @@ from scripts.cat.save_load import (
     get_faded_ids,
     load_faded_cat_ids,
 )
-from scripts.cat.sprites.load_sprites import sprites
 from scripts.clan_package.settings import save_clan_settings, load_clan_settings
 from scripts.clan_package.settings.clan_settings import reset_loaded_clan_settings
 from scripts.clan_resources.freshkill import FreshkillPile, Nutrition
@@ -58,6 +55,9 @@ class Clan:
 
     age = 0
     all_other_clans = []
+
+    dead_cats_to_grieve = []
+    grief_strings = {}
 
     def __init__(
         self,
@@ -425,6 +425,9 @@ class Clan:
             "mediated": game.mediated,
             "starting_season": self.starting_season,
             "temperament": self.temperament,
+            "just_died": game.just_died,
+            "dead_cats_to_grieve": [x.ID for x in game.dead_cats_to_grieve],
+            "grief_to_assign": game.clan.grief_strings,
             "version_name": SAVE_VERSION_NUMBER,
             "version_commit": get_version_info().version_number,
             "source_build": get_version_info().is_source_build,
@@ -862,6 +865,20 @@ class Clan:
                 game.mediated = []
             else:
                 game.mediated = clan_data["mediated"]
+
+        # Cat who had just died
+        if "just_died" in clan_data:
+            game.just_died = clan_data["just_died"]
+
+        # Cats who need to be grieved
+        if "dead_cats_to_grieve" in clan_data:
+            game.dead_cats_to_grieve = [
+                Cat.fetch_cat(x) for x in clan_data["dead_cats_to_grieve"]
+            ]
+
+        # Cats who are gonna grieve
+        if "grief_to_assign" in clan_data:
+            game.clan.grief_strings = clan_data["grief_to_assign"]
 
         self.load_pregnancy(game.clan)
         self.load_herb_supply(game.clan)

--- a/scripts/clan.py
+++ b/scripts/clan.py
@@ -56,7 +56,6 @@ class Clan:
     age = 0
     all_other_clans = []
 
-    dead_cats_to_grieve = []
     grief_strings = {}
 
     def __init__(

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -143,17 +143,17 @@ def one_moon():
     # disaster_events.handle_disasters()
 
     # Handle grief events.
-    if Cat.grief_strings:
+    if game.clan.grief_strings:
         # Grab all the dead or outside cats, who should not have grief text
-        for ID in Cat.grief_strings.copy():
+        for ID in game.clan.grief_strings.copy():
             check_cat = Cat.all_cats.get(ID)
             if isinstance(check_cat, Cat):
                 if check_cat.dead or not check_cat.status.alive_in_player_clan:
-                    Cat.grief_strings.pop(ID)
+                    game.clan.grief_strings.pop(ID)
 
         # Generate events
 
-        for cat_id, details in Cat.grief_strings.items():
+        for cat_id, details in game.clan.grief_strings.items():
             for _info in details:
                 text = _info[0]
                 cats = _info[1]
@@ -169,19 +169,21 @@ def one_moon():
                         Single_Event(text, ["birth_death", "relation"], cats)
                     )
 
-        Cat.grief_strings.clear()
+        game.clan.grief_strings.clear()
 
-    if Cat.dead_cats:
+    if game.dead_cats_to_grieve:
         ghost_names = []
         shaken_cats = []
         extra_event = None
-        for ghost in Cat.dead_cats:
+        for ghost in game.dead_cats_to_grieve:
             ghost_names.append(str(ghost.name))
         insert = adjust_list_text(ghost_names)
 
-        if len(Cat.dead_cats) > 1:
+        if len(game.dead_cats_to_grieve) > 1:
             event = i18n.t(
-                "hardcoded.event_deaths", count=len(Cat.dead_cats), insert=insert
+                "hardcoded.event_deaths",
+                count=len(game.dead_cats_to_grieve),
+                insert=insert,
             )
 
             if len(ghost_names) > 2:
@@ -229,9 +231,11 @@ def one_moon():
             Single_Event(
                 event,
                 ["birth_death"],
-                [i.ID for i in Cat.dead_cats],
+                [i.ID for i in game.dead_cats_to_grieve],
                 cat_dict=(
-                    {"m_c": Cat.dead_cats[0]} if len(Cat.dead_cats) == 1 else None
+                    {"m_c": game.dead_cats_to_grieve[0]}
+                    if len(game.dead_cats_to_grieve) == 1
+                    else None
                 ),
             )
         )
@@ -239,7 +243,7 @@ def one_moon():
             game.cur_events_list.append(
                 Single_Event(extra_event, ["birth_death"], [i.ID for i in shaken_cats])
             )
-        Cat.dead_cats.clear()
+        game.dead_cats_to_grieve.clear()
 
     if game.clan.game_mode in ("expanded", "cruel season") and game.clan.freshkill_pile:
         # make a notification if the Clan does not have enough prey

--- a/scripts/game_structure/game/__init__.py
+++ b/scripts/game_structure/game/__init__.py
@@ -27,7 +27,9 @@ max_name_length = 10
 
 mediated = []  # Keep track of which couples have been mediated this moon.
 just_died = []  # keeps track of which cats died this moon via die()
-
+dead_cats_to_grieve = (
+    []
+)  # keeps track of the cats who died and need a clan grieving message
 cur_events_list = []
 ceremony_events_list = []
 birth_death_events_list = []

--- a/scripts/game_structure/load_cat.py
+++ b/scripts/game_structure/load_cat.py
@@ -42,7 +42,7 @@ def load_cats():
 def json_load():
     Cat.all_cats.clear()
     Cat.all_cats_list.clear()
-    Cat.dead_cats.clear()
+
     all_cats = []
     clanname = switch_get_value(Switch.clan_list)[0]
     clan_cats_json_path = f"{get_save_dir()}/{clanname}/clan_cats.json"

--- a/scripts/screens/MakeClanScreen.py
+++ b/scripts/screens/MakeClanScreen.py
@@ -2159,7 +2159,7 @@ class MakeClanScreen(Screens):
         game.herb_events_list.clear()
         game.clan.herb_supply.start_storage(len(self.members))
         game.clan.save_herb_supply(game.clan)
-        Cat.grief_strings.clear()
+        game.clan.grief_strings.clear()
         Cat.sort_cats()
 
     def get_camp_art_path(self, campnum) -> Optional[str]:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -70,7 +70,7 @@ class TestEvents(unittest.TestCase):
         game.herb_events_list.clear()
         game.clan.herb_supply.start_storage(15)
         game.clan.save_herb_supply(game.clan)
-        Cat.grief_strings.clear()
+        game.clan.grief_strings.clear()
         Cat.sort_cats()
         # prevent them from just dying of starvation
         set_clan_setting("business as usual", False)


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
alr this adds a few new bits to the clan save to preserve info about cats who have just died
- `just_died` all the cats who have died in the last moon
- `dead_cats_to_grieve` cats who died and need to be part of a "clan grieves their death" message
- `grief_to_assign` is the `grief_strings` info, all the collected death reaction messages and/or thought triggers that need to be displayed on timeskip 

In adding these, I moved a couple of them out of the `Cat` object (bc why were they in there to begin with..) and into `game` to match with existing "lists of cats" that we keep in the clan save. Not a huge fan of us having these cat lists in `game` to begin with, but maybe that's something we can fix when gynn gets that cat registry stuff figured out. I think it's fine enough for now.

`grief_strings` got moved into `game.clan` bc, once again, why did we have that in `Cat`.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
fixes #3849
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
<img width="187" height="77" alt="image" src="https://github.com/user-attachments/assets/308ad924-efe3-4e10-93ab-be57fa69c8fc" />
<img width="387" height="272" alt="image" src="https://github.com/user-attachments/assets/259bef79-d23e-40e1-af7b-fc669a7c63a2" />

closed and reopened the game, then timeskipped

<img width="559" height="245" alt="image" src="https://github.com/user-attachments/assets/5ef82cfe-9f19-4f9a-a96b-c073aa274052" />
<img width="392" height="118" alt="image" src="https://github.com/user-attachments/assets/65c6fede-75c2-43bb-a13a-1fd9c55b527e" />

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Grief and just-died cat info is now stored in the save files, aka it's no longer lost upon closing the game
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
