### PR TITLE
[BUGFIX] Unfitting Medicine Cat Relationship Events

### DIFF
--- a/resources/lang/en/events/relationship_events/normal_interactions/like/decrease.json
+++ b/resources/lang/en/events/relationship_events/normal_interactions/like/decrease.json
@@ -585,21 +585,57 @@
 		}
 	},
 	{
-		"id": "dislike_inc_high6",
+		"id": "dislike_inc_high_highrank1",
+		"intensity": "high",
+		"interactions": [
+			"m_c calls r_c a threat to the safety of the Clan.",
+			"m_c and r_c are arguing about something important and risking the Clan's safety.",
+			"m_c claims {PRONOUN/m_c/subject} spoke with StarClan and heard bad things about r_c."
+		],
+		"main_status_constraint": [
+			"medicine cat",
+			"leader"
+		],
+		"reaction_random_cat": {
+			"like": "decrease",
+			"comfort": "decrease",
+			"respect": "decrease",
+			"trust": "decrease"
+		}
+	},
+	{
+		"id": "dislike_inc_high_highrank2",
 		"intensity": "high",
 		"interactions": [
 			"m_c is scolding r_c.",
 			"m_c is bossing r_c around.",
 			"m_c calls r_c a threat to the safety of the Clan.",
 			"m_c and r_c are arguing about something important and risking the Clan's safety.",
-			"m_c threatens r_c with exile.",
-			"m_c makes r_c do a tiring chore for the rest of the moon as punishment for something minor.",
-			"m_c threatens to give r_c a terrible name.",
-			"m_c claims {PRONOUN/m_c/subject} spoke with StarClan and heard bad things about r_c."
+			"m_c makes r_c do a tiring chore for the rest of the moon as punishment for something minor."
 		],
 		"main_status_constraint": [
-			"medicine cat",
 			"deputy",
+			"leader"
+		],
+		"random_status_constraint": [
+			"-leader"
+		],
+		"reaction_random_cat": {
+			"like": "decrease",
+			"comfort": "decrease",
+			"respect": "decrease",
+			"trust": "decrease"
+		}
+	},
+	{
+		"id": "dislike_inc_high_highrank3",
+		"intensity": "high",
+		"interactions": [
+			"m_c threatens r_c with exile.",
+			"m_c makes r_c do a tiring chore for the rest of the moon as punishment for something minor.",
+			"m_c threatens to give r_c a terrible name."
+		],
+		"main_status_constraint": [
 			"leader"
 		],
 		"reaction_random_cat": {


### PR DESCRIPTION
## About The Pull Request

There was a category of high like decreases dealing with high ranks (lead, dep, med), but not all of them fit the ranks equally. I divided the relationship event category into three -- lead + med, lead + dep, and just leader. This way, medicine cats will no longer be threatening others with exile or with giving them bad names.

The lead + dep category also does not allow r_c to be chosen as the leader, to prevent a case where the deputy appears to be assigning the leader chores or bossing them around. That could be a great negative relationship event where the deputy is overstepping, but I would want the text to actually acknowledge that, or otherwise I expect we'd get another bug report. 

## Linked Issues

Fixes: #4609 

## Proof of Testing

<img width="1021" height="602" alt="image" src="https://github.com/user-attachments/assets/b4f6f124-643b-467e-8aa4-6b549392d609" />
game remains unexploded. I can't ensure the generation of these specific events