### PR TITLE
[BUGFIX] Death and Scar Adjustments for Mountainous

### DIFF
--- a/resources/lang/en/patrols/mountainous/border/any.json
+++ b/resources/lang/en/patrols/mountainous/border/any.json
@@ -185,8 +185,7 @@
                     "multi"
                 ],
                 "history_text": {
-                    "scar": "m_c was badly scarred when rogues ambushed {PRONOUN/m_c/poss} patrol.",
-                    "death": "This cat was killed when rogues ambushed {PRONOUN/m_c/poss} patrol."
+                    "death": "m_c was killed when rogues ambushed {PRONOUN/m_c/poss} patrol."
                 },
                 "art": "gen_bord_otherclan_hostile",
                 "frequency": 4
@@ -201,15 +200,12 @@
                         ],
                         "injuries": [
                             "battle_injury"
-                        ],
-                        "scars": [
-                            "FACE"
                         ]
                     }
                 ],
                 "history_text": {
                     "scar": "m_c was badly scarred when rogues ambushed {PRONOUN/m_c/poss} patrol.",
-                    "death": "m_c was killed when rogues ambushed {PRONOUN/m_c/poss} patrol."
+                    "death": "m_c died of {PRONOUN/m_c/poss} injuries after {PRONOUN/m_c/poss} patrol was ambushed by rogues."
                 },
                 "frequency": 4
             }
@@ -268,7 +264,7 @@
                     "r_c"
                 ],
                 "history_text": {
-                    "death": "This cat was killed when rogues ambushed {PRONOUN/m_c/object} while on a solo patrol."
+                    "death": "m_c was killed when rogues ambushed {PRONOUN/m_c/object} while on a solo patrol."
                 },
                 "frequency": 3
             }
@@ -396,8 +392,7 @@
                     "multi"
                 ],
                 "history_text": {
-                    "scar": "m_c was badly scarred when rogues attacked {PRONOUN/m_c/poss} patrol.",
-                    "death": "This cat was killed when rogues attacked {PRONOUN/m_c/poss} patrol."
+                    "death": "m_c was killed when rogues attacked {PRONOUN/m_c/poss} patrol."
                 },
                 "art": "gen_bord_otherclan_hostile",
                 "frequency": 4
@@ -412,15 +407,12 @@
                         ],
                         "injuries": [
                             "battle_injury"
-                        ],
-                        "scars": [
-                            "THROAT"
                         ]
                     }
                 ],
                 "history_text": {
                     "scar": "m_c was badly scarred when rogues attacked {PRONOUN/m_c/poss} patrol.",
-                    "death": "This cat was killed when rogues attacked {PRONOUN/m_c/poss} patrol."
+                    "death": "m_c died of {PRONOUN/m_c/poss} injuries after {PRONOUN/m_c/poss} patrol was attacked by rogues."
                 },
                 "relationships": [
                     {
@@ -526,7 +518,7 @@
                     "r_c"
                 ],
                 "history_text": {
-                    "death": "This cat was killed when rogues ambushed {PRONOUN/m_c/object} while on a solo patrol."
+                    "death": "m_c was killed when rogues ambushed {PRONOUN/m_c/object} while on a solo patrol."
                 },
                 "art": "gen_bord_otherclan_hostile",
                 "frequency": 3
@@ -797,7 +789,7 @@
                     "patrol"
                 ],
                 "history_text": {
-                    "death": "This cat died trying to cross a dangerous river."
+                    "death": "m_c died trying to cross a dangerous river."
                 },
                 "frequency": 2
             },
@@ -808,7 +800,7 @@
                     "multi"
                 ],
                 "history_text": {
-                    "death": "This cat died trying to cross a dangerous river."
+                    "death": "m_c died trying to cross a dangerous river."
                 },
                 "frequency": 2
             },
@@ -839,7 +831,7 @@
                 ],
                 "history_text": {
                     "scar": "m_c was scarred from the injuries obtained by trying to cross a dangerous river.",
-                    "death": "This cat died from injuries obtained by trying to cross a dangerous river."
+                    "death": "m_c died from injuries obtained by trying to cross a dangerous river."
                 },
                 "frequency": 4
             },
@@ -854,7 +846,7 @@
                     "multi"
                 ],
                 "history_text": {
-                    "death": "This cat died trying to cross a dangerous river."
+                    "death": "m_c died trying to cross a dangerous river."
                 },
                 "frequency": 2
             },
@@ -893,7 +885,7 @@
                 ],
                 "history_text": {
                     "scar": "m_c was scarred from the injuries obtained by trying to cross a dangerous river.",
-                    "death": "This cat died from injuries obtained by trying to cross a dangerous river."
+                    "death": "m_c died from injuries obtained by trying to cross a dangerous river."
                 },
                 "frequency": 4
             }
