### PR TITLE
[BUGFIX] fix injuries_and_illnesses typo

### DIFF
--- a/scripts/events_module/thoughts/generate_thoughts.py
+++ b/scripts/events_module/thoughts/generate_thoughts.py
@@ -395,7 +395,7 @@ def _constraints_fulfilled(main_cat: "Cat", random_cat: "Cat", thought) -> bool:
         if "m_c" in thought["has_injuries"]:
             if main_cat.injuries or main_cat.illnesses:
                 injuries_and_illnesses = list(main_cat.injuries.keys()) + list(
-                    main_cat.injuries.keys()
+                    main_cat.illnesses.keys()
                 )
                 if (
                     not [
@@ -412,7 +412,7 @@ def _constraints_fulfilled(main_cat: "Cat", random_cat: "Cat", thought) -> bool:
         if "r_c" in thought["has_injuries"] and random_cat:
             if random_cat.injuries or random_cat.illnesses:
                 injuries_and_illnesses = list(random_cat.injuries.keys()) + list(
-                    random_cat.injuries.keys()
+                    random_cat.illnesses.keys()
                 )
                 if (
                     not [


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

I noticed a bug where in `generate_thoughts.py`, `injuries_and_illnesses` is set equal to two injuries lists when it should use injuries and illnesses as the variable suggests.

This changes the duplicate typo to create a combined list of injuries and illnesses.

No linked issue or open [BUG] report. I noticed this while working on illness/injury thoughts.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Why This Is Good For ClanGen

Otherwise skips over named illnesses on generating thoughts, leading to cats only have types `"has_injuries"` or `"any"` thoughts.

<!-- If this is a bug fix, you can remove this section. -->
<!-- Please add a short description of why you think these changes would benefit the game. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->
<!-- If you have multiple features that can stand on their own, or unrelated bugfixes, please create separate PRs for them. -->

## Proof of Testing

1. Edit a save file to give a cat an illness (`"running_nose"`)
2. Check if they have illness-related thoughts (`running_nose_gen`)

See screenshot:
!["dabs at nose with moss" is a `running_nose_gen` thought](https://github.com/user-attachments/assets/0c996174-9804-494d-922c-c22fa873c9f8)

3. Run `test_thoughts.py`

```text
Ran 10 tests in 0.010s

OK
```
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->