### PR TITLE
[CONTENT] New Negative 5 Cat Group Events

### DIFF
--- a/resources/lang/en/events/relationship_events/group_interactions/5/negative.json
+++ b/resources/lang/en/events/relationship_events/group_interactions/5/negative.json
@@ -166,7 +166,7 @@
 			"m_c wants this training exercise to be a success, but r_c1, r_c2, r_c3, and r_c4 refuse to listen, and m_c gives up.",
 			"It is impossible to make r_c1, r_c2, r_c3, and r_c4 understand the importance of stretching properly, so m_c calls the exercise off.",
 			"r_c1, r_c2, r_c3, and r_c4 are too busy goofing off to listen to m_c's advice.",
-			"m_c tries keeping r_c1, r_c2, r_c3, and r_c4 focused during training, but the four continuously get off topic.",
+			"m_c attempts to keep r_c1, r_c2, r_c3, and r_c4 focused during training, but the four continuously talk about unrelated topics.",
 			"r_c1, r_c2, r_c3, and r_c4 pointedly ignore m_c's reminders to focus on training instead of gossiping."
 		],
 		"status_constraint": {
@@ -247,8 +247,8 @@
 			"m_c calls r_c1, r_c2, r_c3, and r_c4 a bunch of wusses after a play-fight, and it escalates into a fight between the five.",
 			"m_c, r_c1, r_c2, r_c3, and r_c4 can't settle who gets a toy.",
 			"m_c won't stop instigating a fight between r_c1, r_c2, r_c3, and r_c4.",
-			"m_c orders r_c1, r_c2, r_c3, and r_c4 to fork over the toy they are playing with and starts a fight when told no.",
-			"A play-fight turns into a real scuffle between m_c, r_c1, r_c2, r_c3, and r_c4 after they couldn't decide who would be what in the next round.",
+			"m_c orders r_c1, r_c2, r_c3, and r_c4 to give {PRONOUN/m_c/object} a toy they are playing with and starts a fight when told no.",
+			"A game of make-believe turns into a real scuffle between m_c, r_c1, r_c2, r_c3, and r_c4 when they can't decide who will play what in the next round.",
 			"m_c calls everyone in the nursery is a mouse-brain. It leads to an argument between {PRONOUN/m_c/self}, r_c1, r_c2, r_c3, and r_c4.",
 			"m_c screams in r_c1 and r_c2's faces that they both suck, sparking an argument that snowballs and drags in both r_c3 and r_c4.",
 			"m_c keeps hogging being the leader during a game, causing a fight to break out between {PRONOUN/m_c/self}, r_c1, r_c2, r_c3, and r_c4 over who gets to be it next."
@@ -290,12 +290,12 @@
 		"cat_amount": 5,
 		"interactions": [
 			"m_c didn't think it would be too hard to watch the kits, but r_c1, r_c2, r_c3, and r_c4 prove that thought very, very wrong.",
-			"It hasn't been that long since m_c has begun kitsitting r_c1, r_c2, r_c3, and r_c4, but chaos is already underway.",
+			"It hasn't been that long since m_c began kitsitting r_c1, r_c2, r_c3, and r_c4, but chaos is already underway.",
 			"m_c wants to scream into {PRONOUN/m_c/poss} nest after kitsitting r_c1, r_c2, r_c3, and r_c4.",
 			"m_c doesn't have a moment to rest while kitsitting with how prone to trouble r_c1, r_c2, r_c3, and r_c4 are.",
-			"While kitsitting, m_c tries — and fails — to reign in the rambunctiousness of r_c1, r_c2, r_c3, and r_c4.",
+			"While kitsitting, m_c tries — and fails — to rein in the rambunctiousness of r_c1, r_c2, r_c3, and r_c4.",
 			"Nobody ever said kitsitting was easy, but m_c thought that r_c1, r_c2, r_c3, and r_c4 would be easier to watch than they actually are.",
-			"m_c wishes that blinking didn't mean missing a second of the next problem r_c1, r_c2, r_c3, and r_c4 will get into.",
+			"m_c wishes {PRONOUN/m_c/subject} could blink while kitsitting without missing a heartbeat of r_c1, r_c2, r_c3, and r_c4's troublemaking.",
 			"After kitsitting r_c1, r_c2, r_c3, and r_c4, m_c takes time to recover from the four kits' endless mischief."
 		],
 		"status_constraint": {
@@ -314,7 +314,7 @@
 		},
 		"skill_constraint": {
 			"m_c": [
-				"KIT,1"
+				"-KIT,1"
 			]
 		},
 		"relationship_constraint": {

--- a/resources/lang/en/events/relationship_events/group_interactions/5/negative.json
+++ b/resources/lang/en/events/relationship_events/group_interactions/5/negative.json
@@ -166,7 +166,7 @@
 			"m_c wants this training exercise to be a success, but r_c1, r_c2, r_c3, and r_c4 refuse to listen, and m_c gives up.",
 			"It is impossible to make r_c1, r_c2, r_c3, and r_c4 understand the importance of stretching properly, so m_c calls the exercise off.",
 			"r_c1, r_c2, r_c3, and r_c4 are too busy goofing off to listen to m_c's advice.",
-			"m_c tries to keep r_c1, r_c2, r_c3, and r_c4 focused during training, but the four continuously talk about unrelated topics.",
+			"m_c attempts keep r_c1, r_c2, r_c3, and r_c4 focused during training, but the four continuously talk about unrelated topics.",
 			"r_c1, r_c2, r_c3, and r_c4 pointedly ignore m_c's reminders to focus on training instead of gossiping."
 		],
 		"status_constraint": {

--- a/resources/lang/en/events/relationship_events/group_interactions/5/negative.json
+++ b/resources/lang/en/events/relationship_events/group_interactions/5/negative.json
@@ -502,21 +502,30 @@
 			]
 		},
 		"specific_reaction": {
-			"r_c1_to_m_c": {
-				"respect": "decrease"
-			},
-			"r_c1_to_r_c1": {
-				"respect": "decrease"
-			},
 			"r_c2_to_m_c": {
-				"respect": "decrease"
+				"respect": "decrease",
+				"trust": "decrease"
+			},
+			"r_c2_to_r_c1": {
+				"respect": "decrease",
+				"comfort": "decrease"
 			},
 			"r_c3_to_m_c": {
-				"respect": "decrease"
+				"respect": "decrease",
+				"trust": "decrease"
+			},
+			"r_c3_to_r_c1": {
+				"respect": "decrease",
+				"comfort": "decrease"
 			},
 			"r_c4_to_m_c": {
-				"respect": "decrease"
-			}   
+				"respect": "decrease",
+				"trust": "decrease"
+			},
+			"r_c4_to_r_c1": {
+				"respect": "decrease",
+				"comfort": "decrease"
+			}
 		}
 	}
 ]

