### PR TITLE
[BUGFIX] Accurate Death Text for Forest Patrols

### DIFF
--- a/resources/lang/en/patrols/forest/border/any.json
+++ b/resources/lang/en/patrols/forest/border/any.json
@@ -596,7 +596,7 @@
                 ],
                 "history_text": {
                     "scar": "m_c was scarred by a badger.",
-                    "death": "m_c lost {PRONOUN/s_c/poss} life to a badger."
+                    "death": "m_c died of an injury inflicted by a badger."
                 },
                 "relationships": [
                     {"cats_from": ["some_clan"],
@@ -790,7 +790,7 @@
                 ],
                 "history_text": {
                     "scar": "m_c was scarred by a badger.",
-                    "death": "m_c lost {PRONOUN/m_c/poss} life to a badger."
+                    "death": "m_c died of an injury inflicted by a badger."
                 },
                 "relationships": [
                     {
@@ -982,7 +982,7 @@
                 ],
                 "history_text": {
                     "scar": "m_c was scarred by an invading rogue.",
-                    "death": "m_c was killed by an invading rogue."
+                    "death": "m_c died of an injury inflicted by an invading rogue."
                 },
                 "frequency": 3
             }
@@ -1101,7 +1101,7 @@
                 ],
                 "history_text": {
                     "scar": "m_c was scarred by an invading rogue.",
-                    "death": "m_c was killed by an invading rogue."
+                    "death": "m_c died of an injury inflicted by an invading rogue."
                 },
                 "frequency": 3
             }
@@ -1406,7 +1406,7 @@
                 ],
                 "history_text": {
                     "scar": "m_c was scarred by an invading rogue.",
-                    "death": "m_c was killed by an invading rogue."
+                    "death": "m_c died of an injury inflicted by an invading rogue."
                 },
                 "relationships": [
                     {
@@ -1598,7 +1598,7 @@
                 ],
                 "history_text": {
                     "scar": "m_c was scarred by an invading rogue.",
-                    "death": "m_c was killed by an invading rogue."
+                    "death": "m_c died of an injury inflicted by an invading rogue."
                 },
                 "frequency": 3
             }
@@ -2228,8 +2228,8 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "This cat is scarred from bravely defending the Clan against a dog.",
-                    "death": "This cat died to keep c_n safe from a large dog."
+                    "scar": "m_c was scarred while defending the Clan against a dog.",
+                    "death": "m_c died of injuries inflicted by a large dog."
                 },
                 "relationships": [
                     {
@@ -2695,8 +2695,8 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "This cat is scarred from bravely defending the Clan against a dog.",
-                    "death": "This cat died to keep the Clan safe from a large dog."
+                    "scar": "m_c was scarred while defending the Clan against a dog.",
+                    "death": "m_c died of injuries inflicted by a large dog."
                 },
                 "relationships": [
                     {
@@ -2838,8 +2838,8 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "This cat is scarred from bravely defending the Clan against a dog.",
-                    "death": "This cat died to keep the Clan safe from a large dog."
+                    "scar": "m_c was scarred while defending the Clan against a dog.",
+                    "death": "m_c died of injuries inflicted by a large dog."
                 },
                 "relationships": [
                     {
@@ -2962,8 +2962,8 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "This cat got a scar from a fight with a small dog, but {PRONOUN/m_c/subject} always {VERB/m_c/say/says} it was a huge dog.",
-                    "death": "This cat was killed in a fight with a small dog, but {PRONOUN/m_c/subject} took the dog out with {PRONOUN/m_c/object}."
+                    "scar": "m_c got a scar from a fight with a small dog, but {PRONOUN/m_c/subject} always {VERB/m_c/say/says} it was a huge dog.",
+                    "death": "m_c died of injuries inflicted by a small dog."
                 },
                 "relationships": [
                     {
@@ -3125,7 +3125,8 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "This cat got a scar from a fight with a small dog, but {PRONOUN/m_c/subject} always {VERB/m_c/say/says} it was a huge dog."
+                    "scar": "m_c got a scar from a fight with a small dog, but {PRONOUN/m_c/subject} always {VERB/m_c/say/says} it was a huge dog.",
+                    "death": "m_c died of injuries inflicted by a small dog."
                 },
                 "frequency": 3
             }
@@ -3424,7 +3425,7 @@
                 ],
                 "history_text": {
                     "scar": "m_c carries a scar from a fox fight.",
-                    "death": "m_c fell in battle with a fox."
+                    "death": "m_c died of an injury inflicted by a red vixen."
                 },
                 "relationships": [
                     {
@@ -3453,7 +3454,7 @@
                 ],
                 "history_text": {
                     "scar": "m_c carries a scar from a fox fight.",
-                    "death": "m_c fell in battle with a fox."
+                    "death": "m_c died of an injury inflicted by a fox."
                 },
                 "relationships": [
                     {
@@ -3581,7 +3582,10 @@
                         "scars": ["LEFTEAR"]
                     }
                 ],
-                "history_text": { "scar": "m_c carries a scar from a fox fight." }
+                "history_text": {
+                    "scar": "m_c carries a scar from a fox fight.",
+                    "death": "m_c died of an injury inflicted by a fox."
+                }
             },
             {
                 "text": "The patrol overcomes the gray vixen they find and drives her off thanks to a brilliant battle move by s_c. The cats swirl around s_c afterwards, congratulating {PRONOUN/s_c/object} on {PRONOUN/s_c/poss} bravery and skill.",
@@ -3732,7 +3736,10 @@
                         "scars": ["LEFTEAR"]
                     }
                 ],
-                "history_text": { "scar": "m_c carries a scar from a fox fight." },
+                "history_text": {
+                    "scar": "m_c carries a scar from a fox fight.",
+                    "death": "m_c died of an injury inflicted by a fox."
+            },
                 "relationships": [
                     {
                         "cats_to": ["s_c"],

--- a/resources/lang/en/patrols/forest/hunting/any.json
+++ b/resources/lang/en/patrols/forest/hunting/any.json
@@ -677,15 +677,9 @@
                         ],
                         "injuries": [
                             "sprain"
-                        ],
-                        "scars": [
-                            "TOETRAP"
                         ]
                     }
                 ],
