### PR TITLE
Add sum of absolute values for RelationshipScreen

### DIFF
--- a/scripts/cat_relations/relationship.py
+++ b/scripts/cat_relations/relationship.py
@@ -546,6 +546,13 @@ class Relationship:
         return self.romance + self.like + self.respect + self.comfort + self.trust
 
     @property
+    def total_abs_relationship_value(self) -> int:
+        """
+        Returns the sum of the absolute values of all relationship types.
+        """
+        return abs(self.romance) + abs(self.like) + abs(self.respect) + abs(self.comfort) + abs(self.trust)
+
+    @property
     def has_extreme_negative(self) -> bool:
         """
         Returns True if the relationship has an extreme negative value.

--- a/scripts/cat_relations/relationship.py
+++ b/scripts/cat_relations/relationship.py
@@ -550,7 +550,13 @@ class Relationship:
         """
         Returns the sum of the absolute values of all relationship types.
         """
-        return abs(self.romance) + abs(self.like) + abs(self.respect) + abs(self.comfort) + abs(self.trust)
+        return (
+            abs(self.romance)
+            + abs(self.like)
+            + abs(self.respect)
+            + abs(self.comfort)
+            + abs(self.trust)
+        )
 
     @property
     def has_extreme_negative(self) -> bool:

--- a/scripts/screens/RelationshipScreen.py
+++ b/scripts/screens/RelationshipScreen.py
@@ -413,7 +413,7 @@ class RelationshipScreen(Screens):
         if constants.CONFIG["sorting"]["sort_by_rel_total"]:
             self.all_relations = sorted(
                 self.the_cat.relationships.values(),
-                key=lambda x: abs(x.total_relationship_value),
+                key=lambda x: x.total_abs_relationship_value,
                 reverse=True,
             )
         else:


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

Uses the sum of the absolute values of all relationship types when sorting cats in RelationshipScreen. Adds a property `total_abs_relationship_value` to use when cats are sorted.

Allows cats with greater (abs) relationship values (even if conflicting/ canceling out) to appear before cats with overall less relationship values for a given focused cat, i.e., makes consistent that cats more "known" to a focused cat appear before an "unfamiliar cat" does. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues

Fixes #4636

<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing

Created a test clan and modified the relationships for a cat:

Whisperingfeather's relationship tab has this order for the following cats (`[like, respect, comfort, trust]`) :
- Pigeonpelt: `[35, -26, 2, -7]` (abs: 70)
- Lupineghost: `[18, 15, 12, 10]` (abs: 55)
- Silverrun: `[-6, -9, 5, 11]` (abs: 31)
- Seedscreech: `[-10, 12, 5, -4]` (abs: 31)

See order in attached screenshot:
![Whisperingfeather's relationships screen](https://github.com/user-attachments/assets/c44cf62d-c48b-4585-9ed0-9ae8e5f0e188)

Without the fix, the cat order would be:
Lupineghost (55)
Pigeonpelt (4)
Seedscreech (3)
Silverrun (1)

Pigeonpelt's relationship values cancel out substantially without this fix.

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->