### PR TITLE
[BUGFIX] Rel log fixes

### DIFF
--- a/scripts/events_module/consequences.py
+++ b/scripts/events_module/consequences.py
@@ -982,7 +982,7 @@ def unpack_rel_block(
                     cats_to_ob,
                     **value_changes,
                     log=to_log if to_log else from_log,
-                    flip_log=True
+                    flip_log=True,
                 )
             )
 

--- a/scripts/events_module/consequences.py
+++ b/scripts/events_module/consequences.py
@@ -982,6 +982,7 @@ def unpack_rel_block(
                     cats_to_ob,
                     **value_changes,
                     log=to_log if to_log else from_log,
+                    flip_log=True
                 )
             )
 
@@ -997,6 +998,7 @@ def change_relationship_values(
     comfort: int = 0,
     trust: int = 0,
     log: str = None,
+    flip_log: bool = False,
 ) -> dict:
     """
     changes relationship values according to the parameters.
@@ -1011,6 +1013,7 @@ def change_relationship_values(
     :param int comfort: amount to change comfort, default 0
     :param int trust: amount to change trust, default 0
     :param str log: the string to append to the relationship log of cats involved
+    :param bool flip_log: If True, this will "flip" the cats used for to_cat and from_cat abbreviation replacements. This should really only be used for mutual relationship changes from events.
     """
 
     # This is just for test prints - DON'T DELETE - you can use this to test if relationships are changing