-                "history_text": {
-                    "scar": "m_c gained a scar after trying to chase some squirrels up a tree."
-                },
                 "prey": [
                     "very_small"
                 ],
@@ -860,9 +854,6 @@
                         ],
                         "injuries": [
                             "big_bite_injury"
-                        ],
-                        "scars": [
-                            "NECKBITE"
                         ]
                     }
                 ],
@@ -1017,9 +1008,6 @@
                         ],
                         "injuries": [
                             "big_bite_injury"
-                        ],
-                        "scars": [
-                            "NECKBITE"
                         ]
                     }
                 ],
@@ -1269,9 +1257,6 @@
                         ],
                         "injuries": [
                             "big_bite_injury"
-                        ],
-                        "scars": [
-                            "NECKBITE"
                         ]
                     }
                 ],
@@ -2107,9 +2092,6 @@
                         ],
                         "injuries": [
                             "big_bite_injury"
-                        ],
-                        "scars": [
-                            "NECKBITE"
                         ]
                     }
                 ],
@@ -2260,14 +2242,9 @@
                         ],
                         "injuries": [
                             "torn pelt"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
-                "history_text": {
-                    "scar": "m_c was scarred after being scraped by broken glass in a Twoleg den.",
-                    "death": "m_c died from injuries sustained during an escape from a Twoleg den."
-                },
                 "frequency": 3,
             "relationships": [
                 {
@@ -4279,8 +4256,7 @@
                 "injury": [
                     {
                         "cats": ["r_c"],
-                        "injuries": ["big_bite_injury"],
-                        "scars": ["NECKBITE"]
+                        "injuries": ["big_bite_injury"]
                     }
                 ],
                 "history_text": { 
@@ -4317,8 +4293,7 @@
                 "injury": [
                     {
                         "cats": ["s_c"],
-                        "injuries": ["big_bite_injury"],
-                        "scars": ["NECKBITE"]
+                        "injuries": ["big_bite_injury"]
                     }
                 ],
                 "history_text": { 
@@ -4768,8 +4743,7 @@
                 "injury": [
                     {
                         "cats": ["app1"],
-                        "injuries": ["minor_injury"],
-                        "scars": []
+                        "injuries": ["minor_injury"]
                     }
                 ],
                 "relationships": [
@@ -5000,8 +4974,7 @@
                 "injury": [
                     {
                         "cats": ["app1"],
-                        "injuries": ["minor_injury"],
-                        "scars": []
+                        "injuries": ["minor_injury"]
                     }
                 ],
                 "relationships": [
@@ -5818,8 +5791,7 @@
                 "injury": [
                     {
                         "cats": ["r_c"],
-                        "injuries": ["dislocated joint"],
-                        "scars": []
+                        "injuries": ["dislocated joint"]
                     }
                 ],
                 "prey": ["very_small"]
@@ -5895,8 +5867,7 @@
                 "injury": [
                     {
                         "cats": ["r_c"],
-                        "injuries": ["severe headache"],
-                        "scars": []
+                        "injuries": ["severe headache"]
                     }
                 ],
                 "relationships": [
@@ -5984,8 +5955,7 @@
                 "injury": [
                     {
                         "cats": ["r_c"],
-                        "injuries": ["diarrhea"],
-                        "scars": []
+                        "injuries": ["diarrhea"]
                     }
                 ],
                 "prey": ["very_small"]
@@ -6232,8 +6202,7 @@
                 "injury": [
                     {
                         "cats": ["r_c"],
-                        "injuries": ["dislocated joint"],
-                        "scars": []
+                        "injuries": ["dislocated joint"]
                     }
                 ],
                 "prey": ["very_small"]
@@ -6309,8 +6278,7 @@
                 "injury": [
                     {
                         "cats": ["r_c"],
-                        "injuries": ["diarrhea"],
-                        "scars": []
+                        "injuries": ["diarrhea"]
                     }
                 ],
                 "prey": ["very_small"]

--- a/resources/lang/en/patrols/forest/hunting/any.json
+++ b/resources/lang/en/patrols/forest/hunting/any.json
@@ -163,7 +163,7 @@
                 ],
                 "history_text": {
                     "scar": "m_c was scarred by a porcupine while on patrol.",
-                    "death": "m_c was killed by an angry porcupine while on patrol."
+                    "death": "m_c died after being quilled by a porcupine on patrol."
                 },
                 "frequency": 3
             }
@@ -309,7 +309,7 @@
                 ],
                 "history_text": {
                     "scar": "m_c was scarred by a porcupine while on patrol.",
-                    "death": "m_c was killed by an angry porcupine while on patrol."
+                    "death": "m_c died after being quilled by a porcupine on patrol."
                 },
                 "frequency": 3
             }
@@ -868,7 +868,7 @@
                 ],
                 "history_text": {
                     "scar": "m_c was scarred by a coyote protecting its scavenged meal.",
-                    "death": "m_c was killed by a coyote protecting its scavenged meal."
+                    "death": "m_c died from injuries inflicted by a coyote protecting its scavenged meal."
                 },
                 "frequency": 3
             }
@@ -1025,7 +1025,7 @@
                 ],
                 "history_text": {
                     "scar": "m_c was scarred by a coyote protecting its scavenged meal.",
-                    "death": "m_c was killed by a coyote protecting its scavenged meal."
+                    "death": "m_c died from injuries inflicted by a coyote protecting its scavenged meal."
                 },
                 "frequency": 3
             }
