### PR TITLE
[BALANCING] Conditions

### DIFF
--- a/resources/lang/en/events/injury/desert.json
+++ b/resources/lang/en/events/injury/desert.json
@@ -2038,7 +2038,7 @@
         "season": [
             "any"
         ],
-        "frequency": 2,
+        "frequency": 1,
         "event_text": "m_c fell from a cliff and somehow survived, though not without breaking {PRONOUN/m_c/poss} leg.",
         "m_c": {
             "age": [

--- a/resources/lang/en/events/injury/general.json
+++ b/resources/lang/en/events/injury/general.json
@@ -565,7 +565,7 @@
         "season": [
             "any"
         ],
-        "frequency": 3,
+        "frequency": 1,
         "event_text": "m_c had a bad fall while taking a walk through the territory and, once found, has to be carried back home.",
         "m_c": {
             "age": [
@@ -1526,7 +1526,7 @@
         "season": [
             "leaf-bare"
         ],
-        "frequency": 3,
+        "frequency": 1,
         "event_text": "m_c went out for a walk, but slipped on the ice and broke a bone.",
         "m_c": {
             "age": [
@@ -1565,7 +1565,7 @@
         "season": [
             "any"
         ],
-        "frequency": 2,
+        "frequency": 1,
         "event_text": "m_c was grabbed and dropped by an eagle, but {PRONOUN/m_c/subject} somehow survived.",
         "m_c": {
             "status": [
@@ -1657,7 +1657,7 @@
         "season": [
             "any"
         ],
-        "frequency": 4,
+        "frequency": 1,
         "event_text": "m_c couldn't help but try to show off by climbing the tallest tree {PRONOUN/m_c/subject} could find. {PRONOUN/m_c/poss/CAP} plan backfired when {PRONOUN/m_c/subject} fell out of the tree.",
         "m_c": {
             "age": [
@@ -2903,7 +2903,7 @@
         "season": [
             "any"
         ],
-        "frequency": 4,
+        "frequency": 2,
         "event_text": "m_c fought a big dog and was badly injured.",
         "m_c": {
             "status": [
@@ -2953,7 +2953,7 @@
         "season": [
             "any"
         ],
-        "frequency": 4,
+        "frequency": 2,
         "event_text": "m_c saved r_c from a big dog, but was badly injured.",
         "m_c": {
             "status": [

--- a/resources/lang/en/events/injury/mountainous.json
+++ b/resources/lang/en/events/injury/mountainous.json
@@ -8,7 +8,7 @@
             "leaf-fall",
             "leaf-bare"
         ],
-        "frequency": 2,
+        "frequency": 1,
         "event_text": "m_c thought {PRONOUN/m_c/subject} {VERB/m_c/were/was} walking on a snowdrift until it gave way and {PRONOUN/m_c/subject} fell down the mountain, breaking {PRONOUN/m_c/poss} leg.",
         "m_c": {
             "age": [
@@ -86,7 +86,7 @@
         "season": [
             "any"
         ],
-        "frequency": 3,
+        "frequency": 1,
         "event_text": "m_c couldn't help but try to show off by scaling the tallest cliff {PRONOUN/m_c/subject} could find. {PRONOUN/m_c/poss/CAP} plan backfired when {PRONOUN/m_c/subject} slipped and plummeted to the ground.",
         "m_c": {
             "status": [

--- a/scripts/clan_resources/herb/herb_supply.py
+++ b/scripts/clan_resources/herb/herb_supply.py
@@ -1,10 +1,8 @@
-import statistics
-from random import choice, randint, choices
+from random import choice, randint, choices, random
 from typing import Optional
 
 import i18n
 
-from scripts.cat.enums import CatRank
 from scripts.cat.skills import SkillPath
 from scripts.clan_resources.herb.herb import Herb, HERBS
 from scripts.clan_resources.herb.herb_effects import HerbEffect
@@ -659,20 +657,21 @@ class HerbSupply:
 
             chosen_effect = choice(possible_effects)
 
+            # check if perm condition gets treatment
             if (
                 treatment_cat.is_disabled()
                 and name in treatment_cat.permanent_condition
             ):
                 condition_default = source_dict[name]
-                # if chance of death is already low, med cat doesn't treat
+                # only treat if mortality is worse than 20 or the condition's default mortality (whichever is higher)
                 if condition.get("mortality") and condition["mortality"] > max(
                     condition_default["mortality"][treatment_cat.age], 20
                 ):
                     self.__apply_lack_of_herb(treatment_cat, name, chosen_effect)
                     return
-                # if chance of risk is already low, med cat doesn't treat
                 no_treatment = False
                 for i, risk in enumerate(condition.get("risks", [])):
+                    # only treat if risk chance is worse than 20 or the risk's default chance (whichever is higher)
                     if risk["chance"] > max(
                         condition_default["risks"][i]["chance"], 20
                     ):
@@ -716,7 +715,7 @@ class HerbSupply:
                     treatment_cat, name, herb_used, chosen_effect, amount_used, strength
                 )
 
-            else:
+            elif random() > 0.30:  # 70% chance that lack of treatment is detrimental
                 self.__apply_lack_of_herb(treatment_cat, name, chosen_effect)
 
     def _gather_herbs(self, med_cat):

--- a/scripts/clan_resources/herb/herb_supply.py
+++ b/scripts/clan_resources/herb/herb_supply.py
@@ -663,23 +663,23 @@ class HerbSupply:
                 and name in treatment_cat.permanent_condition
             ):
                 condition_default = source_dict[name]
-                no_treatment = False
+                will_not_treat = False
                 # only treat if mortality is worse than 20 or the condition's default mortality (whichever is higher)
                 if condition.get("mortality") and condition["mortality"] > max(
                     condition_default["mortality"][treatment_cat.age], 20
                 ):
-                    no_treatment = True
+                    will_not_treat = True
                 for i, risk in enumerate(condition.get("risks", [])):
                     # only treat if risk chance is worse than 20 or the risk's default chance (whichever is higher)
                     if risk["chance"] > max(
                         condition_default["risks"][i]["chance"], 20
                     ):
-                        no_treatment = True
+                        will_not_treat = True
                     else:  # if any risk needs treatment, then we'll treat
-                        no_treatment = False
+                        will_not_treat = False
                         break
 
-                if no_treatment:
+                if will_not_treat:
                     self.__apply_lack_of_herb(treatment_cat, name, chosen_effect)
                     return
 

--- a/scripts/clan_resources/herb/herb_supply.py
+++ b/scripts/clan_resources/herb/herb_supply.py
@@ -663,21 +663,24 @@ class HerbSupply:
                 and name in treatment_cat.permanent_condition
             ):
                 condition_default = source_dict[name]
+                no_treatment = False
                 # only treat if mortality is worse than 20 or the condition's default mortality (whichever is higher)
                 if condition.get("mortality") and condition["mortality"] > max(
                     condition_default["mortality"][treatment_cat.age], 20
                 ):
-                    self.__apply_lack_of_herb(treatment_cat, name, chosen_effect)
-                    return
-                no_treatment = False
+                    no_treatment = True
                 for i, risk in enumerate(condition.get("risks", [])):
                     # only treat if risk chance is worse than 20 or the risk's default chance (whichever is higher)
                     if risk["chance"] > max(
                         condition_default["risks"][i]["chance"], 20
                     ):
-                        self.__apply_lack_of_herb(treatment_cat, name, chosen_effect)
                         no_treatment = True
+                    else:  # if any risk needs treatment, then we'll treat
+                        no_treatment = False
+                        break
+
                 if no_treatment:
+                    self.__apply_lack_of_herb(treatment_cat, name, chosen_effect)
                     return
 
             if game.clan.game_mode == "classic":

--- a/scripts/clan_resources/herb/herb_supply.py
+++ b/scripts/clan_resources/herb/herb_supply.py
@@ -663,14 +663,19 @@ class HerbSupply:
                 treatment_cat.is_disabled()
                 and name in treatment_cat.permanent_condition
             ):
+                condition_default = source_dict[name]
                 # if chance of death is already low, med cat doesn't treat
-                if condition.get("mortality") and condition.get("mortality", 0) > 20:
+                if condition.get("mortality") and condition["mortality"] > max(
+                    condition_default["mortality"][treatment_cat.age], 20
+                ):
                     self.__apply_lack_of_herb(treatment_cat, name, chosen_effect)
                     return
                 # if chance of risk is already low, med cat doesn't treat
                 no_treatment = False
-                for risk in condition.get("risks", []):
-                    if risk["chance"] > 20:
+                for i, risk in enumerate(condition.get("risks", [])):
+                    if risk["chance"] > max(
+                        condition_default["risks"][i]["chance"], 20
+                    ):
                         self.__apply_lack_of_herb(treatment_cat, name, chosen_effect)
                         no_treatment = True
                 if no_treatment:


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
Intended to help balance conditions, especially perm conditions

- Lowered frequencies of all injury events that give broken bones, based on feedback that cats were breaking bones at silly rates
- Application of herb-lack affects is now chance based instead of guaranteed. Now 70% of the time, if a perm condition does not receive preventative herbs, they will worsen. Based on feedback that permanent condition risks felt prohibitive.  
- The decision to provide preventative herbs to a perm condition or not was previously based on a flat 20 chance threshold. Aka, if a risk had a chance of 20 or higher, then no treatment would be given. However, this meant that some risks could still be allowed far lower than necessarily intended (a risk's default chance might be more like 70, but then be held perpetually at 20 due to the treatment threshold instead of being held at it's default 70).  The change I implemented now makes the threshold the highest number between 20 and the default chance.  So if the default chance is 70, then treatment will be attempted until the chance is 70 or above.  If the default chance is 5, then treatment will be attempted until the chance is 20 or above.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Why This Is Good For ClanGen
This is all based off feedback given by players.  Complaints are mainly around the frequency of broken bones and their eventual consequences of weak legged cats then leading to cats who are perpetually plagued by their perm condition risks.  Hopefully these changes lead to less broken legs (and thus less perm conditions) as well as better support for cats who have perm conditions.  Players likely won't see immediate change though, as they'll need to let their herb supplies build up and cats receive treatment to pull those risk chances back up.  It'll be a little gradual, but hopefully eventually noticeable.
<!-- If this is a bug fix, you can remove this section. -->
<!-- Please add a short description of why you think these changes would benefit the game. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->
<!-- If you have multiple features that can stand on their own, or unrelated bugfixes, please create separate PRs for them. -->

## Proof of Testing
<img width="877" height="226" alt="image" src="https://github.com/user-attachments/assets/96ff3cf6-251c-404e-b2da-2099d74d6de1" />

Risk of sore is lower than it's default (which is 20) so we're going to treat it

<img width="683" height="93" alt="image" src="https://github.com/user-attachments/assets/853238e4-edf8-4d8d-b68e-b84ecf363356" />

treatment being applied later down the line in code i didn't touch ;)

<img width="844" height="217" alt="image" src="https://github.com/user-attachments/assets/474db956-1984-4c03-8a3f-ba6c5e41ac23" />

the opposite! chance of sore is 200+, obv higher than our default. so we don't treat

<img width="623" height="97" alt="image" src="https://github.com/user-attachments/assets/f492c3b0-8e3e-452c-ad42-b268a36779e1" />

instead we apply our lack of herb

<img width="624" height="60" alt="image" src="https://github.com/user-attachments/assets/d5e22593-7310-4caa-a5aa-c9e569cf5eba" />

lack of herbs being applied after no herbs were available and getting through that little 70% chance gateway!

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Lowered frequencies of all injury events that give broken bones, based on feedback that cats were breaking bones at silly rates
- Application of herb-lack affects is now chance based instead of guaranteed. Now 70% of the time, if a perm condition does not receive preventative herbs, they will worsen.  
- The decision to provide preventative herbs to a perm condition or not was previously based on a flat 20 chance threshold. Aka, if a risk had a chance of 20 or higher, then no treatment would be given. However, this meant that some risks could still be allowed far lower than necessarily intended (a risk's default chance might be more like 70, but then be held perpetually at 20 due to the treatment threshold instead of being held at it's default 70).  The change I implemented now makes the threshold the highest number between 20 and the default chance.  So if the default chance is 70, then treatment will be attempted until the chance is 70 or above.  If the default chance is 5, then treatment will be attempted until the chance is 20 or above.
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
