### PR TITLE
[BUGFIX] Exclude involved cats from some_clan and clan reactions

### DIFF
--- a/scripts/events_module/consequences.py
+++ b/scripts/events_module/consequences.py
@@ -829,10 +829,20 @@ def gather_cat_objects(
         # OVERALL CLAN CATS
         elif abbr == "clan":
             found_cat_list.update(clan_cats)
+            # exclude cats involved in the event
+            found_cat_list.discard(getattr(event, "main_cat", None))
+            found_cat_list.discard(getattr(event, "random_cat", None))
+            if getattr(event, "patrol_cats", None):
+                found_cat_list.difference_update(set(event.patrol_cats))
         elif abbr == "some_clan":  # 1 / 8 of clan cats are affected
             found_cat_list.update(
                 sample(clan_cats, randint(1, max(1, round(len(clan_cats) / 8))))
             )
+            # exclude cats involved in the event
+            found_cat_list.discard(getattr(event, "main_cat", None))
+            found_cat_list.discard(getattr(event, "random_cat", None))
+            if getattr(event, "patrol_cats", None):
+                found_cat_list.difference_update(set(event.patrol_cats))
 
         # add/remove cats if found and then continue for loop
         if is_exclusionary and found_cat_list:


### PR DESCRIPTION
## About The Pull Request

With a lot of handholding from scribble, here is the bugfix for the river event.

## Linked Issues

Fixes: 4687

## Proof of Testing

<img width="912" height="508" alt="image" src="https://github.com/user-attachments/assets/121ae710-21b9-4528-9ea7-33ce77899dfa" />

clan facet reaction generating as expected

<img width="962" height="205" alt="image" src="https://github.com/user-attachments/assets/a3b92169-1c6b-4af6-8264-d89fdfd9dcaf" />

the event in question. screenshot shows that Skyfreckle has a high social trait and would have previously also reacted to their own river-saving.