### PR TITLE
[BUGFIX] Missing Relationship Log on Vixen Patrol

### DIFF
--- a/resources/lang/en/patrols/forest/border/any.json
+++ b/resources/lang/en/patrols/forest/border/any.json
@@ -3606,11 +3606,24 @@
                 ],
                 "relationships": [
                     {
-                        "cats_to": ["s_c", "patrol"],
-                        "cats_from": ["patrol", "patrol"],
+                        "cats_to": ["s_c"],
+                        "cats_from": ["patrol"],
                         "mutual": false,
                         "values": ["respect", "trust"],
-                        "amount": 5
+                        "amount": 10,
+                        "log": {
+                            "cats_from": "cat_from was extremely impressed by cat_to's skill in battle against a gray vixen."
+                        }
+                    },
+                    {
+                        "cats_to": ["patrol"],
+                        "cats_from": ["some_clan", "high_aggress"],
+                        "mutual": false,
+                        "values": ["respect"],
+                        "amount": 5,
+                        "log": {
+                            "cats_from": "cat_from heard about how cat_to's patrol drove off a gray vixen."
+                        }
                     }
                 ]
             },


### PR DESCRIPTION
## About The Pull Request

Found a "These cats interacted" on my dev save. I hunted down the culprit -- one of the many fox patrols. I guess I missed that iteration of it. All the other outcomes on the same patrol are logged.

## Proof of Testing

<img width="822" height="226" alt="image" src="https://github.com/user-attachments/assets/e3b6d00c-0a37-4036-bb67-309572d28440" />

log generating properly