@@ -1277,7 +1277,7 @@
                 ],
                 "history_text": {
                     "scar": "m_c was scarred by a wolf protecting its scavenged meal.",
-                    "death": "m_c was killed by a wolf protecting its meal."
+                    "death": "m_c died from injuries inflicted by a wolf protecting its meal."
                 },
                 "frequency": 3
             }
@@ -2264,6 +2264,10 @@
                         "scars": []
                     }
                 ],
+                "history_text": {
+                    "scar": "m_c was scarred after being scraped by broken glass in a Twoleg den.",
+                    "death": "m_c died from injuries sustained during an escape from a Twoleg den."
+                },
                 "frequency": 3,
             "relationships": [
                 {

--- a/resources/lang/en/patrols/forest/hunting/greenleaf.json
+++ b/resources/lang/en/patrols/forest/hunting/greenleaf.json
@@ -648,8 +648,7 @@
                         "injuries": [
                             "minor_injury",
                             "sprain"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "frequency": 4
@@ -1294,8 +1293,7 @@
                             "sprain",
                             "sore",
                             "shivering"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "history_text": {
@@ -2307,8 +2305,7 @@
                         ],
                         "injuries": [
                             "sprain"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "prey": [
@@ -2408,8 +2405,7 @@
                         ],
                         "injuries": [
                             "hot_injury"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "history_text": {
@@ -2489,7 +2485,12 @@
                             "burn",
                             "non_lethal"
                         ],
-                        "scars": []
+                        "scars": [
+                            "BURNBELLY",
+                            "BURNPAWS",
+                            "BURNRUMP",
+                            "BURNTAIL"
+                        ]
                     }
                 ],
                 "frequency": 3
@@ -2651,9 +2652,6 @@
                         ],
                         "injuries": [
                             "big_bite_injury"
-                        ],
-                        "scars": [
-                            "NECKBITE"
                         ]
                     }
                 ],
@@ -2683,9 +2681,6 @@
                         ],
                         "injuries": [
                             "big_bite_injury"
-                        ],
-                        "scars": [
-                            "NECKBITE"
                         ]
                     }
                 ],
@@ -2881,9 +2876,6 @@
                         ],
                         "injuries": [
                             "big_bite_injury"
-                        ],
-                        "scars": [
-                            "NECKBITE"
                         ]
                     }
                 ],
@@ -2913,9 +2905,6 @@
                         ],
                         "injuries": [
                             "big_bite_injury"
-                        ],
-                        "scars": [
-                            "NECKBITE"
                         ]
                     }
                 ],
@@ -3032,8 +3021,7 @@
                         "injuries": [
                             "bruises",
                             "scrapes"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "prey": [
@@ -3086,9 +3074,6 @@
                         ],
                         "injuries": [
                             "big_bite_injury"
-                        ],
-                        "scars": [
-                            "LEGBITE"
                         ]
                     }
                 ],
@@ -3129,9 +3114,6 @@
                         ],
                         "injuries": [
                             "big_bite_injury"
-                        ],
-                        "scars": [
-                            "LEGBITE"
                         ]
                     }
                 ],
