### PR TITLE
[BUGFIX] Accurate Death Text for Beach Patrols

### DIFF
--- a/resources/lang/en/patrols/beach/border/any.json
+++ b/resources/lang/en/patrols/beach/border/any.json
@@ -642,7 +642,7 @@
                 ],
                 "history_text": {
                     "scar": "m_c was injured in a flood.",
-                    "death": "m_c was drowned by floodwaters."
+                    "death": "m_c died of injuries sustained in a flood."
                 },
                 "frequency": 4
             },
@@ -663,7 +663,8 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c was injured in a flood."
+                    "scar": "m_c was injured in a flood.",
+                    "death": "m_c died of injuries sustained in a flood."
                 },
                 "frequency": 4
             }
@@ -1891,7 +1892,7 @@
                 ],
                 "history_text": {
                     "scar": "m_c carries a scar from a fight with a vixen.",
-                    "death": "m_c fell in a battle with a vixen."
+                    "death": "m_c died of injuries inflicted by a vixen."
                 },
                 "relationships": [
                     {
@@ -1951,7 +1952,7 @@
                 ],
                 "history_text": {
                     "scar": "m_c carries a scar from a fight with a red vixen.",
-                    "death": "m_c fell in battle with a red fox."
+                    "death": "m_c died of injuries inflicted by a red vixen."
                 },
                 "relationships": [
                     {
@@ -2081,7 +2082,7 @@
                 ],
                 "history_text": { 
                     "scar": "m_c carries a scar from a fight with a gray vixen.",
-                    "death": "m_c died after a battle with a gray vixen."
+                    "death": "m_c died of injuries inflicted by a gray vixen."
                 }
             },
             {
@@ -2229,7 +2230,7 @@
                 ],
                 "history_text": { 
                     "scar": "m_c carries a scar from a fight with a gray vixen.",
-                    "death": "m_c died after a battle with a gray vixen."
+                    "death": "m_c died from injuries inflicted by a gray vixen."
                 },
                 "relationships": [
                     {

--- a/resources/lang/en/patrols/beach/hunting/any.json
+++ b/resources/lang/en/patrols/beach/hunting/any.json
@@ -781,6 +781,7 @@
                     }
                 ],
                 "history_text": {
+                    "scar": "m_c was scarred after being scraped by broken glass in a Twoleg den.",
                     "death": "m_c bled out after escaping from a Twoleg den."
                 },
                 "frequency": 3,
@@ -922,6 +923,7 @@
                     }
                 ],
                 "history_text": {
+                    "scar": "m_c was scarred after being scraped by broken glass in a Twoleg den.",
                     "death": "m_c bled out after escaping from a Twoleg den."
                 },
                 "frequency": 3
@@ -5364,6 +5366,9 @@
                         "scars": []
                     }
                 ],
+                "history_text": {
+                    "death": "m_c died from the water in {PRONOUN/m_c/poss} lungs after a rogue wave struck {PRONOUN/m_c/object} during a hunt."
+                },
                 "prey": ["very_small"]
             }
         ]
@@ -5778,6 +5783,9 @@
                         "scars": []
                     }
                 ],
+                "history_text": {
+                    "death": "m_c died of water in {PRONOUN/m_c/poss} lungs after a rogue wave struck {PRONOUN/m_c/object} during a hunt."
+                },
                 "prey": ["very_small"]
             }
         ]

--- a/resources/lang/en/patrols/beach/hunting/greenleaf.json
+++ b/resources/lang/en/patrols/beach/hunting/greenleaf.json
@@ -404,7 +404,8 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "r_c was scarred by a rattlesnake."
+                    "scar": "m_c was scarred by a rattlesnake.",
+                    "death": "m_c died after being bitten by a rattlesnake on patrol."
                 },
                 "relationships": [
                     {

--- a/resources/lang/en/patrols/beach/hunting/leaf-bare.json
+++ b/resources/lang/en/patrols/beach/hunting/leaf-bare.json
@@ -434,7 +434,8 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "r_c was scarred by a rattlesnake."
+                    "scar": "m_c was scarred by a rattlesnake.",
+                    "death": "m_c died after being bitten by a rattlesnake on patrol."
                 },
                 "relationships": [
                     {
@@ -774,7 +775,8 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c caught a chill while hunting in leaf-bare."
+                    "scar": "m_c caught a chill while hunting in leaf-bare.",
+                    "death": "m_c got too cold after a snowstorm descended on {PRONOUN/m_c/poss} hunting patrol and never recovered."
                 },
                 "relationships": [
                     {
@@ -873,7 +875,8 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c caught a chill while hunting in leaf-bare."
+                    "scar": "m_c caught a chill while hunting in leaf-bare.",
+                    "death": "m_c got too cold after a snowstorm descended on {PRONOUN/m_c/poss} hunting patrol and never recovered."
                 },
                 "frequency": 4
             }
@@ -1003,7 +1006,8 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c caught a chill while hunting in leaf-bare."
+                    "scar": "m_c caught a chill while hunting in leaf-bare.",
+                    "death": "m_c got too cold after a snowstorm descended on {PRONOUN/m_c/poss} hunting patrol and never recovered."
                 },
                 "prey": [
                     "very_small"

--- a/resources/lang/en/patrols/beach/hunting/leaf-fall.json
+++ b/resources/lang/en/patrols/beach/hunting/leaf-fall.json
@@ -413,8 +413,8 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "r_c was scarred by a rattlesnake.",
-                    "death": "r_c succumbed to a rattlesnake bite."
+                    "scar": "m_c was scarred by a rattlesnake.",
+                    "death": "m_c succumbed to a rattlesnake bite."
                 },
                 "relationships": [
                     {
@@ -700,7 +700,7 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "This cat was scarred by the poison of the death tree.",
+                    "scar": "m_c was scarred by the poison of the death tree.",
                     "death": "m_c died from burns caused by the poison of the death tree."
                 },
                 "relationships": [

--- a/resources/lang/en/patrols/beach/hunting/newleaf.json
+++ b/resources/lang/en/patrols/beach/hunting/newleaf.json
@@ -413,8 +413,8 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "r_c was scarred by a rattlesnake.",
-                    "death": "r_c died after succumbing to a rattlesnake's venom."
+                    "scar": "m_c was scarred by a rattlesnake.",
+                    "death": "m_c succumbed to a rattlesnake's venom."
                 },
                 "relationships": [
                     {

--- a/resources/lang/en/patrols/beach/training/any.json
+++ b/resources/lang/en/patrols/beach/training/any.json
@@ -143,7 +143,8 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c got spiked by a sea urchin while training as an apprentice."
+                    "scar": "m_c got spiked by a sea urchin while training as an apprentice.",
+                    "death": "m_c died after being spiked by a sea urchin."
                 },
                 "frequency": 3
             }
@@ -361,8 +362,8 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c carries a scar from being trapped on patrol.",
-                    "death": "m_c tragically died after being trapped on patrol."
+                    "scar": "m_c was scarred when the sand caved in beneath {PRONOUN/m_c/object}.",
+                    "death": "m_c died of injuries sustained when the sand caved in beneath {PRONOUN/m_c/object}."
                 },
                 "frequency": 3
             },
