### PR TITLE
[BUGFIX] Accurate Death Text & Scar Clean-up for Plains Patrols

### DIFF
--- a/resources/lang/en/patrols/plains/border/any.json
+++ b/resources/lang/en/patrols/plains/border/any.json
@@ -127,9 +127,6 @@
                         ],
                         "injuries": [
                             "battle_injury"
-                        ],
-                        "scars": [
-                            "RIGHTBLIND"
                         ]
                     }
                 ],
@@ -409,9 +406,6 @@
                         ],
                         "injuries": [
                             "battle_injury"
-                        ],
-                        "scars": [
-                            "THROAT"
                         ]
                     }
                 ],
@@ -2222,13 +2216,12 @@
                 "injury": [
                     {
                         "cats": ["r_c"],
-                        "injuries": ["big_bite_injury"],
-                        "scars": ["NECKBITE"]
+                        "injuries": ["big_bite_injury"]
                     }
                 ],
                 "history_text": {
                     "scar": "m_c carries a scar from a fox fight.",
-                    "death": "m_c fell in battle with a fox."
+                    "death": "m_c died of an injury inflicted by a fox."
                 },
                 "relationships": [
                     {
@@ -2251,13 +2244,12 @@
                 "injury": [
                     {
                         "cats": ["s_c"],
-                        "injuries": ["big_bite_injury"],
-                        "scars": ["NECKBITE"]
+                        "injuries": ["big_bite_injury"]
                     }
                 ],
                 "history_text": {
                     "scar": "m_c carries a scar from a fox fight.",
-                    "death": "m_c fell in battle with a fox."
+                    "death": "m_c died of an injury inflicted by a fox."
                 },
                 "relationships": [
                     {
@@ -2555,22 +2547,18 @@
                         "cats": ["app1"],
                         "injuries": [
                             "bruises"
-                        ],
-                        "scars": []
-                    },
-                    {
-                        "cats": ["app1"],
-                        "injuries": [
-                            "torn ear"
-                        ],
-                        "scars": [
-                            "LEFTEAR"
                         ]
                     },
                     {
                         "cats": ["app1"],
                         "injuries": [
-                            "torn pelt"
+                            "torn ear"
+                        ]
+                    },
+                    {
+                        "cats": ["app1"],
+                        "injuries": [
+                            "claw-wound"
                         ],
                         "scars": [
                             "BRIDGE"
@@ -2579,7 +2567,7 @@
                 ],
                 "history_text": {
                     "scar": "m_c was injured after disturbing a wrathful prairie dog.",
-                    "death": "This cat was killed after wounds given by a prairie dog progressed to something worse."
+                    "death": "m_c died of injuries inflicted by a prairie dog."
                 },
                 "relationships": [
                     {
@@ -2618,8 +2606,7 @@
                         "cats": ["patrol"],
                         "injuries": [
                             "shock"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "history_text": {
@@ -2707,23 +2694,19 @@
                         "injuries": [
                             "shock",
                             "constant nightmares"
-                        ],
-                        "scars": []
+                        ]
                     },
                     {
                         "cats": ["patrol"],
                         "injuries": [
                             "big_bite_injury",
                             "claw-wound"
-                        ],
-                        "scars": [
-                            "SIDE"
                         ]
                     }
                 ],
                 "history_text": {
                     "scar": "m_c was scarred by a badger as an apprentice, after being dared to leap down into an unknown burrow.",
-                    "death": "This cat was killed as an apprentice, after being dared to jump into an unknown burrow."
+                    "death": "m_c died of injuries inflicted by a badger after {PRONOUN/m_c/subject} {VERB/m_c/were/was} dared to leap into an unknown burrow."
                 },
                 "frequency": 4
             }
@@ -2893,22 +2876,18 @@
                         "cats": ["app1"],
                         "injuries": [
                             "bruises"
-                        ],
-                        "scars": []
-                    },
-                    {
-                        "cats": ["app1"],
-                        "injuries": [
-                            "torn ear"
-                        ],
-                        "scars": [
-                            "LEFTEAR"
                         ]
                     },
                     {
                         "cats": ["app1"],
                         "injuries": [
-                            "torn pelt"
+                            "torn ear"
+                        ]
+                    },
+                    {
+                        "cats": ["app1"],
+                        "injuries": [
+                            "claw-wound"
                         ],
                         "scars": [
                             "BRIDGE"
@@ -2917,7 +2896,7 @@
                 ],
                 "history_text": {
                     "scar": "m_c was injured after disturbing a wrathful prairie dog.",
-                    "death": "This cat was killed after wounds given by a prairie dog progressed to something worse."
+                    "death": "m_c died of injuries inflicted by a prairie dog."
                 },
                 "frequency": 4
             },
@@ -2977,40 +2956,27 @@
                         "cats": ["app1"],
                         "injuries": [
                             "bruises"
-                        ],
-                        "scars": []
+                        ]
                     },
                     {
                         "cats": ["app1"],
                         "injuries": [
                             "torn ear"
-                        ],
-                        "scars": [
-                            "LEFTEAR"
                         ]
                     },
                     {
                         "cats": ["app1"],
                         "injuries": [
-                            "torn pelt"
+                            "claw-wound"
                         ],
                         "scars": [
                             "BRIDGE"
-                        ]
-                    },
-                    {
-                        "cats": ["app1"],
-                        "injuries": [
-                            "mangled tail"
-                        ],
-                        "scars": [
-                            "MANTAIL"
                         ]
                     }
                 ],
                 "history_text": {
                     "scar": "m_c was injured after disturbing a badger in its sett.",
-                    "death": "This cat was killed after an unfortunate meeting with a badger."
+                    "death": "m_c died of injuries inflicted by a badger."
                 },
                 "frequency": 4
             },
@@ -3066,15 +3032,12 @@
                         "cats": ["app1"],
                         "injuries": [
                             "big_bite_injury"
-                        ],
-                        "scars": [
-                            "THREE"
                         ]
                     }
                 ],
                 "history_text": {
                     "scar": "m_c was injured after disturbing a badger in its sett.",
-                    "death": "This cat was killed after an unfortunate meeting with a badger."
+                    "death": "m_c died of an injury inflicted by a badger."
                 },
                 "frequency": 1
             }
@@ -3202,8 +3165,7 @@
                         "cats": ["patrol"],
                         "injuries": [
                             "shock"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "history_text": {
@@ -3229,40 +3191,27 @@
                         "cats": ["p_l"],
                         "injuries": [
                             "bruises"
-                        ],
-                        "scars": []
+                        ]
                     },
                     {
                         "cats": ["p_l"],
                         "injuries": [
                             "torn ear"
-                        ],
-                        "scars": [
-                            "LEFTEAR"
                         ]
                     },
                     {
                         "cats": ["p_l"],
                         "injuries": [
-                            "torn pelt"
+                            "claw-wound"
                         ],
                         "scars": [
                             "BRIDGE"
-                        ]
-                    },
-                    {
-                        "cats": ["p_l"],
-                        "injuries": [
-                            "mangled tail"
-                        ],
-                        "scars": [
-                            "MANTAIL"
                         ]
                     }
                 ],
                 "history_text": {
                     "scar": "m_c was injured after disturbing a badger in its sett.",
-                    "death": "This cat died to {PRONOUN/m_c/poss} injuries after an unfortunate meeting with a badger."
+                    "death": "m_c died of an injury inflicted by a badger."
                 },
                 "frequency": 4
             },
@@ -3319,15 +3268,12 @@
                         "cats": ["p_l"],
                         "injuries": [
                             "big_bite_injury"
-                        ],
-                        "scars": [
-                            "THREE"
                         ]
                     }
                 ],
                 "history_text": {
                     "scar": "m_c was injured after disturbing a badger in its sett.",
-                    "death": "This cat was killed after an unfortunate meeting with a badger."
+                    "death": "m_c died of injuries inflicted by a badger."
                 },
                 "frequency": 4
             }
@@ -3779,8 +3725,7 @@
                         "cats": ["patrol"],
                         "injuries": [
                             "shock"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "history_text": {
@@ -3882,15 +3827,12 @@
                             "torn ear",
                             "scrapes",
                             "shock"
-                        ],
-                        "scars": [
-                            "THREE"
                         ]
                     }
                 ],
                 "history_text": {
                     "scar": "m_c was injured after disturbing a badger in its sett.",
-                    "death": "This cat was killed after an unfortunate meeting with a badger."
+                    "death": "m_c died of injuries inflicted by a badger."
                 },
                 "relationships": [
                     {
@@ -4048,8 +3990,7 @@
                         "cats": ["p_l"],
                         "injuries": [
                             "shock"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "dead_cats": [
@@ -4069,15 +4010,12 @@
                         "cats": ["p_l"],
                         "injuries": [
                             "big_bite_injury"
-                        ],
-                        "scars": [
-                            "THREE"
                         ]
                     }
                 ],
                 "history_text": {
                     "scar": "m_c was injured after disturbing a badger in its sett.",
-                    "death": "This cat was killed after an unfortunate meeting with a wolverine."
+                    "death": "m_c died of injuries inflicted by a badger."
                 },
                 "frequency": 2
             }
@@ -4378,9 +4316,6 @@
                         "cats": ["s_c"],
                         "injuries": [
                             "claw-wound"
-                        ],
-                        "scars": [
-                            "THREE"
                         ]
                     }
                 ],
