### PR TITLE
[BUGFIX] Typos and Text fixes

### DIFF
--- a/resources/lang/en/conditions/healed_and_death_strings/illness_healed_strings.json
+++ b/resources/lang/en/conditions/healed_and_death_strings/illness_healed_strings.json
@@ -5,7 +5,7 @@
     ],
     "diarrhea": [
         "m_c has stopped constantly running to the dirtplace. It seems {PRONOUN/m_c/poss} brush with diarrhea has ended.",
-        "m_c is finally feeling better, {PRONOUN/m_c/poss} experience with diarrhea now over."
+        "m_c is finally feeling better; {PRONOUN/m_c/poss} experience with diarrhea now over."
     ],
     "breathless fit": [
         "The tightness in m_c's chest has finally abated.",
@@ -17,7 +17,7 @@
     ],
     "greencough": [
         "m_c has recovered from greencough.",
-        "m_c is no longer coughing and sputtering, {PRONOUN/m_c/poss} case of greencough now cured.",
+        "m_c is no longer coughing and sputtering. {PRONOUN/m_c/poss/CAP} case of greencough is now cured.",
         "m_c no longer has greencough."
     ],
     "kittencough": [
@@ -50,13 +50,13 @@
         "m_c's yellowcough is gone."
     ],
     "a festering wound": [
-        "m_c's wound is no longer festering, the infection is gone.",
+        "m_c's wound is no longer festering, and the infection is gone.",
         "m_c's festering wound seems to have gotten a bit better."
     ],
     "heat stroke": [
         "m_c is no longer suffering from heat stroke.",
         "m_c has recovered from heat stroke.",
-        "m_c is feeling much better, {PRONOUN/m_c/subject}{VERB/m_c/'ve/'s} recovered from the heat stroke."
+        "m_c is feeling much better. {PRONOUN/m_c/subject/CAP}{VERB/m_c/'ve/'s} recovered from the heat stroke."
     ],
     "heat exhaustion": [
         "m_c has recovered from the heat exhaustion.",
@@ -78,7 +78,7 @@
         "m_c will always feel {PRONOUN/m_c/poss} grief, but time has softened it, at least a little.",
         "m_c gazes up into Silverpelt and finds that, finally, the grief has begun to lessen.",
         "m_c wakes one day, after moons of numbness, and feels as though the world is less dull.",
-        "m_c tells {PRONOUN/m_c/self} that {PRONOUN/m_c/subject} can't let these feelings consume {PRONOUN/m_c/object}, instead {PRONOUN/m_c/subject} {VERB/m_c/have/has} to learn to live with it.",
+        "m_c tells {PRONOUN/m_c/self} that {PRONOUN/m_c/subject} can't let these feelings consume {PRONOUN/m_c/object}. {PRONOUN/m_c/subject/CAP} {VERB/m_c/have/has} to learn to live with it.",
         "m_c picks {PRONOUN/m_c/self} up out of {PRONOUN/m_c/poss} nest and begins the day anew, a fresh conviction in {PRONOUN/m_c/poss} heart."
     ],
     "carrionplace disease": [
@@ -89,7 +89,7 @@
         "m_c finally feels energized again. It seems the newly consistent meals have done {PRONOUN/m_c/object} good."
     ],
     "starving": [
-        "m_c's paws no longer feel quite so heavy. {PRONOUN/m_c/subject/CAP} can tell that {PRONOUN/m_c/subject} still {VERB/m_c/need/needs} to eat more, but at least the situation isn't as dire.",
+        "m_c's paws no longer feel quite so heavy. {PRONOUN/m_c/subject/CAP} can tell that {PRONOUN/m_c/subject} still {VERB/m_c/need/needs} to eat more, but the situation isn't as dire.",
         "m_c still feels the rumbles of hunger in {PRONOUN/m_c/poss} belly, but it's nothing compared to the emptiness {PRONOUN/m_c/subject}'d so recently experienced."
     ],
     "tick fever": [

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -9999,7 +9999,7 @@
                 "amount": 15,
                 "mutual": false,
                 "log": {
-                    "cats_from": "cat_from was impressed by how cat_to was able to resolve a herb-gathering dispute with o_c_n."
+                    "cats_from": "cat_from was impressed by how cat_to was able to resolve an herb-gathering dispute with o_c_n."
                 }
             }
         ]