@@ -373,8 +374,7 @@
                     "r_c"
                 ],
                 "history_text": {
-                    "scar": "m_c carries a scar from being trapped on patrol",
-                    "death": "m_c tragically died after being trapped on patrol."
+                    "death": "m_c suffocated under the sand when the ground collapsed beneath {PRONOUN/m_c/object} on patrol."
                 },
                 "frequency": 3
             },
@@ -395,8 +395,8 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c carries a scar from being trapped on patrol",
-                    "death": "m_c tragically died after being trapped on patrol."
+                    "scar": "m_c was scarred when the sand caved in beneath {PRONOUN/m_c/object}.",
+                    "death": "m_c died of injuries sustained when the sand caved in beneath {PRONOUN/m_c/object}."
                 },
                 "frequency": 3
             }
@@ -598,8 +598,8 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c carries a scar from being trapped on patrol",
-                    "death": "m_c tragically died after being trapped on patrol."
+                    "scar": "m_c was scarred when the sand caved in beneath {PRONOUN/m_c/object}.",
+                    "death": "m_c died of injuries sustained when the sand caved in beneath {PRONOUN/m_c/object}."
                 },
                 "frequency": 3
             }
@@ -675,8 +675,8 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c carries a scar from being trapped on patrol.",
-                    "death": "m_c tragically died after being trapped on patrol."
+                    "scar": "m_c was scarred when the sand caved in beneath {PRONOUN/m_c/object}.",
+                    "death": "m_c died of injuries sustained when the sand caved in beneath {PRONOUN/m_c/object}."
                 },
                 "frequency": 3
             }
@@ -770,9 +770,6 @@
                         ]
                     }
                 ],
-                "history_text": {
-                    "scar": "m_c got injured as an apprentice while exploring alone."
-                },
                 "frequency": 3
             }
         ]

--- a/resources/lang/en/patrols/beach/training/leaf-fall.json
+++ b/resources/lang/en/patrols/beach/training/leaf-fall.json
@@ -505,8 +505,8 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c was scarred from the bite of the cold rock pool {PRONOUN/m_c/subject} swam in as an apprentice.",
-                    "death": "Falling into a cold rock pool gave m_c problems that eventually resulted in {PRONOUN/m_c/poss} death."
+                    "scar": "m_c was scarred from the bite of the cold rockpool {PRONOUN/m_c/subject} swam in as an apprentice.",
+                    "death": "Falling into a cold rockpool gave m_c problems that eventually resulted in {PRONOUN/m_c/poss} death."
                 },
                 "frequency": 4
             }

--- a/resources/lang/en/patrols/beach/training/newleaf.json
+++ b/resources/lang/en/patrols/beach/training/newleaf.json
@@ -557,7 +557,7 @@
                     }
                 ],
                 "history_text": {
-                    "death": "m_c died from complications caused by inhaling water after falling into a rock pool."
+                    "death": "m_c died from complications caused by inhaling water after falling into a rockpool."
                 },
                 "relationships": [
                     {


### PR DESCRIPTION
## About The Pull Request

As described in #4352, plenty of patrols that cause cats potentially life-threatening injuries either don't have death text (which results in the generic and inaccurate "This cat died on patrol") or have inaccurate death text (text that implies they died ON patrol instead of after).

I edited plenty of scar texts as well to be more specific about the nature of the injury.

## Proof of Testing

<img width="594" height="86" alt="image" src="https://github.com/user-attachments/assets/2f281fc3-67a8-4d53-afbf-d5c2c444191a" />

One of the new scar texts (I was trying to kill him but he recovered)