### PR TITLE
[DEV/savefile-rework] CatFactory

### DIFF
--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -29,6 +29,7 @@ from scripts.cat.factories.typed_dicts import (
     CatTogglesDict,
     InheritanceDict,
     AfterlifeAffinityDict,
+    GenderDict,
 )
 from scripts.cat.history import History
 from scripts.cat.names import Name
@@ -148,12 +149,8 @@ class Cat:
         birth_cooldown: int,
         specsuffix_hidden=False,  # to delete once Name is decoupled from Cat
         *,
-        status_dict: StatusDict = None,
         example=False,
         faded=False,
-        skill_dict=None,
-        loading_cat=False,  # Set to true if you are loading a cat at start-up.
-        disable_random=False,
         **kwargs,
     ):
         """Initialise the cat.
@@ -181,7 +178,7 @@ class Cat:
 
         # This must be at the top. It's a smaller list of things to init, which is only for faded cats
         if faded:
-            # self.init_faded(ID, status_dict, prefix, suffix, moons, **kwargs)
+            self.init_faded(ID, moons, status, inheritance)
             return
 
         self.generate_events = GenerateEvents()
@@ -264,9 +261,6 @@ class Cat:
         self._sprite_working: bool = self.not_working()
         """used to store whether we should be displaying sick sprite or not"""
 
-        # SAVE CAT INTO ALL_CATS DICTIONARY IN CATS-CLASS
-        self.all_cats[self.ID] = self
-
         if self.ID is not None and self.ID != "0":
             Cat.insert_cat(self)
 
@@ -274,30 +268,28 @@ class Cat:
     def age(self):
         return CatAge.get_from_moons(self.moons)
 
-    def init_faded(self, ID, status, prefix, suffix, moons, **kwargs):
-        """Perform faded-specific initialization
-
+    def init_faded(
+        self, ID: str, moons: int, status: Status, inheritance: InheritanceDict
+    ):
+        """
+        Perform faded-specific initialization
         :param ID: Cat ID
-        :param status: Cat status
-        :param prefix: Cat's prefix
-        :param suffix: Cat's suffix
-        :param moons: Age in moons
-        :param kwargs:
-
-        :return: None
+        :param moons: age in moons
+        :param status: last known status
+        :param inheritance: family data
+        :return: bool
         """
         self.ID = ID
-        self.parent1 = None
-        self.parent2 = None
-        self.adoptive_parents = []
-        self.mate = []
-        self.status = Status(**status) if status else Status()
+        self.parent1 = inheritance["parent1"]
+        self.parent2 = inheritance["parent2"]
+        self.adoptive_parents = inheritance["adoptive_parents"]
+        self.faded_offspring = inheritance["faded_offspring"]
+        self.mate = inheritance["mate"]
+        self.status = status
         self._pronouns = {}  # Needs to be set as a dict
         self.moons = moons
         self.inheritance = None  # This should never be used, but just for safety
-        self.name = Name(prefix=prefix, suffix=suffix, cat=self)
-
-        self.set_faded()  # Sets the faded sprite and faded tag (self.faded = True)
+        # name is assigned by FadedCatFactory
         return True
 
     def __repr__(self):
@@ -2841,34 +2833,49 @@ class Cat:
             return False
 
         if isinstance(cat_info["status"], str):
-            status_dict = {"rank": cat_info["status"]}
+            status = Status(rank=cat_info["status"])
+            # they are definitely dead
+            status.send_to_afterlife(
+                CatGroup.DARK_FOREST_ID
+                if cat_info.get("df", False)
+                else CatGroup.STARCLAN_ID
+            )
         else:
-            status_dict = cat_info["status"]
+            status = Status(**cat_info["status"])
 
         cat_ob = Cat(
             ID=cat_info["ID"],
-            prefix=cat_info["name_prefix"],
-            suffix=cat_info["name_suffix"],
-            status_dict=status_dict,
+            gender_dict=GenderDict(sex=None, genderalign=None),
+            pelt=None,
             moons=cat_info["moons"],
+            status=status,
+            backstory="",
+            catskills=None,
+            personality=None,
+            mentorship={},
+            inheritance=InheritanceDict(
+                parent1=cat_info["parent1"],
+                parent2=cat_info["parent2"],
+                adoptive_parents=cat_info["adoptive_parents"],
+                mate=[],
+                previous_mates=[],
+                faded_offspring=cat_info["faded_offspring"],
+            ),
+            affinity={},
+            toggles={},
+            experience=0,
+            birth_cooldown=0,
+            specsuffix_hidden=False,
             faded=True,
         )
-        if cat_info["parent1"]:
-            cat_ob.parent1 = cat_info["parent1"]
-        if cat_info["parent2"]:
-            cat_ob.parent2 = cat_info["parent2"]
-        cat_ob.faded_offspring = cat_info["faded_offspring"]
-        cat_ob.adoptive_parents = (
-            cat_info["adoptive_parents"] if "adoptive_parents" in cat_info else []
+
+        cat_ob.name = Name(
+            prefix=cat_info["name_prefix"],
+            suffix=cat_info["name_suffix"],
+            specsuffix_hidden=False,
+            load_existing_name=True,
+            cat=cat_ob,
         )
-        cat_ob.faded = True
-
-        if cat_info.get("df"):
-            cat_ob.status.send_to_afterlife(target_ID=CatGroup.DARK_FOREST_ID)
-        elif isinstance(cat_info["status"], str):
-            cat_ob.status.send_to_afterlife(target_ID=CatGroup.STARCLAN_ID)
-
-        cat_ob.dead_for = cat_info["dead_for"] if "dead_for" in cat_info else 1
 
         return cat_ob
 

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -183,12 +183,16 @@ class Cat:
         self._moons = None
 
         # Public attributes
+        self.ID = ID
+
         if isinstance(gender, dict):
             self.gender = gender["sex"]
             self.genderalign = gender["genderalign"]
         else:
             self.gender = gender
             self.genderalign = gender
+
+        self.moons = moons
         self.status: Status = Status(**status_dict) if status_dict else Status()
         self.backstory = backstory
         self.age: Optional[CatAge] = None
@@ -242,8 +246,6 @@ class Cat:
         self.specsuffix_hidden = specsuffix_hidden
         self.inheritance = None
 
-        self.ID = ID
-
         # backstory
         if self.backstory is None:
             self.backstory = "clanborn"
@@ -252,8 +254,12 @@ class Cat:
 
         # These things should only run when generating a new cat, rather than loading one in.
         if not loading_cat:
-            self.personality = init_params["personality"]
-            self.experience = init_params["experience"]
+            if init_params is None:
+                init_params = {}
+            self.personality = init_params.get(
+                "personality", Personality(lawful=6, social=6, aggress=6, stable=6)
+            )
+            self.experience = init_params.get("experience", 0)
 
         if "biome" in kwargs:
             biome = kwargs["biome"]

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -24,6 +24,12 @@ from scripts.cat.enums import (
     CatCompatibility,
     CatThought,
 )
+from scripts.cat.factories.typed_dicts import (
+    MentorshipDict,
+    CatTogglesDict,
+    InheritanceDict,
+    AfterlifeAffinityDict,
+)
 from scripts.cat.history import History
 from scripts.cat.names import Name
 from scripts.cat.pelts import Pelt
@@ -126,24 +132,27 @@ class Cat:
 
     def __init__(
         self,
-        prefix=None,
-        gender=None,
+        ID: str,
+        gender_dict: dict,
+        pelt: Pelt,
+        moons: int,
+        status: Status,
+        backstory: str,
+        catskills: CatSkills,
+        personality: Personality,
+        mentorship: MentorshipDict,
+        inheritance: InheritanceDict,
+        affinity: AfterlifeAffinityDict,
+        toggles: CatTogglesDict,
+        experience: int,
+        birth_cooldown: int,
+        specsuffix_hidden=False,  # to delete once Name is decoupled from Cat
+        *,
         status_dict: StatusDict = None,
-        backstory="clanborn",
-        parent1=None,
-        parent2=None,
-        adoptive_parents=None,
-        suffix=None,
-        specsuffix_hidden=False,
-        ID=None,
-        moons=None,
         example=False,
         faded=False,
         skill_dict=None,
-        pelt: Pelt = None,
-        init_params: dict = None,
         loading_cat=False,  # Set to true if you are loading a cat at start-up.
-        *,
         disable_random=False,
         **kwargs,
     ):
@@ -172,7 +181,7 @@ class Cat:
 
         # This must be at the top. It's a smaller list of things to init, which is only for faded cats
         if faded:
-            self.init_faded(ID, status_dict, prefix, suffix, moons, **kwargs)
+            # self.init_faded(ID, status_dict, prefix, suffix, moons, **kwargs)
             return
 
         self.generate_events = GenerateEvents()
@@ -181,122 +190,73 @@ class Cat:
         self._mentor = None  # plz
         self._experience = None
         self._moons = None
+        self._pronouns: Dict[str, List[Dict[str, Union[str, int]]]] = {}
 
         # Public attributes
         self.ID = ID
 
-        if isinstance(gender, dict):
-            self.gender = gender["sex"]
-            self.genderalign = gender["genderalign"]
-            if gender.get("pronouns"):  # pronouns are lazy-loaded for new cats
-                self.pronouns = gender.get("pronouns")
-        else:
-            self.gender = gender
-            self.genderalign = gender
+        self.gender = gender_dict["sex"]
+        self.genderalign = gender_dict["genderalign"]
+        if gender_dict.get("pronouns"):  # pronouns are lazy-loaded for new cats
+            self.pronouns = gender_dict.get("pronouns")
 
-        self.age = CatAge.NEWBORN
-        self.moons = moons if moons else 0
-        self.status: Status = Status(**status_dict) if status_dict else Status()
+        self.pelt: Pelt = pelt
+        self.moons: int = moons
+        self.status: Status = status
         self.backstory = backstory
-        self.age: Optional[CatAge] = None
-        self.skills = CatSkills(skill_dict=skill_dict)
-        self.personality = Personality(
-            trait="troublesome", lawful=0, aggress=0, stable=0, social=0
-        )
-        self.parent1 = parent1
-        self.parent2 = parent2
-        self.adoptive_parents = adoptive_parents if adoptive_parents else []
-        self.pelt = pelt if pelt else Pelt()
-        self.former_mentor = []
-        self.patrol_with_mentor = 0
-        self.apprentice = []
-        self.former_apprentices = []
-        self.relationships = {}
+        self.skills = catskills
+        self.personality = personality
+
+        # mentorship
+        self.mentor = mentorship["mentor"]
+        self.former_mentor = mentorship["former_mentor"]
+        self.patrol_with_mentor = mentorship["patrol_with_mentor"]
+        self.apprentice = mentorship["apprentice"]
+        self.former_apprentices = mentorship["former_apprentices"]
+
+        # inheritance
+        self.parent1 = inheritance["parent1"]
+        self.parent2 = inheritance["parent2"]
+        self.adoptive_parents = inheritance["adoptive_parents"]
+        self.faded_offspring = inheritance["faded_offspring"]
+        """Stores of a list of faded offspring, for relation tracking purposes"""
         self.mate = []
         self.previous_mates = []
-        self._pronouns: Dict[str, List[Dict[str, Union[str, int]]]] = {}
+        self.inheritance = None
+
+        # afterlife affinity
+        self.dark_forest_affinity = affinity["dark_forest"]
+        self.starclan_affinity = affinity["starclan"]
+
+        # toggles
+        self.no_kits = toggles["no_kits"]
+        self.no_mates = toggles["no_mates"]
+        self.no_retire = toggles["no_retire"]
+        self.prevent_fading = toggles["prevent_fading"]  # Prevents a cat from fading
+        self.favourite = toggles["favourite"]
+
+        # misc
+        self.experience = experience
+        self.birth_cooldown = birth_cooldown
+        self.specsuffix_hidden = specsuffix_hidden  # kill this ASAP
+
+        # other misc
+        self.name: Optional[Name] = None
+        self.relationships = {}
         self.placement = None
         self.example = example
         self.thought = ""
-        self.genderalign = None
-        self.birth_cooldown = 0
+
+        # conditions setup
         self.illnesses = {}
         self.injuries = {}
         self.healed_condition = None
         self.leader_death_heal = None
         self.also_got = False
         self.permanent_condition = {}
-        self.experience_level = None
-        self.dark_forest_affinity = 0
-        self.starclan_affinity = 0
-
-        # Various behavior toggles
-        self.no_kits = False
-        self.no_mates = False
-        self.no_retire = False
-
-        self.prevent_fading = False  # Prevents a cat from fading
-
-        self.faded_offspring = (
-            []
-        )  # Stores of a list of faded offspring, for relation tracking purposes
 
         self.faded = faded  # This is only used to flag cats that are faded, but won't be added to the faded list until
         # the next save.
-
-        self.favourite = False
-
-        self.specsuffix_hidden = specsuffix_hidden
-        self.inheritance = None
-
-        # backstory
-        if self.backstory is None:
-            self.backstory = "clanborn"
-        else:
-            self.backstory = self.backstory  # fixme why does this exist
-
-        # These things should only run when generating a new cat, rather than loading one in.
-        if not loading_cat:
-            if init_params is None:
-                init_params = {}
-            self.personality = init_params.get(
-                "personality", Personality(lawful=6, social=6, aggress=6, stable=6)
-            )
-            self.experience = init_params.get("experience", 0)
-
-        if "biome" in kwargs:
-            biome = kwargs["biome"]
-        elif game.clan is not None:
-            biome = (
-                game.clan.biome
-                if not game.clan.override_biome
-                else game.clan.override_biome
-            )
-        else:
-            biome = None
-        # NAME
-        # load_existing_name is needed so existing cats don't get their names changed/fixed for no reason
-        if init_params:
-            self.name = init_params["name"]
-        elif self.pelt is not None:
-            # todo consider whether this can be removed when factory for loading cats is created
-            self.name = Name(
-                prefix,
-                suffix,
-                biome=biome,
-                specsuffix_hidden=self.specsuffix_hidden,
-                load_existing_name=loading_cat,
-                cat=self,
-            )
-        else:
-            self.name = Name(
-                self.status.rank,
-                prefix,
-                suffix,
-                specsuffix_hidden=self.specsuffix_hidden,
-                load_existing_name=loading_cat,
-                cat=self,
-            )
 
         # Private Sprite
         self._sprite: Optional["pygame.Surface"] = None
@@ -309,6 +269,10 @@ class Cat:
 
         if self.ID is not None and self.ID != "0":
             Cat.insert_cat(self)
+
+    @property
+    def age(self):
+        return CatAge.get_from_moons(self.moons)
 
     def init_faded(self, ID, status, prefix, suffix, moons, **kwargs):
         """Perform faded-specific initialization
@@ -333,30 +297,8 @@ class Cat:
         self.inheritance = None  # This should never be used, but just for safety
         self.name = Name(prefix=prefix, suffix=suffix, cat=self)
 
-        self.init_moons_age(moons)
-
         self.set_faded()  # Sets the faded sprite and faded tag (self.faded = True)
         return True
-
-    def init_moons_age(self, moons):
-        """
-        Gets the correct life stage for associated moons
-
-        :param moons: Age in moons
-        :return: None
-        """
-        if moons > 300:
-            # Out of range, always elder
-            self.age = CatAge.SENIOR
-        elif moons == 0:
-            self.age = CatAge.NEWBORN
-        else:
-            # In range
-            for key_age in self.age_moons.keys():
-                if moons in range(
-                    self.age_moons[key_age][0], self.age_moons[key_age][1] + 1
-                ):
-                    self.age = key_age
 
     def __repr__(self):
         return "CAT OBJECT:" + self.ID
@@ -3043,19 +2985,18 @@ class Cat:
     def experience(self):
         return self._experience
 
+    @property
+    def experience_level(self):
+        return next(
+            key
+            for key, (min_exp, max_exp) in self.experience_levels_range.items()
+            if min_exp <= self.experience <= max_exp
+        )
+
     @experience.setter
     def experience(self, exp: int):
         exp = min(exp, self.experience_levels_range["master"][1])
         self._experience = int(exp)
-
-        for x in self.experience_levels_range:
-            if (
-                self.experience_levels_range[x][0]
-                <= exp
-                <= self.experience_levels_range[x][1]
-            ):
-                self.experience_level = x
-                break
 
     @property
     def moons(self):
@@ -3064,7 +3005,6 @@ class Cat:
     @moons.setter
     def moons(self, value: int):
         self._moons = value
-        self.age = CatAge.get_from_moons(value)
 
     @property
     def sprite(self):

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -133,7 +133,7 @@ class Cat:
     def __init__(
         self,
         ID: str,
-        gender_dict: dict,
+        gender_dict: GenderDict,
         pelt: Pelt,
         moons: int,
         status: Status,

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -188,6 +188,8 @@ class Cat:
         if isinstance(gender, dict):
             self.gender = gender["sex"]
             self.genderalign = gender["genderalign"]
+            if gender.get("pronouns"):  # pronouns are lazy-loaded for new cats
+                self.pronouns = gender.get("pronouns")
         else:
             self.gender = gender
             self.genderalign = gender

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -3236,37 +3236,6 @@ class Cat:
 # ---------------------------------------------------------------------------- #
 
 
-def create_option_preview_cat(scar: str = None, acc: str = None):
-    """
-    Creates a cat with the specified scar
-    """
-    new_cat = Cat(
-        loading_cat=True,
-        pelt=Pelt(
-            name="SingleColour",
-            colour="WHITE",
-            length="medium",
-            eye_color="SAGE",
-            reverse=False,
-            white_patches=None,
-            vitiligo=None,
-            points=None,
-            tortie_marking=None,
-            tortie_base=None,
-            tortie_pattern=None,
-            tortie_colour=None,
-            tint="gray",
-            skin="BLUE",
-            scars=[scar] if scar else [],
-            adult_sprite=8,
-            accessory=[acc] if acc else [],
-        ),
-    )
-    new_cat.age = CatAge.ADULT
-
-    return new_cat
-
-
 # CAT CLASS ITEMS
 cat_class = Cat
 game.cat_class = Cat

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -192,7 +192,8 @@ class Cat:
             self.gender = gender
             self.genderalign = gender
 
-        self.moons = moons
+        self.age = CatAge.NEWBORN
+        self.moons = moons if moons else 0
         self.status: Status = Status(**status_dict) if status_dict else Status()
         self.backstory = backstory
         self.age: Optional[CatAge] = None
@@ -3061,19 +3062,7 @@ class Cat:
     @moons.setter
     def moons(self, value: int):
         self._moons = value
-
-        updated_age = False
-        for key_age in self.age_moons.keys():
-            if self._moons in range(
-                self.age_moons[key_age][0], self.age_moons[key_age][1] + 1
-            ):
-                updated_age = True
-                self.age = key_age
-        try:
-            if not updated_age and self.age is not None:
-                self.age = CatAge.SENIOR
-        except AttributeError:
-            print(f"ERROR: cat has no age attribute! Cat ID: {self.ID}")
+        self.age = CatAge.get_from_moons(value)
 
     @property
     def sprite(self):
@@ -3385,8 +3374,8 @@ def create_option_preview_cat(scar: str = None, acc: str = None):
 
 
 # CAT CLASS ITEMS
-cat_class = Cat(example=True)
-game.cat_class = cat_class
+cat_class = Cat
+game.cat_class = Cat
 
 # ---------------------------------------------------------------------------- #
 #                                load json files                               #

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -15,7 +15,7 @@ import i18n
 import ujson  # type: ignore
 
 import scripts.game_structure.localization as pronouns
-from scripts.cat import save_load, pronouns
+from scripts.cat import pronouns
 from scripts.cat.enums import (
     CatAge,
     CatRank,
@@ -36,9 +36,8 @@ from scripts.cat.names import Name
 from scripts.cat.pelts import Pelt
 from scripts.cat.personality import Personality
 from scripts.cat.skills import CatSkills
-from scripts.cat.status import Status, StatusDict
+from scripts.cat.status import Status
 from scripts.events_module.thoughts.generate_thoughts import (
-    new_death_thought,
     new_thought,
     get_other_cat_for_thought,
 )
@@ -3235,60 +3234,6 @@ class Cat:
 # ---------------------------------------------------------------------------- #
 #                               END OF CAT CLASS                               #
 # ---------------------------------------------------------------------------- #
-
-
-# Creates a random cat
-def create_cat(rank, moons=None, biome=None):
-    status_dict = {"rank": rank}
-
-    new_cat = Cat(status_dict=status_dict, biome=biome)
-
-    if moons is not None:
-        new_cat.moons = moons
-    elif new_cat.moons >= 160:
-        new_cat.moons = randint(120, 155)
-    elif new_cat.moons == 0:
-        new_cat.moons = randint(1, 5)
-
-    not_allowed_scars = [
-        "NOPAW",
-        "NOTAIL",
-        "HALFTAIL",
-        "NOEAR",
-        "BOTHBLIND",
-        "RIGHTBLIND",
-        "LEFTBLIND",
-        "BRIGHTHEART",
-        "NOLEFTEAR",
-        "NORIGHTEAR",
-        "MANLEG",
-    ]
-
-    new_cat.pelt.scars = tuple(
-        scar for scar in new_cat.pelt.scars if scar not in not_allowed_scars
-    )
-
-    return new_cat
-
-
-# Twelve example cats
-def create_example_cats():
-    warrior_indices = sample(range(12), 3)
-
-    for cat_index in range(12):
-        if cat_index in warrior_indices:
-            game.choose_cats[cat_index] = create_cat(rank=CatRank.WARRIOR)
-        else:
-            random_rank = choice(
-                [
-                    CatRank.KITTEN,
-                    CatRank.APPRENTICE,
-                    CatRank.WARRIOR,
-                    CatRank.WARRIOR,
-                    CatRank.ELDER,
-                ]
-            )
-            game.choose_cats[cat_index] = create_cat(rank=random_rank)
 
 
 def create_option_preview_cat(scar: str = None, acc: str = None):

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -141,6 +141,7 @@ class Cat:
         faded=False,
         skill_dict=None,
         pelt: Pelt = None,
+        init_params: dict = None,
         loading_cat=False,  # Set to true if you are loading a cat at start-up.
         *,
         disable_random=False,
@@ -163,7 +164,7 @@ class Cat:
         :param skill_dict: TODO find a good definition for this
         :param pelt: Body details, default None
         :param loading_cat: If loading a cat rather than generating a new one, default False
-        :param disable_random: If True, disables as much random generation junk as possible
+        :param init_params: If generating a new cat, extra RNG-based information is provided here
         :param kwargs: TODO what are the possible args here? ["biome", ]
         """
 
@@ -182,7 +183,12 @@ class Cat:
         self._moons = None
 
         # Public attributes
-        self.gender = gender
+        if isinstance(gender, dict):
+            self.gender = gender["sex"]
+            self.genderalign = gender["genderalign"]
+        else:
+            self.gender = gender
+            self.genderalign = gender
         self.status: Status = Status(**status_dict) if status_dict else Status()
         self.backstory = backstory
         self.age: Optional[CatAge] = None
@@ -236,68 +242,7 @@ class Cat:
         self.specsuffix_hidden = specsuffix_hidden
         self.inheritance = None
 
-        # setting ID
-        if ID is None:
-            potential_id = str(next(Cat.id_iter))
-
-            if game.clan:
-                faded_cats = save_load.get_faded_ids()
-            else:
-                faded_cats = []
-
-            while potential_id in self.all_cats or potential_id in faded_cats:
-                potential_id = str(next(Cat.id_iter))
-            self.ID = potential_id
-        else:
-            self.ID = ID
-
-        # age and status
-        if status_dict is None and moons is None:
-            self.age = CatAge.NEWBORN if disable_random else choice([*CatAge])
-            self.status.generate_new_status(age=self.age, disable_random=disable_random)
-        elif moons is not None:
-            self.moons = moons
-            if moons > 300:
-                # Out of range, always elder
-                self.age = CatAge.SENIOR
-            elif moons == 0:
-                self.age = CatAge.NEWBORN
-            else:
-                # In range
-                for key_age in self.age_moons.keys():
-                    if moons in range(
-                        self.age_moons[key_age][0], self.age_moons[key_age][1] + 1
-                    ):
-                        self.age = key_age
-            if status_dict is None:
-                self.status.generate_new_status(
-                    age=self.age, disable_random=disable_random
-                )
-        else:
-            if disable_random or self.status.rank == CatRank.NEWBORN:
-                self.age = CatAge.NEWBORN
-            elif self.status.rank == CatRank.KITTEN:
-                self.age = CatAge.KITTEN
-            elif self.status.rank == CatRank.ELDER:
-                self.age = CatAge.SENIOR
-            elif self.status.rank.is_any_apprentice_rank():
-                self.age = CatAge.ADOLESCENT
-            else:
-                self.age = choice(
-                    [
-                        CatAge.YOUNG_ADULT,
-                        CatAge.ADULT,
-                        CatAge.ADULT,
-                        CatAge.SENIOR_ADULT,
-                    ]
-                )
-        if moons is None:
-            if disable_random:
-                self.moons = 0
-            else:
-                self.moons = randint(
-                    self.age_moons[self.age][0], self.age_moons[self.age][1]
-                )
+        self.ID = ID
 
         # backstory
         if self.backstory is None:
@@ -305,19 +250,11 @@ class Cat:
         else:
             self.backstory = self.backstory  # fixme why does this exist
 
-        # sex!?!??!?!?!??!?!?!?!??
-        if self.gender is None:
-            self.gender = "female" if disable_random else choice(["female", "male"])
-
-        """if self.genderalign == "":
-            self.genderalign = self.gender"""
-
         # These things should only run when generating a new cat, rather than loading one in.
         if not loading_cat:
-            self.init_generate_cat(skill_dict, disable_random)
+            self.personality = init_params["personality"]
+            self.experience = init_params["experience"]
 
-        # In camp status
-        self.in_camp = 1
         if "biome" in kwargs:
             biome = kwargs["biome"]
         elif game.clan is not None:
@@ -330,7 +267,10 @@ class Cat:
             biome = None
         # NAME
         # load_existing_name is needed so existing cats don't get their names changed/fixed for no reason
-        if self.pelt is not None:
+        if init_params:
+            self.name = init_params["name"]
+        elif self.pelt is not None:
+            # todo consider whether this can be removed when factory for loading cats is created
             self.name = Name(
                 prefix,
                 suffix,
@@ -408,82 +348,6 @@ class Cat:
                     self.age_moons[key_age][0], self.age_moons[key_age][1] + 1
                 ):
                     self.age = key_age
-
-    def init_generate_cat(self, skill_dict, disable_random):
-        """
-        Used to roll a new cat
-        :param skill_dict: TODO what is a skill dict exactly
-        :param disable_random: If true, disable randomisation code
-        :return: None
-        """
-        # trans cat chances
-        self.genderalign = self.gender
-        trans_chance = randint(0, 50)
-        nb_chance = randint(0, 75)
-
-        # GENDER IDENTITY
-        if self.age.is_baby() or disable_random:
-            # newborns can't be trans, sorry babies
-            pass
-        elif nb_chance == 1:
-            self.genderalign = "nonbinary"
-        elif trans_chance == 1:
-            if self.gender == "female":
-                self.genderalign = "trans male"
-            else:
-                self.genderalign = "trans female"
-
-        # PRONOUNS AUTO-GENERATE WHEN REQUIRED
-
-        # APPEARANCE
-        self.pelt = Pelt.generate_new_pelt(
-            self.gender,
-            [Cat.fetch_cat(i) for i in (self.parent1, self.parent2) if i],
-            self.age,
-        )
-
-        # Personality
-        if disable_random:
-            self.personality = Personality(
-                lawful=8, social=8, aggress=8, stable=8, kit_trait=self.age.is_baby()
-            )
-        else:
-            self.personality = Personality(kit_trait=self.age.is_baby())
-
-        # experience and current patrol status
-        if self.age.is_baby() or disable_random:
-            self.experience = 0
-        elif self.age == CatAge.ADOLESCENT:
-            m = self.moons
-            self.experience = 0
-            while m > Cat.age_moons[CatAge.ADOLESCENT][0]:
-                ran = constants.CONFIG["graduation"]["base_app_timeskip_ex"]
-                exp = choice(
-                    list(range(ran[0][0], ran[0][1] + 1))
-                    + list(range(ran[1][0], ran[1][1] + 1))
-                )
-                self.experience += exp + 3
-                m -= 1
-        elif self.age in (CatAge.YOUNG_ADULT, CatAge.ADULT):
-            self.experience = randint(
-                Cat.experience_levels_range["prepared"][0],
-                Cat.experience_levels_range["proficient"][1],
-            )
-        elif self.age == CatAge.SENIOR_ADULT:
-            self.experience = randint(
-                Cat.experience_levels_range["competent"][0],
-                Cat.experience_levels_range["expert"][1],
-            )
-        elif self.age == CatAge.SENIOR:
-            self.experience = randint(
-                Cat.experience_levels_range["competent"][0],
-                Cat.experience_levels_range["master"][1],
-            )
-        else:
-            self.experience = 0
-
-        if not skill_dict:
-            self.skills = CatSkills.generate_new_catskills(self.status.rank, self.age)
 
     def __repr__(self):
         return "CAT OBJECT:" + self.ID
@@ -1525,7 +1389,6 @@ class Cat:
         self.moons += 1
         if self.moons == 1 and self.status.rank == CatRank.NEWBORN:
             self.status._change_rank(CatRank.KITTEN)
-        self.in_camp = 1
 
         if old_age != self.age:
             # Things to do if the age changes

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -260,6 +260,9 @@ class Cat:
         self._sprite_working: bool = self.not_working()
         """used to store whether we should be displaying sick sprite or not"""
 
+        # SAVE CAT INTO ALL_CATS DICTIONARY IN CATS-CLASS
+        self.all_cats[self.ID] = self
+
         if self.ID is not None and self.ID != "0":
             Cat.insert_cat(self)
 
@@ -289,6 +292,8 @@ class Cat:
         self.moons = moons
         self.inheritance = None  # This should never be used, but just for safety
         # name is assigned by FadedCatFactory
+
+        self.faded = True
         return True
 
     def __repr__(self):

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -152,25 +152,27 @@ class Cat:
         faded=False,
         **kwargs,
     ):
-        """Initialise the cat.
+        """
+        Initialize the cat.
 
-        :param prefix: Cat's prefix (e.g. Fire- for Fireheart)
-        :param gender: Cat's gender, default None
-        :param status_dict: Dict containing information for Cat's status, default None
-        :param backstory: Cat's origin, default "clanborn"
-        :param parent1: ID of parent 1, default None
-        :param parent2: ID of parent 2, default None
-        :param suffix: Cat's suffix (e.g. -heart for Fireheart)
-        :param specsuffix_hidden: Whether cat has a special suffix (-kit, -paw, etc.), default False
-        :param ID: Cat's unique ID, default None
-        :param moons: Cat's age, default None
-        :param example: If cat is an example cat, default False
-        :param faded: If cat is faded, default False
-        :param skill_dict: TODO find a good definition for this
-        :param pelt: Body details, default None
-        :param loading_cat: If loading a cat rather than generating a new one, default False
-        :param init_params: If generating a new cat, extra RNG-based information is provided here
-        :param kwargs: TODO what are the possible args here? ["biome", ]
+        :param ID: Cat's ID value
+        :param gender_dict: Cat's sex & gender (and pronouns if loading from save)
+        :param pelt: Pelt object
+        :param moons: Cat's age in moons
+        :param status: Status object
+        :param backstory: Cat's backstory
+        :param catskills: CatSkills object
+        :param personality: Personality object
+        :param mentorship: MentorshipDict containing mentor data and apprentice data, including former for both
+        :param inheritance: Inheritance object
+        :param affinity: AffinityDict containing starclan & dark forest affinity values
+        :param toggles: Dict of cat-related behavior toggles
+        :param experience: Cat's experience value
+        :param birth_cooldown: How many moons that must pass before this cat can give birth again
+        :param specsuffix_hidden: Whether to show or hide the "special suffix" for a cat's name
+        :param example: I actually don't know what this does
+        :param faded: Set to True if a cat is faded.
+        :param kwargs: Any other non-specified values. Can include biome for some reason.
         """
 
         self._history = None

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -170,8 +170,8 @@ class Cat:
         :param experience: Cat's experience value
         :param birth_cooldown: How many moons that must pass before this cat can give birth again
         :param specsuffix_hidden: Whether to show or hide the "special suffix" for a cat's name
-        :param example: I actually don't know what this does
-        :param faded: Set to True if a cat is faded.
+        :param example: Marks a cat as being part of the MakeClanScreen
+        :param faded: Set to True if a cat is faded
         :param kwargs: Any other non-specified values. Can include biome for some reason.
         """
 
@@ -218,8 +218,8 @@ class Cat:
         self.adoptive_parents = inheritance["adoptive_parents"]
         self.faded_offspring = inheritance["faded_offspring"]
         """Stores of a list of faded offspring, for relation tracking purposes"""
-        self.mate = []
-        self.previous_mates = []
+        self.mate = inheritance["mate"]
+        self.previous_mates = inheritance["previous_mates"]
         self.inheritance = None
 
         # afterlife affinity

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -169,9 +169,8 @@ class Cat:
 
         self._history = None
 
-        if (
-            faded
-        ):  # This must be at the top. It's a smaller list of things to init, which is only for faded cats
+        # This must be at the top. It's a smaller list of things to init, which is only for faded cats
+        if faded:
             self.init_faded(ID, status_dict, prefix, suffix, moons, **kwargs)
             return
 

--- a/scripts/cat/enums.py
+++ b/scripts/cat/enums.py
@@ -5,6 +5,8 @@ from enum import auto
 from strenum import StrEnum
 from enum import Enum, auto
 
+from scripts.game_structure import constants
+
 
 class CatAge(StrEnum):
     NEWBORN = "newborn"
@@ -20,6 +22,26 @@ class CatAge(StrEnum):
 
     def can_have_mate(self):
         return self not in (CatAge.KITTEN, CatAge.NEWBORN, CatAge.ADOLESCENT)
+
+    @staticmethod
+    def get_from_moons(moons):
+        lookup = {
+            CatAge.NEWBORN: constants.CONFIG["cat_ages"]["newborn"],
+            CatAge.KITTEN: constants.CONFIG["cat_ages"]["kitten"],
+            CatAge.ADOLESCENT: constants.CONFIG["cat_ages"]["adolescent"],
+            CatAge.YOUNG_ADULT: constants.CONFIG["cat_ages"]["young adult"],
+            CatAge.ADULT: constants.CONFIG["cat_ages"]["adult"],
+            CatAge.SENIOR_ADULT: constants.CONFIG["cat_ages"]["senior adult"],
+            CatAge.SENIOR: constants.CONFIG["cat_ages"]["senior"],
+        }
+        return next(
+            (
+                key
+                for key, (min_age, max_age) in lookup.items()
+                if min_age <= moons <= max_age
+            ),
+            None,
+        )
 
 
 class CatSocial(StrEnum):

--- a/scripts/cat/enums.py
+++ b/scripts/cat/enums.py
@@ -34,6 +34,9 @@ class CatAge(StrEnum):
             CatAge.SENIOR_ADULT: constants.CONFIG["cat_ages"]["senior adult"],
             CatAge.SENIOR: constants.CONFIG["cat_ages"]["senior"],
         }
+        if moons > lookup[CatAge.SENIOR][1]:
+            return CatAge.SENIOR
+
         return next(
             (
                 key

--- a/scripts/cat/factories/base_factory.py
+++ b/scripts/cat/factories/base_factory.py
@@ -1,5 +1,7 @@
 from abc import ABC, abstractmethod
 
+from scripts.cat.cats import Cat
+
 
 class BaseCatFactory(ABC):
     @abstractmethod
@@ -7,5 +9,5 @@ class BaseCatFactory(ABC):
         pass
 
     @abstractmethod
-    def create_cat(self, **kwargs):
+    def create_cat(self, **kwargs) -> Cat:
         pass

--- a/scripts/cat/factories/base_factory.py
+++ b/scripts/cat/factories/base_factory.py
@@ -1,11 +1,15 @@
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from random import Random
 
 from scripts.cat.cats import Cat
 
 
 class BaseCatFactory(ABC):
     @abstractmethod
-    def __init__(self, rng):
+    def __init__(self, rng: "Random"):
         pass
 
     @abstractmethod

--- a/scripts/cat/factories/base_factory.py
+++ b/scripts/cat/factories/base_factory.py
@@ -1,0 +1,11 @@
+from abc import ABC, abstractmethod
+
+
+class BaseCatFactory(ABC):
+    @abstractmethod
+    def __init__(self, rng):
+        pass
+
+    @abstractmethod
+    def create_cat(self, **kwargs):
+        pass

--- a/scripts/cat/factories/cat_factory.py
+++ b/scripts/cat/factories/cat_factory.py
@@ -5,14 +5,18 @@ from scripts.cat.factories.new_cat_factory import NewCatFactory
 
 
 class CatFactory:
-    def __init__(self, rng=None):
-        self.rng = rng if rng else random.Random()
+    rng = random.Random()
 
-        self.__factories = {
-            CatType.NEW: NewCatFactory(rng=self.rng),
-            CatType.LOAD: "TODO ADD",
-            CatType.FADED: "TODO ADD",
-        }
+    __factories = {
+        CatType.NEW: NewCatFactory,
+        CatType.LOAD: NewCatFactory,
+        CatType.FADED: NewCatFactory,
+    }
 
-    def create_cat(self, cat_type: CatType, **kwargs):
-        return self.__factories[cat_type](**kwargs)
+    @classmethod
+    def set_rng(cls, rng):
+        cls.rng = rng
+
+    @classmethod
+    def create_cat(cls, cat_type: CatType, **kwargs):
+        return cls.__factories[cat_type](rng=cls.rng).create_cat(**kwargs)

--- a/scripts/cat/factories/cat_factory.py
+++ b/scripts/cat/factories/cat_factory.py
@@ -1,0 +1,18 @@
+import random
+
+from scripts.cat.factories.enums import CatType
+from scripts.cat.factories.new_cat_factory import NewCatFactory
+
+
+class CatFactory:
+    __factories = {
+        CatType.NEW: NewCatFactory,
+        CatType.LOAD: "TODO ADD",
+        CatType.FADED: "TODO ADD",
+    }
+
+    def __init__(self, rng=None):
+        self.rng = rng if rng else random.Random()
+
+    def create_cat(self, cat_type: CatType, **kwargs):
+        return self.__factories[cat_type](**kwargs)

--- a/scripts/cat/factories/cat_factory.py
+++ b/scripts/cat/factories/cat_factory.py
@@ -1,6 +1,7 @@
 import random
 
 from scripts.cat.factories.enums import CatType
+from scripts.cat.factories.load_cat_factory import LoadCatFactory
 from scripts.cat.factories.new_cat_factory import NewCatFactory
 
 
@@ -9,8 +10,9 @@ class CatFactory:
 
     __factories = {
         CatType.NEW: NewCatFactory,
-        CatType.LOAD: NewCatFactory,
-        CatType.FADED: NewCatFactory,
+        CatType.LOAD_JSON: LoadCatFactory,
+        CatType.LOAD_CSV: LoadCatFactory,
+        CatType.FADED: print,
     }
 
     @classmethod

--- a/scripts/cat/factories/cat_factory.py
+++ b/scripts/cat/factories/cat_factory.py
@@ -1,8 +1,11 @@
+from __future__ import annotations
+
 import random
 
 from scripts.cat.factories.enums import CatType
 from scripts.cat.factories.load_cat_factory import LoadCatFactory
 from scripts.cat.factories.new_cat_factory import NewCatFactory
+from scripts.cat.factories.test_cat_factory import TestCatFactory
 
 
 class CatFactory:
@@ -13,6 +16,7 @@ class CatFactory:
         CatType.LOAD_JSON: LoadCatFactory,
         CatType.LOAD_CSV: LoadCatFactory,
         CatType.FADED: LoadCatFactory,
+        CatType.TEST: TestCatFactory,
     }
 
     @classmethod

--- a/scripts/cat/factories/cat_factory.py
+++ b/scripts/cat/factories/cat_factory.py
@@ -5,14 +5,14 @@ from scripts.cat.factories.new_cat_factory import NewCatFactory
 
 
 class CatFactory:
-    __factories = {
-        CatType.NEW: NewCatFactory,
-        CatType.LOAD: "TODO ADD",
-        CatType.FADED: "TODO ADD",
-    }
-
     def __init__(self, rng=None):
         self.rng = rng if rng else random.Random()
+
+        self.__factories = {
+            CatType.NEW: NewCatFactory(rng=self.rng),
+            CatType.LOAD: "TODO ADD",
+            CatType.FADED: "TODO ADD",
+        }
 
     def create_cat(self, cat_type: CatType, **kwargs):
         return self.__factories[cat_type](**kwargs)

--- a/scripts/cat/factories/cat_factory.py
+++ b/scripts/cat/factories/cat_factory.py
@@ -12,7 +12,7 @@ class CatFactory:
         CatType.NEW: NewCatFactory,
         CatType.LOAD_JSON: LoadCatFactory,
         CatType.LOAD_CSV: LoadCatFactory,
-        CatType.FADED: print,
+        CatType.FADED: LoadCatFactory,
     }
 
     @classmethod

--- a/scripts/cat/factories/cat_mapper.py
+++ b/scripts/cat/factories/cat_mapper.py
@@ -1,0 +1,177 @@
+from typing import Optional, Dict, List
+
+from scripts.cat.enums import CatAge
+from scripts.cat.factories.typed_dicts import (
+    InheritanceDict,
+    MentorshipDict,
+    CatTogglesDict,
+    AfterlifeAffinityDict,
+    GenderDict,
+)
+from scripts.cat.pelts import Pelt
+from scripts.cat.personality import Personality
+from scripts.cat.skills import CatSkills
+from scripts.cat.status import Status
+
+
+class CatMapper:
+    """
+    Save mapping for the latest save ver (4) to Cat object.
+    """
+
+    @staticmethod
+    def map(
+        ID: str,
+        name_prefix: str,
+        name_suffix: str,
+        specsuffix_hidden: bool,
+        gender: str,
+        gender_align: str,
+        pronouns: Dict,
+        birth_cooldown: int,
+        status: Dict,
+        dark_forest_affinity: int,
+        starclan_affinity: int,
+        backstory: str,
+        moons: int,
+        trait: str,
+        facets: str,
+        parent1: Optional[str],
+        parent2: Optional[str],
+        adoptive_parents: List,
+        mentor: Optional[str],
+        former_mentor: List,
+        patrol_with_mentor: int,
+        mate: List,
+        previous_mates: List,
+        paralyzed: bool,
+        no_kits: bool,
+        no_retire: bool,
+        no_mates: bool,
+        pelt_name: str,
+        pelt_color: str,
+        pelt_length: str,
+        sprite_newborn: str,
+        sprite_kitten: str,
+        sprite_adolescent: str,
+        sprite_adult: str,
+        sprite_senior: str,
+        sprite_para_adult: str,
+        eye_colour: str,
+        eye_colour2: Optional[str],
+        reverse: bool,
+        white_patches: Optional[str],
+        vitiligo: Optional[str],
+        points: Optional[str],
+        white_patches_tint: Optional[str],
+        tortie_marking: Optional[str],
+        tortie_base: Optional[str],
+        tortie_color: Optional[str],
+        tortie_pattern: Optional[str],
+        skin: str,
+        tint: str,
+        skill_dict: Dict,
+        scars: List,
+        accessory: List,
+        experience: int,
+        current_apprentice: List,
+        former_apprentices: List,
+        faded_offspring: List,
+        opacity: int,
+        prevent_fading: bool,
+        favourite: bool,
+    ):
+        if facets is None:
+            print(f"WARNING: no facets found for cat ID: {ID}")
+            personality = Personality(
+                trait=trait, kit_trait=CatAge.get_from_moons(moons).is_baby()
+            )
+        else:
+            facets = [int(i) for i in facets.split(",")]
+            personality = Personality(
+                trait=trait,
+                kit_trait=CatAge.get_from_moons(moons).is_baby(),
+                lawful=facets[0],
+                social=facets[1],
+                aggress=facets[2],
+                stable=facets[3],
+            )
+
+        return {
+            "ID": ID,
+            "name": {
+                "prefix": name_prefix,
+                "suffix": name_suffix,
+                "specsuffix_hidden": specsuffix_hidden,
+            },
+            "gender_dict": GenderDict(
+                sex=gender,
+                genderalign=gender_align,
+                pronouns=pronouns,
+            ),
+            "pelt": Pelt(
+                **{
+                    "name": pelt_name,
+                    "length": pelt_length,
+                    "colour": pelt_color,
+                    "eye_color": eye_colour,
+                    "eye_colour2": eye_colour2,
+                    "paralyzed": paralyzed,
+                    "newborn_sprite": sprite_newborn,
+                    "kitten_sprite": sprite_kitten,
+                    "adol_sprite": sprite_adolescent,
+                    "adult_sprite": sprite_adult,
+                    "senior_sprite": sprite_senior,
+                    "para_adult_sprite": sprite_para_adult,
+                    "reverse": reverse,
+                    "vitiligo": vitiligo,
+                    "points": points,
+                    "white_patches_tint": white_patches_tint,
+                    "white_patches": white_patches,
+                    "tortie_base": tortie_base,
+                    "tortie_colour": tortie_color,
+                    "tortie_pattern": tortie_pattern,
+                    "tortie_marking": tortie_marking,
+                    "skin": skin,
+                    "tint": tint,
+                    "scars": scars,
+                    "accessory": tuple(
+                        accessory,
+                    ),
+                    "opacity": opacity,
+                }
+            ),
+            "moons": moons,
+            "status": Status(**status),
+            "backstory": backstory,
+            "catskills": CatSkills(skill_dict),
+            "personality": personality,
+            "mentorship": MentorshipDict(
+                mentor=mentor,
+                former_mentor=former_mentor,
+                patrol_with_mentor=patrol_with_mentor,
+                apprentice=current_apprentice,
+                former_apprentices=former_apprentices,
+            ),
+            "inheritance": InheritanceDict(
+                parent1=parent1,
+                parent2=parent2,
+                adoptive_parents=adoptive_parents,
+                faded_offspring=faded_offspring,
+                mate=mate,
+                previous_mates=previous_mates,
+            ),
+            "affinity": AfterlifeAffinityDict(
+                starclan=starclan_affinity, dark_forest=dark_forest_affinity
+            ),
+            "toggles": CatTogglesDict(
+                no_kits=no_kits,
+                no_mates=no_mates,
+                no_retire=no_retire,
+                prevent_fading=prevent_fading,
+                favourite=favourite,
+            ),
+            "experience": experience,
+            "birth_cooldown": birth_cooldown,
+            "specsuffix_hidden": specsuffix_hidden,
+        }

--- a/scripts/cat/factories/create_cat.py
+++ b/scripts/cat/factories/create_cat.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from random import randint, sample, choice
+
+from scripts.cat.enums import CatRank
+from scripts.cat.factories.cat_factory import CatFactory
+from scripts.cat.factories.enums import CatType
+from scripts.game_structure import game
+
+
+def create_cat(rank, moons=None, biome=None):
+    status_dict = {"rank": rank}
+
+    new_cat = CatFactory.create_cat(CatType.TEST, status_dict=status_dict, biome=biome)
+
+    if moons is not None:
+        new_cat.moons = moons
+    elif new_cat.moons >= 160:
+        new_cat.moons = randint(120, 155)
+    elif new_cat.moons == 0:
+        new_cat.moons = randint(1, 5)
+
+    not_allowed_scars = [
+        "NOPAW",
+        "NOTAIL",
+        "HALFTAIL",
+        "NOEAR",
+        "BOTHBLIND",
+        "RIGHTBLIND",
+        "LEFTBLIND",
+        "BRIGHTHEART",
+        "NOLEFTEAR",
+        "NORIGHTEAR",
+        "MANLEG",
+    ]
+
+    new_cat.pelt.scars = tuple(
+        scar for scar in new_cat.pelt.scars if scar not in not_allowed_scars
+    )
+
+    return new_cat
+
+
+def create_example_cats():
+    warrior_indices = sample(range(12), 3)
+
+    for cat_index in range(12):
+        if cat_index in warrior_indices:
+            game.choose_cats[cat_index] = create_cat(rank=CatRank.WARRIOR)
+        else:
+            random_rank = choice(
+                [
+                    CatRank.KITTEN,
+                    CatRank.APPRENTICE,
+                    CatRank.WARRIOR,
+                    CatRank.WARRIOR,
+                    CatRank.ELDER,
+                ]
+            )
+            game.choose_cats[cat_index] = create_cat(rank=random_rank)

--- a/scripts/cat/factories/create_cat.py
+++ b/scripts/cat/factories/create_cat.py
@@ -8,10 +8,10 @@ from scripts.cat.factories.enums import CatType
 from scripts.game_structure import game
 
 
-def create_cat(rank, moons=None, biome=None):
+def create_cat(rank, moons=None, biome=None, cat_type: CatType = CatType.TEST):
     status_dict = {"rank": rank}
 
-    new_cat = CatFactory.create_cat(CatType.TEST, status_dict=status_dict, biome=biome)
+    new_cat = CatFactory.create_cat(cat_type, status_dict=status_dict, biome=biome)
 
     if moons is not None:
         new_cat.moons = moons
@@ -46,7 +46,9 @@ def create_example_cats():
 
     for cat_index in range(12):
         if cat_index in warrior_indices:
-            game.choose_cats[cat_index] = create_cat(rank=CatRank.WARRIOR)
+            game.choose_cats[cat_index] = create_cat(
+                cat_type=CatType.NEW, rank=CatRank.WARRIOR
+            )
         else:
             random_rank = choice(
                 [
@@ -57,4 +59,6 @@ def create_example_cats():
                     CatRank.ELDER,
                 ]
             )
-            game.choose_cats[cat_index] = create_cat(rank=random_rank)
+            game.choose_cats[cat_index] = create_cat(
+                cat_type=CatType.NEW, rank=random_rank
+            )

--- a/scripts/cat/factories/create_cat.py
+++ b/scripts/cat/factories/create_cat.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from random import randint, sample, choice
 
-from scripts.cat.cats import Cat
 from scripts.cat.enums import CatRank, CatAge
 from scripts.cat.factories.cat_factory import CatFactory
 from scripts.cat.factories.enums import CatType

--- a/scripts/cat/factories/create_cat.py
+++ b/scripts/cat/factories/create_cat.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 from random import randint, sample, choice
 
-from scripts.cat.enums import CatRank
+from scripts.cat.cats import Cat
+from scripts.cat.enums import CatRank, CatAge
 from scripts.cat.factories.cat_factory import CatFactory
 from scripts.cat.factories.enums import CatType
+from scripts.cat.pelts import Pelt
 from scripts.game_structure import game
 
 
@@ -62,3 +64,35 @@ def create_example_cats():
             game.choose_cats[cat_index] = create_cat(
                 cat_type=CatType.NEW, rank=random_rank
             )
+
+
+def create_option_preview_cat(scar: str = None, acc: str = None):
+    """
+    Creates a cat with the specified scar
+    """
+    new_cat = CatFactory.create_cat(
+        CatType.TEST,
+        loading_cat=True,
+        pelt=Pelt(
+            name="SingleColour",
+            colour="WHITE",
+            length="medium",
+            eye_color="SAGE",
+            reverse=False,
+            white_patches=None,
+            vitiligo=None,
+            points=None,
+            tortie_marking=None,
+            tortie_base=None,
+            tortie_pattern=None,
+            tortie_colour=None,
+            tint="gray",
+            skin="BLUE",
+            scars=[scar] if scar else [],
+            adult_sprite="8",
+            accessory=[acc] if acc else [],
+        ),
+    )
+    new_cat.age = CatAge.ADULT
+
+    return new_cat

--- a/scripts/cat/factories/enums.py
+++ b/scripts/cat/factories/enums.py
@@ -6,3 +6,4 @@ class CatType(Enum):
     LOAD_JSON = 1
     LOAD_CSV = 2
     FADED = 3
+    TEST = 999

--- a/scripts/cat/factories/enums.py
+++ b/scripts/cat/factories/enums.py
@@ -1,0 +1,7 @@
+from enum import Enum
+
+
+class CatType(Enum):
+    NEW = 0
+    LOAD = 1
+    FADED = 2

--- a/scripts/cat/factories/enums.py
+++ b/scripts/cat/factories/enums.py
@@ -3,5 +3,6 @@ from enum import Enum
 
 class CatType(Enum):
     NEW = 0
-    LOAD = 1
-    FADED = 2
+    LOAD_JSON = 1
+    LOAD_CSV = 2
+    FADED = 3

--- a/scripts/cat/factories/faded_cat_factory.py
+++ b/scripts/cat/factories/faded_cat_factory.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 from scripts.cat.cats import Cat
 from scripts.cat.enums import CatGroup
 from scripts.cat.factories.base_factory import BaseCatFactory
@@ -5,6 +7,8 @@ from scripts.cat.factories.typed_dicts import InheritanceDict, GenderDict
 from scripts.cat.names import Name
 from scripts.cat.status import Status
 
+if TYPE_CHECKING:
+    from random import Random
 
 # be aware that there are many, many warnings in this file.
 # this will continue to be the case until someone makes faded cats separate from regular cats.
@@ -13,7 +17,7 @@ from scripts.cat.status import Status
 
 
 class FadedCatFactory(BaseCatFactory):
-    def __init__(self, rng):
+    def __init__(self, rng: "Random"):
         self.rng = rng
 
     def create_cat(self, **kwargs) -> Cat:

--- a/scripts/cat/factories/faded_cat_factory.py
+++ b/scripts/cat/factories/faded_cat_factory.py
@@ -23,6 +23,8 @@ class FadedCatFactory(BaseCatFactory):
             status.send_to_afterlife(
                 CatGroup.DARK_FOREST_ID
                 if kwargs.get("df", False)
+                else CatGroup.UNKNOWN_RESIDENCE
+                if status.is_outsider and not status.is_former_clancat
                 else CatGroup.STARCLAN_ID
             )
         else:

--- a/scripts/cat/factories/faded_cat_factory.py
+++ b/scripts/cat/factories/faded_cat_factory.py
@@ -1,0 +1,62 @@
+from scripts.cat.cats import Cat
+from scripts.cat.enums import CatGroup
+from scripts.cat.factories.base_factory import BaseCatFactory
+from scripts.cat.factories.typed_dicts import InheritanceDict, GenderDict
+from scripts.cat.names import Name
+from scripts.cat.status import Status
+
+
+# be aware that there are many, many warnings in this file.
+# this will continue to be the case until someone makes faded cats separate from regular cats.
+
+# it's also not usable until the registry is implemented, so enjoy this little teaser
+
+
+class FadedCatFactory(BaseCatFactory):
+    def __init__(self, rng):
+        self.rng = rng
+
+    def create_cat(self, **kwargs) -> Cat:
+        if isinstance(kwargs["status"], str):
+            status = Status(rank=kwargs["status"])
+            # they are definitely dead
+            status.send_to_afterlife(
+                CatGroup.DARK_FOREST_ID
+                if kwargs.get("df", False)
+                else CatGroup.STARCLAN_ID
+            )
+        else:
+            status = Status(**kwargs["status"])
+
+        cat = Cat(
+            ID=kwargs["ID"],
+            gender_dict=GenderDict(sex=None, genderalign=None),
+            pelt=None,
+            moons=kwargs["moons"],
+            status=status,
+            backstory="",
+            catskills=None,
+            personality=None,
+            mentorship={},
+            inheritance=InheritanceDict(
+                parent1=kwargs["parent1"],
+                parent2=kwargs["parent2"],
+                adoptive_parents=kwargs["adoptive_parents"],
+                mate=[],
+                previous_mates=[],
+                faded_offspring=kwargs["faded_offspring"],
+            ),
+            affinity={},
+            toggles={},
+            experience=0,
+            birth_cooldown=0,
+            specsuffix_hidden=False,
+            faded=True,
+        )
+        cat.name = Name(
+            prefix=kwargs["name_prefix"], suffix=kwargs["name_suffix"], cat=cat
+        )
+        cat.dead_for = kwargs.get("dead_for", 0)
+
+        cat.set_faded()
+        return cat

--- a/scripts/cat/factories/load_cat_factory.py
+++ b/scripts/cat/factories/load_cat_factory.py
@@ -1,0 +1,150 @@
+from typing import Dict, Tuple, Optional
+
+from scripts.cat.cats import Cat, BACKSTORIES
+from scripts.cat.enums import CatAge
+from scripts.cat.factories.base_factory import BaseCatFactory
+
+
+class LoadCatFactory(BaseCatFactory):
+    cat_id = None
+
+    def __init__(self, rng):
+        pass  # no need for RNG in cat loading
+
+    def create_cat(self, **kwargs) -> Cat:
+        """
+        Takes a dict from save data & constructs the cat
+        :param kwargs: save file dict
+        :return:
+        """
+        if "ID" not in kwargs:
+            raise KeyError("Cat ID missing!")
+        self.cat_id = kwargs["ID"]
+
+        pelt_params = self._build_pelt_dict(kwargs)
+
+        gender = {
+            "sex": kwargs["gender"],
+            "genderalign": kwargs.get("gender_align", kwargs["gender"]),
+            "pronouns": kwargs.get("pronouns")
+        }
+
+        inheritance = {
+            "parent1": kwargs["parent1"],
+            "parent2": kwargs["parent2"],
+            "adoptive_parents": kwargs.get("adoptive_parents", [])
+        }
+
+        cat_params = {
+            "ID": self.cat_id,
+            "prefix": kwargs["name_prefix"],
+            "suffix": kwargs["name_suffix"],
+            "specsuffix_hidden": kwargs.get("specsuffix_hidden", False),
+            "gender": gender,
+            "status": self._convert_status(kwargs.get("status"), kwargs.get("moons")),
+            "parent1": kwargs["parent1"],
+            "parent2": kwargs["parent2"],
+            "moons": kwargs["moons"],
+            "eye_colour": pelt_params["eye_colour"],
+            "loading_cat": True,
+            "backstory": self._convert_backstory(kwargs.get("backstory"))
+        }
+
+    def _convert_status(self, status, moons) -> Dict:
+        """
+        Check & convert status
+        :param status: Possible status
+        :return: valid status
+        """
+        if status is None:
+            raise TypeError(f"Status is None for cat ID: {self.cat_id}")
+        if moons is None:
+            raise TypeError(f"Moons is None for cat ID: {self.cat_id}")
+
+        if isinstance(status, str):
+            age = CatAge.get_from_moons(moons)
+            return {"rank": status, "age": age}
+
+        return status
+
+    def _convert_eye_color(self, eye_color, eye_color2) -> Tuple[str, Optional[str]]:
+        """
+        Convert old eye colors to new format
+        :param eye_color: Primary eye color
+        :param eye_color2: Secondary eye color, if present
+        :return: Primary eye color and secondary eye color / None if homochromia
+        """
+        if eye_color == "BLUE2":
+            eye_color = "COBALT"
+        if eye_color in ["BLUEYELLOW", "BLUEGREEN"]:
+            # splits into BLUE and either YELLOW or GREEN
+            return eye_color[:4], eye_color[4:]
+        if eye_color2 == "BLUE2":
+            eye_color2 = "COBALT"
+
+        return eye_color, eye_color2
+
+    def _build_pelt_dict(self, kwargs):
+        """
+        Handles some check & convert functionality for pelts
+        :param kwargs: Everything we've ever passed into the factory
+        :return: A dict of the keys needed to build the pelt
+        """
+        eye_colour, eye_colour2 = self._convert_eye_color(
+            kwargs["eye_colour"], kwargs.get("eye_color2")
+        )
+
+        if kwargs.get("tint") == "none":
+            kwargs["tint"] = None
+        if kwargs.get("white_patches_tint") == "none":
+            kwargs["white_patches_tint"] = None
+            # this then gets set to "offwhite" later
+
+        if pattern:= kwargs.get("pattern"):
+            kwargs["tortie_pattern"] = pattern
+
+        # just to be sure that scars exists as a list
+        kwargs["scars"] = kwargs.get("scars", [])
+
+        for specialty in ("specialty", "specialty2"):
+            if old_scars := kwargs.get(specialty):
+                kwargs["scars"] = [*kwargs["scars"], old_scars]
+
+        return {
+            "name": kwargs["pelt_name"],
+            "length": kwargs["pelt_length"],
+            "colour": kwargs["pelt_colour"],
+            "eye_colour": eye_colour,
+            "eye_colour2": eye_colour2,
+            "paralyzed": kwargs["paralyzed"],
+            "newborn_sprite": kwargs.get("sprite_newborn"),
+            "kitten_sprite": kwargs.get("sprite_kitten", kwargs["spirit_kitten"]),
+            "adol_sprite": kwargs.get("sprite_adolescent", kwargs["spirit_adolescent"]),
+            "adult_sprite": kwargs.get("sprite_adult", kwargs["spirit_adult"]),
+            "senior_sprite": kwargs.get("sprite_senior", kwargs["spirit_senior"]),
+            "para_adult_sprite": kwargs.get("sprite_para_adult"),
+            "reverse": kwargs["reverse"],
+            "vitiligo": kwargs.get("vitiligo"),
+            "points": kwargs.get("points"),
+            "white_patches_tint": kwargs.get("white_patches_tint", "offwhite"),
+            "white_patches": kwargs.get("white_patches"),
+            "tortie_base": kwargs.get("tortie_base"),
+            "tortie_colour": kwargs.get("tortie_colour"),
+            "tortie_pattern": kwargs.get("tortie_pattern"),
+            "tortie_marking": kwargs.get("tortie_marking"),
+            "skin": kwargs.get("skin"),
+            "tint": kwargs.get("tint"),
+            "scars": kwargs["scars"],
+            "accessory": kwargs.get("accessory", []),
+            "opacity": kwargs.get("opacity", 100),
+        }
+
+    @staticmethod
+    def _convert_backstory(backstory) -> str:
+        """
+        Convert an old-style backstory to the new version
+        :param backstory:
+        :return: the new-style backstory
+        """
+        # if the key isn't found, return it as the value (no need to convert
+        return BACKSTORIES["conversion"].get(backstory, backstory)

--- a/scripts/cat/factories/load_cat_factory.py
+++ b/scripts/cat/factories/load_cat_factory.py
@@ -146,7 +146,7 @@ class LoadCatFactory(BaseCatFactory):
         Check & convert status to new Status
         :param status_dict: Possible status_dict
         :param moons: age in moons
-        :param old_bools: old-style status bools in a tuple
+        :param old_bools: old-style status bools in a list
         :return: valid status
         """
         if status_dict is None:
@@ -226,7 +226,7 @@ class LoadCatFactory(BaseCatFactory):
 
         for specialty in ("specialty", "specialty2"):
             if old_scars := kwargs.get(specialty):
-                kwargs["scars"] = [*kwargs["scars"], old_scars]
+                kwargs["scars"] = tuple([*kwargs["scars"], old_scars])
 
         pelt = Pelt(
             **{

--- a/scripts/cat/factories/load_cat_factory.py
+++ b/scripts/cat/factories/load_cat_factory.py
@@ -1,4 +1,4 @@
-from typing import Dict, Tuple, Optional, Union, List
+from typing import Dict, Tuple, Optional, Union, List, TYPE_CHECKING
 
 import ujson
 
@@ -19,15 +19,20 @@ from scripts.cat.personality import Personality
 from scripts.cat.skills import CatSkills
 from scripts.cat.status import Status
 
-with open(f"resources/dicts/conversion_dict.json", "r", encoding="utf-8") as read_file:
-    CONVERT = ujson.loads(read_file.read())
+if TYPE_CHECKING:
+    from random import Random
 
 
 class LoadCatFactory(BaseCatFactory):
     cat_id = None
 
-    def __init__(self, rng):
-        self.rng = rng  # turns out we do need rng.
+    with open(
+        f"resources/dicts/conversion_dict.json", "r", encoding="utf-8"
+    ) as read_file:
+        CONVERT = ujson.loads(read_file.read())
+
+    def __init__(self, rng: "Random"):
+        self.rng = rng  # needed for converting skills from old format
 
     def create_cat(self, **kwargs) -> Cat:
         """
@@ -264,7 +269,7 @@ class LoadCatFactory(BaseCatFactory):
                 "opacity": kwargs.get("opacity", 100),
             }
         )
-        pelt.check_and_convert(convert_dict=CONVERT)
+        pelt.check_and_convert(convert_dict=self.CONVERT)
 
         return pelt
 

--- a/scripts/cat/factories/load_cat_factory.py
+++ b/scripts/cat/factories/load_cat_factory.py
@@ -1,15 +1,33 @@
-from typing import Dict, Tuple, Optional
+from typing import Dict, Tuple, Optional, Union, List
+
+import ujson
 
 from scripts.cat.cats import Cat, BACKSTORIES
-from scripts.cat.enums import CatAge
+from scripts.cat.enums import CatAge, CatGroup, CatRank
 from scripts.cat.factories.base_factory import BaseCatFactory
+from scripts.cat.factories.typed_dicts import (
+    MentorshipDict,
+    CatTogglesDict,
+    GenderDict,
+    InheritanceDict,
+    AfterlifeAffinityDict,
+)
+from scripts.cat.history import History
+from scripts.cat.names import Name
+from scripts.cat.pelts import Pelt
+from scripts.cat.personality import Personality
+from scripts.cat.skills import CatSkills
+from scripts.cat.status import Status
+
+with open(f"resources/dicts/conversion_dict.json", "r", encoding="utf-8") as read_file:
+    CONVERT = ujson.loads(read_file.read())
 
 
 class LoadCatFactory(BaseCatFactory):
     cat_id = None
 
     def __init__(self, rng):
-        pass  # no need for RNG in cat loading
+        self.rng = rng  # turns out we do need rng.
 
     def create_cat(self, **kwargs) -> Cat:
         """
@@ -21,53 +39,152 @@ class LoadCatFactory(BaseCatFactory):
             raise KeyError("Cat ID missing!")
         self.cat_id = kwargs["ID"]
 
-        pelt_params = self._build_pelt_dict(kwargs)
+        pelt = self._build_pelt(kwargs)
 
-        gender = {
-            "sex": kwargs["gender"],
-            "genderalign": kwargs.get("gender_align", kwargs["gender"]),
-            "pronouns": kwargs.get("pronouns")
-        }
+        gender = GenderDict(
+            sex=kwargs["gender"],
+            genderalign=kwargs.get("gender_align", kwargs["gender"]),
+            pronouns=kwargs.get("pronouns"),
+        )
 
-        inheritance = {
-            "parent1": kwargs["parent1"],
-            "parent2": kwargs["parent2"],
-            "adoptive_parents": kwargs.get("adoptive_parents", [])
-        }
+        # todo do I want to do this this way
+        mate = kwargs.get("mate")
+        mate = mate if isinstance(mate, list) else [mate]
+        inheritance = InheritanceDict(
+            parent1=kwargs["parent1"],
+            parent2=kwargs["parent2"],
+            adoptive_parents=kwargs.get("adoptive_parents", []),
+            faded_offspring=kwargs.get("faded_offsprings", []),
+            mate=mate,
+            previous_mates=kwargs.get("previous_mates", []),
+        )
+
+        mentorship = MentorshipDict(
+            mentor=kwargs["mentor"],
+            former_mentor=kwargs.get("former_mentor", []),
+            patrol_with_mentor=kwargs.get("patrol_with_mentor", 0),
+            apprentice=kwargs["current_apprentice"],
+            former_apprentices=kwargs["former_apprentices"],
+        )
+
+        toggles = CatTogglesDict(
+            no_kits=kwargs["no_kits"],
+            no_mates=kwargs.get("no_mates", False),
+            no_retire=kwargs.get("no_retire", False),
+            prevent_fading=kwargs.get("prevent_fading", False),
+            favourite=kwargs.get("favourite", False),
+        )
+
+        status = self._convert_status(
+            kwargs.get("status"),
+            kwargs.get("moons"),
+            old_bools=[
+                kwargs.get("dead"),
+                kwargs.get("df"),
+                kwargs.get("driven_out"),
+                kwargs.get("exiled"),
+                kwargs.get("outside"),
+            ],
+        )
+
+        backstory = self._convert_backstory(kwargs.get("backstory"))
+        cat_skill, backstory = self._convert_skill(
+            kwargs.get("skill_dict"),
+            kwargs.get("skill"),
+            backstory,
+            status.rank,
+            CatAge.get_from_moons(kwargs["moons"]),
+        )
+
+        affinity = AfterlifeAffinityDict(
+            starclan=kwargs.get("starclan_affinity", 0),
+            dark_forest=kwargs.get("dark_forest_affinity", 0),
+        )
 
         cat_params = {
             "ID": self.cat_id,
-            "prefix": kwargs["name_prefix"],
-            "suffix": kwargs["name_suffix"],
-            "specsuffix_hidden": kwargs.get("specsuffix_hidden", False),
-            "gender": gender,
-            "status": self._convert_status(kwargs.get("status"), kwargs.get("moons")),
-            "parent1": kwargs["parent1"],
-            "parent2": kwargs["parent2"],
+            "gender_dict": gender,
+            "pelt": pelt,
             "moons": kwargs["moons"],
-            "eye_colour": pelt_params["eye_colour"],
-            "loading_cat": True,
-            "backstory": self._convert_backstory(kwargs.get("backstory"))
+            "status": status,
+            "backstory": backstory,
+            "catskills": cat_skill,
+            "personality": self._build_personality(
+                kwargs.get("facets"),
+                kwargs["trait"],
+                CatAge.get_from_moons(kwargs["moons"]).is_baby(),
+            ),
+            "mentorship": mentorship,
+            "inheritance": inheritance,
+            "affinity": affinity,
+            "toggles": toggles,
+            "experience": kwargs.get("experience"),
+            "birth_cooldown": kwargs.get("birth_cooldown", 0),
+            "specsuffix_hidden": kwargs.get("specsuffix_hidden", False),
         }
 
-    def _convert_status(self, status, moons) -> Dict:
+        cat = Cat(**cat_params)
+        cat.history = self._convert_history(
+            kwargs.get("died_by", []), kwargs.get("scar_event", []), cat=cat
+        )
+        cat.name = Name(
+            prefix=kwargs["name_prefix"],
+            suffix=kwargs["name_suffix"],
+            specsuffix_hidden=kwargs.get("specsuffix_hidden", False),
+            load_existing_name=True,
+            cat=cat,
+        )
+        return cat
+
+    def _convert_status(
+        self,
+        status_dict: Optional[Union[Dict, str]],
+        moons: int,
+        old_bools: List[Optional[bool]],
+    ) -> Status:
         """
-        Check & convert status
-        :param status: Possible status
+        Check & convert status to new Status
+        :param status_dict: Possible status_dict
+        :param moons: age in moons
+        :param old_bools: old-style status bools in a tuple
         :return: valid status
         """
-        if status is None:
+        if status_dict is None:
             raise TypeError(f"Status is None for cat ID: {self.cat_id}")
         if moons is None:
             raise TypeError(f"Moons is None for cat ID: {self.cat_id}")
 
-        if isinstance(status, str):
+        if isinstance(status_dict, str):
             age = CatAge.get_from_moons(moons)
-            return {"rank": status, "age": age}
+            status = Status(rank=status_dict, age=age)
+        else:
+            status = Status(**status_dict)
+
+        if not any(old_bools):
+            # either they're not present or all False
+            return status
+
+        dead, df, driven_out, exiled, outside = old_bools
+
+        if dead and not status.group.is_afterlife():
+            if df:
+                status.send_to_afterlife(target_ID=CatGroup.DARK_FOREST_ID)
+            elif outside:
+                status.send_to_afterlife(target_ID=CatGroup.UNKNOWN_RESIDENCE_ID)
+            else:
+                status.send_to_afterlife(target_ID=CatGroup.STARCLAN_ID)
+        elif exiled:
+            status.exile_from_group()
+        elif outside and not status.is_outsider:
+            status.become_lost()
+
+        if driven_out:
+            status.change_group_nearness(CatGroup.PLAYER_CLAN_ID)
 
         return status
 
-    def _convert_eye_color(self, eye_color, eye_color2) -> Tuple[str, Optional[str]]:
+    @staticmethod
+    def _convert_eye_color(eye_color, eye_color2) -> Tuple[str, Optional[str]]:
         """
         Convert old eye colors to new format
         :param eye_color: Primary eye color
@@ -84,7 +201,7 @@ class LoadCatFactory(BaseCatFactory):
 
         return eye_color, eye_color2
 
-    def _build_pelt_dict(self, kwargs):
+    def _build_pelt(self, kwargs):
         """
         Handles some check & convert functionality for pelts
         :param kwargs: Everything we've ever passed into the factory
@@ -100,8 +217,9 @@ class LoadCatFactory(BaseCatFactory):
             kwargs["white_patches_tint"] = None
             # this then gets set to "offwhite" later
 
-        if pattern:= kwargs.get("pattern"):
-            kwargs["tortie_pattern"] = pattern
+        if "pattern" in kwargs:
+            kwargs["tortie_marking"] = kwargs["pattern"]
+            del kwargs["pattern"]
 
         # just to be sure that scars exists as a list
         kwargs["scars"] = kwargs.get("scars", [])
@@ -110,34 +228,45 @@ class LoadCatFactory(BaseCatFactory):
             if old_scars := kwargs.get(specialty):
                 kwargs["scars"] = [*kwargs["scars"], old_scars]
 
-        return {
-            "name": kwargs["pelt_name"],
-            "length": kwargs["pelt_length"],
-            "colour": kwargs["pelt_colour"],
-            "eye_colour": eye_colour,
-            "eye_colour2": eye_colour2,
-            "paralyzed": kwargs["paralyzed"],
-            "newborn_sprite": kwargs.get("sprite_newborn"),
-            "kitten_sprite": kwargs.get("sprite_kitten", kwargs["spirit_kitten"]),
-            "adol_sprite": kwargs.get("sprite_adolescent", kwargs["spirit_adolescent"]),
-            "adult_sprite": kwargs.get("sprite_adult", kwargs["spirit_adult"]),
-            "senior_sprite": kwargs.get("sprite_senior", kwargs["spirit_senior"]),
-            "para_adult_sprite": kwargs.get("sprite_para_adult"),
-            "reverse": kwargs["reverse"],
-            "vitiligo": kwargs.get("vitiligo"),
-            "points": kwargs.get("points"),
-            "white_patches_tint": kwargs.get("white_patches_tint", "offwhite"),
-            "white_patches": kwargs.get("white_patches"),
-            "tortie_base": kwargs.get("tortie_base"),
-            "tortie_colour": kwargs.get("tortie_colour"),
-            "tortie_pattern": kwargs.get("tortie_pattern"),
-            "tortie_marking": kwargs.get("tortie_marking"),
-            "skin": kwargs.get("skin"),
-            "tint": kwargs.get("tint"),
-            "scars": kwargs["scars"],
-            "accessory": kwargs.get("accessory", []),
-            "opacity": kwargs.get("opacity", 100),
-        }
+        pelt = Pelt(
+            **{
+                "name": kwargs["pelt_name"],
+                "length": kwargs["pelt_length"],
+                "colour": kwargs.get("pelt_color"),
+                "eye_color": eye_colour,
+                "eye_colour2": eye_colour2,
+                "paralyzed": kwargs["paralyzed"],
+                "newborn_sprite": kwargs.get("sprite_newborn"),
+                "kitten_sprite": kwargs.get(
+                    "sprite_kitten", kwargs.get("spirit_kitten")
+                ),
+                "adol_sprite": kwargs.get(
+                    "sprite_adolescent", kwargs.get("spirit_adolescent")
+                ),
+                "adult_sprite": kwargs.get("sprite_adult", kwargs.get("spirit_adult")),
+                "senior_sprite": kwargs.get(
+                    "sprite_senior", kwargs.get("spirit_senior")
+                ),
+                "para_adult_sprite": kwargs.get("sprite_para_adult"),
+                "reverse": kwargs["reverse"],
+                "vitiligo": kwargs.get("vitiligo"),
+                "points": kwargs.get("points"),
+                "white_patches_tint": kwargs.get("white_patches_tint", "offwhite"),
+                "white_patches": kwargs["white_patches"],
+                "tortie_base": kwargs["tortie_base"],
+                "tortie_colour": kwargs["tortie_color"],
+                "tortie_pattern": kwargs["tortie_pattern"],
+                "tortie_marking": kwargs["tortie_marking"],
+                "skin": kwargs.get("skin"),
+                "tint": kwargs.get("tint"),
+                "scars": kwargs["scars"],
+                "accessory": kwargs.get("accessory", []),
+                "opacity": kwargs.get("opacity", 100),
+            }
+        )
+        pelt.check_and_convert(convert_dict=CONVERT)
+
+        return pelt
 
     @staticmethod
     def _convert_backstory(backstory) -> str:
@@ -148,3 +277,65 @@ class LoadCatFactory(BaseCatFactory):
         """
         # if the key isn't found, return it as the value (no need to convert
         return BACKSTORIES["conversion"].get(backstory, backstory)
+
+    def _build_personality(self, facets, trait, is_kit_trait):
+        if facets is not None:
+            facets = [int(i) for i in facets.split(",")]
+            return Personality(
+                trait=trait,
+                kit_trait=is_kit_trait,
+                lawful=facets[0],
+                social=facets[1],
+                aggress=facets[2],
+                stable=facets[3],
+            )
+        else:
+            print(f"WARNING: no facets found for cat ID: {self.cat_id}")
+            return Personality(trait=trait, kit_trait=is_kit_trait)
+
+    def _convert_skill(
+        self, skill_dict, skill, backstory, rank, age
+    ) -> Tuple[CatSkills, str]:
+        """
+        Handle conversion of some *very old* skills & backstories
+        :param skill_dict: modern skill dict
+        :param skill: skill string
+        :param backstory: backstory string
+        :param rank: needed to generate new skills
+        :param age: needed to generate new skills
+        :return:
+        """
+        if skill_dict:
+            return CatSkills(skill_dict), backstory
+        if skill:
+            if backstory is not None:
+                if skill == "formerly a loner":
+                    backstory = self.rng.choice(BACKSTORIES["loner_backstories"])
+                elif skill == "formerly a kittypet":
+                    backstory = self.rng.choice(BACKSTORIES["kittypet_backstories"])
+                else:
+                    backstory = "clanborn"
+            return CatSkills.get_skills_from_old(skill, rank, age), backstory
+        else:
+            raise Exception(f"No skill data provided for cat ID: {self.cat_id}")
+
+    def _convert_history(self, died_by, scar_events, cat) -> History:
+        """
+        Unfortunately, this has to be handled *after* the creation of the cat
+        because of the horrible nested cat. fixme.
+        :param died_by:
+        :param scar_events:
+        :param cat:
+        :return:
+        """
+        deaths = []
+        if died_by:
+            deaths.extend(
+                {"involved": None, "text": death, "moon": "?"} for death in died_by
+            )
+        scars = []
+        if scar_events:
+            scars.extend(
+                {"involved": None, "text": scar, "moon": "?"} for scar in scar_events
+            )
+        return History(died_by=deaths, scar_events=scars, cat=cat)

--- a/scripts/cat/factories/load_cat_factory.py
+++ b/scripts/cat/factories/load_cat_factory.py
@@ -1,23 +1,13 @@
-from typing import Dict, Tuple, Optional, Union, List, TYPE_CHECKING
+from typing import Dict, Tuple, Optional, List, TYPE_CHECKING
 
 import ujson
 
 from scripts.cat.cats import Cat, BACKSTORIES
-from scripts.cat.enums import CatAge, CatGroup, CatRank
 from scripts.cat.factories.base_factory import BaseCatFactory
-from scripts.cat.factories.typed_dicts import (
-    MentorshipDict,
-    CatTogglesDict,
-    GenderDict,
-    InheritanceDict,
-    AfterlifeAffinityDict,
-)
+from scripts.cat.factories.cat_mapper import CatMapper
 from scripts.cat.history import History
 from scripts.cat.names import Name
-from scripts.cat.pelts import Pelt
-from scripts.cat.personality import Personality
 from scripts.cat.skills import CatSkills
-from scripts.cat.status import Status
 
 if TYPE_CHECKING:
     from random import Random
@@ -31,316 +21,211 @@ class LoadCatFactory(BaseCatFactory):
     ) as read_file:
         CONVERT = ujson.loads(read_file.read())
 
-    def __init__(self, rng: "Random"):
+    def __init__(self, rng: "Random", mapper: CatMapper = CatMapper()):
         self.rng = rng  # needed for converting skills from old format
+        self.mapper = (
+            mapper  # typehinted atm as the pure Mapper but can become a Protocol later
+        )
 
-    def create_cat(self, **kwargs) -> Cat:
+    def create_cat(
+        self,
+        ID: str,
+        name_prefix: str,
+        name_suffix: str,
+        specsuffix_hidden: bool,
+        gender: str,
+        gender_align: str,
+        pronouns: Dict,
+        birth_cooldown: int,
+        status: Dict,
+        dark_forest_affinity: int,
+        starclan_affinity: int,
+        backstory: str,
+        moons: int,
+        trait: str,
+        facets: str,
+        parent1: Optional[str],
+        parent2: Optional[str],
+        adoptive_parents: List,
+        mentor: Optional[str],
+        former_mentor: List,
+        patrol_with_mentor: int,
+        mate: List,
+        previous_mates: List,
+        paralyzed: bool,
+        no_kits: bool,
+        no_retire: bool,
+        no_mates: bool,
+        pelt_name: str,
+        pelt_color: str,
+        pelt_length: str,
+        sprite_newborn: str,
+        sprite_kitten: str,
+        sprite_adolescent: str,
+        sprite_adult: str,
+        sprite_senior: str,
+        sprite_para_adult: str,
+        eye_colour: str,
+        eye_colour2: Optional[str],
+        reverse: bool,
+        white_patches: Optional[str],
+        vitiligo: Optional[str],
+        points: Optional[str],
+        white_patches_tint: Optional[str],
+        tortie_marking: Optional[str],
+        tortie_base: Optional[str],
+        tortie_color: Optional[str],
+        tortie_pattern: Optional[str],
+        skin: str,
+        tint: str,
+        skill_dict: Dict,
+        scars: List,
+        accessory: List,
+        experience: int,
+        current_apprentice: List,
+        former_apprentices: List,
+        faded_offspring: List,
+        opacity: int,
+        prevent_fading: bool,
+        favourite: bool,
+        **kwargs,
+    ) -> Cat:
         """
         Takes a dict from save data & constructs the cat
-        :param kwargs: save file dict
         :return:
         """
-        if "ID" not in kwargs:
+        if not ID:
             raise KeyError("Cat ID missing!")
-        self.cat_id = kwargs["ID"]
+        if not isinstance(ID, str) or not ID.isdigit():
+            raise ValueError(f"Cat ID '{ID}' is not a numerical string!")
+        self.cat_id = ID
 
-        pelt = self._build_pelt(kwargs)
-
-        gender = GenderDict(
-            sex=kwargs["gender"],
-            genderalign=kwargs.get("gender_align", kwargs["gender"]),
-            pronouns=kwargs.get("pronouns"),
-        )
-
-        # todo do I want to do this this way
-        mate = kwargs.get("mate")
-        mate = mate if isinstance(mate, list) else [mate]
-        inheritance = InheritanceDict(
-            parent1=kwargs["parent1"],
-            parent2=kwargs["parent2"],
-            adoptive_parents=kwargs.get("adoptive_parents", []),
-            faded_offspring=kwargs.get("faded_offsprings", []),
-            mate=mate,
-            previous_mates=kwargs.get("previous_mates", []),
-        )
-
-        mentorship = MentorshipDict(
-            mentor=kwargs["mentor"],
-            former_mentor=kwargs.get("former_mentor", []),
-            patrol_with_mentor=kwargs.get("patrol_with_mentor", 0),
-            apprentice=kwargs["current_apprentice"],
-            former_apprentices=kwargs["former_apprentices"],
-        )
-
-        toggles = CatTogglesDict(
-            no_kits=kwargs["no_kits"],
-            no_mates=kwargs.get("no_mates", False),
-            no_retire=kwargs.get("no_retire", False),
-            prevent_fading=kwargs.get("prevent_fading", False),
-            favourite=kwargs.get("favourite", False),
-        )
-
-        status = self._convert_status(
-            kwargs.get("status"),
-            kwargs.get("moons"),
-            old_bools=[
-                kwargs.get("dead"),
-                kwargs.get("df"),
-                kwargs.get("driven_out"),
-                kwargs.get("exiled"),
-                kwargs.get("outside"),
-            ],
-        )
-
-        backstory = self._convert_backstory(kwargs.get("backstory"))
-        cat_skill, backstory = self._convert_skill(
-            kwargs.get("skill_dict"),
-            kwargs.get("skill"),
-            backstory,
-            status.rank,
-            CatAge.get_from_moons(kwargs["moons"]),
-        )
-
-        affinity = AfterlifeAffinityDict(
-            starclan=kwargs.get("starclan_affinity", 0),
-            dark_forest=kwargs.get("dark_forest_affinity", 0),
-        )
-
-        cat_params = {
-            "ID": self.cat_id,
-            "gender_dict": gender,
-            "pelt": pelt,
-            "moons": kwargs["moons"],
-            "status": status,
-            "backstory": backstory,
-            "catskills": cat_skill,
-            "personality": self._build_personality(
-                kwargs.get("facets"),
-                kwargs["trait"],
-                CatAge.get_from_moons(kwargs["moons"]).is_baby(),
-            ),
-            "mentorship": mentorship,
-            "inheritance": inheritance,
-            "affinity": affinity,
-            "toggles": toggles,
-            "experience": kwargs.get("experience"),
-            "birth_cooldown": kwargs.get("birth_cooldown", 0),
-            "specsuffix_hidden": kwargs.get("specsuffix_hidden", False),
-        }
-
-        cat = Cat(**cat_params)
-        cat.history = self._convert_history(
-            kwargs.get("died_by", []), kwargs.get("scar_event", []), cat=cat
+        cat = Cat(
+            **self.mapper.map(
+                ID,
+                name_prefix,
+                name_suffix,
+                specsuffix_hidden,
+                gender,
+                gender_align,
+                pronouns,
+                birth_cooldown,
+                status,
+                dark_forest_affinity,
+                starclan_affinity,
+                backstory,
+                moons,
+                trait,
+                facets,
+                parent1,
+                parent2,
+                adoptive_parents,
+                mentor,
+                former_mentor,
+                patrol_with_mentor,
+                mate,
+                previous_mates,
+                paralyzed,
+                no_kits,
+                no_retire,
+                no_mates,
+                pelt_name,
+                pelt_color,
+                pelt_length,
+                sprite_newborn,
+                sprite_kitten,
+                sprite_adolescent,
+                sprite_adult,
+                sprite_senior,
+                sprite_para_adult,
+                eye_colour,
+                eye_colour2,
+                reverse,
+                white_patches,
+                vitiligo,
+                points,
+                white_patches_tint,
+                tortie_marking,
+                tortie_base,
+                tortie_color,
+                tortie_pattern,
+                skin,
+                tint,
+                skill_dict,
+                scars,
+                accessory,
+                experience,
+                current_apprentice,
+                former_apprentices,
+                faded_offspring,
+                opacity,
+                prevent_fading,
+                favourite,
+            )
         )
         cat.name = Name(
-            prefix=kwargs["name_prefix"],
-            suffix=kwargs["name_suffix"],
-            specsuffix_hidden=kwargs.get("specsuffix_hidden", False),
+            prefix=name_prefix,
+            suffix=name_suffix,
+            specsuffix_hidden=specsuffix_hidden,
             load_existing_name=True,
             cat=cat,
         )
+        print(f"WARNING: Unused kwargs: {[c for c in kwargs.keys()]}")
         return cat
 
-    def _convert_status(
-        self,
-        status_dict: Optional[Union[Dict, str]],
-        moons: int,
-        old_bools: List[Optional[bool]],
-    ) -> Status:
-        """
-        Check & convert status to new Status
-        :param status_dict: Possible status_dict
-        :param moons: age in moons
-        :param old_bools: old-style status bools in a list
-        :return: valid status
-        """
-        if status_dict is None:
-            raise TypeError(f"Status is None for cat ID: {self.cat_id}")
-        if moons is None:
-            raise TypeError(f"Moons is None for cat ID: {self.cat_id}")
-
-        if isinstance(status_dict, str):
-            age = CatAge.get_from_moons(moons)
-            status = Status(rank=status_dict, age=age)
-        else:
-            status = Status(**status_dict)
-
-        if not any(old_bools):
-            # either they're not present or all False
-            return status
-
-        dead, df, driven_out, exiled, outside = old_bools
-
-        if dead and not status.group.is_afterlife():
-            if df:
-                status.send_to_afterlife(target_ID=CatGroup.DARK_FOREST_ID)
-            elif outside:
-                status.send_to_afterlife(target_ID=CatGroup.UNKNOWN_RESIDENCE_ID)
-            else:
-                status.send_to_afterlife(target_ID=CatGroup.STARCLAN_ID)
-        elif exiled:
-            status.exile_from_group()
-        elif outside and not status.is_outsider:
-            status.become_lost()
-
-        if driven_out:
-            status.change_group_nearness(CatGroup.PLAYER_CLAN_ID)
-
-        return status
-
-    @staticmethod
-    def _convert_eye_color(eye_color, eye_color2) -> Tuple[str, Optional[str]]:
-        """
-        Convert old eye colors to new format
-        :param eye_color: Primary eye color
-        :param eye_color2: Secondary eye color, if present
-        :return: Primary eye color and secondary eye color / None if homochromia
-        """
-        if eye_color == "BLUE2":
-            eye_color = "COBALT"
-        if eye_color in ["BLUEYELLOW", "BLUEGREEN"]:
-            # splits into BLUE and either YELLOW or GREEN
-            return eye_color[:4], eye_color[4:]
-        if eye_color2 == "BLUE2":
-            eye_color2 = "COBALT"
-
-        return eye_color, eye_color2
-
-    def _build_pelt(self, kwargs):
-        """
-        Handles some check & convert functionality for pelts
-        :param kwargs: Everything we've ever passed into the factory
-        :return: A dict of the keys needed to build the pelt
-        """
-        eye_colour, eye_colour2 = self._convert_eye_color(
-            kwargs["eye_colour"], kwargs.get("eye_color2")
-        )
-
-        if kwargs.get("tint") == "none":
-            kwargs["tint"] = None
-        if kwargs.get("white_patches_tint") == "none":
-            kwargs["white_patches_tint"] = None
-            # this then gets set to "offwhite" later
-
-        if "pattern" in kwargs:
-            kwargs["tortie_marking"] = kwargs["pattern"]
-            del kwargs["pattern"]
-
-        # just to be sure that scars exists as a list
-        kwargs["scars"] = kwargs.get("scars", [])
-
-        for specialty in ("specialty", "specialty2"):
-            if old_scars := kwargs.get(specialty):
-                kwargs["scars"] = tuple([*kwargs["scars"], old_scars])
-
-        pelt = Pelt(
-            **{
-                "name": kwargs["pelt_name"],
-                "length": kwargs["pelt_length"],
-                "colour": kwargs.get("pelt_color"),
-                "eye_color": eye_colour,
-                "eye_colour2": eye_colour2,
-                "paralyzed": kwargs["paralyzed"],
-                "newborn_sprite": kwargs.get("sprite_newborn"),
-                "kitten_sprite": kwargs.get(
-                    "sprite_kitten", kwargs.get("spirit_kitten")
-                ),
-                "adol_sprite": kwargs.get(
-                    "sprite_adolescent", kwargs.get("spirit_adolescent")
-                ),
-                "adult_sprite": kwargs.get("sprite_adult", kwargs.get("spirit_adult")),
-                "senior_sprite": kwargs.get(
-                    "sprite_senior", kwargs.get("spirit_senior")
-                ),
-                "para_adult_sprite": kwargs.get("sprite_para_adult"),
-                "reverse": kwargs["reverse"],
-                "vitiligo": kwargs.get("vitiligo"),
-                "points": kwargs.get("points"),
-                "white_patches_tint": kwargs.get("white_patches_tint", "offwhite"),
-                "white_patches": kwargs["white_patches"],
-                "tortie_base": kwargs["tortie_base"],
-                "tortie_colour": kwargs["tortie_color"],
-                "tortie_pattern": kwargs["tortie_pattern"],
-                "tortie_marking": kwargs["tortie_marking"],
-                "skin": kwargs.get("skin"),
-                "tint": kwargs.get("tint"),
-                "scars": kwargs["scars"],
-                "accessory": kwargs.get("accessory", []),
-                "opacity": kwargs.get("opacity", 100),
-            }
-        )
-        pelt.check_and_convert(convert_dict=self.CONVERT)
-
-        return pelt
-
-    @staticmethod
-    def _convert_backstory(backstory) -> str:
-        """
-        Convert an old-style backstory to the new version
-        :param backstory:
-        :return: the new-style backstory
-        """
-        # if the key isn't found, return it as the value (no need to convert
-        return BACKSTORIES["conversion"].get(backstory, backstory)
-
-    def _build_personality(self, facets, trait, is_kit_trait):
-        if facets is not None:
-            facets = [int(i) for i in facets.split(",")]
-            return Personality(
-                trait=trait,
-                kit_trait=is_kit_trait,
-                lawful=facets[0],
-                social=facets[1],
-                aggress=facets[2],
-                stable=facets[3],
-            )
-        else:
-            print(f"WARNING: no facets found for cat ID: {self.cat_id}")
-            return Personality(trait=trait, kit_trait=is_kit_trait)
-
-    def _convert_skill(
-        self, skill_dict, skill, backstory, rank, age
-    ) -> Tuple[CatSkills, str]:
-        """
-        Handle conversion of some *very old* skills & backstories
-        :param skill_dict: modern skill dict
-        :param skill: skill string
-        :param backstory: backstory string
-        :param rank: needed to generate new skills
-        :param age: needed to generate new skills
-        :return:
-        """
-        if skill_dict:
-            return CatSkills(skill_dict), backstory
-        if skill:
-            if backstory is not None:
-                if skill == "formerly a loner":
-                    backstory = self.rng.choice(BACKSTORIES["loner_backstories"])
-                elif skill == "formerly a kittypet":
-                    backstory = self.rng.choice(BACKSTORIES["kittypet_backstories"])
-                else:
-                    backstory = "clanborn"
-            return CatSkills.get_skills_from_old(skill, rank, age), backstory
-        else:
-            raise Exception(f"No skill data provided for cat ID: {self.cat_id}")
-
-    def _convert_history(self, died_by, scar_events, cat) -> History:
-        """
-        Unfortunately, this has to be handled *after* the creation of the cat
-        because of the horrible nested cat. fixme.
-        :param died_by:
-        :param scar_events:
-        :param cat:
-        :return:
-        """
-        deaths = []
-        if died_by:
-            deaths.extend(
-                {"involved": None, "text": death, "moon": "?"} for death in died_by
-            )
-        scars = []
-        if scar_events:
-            scars.extend(
-                {"involved": None, "text": scar, "moon": "?"} for scar in scar_events
-            )
-        return History(died_by=deaths, scar_events=scars, cat=cat)
+    # @staticmethod
+    # def _convert_backstory(backstory) -> str:
+    #     """
+    #     Convert an old-style backstory to the new version
+    #     :param backstory:
+    #     :return: the new-style backstory
+    #     """
+    #     # if the key isn't found, return it as the value (no need to convert
+    #     return BACKSTORIES["conversion"].get(backstory, backstory)
+    #
+    # def _convert_skill(
+    #     self, skill_dict, skill, backstory, rank, age
+    # ) -> Tuple[CatSkills, str]:
+    #     """
+    #     Handle conversion of some *very old* skills & backstories
+    #     :param skill_dict: modern skill dict
+    #     :param skill: skill string
+    #     :param backstory: backstory string
+    #     :param rank: needed to generate new skills
+    #     :param age: needed to generate new skills
+    #     :return:
+    #     """
+    #     if skill_dict:
+    #         return CatSkills(skill_dict), backstory
+    #     if skill:
+    #         if backstory is not None:
+    #             if skill == "formerly a loner":
+    #                 backstory = self.rng.choice(BACKSTORIES["loner_backstories"])
+    #             elif skill == "formerly a kittypet":
+    #                 backstory = self.rng.choice(BACKSTORIES["kittypet_backstories"])
+    #             else:
+    #                 backstory = "clanborn"
+    #         return CatSkills.get_skills_from_old(skill, rank, age), backstory
+    #     else:
+    #         raise Exception(f"No skill data provided for cat ID: {self.cat_id}")
+    #
+    # def _convert_history(self, died_by, scar_events, cat) -> History:
+    #     """
+    #     Unfortunately, this has to be handled *after* the creation of the cat
+    #     because of the horrible nested cat. fixme.
+    #     :param died_by:
+    #     :param scar_events:
+    #     :param cat:
+    #     :return:
+    #     """
+    #     deaths = []
+    #     if died_by:
+    #         deaths.extend(
+    #             {"involved": None, "text": death, "moon": "?"} for death in died_by
+    #         )
+    #     scars = []
+    #     if scar_events:
+    #         scars.extend(
+    #             {"involved": None, "text": scar, "moon": "?"} for scar in scar_events
+    #         )
+    #     return History(died_by=deaths, scar_events=scars, cat=cat)

--- a/scripts/cat/factories/new_cat_factory.py
+++ b/scripts/cat/factories/new_cat_factory.py
@@ -91,7 +91,10 @@ class NewCatFactory(BaseCatFactory):
             "specsuffix_hidden": False,
         }
 
-        return Cat(**cat_params)
+        cat = Cat(**cat_params)
+        Cat.all_cats[cat.ID] = cat
+
+        return cat
 
     def _random_age(self):
         return self.rng.choice([*CatAge])

--- a/scripts/cat/factories/new_cat_factory.py
+++ b/scripts/cat/factories/new_cat_factory.py
@@ -30,7 +30,7 @@ class NewCatFactory(BaseCatFactory):
         overrides = {k: v for k, v in overrides.items() if v}
 
         # the worst combined dependency ever
-        age, moons, status = self._determine_moons_and_status(
+        age, moons, status = self._determine_age_moons_and_status(
             moons=overrides.get("moons"), status_dict=overrides.get("status_dict", {})
         )
 
@@ -44,7 +44,11 @@ class NewCatFactory(BaseCatFactory):
         if pelt := overrides.get("pelt"):
             pelt = Pelt(pelt)
         else:
-            pelt = self._random_skills_dict(status.rank, age)
+            pelt = self._random_pelt(
+                gender_dict["sex"],
+                (overrides.get("parent1"), overrides.get("parent2")),
+                age,
+            )
 
         skills = overrides.get("skill_dict", self._random_skills_dict(status.rank, age))
         if not isinstance(skills, CatSkills):
@@ -92,6 +96,15 @@ class NewCatFactory(BaseCatFactory):
         }
 
         cat = Cat(**cat_params)
+
+        cat.name = Name(
+            prefix=overrides.get("prefix"),
+            suffix=overrides.get("suffix"),
+            specsuffix_hidden=overrides.get("specsuffix_hidden", False),
+            load_existing_name=True,
+            cat=cat,
+        )
+
         Cat.all_cats[cat.ID] = cat
 
         return cat
@@ -140,7 +153,7 @@ class NewCatFactory(BaseCatFactory):
         """
         return self.rng.randint(Cat.age_moons[age][0], Cat.age_moons[age][1])
 
-    def _determine_moons_and_status(
+    def _determine_age_moons_and_status(
         self, moons, status_dict
     ) -> Tuple[CatAge, int, Status]:
         """
@@ -159,8 +172,18 @@ class NewCatFactory(BaseCatFactory):
         elif not status_dict and moons:
             age = CatAge.get_from_moons(moons)
             status = self._random_status_from_age(age)
-        elif status_dict and "rank" in status_dict and not moons:
-            age = self._random_age_from_rank(status_dict["rank"])
+        elif status_dict and not moons:
+            if "rank" in status_dict:
+                age = self._random_age_from_rank(status_dict["rank"])
+            elif (
+                "group_history" in status_dict
+                and "rank" in status_dict["group_history"][-1]
+            ):
+                age = self._random_age_from_rank(
+                    status_dict["group_history"][-1]["rank"]
+                )
+            else:
+                age = self._random_age()
             status = Status(**status_dict)
             moons = self._random_moons(age)
         else:

--- a/scripts/cat/factories/new_cat_factory.py
+++ b/scripts/cat/factories/new_cat_factory.py
@@ -15,7 +15,7 @@ from scripts.cat.names import Name
 from scripts.cat.pelts import Pelt
 from scripts.cat.personality import Personality
 from scripts.cat.skills import CatSkills
-from scripts.cat.status import Status, StatusDict
+from scripts.cat.status import Status
 from scripts.game_structure import game, constants
 
 BASE_RNG = random.Random

--- a/scripts/cat/factories/new_cat_factory.py
+++ b/scripts/cat/factories/new_cat_factory.py
@@ -1,22 +1,222 @@
 import random
+from typing import Tuple
 
 from scripts.cat import save_load
-from scripts.cat.cat_registry import registry
 from scripts.cat.cats import Cat
-from scripts.game_structure import game
+from scripts.cat.enums import CatAge, CatRank
+from scripts.cat.names import Name
+from scripts.cat.pelts import Pelt
+from scripts.cat.personality import Personality
+from scripts.cat.skills import CatSkills
+from scripts.cat.status import Status, StatusDict
+from scripts.game_structure import game, constants
+
+BASE_RNG = random.Random
 
 
 class NewCatFactory:
-    def __init__(self, rng=None):
-        self.rng = rng or random.Random()
+    def __init__(self, rng):
+        self.rng = rng if rng else BASE_RNG()
 
     def __call__(self, **overrides):
-        cat_id = self.get_free_id()
+        # remove all values that are empty
+        overrides = {k: v for k, v in overrides.items() if v}
 
-        gender = overrides.get("gender", self._random_gender())
+        # the worst combined dependency ever
+        age, moons, status_dict = self._determine_moons_and_status(
+            moons=overrides.get("moons"), status_dict=overrides.get("status_dict", {})
+        )
 
-    def _random_gender(self):
-        return self.rng.choice(("male", "female"))
+        gender_dict = self._random_gender(age)
+
+        init_params: dict = {
+            "personality": self._random_personality(age),
+            "experience": self._random_experience(age, moons),
+        }
+
+        cat_params = {
+            "ID": self.get_free_id(),
+            "gender": overrides.get("gender", self._random_gender(age)),
+            "status_dict": status_dict,
+            "moons": moons,
+            "backstory": overrides.get("backstory", "clanborn"),
+            "parent1": overrides.get("parent1"),
+            "parent2": overrides.get("parent2"),
+            "adoptive_parents": overrides.get("adoptive_parents", []),
+            "mate": overrides.get("mate", []),
+            "skill_dict": overrides.get(
+                "skill_dict", self._random_skills_dict(status_dict["rank"], age)
+            ),
+            "pelt": overrides.get(
+                "pelt",
+                self._random_pelt(
+                    gender_dict["sex"],
+                    (overrides.get("parent1"), overrides.get("parent2")),
+                    age,
+                ),
+            ),
+        }
+
+        if game.clan is not None:
+            biome = (
+                game.clan.biome
+                if not game.clan.override_biome
+                else game.clan.override_biome
+            )
+        else:
+            biome = None
+
+        init_params["name"] = Name(
+            prefix=overrides.get("prefix"),
+            suffix=overrides.get("suffix"),
+            specsuffix_hidden=overrides.get("specsuffix_hidden"),
+            biome=biome,
+        )
+
+        return Cat(**cat_params)
+
+    def _random_age(self):
+        return self.rng.choice([*CatAge])
+
+    def _random_age_from_rank(self, rank):
+        """
+        :param rank: Provided cat's rank
+        :return: Age the cat should be
+        """
+        if not isinstance(rank, CatRank):
+            rank = CatRank(rank)
+
+        if rank == CatRank.NEWBORN or type(self.rng) != BASE_RNG:
+            return CatAge.NEWBORN
+        if rank == CatRank.KITTEN:
+            return CatAge.KITTEN
+        if rank == CatRank.ELDER:
+            return CatAge.SENIOR
+        if rank.is_any_apprentice_rank():
+            return CatAge.ADOLESCENT
+
+        return self.rng.choice(
+            [
+                CatAge.YOUNG_ADULT,
+                CatAge.ADULT,
+                CatAge.ADULT,
+                CatAge.SENIOR_ADULT,
+            ]
+        )
+
+    def _random_status_from_age(self, age):
+        # it's a bit silly that we do this, then undo it,  and finally redo in Cat() but i don't want this refactor getting huge
+        status = Status()
+        status.generate_new_status(age, disable_random=type(self.rng) != BASE_RNG)
+
+        return StatusDict(
+            social=status.social, group_ID=status.group_ID, rank=status.rank
+        )
+
+    def _random_moons(self, age: CatAge) -> int:
+        """
+        Generate random moons appropriate for the given age
+        :param age: CatAge
+        :return: Appropriate moons
+        """
+        return self.rng.randint(Cat.age_moons[age][0], Cat.age_moons[age][1])
+
+    def _determine_moons_and_status(
+        self, moons, status_dict
+    ) -> Tuple[CatAge, int, dict]:
+        """
+
+        :param moons:
+        :param status_dict:
+        :return: moons and status_dict
+        """
+        age = None
+        if not status_dict and not moons:
+            age = self._random_age()
+            status_dict = self._random_status_from_age(age)
+            moons = self._random_moons(age)
+        elif not status_dict and moons:
+            age = CatAge.get_from_moons(moons)
+            status_dict = self._random_status_from_age(age)
+        elif status_dict and "rank" in status_dict and not moons:
+            age = self._random_age_from_rank(status_dict["rank"])
+            moons = self._random_moons(age)
+
+        if not moons or not status_dict or not age:
+            raise Exception("Something went wrong generating moons or status_dict")
+
+        return age, moons, status_dict
+
+    def _random_gender(self, age) -> dict:
+        gender = {
+            "sex": self.rng.choice(("male", "female")),
+        }
+        gender["genderalign"] = gender["sex"]
+
+        if age.is_baby() or type(self.rng) != BASE_RNG:
+            return gender
+
+        trans_chance = self.rng.randint(0, 50)
+        nb_chance = self.rng.randint(0, 75)
+
+        if nb_chance == 1:
+            gender["genderalign"] = "nonbinary"
+        elif trans_chance == 1:
+            gender["genderalign"] = (
+                "trans male" if gender["sex"] == "female" else "trans female"
+            )
+
+        return gender
+
+    @staticmethod
+    def _random_pelt(gender, parents, age):
+        return Pelt.generate_new_pelt(
+            gender,
+            tuple(Cat.fetch_cat(i) for i in parents if i),
+            age,
+        )
+
+    def _random_personality(self, age: CatAge):
+        if self.rng != BASE_RNG:
+            return Personality(
+                lawful=8, social=8, aggress=8, stable=8, kit_trait=age.is_baby()
+            )
+        return Personality(kit_trait=age.is_baby())
+
+    def _random_experience(self, age, moons: int) -> int:
+        if age.is_baby() or self.rng != BASE_RNG:
+            return 0
+
+        if age == CatAge.ADOLESCENT:
+            experience = 0
+            ran = constants.CONFIG["graduation"]["base_app_timeskip_ex"]
+            for i in range(Cat.age_moons[CatAge.ADOLESCENT][0], moons, -1):
+                exp = self.rng.choice(
+                    list(range(ran[0][0], ran[0][1] + 1))
+                    + list(range(ran[1][0], ran[1][1] + 1))
+                )
+                experience += exp + 3
+            return experience
+        elif age in (CatAge.YOUNG_ADULT, CatAge.ADULT):
+            return self.rng.randint(
+                Cat.experience_levels_range["prepared"][0],
+                Cat.experience_levels_range["proficient"][1],
+            )
+        elif age == CatAge.SENIOR_ADULT:
+            return self.rng.randint(
+                Cat.experience_levels_range["competent"][0],
+                Cat.experience_levels_range["expert"][1],
+            )
+        elif age == CatAge.SENIOR:
+            return self.rng.randint(
+                Cat.experience_levels_range["expert"][0],
+                Cat.experience_levels_range["master"][1],
+            )
+        else:
+            return 0
+
+    def _random_skills_dict(self, rank, age):
+        return CatSkills.generate_new_catskills(rank, age, rng=self.rng)
 
     @staticmethod
     def get_free_id():
@@ -27,6 +227,6 @@ class NewCatFactory:
         else:
             faded_cats = []
 
-        while potential_id in registry.all_cats or potential_id in faded_cats:
+        while potential_id in Cat.all_cats or potential_id in faded_cats:
             potential_id = str(next(Cat.id_iter))
         return potential_id

--- a/scripts/cat/factories/new_cat_factory.py
+++ b/scripts/cat/factories/new_cat_factory.py
@@ -5,6 +5,12 @@ from scripts.cat import save_load
 from scripts.cat.cats import Cat
 from scripts.cat.enums import CatAge, CatRank
 from scripts.cat.factories.base_factory import BaseCatFactory
+from scripts.cat.factories.typed_dicts import (
+    MentorshipDict,
+    CatTogglesDict,
+    InheritanceDict,
+    AfterlifeAffinityDict,
+)
 from scripts.cat.names import Name
 from scripts.cat.pelts import Pelt
 from scripts.cat.personality import Personality
@@ -24,57 +30,66 @@ class NewCatFactory(BaseCatFactory):
         overrides = {k: v for k, v in overrides.items() if v}
 
         # the worst combined dependency ever
-        age, moons, status_dict = self._determine_moons_and_status(
+        age, moons, status = self._determine_moons_and_status(
             moons=overrides.get("moons"), status_dict=overrides.get("status_dict", {})
         )
 
-        gender_dict = self._random_gender(age)
+        gender_dict = self._random_gender_and_genderalign(age)
+        # if specified, override the randomizer
+        gender_dict["sex"] = overrides.get("gender", gender_dict["sex"])
+        gender_dict["genderalign"] = overrides.get(
+            "genderalign", gender_dict["genderalign"]
+        )
 
-        init_params: Dict[str, Any] = {
-            "personality": self._random_personality(age),
-            "experience": self._random_experience(age, moons),
-        }
+        if pelt := overrides.get("pelt"):
+            pelt = Pelt(pelt)
+        else:
+            pelt = self._random_skills_dict(status.rank, age)
+
+        skills = overrides.get("skill_dict", self._random_skills_dict(status.rank, age))
+        if not isinstance(skills, CatSkills):
+            skills = CatSkills(skill_dict=skills)
+
+        mate = overrides.get("mate", [])
+        if isinstance(mate, str):
+            mate = [mate]
 
         cat_params = {
             "ID": self.get_free_id(),
-            "gender": overrides.get("gender", self._random_gender_and_genderalign(age)),
-            "status_dict": status_dict,
+            "gender_dict": gender_dict,
+            "pelt": pelt,
             "moons": moons,
+            "status": status,
             "backstory": overrides.get("backstory", "clanborn"),
-            "parent1": overrides.get("parent1"),
-            "parent2": overrides.get("parent2"),
-            "adoptive_parents": overrides.get("adoptive_parents", []),
-            "mate": overrides.get("mate", []),
-            "skill_dict": overrides.get(
-                "skill_dict", self._random_skills_dict(status_dict["rank"], age)
+            "catskills": skills,
+            "personality": self._random_personality(age),
+            "mentorship": MentorshipDict(
+                mentor=None,
+                former_mentor=[],
+                patrol_with_mentor=0,
+                apprentice=[],
+                former_apprentices=[],
             ),
-            "pelt": overrides.get(
-                "pelt",
-                self._random_pelt(
-                    gender_dict["sex"],
-                    (overrides.get("parent1"), overrides.get("parent2")),
-                    age,
-                ),
+            "inheritance": InheritanceDict(
+                parent1=overrides.get("parent1"),
+                parent2=overrides.get("parent2"),
+                adoptive_parents=overrides.get("adoptive_parents", []),
+                faded_offspring=[],
+                mate=mate,
+                previous_mates=[],
             ),
+            "affinity": AfterlifeAffinityDict(starclan=0, dark_forest=0),
+            "toggles": CatTogglesDict(
+                no_kits=False,
+                no_mates=False,
+                no_retire=False,
+                prevent_fading=False,
+                favourite=False,
+            ),
+            "experience": overrides.get("experience", 0),
+            "birth_cooldown": overrides.get("birth_cooldown", 0),
+            "specsuffix_hidden": False,
         }
-
-        if game.clan is not None:
-            biome = (
-                game.clan.biome
-                if not game.clan.override_biome
-                else game.clan.override_biome
-            )
-        else:
-            biome = None
-
-        init_params["name"] = Name(
-            prefix=overrides.get("prefix"),
-            suffix=overrides.get("suffix"),
-            specsuffix_hidden=overrides.get("specsuffix_hidden"),
-            biome=biome,
-        )
-
-        cat_params["init_params"] = init_params
 
         return Cat(**cat_params)
 
@@ -112,9 +127,7 @@ class NewCatFactory(BaseCatFactory):
         status = Status()
         status.generate_new_status(age, disable_random=type(self.rng) != BASE_RNG)
 
-        return StatusDict(
-            social=status.social, group_ID=status.group_ID, rank=status.rank
-        )
+        return status
 
     def _random_moons(self, age: CatAge) -> int:
         """
@@ -126,7 +139,7 @@ class NewCatFactory(BaseCatFactory):
 
     def _determine_moons_and_status(
         self, moons, status_dict
-    ) -> Tuple[CatAge, int, dict]:
+    ) -> Tuple[CatAge, int, Status]:
         """
 
         :param moons:
@@ -134,21 +147,26 @@ class NewCatFactory(BaseCatFactory):
         :return: moons and status_dict
         """
         age = None
+        if status_dict and moons:
+            return CatAge.get_from_moons(moons), moons, Status(**status_dict)
         if not status_dict and not moons:
             age = self._random_age()
-            status_dict = self._random_status_from_age(age)
+            status = self._random_status_from_age(age)
             moons = self._random_moons(age)
         elif not status_dict and moons:
             age = CatAge.get_from_moons(moons)
-            status_dict = self._random_status_from_age(age)
+            status = self._random_status_from_age(age)
         elif status_dict and "rank" in status_dict and not moons:
             age = self._random_age_from_rank(status_dict["rank"])
+            status = Status(**status_dict)
             moons = self._random_moons(age)
+        else:
+            status = None
 
-        if not isinstance(moons, int) or not status_dict or not age:
+        if not isinstance(moons, int) or not status or not age:
             raise Exception("Something went wrong generating age, moons or status_dict")
 
-        return age, moons, status_dict
+        return age, moons, status
 
     def _random_gender_and_genderalign(self, age) -> dict:
         gender = {
@@ -220,7 +238,7 @@ class NewCatFactory(BaseCatFactory):
 
     def _random_skills_dict(self, rank, age):
         skills = CatSkills.generate_new_catskills(rank, age, rng=self.rng)
-        return skills.get_skill_dict()
+        return skills
 
     @staticmethod
     def get_free_id():

--- a/scripts/cat/factories/new_cat_factory.py
+++ b/scripts/cat/factories/new_cat_factory.py
@@ -90,7 +90,9 @@ class NewCatFactory(BaseCatFactory):
                 prevent_fading=False,
                 favourite=False,
             ),
-            "experience": overrides.get("experience", 0),
+            "experience": overrides.get(
+                "experience", self._random_experience(age, moons)
+            ),
             "birth_cooldown": overrides.get("birth_cooldown", 0),
             "specsuffix_hidden": False,
         }

--- a/scripts/cat/factories/new_cat_factory.py
+++ b/scripts/cat/factories/new_cat_factory.py
@@ -37,7 +37,7 @@ class NewCatFactory(BaseCatFactory):
 
         cat_params = {
             "ID": self.get_free_id(),
-            "gender": overrides.get("gender", self._random_gender(age)),
+            "gender": overrides.get("gender", self._random_gender_and_genderalign(age)),
             "status_dict": status_dict,
             "moons": moons,
             "backstory": overrides.get("backstory", "clanborn"),
@@ -150,7 +150,7 @@ class NewCatFactory(BaseCatFactory):
 
         return age, moons, status_dict
 
-    def _random_gender(self, age) -> dict:
+    def _random_gender_and_genderalign(self, age) -> dict:
         gender = {
             "sex": self.rng.choice(("male", "female")),
         }

--- a/scripts/cat/factories/new_cat_factory.py
+++ b/scripts/cat/factories/new_cat_factory.py
@@ -1,0 +1,32 @@
+import random
+
+from scripts.cat import save_load
+from scripts.cat.cat_registry import registry
+from scripts.cat.cats import Cat
+from scripts.game_structure import game
+
+
+class NewCatFactory:
+    def __init__(self, rng=None):
+        self.rng = rng or random.Random()
+
+    def __call__(self, **overrides):
+        cat_id = self.get_free_id()
+
+        gender = overrides.get("gender", self._random_gender())
+
+    def _random_gender(self):
+        return self.rng.choice(("male", "female"))
+
+    @staticmethod
+    def get_free_id():
+        potential_id = str(next(Cat.id_iter))
+
+        if game.clan:
+            faded_cats = save_load.get_faded_ids()
+        else:
+            faded_cats = []
+
+        while potential_id in registry.all_cats or potential_id in faded_cats:
+            potential_id = str(next(Cat.id_iter))
+        return potential_id

--- a/scripts/cat/factories/new_cat_factory.py
+++ b/scripts/cat/factories/new_cat_factory.py
@@ -164,10 +164,11 @@ class NewCatFactory(BaseCatFactory):
         self, moons, status_dict
     ) -> Tuple[CatAge, int, Status]:
         """
+        Figure out the age, moons and status of a cat depending on what's provided
 
-        :param moons:
-        :param status_dict:
-        :return: moons and status_dict
+        :param moons: Moons of the cat
+        :param status_dict: Status dict describing the cat
+        :return: CatAge, moons and Status that all agree with one another
         """
         age = None
         if status_dict and moons is not None:

--- a/scripts/cat/factories/new_cat_factory.py
+++ b/scripts/cat/factories/new_cat_factory.py
@@ -22,7 +22,7 @@ BASE_RNG = random.Random
 
 
 class NewCatFactory(BaseCatFactory):
-    def __init__(self, rng):
+    def __init__(self, rng: random.Random):
         self.rng = rng if rng else BASE_RNG()
 
     def create_cat(self, **overrides):

--- a/scripts/cat/factories/new_cat_factory.py
+++ b/scripts/cat/factories/new_cat_factory.py
@@ -27,11 +27,15 @@ class NewCatFactory(BaseCatFactory):
 
     def create_cat(self, **overrides):
         # remove all values that are empty
-        overrides = {k: v for k, v in overrides.items() if v}
+        overrides = {k: v for k, v in overrides.items() if v is not None}
+
+        status_dict = overrides.get("status_dict", {})
+        if "rank" in overrides:
+            status_dict["rank"] = overrides.get("rank")
 
         # the worst combined dependency ever
         age, moons, status = self._determine_age_moons_and_status(
-            moons=overrides.get("moons"), status_dict=overrides.get("status_dict", {})
+            moons=overrides.get("moons"), status_dict=status_dict
         )
 
         gender_dict = self._random_gender_and_genderalign(age)
@@ -94,6 +98,7 @@ class NewCatFactory(BaseCatFactory):
                 "experience", self._random_experience(age, moons)
             ),
             "birth_cooldown": overrides.get("birth_cooldown", 0),
+            "faded": False,
             "specsuffix_hidden": False,
         }
 
@@ -165,16 +170,16 @@ class NewCatFactory(BaseCatFactory):
         :return: moons and status_dict
         """
         age = None
-        if status_dict and moons:
+        if status_dict and moons is not None:
             return CatAge.get_from_moons(moons), moons, Status(**status_dict)
-        if not status_dict and not moons:
+        if not status_dict and moons is None:
             age = self._random_age()
             status = self._random_status_from_age(age)
             moons = self._random_moons(age)
-        elif not status_dict and moons:
+        elif not status_dict and moons is not None:
             age = CatAge.get_from_moons(moons)
             status = self._random_status_from_age(age)
-        elif status_dict and not moons:
+        elif status_dict and moons is None:
             if "rank" in status_dict:
                 age = self._random_age_from_rank(status_dict["rank"])
             elif (

--- a/scripts/cat/factories/new_cat_factory.py
+++ b/scripts/cat/factories/new_cat_factory.py
@@ -1,9 +1,10 @@
 import random
-from typing import Tuple
+from typing import Tuple, Dict, Any
 
 from scripts.cat import save_load
 from scripts.cat.cats import Cat
 from scripts.cat.enums import CatAge, CatRank
+from scripts.cat.factories.base_factory import BaseCatFactory
 from scripts.cat.names import Name
 from scripts.cat.pelts import Pelt
 from scripts.cat.personality import Personality
@@ -14,11 +15,11 @@ from scripts.game_structure import game, constants
 BASE_RNG = random.Random
 
 
-class NewCatFactory:
+class NewCatFactory(BaseCatFactory):
     def __init__(self, rng):
         self.rng = rng if rng else BASE_RNG()
 
-    def __call__(self, **overrides):
+    def create_cat(self, **overrides):
         # remove all values that are empty
         overrides = {k: v for k, v in overrides.items() if v}
 
@@ -29,7 +30,7 @@ class NewCatFactory:
 
         gender_dict = self._random_gender(age)
 
-        init_params: dict = {
+        init_params: Dict[str, Any] = {
             "personality": self._random_personality(age),
             "experience": self._random_experience(age, moons),
         }
@@ -72,6 +73,8 @@ class NewCatFactory:
             specsuffix_hidden=overrides.get("specsuffix_hidden"),
             biome=biome,
         )
+
+        cat_params["init_params"] = init_params
 
         return Cat(**cat_params)
 
@@ -142,8 +145,8 @@ class NewCatFactory:
             age = self._random_age_from_rank(status_dict["rank"])
             moons = self._random_moons(age)
 
-        if not moons or not status_dict or not age:
-            raise Exception("Something went wrong generating moons or status_dict")
+        if not isinstance(moons, int) or not status_dict or not age:
+            raise Exception("Something went wrong generating age, moons or status_dict")
 
         return age, moons, status_dict
 
@@ -177,14 +180,14 @@ class NewCatFactory:
         )
 
     def _random_personality(self, age: CatAge):
-        if self.rng != BASE_RNG:
+        if type(self.rng) != BASE_RNG:
             return Personality(
                 lawful=8, social=8, aggress=8, stable=8, kit_trait=age.is_baby()
             )
         return Personality(kit_trait=age.is_baby())
 
     def _random_experience(self, age, moons: int) -> int:
-        if age.is_baby() or self.rng != BASE_RNG:
+        if age.is_baby() or type(self.rng) != BASE_RNG:
             return 0
 
         if age == CatAge.ADOLESCENT:
@@ -216,7 +219,8 @@ class NewCatFactory:
             return 0
 
     def _random_skills_dict(self, rank, age):
-        return CatSkills.generate_new_catskills(rank, age, rng=self.rng)
+        skills = CatSkills.generate_new_catskills(rank, age, rng=self.rng)
+        return skills.get_skill_dict()
 
     @staticmethod
     def get_free_id():

--- a/scripts/cat/factories/test_cat_factory.py
+++ b/scripts/cat/factories/test_cat_factory.py
@@ -5,6 +5,7 @@ from scripts.cat.skills import CatSkills, SkillPath
 from scripts.cat.status import Status
 
 # this is a patchwork fix for now
+# should be replaced with a deterministic random.Random module in future
 
 
 class TestCatFactory(NewCatFactory):

--- a/scripts/cat/factories/test_cat_factory.py
+++ b/scripts/cat/factories/test_cat_factory.py
@@ -1,0 +1,50 @@
+from scripts.cat.enums import CatAge
+from scripts.cat.factories.new_cat_factory import NewCatFactory
+from scripts.cat.personality import Personality
+from scripts.cat.skills import CatSkills, SkillPath
+from scripts.cat.status import Status
+
+# this is a patchwork fix for now
+
+
+class TestCatFactory(NewCatFactory):
+    def _random_age(self):
+        return CatAge.NEWBORN
+
+    def _random_age_from_rank(self, rank):
+        return CatAge.NEWBORN
+
+    def _random_status_from_age(self, age):
+        # it's a bit silly that we do this, then undo it,  and finally redo in Cat() but i don't want this refactor getting huge
+        status = Status()
+        status.generate_new_status(age, disable_random=True)
+
+        return status
+
+    def _random_moons(self, age: CatAge) -> int:
+        """
+        Generate random moons appropriate for the given age
+        :param age: CatAge
+        :return: Appropriate moons
+        """
+        return 0
+
+    def _random_gender_and_genderalign(self, age) -> dict:
+        return {"sex": "female", "genderalign": "female"}
+
+    def _random_personality(self, age: CatAge):
+        return Personality(
+            lawful=8, social=8, aggress=8, stable=8, kit_trait=age.is_baby()
+        )
+
+    def _random_experience(self, age, moons: int) -> int:
+        return 0
+
+    def _random_skills_dict(self, rank, age):
+        return CatSkills(
+            primary_path=SkillPath.OMEN,
+            primary_points=0,
+            secondary_path=None,
+            secondary_points=0,
+            interest_only=False,
+        )

--- a/scripts/cat/factories/typed_dicts.py
+++ b/scripts/cat/factories/typed_dicts.py
@@ -1,5 +1,7 @@
 from typing import TypedDict, Optional, List, Dict
 
+from scripts.cat.enums import CatSocial, CatRank, CatAge
+
 
 class GenderDict(TypedDict, total=False):
     sex: str
@@ -23,11 +25,6 @@ class CatTogglesDict(TypedDict):
     favourite: bool
 
 
-class MateshipDict(TypedDict):
-    mate: List[str]
-    previous_mates: List[str]
-
-
 class InheritanceDict(TypedDict):
     parent1: Optional[str]
     parent2: Optional[str]
@@ -40,3 +37,25 @@ class InheritanceDict(TypedDict):
 class AfterlifeAffinityDict(TypedDict):
     starclan: int
     dark_forest: int
+
+
+class StatusDict(TypedDict, total=False):
+    """
+    Dict containing:
+
+    "group_history": list[dict],
+    "standing_history": list[dict],
+    "social": CatSocial,
+    "group": CatGroup
+    "rank": CatRank
+    "age": CatAge
+
+    Dict does not need to contain all keys. However, if you have no group history, then you must include a rank or age
+    """
+
+    group_history: Optional[List[Dict]]
+    standing_history: Optional[List[Dict]]
+    social: Optional[CatSocial]
+    group_ID: Optional[str]
+    rank: Optional[CatRank]
+    age: Optional[CatAge]

--- a/scripts/cat/factories/typed_dicts.py
+++ b/scripts/cat/factories/typed_dicts.py
@@ -3,18 +3,9 @@ from typing import TypedDict, Optional, List, Dict
 from scripts.cat.enums import CatSocial, CatRank, CatAge
 
 
-class GenderDict(TypedDict, total=False):
-    sex: str
-    genderalign: str
-    pronouns: Optional[Dict]
-
-
-class MentorshipDict(TypedDict):
-    mentor: Optional[str]
-    former_mentor: List[str]
-    patrol_with_mentor: int
-    apprentice: List[str]
-    former_apprentices: List[str]
+class AfterlifeAffinityDict(TypedDict):
+    starclan: int
+    dark_forest: int
 
 
 class CatTogglesDict(TypedDict):
@@ -23,6 +14,12 @@ class CatTogglesDict(TypedDict):
     no_retire: bool
     prevent_fading: bool
     favourite: bool
+
+
+class GenderDict(TypedDict, total=False):
+    sex: str
+    genderalign: str
+    pronouns: Optional[Dict]
 
 
 class InheritanceDict(TypedDict):
@@ -34,9 +31,12 @@ class InheritanceDict(TypedDict):
     previous_mates: List[str]
 
 
-class AfterlifeAffinityDict(TypedDict):
-    starclan: int
-    dark_forest: int
+class MentorshipDict(TypedDict):
+    mentor: Optional[str]
+    former_mentor: List[str]
+    patrol_with_mentor: int
+    apprentice: List[str]
+    former_apprentices: List[str]
 
 
 class StatusDict(TypedDict, total=False):

--- a/scripts/cat/factories/typed_dicts.py
+++ b/scripts/cat/factories/typed_dicts.py
@@ -1,0 +1,42 @@
+from typing import TypedDict, Optional, List, Dict
+
+
+class GenderDict(TypedDict, total=False):
+    sex: str
+    genderalign: str
+    pronouns: Optional[Dict]
+
+
+class MentorshipDict(TypedDict):
+    mentor: Optional[str]
+    former_mentor: List[str]
+    patrol_with_mentor: int
+    apprentice: List[str]
+    former_apprentices: List[str]
+
+
+class CatTogglesDict(TypedDict):
+    no_kits: bool
+    no_mates: bool
+    no_retire: bool
+    prevent_fading: bool
+    favourite: bool
+
+
+class MateshipDict(TypedDict):
+    mate: List[str]
+    previous_mates: List[str]
+
+
+class InheritanceDict(TypedDict):
+    parent1: Optional[str]
+    parent2: Optional[str]
+    adoptive_parents: List[str]
+    faded_offspring: List[str]
+    mate: List[str]
+    previous_mates: List[str]
+
+
+class AfterlifeAffinityDict(TypedDict):
+    starclan: int
+    dark_forest: int

--- a/scripts/cat/names.py
+++ b/scripts/cat/names.py
@@ -78,6 +78,7 @@ class Name:
         specsuffix_hidden=False,
         load_existing_name=False,
         cat=None,
+        pelt=None,
     ):
         self.prefix = prefix
         self.suffix = suffix
@@ -85,16 +86,22 @@ class Name:
 
         self.cat = cat
 
-        try:
-            color = cat.pelt.colour
-            eyes = cat.pelt.eye_colour
-            pelt = cat.pelt.name
-            tortie_pattern = cat.pelt.tortie_pattern
-        except AttributeError:
-            color = None
-            eyes = None
-            pelt = None
-            tortie_pattern = None
+        if pelt is not None:
+            color = pelt.colour
+            eyes = pelt.eye_colour
+            pelt = pelt.name
+            tortie_pattern = pelt.tortie_pattern
+        else:
+            try:
+                color = cat.pelt.colour
+                eyes = cat.pelt.eye_colour
+                pelt = cat.pelt.name
+                tortie_pattern = cat.pelt.tortie_pattern
+            except AttributeError:
+                color = None
+                eyes = None
+                pelt = None
+                tortie_pattern = None
 
         name_fixpref = False
         # Set prefix

--- a/scripts/cat/names.py
+++ b/scripts/cat/names.py
@@ -267,6 +267,10 @@ class Name:
             else:
                 self.suffix = random.choice(self.names_dict["normal_suffixes"])
 
+    def change_name(self, prefix, suffix):
+        self.prefix = prefix
+        self.suffix = suffix
+
     def __repr__(self):
         # Handles predefined suffixes (such as newborns being kit),
         # then suffixes based on ages (fixes #2004, just trust me)

--- a/scripts/cat/skills.py
+++ b/scripts/cat/skills.py
@@ -211,7 +211,11 @@ class Skill:
 
     @staticmethod
     def get_random_skill(
-        points: int = None, point_tier: int = None, exclude=(), interest_only=False
+        points: int = None,
+        point_tier: int = None,
+        exclude=(),
+        interest_only=False,
+        rng=random.Random(),
     ):
         """Generates a random skill. If wanted, you can specify a tier for the points
         value to be randomized within."""
@@ -219,12 +223,12 @@ class Skill:
         if isinstance(points, int):
             points = points
         elif isinstance(point_tier, int) and 1 <= point_tier <= 3:
-            points = random.randint(
+            points = rng.randint(
                 Skill.tier_ranges[point_tier - 1][0],
                 Skill.tier_ranges[point_tier - 1][1],
             )
         else:
-            points = random.randint(Skill.point_range[0], Skill.point_range[1])
+            points = rng.randint(Skill.point_range[0], Skill.point_range[1])
 
         if isinstance(exclude, SkillPath):
             exclude = [exclude]
@@ -362,7 +366,10 @@ class CatSkills:
 
     @staticmethod
     def generate_new_catskills(
-        rank: CatRank, age: CatAge, hidden_skill: HiddenSkillEnum = None
+        rank: CatRank,
+        age: CatAge,
+        hidden_skill: HiddenSkillEnum = None,
+        rng=random.Random(),
     ):
         """Generates a new skill"""
         new_skill = CatSkills()
@@ -372,32 +379,39 @@ class CatSkills:
         if rank == CatRank.NEWBORN or age == CatAge.NEWBORN:
             pass
         elif rank == CatRank.KITTEN or age == CatAge.KITTEN:
-            new_skill.primary = Skill.get_random_skill(points=0, interest_only=True)
+            new_skill.primary = Skill.get_random_skill(
+                points=0, interest_only=True, rng=rng
+            )
         elif rank.is_any_apprentice_rank() or age == CatAge.ADOLESCENT:
-            new_skill.primary = Skill.get_random_skill(point_tier=1, interest_only=True)
-            if random.randint(1, 3) == 1:
+            new_skill.primary = Skill.get_random_skill(
+                point_tier=1, interest_only=True, rng=rng
+            )
+            if rng.randint(1, 3) == 1:
                 new_skill.secondary = Skill.get_random_skill(
-                    point_tier=1, interest_only=True, exclude=new_skill.primary.path
+                    point_tier=1,
+                    interest_only=True,
+                    exclude=new_skill.primary.path,
+                    rng=rng,
                 )
         else:
             primary_tier = 1
             secondary_tier = 1
             if age == CatAge.YOUNG_ADULT:
-                primary_tier += random.randint(0, 1)
-                secondary_tier += random.randint(0, 1)
+                primary_tier += rng.randint(0, 1)
+                secondary_tier += rng.randint(0, 1)
             elif age == CatAge.ADULT:
-                primary_tier += random.randint(0, 2)
-                secondary_tier += random.randint(0, 1)
+                primary_tier += rng.randint(0, 2)
+                secondary_tier += rng.randint(0, 1)
             elif age == CatAge.SENIOR_ADULT:
-                primary_tier += random.randint(1, 2)
-                secondary_tier += random.randint(0, 1)
+                primary_tier += rng.randint(1, 2)
+                secondary_tier += rng.randint(0, 1)
             elif age == CatAge.SENIOR:
-                primary_tier -= random.randint(0, 1)
+                primary_tier -= rng.randint(0, 1)
 
-            new_skill.primary = Skill.get_random_skill(point_tier=primary_tier)
-            if random.randint(1, 2) == 1:
+            new_skill.primary = Skill.get_random_skill(point_tier=primary_tier, rng=rng)
+            if rng.randint(1, 2) == 1:
                 new_skill.secondary = Skill.get_random_skill(
-                    point_tier=secondary_tier, exclude=new_skill.primary.path
+                    point_tier=secondary_tier, exclude=new_skill.primary.path, rng=rng
                 )
 
         return new_skill

--- a/scripts/cat/status.py
+++ b/scripts/cat/status.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from itertools import groupby
 from random import choice
-from typing import TypedDict, Optional, List, Dict
+from typing import Optional
 
 from scripts.cat.enums import CatRank, CatSocial, CatStanding, CatAge, CatGroup
 from scripts.game_structure import game
@@ -725,25 +725,3 @@ class Status:
                 return True
 
         return False
-
-
-class StatusDict(TypedDict, total=False):
-    """
-    Dict containing:
-
-    "group_history": list[dict],
-    "standing_history": list[dict],
-    "social": CatSocial,
-    "group": CatGroup
-    "rank": CatRank
-    "age": CatAge
-
-    Dict does not need to contain all keys. However, if you have no group history, then you must include a rank or age
-    """
-
-    group_history: Optional[List[Dict]]
-    standing_history: Optional[List[Dict]]
-    social: Optional[CatSocial]
-    group_ID: Optional[str]
-    rank: Optional[CatRank]
-    age: Optional[CatAge]

--- a/scripts/clan.py
+++ b/scripts/clan.py
@@ -11,20 +11,19 @@ TODO: Docs
 import os
 import statistics
 from random import choice, randint
-from typing import Optional
 
-import pygame
 import ujson
 
 from scripts.cat.cats import Cat, cat_class, BACKSTORIES
 from scripts.cat.enums import CatRank, CatGroup
+from scripts.cat.factories.cat_factory import CatFactory
+from scripts.cat.factories.enums import CatType
 from scripts.cat.names import names
 from scripts.cat.save_load import (
     save_cats,
     get_faded_ids,
     load_faded_cat_ids,
 )
-from scripts.cat.sprites.load_sprites import sprites
 from scripts.clan_package.settings import save_clan_settings, load_clan_settings
 from scripts.clan_package.settings.clan_settings import reset_loaded_clan_settings
 from scripts.clan_resources.freshkill import FreshkillPile, Nutrition
@@ -220,7 +219,8 @@ class Clan:
             )
         )
 
-        self.instructor = Cat(
+        self.instructor = CatFactory.create_cat(
+            CatType.NEW,
             status_dict={"rank": instructor_rank, "group_ID": CatGroup.STARCLAN_ID},
             backstory=choice(
                 BACKSTORIES["backstory_categories"]["clan_guide_backstories"]
@@ -659,11 +659,12 @@ class Clan:
                 game.clan.instructor = Cat.all_cats[instructor_info]
                 game.clan.add_cat(game.clan.instructor)
         else:
-            game.clan.instructor = Cat(
+            game.clan.instructor = CatFactory.create_cat(
+                cat_type=CatType.NEW,
                 status_dict={
                     "rank": choice((CatRank.WARRIOR, CatRank.WARRIOR, CatRank.ELDER)),
                     "group": CatGroup.STARCLAN,
-                }
+                },
             )
             # update_sprite(game.clan.instructor)
             game.clan.instructor.dead = True
@@ -787,11 +788,12 @@ class Clan:
             game.clan.instructor = Cat.all_cats[clan_data["instructor"]]
             game.clan.add_cat(game.clan.instructor)
         else:
-            game.clan.instructor = Cat(
+            game.clan.instructor = CatFactory.create_cat(
+                CatType.NEW,
                 status_dict={
                     "rank": choice((CatRank.WARRIOR, CatRank.WARRIOR, CatRank.ELDER)),
                     "group": CatGroup.STARCLAN,
-                }
+                },
             )
             # update_sprite(game.clan.instructor)
             game.clan.instructor.dead = True
@@ -1471,4 +1473,4 @@ def get_temper_alignment(sociability: int, aggression: int) -> str:
 
 
 clan_class = Clan()
-clan_class.remove_cat(cat_class.ID)
+# clan_class.remove_cat(cat_class.ID)

--- a/scripts/debug_commands/cat.py
+++ b/scripts/debug_commands/cat.py
@@ -1,6 +1,8 @@
 from typing import List
 
 from scripts.cat.cats import Cat
+from scripts.cat.factories.cat_factory import CatFactory
+from scripts.cat.factories.enums import CatType
 from scripts.debug_commands.command import Command
 from scripts.debug_commands.utils import add_output_line_to_log
 from scripts.game_structure import game
@@ -12,7 +14,7 @@ class AddCatCommand(Command):
     aliases = ["a"]
 
     def callback(self, args: List[str]):
-        cat = Cat()
+        cat = CatFactory.create_cat(CatType.NEW)
         game.clan.add_cat(cat)
         add_output_line_to_log(f"Added {cat.name} with ID {cat.ID}")
 

--- a/scripts/events_module/consequences.py
+++ b/scripts/events_module/consequences.py
@@ -13,6 +13,8 @@ from scripts.cat.enums import (
     CatStanding,
     CatThought,
 )
+from scripts.cat.factories.cat_factory import CatFactory
+from scripts.cat.factories.enums import CatType
 from scripts.cat.names import names
 from scripts.cat_relations.enums import RelType
 from scripts.clan_package.settings import get_clan_setting
@@ -583,7 +585,8 @@ def create_new_cat(
             _gender = gender
 
         # first we generate the cat as though they are not part of the clan yet
-        new_cat = Cat(
+        new_cat = CatFactory.create_cat(
+            CatType.NEW,
             moons=moons,
             status_dict={
                 "social": original_social,

--- a/scripts/events_module/relationship/pregnancy_events.py
+++ b/scripts/events_module/relationship/pregnancy_events.py
@@ -16,7 +16,7 @@ from scripts.cat.enums import (
 from scripts.cat.factories.cat_factory import CatFactory
 from scripts.cat.factories.enums import CatType
 from scripts.cat.names import names, Name
-from scripts.cat.status import StatusDict
+from scripts.cat.factories.typed_dicts import StatusDict
 from scripts.cat_relations.relationship import Relationship, RelType
 from scripts.clan_package.settings import get_clan_setting
 from scripts.event_class import Single_Event

--- a/scripts/events_module/relationship/pregnancy_events.py
+++ b/scripts/events_module/relationship/pregnancy_events.py
@@ -13,6 +13,8 @@ from scripts.cat.enums import (
     CatCompatibility,
     CatThought,
 )
+from scripts.cat.factories.cat_factory import CatFactory
+from scripts.cat.factories.enums import CatType
 from scripts.cat.names import names, Name
 from scripts.cat.status import StatusDict
 from scripts.cat_relations.relationship import Relationship, RelType
@@ -889,7 +891,8 @@ class Pregnancy_Events:
                     "group_ID": blood_parent.status.group_ID,
                 }
 
-                kit = Cat(
+                kit = CatFactory.create_cat(
+                    CatType.NEW,
                     parent1=blood_parent.ID,
                     moons=0,
                     backstory=backstory,
@@ -899,7 +902,8 @@ class Pregnancy_Events:
             elif cat and other_cat:
                 # Two parents provided
                 # The cat that gave birth is always parent1 so there is no need to check gender
-                kit = Cat(
+                kit = CatFactory.create_cat(
+                    CatType.NEW,
                     parent1=cat.ID,
                     parent2=other_cat.ID,
                     moons=0,
@@ -907,7 +911,8 @@ class Pregnancy_Events:
                 )
             else:
                 # A one blood parent litter is the only option left.
-                kit = Cat(
+                kit = CatFactory.create_cat(
+                    CatType.NEW,
                     parent1=cat.ID,
                     moons=0,
                     backstory=backstory,

--- a/scripts/events_module/relationship/pregnancy_events.py
+++ b/scripts/events_module/relationship/pregnancy_events.py
@@ -888,7 +888,7 @@ class Pregnancy_Events:
                 kitten_status: StatusDict = {
                     "social": blood_parent.status.social,
                     "age": CatAge.NEWBORN,
-                    "group_ID": blood_parent.status.group_ID,
+                    "group_ID": blood_parent.status.get_last_living_group(),
                 }
 
                 kit = CatFactory.create_cat(

--- a/scripts/game_structure/load_cat.py
+++ b/scripts/game_structure/load_cat.py
@@ -70,7 +70,7 @@ def json_load():
     for i, cat_dict in enumerate(cat_data):
         try:
             cat = CatFactory.create_cat(cat_type=CatType.LOAD_JSON, **cat_dict)
-
+            Cat.all_cats[cat.ID] = cat
             all_cats.append(cat)
 
         except KeyError as e:

--- a/scripts/game_structure/load_cat.py
+++ b/scripts/game_structure/load_cat.py
@@ -175,23 +175,10 @@ def json_load():
             # Runs a bunch of appearance-related conversion of old stuff.
             new_cat.pelt.check_and_convert(convert)
 
-            # converting old specialty saves into new scar parameter
-            if "specialty" in cat or "specialty2" in cat:
-                if cat["specialty"] is not None:
-                    new_cat.pelt.scars = (*new_cat.pelt.scars, cat["specialty"])
-                if cat["specialty2"] is not None:
-                    new_cat.pelt.scars = (*new_cat.pelt.scars, cat["specialty2"])
-
             new_cat.adoptive_parents = (
                 cat["adoptive_parents"] if "adoptive_parents" in cat else []
             )
 
-            new_cat.genderalign = cat["gender_align"]
-            new_cat.pronouns = (
-                cat["pronouns"]
-                if "pronouns" in cat
-                else {i18n.config.get("locale"): get_new_pronouns(new_cat.genderalign)}
-            )
             new_cat.backstory = cat["backstory"] if "backstory" in cat else None
             if new_cat.backstory in BACKSTORIES["conversion"]:
                 new_cat.backstory = BACKSTORIES["conversion"][new_cat.backstory]

--- a/scripts/game_structure/load_cat.py
+++ b/scripts/game_structure/load_cat.py
@@ -17,6 +17,8 @@ from scripts.game_structure.game.switches import (
 )
 from ..cat.factories.cat_factory import CatFactory
 from ..cat.factories.enums import CatType
+from ..cat.factories.typed_dicts import MentorshipDict
+from ..cat.names import Name
 from ..cat.pronouns import get_new_pronouns
 from scripts.housekeeping.version import SAVE_VERSION_NUMBER
 from scripts.game_structure import constants
@@ -30,15 +32,15 @@ logger = logging.getLogger(__name__)
 
 
 def load_cats():
-    # try:
-    json_load()
-    # except FileNotFoundError:
-    #     try:
-    #         csv_load(Cat.all_cats)
-    #     except FileNotFoundError as e:
-    #         switch_set_value(Switch.error_message, "Can't find clan_cats.json!")
-    #         switch_set_value(Switch.traceback, e)
-    #         raise
+    try:
+        json_load()
+    except FileNotFoundError:
+        try:
+            csv_load(Cat.all_cats)
+        except FileNotFoundError as e:
+            switch_set_value(Switch.error_message, "Can't find clan_cats.json!")
+            switch_set_value(Switch.traceback, e)
+            raise
 
 
 def json_load():
@@ -199,22 +201,40 @@ def csv_load(all_cats):
                     Switch.error_message,
                     f"There was an error loading cat # {str(attr[0])} (code: 2)",
                 )
-                the_cat = Cat(
+
+                inheritance = {
+                    "parent1": attr[6],
+                    "parent2": attr[7],
+                }
+
+                mentorship = MentorshipDict(
+                    mentor=attr[8],
+                    former_mentor=[],
+                    patrol_with_mentor=0,
+                    apprentice=[],
+                    former_apprentices=[],
+                )
+
+                the_cat = CatFactory.create_cat(
+                    CatType.LOAD_CSV,
                     ID=attr[0],
-                    prefix=attr[1].split(":")[0],
-                    suffix=attr[1].split(":")[1],
                     gender=attr[2],
                     status={"rank": attr[3]},
+                    inheritance=inheritance,
+                    mentorship=mentorship,
                     pelt=the_pelt,
-                    parent1=attr[6],
-                    parent2=attr[7],
+                )
+
+                the_cat.name = Name(
+                    prefix=attr[1].split(":")[0],
+                    suffix=attr[1].split(":")[1],
                 )
 
                 switch_set_value(
                     Switch.error_message,
                     f"There was an error loading cat # {str(attr[0])} (code: 3)",
                 )
-                the_cat.age, the_cat.mentor = attr[4], attr[8]
+                the_cat.mentor = attr[8]
                 switch_set_value(
                     Switch.error_message,
                     f"There was an error loading cat # {str(attr[0])} (code: 4)",

--- a/scripts/game_structure/load_cat.py
+++ b/scripts/game_structure/load_cat.py
@@ -17,7 +17,7 @@ from scripts.game_structure.game.switches import (
 )
 from ..cat.factories.cat_factory import CatFactory
 from ..cat.factories.enums import CatType
-from ..cat.factories.typed_dicts import MentorshipDict
+from ..cat.factories.typed_dicts import MentorshipDict, StatusDict
 from ..cat.names import Name
 from ..cat.pronouns import get_new_pronouns
 from scripts.housekeeping.version import SAVE_VERSION_NUMBER
@@ -25,7 +25,6 @@ from scripts.game_structure import constants
 from scripts.game_structure import game
 from ..cat.personality import Personality
 from ..cat.skills import CatSkills
-from ..cat.status import StatusDict
 from ..housekeeping.datadir import get_save_dir
 
 logger = logging.getLogger(__name__)

--- a/scripts/game_structure/load_cat.py
+++ b/scripts/game_structure/load_cat.py
@@ -28,15 +28,15 @@ logger = logging.getLogger(__name__)
 
 
 def load_cats():
-    try:
-        json_load()
-    except FileNotFoundError:
-        try:
-            csv_load(Cat.all_cats)
-        except FileNotFoundError as e:
-            switch_set_value(Switch.error_message, "Can't find clan_cats.json!")
-            switch_set_value(Switch.traceback, e)
-            raise
+    # try:
+    json_load()
+    # except FileNotFoundError:
+    #     try:
+    #         csv_load(Cat.all_cats)
+    #     except FileNotFoundError as e:
+    #         switch_set_value(Switch.error_message, "Can't find clan_cats.json!")
+    #         switch_set_value(Switch.traceback, e)
+    #         raise
 
 
 def json_load():

--- a/scripts/game_structure/load_cat.py
+++ b/scripts/game_structure/load_cat.py
@@ -15,6 +15,8 @@ from scripts.game_structure.game.switches import (
     switch_set_value,
     Switch,
 )
+from ..cat.factories.cat_factory import CatFactory
+from ..cat.factories.enums import CatType
 from ..cat.pronouns import get_new_pronouns
 from scripts.housekeeping.version import SAVE_VERSION_NUMBER
 from scripts.game_structure import constants
@@ -65,234 +67,15 @@ def json_load():
     old_tortie_patches = convert["old_tortie_patches"]
 
     # create new cat objects
-    for i, cat in enumerate(cat_data):
+    for i, cat_dict in enumerate(cat_data):
         try:
-            # accounting for old saves
-            # checks first if status is in the old format
-            # if it is then we use the old info to provide an initial status dict
-            if isinstance(cat["status"], str):
-                # this sucks, but we need to get the actual str age to make sure nothing goes wonky
-                age = None
-                for key_age in Cat.age_moons.keys():
-                    if cat["moons"] in range(
-                        Cat.age_moons[key_age][0], Cat.age_moons[key_age][1] + 1
-                    ):
-                        age = key_age
-                status_dict = {"rank": cat["status"], "age": age}
-            else:
-                status_dict = cat["status"]
+            cat = CatFactory.create_cat(cat_type=CatType.LOAD_JSON, **cat_dict)
 
-            new_cat = Cat(
-                ID=cat["ID"],
-                prefix=cat["name_prefix"],
-                suffix=cat["name_suffix"],
-                specsuffix_hidden=(
-                    cat["specsuffix_hidden"] if "specsuffix_hidden" in cat else False
-                ),
-                gender=cat["gender"],
-                status_dict=status_dict,
-                parent1=cat["parent1"],
-                parent2=cat["parent2"],
-                moons=cat["moons"],
-                eye_colour=cat["eye_colour"],
-                loading_cat=True,
-            )
-
-            if cat["eye_colour"] == "BLUE2":
-                cat["eye_colour"] = "COBALT"
-            if cat["eye_colour"] in ["BLUEYELLOW", "BLUEGREEN"]:
-                if cat["eye_colour"] == "BLUEYELLOW":
-                    cat["eye_colour2"] = "YELLOW"
-                elif cat["eye_colour"] == "BLUEGREEN":
-                    cat["eye_colour2"] = "GREEN"
-                cat["eye_colour"] = "BLUE"
-            if "eye_colour2" in cat:
-                if cat["eye_colour2"] == "BLUE2":
-                    cat["eye_colour2"] = "COBALT"
-
-            if "tint" in cat:
-                if cat["tint"] == "none":
-                    cat["tint"] = None
-            if "white_patches_tint" in cat:
-                if cat["white_patches_tint"] == "none":
-                    cat["white_patches_tint"] = None
-
-            if "pattern" in cat:
-                cat["tortie_marking"] = cat["pattern"]
-                del cat["pattern"]
-
-            new_cat.pelt = Pelt(
-                name=cat["pelt_name"],
-                length=cat["pelt_length"],
-                colour=cat["pelt_color"],
-                eye_color=cat["eye_colour"],
-                eye_colour2=cat["eye_colour2"] if "eye_colour2" in cat else None,
-                paralyzed=cat["paralyzed"],
-                newborn_sprite=cat.get("sprite_newborn"),
-                kitten_sprite=(
-                    cat["sprite_kitten"]
-                    if "sprite_kitten" in cat
-                    else cat["spirit_kitten"]
-                ),
-                adol_sprite=(
-                    cat["sprite_adolescent"]
-                    if "sprite_adolescent" in cat
-                    else cat["spirit_adolescent"]
-                ),
-                adult_sprite=(
-                    cat["sprite_adult"]
-                    if "sprite_adult" in cat
-                    else cat["spirit_adult"]
-                ),
-                senior_sprite=(
-                    cat["sprite_senior"]
-                    if "sprite_senior" in cat
-                    else cat["spirit_elder"]
-                ),
-                para_adult_sprite=(
-                    cat["sprite_para_adult"] if "sprite_para_adult" in cat else None
-                ),
-                reverse=cat["reverse"],
-                vitiligo=cat["vitiligo"] if "vitiligo" in cat else None,
-                points=cat["points"] if "points" in cat else None,
-                white_patches_tint=(
-                    cat["white_patches_tint"]
-                    if "white_patches_tint" in cat
-                    else "offwhite"
-                ),
-                white_patches=cat["white_patches"],
-                tortie_base=cat["tortie_base"],
-                tortie_colour=cat["tortie_color"],
-                tortie_pattern=cat["tortie_pattern"],
-                tortie_marking=cat["tortie_marking"],
-                skin=cat["skin"],
-                tint=cat["tint"] if "tint" in cat else None,
-                scars=cat["scars"] if "scars" in cat else [],
-                accessory=cat["accessory"],
-                opacity=cat["opacity"] if "opacity" in cat else 100,
-            )
-
-            # Runs a bunch of appearance-related conversion of old stuff.
-            new_cat.pelt.check_and_convert(convert)
-
-            new_cat.adoptive_parents = (
-                cat["adoptive_parents"] if "adoptive_parents" in cat else []
-            )
-
-            new_cat.backstory = cat["backstory"] if "backstory" in cat else None
-            if new_cat.backstory in BACKSTORIES["conversion"]:
-                new_cat.backstory = BACKSTORIES["conversion"][new_cat.backstory]
-            new_cat.birth_cooldown = (
-                cat["birth_cooldown"] if "birth_cooldown" in cat else 0
-            )
-            new_cat.moons = cat["moons"]
-
-            if "facets" in cat and cat["facets"] is not None:
-                facets = [int(i) for i in cat["facets"].split(",")]
-                new_cat.personality = Personality(
-                    trait=cat["trait"],
-                    kit_trait=new_cat.age in ["newborn", "kitten"],
-                    lawful=facets[0],
-                    social=facets[1],
-                    aggress=facets[2],
-                    stable=facets[3],
-                )
-            else:
-                new_cat.personality = Personality(
-                    trait=cat["trait"], kit_trait=new_cat.age in ["newborn", "kitten"]
-                )
-
-            new_cat.mentor = cat["mentor"]
-            new_cat.former_mentor = (
-                cat["former_mentor"] if "former_mentor" in cat else []
-            )
-            new_cat.patrol_with_mentor = (
-                cat["patrol_with_mentor"] if "patrol_with_mentor" in cat else 0
-            )
-            new_cat.no_kits = cat["no_kits"]
-            new_cat.no_mates = cat["no_mates"] if "no_mates" in cat else False
-            new_cat.no_retire = cat["no_retire"] if "no_retire" in cat else False
-
-            if "skill_dict" in cat:
-                new_cat.skills = CatSkills(cat["skill_dict"])
-            elif "skill" in cat:
-                if new_cat.backstory is None:
-                    if "skill" == "formerly a loner":
-                        backstory = choice(["loner1", "loner2", "rogue1", "rogue2"])
-                        new_cat.backstory = backstory
-                    elif "skill" == "formerly a kittypet":
-                        backstory = choice(["kittypet1", "kittypet2"])
-                        new_cat.backstory = backstory
-                    else:
-                        new_cat.backstory = "clanborn"
-                new_cat.skills = CatSkills.get_skills_from_old(
-                    cat["skill"], new_cat.status.rank, new_cat.age
-                )
-
-            new_cat.mate = cat["mate"] if type(cat["mate"]) is list else [cat["mate"]]
-            if None in new_cat.mate:
-                new_cat.mate = [i for i in new_cat.mate if i is not None]
-            new_cat.previous_mates = (
-                cat["previous_mates"] if "previous_mates" in cat else []
-            )
-
-            # checking for old dead
-            if (
-                cat.get("dead")
-                or cat.get("df")
-                or cat.get("driven_out")
-                or cat.get("exiled")
-                or cat.get("outside")
-            ):
-                if cat.get("dead") and not new_cat.status.group.is_afterlife():
-                    if cat.get("df"):
-                        new_cat.status.send_to_afterlife(
-                            target_ID=CatGroup.DARK_FOREST_ID
-                        )
-                    elif cat.get("outside"):
-                        new_cat.status.send_to_afterlife(
-                            target_ID=CatGroup.UNKNOWN_RESIDENCE_ID
-                        )
-                    else:
-                        new_cat.status.send_to_afterlife(target_ID=CatGroup.STARCLAN_ID)
-
-                else:
-                    # these should properly change the cat's status to align with old bool info
-                    if cat.get("exiled"):
-                        new_cat.status.exile_from_group()
-                    elif cat.get("outside") and not new_cat.status.is_outsider:
-                        new_cat.status.become_lost()
-
-                    if cat.get("driven_out"):
-                        new_cat.status.change_group_nearness(CatGroup.PLAYER_CLAN_ID)
-
-            new_cat.dead_for = cat["dead_moons"]
-            new_cat.experience = cat["experience"]
-            new_cat.apprentice = cat["current_apprentice"]
-            new_cat.former_apprentices = cat["former_apprentices"]
-
-            new_cat.faded_offspring = (
-                cat["faded_offspring"] if "faded_offspring" in cat else []
-            )
-            new_cat.prevent_fading = (
-                cat["prevent_fading"] if "prevent_fading" in cat else False
-            )
-            new_cat.favourite = cat["favourite"] if "favourite" in cat else False
-
-            if "died_by" in cat or "scar_event" in cat or "mentor_influence" in cat:
-                new_cat.convert_history(
-                    cat["died_by"] if "died_by" in cat else [],
-                    cat["scar_event"] if "scar_event" in cat else [],
-                )
-
-            new_cat.starclan_affinity = cat.get("starclan_affinity", 0)
-            new_cat.dark_forest_affinity = cat.get("dark_forest_affinity", 0)
-
-            all_cats.append(new_cat)
+            all_cats.append(cat)
 
         except KeyError as e:
-            if "ID" in cat:
-                key = f" ID #{cat['ID']} "
+            if "ID" in cat_dict:
+                key = f" ID #{cat_dict['ID']} "
             else:
                 key = f" at index {i} "
             switch_set_value(

--- a/scripts/screens/EventEditScreen.py
+++ b/scripts/screens/EventEditScreen.py
@@ -7,7 +7,8 @@ import pygame
 import pygame_gui
 import ujson
 
-from scripts.cat.cats import Cat, BACKSTORIES, create_option_preview_cat
+from scripts.cat.cats import Cat, BACKSTORIES
+from scripts.cat.factories.create_cat import create_option_preview_cat
 from scripts.cat.pelts import Pelt
 from scripts.cat.personality import Personality
 from scripts.cat.skills import SkillPath

--- a/scripts/screens/MakeClanScreen.py
+++ b/scripts/screens/MakeClanScreen.py
@@ -9,12 +9,15 @@ import pygame_gui
 from pygame_gui.core import ObjectID
 
 import scripts.screens.screens_core.screens_core
-from scripts.cat.cats import create_example_cats, create_cat, Cat
+from scripts.cat.cats import Cat
+from ..cat.factories.cat_factory import CatFactory
+from ..cat.factories.create_cat import create_cat, create_example_cats
 from scripts.cat.names import names
 from scripts.clan import Clan
 from scripts.events_module.patrol.patrol import Patrol
 from scripts.game_structure import image_cache, constants
 from scripts.game_structure import game
+from ..cat.factories.enums import CatType
 from ..ui.elements.sprite_button import UISpriteButton
 from ..ui.elements.image_button import UIImageButton
 from ..ui.elements.surface_image_button import UISurfaceImageButton
@@ -1249,9 +1252,9 @@ class MakeClanScreen(Screens):
             self.symbol_selected = f"symbol{self.clan_name.upper()}0"
         else:
             self.symbol_selected = choice(sprites.clan_symbols)
-        self.leader = create_cat(rank=CatRank.WARRIOR)
-        self.deputy = create_cat(rank=CatRank.WARRIOR)
-        self.med_cat = create_cat(rank=CatRank.WARRIOR)
+        self.leader = CatFactory.create_cat(CatType.NEW, rank=CatRank.WARRIOR)
+        self.deputy = CatFactory.create_cat(CatType.NEW, rank=CatRank.WARRIOR)
+        self.med_cat = CatFactory.create_cat(CatType.NEW, rank=CatRank.WARRIOR)
         for _ in range(randrange(4, 8)):
             random_rank = choice(
                 [
@@ -1262,7 +1265,7 @@ class MakeClanScreen(Screens):
                     CatRank.ELDER,
                 ]
             )
-            self.members.append(create_cat(rank=random_rank))
+            self.members.append(CatFactory.create_cat(CatType.NEW, rank=random_rank))
 
     def random_clan_name(self):
         clan_names = (

--- a/scripts/screens/MakeClanScreen.py
+++ b/scripts/screens/MakeClanScreen.py
@@ -1252,9 +1252,15 @@ class MakeClanScreen(Screens):
             self.symbol_selected = f"symbol{self.clan_name.upper()}0"
         else:
             self.symbol_selected = choice(sprites.clan_symbols)
-        self.leader = CatFactory.create_cat(CatType.NEW, rank=CatRank.WARRIOR)
-        self.deputy = CatFactory.create_cat(CatType.NEW, rank=CatRank.WARRIOR)
-        self.med_cat = CatFactory.create_cat(CatType.NEW, rank=CatRank.WARRIOR)
+        self.leader = CatFactory.create_cat(
+            CatType.NEW, status_dict={"rank": CatRank.WARRIOR}
+        )
+        self.deputy = CatFactory.create_cat(
+            CatType.NEW, status_dict={"rank": CatRank.WARRIOR}
+        )
+        self.med_cat = CatFactory.create_cat(
+            CatType.NEW, status_dict={"rank": CatRank.WARRIOR}
+        )
         for _ in range(randrange(4, 8)):
             random_rank = choice(
                 [
@@ -1265,7 +1271,9 @@ class MakeClanScreen(Screens):
                     CatRank.ELDER,
                 ]
             )
-            self.members.append(CatFactory.create_cat(CatType.NEW, rank=random_rank))
+            self.members.append(
+                CatFactory.create_cat(CatType.NEW, status_dict={"rank": random_rank})
+            )
 
     def random_clan_name(self):
         clan_names = (

--- a/scripts/screens/PatrolScreen.py
+++ b/scripts/screens/PatrolScreen.py
@@ -984,8 +984,7 @@ class PatrolScreen(Screens):
         # ASSIGN TO ABLE CATS
         for the_cat in Cat.all_cats_list:
             if (
-                the_cat.in_camp
-                and the_cat.ID not in game.patrolled
+                the_cat.ID not in game.patrolled
                 and the_cat.status.rank.is_allowed_to_patrol()
                 and the_cat.status.alive_in_player_clan
                 and the_cat not in self.current_patrol

--- a/tests/test_cat.py
+++ b/tests/test_cat.py
@@ -1,10 +1,11 @@
 import os
 import unittest
-from unittest.mock import patch
 from copy import deepcopy
+from random import Random
+from unittest.mock import patch
 
 from scripts.cat.factories.cat_factory import CatFactory
-from scripts.cat.factories.enums import CatType
+from scripts.cat.factories.test_cat_factory import TestCatFactory
 
 os.environ["SDL_VIDEODRIVER"] = "dummy"
 os.environ["SDL_AUDIODRIVER"] = "dummy"
@@ -14,59 +15,55 @@ from scripts.game_structure import game
 from scripts.cat.enums import CatAge, CatRank, CatGroup, CatSocial
 from scripts.cat_relations.relationship import Relationship
 
+cat_factory = TestCatFactory(rng=Random())
+
 
 class TestCreationAge(unittest.TestCase):
     # test that a cat with 1-5 moons has the age of a kitten
     def test_kitten(self):
-        test_cat = CatFactory.create_cat(CatType.TEST, moons=5, disable_random=True)
+        test_cat = cat_factory.create_cat(moons=5, disable_random=True)
         self.assertEqual(test_cat.age, CatAge.KITTEN)
 
     # test that a cat with 6-11 moons has the age of an adolescent
     def test_adolescent(self):
-        test_cat = CatFactory.create_cat(CatType.TEST, moons=6, disable_random=True)
+        test_cat = cat_factory.create_cat(moons=6, disable_random=True)
         self.assertEqual(test_cat.age, CatAge.ADOLESCENT)
 
     # test that a cat with 12-47 moons has the age of a young adult
     def test_young_adult(self):
-        test_cat = CatFactory.create_cat(CatType.TEST, moons=12, disable_random=True)
+        test_cat = cat_factory.create_cat(moons=12, disable_random=True)
         self.assertEqual(test_cat.age, CatAge.YOUNG_ADULT)
 
     # test that a cat with 48-95 moons has the age of an adult
     def test_adult(self):
-        test_cat = CatFactory.create_cat(CatType.TEST, moons=48, disable_random=True)
+        test_cat = cat_factory.create_cat(moons=48, disable_random=True)
         self.assertEqual(test_cat.age, CatAge.ADULT)
 
     # test that a cat with 96-119 moons has the age of a senior adult
     def test_senior_adult(self):
-        test_cat = CatFactory.create_cat(CatType.TEST, moons=96, disable_random=True)
+        test_cat = cat_factory.create_cat(moons=96, disable_random=True)
         self.assertEqual(test_cat.age, CatAge.SENIOR_ADULT)
 
     # test that a cat with 120-300 moons has the age of a senior
     def test_elder(self):
-        test_cat = CatFactory.create_cat(CatType.TEST, moons=120, disable_random=True)
+        test_cat = cat_factory.create_cat(moons=120, disable_random=True)
         self.assertEqual(test_cat.age, CatAge.SENIOR)
 
 
 class TestRelativesFunction(unittest.TestCase):
     # test that is_parent returns True for a parent1-cat relationship and False otherwise
     def test_is_parent(self):
-        parent = CatFactory.create_cat(CatType.TEST, disable_random=True)
-        kit = CatFactory.create_cat(
-            CatType.TEST, parent1=parent.ID, disable_random=True
-        )
+        parent = cat_factory.create_cat(disable_random=True)
+        kit = CatFactory.create_cat(parent1=parent.ID, disable_random=True)
         self.assertFalse(kit.is_parent(kit))
         self.assertFalse(kit.is_parent(parent))
         self.assertTrue(parent.is_parent(kit))
 
     # test that is_sibling returns True for cats with a shared parent1 and False otherwise
     def test_is_sibling(self):
-        parent = CatFactory.create_cat(CatType.TEST, disable_random=True)
-        kit1 = CatFactory.create_cat(
-            CatType.TEST, parent1=parent.ID, disable_random=True
-        )
-        kit2 = CatFactory.create_cat(
-            CatType.TEST, parent1=parent.ID, disable_random=True
-        )
+        parent = cat_factory.create_cat(disable_random=True)
+        kit1 = CatFactory.create_cat(parent1=parent.ID, disable_random=True)
+        kit2 = CatFactory.create_cat(parent1=parent.ID, disable_random=True)
         self.assertFalse(parent.is_sibling(kit1))
         self.assertFalse(kit1.is_sibling(parent))
         self.assertTrue(kit2.is_sibling(kit1))
@@ -74,16 +71,10 @@ class TestRelativesFunction(unittest.TestCase):
 
     # test that is_uncle_aunt returns True for a uncle/aunt-cat relationship and False otherwise
     def test_is_uncle_aunt(self):
-        grand_parent = CatFactory.create_cat(CatType.TEST, disable_random=True)
-        sibling1 = CatFactory.create_cat(
-            CatType.TEST, parent1=grand_parent.ID, disable_random=True
-        )
-        sibling2 = CatFactory.create_cat(
-            CatType.TEST, parent1=grand_parent.ID, disable_random=True
-        )
-        kit = CatFactory.create_cat(
-            CatType.TEST, parent1=sibling1.ID, disable_random=True
-        )
+        grand_parent = cat_factory.create_cat(disable_random=True)
+        sibling1 = CatFactory.create_cat(parent1=grand_parent.ID, disable_random=True)
+        sibling2 = CatFactory.create_cat(parent1=grand_parent.ID, disable_random=True)
+        kit = CatFactory.create_cat(parent1=sibling1.ID, disable_random=True)
         self.assertFalse(sibling1.is_uncle_aunt(kit))
         self.assertFalse(sibling1.is_uncle_aunt(sibling2))
         self.assertFalse(kit.is_uncle_aunt(sibling2))
@@ -91,16 +82,10 @@ class TestRelativesFunction(unittest.TestCase):
 
     # test that is_grandparent returns True for a grandparent-cat relationship and False otherwise
     def test_is_grandparent(self):
-        grand_parent = CatFactory.create_cat(CatType.TEST, disable_random=True)
-        sibling1 = CatFactory.create_cat(
-            CatType.TEST, parent1=grand_parent.ID, disable_random=True
-        )
-        sibling2 = CatFactory.create_cat(
-            CatType.TEST, parent1=grand_parent.ID, disable_random=True
-        )
-        kit = CatFactory.create_cat(
-            CatType.TEST, parent1=sibling1.ID, disable_random=True
-        )
+        grand_parent = cat_factory.create_cat(disable_random=True)
+        sibling1 = CatFactory.create_cat(parent1=grand_parent.ID, disable_random=True)
+        sibling2 = CatFactory.create_cat(parent1=grand_parent.ID, disable_random=True)
+        kit = CatFactory.create_cat(parent1=sibling1.ID, disable_random=True)
         self.assertFalse(sibling1.is_grandparent(kit))
         self.assertFalse(sibling1.is_grandparent(sibling2))
         self.assertFalse(kit.is_grandparent(sibling2))
@@ -112,16 +97,10 @@ class TestRelativesFunction(unittest.TestCase):
 class TestPossibleMateFunction(unittest.TestCase):
     # test that is_potential_mate returns False for cats that are related to each other
     def test_relation(self):
-        grand_parent = CatFactory.create_cat(CatType.TEST, disable_random=True)
-        sibling1 = CatFactory.create_cat(
-            CatType.TEST, parent1=grand_parent.ID, disable_random=True
-        )
-        sibling2 = CatFactory.create_cat(
-            CatType.TEST, parent1=grand_parent.ID, disable_random=True
-        )
-        kit = CatFactory.create_cat(
-            CatType.TEST, parent1=sibling1.ID, disable_random=True
-        )
+        grand_parent = cat_factory.create_cat(disable_random=True)
+        sibling1 = CatFactory.create_cat(parent1=grand_parent.ID, disable_random=True)
+        sibling2 = CatFactory.create_cat(parent1=grand_parent.ID, disable_random=True)
+        kit = CatFactory.create_cat(parent1=sibling1.ID, disable_random=True)
         self.assertFalse(kit.is_potential_mate(grand_parent))
         self.assertFalse(kit.is_potential_mate(sibling1))
         self.assertFalse(kit.is_potential_mate(sibling2))
@@ -133,16 +112,10 @@ class TestPossibleMateFunction(unittest.TestCase):
 
     # test that is_potential_mate returns False for cats that are related to each other even if for_love_interest is True
     def test_relation_love_interest(self):
-        grand_parent = CatFactory.create_cat(CatType.TEST, disable_random=True)
-        sibling1 = CatFactory.create_cat(
-            CatType.TEST, parent1=grand_parent.ID, disable_random=True
-        )
-        sibling2 = CatFactory.create_cat(
-            CatType.TEST, parent1=grand_parent.ID, disable_random=True
-        )
-        kit = CatFactory.create_cat(
-            CatType.TEST, parent1=sibling1.ID, disable_random=True
-        )
+        grand_parent = cat_factory.create_cat(disable_random=True)
+        sibling1 = CatFactory.create_cat(parent1=grand_parent.ID, disable_random=True)
+        sibling2 = CatFactory.create_cat(parent1=grand_parent.ID, disable_random=True)
+        kit = CatFactory.create_cat(parent1=sibling1.ID, disable_random=True)
         self.assertFalse(kit.is_potential_mate(grand_parent, for_love_interest=True))
         self.assertFalse(kit.is_potential_mate(sibling1, for_love_interest=True))
         self.assertFalse(kit.is_potential_mate(sibling2, for_love_interest=True))
@@ -157,46 +130,22 @@ class TestPossibleMateFunction(unittest.TestCase):
 
     # test is_potential_mate for age checks
     def test_age_mating(self):
-        kitten_cat2 = CatFactory.create_cat(CatType.TEST, moons=1, disable_random=True)
-        kitten_cat1 = CatFactory.create_cat(CatType.TEST, moons=1, disable_random=True)
-        adolescent_cat1 = CatFactory.create_cat(
-            CatType.TEST, moons=6, disable_random=True
-        )
-        adolescent_cat2 = CatFactory.create_cat(
-            CatType.TEST, moons=6, disable_random=True
-        )
-        too_young_adult_cat1 = CatFactory.create_cat(
-            CatType.TEST, moons=12, disable_random=True
-        )
-        too_young_adult_cat2 = CatFactory.create_cat(
-            CatType.TEST, moons=12, disable_random=True
-        )
-        young_adult_cat1 = CatFactory.create_cat(
-            CatType.TEST, moons=20, disable_random=True
-        )
-        young_adult_cat2 = CatFactory.create_cat(
-            CatType.TEST, moons=20, disable_random=True
-        )
-        adult_cat_in_range1 = CatFactory.create_cat(
-            CatType.TEST, moons=60, disable_random=True
-        )
-        adult_cat_in_range2 = CatFactory.create_cat(
-            CatType.TEST, moons=60, disable_random=True
-        )
-        adult_cat_out_range1 = CatFactory.create_cat(
-            CatType.TEST, moons=65, disable_random=True
-        )
-        adult_cat_out_range2 = CatFactory.create_cat(
-            CatType.TEST, moons=65, disable_random=True
-        )
-        senior_adult_cat1 = CatFactory.create_cat(
-            CatType.TEST, moons=96, disable_random=True
-        )
-        senior_adult_cat2 = CatFactory.create_cat(
-            CatType.TEST, moons=96, disable_random=True
-        )
-        elder_cat1 = CatFactory.create_cat(CatType.TEST, moons=120, disable_random=True)
-        elder_cat2 = CatFactory.create_cat(CatType.TEST, moons=120, disable_random=True)
+        kitten_cat2 = cat_factory.create_cat(moons=1, disable_random=True)
+        kitten_cat1 = cat_factory.create_cat(moons=1, disable_random=True)
+        adolescent_cat1 = CatFactory.create_cat(moons=6, disable_random=True)
+        adolescent_cat2 = CatFactory.create_cat(moons=6, disable_random=True)
+        too_young_adult_cat1 = CatFactory.create_cat(moons=12, disable_random=True)
+        too_young_adult_cat2 = CatFactory.create_cat(moons=12, disable_random=True)
+        young_adult_cat1 = CatFactory.create_cat(moons=20, disable_random=True)
+        young_adult_cat2 = CatFactory.create_cat(moons=20, disable_random=True)
+        adult_cat_in_range1 = CatFactory.create_cat(moons=60, disable_random=True)
+        adult_cat_in_range2 = CatFactory.create_cat(moons=60, disable_random=True)
+        adult_cat_out_range1 = CatFactory.create_cat(moons=65, disable_random=True)
+        adult_cat_out_range2 = CatFactory.create_cat(moons=65, disable_random=True)
+        senior_adult_cat1 = CatFactory.create_cat(moons=96, disable_random=True)
+        senior_adult_cat2 = CatFactory.create_cat(moons=96, disable_random=True)
+        elder_cat1 = cat_factory.create_cat(moons=120, disable_random=True)
+        elder_cat2 = cat_factory.create_cat(moons=120, disable_random=True)
 
         # check for cat mating with itself
         self.assertFalse(kitten_cat1.is_potential_mate(kitten_cat1))
@@ -262,40 +211,20 @@ class TestPossibleMateFunction(unittest.TestCase):
 
     # test is_potential_mate for age checks with for_love_interest set to True
     def test_age_love_interest(self):
-        kitten_cat2 = CatFactory.create_cat(CatType.TEST, moons=1, disable_random=True)
-        kitten_cat1 = CatFactory.create_cat(CatType.TEST, moons=1, disable_random=True)
-        adolescent_cat1 = CatFactory.create_cat(
-            CatType.TEST, moons=6, disable_random=True
-        )
-        adolescent_cat2 = CatFactory.create_cat(
-            CatType.TEST, moons=6, disable_random=True
-        )
-        young_adult_cat1 = CatFactory.create_cat(
-            CatType.TEST, moons=12, disable_random=True
-        )
-        young_adult_cat2 = CatFactory.create_cat(
-            CatType.TEST, moons=12, disable_random=True
-        )
-        adult_cat_in_range1 = CatFactory.create_cat(
-            CatType.TEST, moons=52, disable_random=True
-        )
-        adult_cat_in_range2 = CatFactory.create_cat(
-            CatType.TEST, moons=52, disable_random=True
-        )
-        adult_cat_out_range1 = CatFactory.create_cat(
-            CatType.TEST, moons=65, disable_random=True
-        )
-        adult_cat_out_range2 = CatFactory.create_cat(
-            CatType.TEST, moons=65, disable_random=True
-        )
-        senior_adult_cat1 = CatFactory.create_cat(
-            CatType.TEST, moons=96, disable_random=True
-        )
-        senior_adult_cat2 = CatFactory.create_cat(
-            CatType.TEST, moons=96, disable_random=True
-        )
-        elder_cat1 = CatFactory.create_cat(CatType.TEST, moons=120, disable_random=True)
-        elder_cat2 = CatFactory.create_cat(CatType.TEST, moons=120, disable_random=True)
+        kitten_cat2 = cat_factory.create_cat(moons=1, disable_random=True)
+        kitten_cat1 = cat_factory.create_cat(moons=1, disable_random=True)
+        adolescent_cat1 = CatFactory.create_cat(moons=6, disable_random=True)
+        adolescent_cat2 = CatFactory.create_cat(moons=6, disable_random=True)
+        young_adult_cat1 = CatFactory.create_cat(moons=12, disable_random=True)
+        young_adult_cat2 = CatFactory.create_cat(moons=12, disable_random=True)
+        adult_cat_in_range1 = CatFactory.create_cat(moons=52, disable_random=True)
+        adult_cat_in_range2 = CatFactory.create_cat(moons=52, disable_random=True)
+        adult_cat_out_range1 = CatFactory.create_cat(moons=65, disable_random=True)
+        adult_cat_out_range2 = CatFactory.create_cat(moons=65, disable_random=True)
+        senior_adult_cat1 = CatFactory.create_cat(moons=96, disable_random=True)
+        senior_adult_cat2 = CatFactory.create_cat(moons=96, disable_random=True)
+        elder_cat1 = cat_factory.create_cat(moons=120, disable_random=True)
+        elder_cat2 = cat_factory.create_cat(moons=120, disable_random=True)
 
         # check for cat mating with itself
         self.assertFalse(kitten_cat1.is_potential_mate(kitten_cat1, True))
@@ -356,12 +285,12 @@ class TestPossibleMateFunction(unittest.TestCase):
     @patch("scripts.game_structure.game.clan")
     @patch("scripts.cat.history.History")
     def test_dead_exiled(self, mock_history, _, __):
-        exiled_cat = CatFactory.create_cat(CatType.TEST, disable_random=True)
+        exiled_cat = cat_factory.create_cat(disable_random=True)
         exiled_cat.status.exile_from_group()
-        dead_cat = CatFactory.create_cat(CatType.TEST, disable_random=True)
+        dead_cat = cat_factory.create_cat(disable_random=True)
         dead_cat.history = mock_history()
         dead_cat.dead = True
-        normal_cat = CatFactory.create_cat(CatType.TEST, disable_random=True)
+        normal_cat = cat_factory.create_cat(disable_random=True)
         self.assertFalse(exiled_cat.is_potential_mate(normal_cat))
         self.assertFalse(normal_cat.is_potential_mate(exiled_cat))
         self.assertFalse(dead_cat.is_potential_mate(normal_cat))
@@ -372,8 +301,8 @@ class TestMateFunctions(unittest.TestCase):
     # test that set_mate adds the mate's ID to the cat's mate list
     def test_set_mate(self):
         # given
-        cat1 = CatFactory.create_cat(CatType.TEST, disable_random=True)
-        cat2 = CatFactory.create_cat(CatType.TEST, disable_random=True)
+        cat1 = cat_factory.create_cat(disable_random=True)
+        cat2 = cat_factory.create_cat(disable_random=True)
 
         # when
         cat1.set_mate(cat2)
@@ -386,8 +315,8 @@ class TestMateFunctions(unittest.TestCase):
     # test that unset_mate removes the mate's ID from the cat's mate list
     def test_unset_mate(self):
         # given
-        cat1 = CatFactory.create_cat(CatType.TEST, disable_random=True)
-        cat2 = CatFactory.create_cat(CatType.TEST, disable_random=True)
+        cat1 = cat_factory.create_cat(disable_random=True)
+        cat2 = cat_factory.create_cat(disable_random=True)
         cat1.mate.append(cat2.ID)
         cat2.mate.append(cat1.ID)
 
@@ -404,8 +333,8 @@ class TestMateFunctions(unittest.TestCase):
     # test for relationship comparisons
     def test_set_mate_relationship(self):
         # given
-        cat1 = CatFactory.create_cat(CatType.TEST, disable_random=True)
-        cat2 = CatFactory.create_cat(CatType.TEST, disable_random=True)
+        cat1 = cat_factory.create_cat(disable_random=True)
+        cat2 = cat_factory.create_cat(disable_random=True)
         relation1 = Relationship(cat1, cat2)
         old_relation1 = deepcopy(relation1)
         relation2 = Relationship(cat2, cat1)
@@ -435,8 +364,8 @@ class TestMateFunctions(unittest.TestCase):
     # test for relationship comparisons for cats that are broken up
     def test_unset_mate_relationship(self):
         # given
-        cat1 = CatFactory.create_cat(CatType.TEST, disable_random=True)
-        cat2 = CatFactory.create_cat(CatType.TEST, disable_random=True)
+        cat1 = cat_factory.create_cat(disable_random=True)
+        cat2 = cat_factory.create_cat(disable_random=True)
         relation1 = Relationship(
             cat1,
             cat2,
@@ -490,14 +419,12 @@ class TestUpdateMentor(unittest.TestCase):
     def test_exile_apprentice(self):
         # given
 
-        app = CatFactory.create_cat(
-            CatType.TEST,
+        app = cat_factory.create_cat(
             moons=7,
             status_dict={"rank": CatRank.APPRENTICE},
             disable_random=True,
         )
-        mentor = CatFactory.create_cat(
-            CatType.TEST,
+        mentor = cat_factory.create_cat(
             moons=20,
             status_dict={"rank": CatRank.WARRIOR},
             disable_random=True,
@@ -557,8 +484,8 @@ class TestNameRepr(unittest.TestCase):
         for testset, moons, suffix in statuses:
             for status in testset:
                 with self.subTest("clancats", status_dict=status):
-                    cat = CatFactory.create_cat(
-                        CatType.TEST, moons=moons, status_dict=status, suffix="test"
+                    cat = cat_factory.create_cat(
+                        moons=moons, status_dict=status, suffix="test"
                     )
                     self.assertTrue(str(cat.name).endswith(suffix))
 
@@ -595,8 +522,8 @@ class TestNameRepr(unittest.TestCase):
         for testset, moons, suffix in statuses:
             for status in testset:
                 with self.subTest("clancats specsuffix", status_dict=status):
-                    cat = CatFactory.create_cat(
-                        CatType.TEST, moons=moons, status_dict=status, suffix="test"
+                    cat = cat_factory.create_cat(
+                        moons=moons, status_dict=status, suffix="test"
                     )
                     cat.name.specsuffix_hidden = True
                     self.assertTrue(str(cat.name).endswith(suffix))
@@ -617,8 +544,7 @@ class TestNameRepr(unittest.TestCase):
         for status in outsider_statuses:
             for moons, suffix in age_suffix:
                 with self.subTest("outsiders", status_dict=status, moons=moons):
-                    cat = CatFactory.create_cat(
-                        CatType.TEST,
+                    cat = cat_factory.create_cat(
                         status_dict=status,
                         moons=moons,
                         suffix="test",
@@ -673,8 +599,7 @@ class TestNameRepr(unittest.TestCase):
 
         for status, suffix in ex_clancat_statuses:
             with self.subTest("Exiled cat names", status_dict=status, suffix=suffix):
-                cat = CatFactory.create_cat(
-                    CatType.TEST,
+                cat = cat_factory.create_cat(
                     status_dict=status,
                     moons=20,
                     suffix="test",
@@ -720,8 +645,7 @@ class TestNameRepr(unittest.TestCase):
         for status in outsider_statuses:
             for moons, suffix in age_suffix:
                 with self.subTest("outsiders", status_dict=status, moons=moons):
-                    cat = CatFactory.create_cat(
-                        CatType.TEST,
+                    cat = cat_factory.create_cat(
                         status_dict=status,
                         moons=moons,
                         suffix="test",
@@ -734,8 +658,7 @@ class TestNameRepr(unittest.TestCase):
         for status in ex_clancat_statuses:
             for moons, suffix in age_suffix:
                 with self.subTest("Clan-like names", status_dict=status, moons=moons):
-                    cat = CatFactory.create_cat(
-                        CatType.TEST,
+                    cat = cat_factory.create_cat(
                         status_dict=status,
                         moons=moons,
                         suffix="test",
@@ -757,8 +680,7 @@ class TestNameRepr(unittest.TestCase):
         ]
         for status, moons, suffix in statuses:
             with self.subTest("lost clancats", moons=moons):
-                cat = CatFactory.create_cat(
-                    CatType.TEST,
+                cat = cat_factory.create_cat(
                     status_dict=status,
                     moons=moons,
                     suffix="test",
@@ -780,8 +702,7 @@ class TestNameRepr(unittest.TestCase):
         ]
         for status, moons, suffix in statuses:
             with self.subTest("lost clancats", status_dict=status):
-                cat = CatFactory.create_cat(
-                    CatType.TEST,
+                cat = cat_factory.create_cat(
                     status_dict=status,
                     moons=moons,
                     suffix="test",
@@ -809,8 +730,8 @@ class TestSocialAssignment(unittest.TestCase):
 
         for rank in clancat_ranks:
             with self.subTest("clancat social assignment", rank=rank):
-                cat = CatFactory.create_cat(
-                    CatType.TEST, status_dict={"rank": rank}, disable_random=True
+                cat = cat_factory.create_cat(
+                    status_dict={"rank": rank}, disable_random=True
                 )
                 self.assertEqual(cat.status.social, CatSocial.CLANCAT)
 
@@ -820,7 +741,7 @@ class TestSocialAssignment(unittest.TestCase):
 
         for rank, social in zip(outsider_ranks, outsider_social):
             with self.subTest("outsider social assignment"):
-                cat = CatFactory.create_cat(
-                    CatType.TEST, status_dict={"rank": rank}, disable_random=True
+                cat = cat_factory.create_cat(
+                    status_dict={"rank": rank}, disable_random=True
                 )
                 self.assertTrue(cat.status.social == social)

--- a/tests/test_cat.py
+++ b/tests/test_cat.py
@@ -11,7 +11,6 @@ os.environ["SDL_AUDIODRIVER"] = "dummy"
 
 from scripts.game_structure import game
 
-from scripts.cat.cats import Cat
 from scripts.cat.enums import CatAge, CatRank, CatGroup, CatSocial
 from scripts.cat_relations.relationship import Relationship
 
@@ -19,49 +18,55 @@ from scripts.cat_relations.relationship import Relationship
 class TestCreationAge(unittest.TestCase):
     # test that a cat with 1-5 moons has the age of a kitten
     def test_kitten(self):
-        test_cat = Cat(moons=5, disable_random=True)
+        test_cat = CatFactory.create_cat(CatType.TEST, moons=5, disable_random=True)
         self.assertEqual(test_cat.age, CatAge.KITTEN)
 
     # test that a cat with 6-11 moons has the age of an adolescent
     def test_adolescent(self):
-        test_cat = Cat(moons=6, disable_random=True)
+        test_cat = CatFactory.create_cat(CatType.TEST, moons=6, disable_random=True)
         self.assertEqual(test_cat.age, CatAge.ADOLESCENT)
 
     # test that a cat with 12-47 moons has the age of a young adult
     def test_young_adult(self):
-        test_cat = Cat(moons=12, disable_random=True)
+        test_cat = CatFactory.create_cat(CatType.TEST, moons=12, disable_random=True)
         self.assertEqual(test_cat.age, CatAge.YOUNG_ADULT)
 
     # test that a cat with 48-95 moons has the age of an adult
     def test_adult(self):
-        test_cat = Cat(moons=48, disable_random=True)
+        test_cat = CatFactory.create_cat(CatType.TEST, moons=48, disable_random=True)
         self.assertEqual(test_cat.age, CatAge.ADULT)
 
     # test that a cat with 96-119 moons has the age of a senior adult
     def test_senior_adult(self):
-        test_cat = Cat(moons=96, disable_random=True)
+        test_cat = CatFactory.create_cat(CatType.TEST, moons=96, disable_random=True)
         self.assertEqual(test_cat.age, CatAge.SENIOR_ADULT)
 
     # test that a cat with 120-300 moons has the age of a senior
     def test_elder(self):
-        test_cat = Cat(moons=120, disable_random=True)
+        test_cat = CatFactory.create_cat(CatType.TEST, moons=120, disable_random=True)
         self.assertEqual(test_cat.age, CatAge.SENIOR)
 
 
 class TestRelativesFunction(unittest.TestCase):
     # test that is_parent returns True for a parent1-cat relationship and False otherwise
     def test_is_parent(self):
-        parent = Cat(disable_random=True)
-        kit = Cat(parent1=parent.ID, disable_random=True)
+        parent = CatFactory.create_cat(CatType.TEST, disable_random=True)
+        kit = CatFactory.create_cat(
+            CatType.TEST, parent1=parent.ID, disable_random=True
+        )
         self.assertFalse(kit.is_parent(kit))
         self.assertFalse(kit.is_parent(parent))
         self.assertTrue(parent.is_parent(kit))
 
     # test that is_sibling returns True for cats with a shared parent1 and False otherwise
     def test_is_sibling(self):
-        parent = Cat(disable_random=True)
-        kit1 = Cat(parent1=parent.ID, disable_random=True)
-        kit2 = Cat(parent1=parent.ID, disable_random=True)
+        parent = CatFactory.create_cat(CatType.TEST, disable_random=True)
+        kit1 = CatFactory.create_cat(
+            CatType.TEST, parent1=parent.ID, disable_random=True
+        )
+        kit2 = CatFactory.create_cat(
+            CatType.TEST, parent1=parent.ID, disable_random=True
+        )
         self.assertFalse(parent.is_sibling(kit1))
         self.assertFalse(kit1.is_sibling(parent))
         self.assertTrue(kit2.is_sibling(kit1))
@@ -69,10 +74,16 @@ class TestRelativesFunction(unittest.TestCase):
 
     # test that is_uncle_aunt returns True for a uncle/aunt-cat relationship and False otherwise
     def test_is_uncle_aunt(self):
-        grand_parent = Cat(disable_random=True)
-        sibling1 = Cat(parent1=grand_parent.ID, disable_random=True)
-        sibling2 = Cat(parent1=grand_parent.ID, disable_random=True)
-        kit = Cat(parent1=sibling1.ID, disable_random=True)
+        grand_parent = CatFactory.create_cat(CatType.TEST, disable_random=True)
+        sibling1 = CatFactory.create_cat(
+            CatType.TEST, parent1=grand_parent.ID, disable_random=True
+        )
+        sibling2 = CatFactory.create_cat(
+            CatType.TEST, parent1=grand_parent.ID, disable_random=True
+        )
+        kit = CatFactory.create_cat(
+            CatType.TEST, parent1=sibling1.ID, disable_random=True
+        )
         self.assertFalse(sibling1.is_uncle_aunt(kit))
         self.assertFalse(sibling1.is_uncle_aunt(sibling2))
         self.assertFalse(kit.is_uncle_aunt(sibling2))
@@ -80,10 +91,16 @@ class TestRelativesFunction(unittest.TestCase):
 
     # test that is_grandparent returns True for a grandparent-cat relationship and False otherwise
     def test_is_grandparent(self):
-        grand_parent = Cat(disable_random=True)
-        sibling1 = Cat(parent1=grand_parent.ID, disable_random=True)
-        sibling2 = Cat(parent1=grand_parent.ID, disable_random=True)
-        kit = Cat(parent1=sibling1.ID, disable_random=True)
+        grand_parent = CatFactory.create_cat(CatType.TEST, disable_random=True)
+        sibling1 = CatFactory.create_cat(
+            CatType.TEST, parent1=grand_parent.ID, disable_random=True
+        )
+        sibling2 = CatFactory.create_cat(
+            CatType.TEST, parent1=grand_parent.ID, disable_random=True
+        )
+        kit = CatFactory.create_cat(
+            CatType.TEST, parent1=sibling1.ID, disable_random=True
+        )
         self.assertFalse(sibling1.is_grandparent(kit))
         self.assertFalse(sibling1.is_grandparent(sibling2))
         self.assertFalse(kit.is_grandparent(sibling2))
@@ -95,10 +112,16 @@ class TestRelativesFunction(unittest.TestCase):
 class TestPossibleMateFunction(unittest.TestCase):
     # test that is_potential_mate returns False for cats that are related to each other
     def test_relation(self):
-        grand_parent = Cat(disable_random=True)
-        sibling1 = Cat(parent1=grand_parent.ID, disable_random=True)
-        sibling2 = Cat(parent1=grand_parent.ID, disable_random=True)
-        kit = Cat(parent1=sibling1.ID, disable_random=True)
+        grand_parent = CatFactory.create_cat(CatType.TEST, disable_random=True)
+        sibling1 = CatFactory.create_cat(
+            CatType.TEST, parent1=grand_parent.ID, disable_random=True
+        )
+        sibling2 = CatFactory.create_cat(
+            CatType.TEST, parent1=grand_parent.ID, disable_random=True
+        )
+        kit = CatFactory.create_cat(
+            CatType.TEST, parent1=sibling1.ID, disable_random=True
+        )
         self.assertFalse(kit.is_potential_mate(grand_parent))
         self.assertFalse(kit.is_potential_mate(sibling1))
         self.assertFalse(kit.is_potential_mate(sibling2))
@@ -110,10 +133,16 @@ class TestPossibleMateFunction(unittest.TestCase):
 
     # test that is_potential_mate returns False for cats that are related to each other even if for_love_interest is True
     def test_relation_love_interest(self):
-        grand_parent = Cat(disable_random=True)
-        sibling1 = Cat(parent1=grand_parent.ID, disable_random=True)
-        sibling2 = Cat(parent1=grand_parent.ID, disable_random=True)
-        kit = Cat(parent1=sibling1.ID, disable_random=True)
+        grand_parent = CatFactory.create_cat(CatType.TEST, disable_random=True)
+        sibling1 = CatFactory.create_cat(
+            CatType.TEST, parent1=grand_parent.ID, disable_random=True
+        )
+        sibling2 = CatFactory.create_cat(
+            CatType.TEST, parent1=grand_parent.ID, disable_random=True
+        )
+        kit = CatFactory.create_cat(
+            CatType.TEST, parent1=sibling1.ID, disable_random=True
+        )
         self.assertFalse(kit.is_potential_mate(grand_parent, for_love_interest=True))
         self.assertFalse(kit.is_potential_mate(sibling1, for_love_interest=True))
         self.assertFalse(kit.is_potential_mate(sibling2, for_love_interest=True))
@@ -128,22 +157,46 @@ class TestPossibleMateFunction(unittest.TestCase):
 
     # test is_potential_mate for age checks
     def test_age_mating(self):
-        kitten_cat2 = Cat(moons=1, disable_random=True)
-        kitten_cat1 = Cat(moons=1, disable_random=True)
-        adolescent_cat1 = Cat(moons=6, disable_random=True)
-        adolescent_cat2 = Cat(moons=6, disable_random=True)
-        too_young_adult_cat1 = Cat(moons=12, disable_random=True)
-        too_young_adult_cat2 = Cat(moons=12, disable_random=True)
-        young_adult_cat1 = Cat(moons=20, disable_random=True)
-        young_adult_cat2 = Cat(moons=20, disable_random=True)
-        adult_cat_in_range1 = Cat(moons=60, disable_random=True)
-        adult_cat_in_range2 = Cat(moons=60, disable_random=True)
-        adult_cat_out_range1 = Cat(moons=65, disable_random=True)
-        adult_cat_out_range2 = Cat(moons=65, disable_random=True)
-        senior_adult_cat1 = Cat(moons=96, disable_random=True)
-        senior_adult_cat2 = Cat(moons=96, disable_random=True)
-        elder_cat1 = Cat(moons=120, disable_random=True)
-        elder_cat2 = Cat(moons=120, disable_random=True)
+        kitten_cat2 = CatFactory.create_cat(CatType.TEST, moons=1, disable_random=True)
+        kitten_cat1 = CatFactory.create_cat(CatType.TEST, moons=1, disable_random=True)
+        adolescent_cat1 = CatFactory.create_cat(
+            CatType.TEST, moons=6, disable_random=True
+        )
+        adolescent_cat2 = CatFactory.create_cat(
+            CatType.TEST, moons=6, disable_random=True
+        )
+        too_young_adult_cat1 = CatFactory.create_cat(
+            CatType.TEST, moons=12, disable_random=True
+        )
+        too_young_adult_cat2 = CatFactory.create_cat(
+            CatType.TEST, moons=12, disable_random=True
+        )
+        young_adult_cat1 = CatFactory.create_cat(
+            CatType.TEST, moons=20, disable_random=True
+        )
+        young_adult_cat2 = CatFactory.create_cat(
+            CatType.TEST, moons=20, disable_random=True
+        )
+        adult_cat_in_range1 = CatFactory.create_cat(
+            CatType.TEST, moons=60, disable_random=True
+        )
+        adult_cat_in_range2 = CatFactory.create_cat(
+            CatType.TEST, moons=60, disable_random=True
+        )
+        adult_cat_out_range1 = CatFactory.create_cat(
+            CatType.TEST, moons=65, disable_random=True
+        )
+        adult_cat_out_range2 = CatFactory.create_cat(
+            CatType.TEST, moons=65, disable_random=True
+        )
+        senior_adult_cat1 = CatFactory.create_cat(
+            CatType.TEST, moons=96, disable_random=True
+        )
+        senior_adult_cat2 = CatFactory.create_cat(
+            CatType.TEST, moons=96, disable_random=True
+        )
+        elder_cat1 = CatFactory.create_cat(CatType.TEST, moons=120, disable_random=True)
+        elder_cat2 = CatFactory.create_cat(CatType.TEST, moons=120, disable_random=True)
 
         # check for cat mating with itself
         self.assertFalse(kitten_cat1.is_potential_mate(kitten_cat1))
@@ -209,20 +262,40 @@ class TestPossibleMateFunction(unittest.TestCase):
 
     # test is_potential_mate for age checks with for_love_interest set to True
     def test_age_love_interest(self):
-        kitten_cat2 = Cat(moons=1, disable_random=True)
-        kitten_cat1 = Cat(moons=1, disable_random=True)
-        adolescent_cat1 = Cat(moons=6, disable_random=True)
-        adolescent_cat2 = Cat(moons=6, disable_random=True)
-        young_adult_cat1 = Cat(moons=12, disable_random=True)
-        young_adult_cat2 = Cat(moons=12, disable_random=True)
-        adult_cat_in_range1 = Cat(moons=52, disable_random=True)
-        adult_cat_in_range2 = Cat(moons=52, disable_random=True)
-        adult_cat_out_range1 = Cat(moons=65, disable_random=True)
-        adult_cat_out_range2 = Cat(moons=65, disable_random=True)
-        senior_adult_cat1 = Cat(moons=96, disable_random=True)
-        senior_adult_cat2 = Cat(moons=96, disable_random=True)
-        elder_cat1 = Cat(moons=120, disable_random=True)
-        elder_cat2 = Cat(moons=120, disable_random=True)
+        kitten_cat2 = CatFactory.create_cat(CatType.TEST, moons=1, disable_random=True)
+        kitten_cat1 = CatFactory.create_cat(CatType.TEST, moons=1, disable_random=True)
+        adolescent_cat1 = CatFactory.create_cat(
+            CatType.TEST, moons=6, disable_random=True
+        )
+        adolescent_cat2 = CatFactory.create_cat(
+            CatType.TEST, moons=6, disable_random=True
+        )
+        young_adult_cat1 = CatFactory.create_cat(
+            CatType.TEST, moons=12, disable_random=True
+        )
+        young_adult_cat2 = CatFactory.create_cat(
+            CatType.TEST, moons=12, disable_random=True
+        )
+        adult_cat_in_range1 = CatFactory.create_cat(
+            CatType.TEST, moons=52, disable_random=True
+        )
+        adult_cat_in_range2 = CatFactory.create_cat(
+            CatType.TEST, moons=52, disable_random=True
+        )
+        adult_cat_out_range1 = CatFactory.create_cat(
+            CatType.TEST, moons=65, disable_random=True
+        )
+        adult_cat_out_range2 = CatFactory.create_cat(
+            CatType.TEST, moons=65, disable_random=True
+        )
+        senior_adult_cat1 = CatFactory.create_cat(
+            CatType.TEST, moons=96, disable_random=True
+        )
+        senior_adult_cat2 = CatFactory.create_cat(
+            CatType.TEST, moons=96, disable_random=True
+        )
+        elder_cat1 = CatFactory.create_cat(CatType.TEST, moons=120, disable_random=True)
+        elder_cat2 = CatFactory.create_cat(CatType.TEST, moons=120, disable_random=True)
 
         # check for cat mating with itself
         self.assertFalse(kitten_cat1.is_potential_mate(kitten_cat1, True))
@@ -283,12 +356,12 @@ class TestPossibleMateFunction(unittest.TestCase):
     @patch("scripts.game_structure.game.clan")
     @patch("scripts.cat.history.History")
     def test_dead_exiled(self, mock_history, _, __):
-        exiled_cat = Cat(disable_random=True)
+        exiled_cat = CatFactory.create_cat(CatType.TEST, disable_random=True)
         exiled_cat.status.exile_from_group()
-        dead_cat = Cat(disable_random=True)
+        dead_cat = CatFactory.create_cat(CatType.TEST, disable_random=True)
         dead_cat.history = mock_history()
         dead_cat.dead = True
-        normal_cat = Cat(disable_random=True)
+        normal_cat = CatFactory.create_cat(CatType.TEST, disable_random=True)
         self.assertFalse(exiled_cat.is_potential_mate(normal_cat))
         self.assertFalse(normal_cat.is_potential_mate(exiled_cat))
         self.assertFalse(dead_cat.is_potential_mate(normal_cat))
@@ -299,8 +372,8 @@ class TestMateFunctions(unittest.TestCase):
     # test that set_mate adds the mate's ID to the cat's mate list
     def test_set_mate(self):
         # given
-        cat1 = Cat(disable_random=True)
-        cat2 = Cat(disable_random=True)
+        cat1 = CatFactory.create_cat(CatType.TEST, disable_random=True)
+        cat2 = CatFactory.create_cat(CatType.TEST, disable_random=True)
 
         # when
         cat1.set_mate(cat2)
@@ -313,8 +386,8 @@ class TestMateFunctions(unittest.TestCase):
     # test that unset_mate removes the mate's ID from the cat's mate list
     def test_unset_mate(self):
         # given
-        cat1 = Cat(disable_random=True)
-        cat2 = Cat(disable_random=True)
+        cat1 = CatFactory.create_cat(CatType.TEST, disable_random=True)
+        cat2 = CatFactory.create_cat(CatType.TEST, disable_random=True)
         cat1.mate.append(cat2.ID)
         cat2.mate.append(cat1.ID)
 
@@ -331,8 +404,8 @@ class TestMateFunctions(unittest.TestCase):
     # test for relationship comparisons
     def test_set_mate_relationship(self):
         # given
-        cat1 = Cat(disable_random=True)
-        cat2 = Cat(disable_random=True)
+        cat1 = CatFactory.create_cat(CatType.TEST, disable_random=True)
+        cat2 = CatFactory.create_cat(CatType.TEST, disable_random=True)
         relation1 = Relationship(cat1, cat2)
         old_relation1 = deepcopy(relation1)
         relation2 = Relationship(cat2, cat1)
@@ -362,8 +435,8 @@ class TestMateFunctions(unittest.TestCase):
     # test for relationship comparisons for cats that are broken up
     def test_unset_mate_relationship(self):
         # given
-        cat1 = Cat(disable_random=True)
-        cat2 = Cat(disable_random=True)
+        cat1 = CatFactory.create_cat(CatType.TEST, disable_random=True)
+        cat2 = CatFactory.create_cat(CatType.TEST, disable_random=True)
         relation1 = Relationship(
             cat1,
             cat2,
@@ -417,11 +490,17 @@ class TestUpdateMentor(unittest.TestCase):
     def test_exile_apprentice(self):
         # given
 
-        app = Cat(
-            moons=7, status_dict={"rank": CatRank.APPRENTICE}, disable_random=True
+        app = CatFactory.create_cat(
+            CatType.TEST,
+            moons=7,
+            status_dict={"rank": CatRank.APPRENTICE},
+            disable_random=True,
         )
-        mentor = Cat(
-            moons=20, status_dict={"rank": CatRank.WARRIOR}, disable_random=True
+        mentor = CatFactory.create_cat(
+            CatType.TEST,
+            moons=20,
+            status_dict={"rank": CatRank.WARRIOR},
+            disable_random=True,
         )
         app.update_mentor(mentor.ID)
 
@@ -478,7 +557,9 @@ class TestNameRepr(unittest.TestCase):
         for testset, moons, suffix in statuses:
             for status in testset:
                 with self.subTest("clancats", status_dict=status):
-                    cat = Cat(moons=moons, status_dict=status, suffix="test")
+                    cat = CatFactory.create_cat(
+                        CatType.TEST, moons=moons, status_dict=status, suffix="test"
+                    )
                     self.assertTrue(str(cat.name).endswith(suffix))
 
     def test_specsuffix_clancats(self):
@@ -514,7 +595,9 @@ class TestNameRepr(unittest.TestCase):
         for testset, moons, suffix in statuses:
             for status in testset:
                 with self.subTest("clancats specsuffix", status_dict=status):
-                    cat = Cat(moons=moons, status_dict=status, suffix="test")
+                    cat = CatFactory.create_cat(
+                        CatType.TEST, moons=moons, status_dict=status, suffix="test"
+                    )
                     cat.name.specsuffix_hidden = True
                     self.assertTrue(str(cat.name).endswith(suffix))
 
@@ -534,7 +617,8 @@ class TestNameRepr(unittest.TestCase):
         for status in outsider_statuses:
             for moons, suffix in age_suffix:
                 with self.subTest("outsiders", status_dict=status, moons=moons):
-                    cat = Cat(
+                    cat = CatFactory.create_cat(
+                        CatType.TEST,
                         status_dict=status,
                         moons=moons,
                         suffix="test",
@@ -589,8 +673,12 @@ class TestNameRepr(unittest.TestCase):
 
         for status, suffix in ex_clancat_statuses:
             with self.subTest("Exiled cat names", status_dict=status, suffix=suffix):
-                cat = Cat(
-                    status_dict=status, moons=20, suffix="test", disable_random=True
+                cat = CatFactory.create_cat(
+                    CatType.TEST,
+                    status_dict=status,
+                    moons=20,
+                    suffix="test",
+                    disable_random=True,
                 )
                 self.assertTrue(str(cat.name).endswith(suffix))
 
@@ -632,7 +720,8 @@ class TestNameRepr(unittest.TestCase):
         for status in outsider_statuses:
             for moons, suffix in age_suffix:
                 with self.subTest("outsiders", status_dict=status, moons=moons):
-                    cat = Cat(
+                    cat = CatFactory.create_cat(
+                        CatType.TEST,
                         status_dict=status,
                         moons=moons,
                         suffix="test",
@@ -645,7 +734,8 @@ class TestNameRepr(unittest.TestCase):
         for status in ex_clancat_statuses:
             for moons, suffix in age_suffix:
                 with self.subTest("Clan-like names", status_dict=status, moons=moons):
-                    cat = Cat(
+                    cat = CatFactory.create_cat(
+                        CatType.TEST,
                         status_dict=status,
                         moons=moons,
                         suffix="test",
@@ -667,8 +757,12 @@ class TestNameRepr(unittest.TestCase):
         ]
         for status, moons, suffix in statuses:
             with self.subTest("lost clancats", moons=moons):
-                cat = Cat(
-                    status_dict=status, moons=moons, suffix="test", disable_random=True
+                cat = CatFactory.create_cat(
+                    CatType.TEST,
+                    status_dict=status,
+                    moons=moons,
+                    suffix="test",
+                    disable_random=True,
                 )
                 cat.become_lost()
                 self.assertTrue(str(cat.name).endswith(suffix))
@@ -686,8 +780,12 @@ class TestNameRepr(unittest.TestCase):
         ]
         for status, moons, suffix in statuses:
             with self.subTest("lost clancats", status_dict=status):
-                cat = Cat(
-                    status_dict=status, moons=moons, suffix="test", disable_random=True
+                cat = CatFactory.create_cat(
+                    CatType.TEST,
+                    status_dict=status,
+                    moons=moons,
+                    suffix="test",
+                    disable_random=True,
                 )
                 cat.status.become_lost()
                 cat.name.specsuffix_hidden = True
@@ -711,7 +809,9 @@ class TestSocialAssignment(unittest.TestCase):
 
         for rank in clancat_ranks:
             with self.subTest("clancat social assignment", rank=rank):
-                cat = Cat(status_dict={"rank": rank}, disable_random=True)
+                cat = CatFactory.create_cat(
+                    CatType.TEST, status_dict={"rank": rank}, disable_random=True
+                )
                 self.assertEqual(cat.status.social, CatSocial.CLANCAT)
 
     def test_outsider_social(self):
@@ -720,12 +820,7 @@ class TestSocialAssignment(unittest.TestCase):
 
         for rank, social in zip(outsider_ranks, outsider_social):
             with self.subTest("outsider social assignment"):
-                cat = Cat(status_dict={"rank": rank}, disable_random=True)
+                cat = CatFactory.create_cat(
+                    CatType.TEST, status_dict={"rank": rank}, disable_random=True
+                )
                 self.assertTrue(cat.status.social == social)
-
-
-class TestCatFactory(unittest.TestCase):
-    def test_new_cat(self):
-        cat = CatFactory.create_cat(CatType.NEW)
-
-        print("success?")

--- a/tests/test_cat.py
+++ b/tests/test_cat.py
@@ -4,8 +4,8 @@ from copy import deepcopy
 from random import Random
 from unittest.mock import patch
 
-from scripts.cat.factories.cat_factory import CatFactory
-from scripts.cat.factories.test_cat_factory import TestCatFactory
+from scripts.cat.factories.cat_factory import cat_factory
+from scripts.cat.factories.test_cat_factory import Testcat_factory
 
 os.environ["SDL_VIDEODRIVER"] = "dummy"
 os.environ["SDL_AUDIODRIVER"] = "dummy"
@@ -15,7 +15,7 @@ from scripts.game_structure import game
 from scripts.cat.enums import CatAge, CatRank, CatGroup, CatSocial
 from scripts.cat_relations.relationship import Relationship
 
-cat_factory = TestCatFactory(rng=Random())
+cat_factory = Testcat_factory(rng=Random())
 
 
 class TestCreationAge(unittest.TestCase):
@@ -54,7 +54,7 @@ class TestRelativesFunction(unittest.TestCase):
     # test that is_parent returns True for a parent1-cat relationship and False otherwise
     def test_is_parent(self):
         parent = cat_factory.create_cat(disable_random=True)
-        kit = CatFactory.create_cat(parent1=parent.ID, disable_random=True)
+        kit = cat_factory.create_cat(parent1=parent.ID, disable_random=True)
         self.assertFalse(kit.is_parent(kit))
         self.assertFalse(kit.is_parent(parent))
         self.assertTrue(parent.is_parent(kit))
@@ -62,8 +62,8 @@ class TestRelativesFunction(unittest.TestCase):
     # test that is_sibling returns True for cats with a shared parent1 and False otherwise
     def test_is_sibling(self):
         parent = cat_factory.create_cat(disable_random=True)
-        kit1 = CatFactory.create_cat(parent1=parent.ID, disable_random=True)
-        kit2 = CatFactory.create_cat(parent1=parent.ID, disable_random=True)
+        kit1 = cat_factory.create_cat(parent1=parent.ID, disable_random=True)
+        kit2 = cat_factory.create_cat(parent1=parent.ID, disable_random=True)
         self.assertFalse(parent.is_sibling(kit1))
         self.assertFalse(kit1.is_sibling(parent))
         self.assertTrue(kit2.is_sibling(kit1))
@@ -72,9 +72,9 @@ class TestRelativesFunction(unittest.TestCase):
     # test that is_uncle_aunt returns True for a uncle/aunt-cat relationship and False otherwise
     def test_is_uncle_aunt(self):
         grand_parent = cat_factory.create_cat(disable_random=True)
-        sibling1 = CatFactory.create_cat(parent1=grand_parent.ID, disable_random=True)
-        sibling2 = CatFactory.create_cat(parent1=grand_parent.ID, disable_random=True)
-        kit = CatFactory.create_cat(parent1=sibling1.ID, disable_random=True)
+        sibling1 = cat_factory.create_cat(parent1=grand_parent.ID, disable_random=True)
+        sibling2 = cat_factory.create_cat(parent1=grand_parent.ID, disable_random=True)
+        kit = cat_factory.create_cat(parent1=sibling1.ID, disable_random=True)
         self.assertFalse(sibling1.is_uncle_aunt(kit))
         self.assertFalse(sibling1.is_uncle_aunt(sibling2))
         self.assertFalse(kit.is_uncle_aunt(sibling2))
@@ -83,9 +83,9 @@ class TestRelativesFunction(unittest.TestCase):
     # test that is_grandparent returns True for a grandparent-cat relationship and False otherwise
     def test_is_grandparent(self):
         grand_parent = cat_factory.create_cat(disable_random=True)
-        sibling1 = CatFactory.create_cat(parent1=grand_parent.ID, disable_random=True)
-        sibling2 = CatFactory.create_cat(parent1=grand_parent.ID, disable_random=True)
-        kit = CatFactory.create_cat(parent1=sibling1.ID, disable_random=True)
+        sibling1 = cat_factory.create_cat(parent1=grand_parent.ID, disable_random=True)
+        sibling2 = cat_factory.create_cat(parent1=grand_parent.ID, disable_random=True)
+        kit = cat_factory.create_cat(parent1=sibling1.ID, disable_random=True)
         self.assertFalse(sibling1.is_grandparent(kit))
         self.assertFalse(sibling1.is_grandparent(sibling2))
         self.assertFalse(kit.is_grandparent(sibling2))
@@ -98,9 +98,9 @@ class TestPossibleMateFunction(unittest.TestCase):
     # test that is_potential_mate returns False for cats that are related to each other
     def test_relation(self):
         grand_parent = cat_factory.create_cat(disable_random=True)
-        sibling1 = CatFactory.create_cat(parent1=grand_parent.ID, disable_random=True)
-        sibling2 = CatFactory.create_cat(parent1=grand_parent.ID, disable_random=True)
-        kit = CatFactory.create_cat(parent1=sibling1.ID, disable_random=True)
+        sibling1 = cat_factory.create_cat(parent1=grand_parent.ID, disable_random=True)
+        sibling2 = cat_factory.create_cat(parent1=grand_parent.ID, disable_random=True)
+        kit = cat_factory.create_cat(parent1=sibling1.ID, disable_random=True)
         self.assertFalse(kit.is_potential_mate(grand_parent))
         self.assertFalse(kit.is_potential_mate(sibling1))
         self.assertFalse(kit.is_potential_mate(sibling2))
@@ -113,9 +113,9 @@ class TestPossibleMateFunction(unittest.TestCase):
     # test that is_potential_mate returns False for cats that are related to each other even if for_love_interest is True
     def test_relation_love_interest(self):
         grand_parent = cat_factory.create_cat(disable_random=True)
-        sibling1 = CatFactory.create_cat(parent1=grand_parent.ID, disable_random=True)
-        sibling2 = CatFactory.create_cat(parent1=grand_parent.ID, disable_random=True)
-        kit = CatFactory.create_cat(parent1=sibling1.ID, disable_random=True)
+        sibling1 = cat_factory.create_cat(parent1=grand_parent.ID, disable_random=True)
+        sibling2 = cat_factory.create_cat(parent1=grand_parent.ID, disable_random=True)
+        kit = cat_factory.create_cat(parent1=sibling1.ID, disable_random=True)
         self.assertFalse(kit.is_potential_mate(grand_parent, for_love_interest=True))
         self.assertFalse(kit.is_potential_mate(sibling1, for_love_interest=True))
         self.assertFalse(kit.is_potential_mate(sibling2, for_love_interest=True))
@@ -132,18 +132,18 @@ class TestPossibleMateFunction(unittest.TestCase):
     def test_age_mating(self):
         kitten_cat2 = cat_factory.create_cat(moons=1, disable_random=True)
         kitten_cat1 = cat_factory.create_cat(moons=1, disable_random=True)
-        adolescent_cat1 = CatFactory.create_cat(moons=6, disable_random=True)
-        adolescent_cat2 = CatFactory.create_cat(moons=6, disable_random=True)
-        too_young_adult_cat1 = CatFactory.create_cat(moons=12, disable_random=True)
-        too_young_adult_cat2 = CatFactory.create_cat(moons=12, disable_random=True)
-        young_adult_cat1 = CatFactory.create_cat(moons=20, disable_random=True)
-        young_adult_cat2 = CatFactory.create_cat(moons=20, disable_random=True)
-        adult_cat_in_range1 = CatFactory.create_cat(moons=60, disable_random=True)
-        adult_cat_in_range2 = CatFactory.create_cat(moons=60, disable_random=True)
-        adult_cat_out_range1 = CatFactory.create_cat(moons=65, disable_random=True)
-        adult_cat_out_range2 = CatFactory.create_cat(moons=65, disable_random=True)
-        senior_adult_cat1 = CatFactory.create_cat(moons=96, disable_random=True)
-        senior_adult_cat2 = CatFactory.create_cat(moons=96, disable_random=True)
+        adolescent_cat1 = cat_factory.create_cat(moons=6, disable_random=True)
+        adolescent_cat2 = cat_factory.create_cat(moons=6, disable_random=True)
+        too_young_adult_cat1 = cat_factory.create_cat(moons=12, disable_random=True)
+        too_young_adult_cat2 = cat_factory.create_cat(moons=12, disable_random=True)
+        young_adult_cat1 = cat_factory.create_cat(moons=20, disable_random=True)
+        young_adult_cat2 = cat_factory.create_cat(moons=20, disable_random=True)
+        adult_cat_in_range1 = cat_factory.create_cat(moons=60, disable_random=True)
+        adult_cat_in_range2 = cat_factory.create_cat(moons=60, disable_random=True)
+        adult_cat_out_range1 = cat_factory.create_cat(moons=65, disable_random=True)
+        adult_cat_out_range2 = cat_factory.create_cat(moons=65, disable_random=True)
+        senior_adult_cat1 = cat_factory.create_cat(moons=96, disable_random=True)
+        senior_adult_cat2 = cat_factory.create_cat(moons=96, disable_random=True)
         elder_cat1 = cat_factory.create_cat(moons=120, disable_random=True)
         elder_cat2 = cat_factory.create_cat(moons=120, disable_random=True)
 
@@ -213,16 +213,16 @@ class TestPossibleMateFunction(unittest.TestCase):
     def test_age_love_interest(self):
         kitten_cat2 = cat_factory.create_cat(moons=1, disable_random=True)
         kitten_cat1 = cat_factory.create_cat(moons=1, disable_random=True)
-        adolescent_cat1 = CatFactory.create_cat(moons=6, disable_random=True)
-        adolescent_cat2 = CatFactory.create_cat(moons=6, disable_random=True)
-        young_adult_cat1 = CatFactory.create_cat(moons=12, disable_random=True)
-        young_adult_cat2 = CatFactory.create_cat(moons=12, disable_random=True)
-        adult_cat_in_range1 = CatFactory.create_cat(moons=52, disable_random=True)
-        adult_cat_in_range2 = CatFactory.create_cat(moons=52, disable_random=True)
-        adult_cat_out_range1 = CatFactory.create_cat(moons=65, disable_random=True)
-        adult_cat_out_range2 = CatFactory.create_cat(moons=65, disable_random=True)
-        senior_adult_cat1 = CatFactory.create_cat(moons=96, disable_random=True)
-        senior_adult_cat2 = CatFactory.create_cat(moons=96, disable_random=True)
+        adolescent_cat1 = cat_factory.create_cat(moons=6, disable_random=True)
+        adolescent_cat2 = cat_factory.create_cat(moons=6, disable_random=True)
+        young_adult_cat1 = cat_factory.create_cat(moons=12, disable_random=True)
+        young_adult_cat2 = cat_factory.create_cat(moons=12, disable_random=True)
+        adult_cat_in_range1 = cat_factory.create_cat(moons=52, disable_random=True)
+        adult_cat_in_range2 = cat_factory.create_cat(moons=52, disable_random=True)
+        adult_cat_out_range1 = cat_factory.create_cat(moons=65, disable_random=True)
+        adult_cat_out_range2 = cat_factory.create_cat(moons=65, disable_random=True)
+        senior_adult_cat1 = cat_factory.create_cat(moons=96, disable_random=True)
+        senior_adult_cat2 = cat_factory.create_cat(moons=96, disable_random=True)
         elder_cat1 = cat_factory.create_cat(moons=120, disable_random=True)
         elder_cat2 = cat_factory.create_cat(moons=120, disable_random=True)
 

--- a/tests/test_cat.py
+++ b/tests/test_cat.py
@@ -4,8 +4,7 @@ from copy import deepcopy
 from random import Random
 from unittest.mock import patch
 
-from scripts.cat.factories.cat_factory import cat_factory
-from scripts.cat.factories.test_cat_factory import Testcat_factory
+from scripts.cat.factories.test_cat_factory import TestCatFactory
 
 os.environ["SDL_VIDEODRIVER"] = "dummy"
 os.environ["SDL_AUDIODRIVER"] = "dummy"
@@ -15,7 +14,7 @@ from scripts.game_structure import game
 from scripts.cat.enums import CatAge, CatRank, CatGroup, CatSocial
 from scripts.cat_relations.relationship import Relationship
 
-cat_factory = Testcat_factory(rng=Random())
+cat_factory = TestCatFactory(rng=Random())
 
 
 class TestCreationAge(unittest.TestCase):

--- a/tests/test_cat.py
+++ b/tests/test_cat.py
@@ -3,6 +3,9 @@ import unittest
 from unittest.mock import patch
 from copy import deepcopy
 
+from scripts.cat.factories.cat_factory import CatFactory
+from scripts.cat.factories.enums import CatType
+
 os.environ["SDL_VIDEODRIVER"] = "dummy"
 os.environ["SDL_AUDIODRIVER"] = "dummy"
 
@@ -719,3 +722,10 @@ class TestSocialAssignment(unittest.TestCase):
             with self.subTest("outsider social assignment"):
                 cat = Cat(status_dict={"rank": rank}, disable_random=True)
                 self.assertTrue(cat.status.social == social)
+
+
+class TestCatFactory(unittest.TestCase):
+    def test_new_cat(self):
+        cat = CatFactory.create_cat(CatType.NEW)
+
+        print("success?")

--- a/tests/test_conditions.py
+++ b/tests/test_conditions.py
@@ -1,28 +1,28 @@
 import os
 import unittest
+from random import Random
+
 import ujson
 
 from scripts.cat.enums import CatRank
-from scripts.cat.factories.cat_factory import CatFactory
-from scripts.cat.factories.enums import CatType
+from scripts.cat.factories.test_cat_factory import TestCatFactory
 
 os.environ["SDL_VIDEODRIVER"] = "dummy"
 os.environ["SDL_AUDIODRIVER"] = "dummy"
 
-from scripts.cat.cats import Cat
 from scripts.conditions import medicine_cats_can_cover_clan
+
+cat_factory = TestCatFactory(rng=Random())
 
 
 class TestsMedCondition(unittest.TestCase):
     def test_fulfilled(self):
-        cat1 = CatFactory.create_cat(
-            CatType.TEST,
+        cat1 = cat_factory.create_cat(
             moons=20,
             status_dict={"rank": CatRank.WARRIOR},
             disable_random=True,
         )
-        med = CatFactory.create_cat(
-            CatType.TEST,
+        med = cat_factory.create_cat(
             moons=20,
             status_dict={"rank": CatRank.MEDICINE_CAT},
             disable_random=True,
@@ -32,39 +32,33 @@ class TestsMedCondition(unittest.TestCase):
         self.assertTrue(medicine_cats_can_cover_clan(all_cats, 15))
 
     def test_fulfilled_many_cats(self):
-        cat1 = CatFactory.create_cat(
-            CatType.TEST,
+        cat1 = cat_factory.create_cat(
             moons=20,
             status_dict={"rank": CatRank.WARRIOR},
             disable_random=True,
         )
-        cat2 = CatFactory.create_cat(
-            CatType.TEST,
+        cat2 = cat_factory.create_cat(
             moons=20,
             status_dict={"rank": CatRank.WARRIOR},
             disable_random=True,
         )
-        cat3 = CatFactory.create_cat(
-            CatType.TEST,
+        cat3 = cat_factory.create_cat(
             moons=20,
             status_dict={"rank": CatRank.WARRIOR},
             disable_random=True,
         )
-        cat4 = CatFactory.create_cat(
-            CatType.TEST,
+        cat4 = cat_factory.create_cat(
             moons=20,
             status_dict={"rank": CatRank.WARRIOR},
             disable_random=True,
         )
 
-        med1 = CatFactory.create_cat(
-            CatType.TEST,
+        med1 = cat_factory.create_cat(
             moons=20,
             status_dict={"rank": CatRank.MEDICINE_CAT},
             disable_random=True,
         )
-        med2 = CatFactory.create_cat(
-            CatType.TEST,
+        med2 = cat_factory.create_cat(
             moons=20,
             status_dict={"rank": CatRank.MEDICINE_CAT},
             disable_random=True,
@@ -74,15 +68,13 @@ class TestsMedCondition(unittest.TestCase):
         self.assertTrue(medicine_cats_can_cover_clan(all_cats, 2))
 
     def test_injured_fulfilled(self):
-        cat1 = CatFactory.create_cat(
-            CatType.TEST,
+        cat1 = cat_factory.create_cat(
             moons=20,
             status_dict={"rank": CatRank.WARRIOR},
             disable_random=True,
         )
 
-        med = CatFactory.create_cat(
-            CatType.TEST,
+        med = cat_factory.create_cat(
             moons=20,
             status_dict={"rank": CatRank.MEDICINE_CAT},
             disable_random=True,
@@ -93,15 +85,13 @@ class TestsMedCondition(unittest.TestCase):
         self.assertTrue(medicine_cats_can_cover_clan(all_cats, 15))
 
     def test_illness_fulfilled(self):
-        cat1 = CatFactory.create_cat(
-            CatType.TEST,
+        cat1 = cat_factory.create_cat(
             moons=20,
             status_dict={"rank": CatRank.WARRIOR},
             disable_random=True,
         )
 
-        med = CatFactory.create_cat(
-            CatType.TEST,
+        med = cat_factory.create_cat(
             moons=20,
             status_dict={"rank": CatRank.MEDICINE_CAT},
             disable_random=True,

--- a/tests/test_conditions.py
+++ b/tests/test_conditions.py
@@ -3,6 +3,8 @@ import unittest
 import ujson
 
 from scripts.cat.enums import CatRank
+from scripts.cat.factories.cat_factory import CatFactory
+from scripts.cat.factories.enums import CatType
 
 os.environ["SDL_VIDEODRIVER"] = "dummy"
 os.environ["SDL_AUDIODRIVER"] = "dummy"
@@ -13,35 +15,77 @@ from scripts.conditions import medicine_cats_can_cover_clan
 
 class TestsMedCondition(unittest.TestCase):
     def test_fulfilled(self):
-        cat1 = Cat(moons=20, status_dict={"rank": CatRank.WARRIOR}, disable_random=True)
-        med = Cat(
-            moons=20, status_dict={"rank": CatRank.MEDICINE_CAT}, disable_random=True
+        cat1 = CatFactory.create_cat(
+            CatType.TEST,
+            moons=20,
+            status_dict={"rank": CatRank.WARRIOR},
+            disable_random=True,
+        )
+        med = CatFactory.create_cat(
+            CatType.TEST,
+            moons=20,
+            status_dict={"rank": CatRank.MEDICINE_CAT},
+            disable_random=True,
         )
 
         all_cats = [cat1, med]
         self.assertTrue(medicine_cats_can_cover_clan(all_cats, 15))
 
     def test_fulfilled_many_cats(self):
-        cat1 = Cat(moons=20, status_dict={"rank": CatRank.WARRIOR}, disable_random=True)
-        cat2 = Cat(moons=20, status_dict={"rank": CatRank.WARRIOR}, disable_random=True)
-        cat3 = Cat(moons=20, status_dict={"rank": CatRank.WARRIOR}, disable_random=True)
-        cat4 = Cat(moons=20, status_dict={"rank": CatRank.WARRIOR}, disable_random=True)
-
-        med1 = Cat(
-            moons=20, status_dict={"rank": CatRank.MEDICINE_CAT}, disable_random=True
+        cat1 = CatFactory.create_cat(
+            CatType.TEST,
+            moons=20,
+            status_dict={"rank": CatRank.WARRIOR},
+            disable_random=True,
         )
-        med2 = Cat(
-            moons=20, status_dict={"rank": CatRank.MEDICINE_CAT}, disable_random=True
+        cat2 = CatFactory.create_cat(
+            CatType.TEST,
+            moons=20,
+            status_dict={"rank": CatRank.WARRIOR},
+            disable_random=True,
+        )
+        cat3 = CatFactory.create_cat(
+            CatType.TEST,
+            moons=20,
+            status_dict={"rank": CatRank.WARRIOR},
+            disable_random=True,
+        )
+        cat4 = CatFactory.create_cat(
+            CatType.TEST,
+            moons=20,
+            status_dict={"rank": CatRank.WARRIOR},
+            disable_random=True,
+        )
+
+        med1 = CatFactory.create_cat(
+            CatType.TEST,
+            moons=20,
+            status_dict={"rank": CatRank.MEDICINE_CAT},
+            disable_random=True,
+        )
+        med2 = CatFactory.create_cat(
+            CatType.TEST,
+            moons=20,
+            status_dict={"rank": CatRank.MEDICINE_CAT},
+            disable_random=True,
         )
 
         all_cats = [cat1, cat2, cat3, cat4, med1, med2]
         self.assertTrue(medicine_cats_can_cover_clan(all_cats, 2))
 
     def test_injured_fulfilled(self):
-        cat1 = Cat(moons=20, status_dict={"rank": CatRank.WARRIOR}, disable_random=True)
+        cat1 = CatFactory.create_cat(
+            CatType.TEST,
+            moons=20,
+            status_dict={"rank": CatRank.WARRIOR},
+            disable_random=True,
+        )
 
-        med = Cat(
-            moons=20, status_dict={"rank": CatRank.MEDICINE_CAT}, disable_random=True
+        med = CatFactory.create_cat(
+            CatType.TEST,
+            moons=20,
+            status_dict={"rank": CatRank.MEDICINE_CAT},
+            disable_random=True,
         )
         med.injuries["small cut"] = {"severity": "minor"}
 
@@ -49,10 +93,18 @@ class TestsMedCondition(unittest.TestCase):
         self.assertTrue(medicine_cats_can_cover_clan(all_cats, 15))
 
     def test_illness_fulfilled(self):
-        cat1 = Cat(moons=20, status_dict={"rank": CatRank.WARRIOR}, disable_random=True)
+        cat1 = CatFactory.create_cat(
+            CatType.TEST,
+            moons=20,
+            status_dict={"rank": CatRank.WARRIOR},
+            disable_random=True,
+        )
 
-        med = Cat(
-            moons=20, status_dict={"rank": CatRank.MEDICINE_CAT}, disable_random=True
+        med = CatFactory.create_cat(
+            CatType.TEST,
+            moons=20,
+            status_dict={"rank": CatRank.MEDICINE_CAT},
+            disable_random=True,
         )
         med.illnesses["running nose"] = {"severity": "minor"}
 

--- a/tests/test_event_filters.py
+++ b/tests/test_event_filters.py
@@ -1,6 +1,7 @@
 import unittest
 
-from scripts.cat.cats import Cat, create_cat
+from scripts.cat.cats import Cat
+from scripts.cat.factories.create_cat import create_cat
 from scripts.cat.enums import CatRank
 from scripts.clan import Clan
 from scripts.events_module.event_filters import (

--- a/tests/test_event_filters.py
+++ b/tests/test_event_filters.py
@@ -1,16 +1,17 @@
 import unittest
+from random import Random
 
-from scripts.cat.cats import Cat
-from scripts.cat.factories.create_cat import create_cat
 from scripts.cat.enums import CatRank
+from scripts.cat.factories.test_cat_factory import TestCatFactory
 from scripts.clan import Clan
 from scripts.events_module.event_filters import (
     event_for_location,
     event_for_season,
     event_for_tags,
-    event_for_cat,
 )
 from scripts.game_structure import game
+
+cat_factory = TestCatFactory(rng=Random())
 
 
 class TestEventFilters(unittest.TestCase):
@@ -22,7 +23,7 @@ class TestEventFilters(unittest.TestCase):
         game.clan.starting_season = "Newleaf"
         game.clan.game_mode = "classic"
 
-        self.test_cat = create_cat(CatRank.LEADER, moons=50)
+        self.test_cat = cat_factory.create_cat(rank=CatRank.LEADER, moons=50)
         game.clan.leader = self.test_cat
 
     def test_location(self):

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,28 +1,29 @@
+import os
+import shutil
 import unittest
 from pathlib import Path
-from random import choice
+from random import choice, Random
 from uuid import uuid4
 
-import shutil
-import os
-
+from scripts import events
 from scripts.cat import save_load
 from scripts.cat.cats import Cat
-from scripts.cat.factories.create_cat import create_cat
 from scripts.cat.enums import CatRank
+from scripts.cat.factories.test_cat_factory import TestCatFactory
 from scripts.cat.sprites.load_sprites import sprites
 from scripts.clan import Clan, Afterlife
+from scripts.clan_package.get_clan_cats import (
+    get_living_clan_cat_count,
+)
 from scripts.clan_package.settings import set_clan_setting
-from scripts import events
 from scripts.events_module.short.short_event_generation import (
     filter_events,
 )
 from scripts.game_structure import game
-from scripts.clan_package.get_clan_cats import (
-    get_living_clan_cat_count,
-)
 from scripts.game_structure.game.save_load import read_clans
 from scripts.housekeeping.datadir import get_save_dir
+
+cat_factory = TestCatFactory(rng=Random())
 
 
 class TestEvents(unittest.TestCase):
@@ -42,26 +43,27 @@ class TestEvents(unittest.TestCase):
         game.clan = Clan(
             name=cls.test_clan_name,
             displayname="Test",
-            leader=create_cat(CatRank.LEADER),
-            deputy=create_cat(CatRank.DEPUTY),
-            medicine_cat=create_cat(CatRank.MEDICINE_CAT),
+            leader=cat_factory.create_cat(rank=CatRank.LEADER),
+            deputy=cat_factory.create_cat(rank=CatRank.DEPUTY),
+            medicine_cat=cat_factory.create_cat(rank=CatRank.MEDICINE_CAT),
             biome="Forest",
             camp_bg="camp1",
             symbol="symbolADDER0",
             game_mode="expanded",
             starting_members=[
-                create_cat(
-                    choice(
-                        [
-                            CatRank.KITTEN,
-                            CatRank.APPRENTICE,
-                            CatRank.WARRIOR,
-                            CatRank.WARRIOR,
-                            CatRank.ELDER,
-                        ]
-                    )
-                )
-                for _ in range(10)
+                cat_factory.create_cat(rank=rank)
+                for rank in [
+                    CatRank.KITTEN,
+                    CatRank.APPRENTICE,
+                    CatRank.APPRENTICE,
+                    CatRank.WARRIOR,
+                    CatRank.WARRIOR,
+                    CatRank.WARRIOR,
+                    CatRank.WARRIOR,
+                    CatRank.WARRIOR,
+                    CatRank.WARRIOR,
+                    CatRank.ELDER,
+                ]
             ],
             starting_season="Newleaf",
         )
@@ -127,8 +129,8 @@ class TestEvents(unittest.TestCase):
                     # to give a good chance for event variety without bloat
                     while get_living_clan_cat_count(Cat) < 8:
                         game.clan.add_cat(
-                            create_cat(
-                                choice(
+                            cat_factory.create_cat(
+                                rank=choice(
                                     [
                                         CatRank.KITTEN,
                                         CatRank.APPRENTICE,

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -7,7 +7,8 @@ import shutil
 import os
 
 from scripts.cat import save_load
-from scripts.cat.cats import create_cat, Cat
+from scripts.cat.cats import Cat
+from scripts.cat.factories.create_cat import create_cat
 from scripts.cat.enums import CatRank
 from scripts.cat.sprites.load_sprites import sprites
 from scripts.clan import Clan, Afterlife

--- a/tests/test_filter_patrol.py
+++ b/tests/test_filter_patrol.py
@@ -1,6 +1,9 @@
 import os
 import unittest
 
+from scripts.cat.factories.cat_factory import CatFactory
+from scripts.cat.factories.enums import CatType
+
 os.environ["SDL_VIDEODRIVER"] = "dummy"
 os.environ["SDL_AUDIODRIVER"] = "dummy"
 
@@ -19,9 +22,13 @@ from scripts.events_module.event_filters import filter_relationship_type
 class TestRelationshipConstraintPatrols(unittest.TestCase):
     def test_sibling_patrol(self):
         # given
-        parent = Cat(disable_random=True)
-        cat1 = Cat(parent1=parent.ID, disable_random=True)
-        cat2 = Cat(parent1=parent.ID, disable_random=True)
+        parent = CatFactory.create_cat(CatType.TEST, disable_random=True)
+        cat1 = CatFactory.create_cat(
+            CatType.TEST, parent1=parent.ID, disable_random=True
+        )
+        cat2 = CatFactory.create_cat(
+            CatType.TEST, parent1=parent.ID, disable_random=True
+        )
         cat1.create_inheritance_new_cat()
         cat2.create_inheritance_new_cat()
 
@@ -79,9 +86,9 @@ class TestRelationshipConstraintPatrols(unittest.TestCase):
 
     def test_mates_patrol(self):
         # given
-        mate1 = Cat(disable_random=True)
-        mate2 = Cat(disable_random=True)
-        cat1 = Cat(disable_random=True)
+        mate1 = CatFactory.create_cat(CatType.TEST, disable_random=True)
+        mate2 = CatFactory.create_cat(CatType.TEST, disable_random=True)
+        cat1 = CatFactory.create_cat(CatType.TEST, disable_random=True)
 
         mate1.mate.append(mate2.ID)
         mate2.mate.append(mate1.ID)
@@ -154,9 +161,13 @@ class TestRelationshipConstraintPatrols(unittest.TestCase):
 
     def test_parent_child_patrol(self):
         # given
-        parent = Cat(disable_random=True)
-        cat1 = Cat(parent1=parent.ID, disable_random=True)
-        cat2 = Cat(parent1=parent.ID, disable_random=True)
+        parent = CatFactory.create_cat(CatType.TEST, disable_random=True)
+        cat1 = CatFactory.create_cat(
+            CatType.TEST, parent1=parent.ID, disable_random=True
+        )
+        cat2 = CatFactory.create_cat(
+            CatType.TEST, parent1=parent.ID, disable_random=True
+        )
 
         # when
         con_patrol_event = PatrolEvent(patrol_id="test1")
@@ -233,9 +244,13 @@ class TestRelationshipConstraintPatrols(unittest.TestCase):
 
     def test_child_parent_patrol(self):
         # given
-        parent = Cat(disable_random=True)
-        cat1 = Cat(parent1=parent.ID, disable_random=True)
-        cat2 = Cat(parent1=parent.ID, disable_random=True)
+        parent = CatFactory.create_cat(CatType.TEST, disable_random=True)
+        cat1 = CatFactory.create_cat(
+            CatType.TEST, parent1=parent.ID, disable_random=True
+        )
+        cat2 = CatFactory.create_cat(
+            CatType.TEST, parent1=parent.ID, disable_random=True
+        )
 
         # when
         con_patrol_event = PatrolEvent(patrol_id="test1")
@@ -312,8 +327,8 @@ class TestRelationshipConstraintPatrols(unittest.TestCase):
 
     def test_romantic_constraint_patrol(self):
         # given
-        cat1 = Cat(disable_random=True)
-        cat2 = Cat(disable_random=True)
+        cat1 = CatFactory.create_cat(CatType.TEST, disable_random=True)
+        cat2 = CatFactory.create_cat(CatType.TEST, disable_random=True)
 
         relationship1 = Relationship(cat1, cat2)
         relationship2 = Relationship(cat2, cat1)
@@ -380,8 +395,8 @@ class TestRelationshipConstraintPatrols(unittest.TestCase):
 
     def test_platonic_constraint_patrol(self):
         # given
-        cat1 = Cat(disable_random=True)
-        cat2 = Cat(disable_random=True)
+        cat1 = CatFactory.create_cat(CatType.TEST, disable_random=True)
+        cat2 = CatFactory.create_cat(CatType.TEST, disable_random=True)
 
         relationship1 = Relationship(cat1, cat2)
         relationship2 = Relationship(cat2, cat1)
@@ -447,8 +462,8 @@ class TestRelationshipConstraintPatrols(unittest.TestCase):
 
     def test_dislike_constraint_patrol(self):
         # given
-        cat1 = Cat(disable_random=True)
-        cat2 = Cat(disable_random=True)
+        cat1 = CatFactory.create_cat(CatType.TEST, disable_random=True)
+        cat2 = CatFactory.create_cat(CatType.TEST, disable_random=True)
 
         relationship1 = Relationship(cat1, cat2)
         relationship2 = Relationship(cat2, cat1)
@@ -515,8 +530,8 @@ class TestRelationshipConstraintPatrols(unittest.TestCase):
 
     def test_comfort_constraint_patrol(self):
         # given
-        cat1 = Cat(disable_random=True)
-        cat2 = Cat(disable_random=True)
+        cat1 = CatFactory.create_cat(CatType.TEST, disable_random=True)
+        cat2 = CatFactory.create_cat(CatType.TEST, disable_random=True)
 
         relationship1 = Relationship(cat1, cat2)
         relationship2 = Relationship(cat2, cat1)
@@ -583,8 +598,8 @@ class TestRelationshipConstraintPatrols(unittest.TestCase):
 
     def test_jealousy_patrol(self):
         # given
-        cat1 = Cat(disable_random=True)
-        cat2 = Cat(disable_random=True)
+        cat1 = CatFactory.create_cat(CatType.TEST, disable_random=True)
+        cat2 = CatFactory.create_cat(CatType.TEST, disable_random=True)
 
         relationship1 = Relationship(cat1, cat2)
         relationship2 = Relationship(cat2, cat1)
@@ -651,8 +666,8 @@ class TestRelationshipConstraintPatrols(unittest.TestCase):
 
     def test_trust_patrol(self):
         # given
-        cat1 = Cat(disable_random=True)
-        cat2 = Cat(disable_random=True)
+        cat1 = CatFactory.create_cat(CatType.TEST, disable_random=True)
+        cat2 = CatFactory.create_cat(CatType.TEST, disable_random=True)
 
         relationship1 = Relationship(cat1, cat2)
         relationship2 = Relationship(cat2, cat1)
@@ -719,9 +734,9 @@ class TestRelationshipConstraintPatrols(unittest.TestCase):
 
     def test_multiple_romantic_patrol(self):
         # given
-        cat1 = Cat(disable_random=True)
-        cat2 = Cat(disable_random=True)
-        cat3 = Cat(disable_random=True)
+        cat1 = CatFactory.create_cat(CatType.TEST, disable_random=True)
+        cat2 = CatFactory.create_cat(CatType.TEST, disable_random=True)
+        cat3 = CatFactory.create_cat(CatType.TEST, disable_random=True)
 
         relationship1_2 = Relationship(cat1, cat2)
         relationship1_3 = Relationship(cat1, cat3)
@@ -830,8 +845,8 @@ class TestRelationshipConstraintPatrols(unittest.TestCase):
 
     def test_multiple_constraint_patrol(self):
         # given
-        cat1 = Cat(disable_random=True)
-        cat2 = Cat(disable_random=True)
+        cat1 = CatFactory.create_cat(CatType.TEST, disable_random=True)
+        cat2 = CatFactory.create_cat(CatType.TEST, disable_random=True)
 
         relationship1 = Relationship(cat1, cat2)
         relationship2 = Relationship(cat2, cat1)

--- a/tests/test_filter_patrol.py
+++ b/tests/test_filter_patrol.py
@@ -1,13 +1,12 @@
 import os
 import unittest
+from random import Random
 
-from scripts.cat.factories.cat_factory import CatFactory
-from scripts.cat.factories.enums import CatType
+from scripts.cat.factories.test_cat_factory import TestCatFactory
 
 os.environ["SDL_VIDEODRIVER"] = "dummy"
 os.environ["SDL_AUDIODRIVER"] = "dummy"
 
-from scripts.cat.cats import Cat
 from scripts.cat_relations.relationship import Relationship
 from scripts.clan import Clan
 from scripts.events_module.patrol.patrol import PatrolEvent, Patrol
@@ -19,16 +18,15 @@ from scripts.events_module.event_filters import filter_relationship_type
 # so they are not failing!
 
 
+cat_factory = TestCatFactory(rng=Random())
+
+
 class TestRelationshipConstraintPatrols(unittest.TestCase):
     def test_sibling_patrol(self):
         # given
-        parent = CatFactory.create_cat(CatType.TEST, disable_random=True)
-        cat1 = CatFactory.create_cat(
-            CatType.TEST, parent1=parent.ID, disable_random=True
-        )
-        cat2 = CatFactory.create_cat(
-            CatType.TEST, parent1=parent.ID, disable_random=True
-        )
+        parent = cat_factory.create_cat(disable_random=True)
+        cat1 = cat_factory.create_cat(parent1=parent.ID, disable_random=True)
+        cat2 = cat_factory.create_cat(parent1=parent.ID, disable_random=True)
         cat1.create_inheritance_new_cat()
         cat2.create_inheritance_new_cat()
 
@@ -86,9 +84,9 @@ class TestRelationshipConstraintPatrols(unittest.TestCase):
 
     def test_mates_patrol(self):
         # given
-        mate1 = CatFactory.create_cat(CatType.TEST, disable_random=True)
-        mate2 = CatFactory.create_cat(CatType.TEST, disable_random=True)
-        cat1 = CatFactory.create_cat(CatType.TEST, disable_random=True)
+        mate1 = cat_factory.create_cat(disable_random=True)
+        mate2 = cat_factory.create_cat(disable_random=True)
+        cat1 = cat_factory.create_cat(disable_random=True)
 
         mate1.mate.append(mate2.ID)
         mate2.mate.append(mate1.ID)
@@ -161,13 +159,9 @@ class TestRelationshipConstraintPatrols(unittest.TestCase):
 
     def test_parent_child_patrol(self):
         # given
-        parent = CatFactory.create_cat(CatType.TEST, disable_random=True)
-        cat1 = CatFactory.create_cat(
-            CatType.TEST, parent1=parent.ID, disable_random=True
-        )
-        cat2 = CatFactory.create_cat(
-            CatType.TEST, parent1=parent.ID, disable_random=True
-        )
+        parent = cat_factory.create_cat(disable_random=True)
+        cat1 = cat_factory.create_cat(parent1=parent.ID, disable_random=True)
+        cat2 = cat_factory.create_cat(parent1=parent.ID, disable_random=True)
 
         # when
         con_patrol_event = PatrolEvent(patrol_id="test1")
@@ -244,13 +238,9 @@ class TestRelationshipConstraintPatrols(unittest.TestCase):
 
     def test_child_parent_patrol(self):
         # given
-        parent = CatFactory.create_cat(CatType.TEST, disable_random=True)
-        cat1 = CatFactory.create_cat(
-            CatType.TEST, parent1=parent.ID, disable_random=True
-        )
-        cat2 = CatFactory.create_cat(
-            CatType.TEST, parent1=parent.ID, disable_random=True
-        )
+        parent = cat_factory.create_cat(disable_random=True)
+        cat1 = cat_factory.create_cat(parent1=parent.ID, disable_random=True)
+        cat2 = cat_factory.create_cat(parent1=parent.ID, disable_random=True)
 
         # when
         con_patrol_event = PatrolEvent(patrol_id="test1")
@@ -327,8 +317,8 @@ class TestRelationshipConstraintPatrols(unittest.TestCase):
 
     def test_romantic_constraint_patrol(self):
         # given
-        cat1 = CatFactory.create_cat(CatType.TEST, disable_random=True)
-        cat2 = CatFactory.create_cat(CatType.TEST, disable_random=True)
+        cat1 = cat_factory.create_cat(disable_random=True)
+        cat2 = cat_factory.create_cat(disable_random=True)
 
         relationship1 = Relationship(cat1, cat2)
         relationship2 = Relationship(cat2, cat1)
@@ -395,8 +385,8 @@ class TestRelationshipConstraintPatrols(unittest.TestCase):
 
     def test_platonic_constraint_patrol(self):
         # given
-        cat1 = CatFactory.create_cat(CatType.TEST, disable_random=True)
-        cat2 = CatFactory.create_cat(CatType.TEST, disable_random=True)
+        cat1 = cat_factory.create_cat(disable_random=True)
+        cat2 = cat_factory.create_cat(disable_random=True)
 
         relationship1 = Relationship(cat1, cat2)
         relationship2 = Relationship(cat2, cat1)
@@ -462,8 +452,8 @@ class TestRelationshipConstraintPatrols(unittest.TestCase):
 
     def test_dislike_constraint_patrol(self):
         # given
-        cat1 = CatFactory.create_cat(CatType.TEST, disable_random=True)
-        cat2 = CatFactory.create_cat(CatType.TEST, disable_random=True)
+        cat1 = cat_factory.create_cat(disable_random=True)
+        cat2 = cat_factory.create_cat(disable_random=True)
 
         relationship1 = Relationship(cat1, cat2)
         relationship2 = Relationship(cat2, cat1)
@@ -530,8 +520,8 @@ class TestRelationshipConstraintPatrols(unittest.TestCase):
 
     def test_comfort_constraint_patrol(self):
         # given
-        cat1 = CatFactory.create_cat(CatType.TEST, disable_random=True)
-        cat2 = CatFactory.create_cat(CatType.TEST, disable_random=True)
+        cat1 = cat_factory.create_cat(disable_random=True)
+        cat2 = cat_factory.create_cat(disable_random=True)
 
         relationship1 = Relationship(cat1, cat2)
         relationship2 = Relationship(cat2, cat1)
@@ -598,8 +588,8 @@ class TestRelationshipConstraintPatrols(unittest.TestCase):
 
     def test_jealousy_patrol(self):
         # given
-        cat1 = CatFactory.create_cat(CatType.TEST, disable_random=True)
-        cat2 = CatFactory.create_cat(CatType.TEST, disable_random=True)
+        cat1 = cat_factory.create_cat(disable_random=True)
+        cat2 = cat_factory.create_cat(disable_random=True)
 
         relationship1 = Relationship(cat1, cat2)
         relationship2 = Relationship(cat2, cat1)
@@ -666,8 +656,8 @@ class TestRelationshipConstraintPatrols(unittest.TestCase):
 
     def test_trust_patrol(self):
         # given
-        cat1 = CatFactory.create_cat(CatType.TEST, disable_random=True)
-        cat2 = CatFactory.create_cat(CatType.TEST, disable_random=True)
+        cat1 = cat_factory.create_cat(disable_random=True)
+        cat2 = cat_factory.create_cat(disable_random=True)
 
         relationship1 = Relationship(cat1, cat2)
         relationship2 = Relationship(cat2, cat1)
@@ -734,9 +724,9 @@ class TestRelationshipConstraintPatrols(unittest.TestCase):
 
     def test_multiple_romantic_patrol(self):
         # given
-        cat1 = CatFactory.create_cat(CatType.TEST, disable_random=True)
-        cat2 = CatFactory.create_cat(CatType.TEST, disable_random=True)
-        cat3 = CatFactory.create_cat(CatType.TEST, disable_random=True)
+        cat1 = cat_factory.create_cat(disable_random=True)
+        cat2 = cat_factory.create_cat(disable_random=True)
+        cat3 = cat_factory.create_cat(disable_random=True)
 
         relationship1_2 = Relationship(cat1, cat2)
         relationship1_3 = Relationship(cat1, cat3)
@@ -845,8 +835,8 @@ class TestRelationshipConstraintPatrols(unittest.TestCase):
 
     def test_multiple_constraint_patrol(self):
         # given
-        cat1 = CatFactory.create_cat(CatType.TEST, disable_random=True)
-        cat2 = CatFactory.create_cat(CatType.TEST, disable_random=True)
+        cat1 = cat_factory.create_cat(disable_random=True)
+        cat2 = cat_factory.create_cat(disable_random=True)
 
         relationship1 = Relationship(cat1, cat2)
         relationship2 = Relationship(cat2, cat1)

--- a/tests/test_freshkill.py
+++ b/tests/test_freshkill.py
@@ -1,10 +1,9 @@
 import os
 import shutil
 from pathlib import Path
+from random import Random
 
-from scripts.cat.factories.cat_factory import CatFactory
-from scripts.cat.factories.create_cat import create_cat
-from scripts.cat.factories.enums import CatType
+from scripts.cat.factories.test_cat_factory import TestCatFactory
 from scripts.game_structure.game.save_load import read_clans
 from scripts.housekeeping.datadir import get_save_dir
 
@@ -16,7 +15,6 @@ except ImportError:
 import unittest
 from uuid import uuid4
 
-import ujson
 
 from scripts.cat import save_load
 from scripts.cat.enums import CatRank
@@ -32,6 +30,9 @@ from scripts.cat.skills import Skill, SkillPath
 from scripts.clan import Clan, Afterlife
 from scripts.clan_resources.freshkill import FreshkillPile
 from scripts.clan_package.get_clan_cats import get_alive_clan_queens
+
+
+cat_factory = TestCatFactory(rng=Random())
 
 
 class FreshkillPileTest(unittest.TestCase):
@@ -57,16 +58,16 @@ class FreshkillPileTest(unittest.TestCase):
 
         # set up clan members and some helpful lists for us to use later
         self.warriors = [
-            create_cat(CatRank.WARRIOR, moons=199),
-            create_cat(CatRank.WARRIOR, moons=20),
-            create_cat(CatRank.WARRIOR, moons=13),
+            cat_factory.create_cat(rank=CatRank.WARRIOR, moons=199),
+            cat_factory.create_cat(rank=CatRank.WARRIOR, moons=20),
+            cat_factory.create_cat(rank=CatRank.WARRIOR, moons=13),
         ]
         self.apprentices = [
-            create_cat(CatRank.APPRENTICE, moons=11),
-            create_cat(CatRank.APPRENTICE, moons=7),
+            cat_factory.create_cat(rank=CatRank.APPRENTICE, moons=11),
+            cat_factory.create_cat(rank=CatRank.APPRENTICE, moons=7),
         ]
-        self.elder = create_cat(CatRank.ELDER, moons=200)
-        self.kitten = create_cat(CatRank.KITTEN, moons=3)
+        self.elder = cat_factory.create_cat(rank=CatRank.ELDER, moons=200)
+        self.kitten = cat_factory.create_cat(rank=CatRank.KITTEN, moons=3)
 
         members = [self.elder, self.kitten]
         members.extend(self.warriors)
@@ -77,9 +78,9 @@ class FreshkillPileTest(unittest.TestCase):
         game.clan = Clan(
             name=self.test_clan_name,
             displayname="Test",
-            leader=create_cat(CatRank.LEADER, moons=20),
-            deputy=create_cat(CatRank.DEPUTY, moons=20),
-            medicine_cat=create_cat(CatRank.MEDICINE_CAT, moons=20),
+            leader=cat_factory.create_cat(rank=CatRank.LEADER, moons=20),
+            deputy=cat_factory.create_cat(rank=CatRank.DEPUTY, moons=20),
+            medicine_cat=cat_factory.create_cat(rank=CatRank.MEDICINE_CAT, moons=20),
             biome="Forest",
             camp_bg="camp1",
             symbol="symbolADDER0",
@@ -451,22 +452,19 @@ class FreshkillPileTest(unittest.TestCase):
     def test_queen_handling(self) -> None:
         # given
         # young enough kid
-        mother = CatFactory.create_cat(
-            CatType.TEST,
+        mother = cat_factory.create_cat(
             status_dict={"rank": CatRank.WARRIOR},
             moons=1,
             disable_random=True,
         )
         mother.gender = "female"
-        father = CatFactory.create_cat(
-            CatType.TEST,
+        father = cat_factory.create_cat(
             status_dict={"rank": CatRank.WARRIOR},
             moons=1,
             disable_random=True,
         )
         father.gender = "male"
-        kid = CatFactory.create_cat(
-            CatType.TEST,
+        kid = cat_factory.create_cat(
             status_dict={"rank": CatRank.KITTEN},
             moons=1,
             disable_random=True,
@@ -475,8 +473,7 @@ class FreshkillPileTest(unittest.TestCase):
         kid.parent1 = father
         kid.parent2 = mother
 
-        no_parent = CatFactory.create_cat(
-            CatType.TEST,
+        no_parent = cat_factory.create_cat(
             status_dict={"rank": CatRank.WARRIOR},
             moons=1,
             disable_random=True,
@@ -516,21 +513,18 @@ class FreshkillPileTest(unittest.TestCase):
     def test_pregnant_handling(self) -> None:
         # given
         # young enough kid
-        pregnant_cat = CatFactory.create_cat(
-            CatType.TEST,
+        pregnant_cat = cat_factory.create_cat(
             status_dict={"rank": CatRank.WARRIOR},
             moons=1,
             disable_random=True,
         )
         pregnant_cat.injuries["pregnant"] = {"severity": "minor"}
-        cat2 = CatFactory.create_cat(
-            CatType.TEST,
+        cat2 = cat_factory.create_cat(
             status_dict={"rank": CatRank.WARRIOR},
             moons=1,
             disable_random=True,
         )
-        cat3 = CatFactory.create_cat(
-            CatType.TEST,
+        cat3 = cat_factory.create_cat(
             status_dict={"rank": CatRank.WARRIOR},
             moons=1,
             disable_random=True,

--- a/tests/test_freshkill.py
+++ b/tests/test_freshkill.py
@@ -2,6 +2,9 @@ import os
 import shutil
 from pathlib import Path
 
+from scripts.cat.factories.cat_factory import CatFactory
+from scripts.cat.factories.create_cat import create_cat
+from scripts.cat.factories.enums import CatType
 from scripts.game_structure.game.save_load import read_clans
 from scripts.housekeeping.datadir import get_save_dir
 
@@ -24,7 +27,7 @@ from scripts.game_structure import game
 os.environ["SDL_VIDEODRIVER"] = "dummy"
 os.environ["SDL_AUDIODRIVER"] = "dummy"
 
-from scripts.cat.cats import Cat, create_cat
+from scripts.cat.cats import Cat
 from scripts.cat.skills import Skill, SkillPath
 from scripts.clan import Clan, Afterlife
 from scripts.clan_resources.freshkill import FreshkillPile
@@ -54,16 +57,16 @@ class FreshkillPileTest(unittest.TestCase):
 
         # set up clan members and some helpful lists for us to use later
         self.warriors = [
-            create_cat(CatRank.WARRIOR),
-            create_cat(CatRank.WARRIOR),
-            create_cat(CatRank.WARRIOR),
+            create_cat(CatRank.WARRIOR, moons=199),
+            create_cat(CatRank.WARRIOR, moons=20),
+            create_cat(CatRank.WARRIOR, moons=13),
         ]
         self.apprentices = [
-            create_cat(CatRank.APPRENTICE),
-            create_cat(CatRank.APPRENTICE),
+            create_cat(CatRank.APPRENTICE, moons=11),
+            create_cat(CatRank.APPRENTICE, moons=7),
         ]
-        self.elder = create_cat(CatRank.ELDER)
-        self.kitten = create_cat(CatRank.KITTEN)
+        self.elder = create_cat(CatRank.ELDER, moons=200)
+        self.kitten = create_cat(CatRank.KITTEN, moons=3)
 
         members = [self.elder, self.kitten]
         members.extend(self.warriors)
@@ -74,9 +77,9 @@ class FreshkillPileTest(unittest.TestCase):
         game.clan = Clan(
             name=self.test_clan_name,
             displayname="Test",
-            leader=create_cat(CatRank.LEADER),
-            deputy=create_cat(CatRank.DEPUTY),
-            medicine_cat=create_cat(CatRank.MEDICINE_CAT),
+            leader=create_cat(CatRank.LEADER, moons=20),
+            deputy=create_cat(CatRank.DEPUTY, moons=20),
+            medicine_cat=create_cat(CatRank.MEDICINE_CAT, moons=20),
             biome="Forest",
             camp_bg="camp1",
             symbol="symbolADDER0",
@@ -448,21 +451,35 @@ class FreshkillPileTest(unittest.TestCase):
     def test_queen_handling(self) -> None:
         # given
         # young enough kid
-        mother = Cat(
-            status_dict={"rank": CatRank.WARRIOR}, moons=1, disable_random=True
+        mother = CatFactory.create_cat(
+            CatType.TEST,
+            status_dict={"rank": CatRank.WARRIOR},
+            moons=1,
+            disable_random=True,
         )
         mother.gender = "female"
-        father = Cat(
-            status_dict={"rank": CatRank.WARRIOR}, moons=1, disable_random=True
+        father = CatFactory.create_cat(
+            CatType.TEST,
+            status_dict={"rank": CatRank.WARRIOR},
+            moons=1,
+            disable_random=True,
         )
         father.gender = "male"
-        kid = Cat(status_dict={"rank": CatRank.KITTEN}, moons=1, disable_random=True)
+        kid = CatFactory.create_cat(
+            CatType.TEST,
+            status_dict={"rank": CatRank.KITTEN},
+            moons=1,
+            disable_random=True,
+        )
         kid.moons = 2
         kid.parent1 = father
         kid.parent2 = mother
 
-        no_parent = Cat(
-            status_dict={"rank": CatRank.WARRIOR}, moons=1, disable_random=True
+        no_parent = CatFactory.create_cat(
+            CatType.TEST,
+            status_dict={"rank": CatRank.WARRIOR},
+            moons=1,
+            disable_random=True,
         )
 
         freshkill_pile = FreshkillPile()
@@ -499,12 +516,25 @@ class FreshkillPileTest(unittest.TestCase):
     def test_pregnant_handling(self) -> None:
         # given
         # young enough kid
-        pregnant_cat = Cat(
-            status_dict={"rank": CatRank.WARRIOR}, moons=1, disable_random=True
+        pregnant_cat = CatFactory.create_cat(
+            CatType.TEST,
+            status_dict={"rank": CatRank.WARRIOR},
+            moons=1,
+            disable_random=True,
         )
         pregnant_cat.injuries["pregnant"] = {"severity": "minor"}
-        cat2 = Cat(status_dict={"rank": CatRank.WARRIOR}, moons=1, disable_random=True)
-        cat3 = Cat(status_dict={"rank": CatRank.WARRIOR}, moons=1, disable_random=True)
+        cat2 = CatFactory.create_cat(
+            CatType.TEST,
+            status_dict={"rank": CatRank.WARRIOR},
+            moons=1,
+            disable_random=True,
+        )
+        cat3 = CatFactory.create_cat(
+            CatType.TEST,
+            status_dict={"rank": CatRank.WARRIOR},
+            moons=1,
+            disable_random=True,
+        )
 
         freshkill_pile = FreshkillPile()
         # be able to feed one queen and some of the warrior

--- a/tests/test_group_interaction.py
+++ b/tests/test_group_interaction.py
@@ -1,21 +1,22 @@
 import os
 import unittest
-
-from scripts.cat.factories.cat_factory import CatFactory
-from scripts.cat.factories.enums import CatType
-from scripts.clan import Clan
+from random import Random
 
 from scripts.cat.enums import CatRank
+from scripts.cat.factories.test_cat_factory import TestCatFactory
+from scripts.clan import Clan
 
 os.environ["SDL_VIDEODRIVER"] = "dummy"
 os.environ["SDL_AUDIODRIVER"] = "dummy"
 
-from scripts.cat.cats import Cat, Relationship
+from scripts.cat.cats import Relationship
 from scripts.cat.skills import Skill, SkillPath
 from scripts.events_module.relationship.group_events import (
     GroupEvents,
     GroupInteraction,
 )
+
+cat_factory = TestCatFactory(rng=Random())
 
 
 class MainCatFiltering(unittest.TestCase):
@@ -33,9 +34,7 @@ class MainCatFiltering(unittest.TestCase):
     def test_main_cat_status_one(self):
         # given
         group_events = GroupEvents()
-        main_cat = CatFactory.create_cat(
-            CatType.TEST, status_dict={"rank": CatRank.WARRIOR}
-        )
+        main_cat = cat_factory.create_cat(status_dict={"rank": CatRank.WARRIOR})
         group_events.abbreviations_cat_id = {"m_c": main_cat.ID}
 
         interaction1 = GroupInteraction("1")
@@ -57,9 +56,7 @@ class MainCatFiltering(unittest.TestCase):
     def test_main_cat_status_all(self):
         # given
         group_events = GroupEvents()
-        main_cat = CatFactory.create_cat(
-            CatType.TEST, status_dict={"rank": CatRank.WARRIOR}
-        )
+        main_cat = cat_factory.create_cat(status_dict={"rank": CatRank.WARRIOR})
         group_events.abbreviations_cat_id = {"m_c": main_cat.ID}
 
         interaction1 = GroupInteraction("1")
@@ -82,9 +79,7 @@ class MainCatFiltering(unittest.TestCase):
     def test_main_cat_trait_one(self):
         # given
         group_events = GroupEvents()
-        main_cat = CatFactory.create_cat(
-            CatType.TEST,
-        )
+        main_cat = cat_factory.create_cat()
         main_cat.personality.trait = "calm"
         group_events.abbreviations_cat_id = {"m_c": main_cat.ID}
 
@@ -107,9 +102,7 @@ class MainCatFiltering(unittest.TestCase):
     def test_main_cat_trait_all(self):
         # given
         group_events = GroupEvents()
-        main_cat = CatFactory.create_cat(
-            CatType.TEST,
-        )
+        main_cat = cat_factory.create_cat()
         main_cat.personality.trait = "calm"
         group_events.abbreviations_cat_id = {"m_c": main_cat.ID}
 
@@ -133,7 +126,7 @@ class MainCatFiltering(unittest.TestCase):
     def test_main_cat_skill_one(self):
         # given
         group_events = GroupEvents()
-        main_cat = CatFactory.create_cat(CatType.TEST, moons=40)
+        main_cat = cat_factory.create_cat(moons=40)
         main_cat.skills.primary = Skill(SkillPath.HUNTER, points=9)
         main_cat.skills.secondary = Skill(SkillPath.SWIMMER, points=9)
         group_events.abbreviations_cat_id = {"m_c": main_cat.ID}
@@ -157,9 +150,7 @@ class MainCatFiltering(unittest.TestCase):
     def test_main_cat_skill_all(self):
         # given
         group_events = GroupEvents()
-        main_cat = CatFactory.create_cat(
-            CatType.TEST,
-        )
+        main_cat = cat_factory.create_cat()
         main_cat.skills.primary = Skill(SkillPath.HUNTER, 9)
         group_events.abbreviations_cat_id = {"m_c": main_cat.ID}
 
@@ -183,9 +174,7 @@ class MainCatFiltering(unittest.TestCase):
     def test_main_cat_backstory_one(self):
         # given
         group_events = GroupEvents()
-        main_cat = CatFactory.create_cat(
-            CatType.TEST,
-        )
+        main_cat = cat_factory.create_cat()
         main_cat.backstory = "clanborn"
         group_events.abbreviations_cat_id = {"m_c": main_cat.ID}
 
@@ -208,9 +197,7 @@ class MainCatFiltering(unittest.TestCase):
     def test_main_cat_backstory_all(self):
         # given
         group_events = GroupEvents()
-        main_cat = CatFactory.create_cat(
-            CatType.TEST,
-        )
+        main_cat = cat_factory.create_cat()
         main_cat.backstory = "clanborn"
         group_events.abbreviations_cat_id = {"m_c": main_cat.ID}
 
@@ -235,19 +222,11 @@ class MainCatFiltering(unittest.TestCase):
 class Abbreviations(unittest.TestCase):
     def test_get_abbreviation_possibilities_all(self):
         # given
-        main_cat = CatFactory.create_cat(
-            CatType.TEST, status_dict={"rank": CatRank.WARRIOR}
-        )
+        main_cat = cat_factory.create_cat(status_dict={"rank": CatRank.WARRIOR})
 
-        random1 = CatFactory.create_cat(
-            CatType.TEST, status_dict={"rank": CatRank.WARRIOR}
-        )
-        random2 = CatFactory.create_cat(
-            CatType.TEST, status_dict={"rank": CatRank.WARRIOR}
-        )
-        random3 = CatFactory.create_cat(
-            CatType.TEST, status_dict={"rank": CatRank.WARRIOR}
-        )
+        random1 = cat_factory.create_cat(status_dict={"rank": CatRank.WARRIOR})
+        random2 = cat_factory.create_cat(status_dict={"rank": CatRank.WARRIOR})
+        random3 = cat_factory.create_cat(status_dict={"rank": CatRank.WARRIOR})
 
         interaction1 = GroupInteraction("1")
         interaction1.status_constraint = {"r_c1": ["warrior"]}
@@ -273,19 +252,11 @@ class Abbreviations(unittest.TestCase):
 
     def test_get_abbreviation_possibilities_not_all(self):
         # given
-        main_cat = CatFactory.create_cat(
-            CatType.TEST, status_dict={"rank": CatRank.WARRIOR}
-        )
+        main_cat = cat_factory.create_cat(status_dict={"rank": CatRank.WARRIOR})
 
-        random1 = CatFactory.create_cat(
-            CatType.TEST, status_dict={"rank": CatRank.WARRIOR}
-        )
-        random2 = CatFactory.create_cat(
-            CatType.TEST, status_dict={"rank": CatRank.WARRIOR}
-        )
-        random3 = CatFactory.create_cat(
-            CatType.TEST, status_dict={"rank": CatRank.MEDICINE_CAT}
-        )
+        random1 = cat_factory.create_cat(status_dict={"rank": CatRank.WARRIOR})
+        random2 = cat_factory.create_cat(status_dict={"rank": CatRank.WARRIOR})
+        random3 = cat_factory.create_cat(status_dict={"rank": CatRank.MEDICINE_CAT})
 
         interaction1 = GroupInteraction("1")
         interaction1.status_constraint = {"r_c1": ["warrior"]}
@@ -334,20 +305,12 @@ class Abbreviations(unittest.TestCase):
 
     def test_set_abbreviations_cats(self):
         # given
-        main_cat = CatFactory.create_cat(
-            CatType.TEST, status_dict={"rank": CatRank.WARRIOR}
-        )
+        main_cat = cat_factory.create_cat(status_dict={"rank": CatRank.WARRIOR})
         abbreviations_cat_id = {"m_c": main_cat.ID, "r_c1": None, "r_c2": None}
 
-        random1 = CatFactory.create_cat(
-            CatType.TEST, status_dict={"rank": CatRank.WARRIOR}
-        )
-        random2 = CatFactory.create_cat(
-            CatType.TEST, status_dict={"rank": CatRank.WARRIOR}
-        )
-        random3 = CatFactory.create_cat(
-            CatType.TEST, status_dict={"rank": CatRank.MEDICINE_CAT}
-        )
+        random1 = cat_factory.create_cat(status_dict={"rank": CatRank.WARRIOR})
+        random2 = cat_factory.create_cat(status_dict={"rank": CatRank.WARRIOR})
+        random3 = cat_factory.create_cat(status_dict={"rank": CatRank.MEDICINE_CAT})
 
         # when
         interaction_cats = [random1, random2, random3]
@@ -370,17 +333,13 @@ class Abbreviations(unittest.TestCase):
 class OtherCatsFiltering(unittest.TestCase):
     def test_relationship_allow_true(self):
         # given
-        parent = CatFactory.create_cat(
-            CatType.TEST,
+        parent = cat_factory.create_cat()
+        main_cat = cat_factory.create_cat(
+            parent1=parent.ID, status_dict={"rank": CatRank.WARRIOR}
         )
-        main_cat = CatFactory.create_cat(
-            CatType.TEST, parent1=parent.ID, status_dict={"rank": CatRank.WARRIOR}
-        )
-        random1 = CatFactory.create_cat(
-            CatType.TEST, status_dict={"rank": CatRank.WARRIOR}
-        )
-        random2 = CatFactory.create_cat(
-            CatType.TEST, parent1=parent.ID, status_dict={"rank": CatRank.WARRIOR}
+        random1 = cat_factory.create_cat(status_dict={"rank": CatRank.WARRIOR})
+        random2 = cat_factory.create_cat(
+            parent1=parent.ID, status_dict={"rank": CatRank.WARRIOR}
         )
         abbreviations_cat_id = {
             "m_c": main_cat.ID,
@@ -530,18 +489,14 @@ class OtherCatsFiltering(unittest.TestCase):
 
     def test_relationship_allow_false(self):
         # given
-        parent = CatFactory.create_cat(
-            CatType.TEST,
+        parent = cat_factory.create_cat()
+        main_cat = cat_factory.create_cat(
+            parent1=parent.ID, status_dict={"rank": CatRank.WARRIOR}
         )
-        main_cat = CatFactory.create_cat(
-            CatType.TEST, parent1=parent.ID, status_dict={"rank": CatRank.WARRIOR}
+        random1 = cat_factory.create_cat(
+            parent1=parent.ID, status_dict={"rank": CatRank.WARRIOR}
         )
-        random1 = CatFactory.create_cat(
-            CatType.TEST, parent1=parent.ID, status_dict={"rank": CatRank.WARRIOR}
-        )
-        random2 = CatFactory.create_cat(
-            CatType.TEST, status_dict={"rank": CatRank.WARRIOR}
-        )
+        random2 = cat_factory.create_cat(status_dict={"rank": CatRank.WARRIOR})
         abbreviations_cat_id = {
             "m_c": main_cat.ID,
             "r_c1": random1.ID,

--- a/tests/test_group_interaction.py
+++ b/tests/test_group_interaction.py
@@ -1,6 +1,8 @@
 import os
 import unittest
 
+from scripts.cat.factories.cat_factory import CatFactory
+from scripts.cat.factories.enums import CatType
 from scripts.clan import Clan
 
 from scripts.cat.enums import CatRank
@@ -31,7 +33,9 @@ class MainCatFiltering(unittest.TestCase):
     def test_main_cat_status_one(self):
         # given
         group_events = GroupEvents()
-        main_cat = Cat(status_dict={"rank": CatRank.WARRIOR})
+        main_cat = CatFactory.create_cat(
+            CatType.TEST, status_dict={"rank": CatRank.WARRIOR}
+        )
         group_events.abbreviations_cat_id = {"m_c": main_cat.ID}
 
         interaction1 = GroupInteraction("1")
@@ -53,7 +57,9 @@ class MainCatFiltering(unittest.TestCase):
     def test_main_cat_status_all(self):
         # given
         group_events = GroupEvents()
-        main_cat = Cat(status_dict={"rank": CatRank.WARRIOR})
+        main_cat = CatFactory.create_cat(
+            CatType.TEST, status_dict={"rank": CatRank.WARRIOR}
+        )
         group_events.abbreviations_cat_id = {"m_c": main_cat.ID}
 
         interaction1 = GroupInteraction("1")
@@ -76,7 +82,9 @@ class MainCatFiltering(unittest.TestCase):
     def test_main_cat_trait_one(self):
         # given
         group_events = GroupEvents()
-        main_cat = Cat()
+        main_cat = CatFactory.create_cat(
+            CatType.TEST,
+        )
         main_cat.personality.trait = "calm"
         group_events.abbreviations_cat_id = {"m_c": main_cat.ID}
 
@@ -99,7 +107,9 @@ class MainCatFiltering(unittest.TestCase):
     def test_main_cat_trait_all(self):
         # given
         group_events = GroupEvents()
-        main_cat = Cat()
+        main_cat = CatFactory.create_cat(
+            CatType.TEST,
+        )
         main_cat.personality.trait = "calm"
         group_events.abbreviations_cat_id = {"m_c": main_cat.ID}
 
@@ -123,7 +133,7 @@ class MainCatFiltering(unittest.TestCase):
     def test_main_cat_skill_one(self):
         # given
         group_events = GroupEvents()
-        main_cat = Cat(moons=40)
+        main_cat = CatFactory.create_cat(CatType.TEST, moons=40)
         main_cat.skills.primary = Skill(SkillPath.HUNTER, points=9)
         main_cat.skills.secondary = Skill(SkillPath.SWIMMER, points=9)
         group_events.abbreviations_cat_id = {"m_c": main_cat.ID}
@@ -147,7 +157,9 @@ class MainCatFiltering(unittest.TestCase):
     def test_main_cat_skill_all(self):
         # given
         group_events = GroupEvents()
-        main_cat = Cat()
+        main_cat = CatFactory.create_cat(
+            CatType.TEST,
+        )
         main_cat.skills.primary = Skill(SkillPath.HUNTER, 9)
         group_events.abbreviations_cat_id = {"m_c": main_cat.ID}
 
@@ -171,7 +183,9 @@ class MainCatFiltering(unittest.TestCase):
     def test_main_cat_backstory_one(self):
         # given
         group_events = GroupEvents()
-        main_cat = Cat()
+        main_cat = CatFactory.create_cat(
+            CatType.TEST,
+        )
         main_cat.backstory = "clanborn"
         group_events.abbreviations_cat_id = {"m_c": main_cat.ID}
 
@@ -194,7 +208,9 @@ class MainCatFiltering(unittest.TestCase):
     def test_main_cat_backstory_all(self):
         # given
         group_events = GroupEvents()
-        main_cat = Cat()
+        main_cat = CatFactory.create_cat(
+            CatType.TEST,
+        )
         main_cat.backstory = "clanborn"
         group_events.abbreviations_cat_id = {"m_c": main_cat.ID}
 
@@ -219,11 +235,19 @@ class MainCatFiltering(unittest.TestCase):
 class Abbreviations(unittest.TestCase):
     def test_get_abbreviation_possibilities_all(self):
         # given
-        main_cat = Cat(status_dict={"rank": CatRank.WARRIOR})
+        main_cat = CatFactory.create_cat(
+            CatType.TEST, status_dict={"rank": CatRank.WARRIOR}
+        )
 
-        random1 = Cat(status_dict={"rank": CatRank.WARRIOR})
-        random2 = Cat(status_dict={"rank": CatRank.WARRIOR})
-        random3 = Cat(status_dict={"rank": CatRank.WARRIOR})
+        random1 = CatFactory.create_cat(
+            CatType.TEST, status_dict={"rank": CatRank.WARRIOR}
+        )
+        random2 = CatFactory.create_cat(
+            CatType.TEST, status_dict={"rank": CatRank.WARRIOR}
+        )
+        random3 = CatFactory.create_cat(
+            CatType.TEST, status_dict={"rank": CatRank.WARRIOR}
+        )
 
         interaction1 = GroupInteraction("1")
         interaction1.status_constraint = {"r_c1": ["warrior"]}
@@ -249,11 +273,19 @@ class Abbreviations(unittest.TestCase):
 
     def test_get_abbreviation_possibilities_not_all(self):
         # given
-        main_cat = Cat(status_dict={"rank": CatRank.WARRIOR})
+        main_cat = CatFactory.create_cat(
+            CatType.TEST, status_dict={"rank": CatRank.WARRIOR}
+        )
 
-        random1 = Cat(status_dict={"rank": CatRank.WARRIOR})
-        random2 = Cat(status_dict={"rank": CatRank.WARRIOR})
-        random3 = Cat(status_dict={"rank": CatRank.MEDICINE_CAT})
+        random1 = CatFactory.create_cat(
+            CatType.TEST, status_dict={"rank": CatRank.WARRIOR}
+        )
+        random2 = CatFactory.create_cat(
+            CatType.TEST, status_dict={"rank": CatRank.WARRIOR}
+        )
+        random3 = CatFactory.create_cat(
+            CatType.TEST, status_dict={"rank": CatRank.MEDICINE_CAT}
+        )
 
         interaction1 = GroupInteraction("1")
         interaction1.status_constraint = {"r_c1": ["warrior"]}
@@ -302,12 +334,20 @@ class Abbreviations(unittest.TestCase):
 
     def test_set_abbreviations_cats(self):
         # given
-        main_cat = Cat(status_dict={"rank": CatRank.WARRIOR})
+        main_cat = CatFactory.create_cat(
+            CatType.TEST, status_dict={"rank": CatRank.WARRIOR}
+        )
         abbreviations_cat_id = {"m_c": main_cat.ID, "r_c1": None, "r_c2": None}
 
-        random1 = Cat(status_dict={"rank": CatRank.WARRIOR})
-        random2 = Cat(status_dict={"rank": CatRank.WARRIOR})
-        random3 = Cat(status_dict={"rank": CatRank.MEDICINE_CAT})
+        random1 = CatFactory.create_cat(
+            CatType.TEST, status_dict={"rank": CatRank.WARRIOR}
+        )
+        random2 = CatFactory.create_cat(
+            CatType.TEST, status_dict={"rank": CatRank.WARRIOR}
+        )
+        random3 = CatFactory.create_cat(
+            CatType.TEST, status_dict={"rank": CatRank.MEDICINE_CAT}
+        )
 
         # when
         interaction_cats = [random1, random2, random3]
@@ -330,10 +370,18 @@ class Abbreviations(unittest.TestCase):
 class OtherCatsFiltering(unittest.TestCase):
     def test_relationship_allow_true(self):
         # given
-        parent = Cat()
-        main_cat = Cat(parent1=parent.ID, status_dict={"rank": CatRank.WARRIOR})
-        random1 = Cat(status_dict={"rank": CatRank.WARRIOR})
-        random2 = Cat(parent1=parent.ID, status_dict={"rank": CatRank.WARRIOR})
+        parent = CatFactory.create_cat(
+            CatType.TEST,
+        )
+        main_cat = CatFactory.create_cat(
+            CatType.TEST, parent1=parent.ID, status_dict={"rank": CatRank.WARRIOR}
+        )
+        random1 = CatFactory.create_cat(
+            CatType.TEST, status_dict={"rank": CatRank.WARRIOR}
+        )
+        random2 = CatFactory.create_cat(
+            CatType.TEST, parent1=parent.ID, status_dict={"rank": CatRank.WARRIOR}
+        )
         abbreviations_cat_id = {
             "m_c": main_cat.ID,
             "r_c1": random1.ID,
@@ -482,10 +530,18 @@ class OtherCatsFiltering(unittest.TestCase):
 
     def test_relationship_allow_false(self):
         # given
-        parent = Cat()
-        main_cat = Cat(parent1=parent.ID, status_dict={"rank": CatRank.WARRIOR})
-        random1 = Cat(parent1=parent.ID, status_dict={"rank": CatRank.WARRIOR})
-        random2 = Cat(status_dict={"rank": CatRank.WARRIOR})
+        parent = CatFactory.create_cat(
+            CatType.TEST,
+        )
+        main_cat = CatFactory.create_cat(
+            CatType.TEST, parent1=parent.ID, status_dict={"rank": CatRank.WARRIOR}
+        )
+        random1 = CatFactory.create_cat(
+            CatType.TEST, parent1=parent.ID, status_dict={"rank": CatRank.WARRIOR}
+        )
+        random2 = CatFactory.create_cat(
+            CatType.TEST, status_dict={"rank": CatRank.WARRIOR}
+        )
         abbreviations_cat_id = {
             "m_c": main_cat.ID,
             "r_c1": random1.ID,

--- a/tests/test_handle_short_events.py
+++ b/tests/test_handle_short_events.py
@@ -1,26 +1,23 @@
 import os
 import unittest
+from random import Random
 
-from scripts.cat.factories.cat_factory import CatFactory
-from scripts.cat.factories.enums import CatType
+from scripts.cat.factories.test_cat_factory import TestCatFactory
 from scripts.events_module.short.short_event import ShortEvent
 
 os.environ["SDL_VIDEODRIVER"] = "dummy"
 os.environ["SDL_AUDIODRIVER"] = "dummy"
 
-from scripts.cat.cats import Cat
 from scripts.cat.pelts import Pelt
+
+cat_factory = TestCatFactory(rng=Random())
 
 
 class TestHandleEvent(unittest.TestCase):
     def setUp(self):
         self.chosen_event = ShortEvent(event_id="test")
-        self.chosen_event.main_cat = CatFactory.create_cat(
-            CatType.TEST,
-        )
-        self.chosen_event.random_cat = CatFactory.create_cat(
-            CatType.TEST,
-        )
+        self.chosen_event.main_cat = cat_factory.create_cat()
+        self.chosen_event.random_cat = cat_factory.create_cat()
 
     def test_mc_presence(self):
         # event should always use m_c by default
@@ -68,9 +65,7 @@ class TestHandleNewCats(unittest.TestCase):
 class TestHandleAccessories(unittest.TestCase):
     def setUp(self):
         self.chosen_event = ShortEvent(event_id="test", new_accessory=["TEST"])
-        self.chosen_event.main_cat = CatFactory.create_cat(
-            CatType.TEST, disable_random=True
-        )
+        self.chosen_event.main_cat = cat_factory.create_cat(disable_random=True)
         self.pelts = Pelt
 
     def assert_intersection(self, a, b):
@@ -134,8 +129,8 @@ class TestHandleTransition(unittest.TestCase):
             sub_type=["transition"],
             new_gender=["trans male", "nonbinary"],
         )
-        self.chosen_event.main_cat = CatFactory.create_cat(
-            CatType.TEST, gender="female", disable_random=True
+        self.chosen_event.main_cat = cat_factory.create_cat(
+            gender="female", disable_random=True
         )
 
     def test_cat_transitions(self):
@@ -165,12 +160,8 @@ class TestHandleInjury(unittest.TestCase):
             r_c={"age": "any"},
             injury=[{"cats": ["m_c"], "injuries": ["scrapes"]}],
         )
-        self.chosen_event.main_cat = CatFactory.create_cat(
-            CatType.TEST,
-        )
-        self.chosen_event.random_cat = CatFactory.create_cat(
-            CatType.TEST,
-        )
+        self.chosen_event.main_cat = cat_factory.create_cat()
+        self.chosen_event.random_cat = cat_factory.create_cat()
 
     def test_types(self):
         self.chosen_event.execute_event()

--- a/tests/test_handle_short_events.py
+++ b/tests/test_handle_short_events.py
@@ -1,6 +1,8 @@
 import os
 import unittest
 
+from scripts.cat.factories.cat_factory import CatFactory
+from scripts.cat.factories.enums import CatType
 from scripts.events_module.short.short_event import ShortEvent
 
 os.environ["SDL_VIDEODRIVER"] = "dummy"
@@ -13,8 +15,12 @@ from scripts.cat.pelts import Pelt
 class TestHandleEvent(unittest.TestCase):
     def setUp(self):
         self.chosen_event = ShortEvent(event_id="test")
-        self.chosen_event.main_cat = Cat()
-        self.chosen_event.random_cat = Cat()
+        self.chosen_event.main_cat = CatFactory.create_cat(
+            CatType.TEST,
+        )
+        self.chosen_event.random_cat = CatFactory.create_cat(
+            CatType.TEST,
+        )
 
     def test_mc_presence(self):
         # event should always use m_c by default
@@ -62,7 +68,9 @@ class TestHandleNewCats(unittest.TestCase):
 class TestHandleAccessories(unittest.TestCase):
     def setUp(self):
         self.chosen_event = ShortEvent(event_id="test", new_accessory=["TEST"])
-        self.chosen_event.main_cat = Cat(disable_random=True)
+        self.chosen_event.main_cat = CatFactory.create_cat(
+            CatType.TEST, disable_random=True
+        )
         self.pelts = Pelt
 
     def assert_intersection(self, a, b):
@@ -126,7 +134,9 @@ class TestHandleTransition(unittest.TestCase):
             sub_type=["transition"],
             new_gender=["trans male", "nonbinary"],
         )
-        self.chosen_event.main_cat = Cat(gender="female", disable_random=True)
+        self.chosen_event.main_cat = CatFactory.create_cat(
+            CatType.TEST, gender="female", disable_random=True
+        )
 
     def test_cat_transitions(self):
         self.chosen_event.execute_event()
@@ -155,8 +165,12 @@ class TestHandleInjury(unittest.TestCase):
             r_c={"age": "any"},
             injury=[{"cats": ["m_c"], "injuries": ["scrapes"]}],
         )
-        self.chosen_event.main_cat = Cat()
-        self.chosen_event.random_cat = Cat()
+        self.chosen_event.main_cat = CatFactory.create_cat(
+            CatType.TEST,
+        )
+        self.chosen_event.random_cat = CatFactory.create_cat(
+            CatType.TEST,
+        )
 
     def test_types(self):
         self.chosen_event.execute_event()

--- a/tests/test_interactions.py
+++ b/tests/test_interactions.py
@@ -1,6 +1,8 @@
 import os
 import unittest
 
+from scripts.cat.factories.cat_factory import CatFactory
+from scripts.cat.factories.enums import CatType
 from scripts.cat_relations.enums import rel_type_tiers
 
 from scripts.cat.enums import CatRank
@@ -19,9 +21,11 @@ from scripts.cat_relations.interaction import (
 class RelationshipConstraints(unittest.TestCase):
     def test_siblings(self):
         # given
-        parent = Cat()
-        cat_from = Cat(parent1=parent.ID)
-        cat_to = Cat(parent1=parent.ID)
+        parent = CatFactory.create_cat(
+            CatType.TEST,
+        )
+        cat_from = CatFactory.create_cat(CatType.TEST, parent1=parent.ID)
+        cat_to = CatFactory.create_cat(CatType.TEST, parent1=parent.ID)
         rel = Relationship(cat_from, cat_to, False, True)
 
         # then
@@ -34,8 +38,12 @@ class RelationshipConstraints(unittest.TestCase):
 
     def test_mates(self):
         # given
-        cat_from = Cat()
-        cat_to = Cat()
+        cat_from = CatFactory.create_cat(
+            CatType.TEST,
+        )
+        cat_to = CatFactory.create_cat(
+            CatType.TEST,
+        )
         cat_from.mate.append(cat_to.ID)
         cat_to.mate.append(cat_from.ID)
         rel = Relationship(cat_from, cat_to, True, False)
@@ -50,8 +58,10 @@ class RelationshipConstraints(unittest.TestCase):
 
     def test_parent_child_combo(self):
         # given
-        parent = Cat()
-        child = Cat(parent1=parent.ID)
+        parent = CatFactory.create_cat(
+            CatType.TEST,
+        )
+        child = CatFactory.create_cat(CatType.TEST, parent1=parent.ID)
 
         child_parent_rel = Relationship(child, parent, False, True)
         parent_child_rel = Relationship(parent, child, False, True)
@@ -80,8 +90,12 @@ class RelationshipConstraints(unittest.TestCase):
 
     def test_rel_values_only_constraint_pos(self):
         # given
-        cat_from1 = Cat()
-        cat_to1 = Cat()
+        cat_from1 = CatFactory.create_cat(
+            CatType.TEST,
+        )
+        cat_to1 = CatFactory.create_cat(
+            CatType.TEST,
+        )
         low_rel = Relationship(cat_from1, cat_to1)
         low_rel.romance = 10
         low_rel.like = 10
@@ -89,8 +103,12 @@ class RelationshipConstraints(unittest.TestCase):
         low_rel.trust = 10
         low_rel.respect = 10
 
-        cat_from2 = Cat()
-        cat_to2 = Cat()
+        cat_from2 = CatFactory.create_cat(
+            CatType.TEST,
+        )
+        cat_to2 = CatFactory.create_cat(
+            CatType.TEST,
+        )
         mid_rel = Relationship(cat_from2, cat_to2)
         mid_rel.romance = 50
         mid_rel.like = 50
@@ -98,8 +116,12 @@ class RelationshipConstraints(unittest.TestCase):
         mid_rel.trust = 50
         mid_rel.respect = 50
 
-        cat_from3 = Cat()
-        cat_to3 = Cat()
+        cat_from3 = CatFactory.create_cat(
+            CatType.TEST,
+        )
+        cat_to3 = CatFactory.create_cat(
+            CatType.TEST,
+        )
         high_rel = Relationship(cat_from3, cat_to3)
         high_rel.romance = 90
         high_rel.like = 90
@@ -163,24 +185,36 @@ class RelationshipConstraints(unittest.TestCase):
 
     def test_rel_values_only_constraint_neg(self):
         # given
-        cat_from1 = Cat()
-        cat_to1 = Cat()
+        cat_from1 = CatFactory.create_cat(
+            CatType.TEST,
+        )
+        cat_to1 = CatFactory.create_cat(
+            CatType.TEST,
+        )
         mid_rel = Relationship(cat_from1, cat_to1)
         mid_rel.romance = -50
         mid_rel.like = -50
         mid_rel.comfort = -50
         mid_rel.trust = -50
 
-        cat_from2 = Cat()
-        cat_to2 = Cat()
+        cat_from2 = CatFactory.create_cat(
+            CatType.TEST,
+        )
+        cat_to2 = CatFactory.create_cat(
+            CatType.TEST,
+        )
         low_rel = Relationship(cat_from2, cat_to2)
         low_rel.romance = -10
         low_rel.like = -10
         low_rel.comfort = -10
         low_rel.trust = -10
 
-        cat_from3 = Cat()
-        cat_to3 = Cat()
+        cat_from3 = CatFactory.create_cat(
+            CatType.TEST,
+        )
+        cat_to3 = CatFactory.create_cat(
+            CatType.TEST,
+        )
         high_rel = Relationship(cat_from3, cat_to3)
         high_rel.romance = -90
         high_rel.like = -90
@@ -244,8 +278,12 @@ class RelationshipConstraints(unittest.TestCase):
     def test_rel_values_ranged_constraint(self):
         # given
         # pos side
-        cat_from1 = Cat()
-        cat_to1 = Cat()
+        cat_from1 = CatFactory.create_cat(
+            CatType.TEST,
+        )
+        cat_to1 = CatFactory.create_cat(
+            CatType.TEST,
+        )
         high_rel = Relationship(cat_from1, cat_to1)
         high_rel.romance = 90
         high_rel.like = 90
@@ -254,8 +292,12 @@ class RelationshipConstraints(unittest.TestCase):
         high_rel.respect = 90
 
         # neg side
-        cat_from1 = Cat()
-        cat_to1 = Cat()
+        cat_from1 = CatFactory.create_cat(
+            CatType.TEST,
+        )
+        cat_to1 = CatFactory.create_cat(
+            CatType.TEST,
+        )
         high_rel = Relationship(cat_from1, cat_to1)
         high_rel.romance = -90
         high_rel.like = -90
@@ -318,8 +360,12 @@ class RelationshipConstraints(unittest.TestCase):
 class SingleInteractionCatConstraints(unittest.TestCase):
     def test_status(self):
         # given
-        warrior = Cat(status_dict={"rank": CatRank.WARRIOR})
-        medicine = Cat(status_dict={"rank": CatRank.MEDICINE_CAT})
+        warrior = CatFactory.create_cat(
+            CatType.TEST, status_dict={"rank": CatRank.WARRIOR}
+        )
+        medicine = CatFactory.create_cat(
+            CatType.TEST, status_dict={"rank": CatRank.MEDICINE_CAT}
+        )
 
         # when
         warrior_to_all = SingleInteraction("test")
@@ -385,9 +431,13 @@ class SingleInteractionCatConstraints(unittest.TestCase):
 
     def test_trait(self):
         # given
-        calm = Cat()
+        calm = CatFactory.create_cat(
+            CatType.TEST,
+        )
         calm.personality.trait = "calm"
-        troublesome = Cat()
+        troublesome = CatFactory.create_cat(
+            CatType.TEST,
+        )
         troublesome.personality.trait = "troublesome"
 
         # when
@@ -423,9 +473,9 @@ class SingleInteractionCatConstraints(unittest.TestCase):
 
     def test_skill(self):
         # given
-        hunter = Cat(disable_random=True)
+        hunter = CatFactory.create_cat(CatType.TEST, disable_random=True)
         hunter.skills.primary = Skill(SkillPath.HUNTER, points=9)
-        fighter = Cat(disable_random=True)
+        fighter = CatFactory.create_cat(CatType.TEST, disable_random=True)
         fighter.skills.primary = Skill(SkillPath.FIGHTER, points=9)
 
         # when
@@ -461,9 +511,13 @@ class SingleInteractionCatConstraints(unittest.TestCase):
 
     def test_background(self):
         # given
-        clan = Cat()
+        clan = CatFactory.create_cat(
+            CatType.TEST,
+        )
         clan.backstory = "clanborn"
-        half = Cat()
+        half = CatFactory.create_cat(
+            CatType.TEST,
+        )
         half.backstory = "halfclan1"
 
         # when

--- a/tests/test_interactions.py
+++ b/tests/test_interactions.py
@@ -1,31 +1,30 @@
 import os
 import unittest
-
-from scripts.cat.factories.cat_factory import CatFactory
-from scripts.cat.factories.enums import CatType
-from scripts.cat_relations.enums import rel_type_tiers
+from random import Random
 
 from scripts.cat.enums import CatRank
+from scripts.cat.factories.test_cat_factory import TestCatFactory
+from scripts.cat_relations.enums import rel_type_tiers
 
 os.environ["SDL_VIDEODRIVER"] = "dummy"
 os.environ["SDL_AUDIODRIVER"] = "dummy"
 
-from scripts.cat.cats import Cat, Relationship
+from scripts.cat.cats import Relationship
 from scripts.cat.skills import SkillPath, Skill
 from scripts.cat_relations.interaction import (
     SingleInteraction,
     cats_fulfill_single_interaction_constraints,
 )
 
+cat_factory = TestCatFactory(rng=Random())
+
 
 class RelationshipConstraints(unittest.TestCase):
     def test_siblings(self):
         # given
-        parent = CatFactory.create_cat(
-            CatType.TEST,
-        )
-        cat_from = CatFactory.create_cat(CatType.TEST, parent1=parent.ID)
-        cat_to = CatFactory.create_cat(CatType.TEST, parent1=parent.ID)
+        parent = cat_factory.create_cat()
+        cat_from = cat_factory.create_cat(parent1=parent.ID)
+        cat_to = cat_factory.create_cat(parent1=parent.ID)
         rel = Relationship(cat_from, cat_to, False, True)
 
         # then
@@ -38,12 +37,8 @@ class RelationshipConstraints(unittest.TestCase):
 
     def test_mates(self):
         # given
-        cat_from = CatFactory.create_cat(
-            CatType.TEST,
-        )
-        cat_to = CatFactory.create_cat(
-            CatType.TEST,
-        )
+        cat_from = cat_factory.create_cat()
+        cat_to = cat_factory.create_cat()
         cat_from.mate.append(cat_to.ID)
         cat_to.mate.append(cat_from.ID)
         rel = Relationship(cat_from, cat_to, True, False)
@@ -58,10 +53,8 @@ class RelationshipConstraints(unittest.TestCase):
 
     def test_parent_child_combo(self):
         # given
-        parent = CatFactory.create_cat(
-            CatType.TEST,
-        )
-        child = CatFactory.create_cat(CatType.TEST, parent1=parent.ID)
+        parent = cat_factory.create_cat()
+        child = cat_factory.create_cat(parent1=parent.ID)
 
         child_parent_rel = Relationship(child, parent, False, True)
         parent_child_rel = Relationship(parent, child, False, True)
@@ -90,12 +83,8 @@ class RelationshipConstraints(unittest.TestCase):
 
     def test_rel_values_only_constraint_pos(self):
         # given
-        cat_from1 = CatFactory.create_cat(
-            CatType.TEST,
-        )
-        cat_to1 = CatFactory.create_cat(
-            CatType.TEST,
-        )
+        cat_from1 = cat_factory.create_cat()
+        cat_to1 = cat_factory.create_cat()
         low_rel = Relationship(cat_from1, cat_to1)
         low_rel.romance = 10
         low_rel.like = 10
@@ -103,12 +92,8 @@ class RelationshipConstraints(unittest.TestCase):
         low_rel.trust = 10
         low_rel.respect = 10
 
-        cat_from2 = CatFactory.create_cat(
-            CatType.TEST,
-        )
-        cat_to2 = CatFactory.create_cat(
-            CatType.TEST,
-        )
+        cat_from2 = cat_factory.create_cat()
+        cat_to2 = cat_factory.create_cat()
         mid_rel = Relationship(cat_from2, cat_to2)
         mid_rel.romance = 50
         mid_rel.like = 50
@@ -116,12 +101,8 @@ class RelationshipConstraints(unittest.TestCase):
         mid_rel.trust = 50
         mid_rel.respect = 50
 
-        cat_from3 = CatFactory.create_cat(
-            CatType.TEST,
-        )
-        cat_to3 = CatFactory.create_cat(
-            CatType.TEST,
-        )
+        cat_from3 = cat_factory.create_cat()
+        cat_to3 = cat_factory.create_cat()
         high_rel = Relationship(cat_from3, cat_to3)
         high_rel.romance = 90
         high_rel.like = 90
@@ -185,36 +166,24 @@ class RelationshipConstraints(unittest.TestCase):
 
     def test_rel_values_only_constraint_neg(self):
         # given
-        cat_from1 = CatFactory.create_cat(
-            CatType.TEST,
-        )
-        cat_to1 = CatFactory.create_cat(
-            CatType.TEST,
-        )
+        cat_from1 = cat_factory.create_cat()
+        cat_to1 = cat_factory.create_cat()
         mid_rel = Relationship(cat_from1, cat_to1)
         mid_rel.romance = -50
         mid_rel.like = -50
         mid_rel.comfort = -50
         mid_rel.trust = -50
 
-        cat_from2 = CatFactory.create_cat(
-            CatType.TEST,
-        )
-        cat_to2 = CatFactory.create_cat(
-            CatType.TEST,
-        )
+        cat_from2 = cat_factory.create_cat()
+        cat_to2 = cat_factory.create_cat()
         low_rel = Relationship(cat_from2, cat_to2)
         low_rel.romance = -10
         low_rel.like = -10
         low_rel.comfort = -10
         low_rel.trust = -10
 
-        cat_from3 = CatFactory.create_cat(
-            CatType.TEST,
-        )
-        cat_to3 = CatFactory.create_cat(
-            CatType.TEST,
-        )
+        cat_from3 = cat_factory.create_cat()
+        cat_to3 = cat_factory.create_cat()
         high_rel = Relationship(cat_from3, cat_to3)
         high_rel.romance = -90
         high_rel.like = -90
@@ -278,12 +247,8 @@ class RelationshipConstraints(unittest.TestCase):
     def test_rel_values_ranged_constraint(self):
         # given
         # pos side
-        cat_from1 = CatFactory.create_cat(
-            CatType.TEST,
-        )
-        cat_to1 = CatFactory.create_cat(
-            CatType.TEST,
-        )
+        cat_from1 = cat_factory.create_cat()
+        cat_to1 = cat_factory.create_cat()
         high_rel = Relationship(cat_from1, cat_to1)
         high_rel.romance = 90
         high_rel.like = 90
@@ -292,12 +257,8 @@ class RelationshipConstraints(unittest.TestCase):
         high_rel.respect = 90
 
         # neg side
-        cat_from1 = CatFactory.create_cat(
-            CatType.TEST,
-        )
-        cat_to1 = CatFactory.create_cat(
-            CatType.TEST,
-        )
+        cat_from1 = cat_factory.create_cat()
+        cat_to1 = cat_factory.create_cat()
         high_rel = Relationship(cat_from1, cat_to1)
         high_rel.romance = -90
         high_rel.like = -90
@@ -360,12 +321,8 @@ class RelationshipConstraints(unittest.TestCase):
 class SingleInteractionCatConstraints(unittest.TestCase):
     def test_status(self):
         # given
-        warrior = CatFactory.create_cat(
-            CatType.TEST, status_dict={"rank": CatRank.WARRIOR}
-        )
-        medicine = CatFactory.create_cat(
-            CatType.TEST, status_dict={"rank": CatRank.MEDICINE_CAT}
-        )
+        warrior = cat_factory.create_cat(status_dict={"rank": CatRank.WARRIOR})
+        medicine = cat_factory.create_cat(status_dict={"rank": CatRank.MEDICINE_CAT})
 
         # when
         warrior_to_all = SingleInteraction("test")
@@ -431,13 +388,9 @@ class SingleInteractionCatConstraints(unittest.TestCase):
 
     def test_trait(self):
         # given
-        calm = CatFactory.create_cat(
-            CatType.TEST,
-        )
+        calm = cat_factory.create_cat()
         calm.personality.trait = "calm"
-        troublesome = CatFactory.create_cat(
-            CatType.TEST,
-        )
+        troublesome = cat_factory.create_cat()
         troublesome.personality.trait = "troublesome"
 
         # when
@@ -473,9 +426,9 @@ class SingleInteractionCatConstraints(unittest.TestCase):
 
     def test_skill(self):
         # given
-        hunter = CatFactory.create_cat(CatType.TEST, disable_random=True)
+        hunter = cat_factory.create_cat(disable_random=True)
         hunter.skills.primary = Skill(SkillPath.HUNTER, points=9)
-        fighter = CatFactory.create_cat(CatType.TEST, disable_random=True)
+        fighter = cat_factory.create_cat(disable_random=True)
         fighter.skills.primary = Skill(SkillPath.FIGHTER, points=9)
 
         # when
@@ -511,13 +464,9 @@ class SingleInteractionCatConstraints(unittest.TestCase):
 
     def test_background(self):
         # given
-        clan = CatFactory.create_cat(
-            CatType.TEST,
-        )
+        clan = cat_factory.create_cat()
         clan.backstory = "clanborn"
-        half = CatFactory.create_cat(
-            CatType.TEST,
-        )
+        half = cat_factory.create_cat()
         half.backstory = "halfclan1"
 
         # when

--- a/tests/test_lang.py
+++ b/tests/test_lang.py
@@ -1,12 +1,12 @@
 # Tests for localization
 import os
 import unittest
+from random import Random
 
 import i18n
 import ujson
 
-from scripts.cat.factories.cat_factory import CatFactory
-from scripts.cat.factories.enums import CatType
+from scripts.cat.factories.test_cat_factory import TestCatFactory
 
 os.environ["SDL_VIDEODRIVER"] = "dummy"
 os.environ["SDL_AUDIODRIVER"] = "dummy"
@@ -18,6 +18,8 @@ from scripts.game_structure.localization import (
 from scripts.cat.pronouns import get_new_pronouns, determine_plural_pronouns
 from scripts.events_module.text_adjust import event_text_adjust
 
+cat_factory = TestCatFactory(rng=Random())
+
 
 class TestLocalisation(unittest.TestCase):
     @classmethod
@@ -27,20 +29,20 @@ class TestLocalisation(unittest.TestCase):
         ) as read_file:
             cls.pronouns = ujson.loads(read_file.read())["en"]
 
-        male_cat = CatFactory.create_cat(
-            CatType.TEST, gender="male", genderalign="male", disable_random=True
+        male_cat = cat_factory.create_cat(
+            gender="male", genderalign="male", disable_random=True
         )
 
-        female_cat = CatFactory.create_cat(
-            CatType.TEST, gender="female", genderalign="female", disable_random=True
+        female_cat = cat_factory.create_cat(
+            gender="female", genderalign="female", disable_random=True
         )
 
-        nonbinary_cat = CatFactory.create_cat(
-            CatType.TEST, genderalign="nonbinary", disable_random=True
+        nonbinary_cat = cat_factory.create_cat(
+            genderalign="nonbinary", disable_random=True
         )
 
-        mystery_cat = CatFactory.create_cat(
-            CatType.TEST, gender="potato", genderalign="potato", disable_random=True
+        mystery_cat = cat_factory.create_cat(
+            gender="potato", genderalign="potato", disable_random=True
         )
         cls.cat_combos_two = {
             "male-male": [[male_cat, male_cat], cls.pronouns["1"]],
@@ -85,19 +87,13 @@ class TestLocalisation(unittest.TestCase):
                 )
 
     def test_insert_singular_pronouns(self):
-        male_cat = CatFactory.create_cat(
-            CatType.TEST, gender="male", disable_random=True
-        )
+        male_cat = cat_factory.create_cat(gender="male", disable_random=True)
         male_cat.genderalign = "male"
 
-        female_cat = CatFactory.create_cat(
-            CatType.TEST, gender="female", disable_random=True
-        )
+        female_cat = cat_factory.create_cat(gender="female", disable_random=True)
         female_cat.genderalign = "female"
 
-        nonbinary_cat = CatFactory.create_cat(
-            CatType.TEST,
-        )
+        nonbinary_cat = cat_factory.create_cat()
         nonbinary_cat.genderalign = "nonbinary"
 
         for cat in (male_cat, female_cat, nonbinary_cat):

--- a/tests/test_lang.py
+++ b/tests/test_lang.py
@@ -5,6 +5,9 @@ import unittest
 import i18n
 import ujson
 
+from scripts.cat.factories.cat_factory import CatFactory
+from scripts.cat.factories.enums import CatType
+
 os.environ["SDL_VIDEODRIVER"] = "dummy"
 os.environ["SDL_AUDIODRIVER"] = "dummy"
 
@@ -24,16 +27,21 @@ class TestLocalisation(unittest.TestCase):
         ) as read_file:
             cls.pronouns = ujson.loads(read_file.read())["en"]
 
-        male_cat = Cat(gender="male", disable_random=True)
-        male_cat.genderalign = "male"
+        male_cat = CatFactory.create_cat(
+            CatType.TEST, gender="male", genderalign="male", disable_random=True
+        )
 
-        female_cat = Cat(gender="female", disable_random=True)
-        female_cat.genderalign = "female"
+        female_cat = CatFactory.create_cat(
+            CatType.TEST, gender="female", genderalign="female", disable_random=True
+        )
 
-        nonbinary_cat = Cat()
-        nonbinary_cat.genderalign = "nonbinary"
+        nonbinary_cat = CatFactory.create_cat(
+            CatType.TEST, genderalign="nonbinary", disable_random=True
+        )
 
-        mystery_cat = Cat(gender="potato", disable_random=True)
+        mystery_cat = CatFactory.create_cat(
+            CatType.TEST, gender="potato", genderalign="potato", disable_random=True
+        )
         cls.cat_combos_two = {
             "male-male": [[male_cat, male_cat], cls.pronouns["1"]],
             "male-female": [[male_cat, female_cat], cls.pronouns["1"]],
@@ -77,13 +85,19 @@ class TestLocalisation(unittest.TestCase):
                 )
 
     def test_insert_singular_pronouns(self):
-        male_cat = Cat(gender="male", disable_random=True)
+        male_cat = CatFactory.create_cat(
+            CatType.TEST, gender="male", disable_random=True
+        )
         male_cat.genderalign = "male"
 
-        female_cat = Cat(gender="female", disable_random=True)
+        female_cat = CatFactory.create_cat(
+            CatType.TEST, gender="female", disable_random=True
+        )
         female_cat.genderalign = "female"
 
-        nonbinary_cat = Cat()
+        nonbinary_cat = CatFactory.create_cat(
+            CatType.TEST,
+        )
         nonbinary_cat.genderalign = "nonbinary"
 
         for cat in (male_cat, female_cat, nonbinary_cat):

--- a/tests/test_patrol_condition.py
+++ b/tests/test_patrol_condition.py
@@ -2,6 +2,8 @@ import os
 import unittest
 
 from scripts.cat.enums import CatRank
+from scripts.cat.factories.cat_factory import CatFactory
+from scripts.cat.factories.enums import CatType
 
 os.environ["SDL_VIDEODRIVER"] = "dummy"
 os.environ["SDL_AUDIODRIVER"] = "dummy"
@@ -117,8 +119,11 @@ class TestCondition(unittest.TestCase):
     def test_cold_injury(self):
         # GIVEN
         clan = Clan()
-        patrol_cat = Cat(
-            moons=20, status_dict={"rank": CatRank.WARRIOR}, disable_random=True
+        patrol_cat = CatFactory.create_cat(
+            CatType.TEST,
+            moons=20,
+            status_dict={"rank": CatRank.WARRIOR},
+            disable_random=True,
         )
         patrol_cat.history = History(cat=patrol_cat)
         patrol = Patrol()

--- a/tests/test_patrol_condition.py
+++ b/tests/test_patrol_condition.py
@@ -1,17 +1,18 @@
 import os
 import unittest
+from random import Random
 
 from scripts.cat.enums import CatRank
-from scripts.cat.factories.cat_factory import CatFactory
-from scripts.cat.factories.enums import CatType
+from scripts.cat.factories.test_cat_factory import TestCatFactory
 
 os.environ["SDL_VIDEODRIVER"] = "dummy"
 os.environ["SDL_AUDIODRIVER"] = "dummy"
 
-from scripts.cat.cats import Cat
 from scripts.cat.history import History
 from scripts.clan import Clan
 from scripts.events_module.patrol.patrol import Patrol
+
+cat_factory = TestCatFactory(rng=Random())
 
 
 class TestCondition(unittest.TestCase):
@@ -119,8 +120,7 @@ class TestCondition(unittest.TestCase):
     def test_cold_injury(self):
         # GIVEN
         clan = Clan()
-        patrol_cat = CatFactory.create_cat(
-            CatType.TEST,
+        patrol_cat = cat_factory.create_cat(
             moons=20,
             status_dict={"rank": CatRank.WARRIOR},
             disable_random=True,

--- a/tests/test_relation_events.py
+++ b/tests/test_relation_events.py
@@ -1,24 +1,25 @@
 import os
 import unittest
+from random import Random
 from unittest.mock import patch
 
-from scripts.cat.factories.cat_factory import CatFactory
-from scripts.cat.factories.enums import CatType
+from scripts.cat.factories.test_cat_factory import TestCatFactory
 
 os.environ["SDL_VIDEODRIVER"] = "dummy"
 os.environ["SDL_AUDIODRIVER"] = "dummy"
 
-from scripts.cat.cats import Cat
 from scripts.cat_relations.relationship import Relationship
 from scripts.clan import Clan
 from scripts.events_module.relationship.pregnancy_events import Pregnancy_Events
 from scripts.events_module.relationship.romantic_events import RomanticEvents
 
+cat_factory = TestCatFactory(rng=Random())
+
 
 class CanHaveKits(unittest.TestCase):
     def test_prevent_kits(self):
         # given
-        cat = CatFactory.create_cat(CatType.TEST, disable_random=True)
+        cat = cat_factory.create_cat(disable_random=True)
         cat.no_kits = True
 
         # then
@@ -35,9 +36,9 @@ class CanHaveKits(unittest.TestCase):
         # given
         test_clan = Clan(name="clan")
         test_clan.pregnancy_data = {}
-        cat1 = CatFactory.create_cat(CatType.TEST, gender="female", disable_random=True)
+        cat1 = cat_factory.create_cat(gender="female", disable_random=True)
         cat1.no_kits = True
-        cat2 = CatFactory.create_cat(CatType.TEST, gender="male", disable_random=True)
+        cat2 = cat_factory.create_cat(gender="male", disable_random=True)
 
         cat1.mate.append(cat2.ID)
         cat2.mate.append(cat1.ID)
@@ -58,11 +59,11 @@ class SameSexAdoptions(unittest.TestCase):
     def test_kits_are_adopted(self):
         # given
 
-        cat1 = CatFactory.create_cat(
-            CatType.TEST, gender="female", age="adult", moons=40, disable_random=True
+        cat1 = cat_factory.create_cat(
+            gender="female", age="adult", moons=40, disable_random=True
         )
-        cat2 = CatFactory.create_cat(
-            CatType.TEST, gender="female", age="adult", moons=40, disable_random=True
+        cat2 = cat_factory.create_cat(
+            gender="female", age="adult", moons=40, disable_random=True
         )
         cat1.mate.append(cat2.ID)
         cat2.mate.append(cat1.ID)
@@ -100,8 +101,8 @@ class Pregnancy(unittest.TestCase):
     def test_single_cat_female(self, check_if_can_have_kits):
         # given
         clan = Clan(name="clan")
-        cat = CatFactory.create_cat(
-            CatType.TEST, gender="female", age="adult", moons=40, disable_random=True
+        cat = cat_factory.create_cat(
+            gender="female", age="adult", moons=40, disable_random=True
         )
         clan.pregnancy_data = {}
 
@@ -118,11 +119,11 @@ class Pregnancy(unittest.TestCase):
     def test_pair(self, check_if_can_have_kits):
         # given
         clan = Clan(name="clan")
-        cat1 = CatFactory.create_cat(
-            CatType.TEST, gender="female", age="adult", moons=40, disable_random=True
+        cat1 = cat_factory.create_cat(
+            gender="female", age="adult", moons=40, disable_random=True
         )
-        cat2 = CatFactory.create_cat(
-            CatType.TEST, gender="male", age="adult", moons=40, disable_random=True
+        cat2 = cat_factory.create_cat(
+            gender="male", age="adult", moons=40, disable_random=True
         )
 
         clan.pregnancy_data = {}
@@ -139,8 +140,8 @@ class Pregnancy(unittest.TestCase):
 class Mates(unittest.TestCase):
     def test_platonic_kitten_mating(self):
         # given
-        cat1 = CatFactory.create_cat(CatType.TEST, moons=3, disable_random=True)
-        cat2 = CatFactory.create_cat(CatType.TEST, moons=3, disable_random=True)
+        cat1 = cat_factory.create_cat(moons=3, disable_random=True)
+        cat2 = cat_factory.create_cat(moons=3, disable_random=True)
 
         relationship1 = Relationship(cat1, cat2)
         relationship2 = Relationship(cat2, cat1)
@@ -158,8 +159,8 @@ class Mates(unittest.TestCase):
 
     def test_platonic_apprentice_mating(self):
         # given
-        cat1 = CatFactory.create_cat(CatType.TEST, moons=6, disable_random=True)
-        cat2 = CatFactory.create_cat(CatType.TEST, moons=6, disable_random=True)
+        cat1 = cat_factory.create_cat(moons=6, disable_random=True)
+        cat2 = cat_factory.create_cat(moons=6, disable_random=True)
 
         relationship1 = Relationship(cat1, cat2)
         relationship2 = Relationship(cat2, cat1)
@@ -177,8 +178,8 @@ class Mates(unittest.TestCase):
 
     def test_romantic_kitten_mating(self):
         # given
-        cat1 = CatFactory.create_cat(CatType.TEST, moons=3, disable_random=True)
-        cat2 = CatFactory.create_cat(CatType.TEST, moons=3, disable_random=True)
+        cat1 = cat_factory.create_cat(moons=3, disable_random=True)
+        cat2 = cat_factory.create_cat(moons=3, disable_random=True)
 
         relationship1 = Relationship(cat1, cat2)
         relationship2 = Relationship(cat2, cat1)
@@ -196,8 +197,8 @@ class Mates(unittest.TestCase):
 
     def test_romantic_apprentice_mating(self):
         # given
-        cat1 = CatFactory.create_cat(CatType.TEST, moons=6, disable_random=True)
-        cat2 = CatFactory.create_cat(CatType.TEST, moons=6, disable_random=True)
+        cat1 = cat_factory.create_cat(moons=6, disable_random=True)
+        cat2 = cat_factory.create_cat(moons=6, disable_random=True)
 
         relationship1 = Relationship(cat1, cat2)
         relationship2 = Relationship(cat2, cat1)

--- a/tests/test_relation_events.py
+++ b/tests/test_relation_events.py
@@ -2,6 +2,9 @@ import os
 import unittest
 from unittest.mock import patch
 
+from scripts.cat.factories.cat_factory import CatFactory
+from scripts.cat.factories.enums import CatType
+
 os.environ["SDL_VIDEODRIVER"] = "dummy"
 os.environ["SDL_AUDIODRIVER"] = "dummy"
 
@@ -15,7 +18,7 @@ from scripts.events_module.relationship.romantic_events import RomanticEvents
 class CanHaveKits(unittest.TestCase):
     def test_prevent_kits(self):
         # given
-        cat = Cat(disable_random=True)
+        cat = CatFactory.create_cat(CatType.TEST, disable_random=True)
         cat.no_kits = True
 
         # then
@@ -32,9 +35,9 @@ class CanHaveKits(unittest.TestCase):
         # given
         test_clan = Clan(name="clan")
         test_clan.pregnancy_data = {}
-        cat1 = Cat(gender="female", disable_random=True)
+        cat1 = CatFactory.create_cat(CatType.TEST, gender="female", disable_random=True)
         cat1.no_kits = True
-        cat2 = Cat(gender="male", disable_random=True)
+        cat2 = CatFactory.create_cat(CatType.TEST, gender="male", disable_random=True)
 
         cat1.mate.append(cat2.ID)
         cat2.mate.append(cat1.ID)
@@ -55,8 +58,12 @@ class SameSexAdoptions(unittest.TestCase):
     def test_kits_are_adopted(self):
         # given
 
-        cat1 = Cat(gender="female", age="adult", moons=40, disable_random=True)
-        cat2 = Cat(gender="female", age="adult", moons=40, disable_random=True)
+        cat1 = CatFactory.create_cat(
+            CatType.TEST, gender="female", age="adult", moons=40, disable_random=True
+        )
+        cat2 = CatFactory.create_cat(
+            CatType.TEST, gender="female", age="adult", moons=40, disable_random=True
+        )
         cat1.mate.append(cat2.ID)
         cat2.mate.append(cat1.ID)
 
@@ -93,7 +100,9 @@ class Pregnancy(unittest.TestCase):
     def test_single_cat_female(self, check_if_can_have_kits):
         # given
         clan = Clan(name="clan")
-        cat = Cat(gender="female", age="adult", moons=40, disable_random=True)
+        cat = CatFactory.create_cat(
+            CatType.TEST, gender="female", age="adult", moons=40, disable_random=True
+        )
         clan.pregnancy_data = {}
 
         # when
@@ -109,8 +118,12 @@ class Pregnancy(unittest.TestCase):
     def test_pair(self, check_if_can_have_kits):
         # given
         clan = Clan(name="clan")
-        cat1 = Cat(gender="female", age="adult", moons=40, disable_random=True)
-        cat2 = Cat(gender="male", age="adult", moons=40, disable_random=True)
+        cat1 = CatFactory.create_cat(
+            CatType.TEST, gender="female", age="adult", moons=40, disable_random=True
+        )
+        cat2 = CatFactory.create_cat(
+            CatType.TEST, gender="male", age="adult", moons=40, disable_random=True
+        )
 
         clan.pregnancy_data = {}
 
@@ -126,8 +139,8 @@ class Pregnancy(unittest.TestCase):
 class Mates(unittest.TestCase):
     def test_platonic_kitten_mating(self):
         # given
-        cat1 = Cat(moons=3, disable_random=True)
-        cat2 = Cat(moons=3, disable_random=True)
+        cat1 = CatFactory.create_cat(CatType.TEST, moons=3, disable_random=True)
+        cat2 = CatFactory.create_cat(CatType.TEST, moons=3, disable_random=True)
 
         relationship1 = Relationship(cat1, cat2)
         relationship2 = Relationship(cat2, cat1)
@@ -145,8 +158,8 @@ class Mates(unittest.TestCase):
 
     def test_platonic_apprentice_mating(self):
         # given
-        cat1 = Cat(moons=6, disable_random=True)
-        cat2 = Cat(moons=6, disable_random=True)
+        cat1 = CatFactory.create_cat(CatType.TEST, moons=6, disable_random=True)
+        cat2 = CatFactory.create_cat(CatType.TEST, moons=6, disable_random=True)
 
         relationship1 = Relationship(cat1, cat2)
         relationship2 = Relationship(cat2, cat1)
@@ -164,8 +177,8 @@ class Mates(unittest.TestCase):
 
     def test_romantic_kitten_mating(self):
         # given
-        cat1 = Cat(moons=3, disable_random=True)
-        cat2 = Cat(moons=3, disable_random=True)
+        cat1 = CatFactory.create_cat(CatType.TEST, moons=3, disable_random=True)
+        cat2 = CatFactory.create_cat(CatType.TEST, moons=3, disable_random=True)
 
         relationship1 = Relationship(cat1, cat2)
         relationship2 = Relationship(cat2, cat1)
@@ -183,8 +196,8 @@ class Mates(unittest.TestCase):
 
     def test_romantic_apprentice_mating(self):
         # given
-        cat1 = Cat(moons=6, disable_random=True)
-        cat2 = Cat(moons=6, disable_random=True)
+        cat1 = CatFactory.create_cat(CatType.TEST, moons=6, disable_random=True)
+        cat2 = CatFactory.create_cat(CatType.TEST, moons=6, disable_random=True)
 
         relationship1 = Relationship(cat1, cat2)
         relationship2 = Relationship(cat2, cat1)

--- a/tests/test_romantic_events.py
+++ b/tests/test_romantic_events.py
@@ -1,6 +1,9 @@
 import os
 import unittest
 
+from scripts.cat.factories.cat_factory import CatFactory
+from scripts.cat.factories.enums import CatType
+
 os.environ["SDL_VIDEODRIVER"] = "dummy"
 os.environ["SDL_AUDIODRIVER"] = "dummy"
 
@@ -11,8 +14,8 @@ from scripts.events_module.relationship.romantic_events import RomanticEvents
 class RelationshipConditions(unittest.TestCase):
     def test_main_cat_status_one(self):
         # given
-        cat1 = Cat(disable_random=True)
-        cat2 = Cat(disable_random=True)
+        cat1 = CatFactory.create_cat(CatType.TEST, disable_random=True)
+        cat2 = CatFactory.create_cat(CatType.TEST, disable_random=True)
 
         condition = {
             "romance": 0,

--- a/tests/test_romantic_events.py
+++ b/tests/test_romantic_events.py
@@ -1,21 +1,23 @@
 import os
 import unittest
+from random import Random
 
-from scripts.cat.factories.cat_factory import CatFactory
-from scripts.cat.factories.enums import CatType
+from scripts.cat.factories.test_cat_factory import TestCatFactory
 
 os.environ["SDL_VIDEODRIVER"] = "dummy"
 os.environ["SDL_AUDIODRIVER"] = "dummy"
 
-from scripts.cat.cats import Cat, Relationship
+from scripts.cat.cats import Relationship
 from scripts.events_module.relationship.romantic_events import RomanticEvents
+
+cat_factory = TestCatFactory(rng=Random())
 
 
 class RelationshipConditions(unittest.TestCase):
     def test_main_cat_status_one(self):
         # given
-        cat1 = CatFactory.create_cat(CatType.TEST, disable_random=True)
-        cat2 = CatFactory.create_cat(CatType.TEST, disable_random=True)
+        cat1 = cat_factory.create_cat(disable_random=True)
+        cat2 = cat_factory.create_cat(disable_random=True)
 
         condition = {
             "romance": 0,

--- a/tests/test_thoughts.py
+++ b/tests/test_thoughts.py
@@ -1,6 +1,8 @@
 import os
 import unittest
 
+from scripts.cat.factories.cat_factory import CatFactory
+from scripts.cat.factories.enums import CatType
 from scripts.events_module.thoughts import generate_thoughts
 from scripts.cat.enums import CatRank, CatGroup, CatThought
 
@@ -12,8 +14,12 @@ from scripts.cat.cats import Cat
 
 class TestNotWorkingThoughts(unittest.TestCase):
     def setUp(self):
-        self.main = Cat(status_dict={"rank": CatRank.WARRIOR}, disable_random=True)
-        self.other = Cat(status_dict={"rank": CatRank.WARRIOR}, disable_random=True)
+        self.main = CatFactory.create_cat(
+            CatType.TEST, status_dict={"rank": CatRank.WARRIOR}, disable_random=True
+        )
+        self.other = CatFactory.create_cat(
+            CatType.TEST, status_dict={"rank": CatRank.WARRIOR}, disable_random=True
+        )
         self.biome = "Forest"
         self.season = "Newleaf"
         self.camp = "camp2"
@@ -91,8 +97,12 @@ class TestNotWorkingThoughts(unittest.TestCase):
 class TestsGetStatusThought(unittest.TestCase):
     def test_medicine_thought(self):
         # given
-        medicine = Cat(status_dict={"rank": CatRank.MEDICINE_CAT})
-        warrior = Cat(status_dict={"rank": CatRank.WARRIOR})
+        medicine = CatFactory.create_cat(
+            CatType.TEST, status_dict={"rank": CatRank.MEDICINE_CAT}
+        )
+        warrior = CatFactory.create_cat(
+            CatType.TEST, status_dict={"rank": CatRank.WARRIOR}
+        )
         medicine.trait = "bold"
         biome = "Forest"
         season = "Newleaf"
@@ -116,7 +126,9 @@ class TestsGetStatusThought(unittest.TestCase):
                 {"group": CatGroup.PLAYER_CLAN, "standing": ["member", "exiled"]}
             ],
         }
-        cat = Cat(status_dict=exiled_status, moons=40, disable_random=True)
+        cat = CatFactory.create_cat(
+            CatType.TEST, status_dict=exiled_status, moons=40, disable_random=True
+        )
         biome = "Forest"
         season = "Newleaf"
         camp = "camp2"
@@ -128,7 +140,12 @@ class TestsGetStatusThought(unittest.TestCase):
 
     def test_lost_thoughts(self):
         # given
-        cat = Cat(status_dict={"rank": CatRank.WARRIOR}, moons=40, disable_random=True)
+        cat = CatFactory.create_cat(
+            CatType.TEST,
+            status_dict={"rank": CatRank.WARRIOR},
+            moons=40,
+            disable_random=True,
+        )
         cat.status.become_lost()
         biome = "Forest"
         season = "Newleaf"
@@ -143,8 +160,10 @@ class TestsGetStatusThought(unittest.TestCase):
 class TestFamilyThoughts(unittest.TestCase):
     def test_family_thought_young_children(self):
         # given
-        parent = Cat(moons=40, disable_random=True)
-        kit = Cat(parent1=parent.ID, moons=4, disable_random=True)
+        parent = CatFactory.create_cat(CatType.TEST, moons=40, disable_random=True)
+        kit = CatFactory.create_cat(
+            CatType.TEST, parent1=parent.ID, moons=4, disable_random=True
+        )
         biome = "Forest"
         season = "Newleaf"
         camp = "camp2"
@@ -166,8 +185,8 @@ class TestFamilyThoughts(unittest.TestCase):
 
     def test_family_thought_unrelated(self):
         # given
-        cat1 = Cat(moons=40, disable_random=True)
-        cat2 = Cat(moons=40, disable_random=True)
+        cat1 = CatFactory.create_cat(CatType.TEST, moons=40, disable_random=True)
+        cat2 = CatFactory.create_cat(CatType.TEST, moons=40, disable_random=True)
 
         # when
 

--- a/tests/test_thoughts.py
+++ b/tests/test_thoughts.py
@@ -1,24 +1,24 @@
 import os
 import unittest
+from random import Random
 
-from scripts.cat.factories.cat_factory import CatFactory
-from scripts.cat.factories.enums import CatType
-from scripts.events_module.thoughts import generate_thoughts
 from scripts.cat.enums import CatRank, CatGroup, CatThought
+from scripts.cat.factories.test_cat_factory import TestCatFactory
+from scripts.events_module.thoughts import generate_thoughts
 
 os.environ["SDL_VIDEODRIVER"] = "dummy"
 os.environ["SDL_AUDIODRIVER"] = "dummy"
 
-from scripts.cat.cats import Cat
+cat_factory = TestCatFactory(rng=Random())
 
 
 class TestNotWorkingThoughts(unittest.TestCase):
     def setUp(self):
-        self.main = CatFactory.create_cat(
-            CatType.TEST, status_dict={"rank": CatRank.WARRIOR}, disable_random=True
+        self.main = cat_factory.create_cat(
+            status_dict={"rank": CatRank.WARRIOR}, disable_random=True
         )
-        self.other = CatFactory.create_cat(
-            CatType.TEST, status_dict={"rank": CatRank.WARRIOR}, disable_random=True
+        self.other = cat_factory.create_cat(
+            status_dict={"rank": CatRank.WARRIOR}, disable_random=True
         )
         self.biome = "Forest"
         self.season = "Newleaf"
@@ -97,12 +97,8 @@ class TestNotWorkingThoughts(unittest.TestCase):
 class TestsGetStatusThought(unittest.TestCase):
     def test_medicine_thought(self):
         # given
-        medicine = CatFactory.create_cat(
-            CatType.TEST, status_dict={"rank": CatRank.MEDICINE_CAT}
-        )
-        warrior = CatFactory.create_cat(
-            CatType.TEST, status_dict={"rank": CatRank.WARRIOR}
-        )
+        medicine = cat_factory.create_cat(status_dict={"rank": CatRank.MEDICINE_CAT})
+        warrior = cat_factory.create_cat(status_dict={"rank": CatRank.WARRIOR})
         medicine.trait = "bold"
         biome = "Forest"
         season = "Newleaf"
@@ -126,8 +122,8 @@ class TestsGetStatusThought(unittest.TestCase):
                 {"group": CatGroup.PLAYER_CLAN, "standing": ["member", "exiled"]}
             ],
         }
-        cat = CatFactory.create_cat(
-            CatType.TEST, status_dict=exiled_status, moons=40, disable_random=True
+        cat = cat_factory.create_cat(
+            status_dict=exiled_status, moons=40, disable_random=True
         )
         biome = "Forest"
         season = "Newleaf"
@@ -140,8 +136,7 @@ class TestsGetStatusThought(unittest.TestCase):
 
     def test_lost_thoughts(self):
         # given
-        cat = CatFactory.create_cat(
-            CatType.TEST,
+        cat = cat_factory.create_cat(
             status_dict={"rank": CatRank.WARRIOR},
             moons=40,
             disable_random=True,
@@ -160,10 +155,8 @@ class TestsGetStatusThought(unittest.TestCase):
 class TestFamilyThoughts(unittest.TestCase):
     def test_family_thought_young_children(self):
         # given
-        parent = CatFactory.create_cat(CatType.TEST, moons=40, disable_random=True)
-        kit = CatFactory.create_cat(
-            CatType.TEST, parent1=parent.ID, moons=4, disable_random=True
-        )
+        parent = cat_factory.create_cat(moons=40, disable_random=True)
+        kit = cat_factory.create_cat(parent1=parent.ID, moons=4, disable_random=True)
         biome = "Forest"
         season = "Newleaf"
         camp = "camp2"
@@ -185,8 +178,8 @@ class TestFamilyThoughts(unittest.TestCase):
 
     def test_family_thought_unrelated(self):
         # given
-        cat1 = CatFactory.create_cat(CatType.TEST, moons=40, disable_random=True)
-        cat2 = CatFactory.create_cat(CatType.TEST, moons=40, disable_random=True)
+        cat1 = cat_factory.create_cat(moons=40, disable_random=True)
+        cat2 = cat_factory.create_cat(moons=40, disable_random=True)
 
         # when
 

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -1,21 +1,22 @@
 import os
 import unittest
+from random import Random
 
 from scripts.cat.enums import CatRank, CatCompatibility
-from scripts.cat.factories.cat_factory import CatFactory
-from scripts.cat.factories.enums import CatType
+from scripts.cat.factories.test_cat_factory import TestCatFactory
 from scripts.cat_relations.enums import RelType
 
 os.environ["SDL_VIDEODRIVER"] = "dummy"
 os.environ["SDL_AUDIODRIVER"] = "dummy"
 
-from scripts.cat.cats import Cat
 from scripts.cat_relations.relationship import Relationship
 from scripts.events_module.event_filters import (
     get_highest_romantic_relation,
     get_personality_compatibility,
 )
 from scripts.clan_package.get_clan_cats import get_alive_clan_queens
+
+cat_factory = TestCatFactory(rng=Random())
 
 
 class TestPersonalityCompatibility(unittest.TestCase):
@@ -58,8 +59,8 @@ class TestPersonalityCompatibility(unittest.TestCase):
     def test_some_neutral_combinations(self):
         # TODO: the one who updated the personality should update the tests!!
         pass
-        # cat1 = CatFactory.create_cat(CatType.TEST, )
-        # cat2 = CatFactory.create_cat(CatType.TEST, )
+        # cat1 = cat_factory.create_cat()
+        # cat2 = cat_factory.create_cat()
 
     #
     # cat1.personality.trait = self.current_traits[0]
@@ -86,8 +87,8 @@ class TestPersonalityCompatibility(unittest.TestCase):
         pass
 
     def test_false_trait(self):
-        cat1 = CatFactory.create_cat(CatType.TEST, disable_random=True)
-        cat2 = CatFactory.create_cat(CatType.TEST, disable_random=True)
+        cat1 = cat_factory.create_cat(disable_random=True)
+        cat2 = cat_factory.create_cat(disable_random=True)
         cat1.personality.trait = None
         cat2.personality.trait = None
         self.assertEqual(
@@ -101,10 +102,10 @@ class TestPersonalityCompatibility(unittest.TestCase):
 class TestCountRelation(unittest.TestCase):
     def test_2_cats_jealousy(self):
         # given
-        cat1 = CatFactory.create_cat(CatType.TEST, disable_random=True)
-        cat2 = CatFactory.create_cat(CatType.TEST, disable_random=True)
-        cat3 = CatFactory.create_cat(CatType.TEST, disable_random=True)
-        cat4 = CatFactory.create_cat(CatType.TEST, disable_random=True)
+        cat1 = cat_factory.create_cat(disable_random=True)
+        cat2 = cat_factory.create_cat(disable_random=True)
+        cat3 = cat_factory.create_cat(disable_random=True)
+        cat4 = cat_factory.create_cat(disable_random=True)
 
         relation_1_2 = Relationship(cat_from=cat1, cat_to=cat2)
         relation_3_2 = Relationship(cat_from=cat3, cat_to=cat2)
@@ -145,10 +146,10 @@ class TestCountRelation(unittest.TestCase):
 class TestHighestRomance(unittest.TestCase):
     def test_exclude_mate(self):
         # given
-        cat1 = CatFactory.create_cat(CatType.TEST, disable_random=True)
-        cat2 = CatFactory.create_cat(CatType.TEST, disable_random=True)
-        cat3 = CatFactory.create_cat(CatType.TEST, disable_random=True)
-        cat4 = CatFactory.create_cat(CatType.TEST, disable_random=True)
+        cat1 = cat_factory.create_cat(disable_random=True)
+        cat2 = cat_factory.create_cat(disable_random=True)
+        cat3 = cat_factory.create_cat(disable_random=True)
+        cat4 = cat_factory.create_cat(disable_random=True)
 
         # when
         cat1.mate.append(cat2.ID)
@@ -175,10 +176,10 @@ class TestHighestRomance(unittest.TestCase):
 
     def test_include_mate(self):
         # given
-        cat1 = CatFactory.create_cat(CatType.TEST, disable_random=True)
-        cat2 = CatFactory.create_cat(CatType.TEST, disable_random=True)
-        cat3 = CatFactory.create_cat(CatType.TEST, disable_random=True)
-        cat4 = CatFactory.create_cat(CatType.TEST, disable_random=True)
+        cat1 = cat_factory.create_cat(disable_random=True)
+        cat2 = cat_factory.create_cat(disable_random=True)
+        cat3 = cat_factory.create_cat(disable_random=True)
+        cat4 = cat_factory.create_cat(disable_random=True)
 
         # when
         cat1.mate.append(cat2.ID)
@@ -206,23 +207,23 @@ class TestHighestRomance(unittest.TestCase):
 
 class TestGetQueens(unittest.TestCase):
     def setUp(self) -> None:
-        self.test_cat1 = CatFactory.create_cat(
-            CatType.TEST, status_dict={"rank": CatRank.WARRIOR}, disable_random=True
+        self.test_cat1 = cat_factory.create_cat(
+            status_dict={"rank": CatRank.WARRIOR}, disable_random=True
         )
-        self.test_cat2 = CatFactory.create_cat(
-            CatType.TEST, status_dict={"rank": CatRank.WARRIOR}, disable_random=True
+        self.test_cat2 = cat_factory.create_cat(
+            status_dict={"rank": CatRank.WARRIOR}, disable_random=True
         )
-        self.test_cat3 = CatFactory.create_cat(
-            CatType.TEST, status_dict={"rank": CatRank.WARRIOR}, disable_random=True
+        self.test_cat3 = cat_factory.create_cat(
+            status_dict={"rank": CatRank.WARRIOR}, disable_random=True
         )
-        self.test_cat4 = CatFactory.create_cat(
-            CatType.TEST, status_dict={"rank": CatRank.WARRIOR}, disable_random=True
+        self.test_cat4 = cat_factory.create_cat(
+            status_dict={"rank": CatRank.WARRIOR}, disable_random=True
         )
-        self.test_cat5 = CatFactory.create_cat(
-            CatType.TEST, status_dict={"rank": CatRank.WARRIOR}, disable_random=True
+        self.test_cat5 = cat_factory.create_cat(
+            status_dict={"rank": CatRank.WARRIOR}, disable_random=True
         )
-        self.test_cat6 = CatFactory.create_cat(
-            CatType.TEST, status_dict={"rank": CatRank.WARRIOR}, disable_random=True
+        self.test_cat6 = cat_factory.create_cat(
+            status_dict={"rank": CatRank.WARRIOR}, disable_random=True
         )
 
     def tearDown(self) -> None:

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -2,6 +2,8 @@ import os
 import unittest
 
 from scripts.cat.enums import CatRank, CatCompatibility
+from scripts.cat.factories.cat_factory import CatFactory
+from scripts.cat.factories.enums import CatType
 from scripts.cat_relations.enums import RelType
 
 os.environ["SDL_VIDEODRIVER"] = "dummy"
@@ -56,8 +58,8 @@ class TestPersonalityCompatibility(unittest.TestCase):
     def test_some_neutral_combinations(self):
         # TODO: the one who updated the personality should update the tests!!
         pass
-        # cat1 = Cat()
-        # cat2 = Cat()
+        # cat1 = CatFactory.create_cat(CatType.TEST, )
+        # cat2 = CatFactory.create_cat(CatType.TEST, )
 
     #
     # cat1.personality.trait = self.current_traits[0]
@@ -84,8 +86,8 @@ class TestPersonalityCompatibility(unittest.TestCase):
         pass
 
     def test_false_trait(self):
-        cat1 = Cat(disable_random=True)
-        cat2 = Cat(disable_random=True)
+        cat1 = CatFactory.create_cat(CatType.TEST, disable_random=True)
+        cat2 = CatFactory.create_cat(CatType.TEST, disable_random=True)
         cat1.personality.trait = None
         cat2.personality.trait = None
         self.assertEqual(
@@ -99,10 +101,10 @@ class TestPersonalityCompatibility(unittest.TestCase):
 class TestCountRelation(unittest.TestCase):
     def test_2_cats_jealousy(self):
         # given
-        cat1 = Cat(disable_random=True)
-        cat2 = Cat(disable_random=True)
-        cat3 = Cat(disable_random=True)
-        cat4 = Cat(disable_random=True)
+        cat1 = CatFactory.create_cat(CatType.TEST, disable_random=True)
+        cat2 = CatFactory.create_cat(CatType.TEST, disable_random=True)
+        cat3 = CatFactory.create_cat(CatType.TEST, disable_random=True)
+        cat4 = CatFactory.create_cat(CatType.TEST, disable_random=True)
 
         relation_1_2 = Relationship(cat_from=cat1, cat_to=cat2)
         relation_3_2 = Relationship(cat_from=cat3, cat_to=cat2)
@@ -143,10 +145,10 @@ class TestCountRelation(unittest.TestCase):
 class TestHighestRomance(unittest.TestCase):
     def test_exclude_mate(self):
         # given
-        cat1 = Cat(disable_random=True)
-        cat2 = Cat(disable_random=True)
-        cat3 = Cat(disable_random=True)
-        cat4 = Cat(disable_random=True)
+        cat1 = CatFactory.create_cat(CatType.TEST, disable_random=True)
+        cat2 = CatFactory.create_cat(CatType.TEST, disable_random=True)
+        cat3 = CatFactory.create_cat(CatType.TEST, disable_random=True)
+        cat4 = CatFactory.create_cat(CatType.TEST, disable_random=True)
 
         # when
         cat1.mate.append(cat2.ID)
@@ -173,10 +175,10 @@ class TestHighestRomance(unittest.TestCase):
 
     def test_include_mate(self):
         # given
-        cat1 = Cat(disable_random=True)
-        cat2 = Cat(disable_random=True)
-        cat3 = Cat(disable_random=True)
-        cat4 = Cat(disable_random=True)
+        cat1 = CatFactory.create_cat(CatType.TEST, disable_random=True)
+        cat2 = CatFactory.create_cat(CatType.TEST, disable_random=True)
+        cat3 = CatFactory.create_cat(CatType.TEST, disable_random=True)
+        cat4 = CatFactory.create_cat(CatType.TEST, disable_random=True)
 
         # when
         cat1.mate.append(cat2.ID)
@@ -204,12 +206,24 @@ class TestHighestRomance(unittest.TestCase):
 
 class TestGetQueens(unittest.TestCase):
     def setUp(self) -> None:
-        self.test_cat1 = Cat(status_dict={"rank": CatRank.WARRIOR}, disable_random=True)
-        self.test_cat2 = Cat(status_dict={"rank": CatRank.WARRIOR}, disable_random=True)
-        self.test_cat3 = Cat(status_dict={"rank": CatRank.WARRIOR}, disable_random=True)
-        self.test_cat4 = Cat(status_dict={"rank": CatRank.WARRIOR}, disable_random=True)
-        self.test_cat5 = Cat(status_dict={"rank": CatRank.WARRIOR}, disable_random=True)
-        self.test_cat6 = Cat(status_dict={"rank": CatRank.WARRIOR}, disable_random=True)
+        self.test_cat1 = CatFactory.create_cat(
+            CatType.TEST, status_dict={"rank": CatRank.WARRIOR}, disable_random=True
+        )
+        self.test_cat2 = CatFactory.create_cat(
+            CatType.TEST, status_dict={"rank": CatRank.WARRIOR}, disable_random=True
+        )
+        self.test_cat3 = CatFactory.create_cat(
+            CatType.TEST, status_dict={"rank": CatRank.WARRIOR}, disable_random=True
+        )
+        self.test_cat4 = CatFactory.create_cat(
+            CatType.TEST, status_dict={"rank": CatRank.WARRIOR}, disable_random=True
+        )
+        self.test_cat5 = CatFactory.create_cat(
+            CatType.TEST, status_dict={"rank": CatRank.WARRIOR}, disable_random=True
+        )
+        self.test_cat6 = CatFactory.create_cat(
+            CatType.TEST, status_dict={"rank": CatRank.WARRIOR}, disable_random=True
+        )
 
     def tearDown(self) -> None:
         del self.test_cat1


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

Okay... buckle up. This is cleaning up part of how you create and access Cat objects, hopefully a two-part feature. This one focuses on the use of the Factory pattern to build our Cats. This solves Problem 2 outlined on Discord and copied here below for convenience/transparency.

[Context copied from Discord](https://discord.com/channels/1003759225522110524/1473387504999731412/1473387525039980544)

> ## Problem 2: The Enormous __init__
> Cat.__init__ is enormous. It's a big spaghetti of faded and unfaded cats, new cat generation and existing cat loading, random calls galore... it's a mess. Due to the aforementioned dependency issues, we can't call Cat() in lots of places, meaning we have functions like create_new_cat that sort of awkwardly shoehorn the process into working.
> 
> ### Solution: Industrialisation (CatFactory)
> Make Cat only have to think about the data it stores again, rather than having to care about whether the cat is faded and handle it differently, or whether it's a new cat and therefore needs randomization, or if it's from save data and therefore should just kind of run.
> 
> Given a dictionary data with the appropriate data:
> 
> CatFactory.create_cat(CatData.FADED, data)  # calls FadedCatFactory
> CatFactory.create_cat(CatData.NEW, data)  # calls NewCatFactory
> CatFactory.create_cat(CatData.LOAD, data)  # calls ExistingCatFactory
> 
> 
> The CatFactory class handles calling subfactories for each of the relevant CatFactorys.

There are four CatFactory variants. These are all built on an abstract base class to ensure they have the right components (and one subclasses another for reasons that will be clear shortly). These are accompanied by a new enum that describes the type of Cat being created (new, from JSON, etc.).

- CatType.NEW: this means a new cat is being made. Think kits, encountered loner, etc. Any time the game wants to randomly assign variables, it's a CatType.NEW.
- CatType.LOAD_JSON and CatType.LOAD_CSV: kinda obvious here? At the moment these both use LoadCatFactory, but I wrote it this way so that we could one day put the CSV code into its own factory. Alas, I do not understand the CSV code so I am leaving it for now or this PR would never be made.
- CatType.TEST: the associated Factory extends the CatType.NEW factory, changing the functions to guarantee the same output for all relevant variables (a newborn female clancat). It doesn't change up name or pelt generation because those are fun to leave alone and/or terrifying to mess with.
- CatType.FADED: ahh faded my beloathed. A more elegant solution will be possible once the storage of cats is divorced from the Cat class, but for now we're stuck with this one being implemented but unusable.

This can be expanded in future with more CatTypes for more specific situations if desired. I wanted to keep the initial as barebones as possible to avoid the lines changed being utterly stratospheric.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Why This Is Good For ClanGen

(from Discord above)
> ### Rationale
> Faded cats have a very different data structure (much smaller). Setting them up with their own factory means it'll be easier to fully divorce them from Cat in future if need be, while also removing their logic from the Cat class as much as possible.
> 
> New cats do a lot of randomisation. If this is contained within NewCatFactory, then we can control where random elements are called, and even replace the randomization function with predetermined outcomes (very useful for tests and what brought this back into my head from ages ago).
> 
> Existing cats have very limited data protection on their creation due to having to account for new cat generation. Data could be corrupted or missing and the system just merrily chugs along without a care in the world. Giving them their own ExistingCatFactory means we can print better warnings about missing data, because we know it's not meant to be missing.
> 

<!-- If this is a bug fix, you can remove this section. -->
<!-- Please add a short description of why you think these changes would benefit the game. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->
<!-- If you have multiple features that can stand on their own, or unrelated bugfixes, please create separate PRs for them. -->

## Linked Issues

Related: #4454

<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing

Testing thread in Discord (link soon)

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits

<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
