### PR TITLE
re-adding trait constraint

### DIFF
--- a/resources/lang/en/thoughts/while_alive/general.json
+++ b/resources/lang/en/thoughts/while_alive/general.json
@@ -1015,6 +1015,9 @@
             "Whispers the names of cats who have wronged {PRONOUN/m_c/object} before {PRONOUN/m_c/subject} {VERB/m_c/sleep/sleeps}",
             "Is laughing because a cat {PRONOUN/m_c/subject} {VERB/m_c/don't/doesn't} like got hurt"
         ],
+        "main_trait_constraint": [
+            "vengeful"
+        ],
         "relationship_constraint": [
             "dislikes"
         ],


### PR DESCRIPTION
## About The Pull Request

Fixes the non-vengeful cats having vengeful thoughts. I have a hypothesis that the conversion in relationship values removed some of the trait/skill constraints on some thoughts. It would explain why this happened to both vengeful and strange

## Linked Issues

Fixes: #4633

## Proof of Testing

<img width="639" height="146" alt="image" src="https://github.com/user-attachments/assets/e0ade2f9-1eb5-4ead-97e2-ec7061d039b8" />
behold, a non-vengeful cat NOT having vengeful thoughts