### PR TITLE
[BUGFIX] Audio duping

### DIFF
--- a/main.py
+++ b/main.py
@@ -49,12 +49,13 @@ def load_data():
 
     # load audio
     try:
-        game.audio = AudioManager()
-        pygame.mixer.pre_init(buffer=44100)
-        pygame.mixer.init()
+        if not getattr(game, "audio", None):
+            game.audio = AudioManager()
+            pygame.mixer.pre_init(buffer=44100)
+            pygame.mixer.init()
 
-        # loading sounds here bc they depend on mixer being initialized
-        game.audio.sound.load_sounds()
+            # loading sounds here bc they depend on mixer being initialized
+            game.audio.sound.load_sounds()
     except pygame.error:
         print("Failed to initialize audio. Audio will be disabled.")
         game.audio.disabled = True

--- a/resources/audio/music.json
+++ b/resources/audio/music.json
@@ -1,5 +1,5 @@
 {
-  "menu_playlist": ["Generations.mp3", "Dawn_Patrol.mp3", "Leafbare.mp3", "Newleaf.mp3", "Moonstone.mp3", "Moonhigh_Vigil.mp3", "Ancient_Tunnels.mp3"],
+  "menu_playlist": ["Generations.mp3"],
 
   "general_playlist": ["Dawn_Patrol.mp3", "Moonstone.mp3", "Moonhigh_Vigil.mp3", "Ancient_Tunnels.mp3"],
   "leafbare_playlist": ["Leafbare.mp3"],

--- a/scripts/game_structure/audio/music.py
+++ b/scripts/game_structure/audio/music.py
@@ -209,7 +209,7 @@ class Music:
             delay = randint(30, 300)
         if self.channel and self.channel.get_busy():
             self.channel.fadeout(fadeout)
-            self._start_silence_timer(max(fadeout, delay))
+            self._start_silence_timer(max(fadeout / 100, delay))
             self.music_timer.cancel()
 
     def change_volume(self, new_volume: int):


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
terrifying bug report to receive, i gotta say

The problem though was pretty easily reconciled though. It was caused by us initializing the audio upon data loading without any check to see if the audio was already init! Implementing that check has resolved the issue. 

Also bundled in a second change that isn't really a bugfix, more so a response to feedback. So we have a single main menu exclusive track: Generations. All the other music tracks are allowed during gameplay. This led to at least one player getting confused when they continued a save while Generations was playing, just for it to fade out (as it's only allowed to play in the menus).  When they encountered *different* music on the main menu and *it* didn't fade out upon continuing a save, they assumed the inconsistency was a bug. This isn't ideal.

The two solutions to this are to either make Generations no longer menu-exclusive, or make it the *only* track that *ever* plays on the menu. Since Generations has been our defacto menu music since it's inception, I've opted for the latter.  This should help clear up the confusion on music behavior regarding menus.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
fixes #4573
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing

https://github.com/user-attachments/assets/a00285a8-c99e-4a1d-8e68-302e3df145b3

As you can see, there's no duping of the audio upon loading a new save!
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Music track no longer duplicates upon loading a saved Clan
- Generations is now the only music track that will play on the main menu. This is to make music behavior more consistent, as the prior behavior was being mistaken as a bug.
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