@@ -1061,32 +1064,34 @@ def change_relationship_values(
                 log = i18n.t("relationships.relationship_log")
             if log and isinstance(log, str):
                 replace_dict = {}
+                from_cat = single_cat_to if flip_log else single_cat_from
+                to_cat = single_cat_from if flip_log else single_cat_to
                 if "from_cat" in log:
                     replace_dict["from_cat"] = (
-                        str(single_cat_from.name),
-                        choice(single_cat_from.pronouns),
+                        str(from_cat.name),
+                        choice(from_cat.pronouns),
                     )
                 if "to_cat" in log:
                     replace_dict["to_cat"] = (
-                        str(single_cat_to.name),
-                        choice(single_cat_to.pronouns),
+                        str(to_cat.name),
+                        choice(to_cat.pronouns),
                     )
                 if replace_dict:
                     processed_log = process_text(log, replace_dict)
                 else:
                     processed_log = log
 
-                if single_cat_from in created_rel_logs:
-                    created_rel_logs[single_cat_from] = "<br><br>".join(
-                        [created_rel_logs[single_cat_from], processed_log]
+                if from_cat in created_rel_logs:
+                    created_rel_logs[from_cat] = "<br><br>".join(
+                        [created_rel_logs[from_cat], processed_log]
                     )
                 else:
-                    created_rel_logs.update({single_cat_from: processed_log})
+                    created_rel_logs.update({from_cat: processed_log})
 
                 log_text = processed_log + i18n.t(
                     "relationships.age_postscript",
-                    name=str(single_cat_to.name),
-                    count=single_cat_to.moons,
+                    name=str(from_cat.name),
+                    count=from_cat.moons,
                 )
                 if log_text not in rel.log:
                     rel.log.append(log_text)

--- a/scripts/events_module/relationship/group_events.py
+++ b/scripts/events_module/relationship/group_events.py
@@ -116,16 +116,6 @@ class GroupEvents:
             chosen_interaction.intensity
         ]
 
-        if len(chosen_interaction.general_reaction) > 0:
-            # if there is a general reaction in the interaction, then use this
-            GroupEvents.influence_general_relationship(
-                amount, abbreviations_cat_id, chosen_interaction
-            )
-        else:
-            GroupEvents.influence_specific_relationships(
-                amount, abbreviations_cat_id, chosen_interaction
-            )
-
         # choose the interaction text and display
         interaction_str = choice(chosen_interaction.interactions)
         interaction_str = GroupEvents.prepare_text(
@@ -136,6 +126,17 @@ class GroupEvents:
         interaction_str = interaction_str + i18n.t(
             f"relationships.{inter_type}_postscript"
         )
+
+        if len(chosen_interaction.general_reaction) > 0:
+            # if there is a general reaction in the interaction, then use this
+            GroupEvents.influence_general_relationship(
+                amount, abbreviations_cat_id, chosen_interaction, interaction_str
+            )
+        else:
+            GroupEvents.influence_specific_relationships(
+                amount, abbreviations_cat_id, chosen_interaction, interaction_str
+            )
+
         ids = list(abbreviations_cat_id.values())
         relevant_event_tabs = ["relation", "interaction"]
         if chosen_interaction.get_injuries:
@@ -522,7 +523,7 @@ class GroupEvents:
 
     @staticmethod
     def influence_general_relationship(
-        amount, abbreviations_cat_id, chosen_interaction
+        amount, abbreviations_cat_id, chosen_interaction, log
     ):
         """
         Influence the relationship between all cats with the same amount, defined by the chosen group relationship.
@@ -544,18 +545,19 @@ class GroupEvents:
 
         abbreviations_cat = []
 
-        for cat in abbreviations_cat_id:
+        for cat in abbreviations_cat_id.values():
             abbreviations_cat.append(Cat.fetch_cat(cat))
         for inter_cat in abbreviations_cat:
             change_relationship_values(
                 cats_from=[inter_cat],
                 cats_to=list(abbreviations_cat),
+                log=log,
                 **amount_dict,
             )
 
     @staticmethod
     def influence_specific_relationships(
-        amount, abbreviations_cat_id, chosen_interaction
+        amount, abbreviations_cat_id, chosen_interaction, log
     ):
         """
         Influence the relationships based on the list of the reaction of the chosen group interaction.
@@ -586,7 +588,7 @@ class GroupEvents:
                     )
 
             change_relationship_values(
-                cats_from=[cat_from], cats_to=[cat_to], **amount_dict
+                cats_from=[cat_from], cats_to=[cat_to], log=log, **amount_dict
             )
 
     @staticmethod

--- a/scripts/events_module/relationship/group_events.py
+++ b/scripts/events_module/relationship/group_events.py
@@ -121,7 +121,6 @@ class GroupEvents:
         interaction_str = GroupEvents.prepare_text(
             interaction_str, abbreviations_cat_id
         )
-        # TODO: add the interaction to the relationship log?
 
         interaction_str = interaction_str + i18n.t(
             f"relationships.{inter_type}_postscript"


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
This fixes four different rel log bugs:

- Group interactions now create rel logs.  We weren't actually attempting to add rel logs at all. There was just a todo message about doing it... at some point.
- Group interaction general changes weren't being applied due to an incorrect retrieval of cat objects.
- Cat age postscript now lists the correct cat.
- And now for the one with a kinda hacky solution. Described in #4444, from_cat and to_cat abbreviations are assigned to the opposite cats when creating a the opposite side of a mutual change. This is just due to how we handle mutual changes. In order to fix this, I just added a bool param that would "correct" the rel log abbreviation assignment by flipping it back to the correct cats on mutual changes. It's only a *little* gross, and I think it to be the least gross option we have to fix this.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
fixes #4189
fixes #4444
fixes #4555
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
<img width="795" height="698" alt="image" src="https://github.com/user-attachments/assets/e5046e45-c0a9-451c-ad21-58ddb8e75fc3" />

Here you can see a group interaction in the rel logs. It's also an event that applies general changes, which meant it used to have no affect. As you can see it in the logs, we know that it *did* have an effect here.  You can also see the correct age postscripts assigned (all the prior rel logs are from before the bugfix, meaning you can also see the postscripts that the bug used to produce, where only gingerleap was postscripted for both sides of the log)

<img width="415" height="400" alt="image" src="https://github.com/user-attachments/assets/40f0ceed-2515-4b8a-af5c-bcc52c58f53c" />
<img width="399" height="177" alt="image" src="https://github.com/user-attachments/assets/5ad0d88f-aaf7-4193-b9c4-e0c3d8f81fab" />
<img width="394" height="165" alt="image" src="https://github.com/user-attachments/assets/814e32d2-e1fb-4e1f-979e-73a56073deb6" />

This is the same patrol as #4444, you can see that the rel logs now make sense and match up the patrol text!

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Group interactions now create rel logs
- Some group interactions wouldn't apply any affects, this is now fixed
- Cat age postscripts on rel logs are now created and applied correctly.
- Mutual change rel logs no longer "flip" the names of the cats involved.
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