@@ -3759,8 +3741,7 @@
                         ],
                         "injuries": [
                             "minor_injury"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "frequency": 3
@@ -3784,8 +3765,7 @@
                         ],
                         "injuries": [
                             "minor_injury"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "frequency": 3
@@ -3877,8 +3857,7 @@
                         ],
                         "injuries": [
                             "minor_injury"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "frequency": 4
@@ -3902,8 +3881,7 @@
                         ],
                         "injuries": [
                             "small cut"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
             "relationships": [
@@ -4003,8 +3981,7 @@
                         ],
                         "injuries": [
                             "minor_injury"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "frequency": 4

--- a/resources/lang/en/patrols/forest/hunting/greenleaf.json
+++ b/resources/lang/en/patrols/forest/hunting/greenleaf.json
@@ -448,7 +448,7 @@
                 ],
                 "history_text": {
                     "scar": "This cat was scarred after falling from a tree.",
-                    "death": "m_c died after falling from a tree while hunting."
+                    "death": "m_c died from {PRONOUN/m_c/poss} broken bone after falling from a tree while hunting."
                 },
                 "relationships": [
                     {
@@ -2413,7 +2413,7 @@
                     }
                 ],
                 "history_text": {
-                    "death": "This cat died from heat stroke."
+                    "death": "m_c died from heat stroke."
                 },
                 "prey": [
                     "very_small"

--- a/resources/lang/en/patrols/forest/hunting/leaf-bare.json
+++ b/resources/lang/en/patrols/forest/hunting/leaf-bare.json
@@ -151,8 +151,7 @@
                         ],
                         "injuries": [
                             "cold_injury"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "history_text": {
@@ -251,8 +250,7 @@
                         ],
                         "injuries": [
                             "cold_injury"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "history_text": {
@@ -405,8 +403,7 @@
                         ],
                         "injuries": [
                             "cold_injury"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "history_text": {
@@ -1446,9 +1443,8 @@
                             "r_c"
                         ],
                         "injuries": [
-                            "broken bone"
-                        ],
-                        "scars": []
+                            "blunt_force_injury"
+                        ]
                     }
                 ],
                 "history_text": {
@@ -1589,8 +1585,7 @@
                         ],
                         "injuries": [
                             "shivering"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "history_text": {
@@ -1751,8 +1746,7 @@
                         ],
                         "injuries": [
                             "cold_injury"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "history_text": {
@@ -2134,7 +2128,9 @@
                         "injuries": [
                             "rat_bite"
                         ],
-                        "scars": []
+                        "scars": [
+                            "RATBITE"
+                        ]
                     }
                 ],
                 "history_text": {
@@ -2259,7 +2255,9 @@
                         "injuries": [
                             "rat_bite"
                         ],
-                        "scars": []
+                        "scars": [
+                            "RATBITE"
+                        ]
                     }
                 ],
                 "history_text": {
@@ -2285,7 +2283,9 @@
                         "injuries": [
                             "rat_bite"
                         ],
-                        "scars": []
+                        "scars": [
+                            "RATBITE"
+                        ]
                     }
                 ],
                 "history_text": {
@@ -3051,9 +3051,6 @@
                         "injuries": [
                             "minor_injury",
                             "cold_injury"
-                        ],
-                        "scars": [
-                            "FROSTTAIL"
                         ]
                     }
                 ],
@@ -3078,9 +3075,6 @@
                         "injuries": [
                             "minor_injury",
                             "cold_injury"
-                        ],
-                        "scars": [
-                            "FROSTTAIL"
                         ]
                     }
                 ],
@@ -3213,9 +3207,6 @@
                         "injuries": [
                             "minor_injury",
                             "cold_injury"
-                        ],
-                        "scars": [
-                            "FROSTTAIL"
                         ]
                     }
                 ],
@@ -3255,9 +3246,6 @@
                         "injuries": [
                             "minor_injury",
                             "cold_injury"
-                        ],
-                        "scars": [
-                            "FROSTTAIL"
                         ]
                     }
                 ],
@@ -3788,7 +3776,10 @@
                             "scrapes",
                             "torn ear"
                         ],
-                        "scars": []
+                        "scars": [
+                            "LEFTEAR",
+                            "RIGHTEAR"
+                        ]
                     }
                 ],
                 "history_text": {
@@ -4253,8 +4244,7 @@
                         ],
                         "injuries": [
                             "shivering"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "history_text": {

--- a/resources/lang/en/patrols/forest/hunting/leaf-bare.json
+++ b/resources/lang/en/patrols/forest/hunting/leaf-bare.json
@@ -157,7 +157,7 @@
                 ],
                 "history_text": {
                     "scar": "m_c caught a chill while hunting in leaf-bare.",
-                    "death": "m_c froze to death after hunting in a storm."
+                    "death": "m_c couldn't recover from {PRONOUN/m_c/poss} chill after hunting in a storm."
                 },
                 "relationships": [
                     {
@@ -257,7 +257,7 @@
                 ],
                 "history_text": {
                     "scar": "m_c caught a chill while hunting in leaf-bare.",
-                    "death": "m_c froze to death after hunting in a storm."
+                    "death": "m_c couldn't recover from {PRONOUN/m_c/poss} chill after hunting in a storm."
                 },
                 "frequency": 4
             }
@@ -411,7 +411,7 @@
                 ],
                 "history_text": {
                     "scar": "m_c caught a chill while hunting in leaf-bare.",
-                    "death": "m_c froze to death while hunting in a storm."
+                    "death": "m_c couldn't recover from {PRONOUN/m_c/poss} chill after hunting in a storm."
                 },
                 "frequency": 4
             }
@@ -1452,7 +1452,7 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "This cat was scarred after falling from a tree.",
+                    "scar": "m_c was scarred after falling from a tree.",
                     "death": "m_c died after falling from a tree while hunting."
                 },
                 "relationships": [
@@ -1594,7 +1594,7 @@
                     }
                 ],
                 "history_text": {
-                    "death": "This cat froze to death."
+                    "death": "m_c caught a chill while hunting and couldn't recover."
                 },
                 "relationships": [
                     {
@@ -1757,7 +1757,7 @@
                 ],
                 "history_text": {
                     "scar": "m_c caught a chill while hunting in leaf-bare.",
-                    "death": "m_c froze to death after hunting in leaf-bare."
+                    "death": "m_c couldn't recover from {PRONOUN/m_c/poss} chill after hunting in a storm."
                 },
                 "prey": [
                     "very_small"
@@ -3221,7 +3221,7 @@
                 ],
                 "history_text": {
                     "scar": "m_c was scarred after a brush with frostbite, gotten while hunting in leaf-bare as an apprentice.",
-                    "death": "m_c froze to death, caught in a snowstorm while hunting by themselves."
+                    "death": "m_c died of frostbite after hunting alone in leaf-bare."
                 },
                 "frequency": 4
             },
