### PR TITLE
[BUGFIX] Invited Cats Joining the Clan As Mediators When Settings Don't Allow mediators

### DIFF
--- a/scripts/events.py
+++ b/scripts/events.py
@@ -526,6 +526,9 @@ def handle_lead_den_event():
                         # if cat is an apprentice, make sure they get a mentor!
                         if invited_cat.status.rank == CatRank.APPRENTICE:
                             invited_cat.update_mentor()
+                        # if the cat chose to become a mediator but the settings don't allow it, make them a warrior or medicine cat instead
+                        if invited_cat.status.rank == CatRank.MEDIATOR and not get_clan_setting("become_mediator"):
+                            invited_cat.status._change_rank(random.choice([CatRank.WARRIOR, CatRank.MEDICINE_CAT]))
 
                     invited_cat.create_relationships_new_cat()
 

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -527,8 +527,13 @@ def handle_lead_den_event():
                         if invited_cat.status.rank == CatRank.APPRENTICE:
                             invited_cat.update_mentor()
                         # if the cat chose to become a mediator but the settings don't allow it, make them a warrior or medicine cat instead
-                        if invited_cat.status.rank == CatRank.MEDIATOR and not get_clan_setting("become_mediator"):
-                            invited_cat.status._change_rank(random.choice([CatRank.WARRIOR, CatRank.MEDICINE_CAT]))
+                        if (
+                            invited_cat.status.rank == CatRank.MEDIATOR
+                            and not get_clan_setting("become_mediator")
+                        ):
+                            invited_cat.status._change_rank(
+                                random.choice([CatRank.WARRIOR, CatRank.MEDICINE_CAT])
+                            )
 
                     invited_cat.create_relationships_new_cat()
 

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -526,14 +526,12 @@ def handle_lead_den_event():
                         # if cat is an apprentice, make sure they get a mentor!
                         if invited_cat.status.rank == CatRank.APPRENTICE:
                             invited_cat.update_mentor()
-                        # if the cat chose to become a mediator but the settings don't allow it, make them a warrior or medicine cat instead
+                        # if the cat chose to become a mediator but the settings don't allow it, make them a warrior instead
                         if (
                             invited_cat.status.rank == CatRank.MEDIATOR
                             and not get_clan_setting("become_mediator")
                         ):
-                            invited_cat.status._change_rank(
-                                random.choice([CatRank.WARRIOR, CatRank.MEDICINE_CAT])
-                            )
+                            invited_cat.status._change_rank(CatRank.WARRIOR)
 
                     invited_cat.create_relationships_new_cat()
 


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
Sometimes when invited cats join the clan, and the mediator setting isn't checked, they still have a 1/3 chance of choosing the mediator rank because the code never checked that. This fixes that so if mediators aren't allowed in the game, the cat chooses to become a warrior instead. Good for those who hadn't read that far into the series so they don't have to play with a rank they aren't yet familiar with.


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->


## Linked Issues
Fixes #4524
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
After inviting around 10 different cats into my clan with the mediator setting off, they all chose to become either warriors or medicine cats, no mediators at all.
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->