@@ -4476,15 +4411,12 @@
                         "cats": ["r_c"],
                         "injuries": [
                             "big_bite_injury"
-                        ],
-                        "scars": [
-                            "THREE"
                         ]
                     }
                 ],
                 "history_text": {
                     "scar": "m_c was injured after disturbing a badger in its sett.",
-                    "death": "This cat was killed after an unfortunate meeting with a wolverine."
+                    "death": "m_c died of an injury inflicted by a badger."
                 },
                 "frequency": 2
             }
@@ -4784,13 +4716,14 @@
                             "beak_bite"
                         ],
                         "scars": [
-                            "BEAKSIDE"
+                            "BEAKSIDE",
+                            "BEAKLOWER"
                         ]
                     }
                 ],
                 "history_text": {
                     "scar": "m_c was scarred up by a very indignant burrowing owl.",
-                    "death": "m_c died after injuries {PRONOUN/m_c/subject} got from a burrowing owl progressed to something worse."
+                    "death": "m_c died of an injury inflicted by a burrowing owl."
                 },
                 "frequency": 4
             },
@@ -4804,8 +4737,7 @@
                         "injuries": [
                             "sprain",
                             "sore"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "relationships": [
@@ -4831,8 +4763,7 @@
                         "cats": ["app1"],
                         "injuries": [
                             "bruises"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "relationships": [
@@ -4861,13 +4792,11 @@
                         "cats": ["app1"],
                         "injuries": [
                             "water in their lungs"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c's lungs were never the same after falling into a sinkhole as an apprentice.",
-                    "death": "m_c died after from complications from falling into a sinkhole and being buried as an apprentice."
+                    "death": "m_c died from complications after falling into a sinkhole and being buried as an apprentice."
                 },
                 "relationships": [
                     {
@@ -5219,7 +5148,7 @@
                 ],
                 "history_text": {
                     "scar": "m_c was scarred up by a very indignant burrowing owl.",
-                    "death": "m_c died after injuries {PRONOUN/m_c/subject} got from a burrowing owl progressed to something worse."
+                    "death": "m_c died of an injury inflicted by a burrowing owl."
                 },
                 "relationships": [
                     {
@@ -5295,9 +5224,6 @@
                         "cats": ["s_c"],
                         "injuries": [
                             "big_bite_injury"
-                        ],
-                        "scars": [
-                            "THREE"
                         ]
                     }
                 ],
@@ -5359,15 +5285,12 @@
                         "cats": ["r_c"],
                         "injuries": [
                             "big_bite_injury"
-                        ],
-                        "scars": [
-                            "THREE"
                         ]
                     }
                 ],
                 "history_text": {
                     "scar": "m_c was injured after disturbing a badger in its sett.",
-                    "death": "This cat was killed after an unfortunate meeting with a badger."
+                    "death": "m_c died of injuries inflicted by a badger."
                 },
                 "relationships": [
                     {
@@ -5680,15 +5603,12 @@
                         "cats": ["r_c"],
                         "injuries": [
                             "big_bite_injury"
-                        ],
-                        "scars": [
-                            "BRIGHTHEART"
                         ]
                     }
                 ],
                 "history_text": {
-                    "scar": "This cat is scarred from bravely leading a coyote away from the Clan.",
-                    "death": "This cat died from injuries after trying to lead a coyote away from c_n."
+                    "scar": "m_c was scarred from leading a coyote away from the Clan.",
+                    "death": "m_c died of injuries inflicted by a coyote {PRONOUN/m_c/subject} {VERB/m_c/were/was} trying to lead away from the Clan."
                 },
                 "relationships": [
                     {
@@ -5722,15 +5642,12 @@
                         "cats": ["s_c"],
                         "injuries": [
                             "mangled leg"
-                        ],
-                        "scars": [
-                            "MANLEG"
                         ]
                     }
                 ],
                 "history_text": {
-                    "scar": "This cat bears a mangled leg after thinking {PRONOUN/m_c/subject} could take on a coyote by {PRONOUN/m_c/self}",
-                    "death": "This cat died from {PRONOUN/m_c/poss} injuries after trying to take on a coyote alone."
+                    "scar": "m_c bears a mangled leg after thinking {PRONOUN/m_c/subject} could take on a coyote by {PRONOUN/m_c/self}",
+                    "death": "m_c died from {PRONOUN/m_c/poss} injuries after trying to take on a coyote alone."
                 },
                 "relationships": [
                     {

--- a/resources/lang/en/patrols/plains/border/greenleaf.json
+++ b/resources/lang/en/patrols/plains/border/greenleaf.json
@@ -742,9 +742,6 @@
                         ],
                         "injuries": [
                             "big_bite_injury"
-                        ],
-                        "scars": [
-                            "NECKBITE"
                         ]
                     },
                     {
@@ -753,8 +750,7 @@
                         ],
                         "injuries": [
                             "scrapes"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "dead_cats": [
@@ -800,9 +796,6 @@
                         "injuries": [
                             "minor_injury",
                             "torn ear"
-                        ],
-                        "scars": [
-                            "LEFTEAR"
                         ]
                     }
                 ],
@@ -933,15 +926,12 @@
                         "cats": ["r_c"],
                         "injuries": [
                             "big_bite_injury"
-                        ],
-                        "scars": [
-                            "BRIGHTHEART"
                         ]
                     }
                 ],
                 "history_text": {
-                    "scar": "This cat is scarred from bravely defending the Clan against a coyote.",
-                    "death": "This cat died to keep the Clan safe from a large coyote."
+                    "scar": "m_c was scarred defending the Clan against a coyote.",
+                    "death": "m_c died of injuries inflicted by a coyote."
                 },
                 "relationships": [
                     {
@@ -1137,16 +1127,12 @@
                         ],
                         "injuries": [
                             "scrapes"
-                        ],
-                        "scars": []
+                        ]
                     },
                     {
                         "cats": ["r_c"],
                         "injuries": [
                             "torn ear"
-                        ],
-                        "scars": [
-                            "LEFTEAR"
                         ]
                     }
                 ],
@@ -1251,17 +1237,13 @@
                         "cats": ["r_c"],
                         "injuries": [
                             "bite-wound"
-                        ],
-                        "scars": [
-                            "NECKBITE"
                         ]
                     },
                     {
                         "cats": ["r_c"],
                         "injuries": [
                             "blood loss"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "history_text": {
@@ -1503,9 +1485,6 @@
                         "cats": ["r_c"],
                         "injuries": [
                             "torn ear"
-                        ],
-                        "scars": [
-                            "LEFTEAR"
                         ]
                     }
                 ],
@@ -1539,9 +1518,6 @@
                         ],
                         "injuries": [
                             "big_bite_injury"
-                        ],
-                        "scars": [
-                            "NECKBITE"
                         ]
                     },
                     {
@@ -1550,8 +1526,7 @@
                         ],
                         "injuries": [
                             "scrapes"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "dead_cats": [
@@ -1597,9 +1572,6 @@
                         "injuries": [
                             "minor_injury",
                             "torn ear"
-                        ],
-                        "scars": [
-                            "LEFTEAR"
                         ]
                     }
                 ],
@@ -1714,15 +1686,12 @@
                         "cats": ["r_c"],
                         "injuries": [
                             "big_bite_injury"
-                        ],
-                        "scars": [
-                            "BRIGHTHEART"
                         ]
                     }
                 ],
                 "history_text": {
                     "scar": "This cat is scarred from bravely defending the Clan against a coyote.",
-                    "death": "This cat died to keep the Clan safe from a large coyote."
+                    "death": "m_c died of injuries inflicted by a coyote."
                 },
                 "relationships": [
                     {
@@ -2051,15 +2020,12 @@
                         "cats": ["s_c"],
                         "injuries": [
                             "blunt_force_injury"
-                        ],
-                        "scars": [
-                            "BRIDGE"
                         ]
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c was injured from bounding up to an elk calf after a dare from fellow apprentices.",
-                    "death": "m_c provoked an elk calf and the wounds gotten from the experience eventually killed {PRONOUN/m_c/object}."
+                    "scar": "m_c was scarred from bounding up to an elk calf after a dare from fellow apprentices.",
+                    "death": "m_c provoked an elk calf, and the wounds gotten from the experience eventually killed {PRONOUN/m_c/object}."
                 },
                 "relationships": [
                     {
@@ -2086,22 +2052,19 @@
                         "cats": ["app1"],
                         "injuries": [
                             "sprain"
-                        ],
-                        "scars": []
+                        ]
                     },
                     {
                         "cats": ["app1"],
                         "injuries": [
                             "sore"
-                        ],
-                        "scars": []
+                        ]
                     },
                     {
                         "cats": ["app1"],
                         "injuries": [
                             "bruises"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "frequency": 3
@@ -2134,9 +2097,6 @@
                         "injuries": [
                             "claw-wound",
                             "beak_bite"
-                        ],
-                        "scars": [
-                            "BEAKSIDE"
                         ]
                     }
                 ],
