### PR TITLE
[REL LOGS] Desert Training (GL and LB)

### DIFF
--- a/resources/lang/en/patrols/desert/training/greenleaf.json
+++ b/resources/lang/en/patrols/desert/training/greenleaf.json
@@ -52,20 +52,10 @@
                             "respect",
                             "like"
                         ],
-                        "amount": 10
-                    },
-                    {
-                        "cats_to": [
-                            "patrol"
-                        ],
-                        "cats_from": [
-                            "patrol"
-                        ],
-                        "mutual": false,
-                        "values": [
-                            "like"
-                        ],
-                        "amount": 5
+                        "amount": 10,
+                        "log": {
+                            "cats_from": "from_cat enjoyed to_cat's story about how, in a distant land, the sun brings relief and growth instead of searing death."
+                        }
                     }
                 ],
                 "frequency": 4
@@ -93,20 +83,10 @@
                             "respect",
                             "like"
                         ],
-                        "amount": 10
-                    },
-                    {
-                        "cats_to": [
-                            "patrol"
-                        ],
-                        "cats_from": [
-                            "patrol"
-                        ],
-                        "mutual": false,
-                        "values": [
-                            "like"
-                        ],
-                        "amount": 5
+                        "amount": 10,
+                        "log": {
+                            "cats_from": "from_cat enjoyed to_cat's tales of distant Clans for whom greenleaf is the season of plenty."
+                        }
                     }
                 ],
                 "frequency": 4

--- a/resources/lang/en/patrols/desert/training/leaf-bare.json
+++ b/resources/lang/en/patrols/desert/training/leaf-bare.json
@@ -26,7 +26,7 @@
             "STORY,1",
             "LORE,1"
         ],
-        "intro_text": "The coolness of the rain sliding along r_c's pelt is something to be savored, a rare treat as the gentle rain shower washes by c_n. And the ground - it's so green, so alive! Why under the Stars does c_n not call this season greenleaf, when everything around them springs to life?!",
+        "intro_text": "The coolness of the rain sliding along r_c's pelt is something to be savored, a rare treat as the gentle rain showers c_n. And the ground - it's so green, so alive! Why in StarClan's name does c_n not call this season greenleaf, when everything around them springs to life?!",
         "decline_text": "Not every cat on the patrol is such a fan of the damp, and while r_c is given time to live in the moment, they all want to move on soon.",
         "success_outcomes": [
             {
@@ -52,20 +52,10 @@
                             "respect",
                             "like"
                         ],
-                        "amount": 10
-                    },
-                    {
-                        "cats_to": [
-                            "patrol"
-                        ],
-                        "cats_from": [
-                            "patrol"
-                        ],
-                        "mutual": false,
-                        "values": [
-                            "like"
-                        ],
-                        "amount": 5
+                        "amount": 10,
+                        "log": {
+                            "cats_from": "from_cat enjoyed to_cat's story about how, in a distant land, the sun brings relief and growth instead of searing death."
+                        }
                     }
                 ],
                 "frequency": 4
@@ -93,20 +83,10 @@
                             "respect",
                             "like"
                         ],
-                        "amount": 10
-                    },
-                    {
-                        "cats_to": [
-                            "patrol"
-                        ],
-                        "cats_from": [
-                            "patrol"
-                        ],
-                        "mutual": false,
-                        "values": [
-                            "like"
-                        ],
-                        "amount": 5
+                        "amount": 10,
+                        "log": {
+                            "cats_from": "from_cat enjoyed to_cat's tales of distant Clans for whom greenleaf is the season of plenty."
+                        }
                     }
                 ],
                 "frequency": 4
@@ -140,7 +120,10 @@
                         "values": [
                             "comfort"
                         ],
-                        "amount": 3
+                        "amount": -3,
+                        "log": {
+                            "cats_from": "from_cat and to_cat felt awkward around each other after a rainy training patrol necessitated a trip to the medicine cat den."
+                        }
                     }
                 ],
                 "frequency": 4
@@ -165,11 +148,11 @@
         "min_max_status": {
             "normal adult": [
                 1,
-                6
+                5
             ],
             "apprentice": [
                 1,
-                6
+                5
             ]
         },
         "frequency": 3,
@@ -177,7 +160,7 @@
         "pl_skill_constraint": [
             "STORY,1"
         ],
-        "intro_text": "In the beginning of dreams, the land was flat and empty, p_l whispers, setting the stage for a story.",
+        "intro_text": "In the beginning of dreams, the land was flat and empty, p_l whispers.",
         "decline_text": "Storytime is interrupted by a rain shower, not that anyone minds more water in c_n's territory.",
         "success_outcomes": [
             {
@@ -203,20 +186,10 @@
                             "respect",
                             "like"
                         ],
-                        "amount": 10
-                    },
-                    {
-                        "cats_to": [
-                            "patrol"
-                        ],
-                        "cats_from": [
-                            "patrol"
-                        ],
-                        "mutual": false,
-                        "values": [
-                            "like"
-                        ],
-                        "amount": 5
+                        "amount": 10,
+                        "log": {
+                            "cats_from": "from_cat enjoyed to_cat's story about the Rainbow Serpent who created all other animals."
+                        }
                     }
                 ],
                 "frequency": 4
@@ -224,7 +197,7 @@
         ],
         "fail_outcomes": [
             {
-                "text": "Before dreams? How can you be <i>before dreams</i>, app1 asks, and won't just settle down and let p_l tell the tale.",
+                "text": "Before dreams? How can you be <i>before dreams</i>, app1 asks? {PRONOUN/app1/subject} won't just settle down and let p_l tell the tale.",
                 "exp": 0,
                 "art": "gen_train_argue",
                 "relationships": [
@@ -239,7 +212,10 @@
                         "values": [
                             "like"
                         ],
-                        "amount": -5
+                        "amount": -5,
+                        "log": {
+                            "cats_from": "from_cat was irritated that to_cat kept interrupting {PRONOUN/from_cat/poss} story to ask silly questions."
+                        }
                     }
                 ],
                 "frequency": 4

--- a/resources/lang/en/patrols/desert/training/leaf-bare.json
+++ b/resources/lang/en/patrols/desert/training/leaf-bare.json
@@ -197,7 +197,7 @@
         ],
         "fail_outcomes": [
             {
-                "text": "Before dreams? How can you be <i>before dreams</i>, app1 asks? {PRONOUN/app1/subject} won't just settle down and let p_l tell the tale.",
+                "text": "Before dreams? How can you be <i>before dreams</i>, app1 asks? {PRONOUN/app1/subject/CAP} won't just settle down and let p_l tell the tale.",
                 "exp": 0,
                 "art": "gen_train_argue",
                 "relationships": [


### PR DESCRIPTION
## About The Pull Request

rel logs for desert training patrols -- barely any of them. The newleaf and leaffall files are empty.

## Proof of Testing

<img width="928" height="205" alt="image" src="https://github.com/user-attachments/assets/8e47138a-c940-42b6-8feb-6576af06247f" />

behold