--- a/resources/lang/en/events/relationship_events/group_interactions/5/negative.json
+++ b/resources/lang/en/events/relationship_events/group_interactions/5/negative.json
@@ -1,33 +1,522 @@
 [
-    {
-	"id": "morning_stretches",
-	"biome": ["any"],
-	"season": ["any"],
-	"intensity": "medium",
-	"cat_amount": 5,
-	"interactions": [
-		"m_c, wanting to help keep {PRONOUN/m_c/poss} Clanmates in shape and ready for anything, woke r_c1, r_c2, r_c3, and r_c4 up early for morning stretches."
-	],
-	"status_constraint": {
-		"m_c": ["deputy", "leader", "warrior", "elder", "medicine cat", "mediator"]
+	{
+		"id": "morning_stretches",
+		"intensity": "medium",
+		"cat_amount": 5,
+		"interactions": [
+			"m_c, wanting to help keep {PRONOUN/m_c/poss} Clanmates in shape and ready for anything, wakes r_c1, r_c2, r_c3, and r_c4 up early for morning stretches.",
+			"Early in the morning, m_c rallies r_c1, r_c2, r_c3, and r_c4 to do stretches in hopes of keeping {PRONOUN/m_c/poss} Clanmates prepared for anything.",
+			"r_c1, r_c2, r_c3, and r_c4 can't escape from m_c waking them up to do early morning stretches.",
+			"r_c1, r_c2, r_c3, and r_c4 respect how dutiful m_c is to training, but they all wish they weren't up doing stretches at dawn.",
+			"r_c1, r_c2, r_c3, and r_c4 bemoan m_c's insistence that they get up and do stretches at <i>dawn.</i> While they do it, nobody but m_c likes it.",
+			"m_c rallies r_c1, r_c2, r_c3, and r_c4 to do early morning stretches with {PRONOUN/m_c/object}.",
+			"r_c1, r_c2, r_c3, and r_c4 wish that m_c let them sleep instead of getting them up for early morning stretches.",
+			"Stretching might be good for one's health, but r_c1, r_c2, r_c3, and r_c4 wish m_c didn't insist on stretching at the crack of dawn."
+		],
+		"status_constraint": {
+			"m_c": [
+				"deputy",
+				"leader",
+				"warrior",
+				"elder",
+				"medicine cat",
+				"mediator"
+			],
+			"r_c1": [
+				"-kitten"
+			],
+			"r_c2": [
+				"-kitten"
+			],
+			"r_c3": [
+				"-kitten"
+			],
+			"r_c4": [
+				"-kitten"
+			]
+		},
+		"specific_reaction": {
+			"r_c1_to_m_c": {
+				"respect": "increase",
+				"like": "decrease"
+			},
+			"r_c2_to_m_c": {
+				"respect": "increase",
+				"like": "decrease"
+			},
+			"r_c3_to_m_c": {
+				"respect": "increase",
+				"like": "decrease"
+			},
+			"r_c4_to_m_c": {
+				"respect": "increase",
+				"like": "decrease"
+			}   
+		}
 	},
-	"specific_reaction": {
-		"r_c1_to_m_c": {
-			"respect": "increase",
-			"like": "decrease"
+	{
+		"id": "group_5_campcleanup",
+		"intensity": "medium",
+		"cat_amount": 5,
+		"interactions": [
+			"m_c, noticing the state of disarray the camp is in, gathers r_c1, r_c2, r_c3, and r_c4 to help {PRONOUN/m_c/object} clean up.",
+			"m_c recruits r_c1, r_c2, r_c3, and r_c4 to tidy up camp upon noticing how unorganized it has become.",
+			"Camp has become a disorganized mess, so m_c convinces r_c1, r_c2, r_c3, and r_c4 to help {PRONOUN/m_c/object} tidy it up.",
+			"The dens are in need of repair, so m_c drags r_c1, r_c2, r_c3, and r_c4 to help {PRONOUN/m_c/object} with repairs.",
+			"m_c pesters r_c1, r_c2, r_c3, and r_c4 into helping {PRONOUN/m_c/object} with repairs across camp.",
+			"r_c1, r_c2, r_c3, and r_c4 can respect m_c's dedication to keeping camp clean, but each cat has something else they'd rather be doing instead of cleaning.",
+			"r_c1, r_c2, r_c3, and r_c4 won't deny that camp needs to be cleaned, but they wish that m_c hadn't gathered them to do it.",
+			"Before a den comes caving in, m_c forces r_c1, r_c2, r_c3, and r_c4 to help {PRONOUN/m_c/object} with maintenance."
+		],
+		"status_constraint": {
+			"m_c": [
+				"deputy",
+				"leader",
+				"warrior",
+				"elder",
+				"medicine cat",
+				"mediator"
+			]
 		},
-		"r_c2_to_m_c": {
-			"respect": "increase",
-			"like": "decrease"
+		"skill_constraint": {
+			"m_c": [
+				"CAMP,1"
+			]
 		},
-        "r_c3_to_m_c": {
-			"respect": "increase",
-			"like": "decrease"
+		"specific_reaction": {
+			"r_c1_to_m_c": {
+				"respect": "increase",
+				"like": "decrease"
+			},
+			"r_c2_to_m_c": {
+				"respect": "increase",
+				"like": "decrease"
+			},
+			"r_c3_to_m_c": {
+				"respect": "increase",
+				"like": "decrease"
+			},
+			"r_c4_to_m_c": {
+				"respect": "increase",
+				"like": "decrease"
+			}   
+		}
+	},
+	{
+		"id": "group_5_negative_seniordisrespected_fourapprentices",
+		"intensity": "high",
+		"cat_amount": 5,
+		"interactions": [
+			"m_c attempts to impart {PRONOUN/m_c/poss} knowledge onto r_c1, r_c2, r_c3, and r_c4, but none of the apprentices pay an ounce of attention.",
+			"m_c tries teaching r_c1, r_c2, r_c3, and r_c4 one of {PRONOUN/m_c/poss} skills, but gives up because no apprentice listens.",
+			"m_c had an informative lecture planned for r_c1, r_c2, r_c3, and r_c4, but gives up midway because the apprentices ignore {PRONOUN/m_c/object}.",
+			"r_c1, r_c2, r_c3, and r_c4 will not stop talking to each other during m_c's lesson, and leads m_c to call it off.",
+			"m_c spent an entire day planning a lesson for r_c1, r_c2, r_c3, and r_c4, but it goes to waste as the apprentices are distracted by each other.",
+			"m_c cannot believe how disrespectful r_c1, r_c2, r_c3, and r_c4 are while {PRONOUN/m_c/subject} {VERB/m_c/try/tries} to give a lecture.",
+			"m_c wanted this training exercise to be a success, but r_c1, r_c2, r_c3, and r_c4 refuse to listen and cause m_c to give up."
+		],
+		"age_constraint": {
+			"m_c": [
+				"senior adult",
+				"elder"
+			]
 		},
-        "r_c4_to_m_c": {
-			"respect": "increase",
+		"status_constraint": {
+			"r_c1": [
+				"apprentice",
+				"medicine cat apprentice",
+				"mediator apprentice"
+			],
+			"r_c2": [
+				"apprentice",
+				"medicine cat apprentice",
+				"mediator apprentice"
+			],
+			"r_c3": [
+				"apprentice",
+				"medicine cat apprentice",
+				"mediator apprentice"
+			],
+			"r_c4": [
+				"apprentice",
+				"medicine cat apprentice",
+				"mediator apprentice"
+			]
+		},
+		"specific_reaction": {
+			"m_c_to_r_c1": {
+				"respect": "decrease"
+			},
+			"m_c_to_r_c2": {
+				"respect": "decrease"
+			},
+			"m_c_to_r_c3": {
+				"respect": "decrease"
+			},
+			"m_c_to_r_c4": {
+				"respect": "decrease"
+			}
+		}
+	},
+	{
+		"id": "group_5_negative_groupargument_twohates",
+		"intensity": "medium",
+		"cat_amount": 5,
+		"interactions": [
+			"What begins as a petty argument between m_c and r_c1 turns into a spat involving r_c2, r_c3, and r_c4 as well.",
+			"The argument between m_c and r_c1 spills into r_c2, r_c3, and r_c4's day, leading to the five cats hissing at each other.",
+			"Nobody is safe from m_c and r_c1's dispute, which gets r_c2, r_c3, and r_c4 dragged into it.",
+			"The screaming match between m_c and r_c1 soon involves r_c2, r_c3, and r_c4 as well.",
+			"r_c2, r_c3, and r_c4 wake up to m_c and r_c1's yowling, and the three cats give the snappy pair a piece of their minds.",
+			"Trying to eat while m_c and r_c1 scream at each other is impossible, so r_c2, r_c3, and r_c4 decide to chip in with their opinions."
+		],
+		"relationship_constraint": {
+			"m_c_to_r_c1": [
+				"hates"
+			],
+			"r_c1_to_m_c": [
+				"hates"
+			]
+		},
+		"general_reaction": {
+			"like": "decrease",
+			"respect": "decrease"
+		},
+		"specific_reaction": {
+			"m_c_to_r_c1": {
+				"comfort": "decrease"
+			},
+			"r_c1_to_m_c": {
+				"comfort": "decrease"
+			}
+		}
+	},
+	{
+		"id": "group_5_negative_kitkerfuffle",
+		"intensity": "medium",
+		"cat_amount": 5,
+		"interactions": [
+			"The debate over who gets to be the leader in a game explodes into a hurtful argument between m_c, r_c1, r_c2, r_c3, and r_c4.",
+			"m_c hurls insults at r_c1, r_c2, r_c3, and r_c4 for <i>thinking</i> they deserve a chance to play as the leader.",
+			"m_c is appalled when r_c1, r_c2, r_c3, and r_c4 won't let {PRONOUN/m_c/object} play as the leader, so {PRONOUN/m_c/subject} {VERB/m_c/begin/begins} insulting everyone.",
+			"m_c demands that r_c1 give up playing the leader in a game, which sparks an argument that drags r_c2, r_c3, and r_c4 in as well.",
+			"A fight over a toy escalates into a screaming match between m_c, r_c1, r_c2, r_c3, and r_c4.",
+			"m_c calls r_c1, r_c2, r_c3, and r_c4 a bunch of wusses after a play-fight, and it escalates into a fight between the five.",
+			"m_c, r_c1, r_c2, r_c3, and r_c4 can't settle who gets a toy.",
+			"m_c won't stop instigating a fight between r_c1, r_c2, r_c3, and r_c4.",
+			"m_c orders r_c1, r_c2, r_c3, and r_c4 to fork over the toy they are playing with and starts a fight when told no.",
+			"A play-fight turns into a real scuffle between m_c, r_c1, r_c2, r_c3, and r_c4 after they couldn't decide who would be what in the next round.",
+			"m_c calls everyone in the nursery is a mouse-brain. It leads to an argument between {PRONOUN/m_c/self}, r_c1, r_c2, r_c3, and r_c4.",
+			"m_c screams in r_c1 and r_c2's faces that they both suck, sparking an argument that snowballs and drags in both r_c3 and r_c4.",
+			"m_c keeps hogging being the leader during a game, causing a fight to break out between {PRONOUN/m_c/self}, r_c1, r_c2, r_c3, and r_c4 over who gets to be it next."
+		],
+		"status_constraint": {
+			"m_c": [
+				"kitten"
+			],
+			"r_c1": [
+				"kitten"
+			],
+			"r_c2": [
+				"kitten"
+			],
+			"r_c3": [
+				"kitten"
+			],
+			"r_c4": [
+				"kitten"
+			]
+		},
+		"trait_constraint": {
+			"m_c": [
+				"attention-seeker",
+				"bossy",
+				"bullying",
+				"fearless",
+				"impulsive",
+				"unruly"
+			]
+		},
+		"general_reaction": {
 			"like": "decrease"
-		}   
+		}
+	},
+	{
+		"id": "group_5_neg_kitsitting",
+		"intensity": "medium",
+		"cat_amount": 5,
+		"interactions": [
+			"m_c didn't think it would be too hard to watch the kits, but r_c1, r_c2, r_c3, and r_c4 prove that thought very, very wrong.",
+			"It hasn't been that long since m_c has begun kitsitting r_c1, r_c2, r_c3, and r_c4, but chaos is already underway.",
+			"m_c wants to scream into {PRONOUN/m_c/poss} nest after kitsitting r_c1, r_c2, r_c3, and r_c4.",
+			"m_c doesn't have a moment to rest while kitsitting with how prone to trouble r_c1, r_c2, r_c3, and r_c4 are.",
+			"While kitsitting, m_c tries — and fails — to reign in the rambunctiousness of r_c1, r_c2, r_c3, and r_c4.",
+			"Nobody ever said kitsitting was easy, but m_c thought that r_c1, r_c2, r_c3, and r_c4 would be easier to watch than they actually are.",
+			"m_c wishes that blinking didn't mean missing a second of the next problem r_c1, r_c2, r_c3, and r_c4 will get into.",
+			"After kitsitting r_c1, r_c2, r_c3, and r_c4, m_c takes time to recover from the four kits' endless mischief."
+		],
+		"status_constraint": {
+			"r_c1": [
+				"kitten"
+			],
+			"r_c2": [
+				"kitten"
+			],
+			"r_c3": [
+				"kitten"
+			],
+			"r_c4": [
+				"kitten"
+			]
+		},
+		"skill_constraint": {
+			"m_c": [
+				"KIT,1"
+			]
+		},
+		"relationship_constraint": {
+			"m_c_to_r_c1": [
+				"-parent/child"
+			],
+			"m_c_to_r_c2": [
+				"-parent/child"
+			],
+			"m_c_to_r_c3": [
+				"-parent/child"
+			],
+			"m_c_to_r_c4": [
+				"-parent/child"
+			]
+		},
+		"specific_reaction": {
+			"m_c_to_r_c1": {
+				"like": "decrease",
+				"comfort": "decrease"
+			},
+			"m_c_to_r_c2": {
+				"like": "decrease",
+				"comfort": "decrease"
+			},
+			"m_c_to_r_c3": {
+				"like": "decrease",
+				"comfort": "decrease"
+			},
+			"m_c_to_r_c4": {
+				"like": "decrease",
+				"comfort": "decrease"
+			}   
+		}
+	},
+	{
+		"id": "group_5_neg_siblingappandkits_1",
+		"intensity": "low",
+		"cat_amount": 5,
+		"interactions": [
+			"r_c1 tells m_c to watch r_c2, r_c3, and r_c4. It was a disaster waiting to happen, and m_c adamantly refuses to kitsit again.",
+			"r_c1 suggests that m_c tries to bond with r_c2, r_c3, and r_c4. Everything that can go wrong does, making m_c avoidant of {PRONOUN/m_c/poss} siblings.",
+			"r_c1 needs someone to watch r_c2, r_c3, and r_c4, so it falls to m_c. The moment r_c1 returns, m_c bolts.",
+			"r_c1 entrusts r_c2, r_c3, and r_c4 to m_c. Try as {PRONOUN/m_c/subject} might to connect to {PRONOUN/m_c/poss} younger siblings, it goes up in flames."
+		],
+		"status_constraint": {
+			"m_c": [
+				"apprentice",
+				"medicine cat apprentice",
+				"mediator apprentice"
+			],
+			"r_c2": [
+				"kitten"
+			],
+			"r_c3": [
+				"kitten"
+			],
+			"r_c4": [
+				"kitten"
+			]
+		},
+		"relationship_constraint": {
+			"m_c_to_r_c1": [
+				"child/parent"
+			],
+			"m_c_to_r_c2": [
+				"siblings"
+			],
+			"m_c_to_r_c3": [
+				"siblings"
+			],
+			"m_c_to_r_c4": [
+				"siblings"
+			]
+		},
+		"specific_reaction": {
+			"m_c_to_r_c1": {
+				"like": "decrease"
+			},
+			"m_c_to_r_c2": {
+				"like": "decrease",
+				"comfort": "decrease"
+			},
+			"m_c_to_r_c3": {
+				"like": "decrease",
+				"comfort": "decrease"
+			},
+			"m_c_to_r_c4": {
+				"like": "decrease",
+				"comfort": "decrease"
+			}   
+		}
+	},
+	{
+		"id": "group_5_neg_medicinecatdebates",
+		"intensity": "high",
+		"cat_amount": 5,
+		"interactions": [
+			"m_c, r_c1, r_c2, r_c3, and r_c4 discuss medicine amongst themselves, and it soon sours into a nasty argument.",
+			"m_c is in disbelief about the techniques r_c1, r_c2, r_c3, and r_c4 suggest during a discussion about medicine.",
+			"m_c, r_c1, r_c2, r_c3, and r_c4 cannot find common ground during a discussion about new usages for herbs.",
+			"After a heated argument about herbs, m_c, r_c1, r_c2, r_c3, and r_c4 avoid each other.",
+			"m_c, r_c1, r_c2, r_c3, and r_c4 have differing opinions about how to wrap wounds, and it warps into a controversy.",
+			"m_c refuses to listen to r_c1, r_c2, r_c3, and r_c4's opinions regarding herbs.",
+			"A fiery debate alights between m_c, r_c1, r_c2, r_c3, and r_c4 over how to get to specific herbs."
+		],
+		"status_constraint": {
+			"m_c": [
+				"medicine cat"
+			],
+			"r_c1": [
+				"medicine cat"
+			],
+			"r_c2": [
+				"medicine cat"
+			],
+			"r_c3": [
+				"medicine cat"
+			],
+			"r_c4": [
+				"medicine cat"
+			]
+		},
+		"general_reaction": {
+			"like": "decrease",
+			"trust": "decrease",
+			"respect": "decrease"
+		}
+	},
+	{
+		"id": "group_5_neg_deputyvswarriors",
+		"intensity": "high",
+		"cat_amount": 5,
+		"interactions": [
+			"r_c1, r_c2, r_c3, and r_c4 come to m_c about a complaint regarding patrols, but get blown off by m_c.",
+			"m_c refuses to understand r_c1, r_c2, r_c3, and r_c4's points about patrol organization.",
+			"m_c dismisses r_c1, r_c2, r_c3, and r_c4's arguments by reminding them who their deputy is.",
+			"When r_c1, r_c2, r_c3, and r_c4 begin an argument about hunting, m_c silences them through {PRONOUN/m_c/poss} authority.",
+			"None of r_c1, r_c2, r_c3, or r_c4's critiques about {PRONOUN/m_c/poss} usage of authority matter to m_c."
+		],
+		"status_constraint": {
+			"m_c": [
+				"deputy"
+			],
+			"r_c1": [
+				"warrior"
+			],
+			"r_c2": [
+				"warrior"
+			],
+			"r_c3": [
+				"warrior"
+			],
+			"r_c4": [
+				"warrior"
+			]
+		},
+		"trait_constraint": {
+			"m_c": [
+				"ambitious",
+				"arrogant",
+				"bloodthirsty",
+				"bold",
+				"cold",
+				"fierce",
+				"shameless"
+			]
+		},
+		"specific_reaction": {
+			"r_c1_to_m_c": {
+				"like": "decrease",
+				"respect": "decrease"
+			},
+			"r_c2_to_m_c": {
+				"like": "decrease",
+				"respect": "decrease"
+			},
+			"r_c3_to_m_c": {
+				"like": "decrease",
+				"respect": "decrease"
+			},
+			"r_c4_to_m_c": {
+				"like": "decrease",
+				"respect": "decrease"
+			}   
+		}
+	},
+	{
+		"id": "group_5_neg_leadershiptroubles_1",
+		"intensity": "high",
+		"cat_amount": 5,
+		"interactions": [
+			"m_c is being spoken over by r_c1, but won't curb r_c1's habit even after r_c2, r_c3, and r_c4 bring it up.",
+			"r_c2, r_c3, and r_c4 bring up m_c's tendency to let r_c1 take over Clan affairs, but {PRONOUN/m_c/subject} {VERB/m_c/dismiss/dismisses} the warriors' concern.",
+			"m_c gets interrupted by r_c1 during a meeting, but m_c doesn't correct {PRONOUN/r_c1/object}, and it bothers r_c2, r_c3, and r_c4.",
+			"m_c tries to say something important, but r_c1 derails the conversation. r_c2, r_c3, and r_c4 confront m_c about r_c1's actions, only for m_c to ignore the concerns.",
+			"Every meeting, r_c1 injects something into the conversation. r_c2, r_c3, and r_c4 talk to m_c about their discontent, but it goes nowhere."
+		],
+		"status_constraint": {
+			"m_c": [
+				"leader"
+			],
+			"r_c1": [
+				"deputy"
+			],
+			"r_c2": [
+				"warrior"
+			],
+			"r_c3": [
+				"warrior"
+			],
+			"r_c4": [
+				"warrior"
+			]
+		},
+		"trait_constraint": {
+			"m_c": [
+				"insecure",
+				"lonesome",
+				"nervous"
+			],
+			"r_c1": [
+				"ambitious",
+				"arrogant",
+				"bold",
+				"childish",
+				"troublesome"
+			]
+		},
+		"specific_reaction": {
+			"r_c1_to_m_c": {
+				"respect": "decrease"
+			},
+			"r_c1_to_r_c1": {
+				"respect": "decrease"
+			},
+			"r_c2_to_m_c": {
+				"respect": "decrease"
+			},
+			"r_c3_to_m_c": {
+				"respect": "decrease"
+			},
+			"r_c4_to_m_c": {
+				"respect": "decrease"
+			}   
+		}
 	}
-}
 ]

--- a/resources/lang/en/events/relationship_events/group_interactions/5/negative.json
+++ b/resources/lang/en/events/relationship_events/group_interactions/5/negative.json
@@ -107,10 +107,10 @@
 		"intensity": "high",
 		"cat_amount": 5,
 		"interactions": [
-			"m_c attempts to impart {PRONOUN/m_c/poss} knowledge onto r_c1, r_c2, r_c3, and r_c4, but none of the apprentices pay an ounce of attention.",
-			"m_c tries teaching r_c1, r_c2, r_c3, and r_c4 one of {PRONOUN/m_c/poss} skills, but gives up because no apprentice listens.",
+			"m_c attempts to impart {PRONOUN/m_c/poss} knowledge onto r_c1, r_c2, r_c3, and r_c4, but none of the apprentices pays attention.",
+			"m_c tries teaching r_c1, r_c2, r_c3, and r_c4 one of {PRONOUN/m_c/poss} skills but gives up because no apprentice listens.",
 			"m_c had an informative lecture planned for r_c1, r_c2, r_c3, and r_c4, but gives up midway because the apprentices ignore {PRONOUN/m_c/object}.",
-			"r_c1, r_c2, r_c3, and r_c4 will not stop talking to each other during m_c's lesson, and leads m_c to call it off.",
+			"r_c1, r_c2, r_c3, and r_c4 will not stop talking to each other during m_c's lesson, and m_c calls it off.",
 			"m_c spent an entire day planning a lesson for r_c1, r_c2, r_c3, and r_c4, but it goes to waste as the apprentices are distracted by each other.",
 			"m_c cannot believe how disrespectful r_c1, r_c2, r_c3, and r_c4 are while {PRONOUN/m_c/subject} {VERB/m_c/try/tries} to give a lecture.",
 			"m_c wanted this training exercise to be a success, but r_c1, r_c2, r_c3, and r_c4 refuse to listen and cause m_c to give up."
@@ -159,13 +159,56 @@
 		}
 	},
 	{
+		"id": "group_5_negative_warriordisrespected_fourapprentices",
+		"intensity": "high",
+		"cat_amount": 5,
+		"interactions": [
+			"m_c wants this training exercise to be a success, but r_c1, r_c2, r_c3, and r_c4 refuse to listen, and m_c gives up.",
+			"It is impossible to make r_c1, r_c2, r_c3, and r_c4 understand the importance of stretching properly, so m_c calls the exercise off.",
+			"r_c1, r_c2, r_c3, and r_c4 are too busy goofing off to listen to m_c's advice.",
+			"m_c tries to keep r_c1, r_c2, r_c3, and r_c4 focused during training, but the four continuously talk about unrelated topics.",
+			"r_c1, r_c2, r_c3, and r_c4 pointedly ignore m_c's reminders to focus on training instead of gossiping."
+		],
+		"status_constraint": {
+			"m_c": [
+				"warrior"
+			],
+			"r_c1": [
+				"apprentice"
+			],
+			"r_c2": [
+				"apprentice"
+			],
+			"r_c3": [
+				"apprentice"
+			],
+			"r_c4": [
+				"apprentice"
+			]
+		},
+		"specific_reaction": {
+			"m_c_to_r_c1": {
+				"respect": "decrease"
+			},
+			"m_c_to_r_c2": {
+				"respect": "decrease"
+			},
+			"m_c_to_r_c3": {
+				"respect": "decrease"
+			},
+			"m_c_to_r_c4": {
+				"respect": "decrease"
+			}
+		}
+	},
+	{
 		"id": "group_5_negative_groupargument_twohates",
 		"intensity": "medium",
 		"cat_amount": 5,
 		"interactions": [
 			"What begins as a petty argument between m_c and r_c1 turns into a spat involving r_c2, r_c3, and r_c4 as well.",
 			"The argument between m_c and r_c1 spills into r_c2, r_c3, and r_c4's day, leading to the five cats hissing at each other.",
-			"Nobody is safe from m_c and r_c1's dispute, which gets r_c2, r_c3, and r_c4 dragged into it.",
+			"Nobody is safe from m_c and r_c1's dispute, and r_c2, r_c3, and r_c4 are dragged into it.",
 			"The screaming match between m_c and r_c1 soon involves r_c2, r_c3, and r_c4 as well.",
 			"r_c2, r_c3, and r_c4 wake up to m_c and r_c1's yowling, and the three cats give the snappy pair a piece of their minds.",
 			"Trying to eat while m_c and r_c1 scream at each other is impossible, so r_c2, r_c3, and r_c4 decide to chip in with their opinions."
@@ -374,9 +417,9 @@
 			"m_c is in disbelief about the techniques r_c1, r_c2, r_c3, and r_c4 suggest during a discussion about medicine.",
 			"m_c, r_c1, r_c2, r_c3, and r_c4 cannot find common ground during a discussion about new usages for herbs.",
 			"After a heated argument about herbs, m_c, r_c1, r_c2, r_c3, and r_c4 avoid each other.",
-			"m_c, r_c1, r_c2, r_c3, and r_c4 have differing opinions about how to wrap wounds, and it warps into a controversy.",
+			"m_c, r_c1, r_c2, r_c3, and r_c4 have differing opinions about how to wrap wounds, and it escalates into a controversy.",
 			"m_c refuses to listen to r_c1, r_c2, r_c3, and r_c4's opinions regarding herbs.",
-			"A fiery debate alights between m_c, r_c1, r_c2, r_c3, and r_c4 over how to get to specific herbs."
+			"A fiery debate blazes between m_c, r_c1, r_c2, r_c3, and r_c4 over how to get to specific herbs."
 		],
 		"status_constraint": {
 			"m_c": [
@@ -406,7 +449,7 @@
 		"intensity": "high",
 		"cat_amount": 5,
 		"interactions": [
-			"r_c1, r_c2, r_c3, and r_c4 come to m_c about a complaint regarding patrols, but get blown off by m_c.",
+			"r_c1, r_c2, r_c3, and r_c4 come to m_c with a complaint regarding patrols, but get blown off by m_c.",
 			"m_c refuses to understand r_c1, r_c2, r_c3, and r_c4's points about patrol organization.",
 			"m_c dismisses r_c1, r_c2, r_c3, and r_c4's arguments by reminding them who their deputy is.",
 			"When r_c1, r_c2, r_c3, and r_c4 begin an argument about hunting, m_c silences them through {PRONOUN/m_c/poss} authority.",
@@ -437,7 +480,10 @@
 				"bold",
 				"cold",
 				"fierce",
-				"shameless"
+				"shameless",
+				"confident",
+				"childish",
+				"oblivious"
 			]
 		},
 		"specific_reaction": {
@@ -468,7 +514,7 @@
 			"r_c2, r_c3, and r_c4 bring up m_c's tendency to let r_c1 take over Clan affairs, but {PRONOUN/m_c/subject} {VERB/m_c/dismiss/dismisses} the warriors' concern.",
 			"m_c gets interrupted by r_c1 during a meeting, but m_c doesn't correct {PRONOUN/r_c1/object}, and it bothers r_c2, r_c3, and r_c4.",
 			"m_c tries to say something important, but r_c1 derails the conversation. r_c2, r_c3, and r_c4 confront m_c about r_c1's actions, only for m_c to ignore the concerns.",
-			"Every meeting, r_c1 injects something into the conversation. r_c2, r_c3, and r_c4 talk to m_c about their discontent, but it goes nowhere."
+			"Every meeting, r_c1 speaks over m_c. r_c2, r_c3, and r_c4 talk to m_c about their discontent, but it goes nowhere."
 		],
 		"status_constraint": {
 			"m_c": [

--- a/resources/lang/en/events/relationship_events/group_interactions/5/negative.json
+++ b/resources/lang/en/events/relationship_events/group_interactions/5/negative.json
@@ -166,7 +166,7 @@
 			"m_c wants this training exercise to be a success, but r_c1, r_c2, r_c3, and r_c4 refuse to listen, and m_c gives up.",
 			"It is impossible to make r_c1, r_c2, r_c3, and r_c4 understand the importance of stretching properly, so m_c calls the exercise off.",
 			"r_c1, r_c2, r_c3, and r_c4 are too busy goofing off to listen to m_c's advice.",
-			"m_c attempts keep r_c1, r_c2, r_c3, and r_c4 focused during training, but the four continuously talk about unrelated topics.",
+			"m_c tries keeping r_c1, r_c2, r_c3, and r_c4 focused during training, but the four continuously get off topic.",
 			"r_c1, r_c2, r_c3, and r_c4 pointedly ignore m_c's reminders to focus on training instead of gossiping."
 		],
 		"status_constraint": {


### PR DESCRIPTION
## About The Pull Request

Adds in 71 new group events and 9 new event types for negative group events with five cats. These include new dialogue for:
- morning stretches (with references to the respect increase, and adds a constraint against kits)
- a camp clean-up event for cats with the CAMP skill
- a senior cat being disrespected by four apprentices while attempting to teach
- two cats who hate each other get into an argument and three others have opinions
- kits get into a kerfuffle (often caused directly by m_c)
- a cat with the KIT skill suffers while babysitting four kits
- a sibling (who is an apprentice) is asked by their parent to watch/bond with their younger siblings and it goes wrong
- medicine cats getting into debates about their job
- a deputy (trait-specific) blowing off warriors with concerns
- three warriors taking issue with how a leader (trait-specific) is being talked over by the deputy (trait-specific), but nothing is done about it

## Why This Is Good For ClanGen

Freedom from the morning stretches at long last! I think a variety of negative group events will help expand on worldbuilding for players and offer fun opportunities to tell stories.

## Proof of Testing

<img width="383" height="96" alt="image" src="https://github.com/user-attachments/assets/abd82c66-fc8b-4cea-905b-a92a0ee960b9" />
<img width="382" height="92" alt="image" src="https://github.com/user-attachments/assets/97c9b1ff-c49d-45bf-90a3-77552ad44619" />
<img width="383" height="95" alt="image" src="https://github.com/user-attachments/assets/5aef4130-efb8-4b7d-b66e-0a952d967d9d" />
<img width="388" height="98" alt="image" src="https://github.com/user-attachments/assets/3657ae12-dbfc-4e94-a9cd-235367a5c391" />

## Changelog/Credits

Discord is shadowperch.