@@ -1301,7 +1293,7 @@
                     "r_c"
                 ],
                 "history_text": {
-                    "death": "This cat died to keep c_n safe from a wolf."
+                    "death": "m_c died to keep c_n safe from a wolf."
                 },
                 "relationships": [
                     {
@@ -1334,15 +1326,12 @@
                         ],
                         "injuries": [
                             "big_bite_injury"
-                        ],
-                        "scars": [
-                            "BRIGHTHEART"
                         ]
                     }
                 ],
                 "history_text": {
-                    "scar": "This cat is scarred from bravely defending c_n against a wolf.",
-                    "death": "This cat died to keep c_n safe from a large wolf."
+                    "scar": "m_c was scarred defending c_n against a wolf.",
+                    "death": "m_c died of injuries inflicted by a large wolf."
                 },
                 "relationships": [
                     {
@@ -1379,15 +1368,12 @@
                         ],
                         "injuries": [
                             "mangled leg"
-                        ],
-                        "scars": [
-                            "MANLEG"
                         ]
                     }
                 ],
                 "history_text": {
-                    "scar": "This cat bears a mangled leg from a confrontation with a large wolf.",
-                    "death": "This cat died from a confrontation with a large wolf."
+                    "scar": "m_c bears a mangled leg after thinking {PRONOUN/m_c/subject} could take on a wolf by {PRONOUN/m_c/self}",
+                    "death": "m_c died from {PRONOUN/m_c/poss} injuries after trying to take on a wolf alone."
                 },
                 "relationships": [
                     {
@@ -1418,7 +1404,7 @@
                     "s_c"
                 ],
                 "history_text": {
-                    "death": "This cat died from a confrontation with a large wolf."
+                    "death": "m_c died after trying to take on a wolf alone."
                 },
                 "frequency": 3
             },
@@ -1433,7 +1419,7 @@
                     "s_c"
                 ],
                 "history_text": {
-                    "death": "This cat died from a confrontation with a large wolf."
+                    "death": "m_c died to a wolf after freezing up."
                 },
                 "frequency": 3
             },
@@ -1449,13 +1435,13 @@
                             "mangled tail"
                         ],
                         "scars": [
-                            "HALFTAIL"
+                            "HALFTAIL","NOTAIL"
                         ]
                     }
                 ],
                 "history_text": {
-                    "scar": "This cat's tail was mangled by a wolf.",
-                    "death": "This cat died from the wounds suffered in a confrontation with a large wolf."
+                    "scar": "m_c lost {PRONOUN/m_c/poss} tail to a wolf.",
+                    "death": "m_c died of an injury inflicted by a wolf."
                 },
                 "frequency": 4
             },
@@ -1473,7 +1459,7 @@
                     "oblivious"
                 ],
                 "history_text": {
-                    "death": "This cat died due to a large wolf."
+                    "death": "m_c died due to not paying attention to {PRONOUN/m_c/poss} surroundings."
                 },
                 "frequency": 4
             }

--- a/resources/lang/en/patrols/mountainous/border/greenleaf.json
+++ b/resources/lang/en/patrols/mountainous/border/greenleaf.json
@@ -88,7 +88,6 @@
                     "r_c"
                 ],
                 "history_text": {
-                    "scar": "m_c was scarred by an invading rogue.",
                     "death": "m_c was killed by an invading rogue."
                 },
                 "frequency": 3
@@ -103,15 +102,12 @@
                         ],
                         "injuries": [
                             "battle_injury"
-                        ],
-                        "scars": [
-                            "BRIDGE"
                         ]
                     }
                 ],
                 "history_text": {
                     "scar": "m_c was scarred by an invading rogue.",
-                    "death": "m_c was killed by an invading rogue."
+                    "death": "m_c died of injuries inflicted by an invading rogue."
                 },
                 "frequency": 3
             },
@@ -203,7 +199,6 @@
                     "r_c"
                 ],
                 "history_text": {
-                    "scar": "m_c was scarred by an invading rogue.",
                     "death": "m_c was killed by an invading rogue."
                 },
                 "frequency": 3
@@ -218,15 +213,12 @@
                         ],
                         "injuries": [
                             "battle_injury"
-                        ],
-                        "scars": [
-                            "BRIDGE"
                         ]
                     }
                 ],
                 "history_text": {
                     "scar": "m_c was scarred by an invading rogue.",
-                    "death": "m_c was killed by an invading rogue."
+                    "death": "m_c died of injuries inflicted by an invading rogue."
                 },
                 "frequency": 3
             }
@@ -411,13 +403,13 @@
                         ],
                         "injuries": [
                             "battle_injury"
-                        ],
-                        "scars": [
-                            "BRIDGE"
                         ]
                     }
                 ],
-                "history_text": {"scar": "m_c was scarred by an invading rogue."},
+                "history_text": {
+                    "scar": "m_c was scarred by an invading rogue.",
+                    "death": "m_c died of injuries inflicted by an invading rogue."
+                },
                 "relationships": [
                     {
                         "cats_to": ["s_c"],
@@ -555,14 +547,12 @@
                         ],
                         "injuries": [
                             "battle_injury"
-                        ],
-                        "scars": [
-                            "SNOUT"
                         ]
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c was scarred by an invading rogue."
+                    "scar": "m_c was scarred by an invading rogue.",
+                    "death": "m_c died of injuries inflicted by an invading rogue."
                 },
                 "relationships": [
                     {

--- a/resources/lang/en/patrols/mountainous/hunting/any.json
+++ b/resources/lang/en/patrols/mountainous/hunting/any.json
@@ -583,14 +583,12 @@
                         ],
                         "injuries": [
                             "big_bite_injury"
-                        ],
-                        "scars": [
-                            "NECKBITE"
                         ]
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c gained a scar from a fox."
+                    "scar": "m_c was scarred by a fox.",
+                    "death": "m_c died of injuries inflicted by a fox."
                 },
                 "prey": [
                     "very_small"
@@ -675,7 +673,6 @@
                     "r_c"
                 ],
                 "history_text": {
-                    "scar": "m_c gained a scar from a fox.",
                     "death": "m_c was killed by a wolverine."
                 },
                 "frequency": 3