--- a/resources/lang/en/patrols/forest/hunting/leaf-bare.json
+++ b/resources/lang/en/patrols/forest/hunting/leaf-bare.json
@@ -710,7 +710,7 @@
         ]
     },
     {
-        "patrol_id": "fst_hunt_leaf-bare_mice_ohnotheyrehot1",
+        "patrol_id": "fst_hunt_leafbare_mice_ohnotheyrehot1",
         "biome": [
             "forest"
         ],

--- a/resources/lang/en/patrols/forest/hunting/leaf-bare.json
+++ b/resources/lang/en/patrols/forest/hunting/leaf-bare.json
@@ -773,6 +773,9 @@
                 "prey": [
                     "medium"
                 ],
+                "can_have_stat": [
+                    "r_c"
+                ],
                 "relationships": [
                     {
                         "cats_to": [
@@ -818,6 +821,9 @@
                     "fierce",
                     "shameless",
                     "troublesome"
+                ],
+                "can_have_stat": [
+                    "r_c"
                 ],
                 "prey": [
                     "medium"
@@ -3468,194 +3474,6 @@
                         "values": [
                             "comfort",
                             "trust"
-                        ],
-                        "amount": -5
-                    }
-                ],
-                "prey": [
-                    "very_small"
-                ],
-                "frequency": 4
-            }
-        ]
-    },
-    {
-        "patrol_id": "fst_hunt_mice_ohnotheyrehot4",
-        "biome": [
-            "forest"
-        ],
-        "season": [ "leaf-bare" ],
-        "types": [ "hunting" ],
-        "tags": [ "romance" ],
-        "patrol_art": "fst_hunt_mice_ohnotheyrehot",
-        "min_cats": 3,
-        "max_cats": 6,
-        "min_max_status": {},
-        "frequency": 3,
-        "intro_text": "As the patrol heads out into the forest to hunt, r_c seems to be absolutely unconcerned with {PRONOUN/r_c/poss} duties, instead ambling along as through the prey is going to waltz into {PRONOUN/r_c/poss} paws.",
-        "decline_text": "The cats are called back to camp — there's something the deputy needs to discuss with them.",
-        "chance_of_success": 20,
-        "success_outcomes": [
-            {
-                "text": "r_c makes it look easy, and when the patrol is done mousing everyone else ends up carrying catches mostly brought down by {PRONOUN/r_c/object}. {PRONOUN/r_c/subject/CAP} {VERB/r_c/lead/leads} the way back to camp, sauntering with a distinctly smug sway of {PRONOUN/r_c/poss} hips.",
-                "exp": 20,
-                "prey": [
-                    "medium"
-                ],
-                "relationships": [
-                    {
-                        "cats_to": [
-                            "r_c"
-                        ],
-                        "cats_from": [
-                            "patrol"
-                        ],
-                        "mutual": false,
-                        "values": [
-                            "romance",
-                            "respect"
-                        ],
-                        "amount": 5
-                    },
-                    {
-                        "cats_to": [
-                            "r_c"
-                        ],
-                        "cats_from": [
-                            "patrol"
-                        ],
-                        "mutual": false,
-                        "values": [
-                            "like"
-                        ],
-                        "amount": -5
-                    }
-                ],
-                "frequency": 4
-            },
-            {
-                "text": "Of course s_c is unconcerned, s_c knows {PRONOUN/s_c/poss} own skills well, and mice? Not a challenge. After {PRONOUN/s_c/poss} fifth catch, the rest of the patrol is forced to admit {PRONOUN/s_c/subject} might have a point about not needing to worry.",
-                "exp": 20,
-                "stat_skill": [
-                    "HUNTER,1"
-                ],
-                "can_have_stat": [
-                    "r_c"
-                ],
-                "prey": [
-                    "medium"
-                ],
-                "relationships": [
-                    {
-                        "cats_to": [
-                            "r_c"
-                        ],
-                        "cats_from": [
-                            "patrol"
-                        ],
-                        "mutual": false,
-                        "values": [
-                            "romance",
-                            "respect"
-                        ],
-                        "amount": 5
-                    },
-                    {
-                        "cats_to": [
-                            "r_c"
-                        ],
-                        "cats_from": [
-                            "patrol"
-                        ],
-                        "mutual": false,
-                        "values": [
-                            "like"
-                        ],
-                        "amount": -5
-                    }
-                ],
-                "frequency": 4
-            },
-            {
-                "text": "The patrol settles into the hunt, following the scents of mice. s_c wanders back, and as {PRONOUN/s_c/subject} {VERB/s_c/put/puts} a paw down, the ground squeaks. {PRONOUN/s_c/subject/CAP} {VERB/s_c/lean/leans} down, jaws snapping, and {VERB/s_c/meet/meets} the eyes of the rest of the patrol with an insolent smirk.",
-                "exp": 20,
-                "stat_trait": [
-                    "bold",
-                    "charismatic",
-                    "childish",
-                    "confident",
-                    "daring",
-                    "fierce",
-                    "shameless",
-                    "troublesome"
-                ],
-                "can_have_stat": [
-                    "r_c"
-                ],
-                "prey": [
-                    "medium"
-                ],
-                "relationships": [
-                    {
-                        "cats_to": [
-                            "r_c"
-                        ],
-                        "cats_from": [
-                            "patrol"
-                        ],
-                        "mutual": false,
-                        "values": [
-                            "romance",
-                            "respect"
-                        ],
-                        "amount": 5
-                    },
-                    {
-                        "cats_to": [
-                            "r_c"
-                        ],
-                        "cats_from": [
-                            "patrol"
-                        ],
-                        "mutual": false,
-                        "values": [
-                            "like"
-                        ],
-                        "amount": -5
-                    }
-                ],
-                "frequency": 4
-            }
-        ],
-        "fail_outcomes": [
-            {
-                "text": "r_c doesn't bring much home, impressing nobody.",
-                "exp": 0,
-                "relationships": [
-                    {
-                        "cats_to": [
-                            "r_c"
-                        ],
-                        "cats_from": [
-                            "patrol"
-                        ],
-                        "mutual": false,
-                        "values": [
-                            "romance",
-                            "respect"
-                        ],
-                        "amount": 5
-                    },
-                    {
-                        "cats_to": [
-                            "r_c"
-                        ],
-                        "cats_from": [
-                            "patrol"
-                        ],
-                        "mutual": false,
-                        "values": [
-                            "like"
                         ],
                         "amount": -5
                     }

--- a/resources/lang/en/patrols/general/medcat.json
+++ b/resources/lang/en/patrols/general/medcat.json
@@ -2625,7 +2625,7 @@
                         ],
                         "amount": 10,
                         "log": {
-                            "cats_from": "cat_from was impressed when cat_to found a huge patch of herbs on a herb-gathering patrol."
+                            "cats_from": "cat_from was impressed when cat_to found a huge patch of herbs on an herb-gathering patrol."
                         }
                     }
                 ],
@@ -2711,7 +2711,7 @@
                         ],
                         "amount": 12,
                         "log": {
-                            "cats_from": "cat_from and cat_to enjoyed a herb-gathering contest on patrol."
+                            "cats_from": "cat_from and cat_to enjoyed an herb-gathering contest on patrol."
                         }
                     }
                 ],
