### PR TITLE
[FREQFIX] Tick Fever

### DIFF
--- a/resources/dicts/conditions/illnesses_seasons.json
+++ b/resources/dicts/conditions/illnesses_seasons.json
@@ -1,21 +1,21 @@
 {
     "Newleaf":{
         "running nose": 2,
-        "stomachache": 1
+        "stomachache": 1,
+        "tick fever": 1
     },
     "Greenleaf":{
         "fleas": 2,
         "stomachache":1,
         "heat exhaustion":3,
         "heat stroke":1,
-        "tick fever":2
+        "tick fever":1
     },
     "Leaf-fall":{
         "stomachache":1,
         "greencough": 1,
         "kittencough": 4,
-        "running nose": 3,
-        "tick fever":1
+        "running nose": 3
     },
     "Leaf-bare":{
         "stomachache":1,

--- a/resources/dicts/conditions/injuries.json
+++ b/resources/dicts/conditions/injuries.json
@@ -297,11 +297,11 @@
         "risks": [
             {
                 "name": "an infected wound",
-                "chance": 40
+                "chance": 30
             },
             {
                 "name": "tick fever",
-                "chance": 60
+                "chance": 50
             }
         ],
         "also_got": [],

--- a/resources/lang/en/conditions/condition_got_strings/gain_illness_strings.json
+++ b/resources/lang/en/conditions/condition_got_strings/gain_illness_strings.json
@@ -42,7 +42,9 @@
         "m_c is starving."
     ],
     "tick fever": [
-        "m_c missed a tick while grooming, and is now suffering the consequences — {PRONOUN/m_c/subject} {VERB/m_c/have/has} tick fever.",
-        "Even if {PRONOUN/m_c/subject} can't find the exact bug responsible, m_c's new rash and fever clearly point to tick-borne illness."
+        "m_c missed a tick while grooming, and is now suffering the consequences. {PRONOUN/m_c/subject/CAP} {VERB/m_c/have/has} tick fever.",
+        "Even if {PRONOUN/m_c/subject} can't find the exact bug responsible, m_c's new rash and fever clearly point to tick-borne illness.",
+        "m_c has tick fever.",
+        "m_c is sick with tick fever."
     ]
     }

--- a/resources/lang/en/conditions/healed_and_death_strings/illness_healed_strings.json
+++ b/resources/lang/en/conditions/healed_and_death_strings/illness_healed_strings.json
@@ -94,6 +94,8 @@
     ],
     "tick fever": [
         "m_c sighs in relief as the rashes fade, promising StarClan to check <i>twice</i> for ticks next time.",
-        "r_c purrs as m_c starts asking to get back to {PRONOUN/m_c/poss} duties. Tick fever can be so touch-and-go, but m_c pulled through!"
+        "r_c purrs as m_c starts asking to get back to {PRONOUN/m_c/poss} duties. Tick fever can be so touch-and-go, but m_c pulled through!",
+        "m_c's tick fever has subsided.",
+        "m_c is no longer suffering from tick fever."
     ]
 }


### PR DESCRIPTION
## About The Pull Request

Addressing my own feedback, plus some on Discord -- tick fever is still feeling too common. I addressed this in three ways: I dropped its seasonal frequency, I reduced the likelihood of tick bites progressing to tick fever, and I added shorter strings for contracting/recovering from tick fever.

The latter is based in my assumption that part of the problem with tick fever feeling constant is that it doesn't have the brief "generic" strings that other illnesses and injuries have. These brief/generic strings help players' eyes skip over the event, whereas the lengthy current ones demand more attention.

The last change I made was to switch the seasonality(freq) from Greenleaf(2)/Leaf-fall(1) to Newleaf(1)/Greenleaf(1) because I did a quick Web Search TM and discovered lyme disease is most common in spring and early summer. If the dev who chose greenleaf/leaf-fall for tick fever was using a different rationale, then please speak now lol.

It should be a little under 2/3rds its current rarity after these tweaks, and I hope the generic text strings will make up a bit of ground as well.

## Why This Is Good For ClanGen

Addresses player feedback

## Proof of Testing

<img width="307" height="56" alt="image" src="https://github.com/user-attachments/assets/ecc03f5c-348c-49c5-aaba-20bb352fd186" />
