### PR TITLE
[BUGFIX] Fix dead_for much longer than 'dead_moons' bug

### DIFF
--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -3404,7 +3404,6 @@ class Cat:
                 "scars": self.pelt.scars or [],
                 "accessory": self.pelt.accessory,
                 "experience": self.experience,
-                "dead_moons": self.dead_for,
                 "current_apprentice": list(self.apprentice),
                 "former_apprentices": list(self.former_apprentices),
                 "faded_offspring": self.faded_offspring,

--- a/scripts/game_structure/load_cat.py
+++ b/scripts/game_structure/load_cat.py
@@ -279,7 +279,8 @@ def json_load():
                     if cat.get("driven_out"):
                         new_cat.status.change_group_nearness(CatGroup.PLAYER_CLAN_ID)
 
-            new_cat.dead_for = cat["dead_moons"]
+            if "dead_moons" in cat and cat["dead_moons"] is not None:
+                new_cat.dead_for = cat["dead_moons"]
             new_cat.experience = cat["experience"]
             new_cat.apprentice = cat["current_apprentice"]
             new_cat.former_apprentices = cat["former_apprentices"]

--- a/scripts/game_structure/load_cat.py
+++ b/scripts/game_structure/load_cat.py
@@ -279,7 +279,7 @@ def json_load():
                     if cat.get("driven_out"):
                         new_cat.status.change_group_nearness(CatGroup.PLAYER_CLAN_ID)
 
-            if "dead_moons" in cat and cat["dead_moons"] is not None:
+            if cat.get("dead_moons"):
                 new_cat.dead_for = cat["dead_moons"]
             new_cat.experience = cat["experience"]
             new_cat.apprentice = cat["current_apprentice"]


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

Variable `dead_for` was set to `cat["dead_moons"]` which would then be used to update the `group_history[-1]` entry as the sum of all `"dead_moons"` entries, inflating the value with every save+reload of the game.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues

Fixes #4475
Fixes #4684 

<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing

Steps to replicate the bug:
1. Convert a StarClan cat to join the Dark Forest (ideally the clan's `guide`/ a cat that has been dead for a while)
```json
"group_history": [
            {
                "group": CatGroup.PLAYER_CLAN_ID,
                "rank": CatRank.WARRIOR,
                "moons_as": 30,
            },
            {
                "group": CatGroup.STARCLAN_ID,
                "rank": CatRank.WARRIOR,
                "moons_as": 10,
            }
        ],
```
2. Moonskip to add to the overall "dead_moons" value
```json
            {
                "group": CatGroup.DARK_FOREST_ID,
                "rank": CatRank.WARRIOR,
                "moons_as": 5,
            },
```
- where total in this example would be
```text
30 moons (in life)
15 moons (in death)
```
3. Save, close, reload game
4. Find that cat's "dead_moons" value to be inflated:
```text
30 moons (in life)
25 moons (in death)
```
where 25 != 15

Attempted to replicate bug again with the same steps and could not; `cat moons (in death)` remained stable on reload.

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->