### PR TITLE
[BUGFIX] Add old_age_death event check for multiple cats

### DIFF
--- a/scripts/events_module/short/short_event_generation.py
+++ b/scripts/events_module/short/short_event_generation.py
@@ -396,12 +396,18 @@ def filter_events(
                     continue
 
         # check for old age
-        if (
-            "old_age" in event.sub_type
-            and main_cat.moons
-            < constants.CONFIG["death_related"]["old_age_death_start"]
-        ):
-            continue
+        if "old_age" in event.sub_type:
+            if (
+                main_cat.moons
+                < constants.CONFIG["death_related"]["old_age_death_start"]
+            ):
+                continue
+            if (
+                random_cat
+                and random_cat.moons
+                < constants.CONFIG["death_related"]["old_age_death_start"]
+            ):
+                continue
         # remove some non-old age events to encourage elders to die of old age more often
         if (
             "old_age" not in event.sub_type
@@ -600,6 +606,15 @@ def filter_events(
             failed_ids.append(chosen_event.event_id)
             final_events.remove(chosen_event)
             chosen_event = None
+        elif (
+            "old_age" in chosen_event.sub_type
+            and chosen_cat.moons
+            < constants.CONFIG["death_related"]["old_age_death_start"]
+        ):
+            failed_ids.append(chosen_event.event_id)
+            final_events.remove(chosen_event)
+            chosen_event = None
+            chosen_cat = None
         else:
             break
 


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

Checks if any cat is younger than the `old_age_death_start` during `short_event_generation`.

Prevents cats from dying of old age in paired events (e.g. `gen_death_age_any5`) where only one cat meets the age threshold.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues

Fixes #3983

<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing

1. Make a cat couple elders (one < 150 moons, one > 150 moons)
3. Force bug event with `game_config.toml`:
```toml
[event_generation]
  debug_ensure_event_id = "gen_death_age_any5"
```
4. Moonskip; the event is not selected:
![](https://github.com/user-attachments/assets/3ffd8de7-b37e-4113-9a68-fb9c2b9dbf0f)

Where Cliffspots is 170 moons and Sablestar is 140 moons.

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->