### PR TITLE
[BUGFIX] n_c:0 in Hitman Murder History Text

### DIFF
--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -7547,7 +7547,7 @@
     "season": ["any"],
     "sub_type": ["murder"],
     "tags": [],
-    "frequency": 2,
+    "frequency": 1,
     "event_text": "r_c meets with a rogue named n_c:0 on the border. A quarter-moon later, m_c turns up dead along the border, n_c:0's scent on {PRONOUN/m_c/poss} cold body.",
     "m_c": {
         "status": [
@@ -7567,7 +7567,7 @@
     "history": [
         {
             "cats": ["m_c"],
-            "death": "m_c was murdered by a rogue named n_c:0, hired by r_c."
+            "death": "m_c was murdered by a rogue hired by r_c."
         }
     ],
     "relationships": [
@@ -7627,7 +7627,7 @@
     "history": [
         {
             "cats": ["m_c"],
-            "death": "m_c died when a rogue named n_c:0 attacked {PRONOUN/m_c/object} on r_c's orders"
+            "death": "m_c died when a rogue attacked {PRONOUN/m_c/object} on r_c's orders"
         }
     ],
     "relationships": [
@@ -7685,7 +7685,7 @@
     "history": [
         {
             "cats": ["m_c"],
-            "death": "m_c was murdered by a rogue named n_c:0, hired by r_c."
+            "death": "m_c was murdered by a rogue hired by r_c."
         }
     ],
     "relationships": [
@@ -7729,7 +7729,7 @@
     "season": ["any"],
     "sub_type": ["murder"],
     "tags": [],
-    "frequency": 4,
+    "frequency": 1,
     "event_text": "r_c promises n_c:0 a new beginning in c_n... at a price paid in blood. Within the moon, m_c is dead and r_c vouches for n_c:0 to join c_n.",
     "m_c": {
         "status": [
@@ -7749,7 +7749,7 @@
     "history": [
         {
             "cats": ["m_c"],
-            "death": "m_c was murdered by a rogue named n_c:0, hired by r_c in exchange for a place in the Clan."
+            "death": "m_c was murdered by a rogue hired by r_c in exchange for a place in the Clan."
         }
     ],
     "relationships": [


### PR DESCRIPTION
## About The Pull Request

Deleting the n_c:0 in history text on the hitman murders. I also lowered the frequency for most of them because in my own experience they were generating as much or more than other murders, and I only ever intended for them to be a kind of unusual alternate kind of murder.

## Linked Issues

Fixes: #4383 

## Proof of Testing

<img width="811" height="51" alt="image" src="https://github.com/user-attachments/assets/46370e8f-f92a-4b3c-b607-165543c70f32" />
no more n_c:0 in hist text