@@ -3263,7 +3263,7 @@
                 ],
                 "history_text": {
                     "scar": "m_c was scarred after a brush with frostbite, gotten while hunting in leaf-bare as an apprentice.",
-                    "death": "m_c froze to death, caught in a snowstorm while hunting by {PRONOUN/app1/self}."
+                    "death": "m_c died of frostbite after hunting alone in leaf-bare."
                 },
                 "frequency": 4
             }
@@ -4259,7 +4259,7 @@
                 ],
                 "history_text": {
                     "scar": "m_c was scarred from the bite of the cold stream {PRONOUN/m_c/subject} fell into as an apprentice.",
-                    "death": "The viewpoint c_n thought was safe from avalanches... was not."
+                    "death": "m_c couldn't recover from {PRONOUN/m_c/poss} chill after falling in a freezing stream."
                 },
                 "frequency": 4
             }

--- a/resources/lang/en/patrols/forest/hunting/leaf-fall.json
+++ b/resources/lang/en/patrols/forest/hunting/leaf-fall.json
@@ -429,9 +429,8 @@
                             "r_c"
                         ],
                         "injuries": [
-                            "broken bone"
-                        ],
-                        "scars": []
+                            "blunt_force_injury"
+                        ]
                     }
                 ],
                 "history_text": {
@@ -718,12 +717,11 @@
                         ],
                         "injuries": [
                             "shivering"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c was scarred after disappearing on patrol and being found soaked and freezing.",
+                    "scar": "m_c was scarred after catching a chill on patrol.",
                     "death": "m_c caught a chill on patrol and never recovered."
                 },
             "relationships": [
@@ -1070,7 +1068,9 @@
                         "injuries": [
                             "rat_bite"
                         ],
-                        "scars": []
+                        "scars": [
+                            "RATBITE"
+                        ]
                     }
                 ],
                 "history_text": {
@@ -1177,7 +1177,9 @@
                         "injuries": [
                             "rat_bite"
                         ],
-                        "scars": []
+                        "scars": [
+                            "RATBITE"
+                        ]
                     }
                 ],
                 "history_text": {
@@ -1203,7 +1205,9 @@
                         "injuries": [
                             "rat_bite"
                         ],
-                        "scars": []
+                        "scars": [
+                            "RATBITE"
+                        ]
                     }
                 ],
                 "history_text": {
@@ -2154,8 +2158,7 @@
                         ],
                         "injuries": [
                             "minor_injury"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "frequency": 3
@@ -2174,8 +2177,7 @@
                         ],
                         "injuries": [
                             "minor_injury"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "frequency": 3
@@ -2308,8 +2310,7 @@
                         ],
                         "injuries": [
                             "minor_injury"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "frequency": 4
@@ -2328,8 +2329,7 @@
                         ],
                         "injuries": [
                             "minor_injury"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "relationships": [

--- a/resources/lang/en/patrols/forest/hunting/leaf-fall.json
+++ b/resources/lang/en/patrols/forest/hunting/leaf-fall.json
@@ -435,7 +435,7 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "This cat was scarred after falling from a tree.",
+                    "scar": "m_c was scarred after falling from a tree.",
                     "death": "m_c died after falling from a tree while hunting."
                 },
                 "relationships": [
@@ -723,7 +723,8 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c was scarred after disappearing on patrol and being found soaked and freezing."
+                    "scar": "m_c was scarred after disappearing on patrol and being found soaked and freezing.",
+                    "death": "m_c caught a chill on patrol and never recovered."
                 },
             "relationships": [
                 {
@@ -1073,7 +1074,8 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c carries a scar from fighting a swarm of rats."
+                    "scar": "m_c carries a scar from fighting a swarm of rats.",
+                    "death": "m_c died of a rat bite."
                 },
                 "prey": [
                     "very_small"
@@ -1179,7 +1181,8 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c was scarred fighting a Rat King."
+                    "scar": "m_c was scarred fighting a Rat King.",
+                    "death": "m_c died of a rat bite sustained while fighting a Rat King."
                 },
                 "prey": [
                     "very_small"
@@ -1204,7 +1207,8 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c was scarred fighting a Rat King."
+                    "scar": "m_c was scarred fighting a Rat King.",
+                    "death": "m_c died of a rat bite sustained while fighting a Rat King."
                 },
                 "prey": [
                     "very_small"

--- a/resources/lang/en/patrols/forest/hunting/newleaf.json
+++ b/resources/lang/en/patrols/forest/hunting/newleaf.json
@@ -434,6 +434,10 @@
                         "scars": []
                     }
                 ],
+                "history_text": {
+                    "scar": "m_c was scarred after {PRONOUN/m_c/subject} fell out of a tree during a hunt.",
+                    "death": "m_c died of a broken bone after falling out of a tree during a hunt."
+                },
                 "relationships": [
                     {
                         "cats_to": [
@@ -773,7 +777,8 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c was scarred after disappearing on patrol and being discovered injured."
+                    "scar": "m_c was scarred after disappearing on patrol and being discovered injured.",
+                    "death": "m_c caught a chill on patrol and never recovered."
                 },
                 "relationships": [
                     {
@@ -1216,7 +1221,8 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c carries a scar from fighting a swarm of rats."
+                    "scar": "m_c carries a scar from fighting a swarm of rats.",
+                    "death": "m_c died of a rat bite."
                 },
                 "prey": [
                     "very_small"
@@ -1339,7 +1345,8 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c was scarred fighting a Rat King."
+                    "scar": "m_c was scarred fighting a Rat King.",
+                    "death": "m_c died of a rat bite sustained while fighting a Rat King."
                 },
                 "relationships": [
                     {
@@ -1381,7 +1388,8 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c was scarred fighting a Rat King."
+                    "scar": "m_c was scarred fighting a Rat King.",
+                    "death": "m_c died of a rat bite sustained while fighting a Rat King."
                 },
             "relationships": [
                 {
@@ -2922,7 +2930,7 @@
                 ],
                 "history_text": {
                     "scar": "m_c will always carry the scars from falling from the treetops while nest raiding alone.",
-                    "death": "m_c died falling from the treetops, out on a solo nest raid."
+                    "death": "m_c died of {PRONOUN/m_c/poss} injuries after falling from the treetops, out on a solo nest raid."
                 },
                 "frequency": 2
             }
@@ -3030,7 +3038,7 @@
                 ],
                 "history_text": {
                     "scar": "m_c will always carry the scars from falling from the treetops while nest raiding alone.",
-                    "death": "m_c died falling from the treetops, out on a solo nest raid."
+                    "death": "m_c died of {PRONOUN/m_c/poss} injuries after falling from the treetops, out on a solo nest raid."
                 },
                 "frequency": 3
             },
@@ -3082,7 +3090,7 @@
                 ],
                 "history_text": {
                     "scar": "m_c will always carry the scars from falling from the treetops while nest raiding alone.",
-                    "death": "m_c died falling from the treetops, out on a solo nest raid."
+                    "death": "m_c died of {PRONOUN/m_c/poss} injuries after falling from the treetops, out on a solo nest raid."
                 },
                 "frequency": 2
             }
@@ -3334,7 +3342,8 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c will always carry the scars from falling from the treetops while nest raiding alone as an apprentice."
+                    "scar": "m_c will always carry the scars from falling from the treetops while nest raiding alone as an apprentice.",
+                    "death": "m_c died of {PRONOUN/m_c/poss} injuries after falling from the treetops, out on a solo nest raid."
                 },
                 "frequency": 2
             },
