### PR TITLE
[BUGFIX] rel event warnings

### DIFF
--- a/resources/lang/en/events/relationship_events/normal_interactions/like/decrease.json
+++ b/resources/lang/en/events/relationship_events/normal_interactions/like/decrease.json
@@ -63,6 +63,7 @@
 	},
 	{
 		"id": "platonic_de_med2",
+		"intensity": "medium",
 		"interactions": [
 			"m_c is annoyed that {PRONOUN/m_c/subject} {VERB/m_c/have/has} to pull ticks off of r_c today.",
 			"m_c doesn't like being bossed around by r_c just because {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} young.",
@@ -79,6 +80,7 @@
 	},
 	{
 		"id": "platonic_de_med3",
+		"intensity": "medium",
 		"interactions": [
 			"r_c makes sure m_c is following the Warrior Code.",
 			"r_c snaps at m_c for making a joke about the Clan.",
@@ -90,6 +92,7 @@
 	},
 	{
 		"id": "platonic_de_med4",
+		"intensity": "medium",
 		"interactions": [
 			"r_c is not backing down in an argument with m_c.",
 			"r_c is getting too violent in an argument with m_c.",
@@ -267,7 +270,8 @@
 	},
 	{
 		"id": "dislike_inc_med1",
-		"intensity": [
+		"intensity": "medium",
+		"interactions": [
 			"m_c wishes r_c would take things more seriously.",
 			"m_c thinks r_c is acting childish lately.",
 			"m_c keeps complaining about something r_c did.",
@@ -282,6 +286,7 @@
 	},
 	{
 		"id": "dislike_inc_med2",
+		"intensity": "medium",
 		"interactions": [
 			"m_c ignores r_c.",
 			"m_c had a huge argument with r_c.",
@@ -301,6 +306,7 @@
 	},
 	{
 		"id": "dislike_inc_med3",
+		"intensity": "medium",
 		"interactions": [
 			"m_c had a disagreement with r_c while on patrol earlier.",
 			"m_c stole r_c's catch right out from under {PRONOUN/r_c/poss} claws.",
@@ -331,6 +337,7 @@
 	},
 	{
 		"id": "dislike_inc_med4",
+		"intensity": "medium",
 		"interactions": [
 			"m_c is thinking about how r_c wronged {PRONOUN/m_c/object}.",
 			"m_c is watching r_c scornfully.",
@@ -347,6 +354,7 @@
 	},
 	{
 		"id": "dislike_inc_med5",
+		"intensity": "medium",
 		"interactions": [
 			"r_c is asking m_c to tell {PRONOUN/r_c/object} about how good {PRONOUN/r_c/subject} {VERB/m_c/look/looks}.",
 			"r_c offends m_c with {PRONOUN/r_c/poss} brutal honesty.",
@@ -362,6 +370,7 @@
 	},
 	{
 		"id": "dislike_inc_med6",
+		"intensity": "medium",
 		"interactions": [
 			"r_c pulled a prank on m_c.",
 			"r_c blamed m_c for {PRONOUN/r_c/poss} own mistake.",
@@ -377,6 +386,7 @@
 	},
 	{
 		"id": "dislike_effect_other1",
+		"intensity": "medium",
 		"relationship_constraint": [
 			"hates"
 		],
@@ -397,6 +407,7 @@
 	},
 	{
 		"id": "dislike_kit_inc_med1",
+		"intensity": "medium",
 		"interactions": [
 			"m_c trips over r_c.",
 			"m_c had to nip r_c on the rump because {PRONOUN/r_c/subject} {VERB/r_c/were/was} being naughty.",
@@ -424,6 +435,7 @@
 	},
 	{
 		"id": "dislike_dep_leader_inc_med1",
+		"intensity": "medium",
 		"interactions": [
 			"m_c punishes r_c with extra work.",
 			"m_c divides r_c into extra patrols.",
@@ -445,6 +457,7 @@
 	},
 	{
 		"id": "dislike_dep_leader_inc_med2",
+		"intensity": "medium",
 		"interactions": [
 			"m_c punishes r_c with extra work.",
 			"m_c divides r_c into extra patrols.",
@@ -467,6 +480,7 @@
 	},
 	{
 		"id": "dislike_med_inc_med1",
+		"intensity": "medium",
 		"interactions": [
 			"m_c gives r_c bitter herbs on purpose.",
 			"m_c snaps at r_c for seeking treatment for something trivial and wasting {PRONOUN/m_c/poss} time.",
@@ -634,6 +648,7 @@
 	},
 	{
 		"id": "dislike_kit_de_med1",
+		"intensity": "medium",
 		"interactions": [
 			"m_c sticks {PRONOUN/m_c/poss} tongue out at r_c.",
 			"m_c makes stinky faces at r_c for seemingly no reason.",
@@ -649,6 +664,7 @@
 	},
 	{
 		"id": "dislike_kit_de_med2",
+		"intensity": "medium",
 		"interactions": [
 			"m_c tried to have a friendly discussion with r_c about what prey tastes best, but it turned into an argument.",
 			"m_c and r_c always end up arguing over what games to play.",
@@ -669,6 +685,7 @@
 	},
 	{
 		"id": "dislike_kit_inc_med3",
+		"intensity": "medium",
 		"interactions": [
 			"m_c whines that r_c won't play with {PRONOUN/m_c/object}, even though {PRONOUN/r_c/subject}{VERB/r_c/'re/'s} always around camp.",
 			"m_c doesn't understand why r_c won't let {PRONOUN/m_c/object} play in the medicine cat den."

--- a/resources/lang/en/events/relationship_events/normal_interactions/like/increase.json
+++ b/resources/lang/en/events/relationship_events/normal_interactions/like/increase.json
@@ -79,7 +79,7 @@
 	},
 	{
 		"id": "like_inc_med1",
-		"intensity": "med",
+		"intensity": "medium",
 		"interactions": [
 			"m_c saw r_c the other day and did get a chance to meow hello!",
 			"r_c points out that m_c's fresh-kill has gone bad before {PRONOUN/r_c/subject} {VERB/r_c/eat/eats} it.",
@@ -92,7 +92,7 @@
 	},
 	{
 		"id": "like_inc_med2",
-		"intensity": "med",
+		"intensity": "medium",
 		"interactions": [
 			"m_c tells a story to r_c.",
 			"m_c shares a piece of fresh-kill with r_c.",
@@ -111,7 +111,7 @@
 	},
 	{
 		"id": "like_inc_med3",
-		"intensity": "med",
+		"intensity": "medium",
 		"interactions": [
 			"m_c waves to r_c with {PRONOUN/m_c/poss} tail as their patrols cross paths on the territory.",
 			"m_c calls to r_c to catch {PRONOUN/m_c/object} a fat mouse on {PRONOUN/r_c/poss} next hunting patrol.",
@@ -141,7 +141,7 @@
 	},
 	{
 		"id": "like_inc_med4",
-		"intensity": "med",
+		"intensity": "medium",
 		"interactions": [
 			"r_c charms m_c.",
 			"r_c smiles at m_c whenever they meet.",
@@ -161,7 +161,7 @@
 	},
 	{
 		"id": "like_inc_med5",
-		"intensity": "med",
+		"intensity": "medium",
 		"interactions": [
 			"r_c relaxes with m_c.",
 			"r_c helps m_c calm down.",
@@ -173,7 +173,7 @@
 	},
 	{
 		"id": "like_inc_med6",
-		"intensity": "med",
+		"intensity": "medium",
 		"interactions": [
 			"r_c challenges m_c to a race.",
 			"m_c knows hanging out with r_c will always bring an adrenaline rush.",
@@ -185,7 +185,7 @@
 	},
 	{
 		"id": "like_inc_med7",
-		"intensity": "med",
+		"intensity": "medium",
 		"interactions": [
 			"r_c is making sure m_c knows that {PRONOUN/m_c/subject} {VERB/m_c/are/is} loved.",
 			"r_c is telling m_c how much {PRONOUN/r_c/subject} {VERB/r_c/cherish/cherishes} {PRONOUN/m_c/object}.",
@@ -200,7 +200,7 @@
 	},
 	{
 		"id": "like_inc_med8",
-		"intensity": "med",
+		"intensity": "medium",
 		"interactions": [
 			"r_c is playing tag with m_c.",
 			"r_c bats a moss ball towards m_c to play.",
@@ -213,7 +213,7 @@
 	},
 	{
 		"id": "like_inc_med9",
-		"intensity": "med",
+		"intensity": "medium",
 		"interactions": [
 			"m_c feels bad that {PRONOUN/m_c/subject} caused a problem for r_c.",
 			"m_c convinces r_c to help {PRONOUN/m_c/object} pull a prank on a Clanmate."
@@ -228,7 +228,7 @@
 	},
 	{
 		"id": "like_inc_med10",
-		"intensity": "med",
+		"intensity": "medium",
 		"interactions": [
 			"m_c wants to explore Twolegplace with r_c.",
 			"m_c wants to sneak along the border with r_c.",
@@ -240,7 +240,7 @@
 	},
 	{
 		"id": "like_inc_med10",
-		"intensity": "med",
+		"intensity": "medium",
 		"interactions": [
 			"m_c is hiding behind a bush ready to pounce on r_c."
 		],
@@ -250,7 +250,7 @@
 	},
 	{
 		"id": "like_inc_med4",
-		"intensity": "med",
+		"intensity": "medium",
 		"interactions": [
 			"m_c wants to explore the whole territory with r_c!",
 			"m_c claims that r_c is one of {PRONOUN/m_c/poss} best friends.",
@@ -271,7 +271,7 @@
 	},
 	{
 		"id": "like_to_app_inc_med1",
-		"intensity": "med",
+		"intensity": "medium",
 		"interactions": [
 			"m_c noticed that r_c is falling behind in training and offered to help {PRONOUN/r_c/object} catch up.",
 			"m_c gives r_c advice on an upcoming assessment."
@@ -291,7 +291,7 @@
 	},
 	{
 		"id": "like_kit_inc_med1",
-		"intensity": "med",
+		"intensity": "medium",
 		"interactions": [
 			"m_c plays moss-ball with r_c.",
 			"m_c wants to show r_c {PRONOUN/m_c/poss} favorite toy."
@@ -305,7 +305,7 @@
 	},
 	{
 		"id": "like_kit_inc_med3",
-		"intensity": "med",
+		"intensity": "medium",
 		"interactions": [
 			"m_c lets r_c play with {PRONOUN/m_c/poss} favorite toy.",
 			"m_c pretends to be a warrior with r_c.",
@@ -338,7 +338,7 @@
 	},
 	{
 		"id": "like_kit_inc_med4",
-		"intensity": "med",
+		"intensity": "medium",
 		"interactions": [
 			"m_c decorates {PRONOUN/m_c/poss} nest with gifts that r_c brought {PRONOUN/m_c/object}.",
 			"m_c follows r_c around everywhere."
@@ -355,7 +355,7 @@
 	},
 	{
 		"id": "like_kit_inc_med5",
-		"intensity": "med",
+		"intensity": "medium",
 		"interactions": [
 			"m_c asks r_c what it's like to be in training.",
 			"m_c tells r_c {PRONOUN/m_c/subject}'ll be {PRONOUN/r_c/poss} apprentice one day.",
@@ -376,7 +376,7 @@
 	},
 	{
 		"id": "like_kit_inc_med6",
-		"intensity": "med",
+		"intensity": "medium",
 		"interactions": [
 			"m_c is watching over r_c.",
 			"m_c trains playfully with r_c.",
@@ -406,7 +406,7 @@
 	},
 	{
 		"id": "like_kit_inc_odd1",
-		"intensity": "med",
+		"intensity": "medium",
 		"interactions": [
 			"m_c is asking r_c where kits come from."
 		],
@@ -426,7 +426,7 @@
 	},
 	{
 		"id": "like_app_med1",
-		"intensity": "med",
+		"intensity": "medium",
 		"interactions": [
 			"m_c is telling r_c about a hunting technique.",
 			"m_c is thinking about how much r_c reminds {PRONOUN/m_c/subject} of {PRONOUN/m_c/poss} own apprentice days.",
@@ -448,7 +448,7 @@
 	},
 	{
 		"id": "like_app_med2",
-		"intensity": "med",
+		"intensity": "medium",
 		"interactions": [
 			"m_c brings r_c a piece of prey to share after a long day of training.",
 			"m_c offers to help r_c clean out the elder's bedding.",
@@ -467,7 +467,7 @@
 	},
 	{
 		"id": "like_app_med3",
-		"intensity": "med",
+		"intensity": "medium",
 		"interactions": [
 			"m_c daydreams with r_c about their future warrior ceremonies.",
 			"m_c feels like training goes by much faster when {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} with r_c.",
@@ -487,7 +487,7 @@
 	},
 	{
 		"id": "like_app_med4",
-		"intensity": "med",
+		"intensity": "medium",
 		"interactions": [
 			"m_c listens closely as r_c tells {PRONOUN/m_c/object} about the new herb {PRONOUN/r_c/subject} learned to recognize today.",
 			"m_c playfully teases r_c for having herbs stuck in {PRONOUN/r_c/poss} fur.",
@@ -504,7 +504,7 @@
 	},
 	{
 		"id": "like_app_med5",
-		"intensity": "med",
+		"intensity": "medium",
 		"interactions": [
 			"m_c gently grooms some cobwebs off r_c's fur.",
 			"m_c tells r_c that {PRONOUN/r_c/subject}'ll be an amazing medicine cat someday.",
@@ -522,7 +522,7 @@
 	},
 	{
 		"id": "like_warrior_inc_med1",
-		"intensity": "med",
+		"intensity": "medium",
 		"interactions": [
 			"m_c greets r_c as {PRONOUN/r_c/subject}{VERB/r_c/'re/'s} exiting the warriors' den.",
 			"m_c chats quietly with r_c while they're both on camp guard duty.",
@@ -540,7 +540,7 @@
 	},
 	{
 		"id": "like_elder_med1",
-		"intensity": "med",
+		"intensity": "medium",
 		"interactions": [
 			"m_c is pestering r_c for a story.",
 			"m_c settles down next to r_c to listen to {PRONOUN/r_c/poss} stories.",
@@ -556,7 +556,7 @@
 	},
 	{
 		"id": "like_incfromneg_med1",
-		"intensity": "med",
+		"intensity": "medium",
 		"interactions": [
 			"m_c realized that {PRONOUN/m_c/subject} {VERB/m_c/were/was} too harsh in {PRONOUN/m_c/poss} judgement of r_c.",
 			"m_c is still hurt by r_c but wants to make amends.",
@@ -576,7 +576,7 @@
 	},
 	{
 		"id": "like_incfromneg_med2",
-		"intensity": "med",
+		"intensity": "medium",
 		"interactions": [
 			"m_c covered for r_c on something minor.",
 			"m_c spends some time with r_c and they both end up understanding each other a little better.",
@@ -856,7 +856,7 @@
 	},
 	{
 		"id": "like_inc_respect_de1",
-		"intensity": "med",
+		"intensity": "medium",
 		"interactions": [
 			"m_c feels like {PRONOUN/m_c/subject}'ll never accomplish as much as r_c.",
 			"m_c wonders if {PRONOUN/m_c/subject} can ever be as good as r_c.",
@@ -889,7 +889,7 @@
 	},
 	{
 		"id": "like_inc_respect_de2",
-		"intensity": "med",
+		"intensity": "medium",
 		"interactions": [
 			"m_c thinks r_c is so much braver than {PRONOUN/m_c/object}.",
 			"If it were a life-or-death situation, m_c thinks that r_c should be saved first.",

--- a/resources/lang/en/events/relationship_events/normal_interactions/respect/decrease.json
+++ b/resources/lang/en/events/relationship_events/normal_interactions/respect/decrease.json
@@ -41,7 +41,7 @@
 	},
 	{
 		"id": "respect_de_med1",
-		"intensity": "med",
+		"intensity": "medium",
 		"interactions": [
 			"m_c saw r_c take the last piece of prey from the fresh-kill pile.",
 			"m_c is frustrated that r_c won't take {PRONOUN/r_c/poss} actions more seriously.",

--- a/scripts/events_module/consequences.py
+++ b/scripts/events_module/consequences.py
@@ -872,7 +872,8 @@ def gather_cat_objects(
             continue
 
         else:
-            print(f"WARNING: Unsupported abbreviation {abbr}")
+            print(f"WARNING: No cats found for {abbr_list}")
+            return list(found_cat_list)
 
     return list(out_set)
 


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
This fixes mistagged intensities in the rel events. We were also having an issue with rel changes being applied incorrectly when facet tag filtering resulted in no cats being available. I just needed to account for that possibility and ensure that an empty cat list was returned when no cats matched the given filters.

fixes #4610
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Proof of Testing
<img width="827" height="245" alt="image" src="https://github.com/user-attachments/assets/7b8c5cfd-f9b5-491b-8645-bc2a41d4c662" />

Did some moonskipping and didn't get any of the warning about missing rel events. The "no cats found" warning is expected and intentional here.
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Mistagged rel events corrected
- Rel changes are now correctly handled when no matching cats are found.
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
