### PR TITLE
[BUGFIX] Incorrect Badger Warning Relationship Log

### DIFF
--- a/resources/lang/en/patrols/other_clan.json
+++ b/resources/lang/en/patrols/other_clan.json
@@ -4732,12 +4732,12 @@
                     "MEDIATOR,1"
                 ],
                 "can_have_stat": [
-                    "adult"
+                    "p_l"
                 ],
                 "relationships": [
                     {
                         "cats_to": [
-                            "s_c"
+                            "p_l"
                         ],
                         "cats_from": [
                             "some_clan"
@@ -4760,24 +4760,6 @@
             {
                 "text": "The patrol waits patiently at the border for any o_c_n cat to appear but they are out of luck that day. p_l decides to continue the patrol as {PRONOUN/p_l/subject} {VERB/p_l/have/has} tried waiting long enough.",
                 "exp": 0,
-                "relationships": [
-                    {
-                        "cats_to": [
-                            "s_c"
-                        ],
-                        "cats_from": [
-                            "some_clan"
-                        ],
-                        "mutual": false,
-                        "values": [
-                            "respect"
-                        ],
-                        "amount": 5,
-                        "log": {
-                            "cats_from": "cat_from heard about cat_to's efforts to ensure no cat gets caught unawares by a badger."
-                        }
-                    }
-                ],
                 "frequency": 4
             }
         ],


### PR DESCRIPTION
## About The Pull Request

Wrong rel log, related to another problem where s_c was supposed to be p_l, but wasn't. I corrected that and then found another incident of the log on a fail outcome, which I deleted altogether.

## Proof of Testing

<img width="532" height="343" alt="image" src="https://github.com/user-attachments/assets/9f761f3c-21af-447c-bf0e-9eaf5a072352" />

emberdapple's smooth talking skills are mentioned in the outcome

<img width="714" height="196" alt="image" src="https://github.com/user-attachments/assets/b5e07182-04cf-4b09-a1cc-cea133772712" />

rel log correctly mentions emberdapple