### PR TITLE
[BUGFIX] Fix tick fever localization inconsistency.

### DIFF
--- a/resources/lang/en/conditions/condition_got_strings/gain_illness_strings.json
+++ b/resources/lang/en/conditions/condition_got_strings/gain_illness_strings.json
@@ -41,9 +41,9 @@
     "starving": [
         "m_c is starving."
     ],
-    "tick illness": [
-        "r_c worries over m_c, looking for any tick-heads an apprentice might have left, but {PRONOUN/r_c/subject} can only find a distinctive rash. m_c knows what it means- tick illness.",
-        "m_c's heart sinks as {PRONOUN/m_c/poss} fur starts falling out. The apprentices must have missed a tick- r_c confirms it's tick illness.",
-        "m_c complains about a new rash, going silent when r_c finds a tick-head. {PRONOUN/m_c/subject/CAP} has tick illness."
+    "tick fever": [
+        "r_c worries over m_c, looking for any tick-heads an apprentice might have left, but {PRONOUN/r_c/subject} can only find a distinctive rash. m_c knows what it means- tick fever.",
+        "m_c's heart sinks as {PRONOUN/m_c/poss} fur starts falling out. The apprentices must have missed a tick- r_c confirms it's tick fever.",
+        "m_c complains about a new rash, going silent when r_c finds a tick-head. {PRONOUN/m_c/subject/CAP} has tick fever."
     ]
     }


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

Changes "tick illness" to "tick fever" in `condition_got_strings/gain_illness_strings.json`

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues

Fixes #4376 

<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing

Created tick bites conditions.json for all cats in a clan
Increased `expanded_illness_chance` to 10/25 from 10/250
Reload game and moonskip until Cat's condition progresses to illness. 

Find attached changed "tick fever" strings appearing in-game.

There's an unrelated issue of r_c appearing as a string. Can modify current PR or open a separate PR if not currently addressed or planned. 

![tick bites progressed to fever](https://github.com/user-attachments/assets/9602d6ce-2b82-42b3-8aa6-c3f78dd205bb)

![tick fever condition](https://github.com/user-attachments/assets/5156a740-a219-488f-81e7-08281ed04838)

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->