### PR TITLE
[BUGFIX] "mtn_misc_camptwoleafbaremultilore1" incorrectly tags an extra cat as involved

### DIFF
--- a/resources/lang/en/events/misc/mountainous.json
+++ b/resources/lang/en/events/misc/mountainous.json
@@ -94,19 +94,7 @@
             "skill": [
                 "LORE,1"
             ]
-        },
-        "relationships": [
-            {
-                "cats_from": ["r_c"],
-                "cats_to": ["m_c"],
-                "values": ["like", "respect"],
-                "amount": 15,
-                "mutual": false,
-                "log": {
-                    "cats_from": "from_cat listened raptly to to_cat's stories of c_n's ancestors."
-                }
-            }
-        ]
+        }
     },
     {
         "event_id": "mtn_misc_any_patch_accessory",

--- a/resources/lang/en/events/misc/mountainous.json
+++ b/resources/lang/en/events/misc/mountainous.json
@@ -95,9 +95,6 @@
                 "LORE,1"
             ]
         },
-        "r_c": {
-            "age": ["kitten"]
-        },
         "relationships": [
             {
                 "cats_from": ["r_c"],


### PR DESCRIPTION
## About The Pull Request

Bugfix for an event that was incorrectly tagging a kitten as r_c even though r_c isn't mentioned in the event. This also meant deleting the relationship change.

## Linked Issues

Fixes: #4611 

## Proof of Testing

<img width="777" height="224" alt="image" src="https://github.com/user-attachments/assets/29ff3017-bf6b-4829-bd08-aaf889f5f840" />
no longer tagging a kit. Ignore the apprentice being the elder in this event lol. I just had to override it to get the event generated