@@ -690,15 +687,12 @@
                         ],
                         "injuries": [
                             "big_bite_injury"
-                        ],
-                        "scars": [
-                            "NECKBITE"
                         ]
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c gained a scar from a fox.",
-                    "death": "m_c was killed by a fox."
+                    "scar": "m_c was scarred by a fox.",
+                    "death": "m_c died of injuries inflicted by a fox."
                 },
                 "frequency": 3
             }
@@ -768,7 +762,6 @@
                     "r_c"
                 ],
                 "history_text": {
-                    "scar": "m_c gained a scar from a wolverine.",
                     "death": "m_c was killed by a wolverine while patrolling alone."
                 },
                 "frequency": 3
@@ -783,15 +776,12 @@
                         ],
                         "injuries": [
                             "big_bite_injury"
-                        ],
-                        "scars": [
-                            "NECKBITE"
                         ]
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c gained a scar from a fox.",
-                    "death": "m_c was killed by a fox while patrolling alone."
+                    "scar": "m_c was scarred by a fox.",
+                    "death": "m_c died of injuries inflicted by a fox."
                 },
                 "frequency": 3
             }
@@ -1352,23 +1342,31 @@
                             "app1"
                         ],
                         "injuries": [
-                            "small cut",
+                            "small cut"
+                        ],
+                        "scars": [
+                            "BRIDGE", "FACE", "SNOUT", "QUILLSCRATCH"
+                        ]
+                    },
+                    {
+                        "cats": [
+                            "app1"
+                        ],
+                        "injuries": [
                             "beak_bite"
                         ],
                         "scars": [
-                            "SNOUT",
-                            "BEAKCHEEK"
-                        ],
-                        "no_results": false
-                        }
-                    ],
-                    "history_text": {
-                        "scar": "m_c was scarred after underestimating a grouse.",
-                        "death": "m_c died after underestimating a grouse on a hunt as a foolish apprentice."
-                        },
-                        "frequency": 1
-                }
-            ]
+                            "BEAKCHEEK", "BEAKLOWER"
+                        ]
+                    }
+                ],
+                "history_text": {
+                    "scar": "m_c was scarred after underestimating a grouse.",
+                    "death": "m_c died of {PRONOUN/m_c/poss} injuries after underestimating a grouse on a hunt as a foolish apprentice."
+                },
+                "frequency": 1
+            }
+        ]
     },
     
     {
@@ -1649,11 +1647,13 @@
                 "injury": [
                     {
                         "cats": ["r_c"],
-                        "injuries": ["big_bite_injury"],
-                        "scars": ["NECKBITE"]
+                        "injuries": ["big_bite_injury"]
                     }
                 ],
-                "history_text": { "scar": "m_c carries a scar from a fox fight." },
+                "history_text": {
+                    "scar": "m_c carries a scar from a fox fight.",
+                    "death": "m_c died of injuries inflicted by a fox."
+                },
                 "relationships": [
                     {
                         "cats_to": ["patrol"],
@@ -1676,11 +1676,13 @@
                 "injury": [
                     {
                         "cats": ["s_c"],
-                        "injuries": ["big_bite_injury"],
-                        "scars": ["NECKBITE"]
+                        "injuries": ["big_bite_injury"]
                     }
                 ],
-                "history_text": { "scar": "m_c carries a scar from a fox fight." },
+                "history_text": {
+                    "scar": "m_c carries a scar from a fox fight.",
+                    "death": "m_c died of {PRONOUN/m_c/poss} injuries after underestimating a fox."
+                },
                 "relationships": [
                     {
                         "cats_to": ["s_c"],
@@ -1800,8 +1802,7 @@
                 "injury": [
                     {
                         "cats": ["app1"],
-                        "injuries": ["minor_injury"],
-                        "scars": []
+                        "injuries": ["minor_injury"]
                     }
                 ],
                 "relationships": [
@@ -2032,8 +2033,7 @@
                 "injury": [
                     {
                         "cats": ["app1"],
-                        "injuries": ["minor_injury"],
-                        "scars": []
+                        "injuries": ["minor_injury"]
                     }
                 ],
                 "relationships": [
@@ -2850,8 +2850,7 @@
                 "injury": [
                     {
                         "cats": ["r_c"],
-                        "injuries": ["dislocated joint"],
-                        "scars": []
+                        "injuries": ["dislocated joint"]
                     }
                 ],
                 "prey": ["very_small"]
@@ -2927,8 +2926,7 @@
                 "injury": [
                     {
                         "cats": ["r_c"],
-                        "injuries": ["severe headache"],
-                        "scars": []
+                        "injuries": ["severe headache"]
                     }
                 ],
                 "relationships": [
@@ -3016,10 +3014,12 @@
                 "injury": [
                     {
                         "cats": ["r_c"],
-                        "injuries": ["diarrhea"],
-                        "scars": []
+                        "injuries": ["diarrhea"]
                     }
                 ],
+                "history_text": {
+                    "death": "m_c died to diarrhea."
+                },
                 "prey": ["very_small"]
             }
         ]
@@ -3264,8 +3264,7 @@
                 "injury": [
                     {
                         "cats": ["r_c"],
-                        "injuries": ["dislocated joint"],
-                        "scars": []
+                        "injuries": ["dislocated joint"]
                     }
                 ],
                 "prey": ["very_small"]
@@ -3341,10 +3340,12 @@
                 "injury": [
                     {
                         "cats": ["r_c"],
-                        "injuries": ["diarrhea"],
-                        "scars": []
+                        "injuries": ["diarrhea"]
                     }
                 ],
+                "history_text": {
+                    "death": "m_c died to diarrhea."
+                },
                 "prey": ["very_small"]
             }
         ]
@@ -3507,14 +3508,12 @@
                         ],
                         "injuries": [
                             "beak_bite"
-                        ],
-                        "scars": [
-                            "BEAKCHEEK"
                         ]
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c carries a scar from an eagle's beak."
+                    "scar": "m_c carries a scar from an eagle's beak.",
+                    "death": "m_c died of injuries that were inflicted by an eagle while scrapping over food."
                 },
                 "relationships": [
                     {
@@ -3731,14 +3730,12 @@
                         ],
                         "injuries": [
                             "beak_bite"
-                        ],
-                        "scars": [
-                            "BEAKCHEEK"
                         ]
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c carries a scar from an eagle's beak."
+                    "scar": "m_c carries a scar from an eagle's beak.",
+                    "death": "m_c died of injuries that were inflicted by an eagle while scrapping over food."
                 },
                 "relationships": [
                     {

--- a/resources/lang/en/patrols/mountainous/hunting/greenleaf.json
+++ b/resources/lang/en/patrols/mountainous/hunting/greenleaf.json
@@ -545,10 +545,13 @@
                         ],
                         "injuries": [
                             "broken bone"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
+                "history_text": {
+                    "scar": "m_c was scarred by a fox.",
+                    "death": "m_c died of injuries inflicted by a fox."
+                },
                 "relationships": [
                     {
                         "cats_to": [

--- a/resources/lang/en/patrols/mountainous/hunting/leaf-bare.json
+++ b/resources/lang/en/patrols/mountainous/hunting/leaf-bare.json
@@ -1442,6 +1442,7 @@
                     }
                 ],
                 "history_text": {
+                    "scar": "m_c caught a chill while hunting in leaf-bare.",
                     "death": "m_c died to a chill {PRONOUN/m_c/subject} caught while hunting in leaf-bare."
                 },
                 "relationships": [

--- a/resources/lang/en/patrols/mountainous/hunting/leaf-bare.json
+++ b/resources/lang/en/patrols/mountainous/hunting/leaf-bare.json
@@ -158,8 +158,7 @@
                     "r_c"
                 ],
                 "history_text": {
-                    "scar": "m_c carries a scar from an eagle's beak.",
-                    "death": "m_c was killed by an eagle, scrapping over food."
+                    "death": "m_c was killed by an eagle while scrapping over food."
                 },
                 "relationships": [
                     {
@@ -191,15 +190,12 @@
                         ],
                         "injuries": [
                             "beak_bite"
-                        ],
-                        "scars": [
-                            "BEAKCHEEK"
                         ]
                     }
                 ],
                 "history_text": {
                     "scar": "m_c carries a scar from an eagle's beak.",
-                    "death": "m_c was killed by an eagle, scrapping over food."
+                    "death": "m_c died of injuries that were inflicted by an eagle while scrapping over food."
                 },
                 "relationships": [
                     {
@@ -409,15 +405,12 @@
                         ],
                         "injuries": [
                             "beak_bite"
-                        ],
-                        "scars": [
-                            "BEAKLOWER"
                         ]
                     }
                 ],
                 "history_text": {
                     "scar": "m_c carries a scar from an eagle's beak.",
-                    "death": "m_c was killed by an eagle, scrapping over food."
+                    "death": "m_c died of injuries that were inflicted by an eagle while scrapping over food."
                 },
                 "relationships": [
                     {
@@ -593,14 +586,12 @@
                         ],
                         "injuries": [
                             "cold_injury"
-                        ],
-                        "scars": [
-                            "FROSTFACE"
                         ]
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c caught a chill while hunting in leaf-bare."
+                    "scar": "m_c caught a chill while hunting in leaf-bare.",
+                    "death": "m_c died to a chill {PRONOUN/m_c/subject} caught while hunting in leaf-bare."
                 },
                 "relationships": [
                     {
@@ -691,7 +682,6 @@
                     "r_c"
                 ],
                 "history_text": {
-                    "scar": "m_c caught a chill while hunting in leaf-bare.",
                     "death": "m_c died trying to provide for c_n during leaf-bare."
                 },
                 "frequency": 4
@@ -706,15 +696,12 @@
                         ],
                         "injuries": [
                             "cold_injury"
-                        ],
-                        "scars": [
-                            "FROSTFACE"
                         ]
                     }
                 ],
                 "history_text": {
                     "scar": "m_c caught a chill while hunting in leaf-bare.",
-                    "death": "m_c died trying to provide for c_n during leaf-bare."
+                    "death": "m_c died to a chill {PRONOUN/m_c/subject} caught while hunting in leaf-bare."
                 },
                 "frequency": 4
             }
