### PR TITLE
[BUGFIX] History Text related to deaths caused by permanent conditions

### DIFF
--- a/resources/display_settings.toml
+++ b/resources/display_settings.toml
@@ -156,7 +156,7 @@
         "show dead relation" = [
             false, true
         ]
-        "show_empty relation" = [
+        "show empty relation" = [
             false, true
         ]
         "den labels" = [

--- a/scripts/events_module/short/condition_events.py
+++ b/scripts/events_module/short/condition_events.py
@@ -919,7 +919,10 @@ class Condition_Events:
 
                 # add to death history
                 cat.history.add_death(
-                    death_text=i18n.t("defaults.complications_death_history", condition=translated_condition)
+                    death_text=i18n.t(
+                        "defaults.complications_death_history",
+                        condition=translated_condition,
+                    )
                 )
 
                 game.herb_events_list.append(event)

--- a/scripts/events_module/short/condition_events.py
+++ b/scripts/events_module/short/condition_events.py
@@ -919,8 +919,7 @@ class Condition_Events:
 
                 # add to death history
                 cat.history.add_death(
-                    death_text=i18n.t("defaults.complications_death_history"),
-                    condition=translated_condition,
+                    death_text=i18n.t("defaults.complications_death_history", condition=translated_condition)
                 )
 
                 game.herb_events_list.append(event)


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

Fixes the one bug in condition_events where the condition wasn't actually a part of the function call. 
I had also made a commit fixing a bug that was later fixed and merged by someone else.

## Linked Issues

#4623

## Proof of Testing
<img width="1323" height="113" alt="image" src="https://github.com/user-attachments/assets/d1b2c20d-c860-4240-ad63-ca1f3a29295b" />
<img width="523" height="27" alt="image" src="https://github.com/user-attachments/assets/e2ecd8c4-7e33-426a-996a-007fbf3050f6" />


## Changelog/Credits

Changelog: Fixed history text display of deaths caused by existing permanent conditions