@@ -2193,9 +2153,6 @@
                         "injuries": [
                             "claw-wound",
                             "beak_bite"
-                        ],
-                        "scars": [
-                            "BEAKSIDE"
                         ]
                     }
                 ],
@@ -2258,12 +2215,11 @@
                         "cats": ["patrol"],
                         "injuries": [
                             "dehydrated"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "history_text": {
-                    "death": "m_c died from overheating on a patrol."
+                    "death": "m_c died after overheating on a patrol."
                 },
                 "relationships": [
                     {
@@ -2292,12 +2248,11 @@
                         ],
                         "injuries": [
                             "hot_injury"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "history_text": {
-                    "death": "m_c died from overheating on a patrol."
+                    "death": "m_c died after overheating on a patrol."
                 },
                 "relationships": [
                     {
@@ -2327,9 +2282,6 @@
                         "cats": ["app1"],
                         "injuries": [
                             "battle_injury"
-                        ],
-                        "scars": [
-                            "SCRATCHSIDE"
                         ]
                     },
                     {
@@ -2338,18 +2290,12 @@
                         ],
                         "injuries": [
                             "battle_injury"
-                        ],
-                        "scars": [
-                            "SCRATCHSIDE"
                         ]
                     },
                     {
                         "cats": ["app1"],
                         "injuries": [
                             "torn ear"
-                        ],
-                        "scars": [
-                            "RIGHTEAR"
                         ]
                     },
                     {
@@ -2358,9 +2304,6 @@
                         ],
                         "injuries": [
                             "torn ear"
-                        ],
-                        "scars": [
-                            "RIGHTEAR"
                         ]
                     }
                 ],

--- a/resources/lang/en/patrols/plains/border/leaf-bare.json
+++ b/resources/lang/en/patrols/plains/border/leaf-bare.json
@@ -193,17 +193,12 @@
                         ],
                         "injuries": [
                             "frostbite"
-                        ],
-                        "scars": [
-                            "FROSTSOCK",
-                            "FROSTTAIL"
-                        ],
-                        "no_results": false
+                        ]
                     }
                 ],
                 "history_text": {
                     "scar": "r_c carried the marks of frostbite on {PRONOUN/r_c/poss} pelt from a freezing border patrol in leaf-bare.",
-                    "death": "r_c died from a freezing border patrol in leaf-bare after getting frostbitten."
+                    "death": "r_c died from frostbite after a freezing border patrol in leaf-bare."
                 },
                 "relationships": [
                     {
@@ -269,6 +264,10 @@
                         ]
                     }
                 ],
+                "history_text": {
+                    "scar": "m_c was scarred after a chill caught on patrol progressed to frostbite.",
+                    "death": "m_c caught a chill on patrol and never recovered."
+                },
                 "relationships": [
                     {
                         "cats_to": ["s_c"],
@@ -623,17 +622,16 @@
                             "patrol"
                         ],
                         "injuries": [
-                            "shock"
-                        ],
-                        "scars": []
+                            "shock",
+                            "non_lethal"
+                        ]
                     }
                 ],
                 "dead_cats": [
                     "r_c"
                 ],
                 "history_text": {
-                    "scar": "",
-                    "death": "r_c was killed by a coyote male trying to offer a courting gift to a female."
+                    "death": "m_c was killed by a coyote male trying to offer a courting gift to a female."
                 },
                 "relationships": [
                     {
@@ -673,15 +671,12 @@
                         ],
                         "injuries": [
                             "big_bite_injury"
-                        ],
-                        "scars": [
-                            "NECKBITE"
                         ]
                     }
                 ],
                 "history_text": {
-                    "scar": "Courting coyotes scarred r_c's pelt.",
-                    "death": "r_c was killed by a coyote male trying to offer a courting gift to a female."
+                    "scar": "Courting coyotes scarred m_c's pelt.",
+                    "death": "m_c died of {PRONOUN/m_c/poss} injuries after a coyote male tried to offer {PRONOUN/m_c/object} as a courting gift to a female."
                 },
                 "frequency": 4
             },
@@ -703,9 +698,6 @@
                         "injuries": [
                             "minor_injury",
                             "torn ear"
-                        ],
-                        "scars": [
-                            "LEFTEAR"
                         ]
                     }
                 ],
@@ -838,15 +830,12 @@
                         ],
                         "injuries": [
                             "big_bite_injury"
-                        ],
-                        "scars": [
-                            "BRIGHTHEART"
                         ]
                     }
                 ],
                 "history_text": {
-                    "scar": "This cat is scarred from bravely defending the Clan against a coyote.",
-                    "death": "This cat died to keep the Clan safe from a large coyote."
+                    "scar": "m_c was scarred defending the Clan against a coyote.",
+                    "death": "m_c died of injuries inflicted by a coyote."
                 },
                 "relationships": [
                     {
@@ -1329,9 +1318,6 @@
                         ],
                         "injuries": [
                             "torn ear"
-                        ],
-                        "scars": [
-                            "LEFTEAR"
                         ]
                     }
                 ],
@@ -1365,16 +1351,16 @@
                             "patrol"
                         ],
                         "injuries": [
-                            "shock"
-                        ],
-                        "scars": []
+                            "shock",
+                            "non_lethal"
+                        ]
                     }
                 ],
                 "dead_cats": [
                     "r_c"
                 ],
                 "history_text": {
-                    "death": "r_c was killed by a coyote male trying to offer a courting gift to a female."
+                    "death": "m_c was killed by a coyote male trying to offer a courting gift to a female."
                 },
                 "frequency": 4
             },
@@ -1389,24 +1375,20 @@
                         ],
                         "injuries": [
                             "minor_injury"
-                        ],
-                        "scars": []
+                        ]
                     },
                     {
                         "cats": [
-                            "patrol"
+                            "r_c"
                         ],
                         "injuries": [
                             "big_bite_injury"
-                        ],
-                        "scars": [
-                            "NECKBITE"
                         ]
                     }
                 ],
                 "history_text": {
-                    "scar": "Courting coyotes scarred r_c's pelt.",
-                    "death": "r_c was killed by a coyote male trying to offer a courting gift to a female."
+                    "scar": "Courting coyotes scarred m_c's pelt.",
+                    "death": "m_c died of injuries inflicted by a coyote male trying to offer {PRONOUN/m_c/object} as a courting gift to a female."
                 },
                 "relationships": [
                     {
@@ -1447,9 +1429,6 @@
                         "injuries": [
                             "minor_injury",
                             "torn ear"
-                        ],
-                        "scars": [
-                            "LEFTEAR"
                         ]
                     }
                 ],
@@ -1500,9 +1479,6 @@
                         "injuries": [
                             "big_bite_injury",
                             "scrapes"
-                        ],
-                        "scars": [
-                            "NECKBITE"
                         ]
                     },
                     {
@@ -1511,8 +1487,7 @@
                         ],
                         "injuries": [
                             "scrapes"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "dead_cats": [
@@ -1576,9 +1551,6 @@
                         ],
                         "injuries": [
                             "bite-wound"
-                        ],
-                        "scars": [
-                            "NECKBITE"
                         ]
                     },
                     {
@@ -1587,8 +1559,7 @@
                         ],
                         "injuries": [
                             "blood loss"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "history_text": {
@@ -1688,15 +1659,12 @@
                         ],
                         "injuries": [
                             "big_bite_injury"
-                        ],
-                        "scars": [
-                            "BRIGHTHEART"
                         ]
                     }
                 ],
                 "history_text": {
                     "scar": "This cat is scarred from bravely defending the Clan against a coyote.",
-                    "death": "This cat died to keep the Clan safe from a large coyote."
+                    "death": "m_c died of injuries inflicted by a coyote."
                 },
                 "relationships": [
                     {
@@ -2043,15 +2011,12 @@
                         ],
                         "injuries": [
                             "shivering"
-                        ],
-                        "scars": [
-                            "FROSTFACE"
                         ]
                     }
                 ],
                 "history_text": {
                     "scar": "m_c was caught out in the cold on a border patrol, and the cold burned {PRONOUN/m_c/object}.",
-                    "death": "m_c was killed by the consequences of {PRONOUN/m_c/poss} border patrol failing to find shelter in a sleet storm."
+                    "death": "Though m_c's patrol found shelter during a snowstorm, m_c still caught a chill that eventually killed {PRONOUN/m_c/object}."
                 },
                 "relationships": [
                     {
@@ -2103,15 +2068,12 @@
                         ],
                         "injuries": [
                             "cold_injury"
-                        ],
-                        "scars": [
-                            "FROSTFACE"
                         ]
                     }
                 ],
                 "history_text": {
                     "scar": "m_c was caught out in the cold on a border patrol, and the cold burned {PRONOUN/m_c/object}.",
-                    "death": "m_c was killed by the consequences of {PRONOUN/m_c/poss} border patrol failing to find shelter in a sleet storm."
+                    "death": "m_c died of {PRONOUN/m_c/poss} injuries when {PRONOUN/m_c/poss} border patrol failed to find shelter in a sleet storm."
                 },
                 "relationships": [
                     {
@@ -2144,9 +2106,6 @@
                         ],
                         "injuries": [
                             "cold_injury"
-                        ],
-                        "scars": [
-                            "FROSTFACE"
                         ]
                     }
                 ],
