### PR TITLE
[BUGFIX/ENHANCEMENT] Add damaged throat risk strings + reword death event

### DIFF
--- a/resources/lang/en/conditions/risk_strings/permanent_condition_risk_strings.json
+++ b/resources/lang/en/conditions/risk_strings/permanent_condition_risk_strings.json
@@ -16,6 +16,12 @@
             "The muscles in m_c's stump don't seem to understand they aren't connected to anything any more — m_c purrs gratefully when a Clanmate helps massage them."
         ]
     },
+    "damaged throat": {
+        "sore throat": [
+            "m_c overexerted {PRONOUN/m_c/poss} voice and now can hardly speak at all, with how horribly sore {PRONOUN/m_c/poss} throat is.",
+            "m_c mimes the motions for numbing herbs to r_c, who understands and supplies them swiftly. Something must have irritated m_c's damaged throat."
+        ]
+    },
     "born without a leg": {
         "sore": [
             "m_c reports to r_c with the ease of familiarity, asking for help sleeping at night — {PRONOUN/m_c/poss} missing limb is giving {PRONOUN/m_c/object} a bit of pain on that side of {PRONOUN/m_c/poss} body.",

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -8113,7 +8113,7 @@
         ],
         "tags": [],
         "frequency": 2,
-        "event_text": "m_c mixed up the herb dosages for r_c, and despite {PRONOUN/m_c/poss} desperate efforts, r_c perished from the overdose.",
+        "event_text": "m_c mixed up the herb dosages for r_c, poisoning {PRONOUN/m_c/object} fatally.",
         "m_c": {
             "status": [
                 "medicine cat",

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -8113,7 +8113,7 @@
         ],
         "tags": [],
         "frequency": 2,
-        "event_text": "m_c mixed up the herb dosages for r_c, poisoning {PRONOUN/m_c/object} fatally.",
+        "event_text": "m_c mixed up the herb dosages for r_c, and despite {PRONOUN/m_c/poss} desperate efforts, the poisoning is fatal.",
         "m_c": {
             "status": [
                 "medicine cat",


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
Adds the sore throat risk strings for damaged throat. Rewords my medmessup death.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Why This Is Good For ClanGen
Previous medmessup was awkward/clunky imo.
<!-- If this is a bug fix, you can remove this section. -->
<!-- Please add a short description of why you think these changes would benefit the game. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->
<!-- If you have multiple features that can stand on their own, or unrelated bugfixes, please create separate PRs for them. -->

## Linked Issues

<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
<img width="394" height="81" alt="image" src="https://github.com/user-attachments/assets/f57fe3df-894e-4343-8d73-62241f646676" />
<img width="389" height="80" alt="image" src="https://github.com/user-attachments/assets/7da28f5d-f62f-40b2-861e-a3181bf082d3" />
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits

- Adds sore throat risk strings for damaged throat condition
- Rewords a death event

<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