@@ -827,7 +814,6 @@
                     "r_c"
                 ],
                 "history_text": {
-                    "scar": "m_c caught a chill while hunting in leaf-bare.",
                     "death": "m_c froze to death while hunting in a storm."
                 },
                 "relationships": [
@@ -854,15 +840,12 @@
                         ],
                         "injuries": [
                             "cold_injury"
-                        ],
-                        "scars": [
-                            "FROSTTAIL"
                         ]
                     }
                 ],
                 "history_text": {
                     "scar": "m_c caught a chill while hunting in leaf-bare.",
-                    "death": "m_c froze to death while hunting in a storm."
+                    "death": "m_c died to a chill {PRONOUN/m_c/subject} caught while hunting in leaf-bare."
                 },
                 "frequency": 4
             }
@@ -1320,8 +1303,8 @@
                     }
                 ],
                 "history_text": {
-                    "death": "m_c died after falling out of a tree on a hunt.",
-                    "scar": "m_c was scarred after falling out of a tree on a hunt."
+                    "scar": "m_c was scarred after falling out of a tree on a hunt.",
+                    "death": "m_c succumbed to a broken bone after falling out of a tree."
                 },
                 "relationships": [
                     {
@@ -1455,10 +1438,12 @@
                         ],
                         "injuries": [
                             "shivering"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
+                "history_text": {
+                    "death": "m_c died to a chill {PRONOUN/m_c/subject} caught while hunting in leaf-bare."
+                },
                 "relationships": [
                     {
                         "cats_to": [
@@ -1731,14 +1716,12 @@
                         ],
                         "injuries": [
                             "beak_bite"
-                        ],
-                        "scars": [
-                            "BEAKCHEEK"
                         ]
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c got a scar underestimating a blue jay."
+                    "scar": "m_c got a scar underestimating a blue jay.",
+                    "death": "m_c died to injuries {PRONOUN/m_c/subject} got after underestimating a blue jay."
                 },
                 "relationships": [
                     {
@@ -1784,14 +1767,12 @@
                         ],
                         "injuries": [
                             "beak_bite"
-                        ],
-                        "scars": [
-                            "BEAKCHEEK"
                         ]
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c got a scar underestimating a blue jay."
+                    "scar": "m_c got a scar underestimating a blue jay.",
+                    "death": "m_c died to injuries {PRONOUN/m_c/subject} got after underestimating a blue jay."
                 },
                 "relationships": [
                     {
@@ -2062,7 +2043,6 @@
                     "all_lives"
                 ],
                 "history_text": {
-                    "scar": "m_c mistook a buzzard for a vulture and got pecked",
                     "death": "m_c was scared off a cliff by a large bird."
                 },
                 "frequency": 3
@@ -2077,15 +2057,12 @@
                         ],
                         "injuries": [
                             "beak_bite"
-                        ],
-                        "scars": [
-                            "BEAKLOWER"
                         ]
                     }
                 ],
                 "history_text": {
                     "scar": "m_c mistook a buzzard for a vulture and got pecked",
-                    "death": "m_c was scared off a cliff by a large bird."
+                    "death": "m_c died of injuries sustained after mistaking a buzzard for a vulture."
                 },
                 "frequency": 3
             },