@@ -2155,7 +2114,7 @@
                 ],
                 "history_text": {
                     "scar": "m_c was caught out in the cold on a border patrol, and the cold burned {PRONOUN/m_c/object}.",
-                    "death": "m_c was killed by the consequences of {PRONOUN/m_c/poss} border patrol failing to find shelter in a sleet storm."
+                    "death": "m_c died of {PRONOUN/m_c/poss} injuries when {PRONOUN/m_c/poss} border patrol failed to find shelter in a sleet storm."
                 },
                 "relationships": [
                     {
@@ -2194,15 +2153,12 @@
                         ],
                         "injuries": [
                             "frostbite"
-                        ],
-                        "scars": [
-                            "FROSTFACE"
                         ]
                     }
                 ],
                 "history_text": {
                     "scar": "m_c was caught out in the cold on a border patrol, and the cold burned {PRONOUN/m_c/object}.",
-                    "death": "m_c was killed by the consequences of failing to find shelter in a sleet storm."
+                    "death": "m_c thought {PRONOUN/m_c/subject} could outrun a snowstorm, but {PRONOUN/m_c/subject} succumbed to frostbite."
                 },
                 "relationships": [
                     {
@@ -2249,15 +2205,12 @@
                         ],
                         "injuries": [
                             "frostbite"
-                        ],
-                        "scars": [
-                            "FROSTFACE"
                         ]
                     }
                 ],
                 "history_text": {
                     "scar": "m_c was caught out in the cold on a border patrol, and the cold burned {PRONOUN/m_c/object}.",
-                    "death": "m_c was killed by the consequences of failing to find shelter in a sleet storm."
+                    "death": "m_c died of frostbite after attempting to return to camp during a snowstorm instead of sheltering."
                 },
                 "relationships": [
                     {
@@ -2505,12 +2458,13 @@
                             "shivering"
                         ],
                         "scars": [
-                            "FROSTTAIL"
+                            "FROSTSOCK",
+                            "FROSTMITT"
                         ]
                     }
                 ],
                 "history_text": {
-                    "scar": "Digging out a tunnel in leafbare wasn't a good idea, and left m_c marked by frostbite.",
+                    "scar": "Digging out a tunnel in leafbare wasn't a good idea and left m_c marked by frostbite.",
                     "death": "Digging out a tunnel in leafbare wasn't a good idea, and the cold killed m_c."
                 },
                 "frequency": 4
@@ -2526,15 +2480,12 @@
                         ],
                         "injuries": [
                             "big_bite_injury"
-                        ],
-                        "scars": [
-                            "MANLEG"
                         ]
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c was injured after disturbing a sheltering coyote in leaf-bare.",
-                    "death": "This cat was killed after disturbing a sheltering coyote in leaf-bare."
+                    "scar": "m_c was scarred after disturbing a sheltering coyote in leaf-bare.",
+                    "death": "m_c died of injuries inflicted by a coyote sheltering from leaf-bare's cold."
                 },
                 "frequency": 4
             },
@@ -2549,15 +2500,12 @@
                         ],
                         "injuries": [
                             "claw-wound"
-                        ],
-                        "scars": [
-                            "MANLEG"
                         ]
                     }
                 ],
                 "history_text": {
                     "scar": "m_c was injured after disturbing a sheltering coyote in leaf-bare.",
-                    "death": "This cat was killed after disturbing a sheltering coyote in leaf-bare."
+                    "death": "m_c died of injuries inflicted by a coyote sheltering from leaf-bare's cold."
                 },
                 "frequency": 4
             },
@@ -2986,9 +2934,6 @@
                         ],
                         "injuries": [
                             "shivering"
-                        ],
-                        "scars": [
-                            "FROSTMITT"
                         ]
                     },
                     {
@@ -2999,7 +2944,8 @@
                             "frostbite"
                         ],
                         "scars": [
-                            "FROSTMITT"
+                            "FROSTMITT",
+                            "FROSTSOCK"
                         ]
                     }
                 ],
@@ -3039,15 +2985,12 @@
                         ],
                         "injuries": [
                             "shivering"
-                        ],
-                        "scars": [
-                            "FROSTMITT"
                         ]
                     }
                 ],
                 "history_text": {
-                    "scar": "A snowstorm struck while m_c was out patrolling in leaf-bare, causing the cold to bite in a way that marked {PRONOUN/m_c/poss} coat.",
-                    "death": "A snowstorm struck while m_c was out patrolling in leaf-bare, killing {PRONOUN/m_c/object}."
+                    "scar": "A snowstorm struck while m_c was out patrolling in leaf-bare, and frostbite left its mark on m_c.",
+                    "death": "While sheltering from a snowstorm, m_c caught a chill that eventually killed {PRONOUN/m_c/object}."
                 },
                 "relationships": [
                     {
@@ -3166,9 +3109,6 @@
                             "torn ear",
                             "scrapes",
                             "shock"
-                        ],
-                        "scars": [
-                            "THREE"
                         ]
                     },
                     {
@@ -3179,9 +3119,6 @@
                             "torn ear",
                             "scrapes",
                             "shock"
-                        ],
-                        "scars": [
-                            "LEFTEAR"
                         ]
                     },
                     {
@@ -3191,13 +3128,12 @@
                         "injuries": [
                             "scrapes",
                             "shock"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "history_text": {
                     "scar": "m_c was injured after disturbing a badger in its sett.",
-                    "death": "This cat was killed after an unfortunate meeting with a badger."
+                    "death": "m_c died of injuries inflicted by a badger."
                 },
                 "relationships": [
                     {
@@ -3389,9 +3325,9 @@
                             "p_l"
                         ],
                         "injuries": [
-                            "shock"
-                        ],
-                        "scars": []
+                            "shock",
+                            "non_lethal"
+                        ]
                     }
                 ],
                 "dead_cats": [
@@ -3399,7 +3335,7 @@
                 ],
                 "history_text": {
                     "scar": "m_c was injured after disturbing a badger in its sett.",
-                    "death": "This cat was killed saving an older warrior from a badger as an apprentice."
+                    "death": "m_c was killed saving an older warrior from a badger as an apprentice."
                 },
                 "frequency": 4
             },
@@ -3414,15 +3350,12 @@
                         ],
                         "injuries": [
                             "big_bite_injury"
-                        ],
-                        "scars": [
-                            "THREE"
                         ]
                     }
                 ],
                 "history_text": {
                     "scar": "m_c was injured after disturbing a badger in its sett.",
-                    "death": "This cat was killed after an unfortunate meeting with a wolverine."
+                    "death": "m_c died of injuries inflicted by a badger."
                 },
                 "frequency": 1
             }
@@ -3567,15 +3500,12 @@
                         ],
                         "injuries": [
                             "shivering"
-                        ],
-                        "scars": [
-                            "FROSTMITT"
                         ]
                     }
                 ],
                 "history_text": {
-                    "scar": "The weather caved in while m_c was out patrolling in leaf-bare, causing the cold to bite in a way that marked {PRONOUN/m_c/poss} coat.",
-                    "death": "The weather caved in while m_c was out patrolling in leaf-bare, killing {PRONOUN/m_c/object}."
+                    "scar": "The weather caved in while m_c was out patrolling in leaf-bare, and frostbite left its mark on m_c.",
+                    "death": "m_c caught a chill while sheltering from a leaf-bare storm and couldn't recover."
                 },
                 "frequency": 4
             },
@@ -3635,15 +3565,12 @@
                         ],
                         "injuries": [
                             "big_bite_injury"
-                        ],
-                        "scars": [
-                            "THREE"
                         ]
                     }
                 ],
                 "history_text": {
                     "scar": "m_c was injured after disturbing a badger in its sett.",
-                    "death": "This cat was killed after an unfortunate meeting with a badger."
+                    "death": "m_c died of injuries inflicted by a badger."
                 },
                 "frequency": 1
             }
@@ -3848,8 +3775,7 @@
                         ],
                         "injuries": [
                             "sore"
-                        ],
-                        "scars": []
+                        ]
                     },
                     {
                         "cats": [
@@ -3857,15 +3783,12 @@
                         ],
                         "injuries": [
                             "frostbite"
-                        ],
-                        "scars": [
-                            "FROSTFACE"
                         ]
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c went out on a border patrol alone as an apprentice during leaf-bare, and still bears the marks of that lesson.",
-                    "death": "This cat was killed after a leaf-bare storm caught {PRONOUN/s_c/object} on patrol as an apprentice."
+                    "scar": "m_c went out on a border patrol alone as an apprentice during leaf-bare and still bears the marks of that lesson.",
+                    "death": "m_c died of frostbite after exploring alone in leaf-bare."
                 },
                 "frequency": 4
             },
