### PR TITLE
[BUGFIX] rel log text still doesn't match patrol text on plains_bord_story1 

### DIFF
--- a/resources/lang/en/patrols/forest/border/any.json
+++ b/resources/lang/en/patrols/forest/border/any.json
@@ -1966,6 +1966,7 @@
                     "SPEAKER,1",
                     "STORY,1"
                 ],
+                "can_have_stat": ["p_l"],
                 "relationships": [
                     {
                         "cats_to": ["s_c"],
@@ -1990,6 +1991,7 @@
                     "playful",
                     "loving"
                 ],
+                "can_have_stat": ["p_l"],
                 "relationships": [
                     {
                         "cats_to": ["patrol"],

--- a/resources/lang/en/patrols/mountainous/border/any.json
+++ b/resources/lang/en/patrols/mountainous/border/any.json
@@ -575,8 +575,10 @@
                 "text": "s_c spins a vivid, engaging tale of a massive war their ancestors fought over the border the patrol is headed to mark. Not only does it keep every cat entertained, but it also emphasizes the importance of the patrol and motivates everyone.",
                 "exp": 20,
                 "stat_skill": [
-                    "SPEAKER,1"
+                    "SPEAKER,1",
+                    "STORY,1"
                 ],
+                "can_have_stat": ["r_c"],
                 "relationships": [
                     {
                         "cats_to": ["s_c"],
@@ -600,6 +602,7 @@
                     "playful",
                     "loving"
                 ],
+                "can_have_stat": ["r_c"],
                 "relationships": [
                     {
                         "cats_to": ["patrol"],

--- a/resources/lang/en/patrols/plains/border/any.json
+++ b/resources/lang/en/patrols/plains/border/any.json
@@ -1509,7 +1509,7 @@
                 "exp": 20,
                 "relationships": [
                     {
-                        "cats_to": ["p_l"],
+                        "cats_to": ["r_c"],
                         "cats_from": ["patrol"],
                         "mutual": false,
                         "values": ["like", "respect", "comfort"],
@@ -1528,6 +1528,7 @@
                     "SPEAKER,1",
                     "STORY,1"
                 ],
+                "can_have_stat": ["r_c"],
                 "relationships": [
                     {
                         "cats_to": ["s_c"],

--- a/resources/lang/en/patrols/wetlands/border/any.json
+++ b/resources/lang/en/patrols/wetlands/border/any.json
@@ -1762,6 +1762,7 @@
                     "STORY,1",
                     "SPEAKER,1"
                 ],
+                "can_have_stat": ["r_c"],
                 "relationships": [
                     {
                         "cats_to": ["s_c"],
@@ -1787,6 +1788,7 @@
                     "loving",
                     "confident"
                 ],
+                "can_have_stat": ["r_c"],
                 "relationships": [
                     {
                         "cats_to": ["s_c"],


### PR DESCRIPTION
## About The Pull Request

Fixing a rel log bug. The patrol describes r_c telling a story but the rel log affected p_l. It seems like plains just had an unusual variation on the patrol. I also verified that the relationship changes were pointed in the right direction on the other biome versions of the same patrol. And I fixed a little bug that had annoyed me for a while about how the intro text can mention one cat telling a story, but sometimes an s_c outcome will refer to a different cat.

## Linked Issues

Fixes: #4618 

## Proof of Testing

<img width="709" height="354" alt="image" src="https://github.com/user-attachments/assets/8acc617d-33d5-4a30-8ae9-c1e7ecdba168" />
