### PR TITLE
["BUG"FIX] Death Reactions that don't mention m_c

### DIFF
--- a/resources/lang/en/events/death/death_reactions/child/child_comfort.json
+++ b/resources/lang/en/events/death/death_reactions/child/child_comfort.json
@@ -89,12 +89,6 @@
         "no_body": [
         ]
     },
-    "empathetic": {
-        "body": [
-        ],
-        "no_body": [
-        ]
-    },
     "faithful": {
         "body": [
         ],

--- a/resources/lang/en/events/death/death_reactions/child/child_like.json
+++ b/resources/lang/en/events/death/death_reactions/child/child_like.json
@@ -86,12 +86,6 @@
         "no_body": [
         ]
     },
-    "empathetic": {
-        "body": [
-        ],
-        "no_body": [
-        ]
-    },
     "faithful": {
         "body": [
         ],

--- a/resources/lang/en/events/death/death_reactions/child/child_neg_like.json
+++ b/resources/lang/en/events/death/death_reactions/child/child_neg_like.json
@@ -126,14 +126,6 @@
 
     ]
   },
-  "empathetic": {
-    "body": [
-
-    ],
-    "no_body": [
-
-    ]
-  },
   "faithful": {
     "body": [
 

--- a/resources/lang/en/events/death/death_reactions/child/child_neg_respect.json
+++ b/resources/lang/en/events/death/death_reactions/child/child_neg_respect.json
@@ -119,14 +119,6 @@
 
     ]
   },
