### PR TITLE
[BUGFIX] April fools on halloween

### DIFF
--- a/scripts/special_dates.py
+++ b/scripts/special_dates.py
@@ -79,7 +79,7 @@ def is_today(date: SpecialDate) -> bool:
     """
     if not game_setting_get("special_dates"):
         return False
-    if constants.CONFIG["fun"].get("always_halloween", False):
+    if constants.CONFIG["fun"].get("april_fools", False):
         return True
 
     d = _date_map.get(date, None)


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
I'm a little baffled when it comes to our special_date functions. We seem to have two of them that do mostly the same thing, but one is used for event filtering and the other is used for sprite loading.  The sprite loading one was returning True when `always_halloween` was one, despite us only having april fools lineart and no halloween lineart. Changing it to detect the `april_fools` fun setting has fixed the problem.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
fixes #4482
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
<img width="795" height="687" alt="image" src="https://github.com/user-attachments/assets/e2f3114f-3b68-42c0-8fa9-4d34e37105e1" />

with always_halloween on

<img width="792" height="691" alt="image" src="https://github.com/user-attachments/assets/fbc35dea-ff4e-4765-af4c-f9671038ee42" />

with april fools on
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- The `always_halloween` config setting no longer applies april fools lineart to the cats
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