@@ -3361,7 +3370,8 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c will always carry the scars from falling from the treetops while nest raiding alone as an apprentice."
+                    "scar": "m_c will always carry the scars from falling from the treetops while nest raiding alone as an apprentice.",
+                    "death": "m_c died of {PRONOUN/m_c/poss} injuries after falling from the treetops, out on a solo nest raid."
                 },
                 "frequency": 1
             },

--- a/resources/lang/en/patrols/forest/hunting/newleaf.json
+++ b/resources/lang/en/patrols/forest/hunting/newleaf.json
@@ -429,9 +429,8 @@
                             "r_c"
                         ],
                         "injuries": [
-                            "broken bone"
-                        ],
-                        "scars": []
+                            "blunt_force_injury"
+                        ]
                     }
                 ],
                 "history_text": {
@@ -772,12 +771,11 @@
                             "sprain",
                             "sore",
                             "shivering"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c was scarred after disappearing on patrol and being discovered injured.",
+                    "scar": "m_c was scarred after disappearing on patrol and catching a chill.",
                     "death": "m_c caught a chill on patrol and never recovered."
                 },
                 "relationships": [
@@ -1217,7 +1215,9 @@
                         "injuries": [
                             "rat_bite"
                         ],
-                        "scars": []
+                        "scars": [
+                            "RATBITE"
+                        ]
                     }
                 ],
                 "history_text": {
@@ -1341,7 +1341,9 @@
                         "injuries": [
                             "rat_bite"
                         ],
-                        "scars": []
+                        "scars": [
+                            "RATBITE"
+                        ]
                     }
                 ],
                 "history_text": {
@@ -1384,7 +1386,9 @@
                         "injuries": [
                             "rat_bite"
                         ],
-                        "scars": []
+                        "scars": [
+                            "RATBITE"
+                        ]
                     }
                 ],
                 "history_text": {
@@ -2311,8 +2315,7 @@
                         ],
                         "injuries": [
                             "minor_injury"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "frequency": 3
@@ -2331,8 +2334,7 @@
                         ],
                         "injuries": [
                             "minor_injury"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "frequency": 3
@@ -2422,8 +2424,7 @@
                         ],
                         "injuries": [
                             "minor_injury"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "frequency": 4
@@ -2442,8 +2443,7 @@
                         ],
                         "injuries": [
                             "minor_injury"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
             "relationships": [
@@ -2893,8 +2893,7 @@
                         ],
                         "injuries": [
                             "minor_injury"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "frequency": 3
@@ -2922,9 +2921,6 @@
                         ],
                         "injuries": [
                             "blunt_force_injury"
-                        ],
-                        "scars": [
-                            "TWO"
                         ]
                     }
                 ],
@@ -3030,9 +3026,6 @@
                         "injuries": [
                             "minor_injury",
                             "blunt_force_injury"
-                        ],
-                        "scars": [
-                            "TWO"
                         ]
                     }
                 ],
