### PR TITLE
[BUGFIX] Patrol tags the wrong cat 

### DIFF
--- a/resources/lang/en/patrols/desert/hunting/any.json
+++ b/resources/lang/en/patrols/desert/hunting/any.json
@@ -1287,7 +1287,7 @@
         "chance_of_success": 50,
         "success_outcomes": [
             {
-                "text": "r_c pounces on the mouse, with a squeak of surprise from both prey and apprentice.",
+                "text": "app1 pounces on the mouse, with a squeak of surprise from both prey and apprentice.",
                 "exp": 10,
                 "prey": [
                     "small"

--- a/resources/lang/en/patrols/forest/hunting/leaf-bare.json
+++ b/resources/lang/en/patrols/forest/hunting/leaf-bare.json
@@ -542,7 +542,7 @@
         "chance_of_success": 10,
         "success_outcomes": [
             {
-                "text": "r_c pounces on the mouse, with a squeak of surprise from both prey and apprentice.",
+                "text": "app1 pounces on the mouse, with a squeak of surprise from both prey and apprentice.",
                 "exp": 40,
                 "prey": [
                     "medium"
@@ -550,7 +550,7 @@
             "relationships": [
                 {
                     "cats_from": ["some_clan"],
-                    "cats_to": ["r_c"],
+                    "cats_to": ["app1"],
                     "values": ["trust", "respect"],
                     "mutual": false,
                     "amount": 8,
@@ -3352,7 +3352,7 @@
         "chance_of_success": 10,
         "success_outcomes": [
             {
-                "text": "r_c pounces on the mouse, with a squeak of surprise from both prey and apprentice.",
+                "text": "app1 pounces on the mouse, with a squeak of surprise from both prey and apprentice.",
                 "exp": 40,
                 "prey": [
                     "medium"

--- a/resources/lang/en/patrols/forest/hunting/leaf-fall.json
+++ b/resources/lang/en/patrols/forest/hunting/leaf-fall.json
@@ -1582,7 +1582,7 @@
         "chance_of_success": 30,
         "success_outcomes": [
             {
-                "text": "r_c pounces on the mouse, with a squeak of surprise from both prey and apprentice.",
+                "text": "app1 pounces on the mouse, with a squeak of surprise from both prey and apprentice.",
                 "exp": 30,
                 "prey": [
                     "medium"
@@ -1590,7 +1590,7 @@
             "relationships": [
                 {
                     "cats_from": ["some_clan"],
-                    "cats_to": ["r_c"],
+                    "cats_to": ["app1"],
                     "values": ["trust", "respect"],
                     "mutual": false,
                     "amount": 5,

--- a/resources/lang/en/patrols/mountainous/hunting/any.json
+++ b/resources/lang/en/patrols/mountainous/hunting/any.json
@@ -1040,7 +1040,7 @@
         "chance_of_success": 50,
         "success_outcomes": [
             {
-                "text": "r_c pounces on the mouse, with a squeak of surprise from both prey and apprentice.",
+                "text": "app1 pounces on the mouse, with a squeak of surprise from both prey and apprentice.",
                 "exp": 10,
                 "prey": [
                     "small"

--- a/resources/lang/en/patrols/plains/hunting/any.json
+++ b/resources/lang/en/patrols/plains/hunting/any.json
@@ -4280,7 +4280,7 @@
         "chance_of_success": 50,
         "success_outcomes": [
             {
-                "text": "r_c pounces on the mouse, with a squeak of surprise from both prey and apprentice.",
+                "text": "app1 pounces on the mouse, with a squeak of surprise from both prey and apprentice.",
                 "exp": 10,
                 "prey": [
                     "small"


### PR DESCRIPTION
## About The Pull Request

"r_c" was supposed to be app1. To make sure this doesn't happen again, I edited every version of this patrol to use only "app1" to refer to app1. Even on solo patrols where p_l and r_c would both be app1 anyway.

## Linked Issues

Fixes: #4751

## Proof of Testing

<img width="1048" height="802" alt="image" src="https://github.com/user-attachments/assets/b6f197a6-b060-4512-81d3-fe843ce76f56" />
app1 is correctly selected