### PR TITLE
Fix show empty typo that causes a crash

### DIFF
--- a/resources/display_settings.toml
+++ b/resources/display_settings.toml
@@ -96,7 +96,7 @@
         "show dead relation" = [
             false, true
         ]
-        "show_empty relation" = [
+        "show empty relation" = [
             false, true
         ]
         "den labels" = [


### PR DESCRIPTION
this typo caused a crash while my child was playing:

<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

```
Traceback (most recent call last):
  File "/Users/jpollak/src/jbcpollak/clangen/main.py", line 283, in <module>
    asyncio.run(main())
    ~~~~~~~~~~~^^^^^^^^
  File "/Users/jpollak/.local/share/uv/python/cpython-3.13.10-macos-aarch64-none/lib/python3.13/asyncio/runners.py", line 195, in run
    return runner.run(main)
           ~~~~~~~~~~^^^^^^
  File "/Users/jpollak/.local/share/uv/python/cpython-3.13.10-macos-aarch64-none/lib/python3.13/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/Users/jpollak/.local/share/uv/python/cpython-3.13.10-macos-aarch64-none/lib/python3.13/asyncio/base_events.py", line 725, in run_until_complete
    return future.result()
           ~~~~~~~~~~~~~^^
  File "/Users/jpollak/src/jbcpollak/clangen/main.py", line 202, in main
    all_screens.get_screen(game.current_screen.replace(" ", "_")).handle_event(
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        event
        ^^^^^
    )
    ^
  File "/Users/jpollak/src/jbcpollak/clangen/scripts/screens/RelationshipScreen.py", line 194, in handle_event
    switch_clan_setting("show empty relation")
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jpollak/src/jbcpollak/clangen/scripts/clan_package/settings/clan_settings.py", line 70, in switch_clan_setting
    list_index = setting_lists[setting_name].index(clan_settings[setting_name])
                 ~~~~~~~~~~~~~^^^^^^^^^^^^^^
KeyError: 'show empty relation'
```

## Proof of Testing

We manually walked through clicking "Show Empty" on the relationships screen and saw that the game no longer crashed.