### PR TITLE
fix: Starclan was not properly initialized, causing the game to crash if the user tried to view dead cats before any had died

### DIFF
--- a/scripts/clan.py
+++ b/scripts/clan.py
@@ -205,6 +205,8 @@ class Clan:
         game.reset_used_group_IDs()
         switch_set_value(Switch.clan_name, self.name)
         reset_loaded_clan_settings()
+        game.starclan = Afterlife()
+        game.dark_forest = Afterlife()
         instructor_rank = choice(
             (
                 CatRank.APPRENTICE,

--- a/scripts/screens/ListScreen.py
+++ b/scripts/screens/ListScreen.py
@@ -718,14 +718,14 @@ class ListScreen(Screens):
             else:
                 group = i18n.t(f"general.{self.current_group}")
             if self.current_group == "starclan":
-                if not game.starclan.influencing_cats:
+                if not game.starclan or not game.starclan.influencing_cats:
                     self.temper_message.hide()
 
                     # this means there's probably no cats in starclan, so no temper
                     return ""
                 temper = i18n.t(f"screens.leader_den.{game.starclan.temperament}")
             else:
-                if not game.dark_forest.influencing_cats:
+                if not game.dark_forest or not game.dark_forest.influencing_cats:
                     self.temper_message.hide()
                     # this means there's probably no cats in df, so no temper
                     return ""


### PR DESCRIPTION

<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

game.starclan was not properly initialized, causing the game to crash if the user tried to view dead cats before any had died.

See stack trace below. This happened on a first run, which I think skips Afterlife() initialization in main.py:load_data() (because there is no data to load).

```
Traceback (most recent call last):
  File "/Users/jpollak/src/jbcpollak/clangen/main.py", line 198, in <module>
    all_screens.get_screen(game.current_screen.replace(" ", "_")).handle_event(
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        event
        ^^^^^
    )
    ^
  File "/Users/jpollak/src/jbcpollak/clangen/scripts/screens/ListScreen.py", line 194, in handle_event
    self.update_cat_list(
    ~~~~~~~~~~~~~~~~~~~~^
        self.cat_list_bar_elements["search_bar_entry"].get_text()
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/Users/jpollak/src/jbcpollak/clangen/scripts/screens/ListScreen.py", line 611, in update_cat_list
    self._update_cat_display()
    ~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/Users/jpollak/src/jbcpollak/clangen/scripts/screens/ListScreen.py", line 681, in _update_cat_display
    self.set_bg_and_heading()
    ~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/Users/jpollak/src/jbcpollak/clangen/scripts/screens/ListScreen.py", line 687, in set_bg_and_heading
    self.temper_message.set_text(self.get_group_temper_message())
                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/Users/jpollak/src/jbcpollak/clangen/scripts/screens/ListScreen.py", line 721, in get_group_temper_message
    if not game.starclan.influencing_cats:
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

## Proof of Testing

Tested manually.