@@ -3880,18 +3803,6 @@
                         ],
                         "injuries": [
                             "bruises"
-                        ],
-                        "scars": []
-                    },
-                    {
-                        "cats": [
-                            "app1"
-                        ],
-                        "injuries": [
-                            "torn ear"
-                        ],
-                        "scars": [
-                            "LEFTEAR"
                         ]
                     },
                     {
@@ -3899,7 +3810,15 @@
                             "app1"
                         ],
                         "injuries": [
-                            "torn pelt"
+                            "torn ear"
+                        ]
+                    },
+                    {
+                        "cats": [
+                            "app1"
+                        ],
+                        "injuries": [
+                            "claw-wound"
                         ],
                         "scars": [
                             "BRIDGE"
@@ -3908,7 +3827,7 @@
                 ],
                 "history_text": {
                     "scar": "m_c was injured after disturbing a wrathful prairie dog.",
-                    "death": "This cat was killed after wounds given by a prairie dog progressed to something worse."
+                    "death": "m_c died of injuries inflicted by a prairie dog."
                 },
                 "frequency": 3
             },
@@ -3971,8 +3890,7 @@
                         ],
                         "injuries": [
                             "bruises"
-                        ],
-                        "scars": []
+                        ]
                     },
                     {
                         "cats": [
@@ -3980,9 +3898,6 @@
                         ],
                         "injuries": [
                             "torn ear"
-                        ],
-                        "scars": [
-                            "LEFTEAR"
                         ]
                     },
                     {
@@ -3990,27 +3905,13 @@
                             "p_l"
                         ],
                         "injuries": [
-                            "torn pelt"
-                        ],
-                        "scars": [
-                            "BRIDGE"
-                        ]
-                    },
-                    {
-                        "cats": [
-                            "p_l"
-                        ],
-                        "injuries": [
-                            "mangled tail"
-                        ],
-                        "scars": [
-                            "MANTAIL"
+                            "claw-wound"
                         ]
                     }
                 ],
                 "history_text": {
                     "scar": "m_c was injured after disturbing a badger in its sett.",
-                    "death": "This cat was killed after an unfortunate meeting with a badger."
+                    "death": "m_c died of injuries inflicted by a badger."
                 },
                 "frequency": 3
             },
@@ -4327,15 +4228,14 @@
                         ],
                         "injuries": [
                             "constant nightmares"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "dead_cats": [
                     "app2"
                 ],
                 "history_text": {
-                    "death": "m_c was killed when another apprentice made the wrong judgement call on a border patrol."
+                    "death": "m_c was killed when another apprentice made the wrong judgment call on a border patrol."
                 },
                 "relationships": [
                     {
@@ -4384,18 +4284,6 @@
                         ],
                         "injuries": [
                             "bruises"
-                        ],
-                        "scars": []
-                    },
-                    {
-                        "cats": [
-                            "app1"
-                        ],
-                        "injuries": [
-                            "torn ear"
-                        ],
-                        "scars": [
-                            "LEFTEAR"
                         ]
                     },
                     {
@@ -4403,7 +4291,15 @@
                             "app1"
                         ],
                         "injuries": [
-                            "torn pelt"
+                            "torn ear"
+                        ]
+                    },
+                    {
+                        "cats": [
+                            "app1"
+                        ],
+                        "injuries": [
+                            "claw-wound"
                         ],
                         "scars": [
                             "BRIDGE"
@@ -4412,7 +4308,7 @@
                 ],
                 "history_text": {
                     "scar": "m_c was injured after disturbing a wrathful prairie dog.",
-                    "death": "This cat was killed after wounds given by a prairie dog progressed to something worse."
+                    "death": "m_c died of injuries inflicted by a prairie dog."
                 },
                 "relationships": [
                     {
@@ -4444,8 +4340,7 @@
                         ],
                         "injuries": [
                             "shock"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "history_text": {
@@ -4467,12 +4362,10 @@
                         ],
                         "injuries": [
                             "shock"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "history_text": {
-                    "scar": "",
                     "death": "This cat was killed by the shock of watching fellow apprentices be kidnapped by Twolegs."
                 },
                 "frequency": 2
@@ -4536,9 +4429,9 @@
                         ],
                         "injuries": [
                             "shock",
-                            "constant nightmares"
-                        ],
-                        "scars": []
+                            "constant nightmares",
+                            "non_lethal"
+                        ]
                     },
                     {
                         "cats": [
@@ -4546,15 +4439,12 @@
                         ],
                         "injuries": [
                             "cold_injury"
-                        ],
-                        "scars": [
-                            "FROSTFACE"
                         ]
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c went out with a group of friends as an apprentice, and they were all caught in sleet, which has left its marks on {PRONOUN/m_c/poss} pelt.",
-                    "death": "This cat was killed as an apprentice, after {PRONOUN/m_c/subject} went on a border patrol with {PRONOUN/m_c/poss} friends and got caught in a sleetstorm."
+                    "scar": "m_c was frostbitten after going out with a group of friends as apprentices and getting caught in a sleet storm.",
+                    "death": "m_c was killed after {PRONOUN/m_c/subject} went on a border patrol with {PRONOUN/m_c/poss} friends and got caught in a sleet storm."
                 },
                 "frequency": 4
             },
@@ -4583,8 +4473,7 @@
                         "injuries": [
                             "shock",
                             "constant nightmares"
-                        ],
-                        "scars": []
+                        ]
                     },
                     {
                         "cats": [
@@ -4592,15 +4481,12 @@
                         ],
                         "injuries": [
                             "cold_injury"
-                        ],
-                        "scars": [
-                            "FROSTFACE"
                         ]
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c went out with a group of friends as an apprentice, and they were all caught in sleet, which has left its marks on {PRONOUN/m_c/poss} pelt.",
-                    "death": "This cat was killed as an apprentice, after {PRONOUN/m_c/subject} went on a border patrol with {PRONOUN/m_c/poss} friends and got caught in a sleetstorm."
+                    "scar": "m_c was frostbitten after going out with a group of friends as apprentices and getting caught in a sleet storm.",
+                    "death": "m_c was killed after {PRONOUN/m_c/subject} went on a border patrol with {PRONOUN/m_c/poss} friends and got caught in a sleet storm."
                 },
                 "frequency": 4
             }

--- a/resources/lang/en/patrols/plains/border/leaf-bare.json
+++ b/resources/lang/en/patrols/plains/border/leaf-bare.json
@@ -798,7 +798,7 @@
                     "r_c"
                 ],
                 "history_text": {
-                    "death": "This cat died to keep the Clan safe from a large coyote."
+                    "death": "m_c died to keep the Clan safe from a large coyote."
                 },
                 "relationships": [
                     {
@@ -1627,8 +1627,7 @@
                     "r_c"
                 ],
                 "history_text": {
-                    "scar": "This cat is scarred from bravely defending the Clan against a coyote.",
-                    "death": "This cat died to keep the Clan safe from a large coyote."
+                    "death": "m_c died to keep the Clan safe from a large coyote."
                 },
                 "relationships": [
                     {
@@ -1663,7 +1662,7 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "This cat is scarred from bravely defending the Clan against a coyote.",
+                    "scar": "m_c was scarred defending the Clan against a coyote.",
                     "death": "m_c died of injuries inflicted by a coyote."
                 },
                 "relationships": [

--- a/resources/lang/en/patrols/plains/border/leaf-fall.json
+++ b/resources/lang/en/patrols/plains/border/leaf-fall.json
@@ -684,7 +684,7 @@
                     "r_c"
                 ],
                 "history_text": {
-                    "death": "This cat died to keep the Clan safe from a large coyote."
+                    "death": "m_c died to keep the Clan safe from a large coyote."
                 },
                 "relationships": [
                     {
@@ -720,7 +720,7 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "This cat is scarred from bravely defending the Clan against a coyote.",
+                    "scar": "m_c was scarred defending the Clan against a coyote.",
                     "death": "m_c died of injuries inflicted by a coyote."
                 },
                 "relationships": [
@@ -1460,8 +1460,7 @@
                     "r_c"
                 ],
                 "history_text": {
-                    "scar": "This cat is scarred from bravely defending the Clan against a coyote.",
-                    "death": "This cat died to keep the Clan safe from a large coyote."
+                    "death": "m_c died to keep the Clan safe from a large coyote."
                 },
                 "relationships": [
                     {
@@ -1492,15 +1491,12 @@
                         ],
                         "injuries": [
                             "big_bite_injury"
-                        ],
-                        "scars": [
-                            "BRIGHTHEART"
                         ]
                     }
                 ],
                 "history_text": {
-                    "scar": "This cat is scarred from bravely defending the Clan against a coyote.",
-                    "death": "This cat died to keep the Clan safe from a large coyote."
+                    "scar": "m_c was scarred defending the Clan against a coyote.",
+                    "death": "m_c died of injuries inflicted by a coyote."
                 },
                 "relationships": [
                     {

--- a/resources/lang/en/patrols/plains/border/leaf-fall.json
+++ b/resources/lang/en/patrols/plains/border/leaf-fall.json
@@ -533,8 +533,7 @@
                         ],
                         "injuries": [
                             "minor_injury"
-                        ],
-                        "scars": []
+                        ]
                     },
                     {
                         "cats": [
@@ -542,15 +541,12 @@
                         ],
                         "injuries": [
                             "big_bite_injury"
-                        ],
-                        "scars": [
-                            "NECKBITE"
                         ]
                     }
                 ],
                 "history_text": {
                     "scar": "An adolescent coyote scarred m_c's pelt.",
-                    "death": "m_c was killed by trying to fight an adolescent coyote with a small patrol."
+                    "death": "m_c died of injuries inflicted by an adolescent coyote."
                 },
                 "relationships": [
                     {
@@ -588,9 +584,6 @@
                         "injuries": [
                             "minor_injury",
                             "torn ear"
-                        ],
-                        "scars": [
-                            "LEFTEAR"
                         ]
                     }
                 ],