@@ -2783,7 +2783,7 @@
                         ],
                         "amount": 10,
                         "log": {
-                            "cats_from": "p_l enjoyed bossing r_c around on a herb-gathering patrol, and r_c indulged {PRONOUN/p_l/object}."
+                            "cats_from": "p_l enjoyed bossing r_c around on an herb-gathering patrol, and r_c indulged {PRONOUN/p_l/object}."
                         }
                     }
                 ],
@@ -2806,7 +2806,7 @@
                         ],
                         "amount": 10,
                         "log": {
-                            "cats_from": "p_l enjoyed bossing r_c around on a herb-gathering patrol, and r_c indulged {PRONOUN/p_l/object}, remembering what it was like to be young."
+                            "cats_from": "p_l enjoyed bossing r_c around on an herb-gathering patrol, and r_c indulged {PRONOUN/p_l/object}, remembering what it was like to be young."
                         }
                     }
                 ],
@@ -3674,7 +3674,7 @@
                         ],
                         "amount": -8,
                         "log": {
-                            "cats_from": "cat_to was no help to cat_from on a herb-gathering patrol."
+                            "cats_from": "cat_to was no help to cat_from on an herb-gathering patrol."
                         }
                     }
                 ],
@@ -3710,7 +3710,7 @@
                         ],
                         "amount": -10,
                         "log": {
-                            "cats_from": "cat_from found cat_to's questions on a herb-gathering patrol obnoxious."
+                            "cats_from": "cat_from found cat_to's questions on an herb-gathering patrol obnoxious."
                         }
                     }
                 ],
@@ -3954,7 +3954,7 @@
                         ],
                         "amount": 8,
                         "log": {
-                            "cats_from": "cat_from and cat_to spent a herb-gathering patrol discussing the possibility of taking on another medicine cat apprentice."
+                            "cats_from": "cat_from and cat_to spent an herb-gathering patrol discussing the possibility of taking on another medicine cat apprentice."
                         }
                     }
                 ],
