### PR TITLE
[BUGFIX & ENHANCEMENT] un-involved cats and frequency override

### DIFF
--- a/resources/game_config.toml
+++ b/resources/game_config.toml
@@ -438,6 +438,9 @@ dev_tools = false
   # forces specified event to occur regardless of if requirements are met
   debug_override_requirements = false
 
+  # forces the given frequency, frequency can be a number from 1-4
+  debug_override_frequency = 0
+
 [death_related]
   # base 1/chance that leader will die
   leader_death_chance = 50

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -2954,9 +2954,7 @@
                 "mates"
             ]
         },
-        "r_c": {
-            "age": ["any"]
-        },
+        "r_c": {},
         "relationships": [
             {
                 "cats_to": [
@@ -10900,6 +10898,7 @@
         "frequency": 4,
         "event_text": "m_c seemed to be watching r_c closely this moon.",
         "m_c": {},
+        "r_c": {},
         "relationships": [
             {
                 "cats_from": ["r_c"],
@@ -10927,6 +10926,7 @@
         "frequency": 4,
         "event_text": "r_c couldn't help but feel uneasy around m_c this moon.",
         "m_c": {},
+        "r_c": {},
         "relationships": [
             {
                 "cats_from": ["r_c"],
@@ -10954,6 +10954,7 @@
         "frequency": 4,
         "event_text": "r_c feels as though {PRONOUN/r_c/subject}{VERB/r_c/'re/'s} being followed.",
         "m_c": {},
+        "r_c": {},
         "exclude_involved": ["m_c"]
     },
     {
@@ -11293,9 +11294,11 @@
         ],
         "frequency": 4,
         "event_text": "A single crow feather appeared in r_c's nest one day. No one knew where it came from.",
+        "m_c": {},
         "r_c": {
             "skill": ["CAMP,1"]
-        }
+        },
+        "exclude_involved": ["m_c"]
     },
     {
         "event_id": "gen_misc_failedmurder_clever1",

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -2954,7 +2954,9 @@
                 "mates"
             ]
         },
-        "r_c": {},
+        "r_c": {
+            "age": ["any"]
+        },
         "relationships": [
             {
                 "cats_to": [

--- a/scripts/events_module/short/short_event_generation.py
+++ b/scripts/events_module/short/short_event_generation.py
@@ -231,8 +231,10 @@ def generate_event_objects(event_triggered, biome, frequency) -> list:
     :param biome: The biome to pull events for
     :param frequency: The frequency to pull events for
     """
+    debug_freq = constants.CONFIG["event_generation"]["debug_override_frequency"]
+
     file_path = f"{event_triggered}/{biome}.json"
-    load_name = f"{file_path}_{frequency}"
+    load_name = f"{file_path}_{debug_freq if debug_freq else frequency}"
 
     try:
         if file_path in loaded_events:
@@ -326,25 +328,6 @@ def filter_events(
     incorrect_format = []
 
     for event in possible_events:
-        if event.history:
-            if not isinstance(event.history, list) or "cats" not in event.history[0]:
-                if (
-                    f"{event.event_id} history formatted incorrectly"
-                    not in incorrect_format
-                ):
-                    incorrect_format.append(
-                        f"{event.event_id} history formatted incorrectly"
-                    )
-        if event.injury:
-            if not isinstance(event.injury, list) or "cats" not in event.injury[0]:
-                if (
-                    f"{event.event_id} injury formatted incorrectly"
-                    not in incorrect_format
-                ):
-                    incorrect_format.append(
-                        f"{event.event_id} injury formatted incorrectly"
-                    )
-
         # check if event is in allowed or excluded
         if allowed_events and event.event_id not in allowed_events:
             continue

--- a/scripts/events_module/short/short_event_generation.py
+++ b/scripts/events_module/short/short_event_generation.py
@@ -261,6 +261,17 @@ def generate_event_objects(event_triggered, biome, frequency) -> list:
                 if frequency != event_frequency:
                     continue
 
+                # this is a catch for empty dict r_c
+                if "r_c" in event:
+                    # check if it's an empty dict.
+                    # we assume if the param is present but empty, then we just want any available cat
+                    if not event["r_c"]:
+                        r_c = {"age": ["any"]}
+                    else:
+                        r_c = event["r_c"]
+                else:
+                    r_c = {}
+
                 event = ShortEvent(
                     event_id=event["event_id"] if "event_id" in event else "",
                     location=event["location"] if "location" in event else ["any"],
@@ -272,7 +283,7 @@ def generate_event_objects(event_triggered, biome, frequency) -> list:
                         event["new_accessory"] if "new_accessory" in event else []
                     ),
                     m_c=event["m_c"] if "m_c" in event else {},
-                    r_c=event["r_c"] if "r_c" in event else {},
+                    r_c=r_c,
                     new_cat=event["new_cat"] if "new_cat" in event else [],
                     injury=event["injury"] if "injury" in event else [],
                     exclude_involved=(


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
Added detection for empty r_c dicts that defaults them into a `{"age": ["any"]}` value so that they won't be detected as NoneTypes.  Instead we just assume that if the param was present, then we wanted to use any cat.  This fixes some missing involved cat buttons for a few different events.

Also, in testing, got fed up with frequency screwing over the event debug, so finally bashed in a frequency override so that we don't have to worry about that anymore.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
fixes #4359
fixes #4443
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
<img width="541" height="122" alt="image" src="https://github.com/user-attachments/assets/3fa8f4cc-29e0-4d53-a807-ab73fb98f0ee" />

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Fixed r_c detection on short events, preventing some instances of missing involved cat buttons and unconverted r_c abbreviations
- Added `debug_override_frequency` to short event debugging in the game config, this allows you to force a specific frequency
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