@@ -3082,9 +3075,6 @@
                         "injuries": [
                             "minor_injury",
                             "blunt_force_injury"
-                        ],
-                        "scars": [
-                            "TWO"
                         ]
                     }
                 ],
@@ -3335,9 +3325,6 @@
                         ],
                         "injuries": [
                             "blunt_force_injury"
-                        ],
-                        "scars": [
-                            "TWO"
                         ]
                     }
                 ],
@@ -3363,9 +3350,6 @@
                         ],
                         "injuries": [
                             "blunt_force_injury"
-                        ],
-                        "scars": [
-                            "TWO"
                         ]
                     }
                 ],

--- a/resources/lang/en/patrols/forest/med/greenleaf.json
+++ b/resources/lang/en/patrols/forest/med/greenleaf.json
@@ -241,7 +241,7 @@
                     }
                 ],
                 "history_text": {
-                    "death": "This cat was poisoned by a corpse lily."
+                    "death": "m_c was poisoned by a corpse lily."
                 },
                 "frequency": 4
             },

--- a/resources/lang/en/patrols/forest/training/any.json
+++ b/resources/lang/en/patrols/forest/training/any.json
@@ -782,7 +782,7 @@
                     "r_c"
                 ],
                 "history_text": {
-                    "death": "m_c tragically died after being trapped on patrol."
+                    "death": "m_c was killed by a falling branch on patrol."
                 },
                 "art": "fst_train_stuck_outcome",
                 "frequency": 3
@@ -820,7 +820,7 @@
                     "r_c"
                 ],
                 "history_text": {
-                    "death": "m_c tragically died after being trapped on patrol."
+                    "death": "m_c was killed by a falling branch on patrol."
                 },
                 "art": "fst_train_stuck_outcome",
                 "frequency": 3
@@ -1021,7 +1021,7 @@
                     "r_c"
                 ],
                 "history_text": {
-                    "death": "m_c tragically died after being trapped on patrol."
+                    "death": "m_c was killed by a falling branch on patrol."
                 },
                 "art": "fst_train_stuck_outcome",
                 "frequency": 3
@@ -1102,7 +1102,7 @@
                     "r_c"
                 ],
                 "history_text": {
-                    "death": "m_c tragically died after being trapped on patrol."
+                    "death": "m_c was killed by a falling branch on patrol."
                 },
                 "art": "fst_train_stuck_outcome",
                 "frequency": 3

--- a/resources/lang/en/patrols/forest/training/any.json
+++ b/resources/lang/en/patrols/forest/training/any.json
@@ -382,7 +382,7 @@
                 ],
                 "history_text": {
                     "scar": "m_c was scarred by a badger.",
-                    "death": "m_c lost their life to a badger."
+                    "death": "m_c died of injuries inflicted by a badger."
                 },
                 "frequency": 3
             }
@@ -807,8 +807,8 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c carries a scar from being trapped on patrol.",
-                    "death": "m_c tragically died after being trapped on patrol."
+                    "scar": "m_c carries a scar from when a branch fell on {PRONOUN/m_c/object}.",
+                    "death": "m_c died from {PRONOUN/m_c/poss} injuries after a branch fell on {PRONOUN/m_c/object}."
                 },
                 "art": "fst_train_stuck_outcome",
                 "frequency": 3
@@ -842,8 +842,8 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c carries a scar from being trapped on patrol",
-                    "death": "m_c tragically died after being trapped on patrol."
+                    "scar": "m_c carries a scar from when a branch fell on {PRONOUN/m_c/object}.",
+                    "death": "m_c died from {PRONOUN/m_c/poss} injuries after a branch fell on {PRONOUN/m_c/object}."
                 },
                 "art": "fst_train_stuck_outcome",
                 "frequency": 3
@@ -1043,8 +1043,8 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c carries a scar from being trapped on patrol",
-                    "death": "m_c tragically died after being trapped on patrol."
+                    "scar": "m_c carries a scar from when a branch fell on {PRONOUN/m_c/object}.",
+                    "death": "m_c died from {PRONOUN/m_c/poss} injuries after a branch fell on {PRONOUN/m_c/object}."
                 },
                 "art": "fst_train_stuck_outcome",
                 "frequency": 3
@@ -1124,8 +1124,8 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c carries a scar from being trapped on patrol.",
-                    "death": "m_c tragically died after being trapped on patrol."
+                    "scar": "m_c carries a scar from when a branch fell on {PRONOUN/m_c/object}.",
+                    "death": "m_c died from {PRONOUN/m_c/poss} injuries after a branch fell on {PRONOUN/m_c/object}."
                 },
                 "art": "fst_train_stuck_outcome",
                 "frequency": 3
@@ -1220,9 +1220,6 @@
                         ]
                     }
                 ],
-                "history_text": {
-                    "scar": "m_c got injured as an apprentice, exploring alone."
-                },
                 "frequency": 3
             }
         ]

--- a/resources/lang/en/patrols/forest/training/any.json
+++ b/resources/lang/en/patrols/forest/training/any.json
@@ -177,15 +177,9 @@
                         ],
                         "injuries": [
                             "minor_injury"
-                        ],
-                        "scars": [
-                            "TOETRAP"
                         ]
                     }
                 ],
-                "history_text": {
-                    "scar": "m_c got scarred training in the forest as an apprentice."
-                },
                 "frequency": 3
             }
         ]