@@ -2107,8 +2084,7 @@
                     "all_lives"
                 ],
                 "history_text": {
-                    "scar": "m_c mistook a buzzard for a vulture and got pecked",
-                    "death": "m_c was scared off a cliff by a large bird."
+                    "death": "m_c slipped off a cliff while trying to catch a buzzard."
                 },
                 "frequency": 3
             },
@@ -2132,15 +2108,12 @@
                         ],
                         "injuries": [
                             "beak_bite"
-                        ],
-                        "scars": [
-                            "BEAKLOWER"
                         ]
                     }
                 ],
                 "history_text": {
                     "scar": "m_c mistook a buzzard for a vulture and got pecked",
-                    "death": "m_c was scared off a cliff by a large bird."
+                    "death": "m_c died of injuries sustained after mistaking a buzzard for a vulture."
                 },
                 "frequency": 3
             }
@@ -2389,12 +2362,11 @@
                             "sore",
                             "scrapes",
                             "torn ear"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "history_text": {
-                    "scar": "r_c tore {PRONOUN/r_c/poss} ear while learning a harsh lesson about overestimating prey as an apprentice."
+                    "scar": "m_c was scarred while learning a harsh lesson about underestimating prey as an apprentice."
                 },
                 "relationships": [
                     {

--- a/resources/lang/en/patrols/mountainous/hunting/leaf-fall.json
+++ b/resources/lang/en/patrols/mountainous/hunting/leaf-fall.json
@@ -1342,6 +1342,7 @@
                     }
                 ],
                 "history_text": {
+                    "scar": "m_c caught a chill while hunting in leaf-bare.",
                     "death": "m_c died to a chill {PRONOUN/m_c/subject} caught while hunting in leaf-fall."
                 },
                 "relationships": [

--- a/resources/lang/en/patrols/mountainous/hunting/leaf-fall.json
+++ b/resources/lang/en/patrols/mountainous/hunting/leaf-fall.json
@@ -483,14 +483,12 @@
                         ],
                         "injuries": [
                             "cold_injury"
-                        ],
-                        "scars": [
-                            "FROSTFACE"
                         ]
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c caught a chill while hunting in leaf-fall."
+                    "scar": "m_c caught a chill while hunting in leaf-fall.",
+                    "death": "m_c died to a chill {PRONOUN/m_c/subject} caught while hunting in leaf-fall."
                 },
                 "relationships": [
                     {
@@ -592,14 +590,12 @@
                         ],
                         "injuries": [
                             "cold_injury"
-                        ],
-                        "scars": [
-                            "FROSTFACE"
                         ]
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c caught a chill while hunting in leaf-fall."
+                    "scar": "m_c caught a chill while hunting in leaf-fall.",
+                    "death": "m_c died to a chill {PRONOUN/m_c/subject} caught while hunting in leaf-fall."
                 },
                 "frequency": 3
             }
@@ -721,14 +717,12 @@
                         ],
                         "injuries": [
                             "cold_injury"
-                        ],
-                        "scars": [
-                            "FROSTTAIL"
                         ]
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c caught a chill while hunting in leaf-fall."
+                    "scar": "m_c caught a chill while hunting in leaf-fall.",
+                    "death": "m_c died to a chill {PRONOUN/m_c/subject} caught while hunting in leaf-fall."
                 },
                 "frequency": 4
             }