@@ -723,15 +716,12 @@
                         ],
                         "injuries": [
                             "big_bite_injury"
-                        ],
-                        "scars": [
-                            "BRIGHTHEART"
                         ]
                     }
                 ],
                 "history_text": {
                     "scar": "This cat is scarred from bravely defending the Clan against a coyote.",
-                    "death": "This cat died to keep the Clan safe from a large coyote."
+                    "death": "m_c died of injuries inflicted by a coyote."
                 },
                 "relationships": [
                     {
@@ -1059,9 +1049,6 @@
                         ],
                         "injuries": [
                             "bite-wound"
-                        ],
-                        "scars": [
-                            "NECKBITE"
                         ]
                     },
                     {
@@ -1070,8 +1057,7 @@
                         ],
                         "injuries": [
                             "blood loss"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "history_text": {
@@ -1312,9 +1298,6 @@
                         ],
                         "injuries": [
                             "torn ear"
-                        ],
-                        "scars": [
-                            "LEFTEAR"
                         ]
                     },
                     {
@@ -1323,8 +1306,7 @@
                         ],
                         "injuries": [
                             "scrapes"
-                        ],
-                        "scars": []
+                        ]
                     },
                     {
                         "cats": [
@@ -1332,8 +1314,7 @@
                         ],
                         "injuries": [
                             "bruises"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "history_text": {
@@ -1366,9 +1347,6 @@
                         ],
                         "injuries": [
                             "big_bite_injury"
-                        ],
-                        "scars": [
-                            "NECKBITE"
                         ]
                     },
                     {
@@ -1377,8 +1355,7 @@
                         ],
                         "injuries": [
                             "scrapes"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "history_text": {

--- a/resources/lang/en/patrols/plains/border/newleaf.json
+++ b/resources/lang/en/patrols/plains/border/newleaf.json
@@ -482,8 +482,7 @@
                         ],
                         "injuries": [
                             "minor_injury"
-                        ],
-                        "scars": []
+                        ]
                     },
                     {
                         "cats": [
@@ -491,15 +490,12 @@
                         ],
                         "injuries": [
                             "big_bite_injury"
-                        ],
-                        "scars": [
-                            "NECKBITE"
                         ]
                     }
                 ],
                 "history_text": {
-                    "scar": "A nursing coyote scarred r_c's pelt.",
-                    "death": "r_c was killed by trying to fight a nursing coyote with a small patrol."
+                    "scar": "A nursing coyote scarred m_c's pelt.",
+                    "death": "m_c died of injuries inflicted by a nursing coyote."
                 },
                 "relationships": [
                     {
@@ -537,9 +533,6 @@
                         "injuries": [
                             "minor_injury",
                             "torn ear"
-                        ],
-                        "scars": [
-                            "LEFTEAR"
                         ]
                     }
                 ],
@@ -671,15 +664,12 @@
                         ],
                         "injuries": [
                             "big_bite_injury"
-                        ],
-                        "scars": [
-                            "BRIGHTHEART"
                         ]
                     }
                 ],
                 "history_text": {
                     "scar": "This cat is scarred from bravely defending the Clan against a coyote.",
-                    "death": "This cat died to keep the Clan safe from a large coyote."
+                    "death": "m_c died of injuries inflicted by a coyote."
                 },
                 "relationships": [
                     {
@@ -1019,10 +1009,7 @@
                             "r_c"
                         ],
                         "injuries": [
-                            "torn pelt"
-                        ],
-                        "scars": [
-                            "SCRATCHSIDE"
+                            "bite-wound"
                         ]
                     },
                     {
@@ -1031,8 +1018,7 @@
                         ],
                         "injuries": [
                             "blood loss"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "history_text": {
@@ -1273,8 +1259,7 @@
                         ],
                         "injuries": [
                             "minor_injury"
-                        ],
-                        "scars": []
+                        ]
                     },
                     {
                         "cats": [
@@ -1282,9 +1267,6 @@
                         ],
                         "injuries": [
                             "big_bite_injury"
-                        ],
-                        "scars": [
-                            "NECKBITE"
                         ]
                     },
                     {
@@ -1294,13 +1276,12 @@
                         "injuries": [
                             "scrapes",
                             "torn ear"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "history_text": {
                     "scar": "A nursing coyote scarred r_c.",
-                    "death": "r_c was killed by trying to fight a nursing coyote with a small patrol."
+                    "death": "m_c died of injuries inflicted by a nursing coyote."
                 },
                 "frequency": 4
             },
@@ -1322,9 +1303,6 @@
                         "injuries": [
                             "minor_injury",
                             "torn ear"
-                        ],
-                        "scars": [
-                            "LEFTEAR"
                         ]
                     }
                 ],
@@ -1368,9 +1346,6 @@
                         "injuries": [
                             "minor_injury",
                             "torn ear"
-                        ],
-                        "scars": [
-                            "LEFTEAR"
                         ]
                     }
                 ],
@@ -1410,9 +1385,6 @@
                         ],
                         "injuries": [
                             "torn ear"
-                        ],
-                        "scars": [
-                            "LEFTEAR"
                         ]
                     }
                 ],
@@ -1512,15 +1484,12 @@
                         ],
                         "injuries": [
                             "big_bite_injury"
-                        ],
-                        "scars": [
-                            "BRIGHTHEART"
                         ]
                     }
                 ],
                 "history_text": {
                     "scar": "This cat is scarred from bravely defending the Clan against a coyote.",
-                    "death": "This cat died to keep the Clan safe from a large coyote."
+                    "death": "m_c died of injuries inflicted by coyote."
                 },
                 "relationships": [
                     {

--- a/resources/lang/en/patrols/plains/hunting/any.json
+++ b/resources/lang/en/patrols/plains/hunting/any.json
@@ -1748,9 +1748,6 @@
                         ],
                         "injuries": [
                             "big_bite_injury"
-                        ],
-                        "scars": [
-                            "NECKBITE"
                         ]
                     }
                 ],
@@ -1867,9 +1864,6 @@
                         ],
                         "injuries": [
                             "big_bite_injury"
-                        ],
-                        "scars": [
-                            "NECKBITE"
                         ]
                     }
                 ],
@@ -2022,8 +2016,7 @@
                         ],
                         "injuries": [
                             "scrapes"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "frequency": 3,
@@ -2689,11 +2682,13 @@
                 "injury": [
                     {
                         "cats": ["r_c"],
-                        "injuries": ["small_bite_injury"],
-                        "scars": ["LEGBITE"]
+                        "injuries": ["small_bite_injury"]
                     }
                 ],
-                "history_text": { "scar": "m_c was scarred by a kit fox." },
+                "history_text": {
+                    "scar": "m_c was scarred by a kit fox.",
+                    "death": "m_c died of injuries inflicted by a kit fox."
+                },
                 "relationships": [
                     {
                         "cats_to": ["r_c"],
@@ -2968,14 +2963,12 @@
                         ],
                         "injuries": [
                             "small_bite_injury"
-                        ],
-                        "scars": [
-                            "LEGBITE"
                         ]
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c carries a scar from a fight with a kit fox."
+                    "scar": "m_c carries a scar from a fight with a kit fox.",
+                    "death": "m_c died of injuries inflicted by a kit fox."
                 },
                 "prey": [
                     "very_small"
@@ -3147,14 +3140,12 @@
                         "injuries": [
                             "small_bite_injury",
                             "shock"
-                        ],
-                        "scars": [
-                            "FACE"
                         ]
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c carries a scar from irritating a maned wolf as an apprentice."
+                    "scar": "m_c carries a scar from irritating a maned wolf as an apprentice.",
+                    "death": "m_c died of injuries inflicted by a maned wolf."
                 },
                 "frequency": 3
             },
@@ -3182,14 +3173,12 @@
                         "injuries": [
                             "small_bite_injury",
                             "shock"
-                        ],
-                        "scars": [
-                            "FACE"
                         ]
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c carries a scar from irritating a maned wolf as an apprentice."
+                    "scar": "m_c carries a scar from irritating a maned wolf as an apprentice.",
+                    "death": "m_c died of injuries inflicted by a maned wolf."
                 },
                 "frequency": 3
             }