@@ -374,9 +368,6 @@
                         ],
                         "injuries": [
                             "big_bite_injury"
-                        ],
-                        "scars": [
-                            "BELLY"
                         ]
                     }
                 ],
@@ -560,9 +551,6 @@
                         ],
                         "injuries": [
                             "big_bite_injury"
-                        ],
-                        "scars": [
-                            "THROAT"
                         ]
                     }
                 ],
@@ -800,9 +788,6 @@
                         ],
                         "injuries": [
                             "blunt_force_injury"
-                        ],
-                        "scars": [
-                            "SIDE"
                         ]
                     }
                 ],
@@ -835,9 +820,6 @@
                         ],
                         "injuries": [
                             "blunt_force_injury"
-                        ],
-                        "scars": [
-                            "LEFTEAR"
                         ]
                     }
                 ],
@@ -1036,9 +1018,6 @@
                         ],
                         "injuries": [
                             "blunt_force_injury"
-                        ],
-                        "scars": [
-                            "LEFTEAR"
                         ]
                     }
                 ],
@@ -1117,9 +1096,6 @@
                         ],
                         "injuries": [
                             "blunt_force_injury"
-                        ],
-                        "scars": [
-                            "SIDE"
                         ]
                     }
                 ],
@@ -1214,8 +1190,7 @@
                         ],
                         "injuries": [
                             "minor_injury"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "frequency": 3
@@ -2358,8 +2333,7 @@
                         ],
                         "injuries": [
                             "poisoned"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "history_text": {
@@ -2457,8 +2431,7 @@
                         ],
                         "injuries": [
                             "poisoned"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "history_text": {
@@ -2526,8 +2499,7 @@
                         ],
                         "injuries": [
                             "stomachache"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "relationships": [

--- a/resources/lang/en/patrols/forest/training/any.json
+++ b/resources/lang/en/patrols/forest/training/any.json
@@ -1215,9 +1215,7 @@
                         "injuries": [
                             "minor_injury"
                         ],
-                        "scars": [
-                            "LEFTEAR"
-                        ]
+                        "scars": []
                     }
                 ],
                 "frequency": 3

--- a/resources/lang/en/patrols/forest/training/any.json
+++ b/resources/lang/en/patrols/forest/training/any.json
@@ -820,7 +820,7 @@
                     "r_c"
                 ],
                 "history_text": {
-                    "death": "m_c was killed by a falling branch on patrol."
+                    "death": "m_c was killed by a falling branch while on patrol."
                 },
                 "art": "fst_train_stuck_outcome",
                 "frequency": 3
@@ -1021,7 +1021,7 @@
                     "r_c"
                 ],
                 "history_text": {
-                    "death": "m_c was killed by a falling branch on patrol."
+                    "death": "m_c was killed by a falling branch while on patrol."
                 },
                 "art": "fst_train_stuck_outcome",
                 "frequency": 3
@@ -1102,7 +1102,7 @@
                     "r_c"
                 ],
                 "history_text": {
-                    "death": "m_c was killed by a falling branch on patrol."
+                    "death": "m_c was killed by a falling branch while on patrol."
                 },
                 "art": "fst_train_stuck_outcome",
                 "frequency": 3

--- a/resources/lang/en/patrols/forest/training/any.json
+++ b/resources/lang/en/patrols/forest/training/any.json
@@ -782,7 +782,7 @@
                     "r_c"
                 ],
                 "history_text": {
-                    "death": "m_c was killed by a falling branch on patrol."
+                    "death": "m_c was killed by a falling branch while on patrol."
                 },
                 "art": "fst_train_stuck_outcome",
                 "frequency": 3

--- a/resources/lang/en/patrols/forest/training/leaf-bare.json
+++ b/resources/lang/en/patrols/forest/training/leaf-bare.json
@@ -195,7 +195,7 @@
                 ],
                 "history_text": {
                     "scar": "m_c was soaked in leaf-bare, and it progressed to scarring frostbite.",
-                    "death": "m_c was soaked in leaf-bare, eventually killing {PRONOUN/m_c/object}."
+                    "death": "m_c was soaked in leaf-bare, and the chill eventually killed {PRONOUN/m_c/object}."
                 },
                 "relationships": [
                     {
@@ -353,7 +353,7 @@
                 ],
                 "history_text": {
                     "scar": "m_c was soaked in leaf-bare, and it progressed to scarring frostbite.",
-                    "death": "m_c was soaked in leaf-bare, eventually killing {PRONOUN/m_c/object}."
+                    "death": "m_c was soaked in leaf-bare, and the chill eventually killed {PRONOUN/m_c/object}."
                 },
                 "relationships": [
                     {


### PR DESCRIPTION
## About The Pull Request

As described in https://github.com/ClanGenOfficial/clangen/issues/4352, plenty of patrols that cause cats potentially life-threatening injuries either don't have death text (which results in the generic and inaccurate "This cat died on patrol") or have inaccurate death text (text that implies they died ON patrol instead of after).

I edited plenty of scar texts as well to be more specific about the nature of the injury. I also removed the scars for all the injuries that give injuries from a pool and deleted empty scar lists for injuries that cannot scar (mostly minor_injury pools)

## Proof of Testing

<img width="561" height="58" alt="image" src="https://github.com/user-attachments/assets/0e454d83-7953-4acd-8b76-798b83f13586" />
