### PR TITLE
[BUGFIX] Add missing trait constraint to strange_not_kittypet thought…

### DIFF
--- a/resources/lang/en/thoughts/while_alive/general.json
+++ b/resources/lang/en/thoughts/while_alive/general.json
@@ -913,6 +913,8 @@
         "main_status_constraint": [
             "-kittypet"
         ],
+        "main_trait_constraint": ["strange"],
+
         "main_status_history": [
             "-kittypet"
         ]


### PR DESCRIPTION
Bugfix: Add missing trait constraint to strange_not_kittypet thought (#4554)

## About The Pull Request
The `strange_not_kittypet` thought was missing its `main_trait_constraint`, meaning any cat regardless of trait could receive the thought "Wants to change their name to be like a kittypet", including cats who already have kittypet names. Added the missing `"main_trait_constraint": ["strange"]`.

## Linked Issues
Fixes: #4554

## Proof of Testing
Verified the constraint was missing by diffing against HEAD. Confirmed `main_trait_constraint` is the correct key used throughout all other thought files.

## Changelog/Credits
Bugfix: Cats with kittypet names will no longer receive the thought "Wants to change their name to be like a kittypet".