### PR TITLE
[BUGFIX] Vengeful/Bloodthirsty r_c naming m_c instead

### DIFF
--- a/resources/lang/en/thoughts/while_alive/clancat.json
+++ b/resources/lang/en/thoughts/while_alive/clancat.json
@@ -6678,10 +6678,10 @@
     {
         "id": "gen_to_bloodthirsty_vengeful",
         "thoughts": [
-			"Seems to be oblivious to m_c glaring from across camp",
-			"Wonders when m_c learned so much about cat anatomy",
-			"Has to snap m_c out of staring darkly at a Clanmate",
-			"Wonders why m_c knows so much about a Clanmate {PRONOUN/r_c/subject} {VERB/r_c/don't/doesn't} like"
+			"Seems oblivious to r_c glaring from across camp",
+			"Wonders when r_c learned so much about cat anatomy",
+			"Has to snap r_c out of staring darkly at a Clanmate",
+			"Wonders why r_c knows so much about a Clanmate {PRONOUN/r_c/subject} {VERB/r_c/don't/doesn't} like"
         ],
         "random_trait_constraint": [
             "bloodthirsty",


### PR DESCRIPTION
## About The Pull Request

m_c was used instead of r_c by mistake. all these thoughts are supposed to select r_c as a bloodthirsty/vengeful cat, but the thoughts used "m_c", leading to cats thinking about themselves. I also trimmed one thought

## Linked Issues

reported in #1818

## Proof of Testing

<img width="650" height="113" alt="image" src="https://github.com/user-attachments/assets/46298e6c-fe72-4277-9e5a-f8f313fe1bac" />

cat no longer glaring at themself