### PR TITLE
BUGFIX: freshkill crashed while sorting hungry cats

### DIFF
--- a/scripts/clan_resources/freshkill.py
+++ b/scripts/clan_resources/freshkill.py
@@ -366,7 +366,7 @@ class FreshkillPile:
 
         # sort the hungry
         hungry_cats_sorted = sorted(
-            list(hungry_cats), key=lambda x: self.nutrition_info[x.ID]
+            list(hungry_cats), key=lambda x: self.nutrition_info[x.ID].percentage
         )
 
         self._feed_group(hungry_cats_sorted)


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

This commit fixes:

```
"clangen/scripts/clan_resources/freshkill.py", line 368, in _feed_by_hungry_first
    hungry_cats_sorted = sorted(
        list(hungry_cats), key=lambda x: self.nutrition_info[x.ID]
    )
TypeError: '<' not supported between instances of 'Nutrition' and 'Nutrition'
```

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Proof of Testing

discovered during play testing, I'm not entirely sure this is the intended behavior but Nutrition doesn't have a `<` operator.