@@ -1185,9 +1179,9 @@
                     }
                 ],
                 "history_text": {
-                        "death": "m_c succumbed to a broken bone after falling out of a tree.",
-                        "scar": "m_c carries a scar after falling out of a tree and breaking a bone."
-                    },
+                    "scar": "m_c was scarred after falling out of a tree on a hunt.",
+                    "death": "m_c succumbed to a broken bone after falling out of a tree."
+                },
                 "relationships": [
                     {
                         "cats_to": [
@@ -1344,10 +1338,12 @@
                         ],
                         "injuries": [
                             "shivering"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
+                "history_text": {
+                    "death": "m_c died to a chill {PRONOUN/m_c/subject} caught while hunting in leaf-fall."
+                },
                 "relationships": [
                     {
                         "cats_to": [
@@ -1554,10 +1550,17 @@
             ],
             "injury": [
                 {
-                    "cats": ["s_c"],
-                    "injuries": ["water in their lungs"]
+                    "cats": [
+                        "s_c"
+                    ],
+                    "injuries": [
+                        "water in their lungs"
+                    ]
                 }
             ],
+            "history_text": {
+                "death": "m_c died to complications caused by water in {PRONOUN/m_c/poss} lungs."
+            },
             "art": "gen_fallenwater_cat2"
         },
         {

--- a/resources/lang/en/patrols/mountainous/hunting/newleaf.json
+++ b/resources/lang/en/patrols/mountainous/hunting/newleaf.json
@@ -151,14 +151,12 @@
                         ],
                         "injuries": [
                             "cold_injury"
-                        ],
-                        "scars": [
-                            "FROSTFACE"
                         ]
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c caught a chill while hunting in newleaf."
+                    "scar": "m_c caught a chill while hunting in newleaf.",
+                    "death": "m_c died to a chill {PRONOUN/m_c/subject} caught while hunting in newleaf."
                 },
                 "relationships": [
                     {
@@ -257,14 +255,12 @@
                         ],
                         "injuries": [
                             "cold_injury"
-                        ],
-                        "scars": [
-                            "FROSTTAIL"
                         ]
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c caught a chill while hunting in newleaf."
+                    "scar": "m_c caught a chill while hunting in newleaf.",
+                    "death": "m_c died to a chill {PRONOUN/m_c/subject} caught while hunting in newleaf."
                 },
                 "frequency": 3
             }
@@ -386,14 +382,12 @@
                         ],
                         "injuries": [
                             "cold_injury"
-                        ],
-                        "scars": [
-                            "FROSTTAIL"
                         ]
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c caught a chill while hunting in newleaf."
+                    "scar": "m_c caught a chill while hunting in newleaf.",
+                    "death": "m_c died to a chill {PRONOUN/m_c/subject} caught while hunting in newleaf."
                 },
                 "frequency": 4
             }
@@ -850,8 +844,8 @@
                     }
                 ],
                 "history_text": {
-                    "death": "m_c succumbed to a broken bone after falling out of a tree.",
-                    "scar": "m_c carries a scar after falling out of a tree and breaking a bone."
+                    "scar": "m_c was scarred after falling out of a tree on a hunt.",
+                    "death": "m_c succumbed to a broken bone after falling out of a tree."
                     },
                 "relationships": [
                     {
@@ -1009,10 +1003,12 @@
                         ],
                         "injuries": [
                             "shivering"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
+                "history_text": {
+                    "death": "m_c died to a chill {PRONOUN/m_c/subject} caught while hunting in newleaf."
+                },
                 "relationships": [
                     {
                         "cats_to": [

--- a/resources/lang/en/patrols/mountainous/hunting/newleaf.json
+++ b/resources/lang/en/patrols/mountainous/hunting/newleaf.json
@@ -1007,6 +1007,7 @@
                     }
                 ],
                 "history_text": {
+                    "scar": "m_c caught a chill while hunting in leaf-bare.",
                     "death": "m_c died to a chill {PRONOUN/m_c/subject} caught while hunting in newleaf."
                 },
                 "relationships": [

--- a/resources/lang/en/patrols/mountainous/training/any.json
+++ b/resources/lang/en/patrols/mountainous/training/any.json
@@ -735,7 +735,7 @@
                     "r_c"
                 ],
                 "history_text": {
-                    "death": "m_c tragically died after being trapped on patrol."
+                    "death": "m_c tragically died after a scree slope collapsed beneath {PRONOUN/m_c/object}."
                 },
                 "frequency": 3
             },
@@ -756,8 +756,8 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c carries a scar from being trapped on patrol",
-                    "death": "m_c died to injuries sustained after getting trapped on patrol."
+                    "scar": "m_c carries a scar from when a scree slope collapsed beneath {PRONOUN/m_c/object}.",
+                    "death": "m_c died from {PRONOUN/m_c/poss} injuries after a scree slope collapsed beneath {PRONOUN/m_c/object}."
                 },
                 "frequency": 3
             },
@@ -768,7 +768,7 @@
                     "r_c"
                 ],
                 "history_text": {
-                    "death": "m_c tragically died after being trapped on patrol."
+                    "death": "m_c tragically died after a scree slope collapsed beneath {PRONOUN/m_c/object}."
                 },
                 "frequency": 3
             },
@@ -786,8 +786,8 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c carries a scar from being trapped on patrol",
-                    "death": "m_c died to injuries sustained after getting trapped on patrol."
+                    "scar": "m_c carries a scar from when a scree slope collapsed beneath {PRONOUN/m_c/object}.",
+                    "death": "m_c died from {PRONOUN/m_c/poss} injuries after a scree slope collapsed beneath {PRONOUN/m_c/object}."
                 },
                 "frequency": 3
             }
