### PR TITLE
[BUGFIX] Fix rel tag in rattlesnake patrols

### DIFF
--- a/resources/lang/en/patrols/beach/hunting/greenleaf.json
+++ b/resources/lang/en/patrols/beach/hunting/greenleaf.json
@@ -404,7 +404,7 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c was scarred by a rattlesnake."
+                    "scar": "r_c was scarred by a rattlesnake."
                 },
                 "relationships": [
                     {
@@ -418,7 +418,7 @@
                         "values": ["trust"],
                         "amount": -5,
                         "log": {
-                            "cats_from": "from_cat and to_cat were unable to stop a rattlesnake from biting m_c."
+                            "cats_from": "from_cat and to_cat were unable to stop a rattlesnake from biting r_c."
                         }
                     }
                 ],

--- a/resources/lang/en/patrols/beach/hunting/leaf-bare.json
+++ b/resources/lang/en/patrols/beach/hunting/leaf-bare.json
@@ -434,7 +434,7 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c was scarred by a rattlesnake."
+                    "scar": "r_c was scarred by a rattlesnake."
                 },
                 "relationships": [
                     {
@@ -448,7 +448,7 @@
                         "values": ["trust"],
                         "amount": -5,
                         "log": {
-                            "cats_from": "from_cat and to_cat were unable to stop a rattlesnake from biting m_c."
+                            "cats_from": "from_cat and to_cat were unable to stop a rattlesnake from biting r_c."
                         }
                     }
                 ],

--- a/resources/lang/en/patrols/beach/hunting/leaf-fall.json
+++ b/resources/lang/en/patrols/beach/hunting/leaf-fall.json
@@ -413,8 +413,8 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c was scarred by a rattlesnake.",
-                    "death": "m_c succumbed to a rattlesnake bite."
+                    "scar": "r_c was scarred by a rattlesnake.",
+                    "death": "r_c succumbed to a rattlesnake bite."
                 },
                 "relationships": [
                     {
@@ -428,7 +428,7 @@
                         "values": ["trust"],
                         "amount": -5,
                         "log": {
-                            "cats_from": "from_cat and to_cat were unable to stop a rattlesnake from biting m_c."
+                            "cats_from": "from_cat and to_cat were unable to stop a rattlesnake from biting r_c."
                         }
                     }
                 ],

--- a/resources/lang/en/patrols/beach/hunting/newleaf.json
+++ b/resources/lang/en/patrols/beach/hunting/newleaf.json
@@ -413,8 +413,8 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c was scarred by a rattlesnake.",
-                    "death": "m_c died after succumbing to a rattlesnake's venom."
+                    "scar": "r_c was scarred by a rattlesnake.",
+                    "death": "r_c died after succumbing to a rattlesnake's venom."
                 },
                 "relationships": [
                     {
@@ -428,7 +428,7 @@
                         "values": ["trust"],
                         "amount": -5,
                         "log": {
-                            "cats_from": "from_cat and to_cat were unable to stop a rattlesnake from biting m_c."
+                            "cats_from": "from_cat and to_cat were unable to stop a rattlesnake from biting r_c."
                         }
                     }
                 ],


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

Changes broken `m_c` tag to `r_c` as cat with injury for all seasons of the rattlesnake patrol.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues

Fixes #4519

<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing

the game_config.toml settings changed to replicate the bug:
```toml
[patrol_generation]
  debug_ensure_patrol_id = "bch_hunt_leaf-bare_squirrel_rattlesnakerumble1"
  debug_override_patrol_stat_requirements = true
  debug_ensure_patrol_outcome = false
```

and the (abbreviated) patrol log:
```text
PATROL START ---------------------------------------------------
Patrol Leader: Gentlesong
Random Cat: Roachscar
---
Finding stat cat. Outcome Type: Success = True, Antag = False
Can Have Stat: []
POSSIBLE STAT CATS ['Alderchase', 'Skystar', 'Fishpaw']
No Stat Cat Found
---
The outcome of bch_hunt_leaf-bare_squirrel_rattlesnakerumble1 was altered to False
PATROL ID: bch_hunt_leaf-bare_squirrel_rattlesnakerumble1 | SUCCESS: False
Patrol Frequency: 4 | Patrol Weight: 39
Outcome Frequency: 3 | Outcome Weight: 1
PATROL END -----------------------------------------------------
```

![Roachscar is bitten by a rattlesnake with corrected tag](https://github.com/user-attachments/assets/83c5e562-f969-4b59-afbf-da4158181f3e)

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->