### PR TITLE
[BUGFIX] Rel log window fixes

### DIFF
--- a/resources/theme/master_screen_scale.json
+++ b/resources/theme/master_screen_scale.json
@@ -89,7 +89,7 @@
         },
         "colours": {"normal_border": "#2E2818"}
     },
-    "#rel_log_cat_sprite.tool_tip":{"misc": {"rect_width": "300", "text_horiz_alignment": "center"}},
+    "#rel_log_cat_sprite.tool_tip":{"misc": {"rect_width": "400", "text_horiz_alignment": "center"}},
     "@checked_checkbox_smalltooltip.tool_tip": {"misc": {"rect_width": "100"}},
     "@unchecked_checkbox_smalltooltip.tool_tip": {"misc": {"rect_width": "100"}},
     "#clan_screen_cat_tooltip": {"misc": {"rect_width": "120", "text_horiz_alignment": "center"}},

--- a/scripts/ui/elements/cat_list_display.py
+++ b/scripts/ui/elements/cat_list_display.py
@@ -272,7 +272,9 @@ class UICatListDisplay(UIContainer):
         elif self.tool_tip_name:
             tooltip_text = str(kitty.name)
         elif self.tool_tip_text:
-            tooltip_text = self.tool_tip_text[i]
+            tooltip_text = self.tool_tip_text[
+                i + ((self.current_page - 1) * self.cats_displayed)
+            ]
         else:
             tooltip_text = None
 


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
Fixes two bugs with rel log window tooltips:
- I widened the tooltip size. This helps prevent the weird flickering that was being experienced. The flickering was caused by the tooltip rect defaulting that occurs when the tooltip can't find a valid position (aka, it's too large in some way and can't find a way to display all of itself at it's original position). The tooltip defaults to 0, 0 (aka the top left corner). If the cat was close enough to the left corner, then when the tooltip would default, it would cover the cat.  This would cause the code to think the cat was now unhovered (as the hover is being detected by the tooltip object instead), thus killing the tooltip.  Then it would detect the cat as hovered again, creating the tooltip once more. This would loop over and over as long as the mouse remained over the cat, causing the quick flickering as the tooltip is killed and created again rapidly.  The main cause of the tooltip size being too large to fit was height, so just widening it seems to have gotten rid of that problem completely, as it no longer needs to be so tall to contain all the information.
- Cat tooltip text was being found via a list of all rel logs. The index used to find the correct rel logs was based on the index of the cat sprite within the cat list. However, this would break when looking at other pages than the first, as the index search wasn't accounting for the page difference. The fix for this was just to account for that difference by adding `(page_number - 1) * cats_displayed)` to the index. Page number has to be -1 as we *start* on page 1, not page 0. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
fixes #4541
fixes #4560
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
<img width="800" height="702" alt="image" src="https://github.com/user-attachments/assets/5559b78f-d3ec-4588-ab24-c71b53d9a7f4" />

This is the same patrol that would cause flickering before! With a widened tooltip, the flickering no longer occurs.

<img width="606" height="405" alt="image" src="https://github.com/user-attachments/assets/7e32730b-ad85-4be1-a62a-bc97b61bb1ee" />
<img width="597" height="402" alt="image" src="https://github.com/user-attachments/assets/3709ad32-ca5b-4eb4-8b5e-16e2ce58902b" />
<img width="611" height="405" alt="image" src="https://github.com/user-attachments/assets/b71acea1-8f7f-49a2-8291-c5ba118682a5" />

Tooltips are now attributed to the correct cats on each page.
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Flickering tooltips should no longer appear when viewing large rel logs changes in the relationship change details window.
- New rel logs are now attributed to the correct cats when multiple pages of cats can be viewed on the relationship change details window.
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