@@ -3519,14 +3508,12 @@
                         "injuries": [
                             "big_bite_injury",
                             "shock"
-                        ],
-                        "scars": [
-                            "THREE"
                         ]
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c was scarred by a maned wolf, fighting over food."
+                    "scar": "m_c was scarred by a maned wolf, fighting over food.",
+                    "death": "m_c died of injuries inflicted by a maned wolf."
                 },
                 "relationships": [
                     {
@@ -3566,14 +3553,12 @@
                         "injuries": [
                             "big_bite_injury",
                             "shock"
-                        ],
-                        "scars": [
-                            "THREE"
                         ]
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c was scarred by a maned wolf, fighting over food."
+                    "scar": "m_c was scarred by a maned wolf, fighting over food.",
+                    "death": "m_c died of injuries inflicted by a maned wolf."
                 },
                 "relationships": [
                     {
@@ -3863,11 +3848,13 @@
                 "injury": [
                     {
                         "cats": ["r_c"],
-                        "injuries": ["big_bite_injury"],
-                        "scars": ["NECKBITE"]
+                        "injuries": ["big_bite_injury"]
                     }
                 ],
-                "history_text": { "scar": "m_c carries a scar from a fox fight." },
+                "history_text": {
+                    "scar": "m_c carries a scar from a fox fight.",
+                    "death": "m_c died of injuries inflicted by a fox."
+                },
                 "relationships": [
                     {
                         "cats_to": ["patrol"],
@@ -3890,11 +3877,13 @@
                 "injury": [
                     {
                         "cats": ["s_c"],
-                        "injuries": ["big_bite_injury"],
-                        "scars": ["NECKBITE"]
+                        "injuries": ["big_bite_injury"]
                     }
                 ],
-                "history_text": { "scar": "m_c carries a scar from a fox fight." },
+                "history_text": {
+                    "scar": "m_c carries a scar from a fox fight.",
+                    "death": "m_c died of injuries inflicted by a fox."
+                },
                 "relationships": [
                     {
                         "cats_to": ["s_c"],
@@ -4475,16 +4464,12 @@
                             "small cut",
                             "damaged eyes"
                         ],
-                        "scars": [
-                            "SNOUT",
-                            "LEFTBLIND"
-                        ],
                         "no_results": false
                         }
                     ],
                     "history_text": {
                         "scar": "m_c was permanently marked by the claws of a hare as an apprentice - but {PRONOUN/m_c/subject} survived.",
-                        "death": "m_c died from the claws of a hare encountered on a hunt as a foolish apprentice."
+                        "death": "m_c died from injuries inflicted by a hare {PRONOUN/m_c/subject} encountered on a hunt as a foolish apprentice."
                         },
                     "frequency": 4
                 }
@@ -4593,8 +4578,7 @@
                 "injury": [
                     {
                         "cats": ["app1"],
-                        "injuries": ["minor_injury"],
-                        "scars": []
+                        "injuries": ["minor_injury"]
                     }
                 ],
                 "relationships": [
@@ -4825,8 +4809,7 @@
                 "injury": [
                     {
                         "cats": ["app1"],
-                        "injuries": ["minor_injury"],
-                        "scars": []
+                        "injuries": ["minor_injury"]
                     }
                 ],
                 "relationships": [
@@ -5643,8 +5626,7 @@
                 "injury": [
                     {
                         "cats": ["r_c"],
-                        "injuries": ["dislocated joint"],
-                        "scars": []
+                        "injuries": ["dislocated joint"]
                     }
                 ],
                 "prey": ["very_small"]
@@ -5720,8 +5702,7 @@
                 "injury": [
                     {
                         "cats": ["r_c"],
-                        "injuries": ["severe headache"],
-                        "scars": []
+                        "injuries": ["severe headache"]
                     }
                 ],
                 "relationships": [
@@ -5809,8 +5790,7 @@
                 "injury": [
                     {
                         "cats": ["r_c"],
-                        "injuries": ["diarrhea"],
-                        "scars": []
+                        "injuries": ["diarrhea"]
                     }
                 ],
                 "prey": ["very_small"]
@@ -6057,8 +6037,7 @@
                 "injury": [
                     {
                         "cats": ["r_c"],
-                        "injuries": ["dislocated joint"],
-                        "scars": []
+                        "injuries": ["dislocated joint"]
                     }
                 ],
                 "prey": ["very_small"]
@@ -6134,8 +6113,7 @@
                 "injury": [
                     {
                         "cats": ["r_c"],
-                        "injuries": ["diarrhea"],
-                        "scars": []
+                        "injuries": ["diarrhea"]
                     }
                 ],
                 "prey": ["very_small"]
@@ -6255,12 +6233,15 @@
                             "non_lethal"
                         ],
                         "scars": [
-                            "SNOUT"
+                            "SNOUT",
+                            "FACE",
+                            "BRIDGE"
                         ]
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c was scarred as an apprentice by an angry ground squirrel."
+                    "scar": "m_c was scarred as an apprentice by an angry ground squirrel.",
+                    "death": "m_c died of injuries inflicted by a ground squirrel."
                 },
                 "relationships": [
                     {

--- a/resources/lang/en/patrols/plains/hunting/greenleaf.json
+++ b/resources/lang/en/patrols/plains/hunting/greenleaf.json
@@ -97,12 +97,11 @@
                         ],
                         "injuries": [
                             "hot_injury"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "history_text": {
-                    "scar": "This cat got heat exhaustion while on a patrol."
+                    "death": "m_c died after overheating on patrol."
                 },
             "relationships": [
                 {
@@ -175,14 +174,12 @@
                         ],
                         "injuries": [
                             "torn ear"
-                        ],
-                        "scars": [
-                            "LEFTEAR"
                         ]
                     }
                 ],
                 "history_text": {
-                    "scar": "r_c was scarred by a sharp piece of Twoleg garbage."
+                    "scar": "r_c was scarred by a sharp piece of Twoleg garbage.",
+                    "death": "m_c died after being cut by a piece of Twoleg garbage."
                 },
                 "frequency": 3
             }
@@ -316,14 +313,12 @@
                         ],
                         "injuries": [
                             "big_bite_injury"
-                        ],
-                        "scars": [
-                            "NECKBITE"
                         ]
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c was marked by a fight with a swift fox vixen."
+                    "scar": "m_c was marked by a fight with a swift fox.",
+                    "death": "m_c died of injuries inflicted by a swift fox."
                 },
                 "relationships": [
                     {
@@ -1136,12 +1131,9 @@
                             "snake bite",
                             "poisoned"
                         ],
-                        "scars": [
-                            "SNAKE"
-                        ],
                         "history_text": {
                             "scar": "This cat was scarred by a rattlesnake while hunting.",
-                            "death": "This cat was killed by a rattlesnake while hunting."
+                            "death": "m_c died of a rattlesnake bite."
                         }
                     }
                 ],
@@ -1177,14 +1169,13 @@
                             "damaged eyes"
                         ],
                         "scars": [
-                            "RIGHTBLIND",
                             "LEFTBLIND",
+                            "RIGHTBLIND",
                             "BOTHBLIND"
                         ],
                         "history_text": {
-                            "scar": "This cat was scarred by a rattlesnake while hunting.",
-                            "condition": "this cat was blinded by a rattlesnake while hunting",
-                            "death": "This cat was killed by a rattlesnake while hunting."
+                            "scar": "m_c was scarred by a rattlesnake while hunting.",
+                            "death": "m_c died of a rattlesnake bite."
                         }
                     }
                 ],

--- a/resources/lang/en/patrols/plains/hunting/leaf-bare.json
+++ b/resources/lang/en/patrols/plains/hunting/leaf-bare.json
@@ -156,7 +156,8 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c caught a chill while hunting in leaf-bare."
+                    "scar": "m_c caught a chill while hunting in leaf-bare.",
+                    "death": "m_c was frostbitten on patrol and never recovered."
                 },
                 "relationships": [
                     {
@@ -251,11 +252,16 @@
                         "injuries": [
                             "cold_injury"
                         ],
-                        "scars": []
+                        "scars": [
+                            "FROSTTAIL",
+                            "FROSTSOCK",
+                            "FROSTMITT"
+                        ]
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c caught a chill while hunting in leaf-bare."
+                    "scar": "m_c caught a chill while hunting in leaf-bare.",
+                    "death": "m_c got frostbitten on patrol and never recovered."
                 },
                 "frequency": 4
             }
@@ -395,13 +401,12 @@
                         ],
                         "injuries": [
                             "cold_injury"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "history_text": {
                     "scar": "m_c caught a chill while hunting in leaf-bare.",
-                    "death": "m_c froze to death while hunting in a storm."
+                    "death": "m_c caught a chill while hunting in leaf-bare and never recovered."
                 },
                 "frequency": 4
             }