-  "empathetic": {
-    "body": [
-
-    ],
-    "no_body": [
-
-    ]
-  },
   "faithful": {
     "body": [
 

--- a/resources/lang/en/events/death/death_reactions/child/child_respect.json
+++ b/resources/lang/en/events/death/death_reactions/child/child_respect.json
@@ -89,12 +89,6 @@
         "no_body": [
         ]
     },
-    "empathetic": {
-        "body": [
-        ],
-        "no_body": [
-        ]
-    },
     "faithful": {
         "body": [
         ],

--- a/resources/lang/en/events/death/death_reactions/child/child_trust.json
+++ b/resources/lang/en/events/death/death_reactions/child/child_trust.json
@@ -90,12 +90,6 @@
         "no_body": [
         ]
     },
-    "empathetic": {
-        "body": [
-        ],
-        "no_body": [
-        ]
-    },
     "faithful": {
         "body": [
         ],

--- a/resources/lang/en/events/death/death_reactions/general/general_comfort.json
+++ b/resources/lang/en/events/death/death_reactions/general/general_comfort.json
@@ -70,7 +70,7 @@
     },
     "careful": {
         "body": [
-            "Staring at m_c's lifeless body, r_c replays every moment that lead to this, over and over, wondering what {PRONOUN/r_c/subject} could have done to stop it."
+            "Staring at m_c's lifeless body, r_c replays every moment that led to this, over and over, wondering what {PRONOUN/r_c/subject} could have done to stop it."
         ],
         "no_body": [
             "r_c replays every moment that lead to losing m_c, over and over, wondering what {PRONOUN/r_c/subject} could have done to stop it."
@@ -104,10 +104,12 @@
     },
     "compassionate": {
         "body": [
-            "r_c moves quietly from cat to cat, sharing tearful but fond memories of m_c and making sure that no Clanmate grieves alone."
+            "r_c moves quietly from cat to cat, sharing tearful but fond memories of m_c and making sure that no Clanmate grieves alone.",
+            "r_c's heart aches, not just for {PRONOUN/r_c/poss} personal loss of m_c, but for everyone else who also feels the pain of losing {PRONOUN/m_c/object}. The weight of everyone's pain is almost unbearable to r_c."
         ],
         "no_body": [
-            "r_c moves quietly from cat to cat, sharing tearful but fond memories of m_c and making sure that no Clanmate grieves alone."
+            "r_c moves quietly from cat to cat, sharing tearful but fond memories of m_c and making sure that no Clanmate grieves alone.",
+            "r_c's heart aches, not just for {PRONOUN/r_c/poss} personal loss of m_c, but for everyone else who also feels the pain of losing {PRONOUN/m_c/object}. The weight of everyone's pain is almost unbearable to r_c."
         ]
     },
     "confident": {
@@ -124,14 +126,6 @@
         ],
         "no_body": [
             "Filled with overwhelming emotions, r_c yowls at the sky during m_c's vigil, to demand that StarClan send m_c back to {PRONOUN/r_c/object}."
-        ]
-    },
-    "empathetic": {
-        "body": [
-            "r_c's heart aches, not just for {PRONOUN/r_c/poss} personal loss of m_c, but for everyone else who also feels the pain of losing {PRONOUN/m_c/object}. The weight of everyone's pain is almost unbearable to r_c."
-        ],
-        "no_body": [
-            "r_c's heart aches, not just for {PRONOUN/r_c/poss} personal loss of m_c, but for everyone else who also feels the pain of losing {PRONOUN/m_c/object}. The weight of everyone's pain is almost unbearable to r_c."
         ]
     },
     "faithful": {
@@ -174,11 +168,11 @@
     },
     "loving": {
         "body": [
-            "r_c's tender heart breaks at the sight of m_c's body. Nothing will ever be the same again, how could it ever be?",
+            "r_c's tender heart breaks at the sight of m_c's body. Nothing will ever be the same again. How could it ever be?",
             "The sight of c_n grieving the loss of m_c is almost too much for r_c. The collective pain washes over {PRONOUN/r_c/object} in crashing waves."
         ],
         "no_body": [
-            "r_c's tender heart aches at the loss of m_c. Nothing will ever be the same again, how could it ever be?",
+            "r_c's tender heart aches at the loss of m_c. Nothing will ever be the same again. How could it ever be?",
             "The sight of c_n grieving the loss of m_c is almost too much for r_c. The collective pain washes over {PRONOUN/r_c/object} in crashing waves."
         ]
     },
@@ -194,10 +188,10 @@
     },
     "nervous": {
         "body": [
-            "r_c shakes uncontrollably at m_c's vigil. Staring at {PRONOUN/m_c/poss} body, replaying every recent interaction and wondering what m_c was thinking of when {PRONOUN/m_c/subject} died."
+            "r_c shakes uncontrollably at m_c's vigil, staring at {PRONOUN/m_c/poss} body and replaying every recent interaction, wondering what m_c was thinking of when {PRONOUN/m_c/subject} died."
         ],
         "no_body": [
-            "r_c shakes uncontrollably at m_c's vigil. Staring into the sky, replaying every recent interaction and wondering what m_c was thinking of when {PRONOUN/m_c/subject} died."
+            "r_c shakes uncontrollably at m_c's vigil, staring into the sky and replaying every recent interaction, wondering what m_c was thinking of when {PRONOUN/m_c/subject} died."
         ]
     },
     "playful": {
@@ -262,10 +256,10 @@
     },
     "strict": {
         "body": [
-            "r_c watches over m_c's vigil closely, making sure every little detail is correct. {PRONOUN/r_c/poss/CAP} friend deserves nothing less than perfection."
+            "r_c watches over m_c's vigil closely, making sure every little detail is correct. A cat like m_c deserves nothing less than perfection."
         ],
         "no_body": [
-            "r_c watches over m_c's vigil closely, making sure every little detail is correct. {PRONOUN/r_c/poss/CAP} friend deserves nothing less than perfection."
+            "r_c watches over m_c's vigil closely, making sure every little detail is correct. A cat like m_c deserves nothing less than perfection."
         ]
     },
     "thoughtful": {
@@ -419,18 +413,18 @@
     },
     "know-it-all": {
         "body": [
-            "r_c begs the older cats for explanations, but the vague answers only make it worse. If m_c was here, {PRONOUN/r_c/subject} would tell {PRONOUN/r_c/object} the truth..."
+            "r_c begs the older cats for explanations, but the vague answers only make it worse. If m_c was here, {PRONOUN/m_c/subject} would tell {PRONOUN/r_c/object} the truth..."
         ],
         "no_body": [
-            "r_c begs the older cats for explanations, but the vague answers only make it worse. If m_c was here, {PRONOUN/r_c/subject} would tell {PRONOUN/r_c/object} the truth..."
+            "r_c begs the older cats for explanations, but the vague answers only make it worse. If m_c was here, {PRONOUN/m_c/subject} would tell {PRONOUN/r_c/object} the truth..."
         ]
     },
     "noisy": {
         "body": [
-            "The chilling sound of r_c's heartbreaking wails make all of c_n feel the loss of m_c twice as hard."
+            "The chilling sound of r_c's heartbroken wails make all of c_n feel the loss of m_c twice as hard."
         ],
         "no_body": [
-            "The chilling sound of r_c's heartbreaking wails make all of c_n feel the loss of m_c twice as hard."
+            "The chilling sound of r_c's heartbroken wails make all of c_n feel the loss of m_c twice as hard."
         ]
     },
     "polite": {

--- a/resources/lang/en/events/death/death_reactions/general/general_like.json
+++ b/resources/lang/en/events/death/death_reactions/general/general_like.json
@@ -16,8 +16,8 @@
             "r_c avoids m_c's vigil. The sight of {PRONOUN/m_c/poss} slumped body is more than {PRONOUN/r_c/subject} can take.",
             "r_c is eager to get up and busy {PRONOUN/r_c/self} the next day. {PRONOUN/r_c/subject/CAP} {VERB/r_c/refuse/refuses} to sit still for even a moment, lest {PRONOUN/r_c/poss} thoughts begin to linger on m_c's death.",
             "As the vigil draws to a close, someone suggests r_c should eat. It feels like dung in {PRONOUN/r_c/poss} mouth, but {PRONOUN/r_c/subject} {VERB/r_c/know/knows} m_c would want {PRONOUN/r_c/object} to take care of {PRONOUN/r_c/self}.",
-            "r_c keeps searching for tasks to do, cats to comfort, distractions against the hole in {PRONOUN/r_c/poss} heart, as {PRONOUN/r_c/subject} {VERB/r_c/fight/fights} to keep the grief from consuming {PRONOUN/r_c/object}.",
-            "The world seems dim and lifeless, and r_c keeps close to {PRONOUN/r_c/poss} Clan, seeking out their comfort and company.",
+            "r_c keeps searching for tasks to do, cats to comfort, distractions against the hole in {PRONOUN/r_c/poss} heart, as {PRONOUN/r_c/subject} {VERB/r_c/fight/fights} to keep the grief of m_c's death from consuming {PRONOUN/r_c/object}.",
+            "The world seems dim and lifeless without m_c, and r_c keeps close to {PRONOUN/r_c/poss} Clan, seeking out their comfort and company.",
             "r_c goes over the best of the moments {PRONOUN/r_c/subject} shared with m_c in {PRONOUN/r_c/poss} mind, again and again, until {PRONOUN/r_c/subject}{VERB/r_c/'re/'s} certain {PRONOUN/r_c/subject}'ll remember m_c forever.",
             "r_c wonders if, maybe, if {PRONOUN/r_c/subject}{VERB/r_c/'re/'s} lucky, m_c might visit {PRONOUN/r_c/object} in a vision from StarClan.",
             "r_c curls tightly in {PRONOUN/r_c/poss} nest once the vigil comes to a close, throat raw from crying. Miserably, {PRONOUN/r_c/subject} {VERB/r_c/dwell/dwells} on how m_c won't see another morning.",
@@ -32,7 +32,7 @@
             "As the vigil for m_c draws to a close, someone suggests r_c should eat. {PRONOUN/r_c/subject/CAP} {VERB/r_c/refuse/refuses}, not so much as shifting {PRONOUN/r_c/poss} vacant gaze.",
             "When no one needs anything from r_c, {PRONOUN/r_c/subject/} {VERB/r_c/break/breaks} down, wailing uncontrollably and cursing the world that took m_c instead of {PRONOUN/r_c/object}.",
             "As the days pass, r_c becomes angry and withdrawn. It feels like the entire Clan is just moving on from m_c's death, which {PRONOUN/r_c/subject} {VERB/r_c/refuse/refuses} to do.",
-            "Cats come to r_c afterwards, offering {PRONOUN/r_c/object} the biggest, juiciest pieces of fresh-kill, but {PRONOUN/r_c/subject} {VERB/r_c/refuse/refuses} it all, staring at the walls of {PRONOUN/r_c/poss} den in silence.",
+            "Cats come to r_c after m_c's vigil, offering {PRONOUN/r_c/object} the biggest, juiciest pieces of fresh-kill, but {PRONOUN/r_c/subject} {VERB/r_c/refuse/refuses} it all, staring at the walls of {PRONOUN/r_c/poss} den in silence.",
             "Things are never going to be the same now. Could never be the same, without m_c. r_c refuses to accept it.",
             "r_c spends time by {PRONOUN/r_c/self}, letting {PRONOUN/r_c/self} mourn m_c and the time they should have had together. No one can begrudge {PRONOUN/r_c/object} the need to grieve.",
             "Cats offer r_c comfort and care in the wake of m_c's death. {PRONOUN/r_c/subject/CAP} {VERB/r_c/refuse/refuses} all of it.",
@@ -40,9 +40,9 @@
             "r_c makes a point of removing foliage from m_c's nest, snapping at any hindrance. {PRONOUN/r_c/poss/CAP} paws tremble over the material, distraught when {PRONOUN/r_c/subject} {VERB/r_c/realize/realizes} how fast m_c's scent is fading.",
             "Nobody can comfort r_c during the vigil; {PRONOUN/r_c/subject}{VERB/r_c/'re/'s} absolutely inconsolable, convinced that {PRONOUN/r_c/subject}'ll never feel normal again without m_c beside {PRONOUN/r_c/object}.",
             "In the dead of the night, r_c wails into the vast sky, unable to fathom StarClan's cruelty in taking m_c away. {PRONOUN/r_c/subject/CAP} {VERB/r_c/glare/glares} up at Silverpelt, gouging the earth with shaky claws.",
-            "r_c is barely able to move {PRONOUN/r_c/poss} body, and has to be gently guided to {PRONOUN/r_c/poss} nest, fatigue threatening to consume {PRONOUN/r_c/object}.",
+            "r_c is barely able to move {PRONOUN/r_c/poss} body away from m_c's and has to be gently guided to {PRONOUN/r_c/poss} nest, fatigue threatening to consume {PRONOUN/r_c/object}.",
             "Once night comes, and {PRONOUN/r_c/subject} {VERB/r_c/fall/falls} asleep, r_c desperately wails m_c's name, movements frantic as {PRONOUN/r_c/subject} {VERB/r_c/struggle/struggles} — no, {VERB/r_c/refuse/refuses} — to accept {PRONOUN/m_c/poss} death.",
-            "In the following days, r_c visits m_c's grave, gazing blankly, unmovingly, at the ground for hours on end.",
+            "In the days following the vigil, r_c visits m_c's grave, gazing blankly, unmovingly, at the ground for hours on end.",
             "r_c trembles, tearing at {PRONOUN/r_c/poss} nest, unable to sleep as {PRONOUN/r_c/subject} {VERB/r_c/brood/broods} over m_c's last moments. Did {PRONOUN/m_c/subject} suffer? {VERB/m_c/Were/Was} {PRONOUN/m_c/subject} scared?",
             "Bitterness and rage floods r_c as m_c's life is recalled at the vigil. {PRONOUN/r_c/subject/CAP} coldly {VERB/r_c/turn/turns} away any who offer comfort. Without m_c, what's the point?",
             "The loss takes such a toll on r_c that {PRONOUN/r_c/subject} can barely find {PRONOUN/r_c/poss} footing as {PRONOUN/r_c/subject} {VERB/r_c/stumble/stumbles} to {PRONOUN/r_c/poss} nest, wailing for m_c."
@@ -53,7 +53,6 @@
             "r_c is rocked by the loss of m_c. All those memories and shared moments are now burdens that {PRONOUN/r_c/subject} must carry alone.",
             "m_c was so important to r_c. How could the world be so cruel as to take {PRONOUN/m_c/object} away from {PRONOUN/r_c/object}?",
             "Grief swells up to swallow r_c when {PRONOUN/r_c/subject} {VERB/r_c/hear/hears} the news about m_c.",
-            "m_c, dead? But... r_c shakes {PRONOUN/r_c/poss} head, bewildered, insisting they spoke just a sunrise ago.",
             "c_n is shocked by r_c's outburst of wails and cries at m_c's vigil. {PRONOUN/r_c/subject/CAP} {VERB/r_c/flee/flees} camp to process this shattering loss on {PRONOUN/r_c/poss} own.",
             "r_c tries to put on a brave face for {PRONOUN/r_c/poss} Clanmates, but as {PRONOUN/r_c/subject} {VERB/r_c/speak/speaks} about m_c, {PRONOUN/r_c/poss} voice wavers and then breaks off into nothing. With a trembling gasp, {PRONOUN/r_c/subject} {VERB/r_c/retreat/retreats} to let another Clanmate speak.",
             "After learning about m_c's death, r_c can't seem to catch {PRONOUN/r_c/poss} breath as fits of sobs and cries come over {PRONOUN/r_c/object}.",
@@ -62,7 +61,7 @@
             "r_c is eager to get up and busy {PRONOUN/r_c/self} the next day. {PRONOUN/r_c/subject/CAP} {VERB/r_c/refuse/refuses} to sit still for even a moment, lest {PRONOUN/r_c/poss} thoughts begin to linger on m_c's death.",
             "As the vigil draws to a close, someone suggests r_c should eat. It feels like dung in {PRONOUN/r_c/poss} mouth, but {PRONOUN/r_c/subject} {VERB/r_c/know/knows} m_c would want {PRONOUN/r_c/object} to take care of {PRONOUN/r_c/self}.",
             "r_c keeps searching for tasks to do, cats to comfort, distractions against the hole in {PRONOUN/r_c/poss} heart, as {PRONOUN/r_c/subject} {VERB/r_c/fight/fights} to keep the grief of m_c's death from consuming {PRONOUN/r_c/object}.",
-            "The world seems dim and lifeless, and r_c keeps close to {PRONOUN/r_c/poss} Clan, seeking out their comfort and company in the wake of m_c's death.",
+            "The world seems dim and lifeless without m_c, and r_c keeps close to {PRONOUN/r_c/poss} Clan, seeking out their comfort and company in the wake of m_c's death.",
             "r_c goes over the best of the moments {PRONOUN/r_c/subject} shared with m_c in {PRONOUN/r_c/poss} mind, again and again, until {PRONOUN/r_c/subject}{VERB/r_c/'re/'s} certain {PRONOUN/r_c/subject}'ll remember m_c forever.",
             "r_c wonders if, maybe, if {PRONOUN/r_c/subject}{VERB/r_c/'re/'s} lucky, m_c might visit {PRONOUN/r_c/object} in a vision from StarClan.",
             "r_c curls tightly in {PRONOUN/r_c/poss} nest once the vigil comes to a close, throat raw from crying. Miserably, {PRONOUN/r_c/subject} {VERB/r_c/dwell/dwells} on how m_c won't see another morning.",
@@ -77,7 +76,7 @@
             "As the vigil for m_c draws to a close, someone suggests r_c should eat. {PRONOUN/r_c/subject/CAP} {VERB/r_c/refuse/refuses}, not so much as shifting {PRONOUN/r_c/poss} vacant gaze.",
             "When no one needs anything from r_c, {PRONOUN/r_c/subject/} {VERB/r_c/break/breaks} down, wailing uncontrollably and cursing the world that took m_c instead of {PRONOUN/r_c/object}.",
             "As the days pass, r_c becomes angry and withdrawn. It feels like the entire Clan is just moving on from m_c's death, which {PRONOUN/r_c/subject} {VERB/r_c/refuse/refuses} to do.",
-            "Cats come to r_c afterwards, offering {PRONOUN/r_c/object} the biggest, juiciest pieces of fresh-kill, but {PRONOUN/r_c/subject} {VERB/r_c/refuse/refuses} it all, staring at the walls of {PRONOUN/r_c/poss} den in silence.",
+            "Cats come to r_c after m_c's vigil, offering {PRONOUN/r_c/object} the biggest, juiciest pieces of fresh-kill, but {PRONOUN/r_c/subject} {VERB/r_c/refuse/refuses} it all, staring at the walls of {PRONOUN/r_c/poss} den in silence.",
             "Things are never going to be the same now. Could never be the same, without m_c. r_c refuses to accept it.",
             "r_c spends time by {PRONOUN/r_c/self}, letting {PRONOUN/r_c/self} mourn m_c and the time they should have had together. No one can begrudge {PRONOUN/r_c/object} the need to grieve.",
             "Cats offer r_c comfort and care in the wake of m_c's death. {PRONOUN/r_c/subject/CAP} {VERB/r_c/refuse/refuses} all of it.",
@@ -85,7 +84,7 @@
             "r_c makes a point of removing foliage from m_c's nest, snapping at any hindrance. {PRONOUN/r_c/poss/CAP} paws tremble over the material, distraught when {PRONOUN/r_c/subject} {VERB/r_c/realize/realizes} how fast m_c's scent is fading.",
             "Nobody can comfort r_c during the vigil; {PRONOUN/r_c/subject}{VERB/r_c/'re/'s} absolutely inconsolable, convinced that {PRONOUN/r_c/subject}'ll never feel normal again without m_c beside {PRONOUN/r_c/object}.",
             "In the dead of the night, r_c wails into the vast sky, unable to fathom StarClan's cruelty in taking m_c away. {PRONOUN/r_c/subject/CAP} {VERB/r_c/glare/glares} up at Silverpelt, gouging the earth with shaky claws.",
-            "r_c is barely able to move {PRONOUN/r_c/poss} body, and has to be gently guided to {PRONOUN/r_c/poss} nest, fatigue threatening to consume {PRONOUN/r_c/object}.",
+            "r_c is barely able to move {PRONOUN/r_c/poss} body after the vigil and has to be gently guided to {PRONOUN/r_c/poss} nest, fatigue threatening to consume {PRONOUN/r_c/object}.",
             "Once night comes, and {PRONOUN/r_c/subject} {VERB/r_c/fall/falls} asleep, r_c desperately wails m_c's name, movements frantic as {PRONOUN/r_c/subject} {VERB/r_c/struggle/struggles} — no, {VERB/r_c/refuse/refuses} — to accept {PRONOUN/m_c/poss} death.",
             "In the following days, r_c visits m_c's grave, gazing blankly, unmovingly, at the ground for hours on end.",
             "r_c trembles, tearing at {PRONOUN/r_c/poss} nest, unable to sleep as {PRONOUN/r_c/subject} {VERB/r_c/brood/broods} over m_c's last moments. Did {PRONOUN/m_c/subject} suffer? {VERB/m_c/Were/Was} {PRONOUN/m_c/subject} scared?",
@@ -138,7 +137,7 @@
     },
     "careful": {
         "body": [
-            "Staring at m_c's lifeless body, r_c replays every moment that lead to this, over and over, wondering what {PRONOUN/r_c/subject} could have done to stop it."
+            "Staring at m_c's lifeless body, r_c replays every moment that led to this, over and over, wondering what {PRONOUN/r_c/subject} could have done to stop it."
         ],
         "no_body": [
             "r_c replays every moment that lead to losing m_c, over and over, wondering what {PRONOUN/r_c/subject} could have done to stop it."
@@ -172,10 +171,12 @@
     },
     "compassionate": {
         "body": [
-            "r_c moves quietly from cat to cat, sharing tearful but fond memories of m_c and making sure that no Clanmate grieves alone."
+            "r_c moves quietly from cat to cat, sharing tearful but fond memories of m_c and making sure that no Clanmate grieves alone.",
+            "r_c's heart aches, not just for {PRONOUN/r_c/poss} personal loss of m_c, but for everyone else who also feels the pain of losing {PRONOUN/m_c/object}. The weight of everyone's pain is almost unbearable to r_c."
         ],
         "no_body": [
-            "r_c moves quietly from cat to cat, sharing tearful but fond memories of m_c and making sure that no Clanmate grieves alone."
+            "r_c moves quietly from cat to cat, sharing tearful but fond memories of m_c and making sure that no Clanmate grieves alone.",
+            "r_c's heart aches, not just for {PRONOUN/r_c/poss} personal loss of m_c, but for everyone else who also feels the pain of losing {PRONOUN/m_c/object}. The weight of everyone's pain is almost unbearable to r_c."
         ]
     },
     "confident": {
@@ -192,14 +193,6 @@
         ],
         "no_body": [
             "Filled with overwhelming emotions, r_c yowls at the sky during m_c's vigil, to demand that StarClan send m_c back to {PRONOUN/r_c/object}."
-        ]
-    },
-    "empathetic": {
-        "body": [
-            "r_c's heart aches, not just for {PRONOUN/r_c/poss} personal loss of m_c, but for everyone else who also feels the pain of losing {PRONOUN/m_c/object}. The weight of everyone's pain is almost unbearable to r_c."
-        ],
-        "no_body": [
-            "r_c's heart aches, not just for {PRONOUN/r_c/poss} personal loss of m_c, but for everyone else who also feels the pain of losing {PRONOUN/m_c/object}. The weight of everyone's pain is almost unbearable to r_c."
         ]
     },
     "faithful": {
@@ -242,11 +235,11 @@
     },
     "loving": {
         "body": [
-            "r_c's tender heart breaks at the sight of m_c's body. Nothing will ever be the same again, how could it ever be?",
+            "r_c's tender heart breaks at the sight of m_c's body. Nothing will ever be the same again. How could it ever be?",
             "The sight of c_n grieving the loss of m_c is almost too much for r_c. The collective pain washes over {PRONOUN/r_c/object} in crashing waves."
         ],
         "no_body": [
-            "r_c's tender heart aches at the loss of m_c. Nothing will ever be the same again, how could it ever be?",
+            "r_c's tender heart aches at the loss of m_c. Nothing will ever be the same again. How could it ever be?",
             "The sight of c_n grieving the loss of m_c is almost too much for r_c. The collective pain washes over {PRONOUN/r_c/object} in crashing waves."
         ]
     },
