### PR TITLE
Fix Missing Absent in scarless_conditions

### DIFF
--- a/scripts/events_module/short/condition_events.py
+++ b/scripts/events_module/short/condition_events.py
@@ -483,6 +483,7 @@ class Condition_Events:
             "persistent headaches",
             "selective mutism",
             "absent",
+            "crooked jaw",
         )
 
         got_condition = False

--- a/scripts/events_module/short/condition_events.py
+++ b/scripts/events_module/short/condition_events.py
@@ -482,6 +482,7 @@ class Condition_Events:
             "lasting grief",
             "persistent headaches",
             "selective mutism",
+            "absent",
         )
 
         got_condition = False


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
Fixes a bug where injuries (lingering shock and head damage) couldn't give absent due to it being missing in scarless_conditions. Found the bug myself when (ironically) trying to stop absent from spawning due to triggers.
(Edit: also added crooked jaw to scarless_conditions!)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Proof of Testing
I tried 8 times (a ~96% chance of it happening once) to get absent from lingering shock without the fix and it didn't happen. However, with the fix, the first try gave me absent!
<img width="519" height="83" alt="image" src="https://github.com/user-attachments/assets/4faa15e4-d032-4947-8450-08a75580f2a2" />
<img width="460" height="511" alt="image" src="https://github.com/user-attachments/assets/47c11ff8-770c-479c-a6ec-4e212ef38791" />
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Fixes absent being unable to spawn from lingering shock and head damage
- (Edit: also fixes crooked jaw!)
- Discord user is blackkat312 if you wanna add me as a dev!
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
