### PR TITLE
[BUGFIX] Add cat to nutrition on add_to_clan

### DIFF
--- a/scripts/clan.py
+++ b/scripts/clan.py
@@ -313,6 +313,9 @@ class Clan:
             Cat.outside_cats.pop(cat.ID)
             cat.clan = str(game.clan.name)
 
+            if self.freshkill_pile and cat.ID not in self.freshkill_pile.nutrition_info:
+                self.freshkill_pile.add_cat_to_nutrition(cat)
+
     def remove_cat(self, ID):  # ID is cat.ID
         """
         This function is for completely removing the cat from the game,


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

Adds cat to nutrition on add_to_clan(cat), avoids cat rejoin event from skipping add_cat_to_nutrition() 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues

fixes #4547 

<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing

replicated steps in bug report and lost cat was added to clan without error log.