@@ -262,7 +255,7 @@
     },
     "nervous": {
         "body": [
-            "r_c shakes uncontrollably at m_c's vigil. Staring at {PRONOUN/m_c/poss} body, replaying every recent interaction and wondering what m_c was thinking of when {PRONOUN/m_c/subject} died."
+            "r_c shakes uncontrollably at m_c's vigil, staring at {PRONOUN/m_c/poss} body and replaying every recent interaction, wondering what m_c was thinking of when {PRONOUN/m_c/subject} died."
         ],
         "no_body": [
             "r_c shakes uncontrollably at m_c's vigil. Staring into the sky, replaying every recent interaction and wondering what m_c was thinking of when {PRONOUN/m_c/subject} died."
@@ -330,10 +323,10 @@
     },
     "strict": {
         "body": [
-            "r_c watches over m_c's vigil closely, making sure every little detail is correct. {PRONOUN/r_c/poss/CAP} friend deserves nothing less than perfection."
+            "r_c watches over m_c's vigil closely, making sure every little detail is correct. A cat like m_c deserves nothing less than perfection."
         ],
         "no_body": [
-            "r_c watches over m_c's vigil closely, making sure every little detail is correct. {PRONOUN/r_c/poss/CAP} friend deserves nothing less than perfection."
+            "r_c watches over m_c's vigil closely, making sure every little detail is correct. A cat like m_c deserves nothing less than perfection."
         ]
     },
     "thoughtful": {
@@ -487,18 +480,18 @@
     },
     "know-it-all": {
         "body": [
-            "r_c begs the older cats for explanations, but the vague answers only make it worse. If m_c was here, {PRONOUN/r_c/subject} would tell {PRONOUN/r_c/object} the truth..."
+            "r_c begs the older cats for explanations, but the vague answers only make it worse. If m_c was here, {PRONOUN/m_c/subject} would tell {PRONOUN/r_c/object} the truth..."
         ],
         "no_body": [
-            "r_c begs the older cats for explanations, but the vague answers only make it worse. If m_c was here, {PRONOUN/r_c/subject} would tell {PRONOUN/r_c/object} the truth..."
+            "r_c begs the older cats for explanations, but the vague answers only make it worse. If m_c was here, {PRONOUN/m_c/subject} would tell {PRONOUN/r_c/object} the truth..."
         ]
     },
     "noisy": {
         "body": [
-            "The chilling sound of r_c's heartbreaking wails make all of c_n feel the loss of m_c twice as hard."
+            "The chilling sound of r_c's heartbroken wails make all of c_n feel the loss of m_c twice as hard."
         ],
         "no_body": [
-            "The chilling sound of r_c's heartbreaking wails make all of c_n feel the loss of m_c twice as hard."
+            "The chilling sound of r_c's heartbroken wails make all of c_n feel the loss of m_c twice as hard."
         ]
     },
     "polite": {

--- a/resources/lang/en/events/death/death_reactions/general/general_neg_like.json
+++ b/resources/lang/en/events/death/death_reactions/general/general_neg_like.json
@@ -122,12 +122,6 @@
         "no_body": [
         ]
     },
-    "empathetic": {
-        "body": [
-        ],
-        "no_body": [
-        ]
-    },
     "faithful": {
         "body": [
         ],

--- a/resources/lang/en/events/death/death_reactions/general/general_neg_respect.json
+++ b/resources/lang/en/events/death/death_reactions/general/general_neg_respect.json
@@ -106,12 +106,6 @@
         "no_body": [
         ]
     },
-    "empathetic": {
-        "body": [
-        ],
-        "no_body": [
-        ]
-    },
     "faithful": {
         "body": [
         ],

--- a/resources/lang/en/events/death/death_reactions/general/general_respect.json
+++ b/resources/lang/en/events/death/death_reactions/general/general_respect.json
@@ -105,12 +105,6 @@
         "no_body": [
         ]
     },
-    "empathetic": {
-        "body": [
-        ],
-        "no_body": [
-        ]
-    },
     "faithful": {
         "body": [
         ],

--- a/resources/lang/en/events/death/death_reactions/general/general_trust.json
+++ b/resources/lang/en/events/death/death_reactions/general/general_trust.json
@@ -100,12 +100,6 @@
         "no_body": [
         ]
     },
-    "empathetic": {
-        "body": [
-        ],
-        "no_body": [
-        ]
-    },
     "faithful": {
         "body": [
         ],

--- a/resources/lang/en/events/death/death_reactions/parent/parent_comfort.json
+++ b/resources/lang/en/events/death/death_reactions/parent/parent_comfort.json
@@ -95,12 +95,6 @@
         "no_body": [
         ]
     },
-    "empathetic": {
-        "body": [
-        ],
-        "no_body": [
-        ]
-    },
     "faithful": {
         "body": [
         ],

--- a/resources/lang/en/events/death/death_reactions/parent/parent_like.json
+++ b/resources/lang/en/events/death/death_reactions/parent/parent_like.json
@@ -94,12 +94,6 @@
         "no_body": [
         ]
     },
-    "empathetic": {
-        "body": [
-        ],
-        "no_body": [
-        ]
-    },
     "faithful": {
         "body": [
         ],

--- a/resources/lang/en/events/death/death_reactions/parent/parent_neg_like.json
+++ b/resources/lang/en/events/death/death_reactions/parent/parent_neg_like.json
@@ -91,12 +91,6 @@
         "no_body": [
         ]
     },
-    "empathetic": {
-        "body": [
-        ],
-        "no_body": [
-        ]
-    },
     "faithful": {
         "body": [
         ],

--- a/resources/lang/en/events/death/death_reactions/parent/parent_neg_respect.json
+++ b/resources/lang/en/events/death/death_reactions/parent/parent_neg_respect.json
@@ -87,12 +87,6 @@
         "no_body": [
         ]
     },
-    "empathetic": {
-        "body": [
-        ],
-        "no_body": [
-        ]
-    },
     "faithful": {
         "body": [
         ],

--- a/resources/lang/en/events/death/death_reactions/parent/parent_respect.json
+++ b/resources/lang/en/events/death/death_reactions/parent/parent_respect.json
@@ -95,12 +95,6 @@
         "no_body": [
         ]
     },
-    "empathetic": {
-        "body": [
-        ],
-        "no_body": [
-        ]
-    },
     "faithful": {
         "body": [
         ],

--- a/resources/lang/en/events/death/death_reactions/parent/parent_trust.json
+++ b/resources/lang/en/events/death/death_reactions/parent/parent_trust.json
@@ -95,12 +95,6 @@
         "no_body": [
         ]
     },
-    "empathetic": {
-        "body": [
-        ],
-        "no_body": [
-        ]
-    },
     "faithful": {
         "body": [
         ],

--- a/resources/lang/en/events/death/death_reactions/sibling/sibling_comfort.json
+++ b/resources/lang/en/events/death/death_reactions/sibling/sibling_comfort.json
@@ -91,12 +91,6 @@
         "no_body": [
         ]
     },
-    "empathetic": {
-        "body": [
-        ],
-        "no_body": [
-        ]
-    },
     "faithful": {
         "body": [
         ],

--- a/resources/lang/en/events/death/death_reactions/sibling/sibling_like.json
+++ b/resources/lang/en/events/death/death_reactions/sibling/sibling_like.json
@@ -91,12 +91,6 @@
         "no_body": [
         ]
     },
-    "empathetic": {
-        "body": [
-        ],
-        "no_body": [
-        ]
-    },
     "faithful": {
         "body": [
         ],

--- a/resources/lang/en/events/death/death_reactions/sibling/sibling_neg_like.json
+++ b/resources/lang/en/events/death/death_reactions/sibling/sibling_neg_like.json
@@ -91,12 +91,6 @@
         "no_body": [
         ]
     },
-    "empathetic": {
-        "body": [
-        ],
-        "no_body": [
-        ]
-    },
     "faithful": {
         "body": [
         ],

--- a/resources/lang/en/events/death/death_reactions/sibling/sibling_neg_respect.json
+++ b/resources/lang/en/events/death/death_reactions/sibling/sibling_neg_respect.json
@@ -91,12 +91,6 @@
         "no_body": [
         ]
     },
-    "empathetic": {
-        "body": [
-        ],
-        "no_body": [
-        ]
-    },
     "faithful": {
         "body": [
         ],

--- a/resources/lang/en/events/death/death_reactions/sibling/sibling_respect.json
+++ b/resources/lang/en/events/death/death_reactions/sibling/sibling_respect.json
@@ -91,12 +91,6 @@
         "no_body": [
         ]
     },
-    "empathetic": {
-        "body": [
-        ],
-        "no_body": [
-        ]
-    },
     "faithful": {
         "body": [
         ],

--- a/resources/lang/en/events/death/death_reactions/sibling/sibling_trust.json
+++ b/resources/lang/en/events/death/death_reactions/sibling/sibling_trust.json
@@ -91,12 +91,6 @@
         "no_body": [
         ]
     },
-    "empathetic": {
-        "body": [
-        ],
-        "no_body": [
-        ]
-    },
     "faithful": {
         "body": [
         ],


### PR DESCRIPTION
## About The Pull Request

Now that we've split up the prev "major" grief indicators into their own reactions, I went through to make sure every grief event actually mentions the cat being grieved. Along the way, I found a few grammatically awkward or incorrect bits. I also deleted all the blank lists with strings for "empathetic" death reactions and moved existing strings into compassionate.

## Proof of Testing

<img width="757" height="131" alt="image" src="https://github.com/user-attachments/assets/ed37eac3-1ac3-4cbd-88dc-6d699c1d73b7" />

i think this is one of the ones i added an m_c to