@@ -527,12 +532,15 @@
                             "non_lethal"
                         ],
                         "scars": [
-                            "SNOUT"
+                            "SNOUT",
+                            "BRIDGE",
+                            "FACE"
                         ]
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c was scarred as an apprentice by an angry ground squirrel."
+                    "scar": "m_c was scarred as an apprentice by an angry ground squirrel.",
+                    "death": "m_c died of injuries inflicted by a ground squirrel."
                 },
                 "relationships": [
                     {

--- a/resources/lang/en/patrols/plains/hunting/leaf-bare.json
+++ b/resources/lang/en/patrols/plains/hunting/leaf-bare.json
@@ -914,7 +914,9 @@
                         "injuries": [
                             "cold_injury"
                         ],
-                        "scars": []
+                        "scars": [
+                            "FROSTMITT"
+                        ]
                     }
                 ],
                 "history_text": {

--- a/resources/lang/en/patrols/plains/hunting/leaf-fall.json
+++ b/resources/lang/en/patrols/plains/hunting/leaf-fall.json
@@ -401,7 +401,8 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c was scarred as an apprentice by an angry ground squirrel."
+                    "scar": "m_c was scarred as an apprentice by an angry ground squirrel.",
+                    "death": "m_c died of injuries inflicted by a ground squirrel."
                 },
                 "relationships": [
                     {

--- a/resources/lang/en/patrols/plains/hunting/leaf-fall.json
+++ b/resources/lang/en/patrols/plains/hunting/leaf-fall.json
@@ -394,7 +394,9 @@
                             "non_lethal"
                         ],
                         "scars": [
-                            "SNOUT"
+                            "SNOUT",
+                            "FACE",
+                            "BRIDGE"
                         ]
                     }
                 ],

--- a/resources/lang/en/patrols/plains/training/any.json
+++ b/resources/lang/en/patrols/plains/training/any.json
@@ -144,14 +144,12 @@
                         ],
                         "injuries": [
                             "bite-wound"
-                        ],
-                        "scars": [
-                            "LEGBITE"
                         ]
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c got scarred training in the plains as an apprentice."
+                    "scar": "m_c got scarred training in the plains as an apprentice.",
+                    "death": "m_c died from a bite-wound {PRONOUN/m_c/subject} got while training in the tall grass."
                 },
                 "relationships": [
                     {
@@ -356,15 +354,12 @@
                         ],
                         "injuries": [
                             "big_bite_injury"
-                        ],
-                        "scars": [
-                            "MANLEG"
                         ]
                     }
                 ],
                 "history_text": {
                     "scar": "m_c was scarred by a badger.",
-                    "death": "m_c lost their life to a badger."
+                    "death": "m_c died of injuries inflicted by a badger."
                 },
                 "frequency": 3
             }
@@ -540,15 +535,12 @@
                         ],
                         "injuries": [
                             "big_bite_injury"
-                        ],
-                        "scars": [
-                            "SIDE"
                         ]
                     }
                 ],
                 "history_text": {
-                    "scar": "This cat was scarred by a badger.",
-                    "death": "This cat died from wounds inflicted by a badger."
+                    "scar": "m_c was scarred by a badger.",
+                    "death": "m_c died of injuries inflicted by a badger."
                 },
                 "relationships": [
                     {
@@ -755,8 +747,7 @@
                     "r_c"
                 ],
                 "history_text": {
-                    "scar": "m_c carries a scar from being trapped on patrol",
-                    "death": "m_c tragically died after being trapped on patrol."
+                    "death": "m_c suffocated after the earth caved in beneath {PRONOUN/m_c/poss} paws."
                 },
                 "frequency": 3
             },
@@ -773,15 +764,12 @@
                         ],
                         "injuries": [
                             "blunt_force_injury"
-                        ],
-                        "scars": [
-                            "LEFTEAR"
                         ]
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c carries a scar from being trapped on patrol",
-                    "death": "m_c tragically died after being trapped on patrol."
+                    "scar": "m_c was scarred after the earth caved in beneath {PRONOUN/m_c/poss} paws.",
+                    "death": "m_c died of injuries {PRONOUN/m_c/subject} sustained when the earth caved in beneath {PRONOUN/m_c/poss} paws."
                 },
                 "frequency": 3
             },
@@ -792,8 +780,7 @@
                     "r_c"
                 ],
                 "history_text": {
-                    "scar": "m_c carries a scar from being trapped on patrol",
-                    "death": "m_c tragically died after being trapped on patrol."
+                    "death": "m_c suffocated after the earth caved in beneath {PRONOUN/m_c/poss} paws."
                 },
                 "frequency": 3
             },
@@ -807,15 +794,12 @@
                         ],
                         "injuries": [
                             "blunt_force_injury"
-                        ],
-                        "scars": [
-                            "LEFTEAR"
                         ]
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c carries a scar from being trapped on patrol",
-                    "death": "m_c tragically died after being trapped on patrol."
+                    "scar": "m_c was scarred after the earth caved in beneath {PRONOUN/m_c/poss} paws.",
+                    "death": "m_c died of injuries {PRONOUN/m_c/subject} sustained when the earth caved in beneath {PRONOUN/m_c/poss} paws."
                 },
                 "frequency": 3
             }
@@ -989,8 +973,8 @@
                     "r_c"
                 ],
                 "history_text": {
-                    "scar": "m_c carries a scar from being trapped on patrol",
-                    "death": "m_c tragically died after being trapped on patrol."
+                    "scar": "m_c was scarred after the earth caved in beneath {PRONOUN/m_c/poss} paws.",
+                    "death": "m_c died of injuries {PRONOUN/m_c/subject} sustained when the earth caved in beneath {PRONOUN/m_c/poss} paws."
                 },
                 "frequency": 3
             },
@@ -1004,15 +988,12 @@
                         ],
                         "injuries": [
                             "blunt_force_injury"
-                        ],
-                        "scars": [
-                            "LEFTEAR"
                         ]
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c carries a scar from being trapped on patrol",
-                    "death": "m_c tragically died after being trapped on patrol."
+                    "scar": "m_c was scarred after the earth caved in beneath {PRONOUN/m_c/poss} paws.",
+                    "death": "m_c died of injuries {PRONOUN/m_c/subject} sustained when the earth caved in beneath {PRONOUN/m_c/poss} paws."
                 },
                 "frequency": 3
             }
@@ -1081,15 +1062,12 @@
                         ],
                         "injuries": [
                             "blunt_force_injury"
-                        ],
-                        "scars": [
-                            "RIGHTEAR"
                         ]
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c carries a scar from being trapped on patrol.",
-                    "death": "m_c tragically died after being trapped on patrol."
+                    "scar": "m_c was scarred after the earth caved in beneath {PRONOUN/m_c/poss} paws.",
+                    "death": "m_c died of injuries {PRONOUN/m_c/subject} sustained when the earth caved in beneath {PRONOUN/m_c/poss} paws."
                 },
                 "frequency": 3
             }
@@ -1182,15 +1160,9 @@
                         ],
                         "injuries": [
                             "minor_injury"
-                        ],
-                        "scars": [
-                            "CHEEK"
                         ]
                     }
                 ],
-                "history_text": {
-                    "scar": "m_c got injured as an apprentice, exploring alone."
-                },
                 "frequency": 3
             }
         ]
@@ -3144,8 +3116,7 @@
                         ],
                         "injuries": [
                             "minor_injury"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "relationships": [
@@ -4184,9 +4155,6 @@
                         ],
                         "injuries": [
                             "torn pelt"
-                        ],
-                        "scars": [
-                            "SCRATCHSIDE"
                         ]
                     },
                     {
@@ -4195,14 +4163,9 @@
                         ],
                         "injuries": [
                             "scrapes"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
-                "history_text": {
-                    "scar": "m_c was scarred from being dragged away from a Thunderpath {PRONOUN/m_c/subject} got too close to as a curious apprentice.",
-                    "death": "Being hauled away from the Thunderpath was intended to protect {PRONOUN/m_c/object}, but the wounds on {PRONOUN/m_c/poss} pelt progressed to infection and death for m_c"
-                },
                 "frequency": 4
             },
             {

--- a/resources/lang/en/patrols/plains/training/greenleaf.json
+++ b/resources/lang/en/patrols/plains/training/greenleaf.json
@@ -145,13 +145,11 @@
                         ],
                         "injuries": [
                             "dehydrated"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "history_text": {
-                    "reg_death": "The hot greenleaf sun is more dangerous than m_c realized, and its heat killed m_c.",
-                    "lead_death": "got dehydrated and couldn't recover"
+                    "death": "m_c became dehydrated on a greenleaf patrol and never recovered."
                 },
                 "frequency": 4
             },


### PR DESCRIPTION
## About The Pull Request

See previous PRs.

In the case of a wolverine burrow patrol, I changed torn pelt to claw-wound and gave it the bridge scar. Some variations of the patrol involved p_l getting a mangled tail on top of the torn pelt (now claw-wound). On those variations, I deleted the mangled tail altogether, since I increased the severity of injuries by doing torn pelt > claw-wound.

## Proof of Testing

<img width="600" height="77" alt="image" src="https://github.com/user-attachments/assets/682cad6e-d937-47d1-9b0e-1eaafafd7e01" />