@@ -3977,7 +3977,7 @@
                         ],
                         "amount": 8,
                         "log": {
-                            "cats_from": "cat_from and cat_to spent a herb-gathering patrol discussing the possibility of taking on another medicine cat apprentice."
+                            "cats_from": "cat_from and cat_to spent an herb-gathering patrol discussing the possibility of taking on another medicine cat apprentice."
                         }
                     }
                 ],
@@ -4384,7 +4384,7 @@
                         ],
                         "amount": 8,
                         "log": {
-                            "cats_from": "cat_from and cat_to both harvested many herbs while on a herb-gathering patrol together."
+                            "cats_from": "cat_from and cat_to both harvested many herbs while on an herb-gathering patrol together."
                         }
                     }
                 ],
@@ -4460,7 +4460,7 @@
                         ],
                         "amount": -8,
                         "log": {
-                            "cats_from": "cat_from and cat_to argued on a herb-gathering patrol after s_c blamed r_c for distracting {PRONOUN/s_c/object}."
+                            "cats_from": "cat_from and cat_to argued on an herb-gathering patrol after s_c blamed r_c for distracting {PRONOUN/s_c/object}."
                         }
                     }
                 ],
@@ -4531,7 +4531,7 @@
                         ],
                         "amount": 10,
                         "log": {
-                            "cats_from": "p_l and r_c enjoyed some catmint stems on a herb-gathering patrol."
+                            "cats_from": "p_l and r_c enjoyed some catmint stems on an herb-gathering patrol."
                         }
                     }
                 ],
@@ -6156,7 +6156,7 @@
                         ],
                         "amount": 15,
                         "log": {
-                            "cats_from": "r_c was flustered by s_c's surprising reflexes when s_c killed a snake lurking around a juniper bush during a herb-gathering patrol."
+                            "cats_from": "r_c was flustered by s_c's surprising reflexes when s_c killed a snake lurking around a juniper bush during an herb-gathering patrol."
                         }
                     }
                 ],
@@ -6499,7 +6499,7 @@
                         ],
                         "amount": -13,
                         "log": {
-                            "cats_from": "app1 bossed app2 around the whole time on a herb-gathering patrol, and to make matters worse, the patrol was highly successful."
+                            "cats_from": "app1 bossed app2 around the whole time on an herb-gathering patrol, and to make matters worse, the patrol was highly successful."
                         }
                     }
                 ],
@@ -7323,7 +7323,7 @@
                         ],
                         "amount": -13,
                         "log": {
-                            "cats_from": "app1 bossed cat_to around the whole time on a herb-gathering patrol, and to make matters worse, the patrol was highly successful."
+                            "cats_from": "app1 bossed cat_to around the whole time on an herb-gathering patrol, and to make matters worse, the patrol was highly successful."
                         }
                     }
                 ],
@@ -11857,7 +11857,7 @@
                         ],
                         "amount": -5,
                         "log": {
-                            "cats_from": "cat_from and cat_to had little to chat about during a herb-gathering patrol."
+                            "cats_from": "cat_from and cat_to had little to chat about during an herb-gathering patrol."
                         }
                     }
                 ],
@@ -23054,7 +23054,7 @@
                         ],
                         "amount": -5,
                         "log": {
-                            "cats_from": "cat_from and cat_to had little to chat about during a herb-gathering patrol."
+                            "cats_from": "cat_from and cat_to had little to chat about during an herb-gathering patrol."
                         }
                     }
                 ],
@@ -30380,7 +30380,7 @@
                         ],
                         "amount": -5,
                         "log": {
-                            "cats_from": "cat_from and cat_to had little to chat about during a herb-gathering patrol."
+                            "cats_from": "cat_from and cat_to had little to chat about during an herb-gathering patrol."
                         }
                     }
                 ],


### PR DESCRIPTION
## About The Pull Request

This isn't addressing an existing bug report, but I noticed this patrol has a duplicate version of the "oh no they're hot" patrol without relationship logs. It also has s_c outcomes that should be r_c only.

Since this is a small mistake, I stuck in some other things that were annoying me. A lot of injury strings had comma splices, so I fixed ones I could find, and I changed instances of "a herb-gathering" to "an herb-gathering" across all files.

## Proof of Testing

<img width="527" height="246" alt="image" src="https://github.com/user-attachments/assets/73c230f7-c59d-44ad-aa26-e72e2520249e" />

<img width="461" height="137" alt="image" src="https://github.com/user-attachments/assets/f7e1c4d7-f656-4bd4-84af-502aed25b470" />

Swanrump is correctly chosen as stat cat when also being r_c