@@ -961,7 +961,7 @@
                     "r_c"
                 ],
                 "history_text": {
-                    "death": "m_c tragically died after being trapped on patrol."
+                    "death": "m_c tragically died after a scree slope collapsed beneath {PRONOUN/m_c/object}."
                 },
                 "frequency": 3
             },
@@ -979,8 +979,8 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c carries a scar from being trapped on patrol",
-                    "death": "m_c died to injuries sustained after getting trapped on patrol."
+                    "scar": "m_c carries a scar from when a scree slope collapsed beneath {PRONOUN/m_c/object}.",
+                    "death": "m_c died from {PRONOUN/m_c/poss} injuries after a scree slope collapsed beneath {PRONOUN/m_c/object}."
                 },
                 "frequency": 3
             }
@@ -1034,7 +1034,7 @@
                     "r_c"
                 ],
                 "history_text": {
-                    "death": "m_c tragically died after being trapped on a solo patrol."
+                    "death": "m_c tragically died after a scree slope collapsed beneath {PRONOUN/m_c/object}."
                 },
                 "frequency": 3
             },
@@ -1052,8 +1052,8 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c carries a scar from being trapped on a solo patrol",
-                    "death": "m_c died to injuries sustained after getting trapped on a solo patrol."
+                    "scar": "m_c carries a scar from when a scree slope collapsed beneath {PRONOUN/m_c/object}.",
+                    "death": "m_c died from {PRONOUN/m_c/poss} injuries after a scree slope collapsed beneath {PRONOUN/m_c/object}."
                 },
                 "frequency": 3
             }

--- a/resources/lang/en/patrols/mountainous/training/any.json
+++ b/resources/lang/en/patrols/mountainous/training/any.json
@@ -145,16 +145,18 @@
                             "app1"
                         ],
                         "injuries": [
-                            "minor_injury"
+                            "sprain"
+                        ]
+                    },
+                    {
+                        "cats": [
+                            "app1"
                         ],
-                        "scars": [
-                            "RIGHTEAR"
+                        "injuries": [
+                            "bruises"
                         ]
                     }
                 ],
-                "history_text": {
-                    "scar": "m_c got scarred tumbling off a cliff during apprentice training."
-                },
                 "frequency": 3
             }
         ]
@@ -339,16 +341,13 @@
                             "r_c"
                         ],
                         "injuries": [
-                            "big_bite_injury"
-                        ],
-                        "scars": [
-                            "ONE"
+                            "claw-wound"
                         ]
                     }
                 ],
                 "history_text": {
                     "scar": "m_c was scarred by a badger.",
-                    "death": "m_c lost their life to a badger."
+                    "death": "m_c died from wounds inflicted by a badger."
                 },
                 "frequency": 3
             }
@@ -524,15 +523,12 @@
                         ],
                         "injuries": [
                             "big_bite_injury"
-                        ],
-                        "scars": [
-                            "SIDE"
                         ]
                     }
                 ],
                 "history_text": {
-                    "scar": "This cat was scarred by a badger.",
-                    "death": "This cat died from wounds inflicted by a badger."
+                    "scar": "m_c was scarred by a badger.",
+                    "death": "m_c died from wounds inflicted by a badger."
                 },
                 "relationships": [
                     {
@@ -739,7 +735,6 @@
                     "r_c"
                 ],
                 "history_text": {
-                    "scar": "m_c carries a scar from being trapped on patrol",
                     "death": "m_c tragically died after being trapped on patrol."
                 },
                 "frequency": 3
@@ -757,15 +752,12 @@
                         ],
                         "injuries": [
                             "blunt_force_injury"
-                        ],
-                        "scars": [
-                            "LEFTEAR"
                         ]
                     }
                 ],
                 "history_text": {
                     "scar": "m_c carries a scar from being trapped on patrol",
-                    "death": "m_c tragically died after being trapped on patrol."
+                    "death": "m_c died to injuries sustained after getting trapped on patrol."
                 },
                 "frequency": 3
             },
@@ -776,7 +768,6 @@
                     "r_c"
                 ],
                 "history_text": {
-                    "scar": "m_c carries a scar from being trapped on patrol",
                     "death": "m_c tragically died after being trapped on patrol."
                 },
                 "frequency": 3
@@ -791,15 +782,12 @@
                         ],
                         "injuries": [
                             "blunt_force_injury"
-                        ],
-                        "scars": [
-                            "LEFTEAR"
                         ]
                     }
                 ],
                 "history_text": {
                     "scar": "m_c carries a scar from being trapped on patrol",
-                    "death": "m_c tragically died after being trapped on patrol."
+                    "death": "m_c died to injuries sustained after getting trapped on patrol."
                 },
                 "frequency": 3
             }
@@ -973,7 +961,6 @@
                     "r_c"
                 ],
                 "history_text": {
-                    "scar": "m_c carries a scar from being trapped on patrol",
                     "death": "m_c tragically died after being trapped on patrol."
                 },
                 "frequency": 3
@@ -988,15 +975,12 @@
                         ],
                         "injuries": [
                             "blunt_force_injury"
-                        ],
-                        "scars": [
-                            "LEFTEAR"
                         ]
                     }
                 ],
                 "history_text": {
                     "scar": "m_c carries a scar from being trapped on patrol",
-                    "death": "m_c tragically died after being trapped on patrol."
+                    "death": "m_c died to injuries sustained after getting trapped on patrol."
                 },
                 "frequency": 3
             }
@@ -1050,8 +1034,7 @@
                     "r_c"
                 ],
                 "history_text": {
-                    "scar": "m_c carries a scar from being trapped on patrol.",
-                    "death": "m_c tragically died after being trapped on patrol."
+                    "death": "m_c tragically died after being trapped on a solo patrol."
                 },
                 "frequency": 3
             },
@@ -1065,15 +1048,12 @@
                         ],
                         "injuries": [
                             "blunt_force_injury"
-                        ],
-                        "scars": [
-                            "TOETRAP"
                         ]
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c carries a scar from being trapped on patrol.",
-                    "death": "m_c tragically died after being trapped on patrol."
+                    "scar": "m_c carries a scar from being trapped on a solo patrol",
+                    "death": "m_c died to injuries sustained after getting trapped on a solo patrol."
                 },
                 "frequency": 3
             }
@@ -1161,15 +1141,9 @@
                         ],
                         "injuries": [
                             "minor_injury"
-                        ],
-                        "scars": [
-                            "LEFTEAR"
                         ]
                     }
                 ],
-                "history_text": {
-                    "scar": "m_c got injured as an apprentice, exploring alone."
-                },
                 "frequency": 3
             }
         ]
@@ -1585,9 +1559,7 @@
                         ],
                         "injuries": [
                             "constant nightmares"
-                        ],
-                        "scars": [],
-                        "no_results": false
+                        ]
                     }
                 ],
                 "relationships": [
@@ -2523,7 +2495,7 @@
                             "cat bite"
                         ],
                         "scars": [
-                            "TAILBASE"
+                            "BACK", "TAILBASE"
                         ]
                     }
                 ],
@@ -2722,14 +2694,9 @@
                         "cats": ["r_c"],
                         "injuries": [
                             "constant nightmares"
-                        ],
-                        "scars": [],
-                        "no_results": false
+                        ]
                     }
                 ],
-                "history_text": {
-                    "death": "m_c died from lack of sleep, {PRONOUN/m_c/poss} vision haunted by dark shadows."
-                },
                 "frequency": 4
             },
             {
@@ -2971,9 +2938,8 @@
                     {
                         "cats": ["app1"],
                         "injuries": [
-                            "shivering"
-                        ],
-                        "scars": []
+                            "running nose"
+                        ]
                     }
                 ],
                 "relationships": [
@@ -3206,8 +3172,7 @@
                         ],
                         "injuries": [
                             "poisoned"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "history_text": {
@@ -3308,8 +3273,7 @@
                         ],
                         "injuries": [
                             "poisoned"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "history_text": {

--- a/resources/lang/en/patrols/mountainous/training/greenleaf.json
+++ b/resources/lang/en/patrols/mountainous/training/greenleaf.json
@@ -835,8 +835,7 @@
                         ],
                         "injuries": [
                             "stomachache"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "relationships": [
@@ -1162,9 +1161,7 @@
                         "injuries": [
                             "scrapes",
                             "bruises"
-                        ],
-                        "scars": [],
-                        "no_results": false
+                        ]
                     }
                 ],
                 "frequency": 4

--- a/resources/lang/en/patrols/mountainous/training/leaf-bare.json
+++ b/resources/lang/en/patrols/mountainous/training/leaf-bare.json
@@ -151,9 +151,8 @@
                     {
                         "cats": ["app1"],
                         "injuries": [
-                            "shivering"
-                        ],
-                        "scars": []
+                            "running nose"
+                        ]
                     }
                 ],
                 "relationships": [
@@ -714,14 +713,9 @@
                         "cats": ["r_c"],
                         "injuries": [
                             "constant nightmares"
-                        ],
-                        "scars": [],
-                        "no_results": false
+                        ]
                     }
                 ],
-                "history_text": {
-                    "death": "m_c died from lack of sleep, {PRONOUN/m_c/poss} vision haunted by dark shadows."
-                },
                 "frequency": 4
             },
             {
@@ -868,9 +862,7 @@
                         "cats": ["r_c"],
                         "injuries": [
                             "shivering"
-                        ],
-                        "scars": [],
-                        "no_results": false
+                        ]
                     }
                 ],
                 "history_text": {
@@ -1279,15 +1271,13 @@
                         "cats": ["patrol"],
                         "injuries": [
                             "shivering"
-                        ],
-                        "scars": []
+                        ]
                     }
                 ],
                 "dead_cats": [
                     "multi"
                 ],
                 "history_text": {
-                    "scar": "m_c was scarred from the bite of the cold of an avalanche, though {PRONOUN/m_c/subject} escaped with {PRONOUN/m_c/poss} life.",
                     "death": "The view point c_n thought was safe from avalanches... was not."
                 },
                 "relationships": [

--- a/resources/lang/en/patrols/mountainous/training/leaf-bare.json
+++ b/resources/lang/en/patrols/mountainous/training/leaf-bare.json
@@ -866,6 +866,7 @@
                     }
                 ],
                 "history_text": {
+                    "scar": "m_c got frostbite while repairing some dens.",
                     "death": "m_c died after getting too cold while repairing some dens."
                 },
                 "frequency": 4
@@ -1278,6 +1279,7 @@
                     "multi"
                 ],
                 "history_text": {
+                    "scar": "m_c was scarred from the bite of the cold of an avalanche, though {PRONOUN/m_c/subject} escaped with {PRONOUN/m_c/poss} life.",
                     "death": "The view point c_n thought was safe from avalanches... was not."
                 },
                 "relationships": [


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
Add/remove/modify scars pool and death string for mountainous patrols. Also changes injury pool for some outcomes that I felt did not reflect the text accurately.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->


## Linked Issues
#4346 and #4352
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->


