### PR TITLE
[BUGFIX] apprentice-ship was a misspelling, there is no hyphen needed.

### DIFF
--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -6781,7 +6781,7 @@
             "no_body"
         ],
         "frequency": 4,
-        "event_text": "m_c boasted about how ready {PRONOUN/m_c/subject} {VERB/m_c/were/was} for apprentice-ship. {PRONOUN/m_c/subject/CAP} snuck away to prove it and the Clan finds only blood and raccoon-scent in the morning.",
+        "event_text": "m_c boasted about how ready {PRONOUN/m_c/subject} {VERB/m_c/were/was} for apprenticeship. {PRONOUN/m_c/subject/CAP} snuck away to prove it and the Clan finds only blood and raccoon-scent in the morning.",
         "m_c": {
             "status": [
                 "kitten"


### PR DESCRIPTION
apprentice-ship was a misspelling, there is no hyphen needed.

## About The Pull Request

minor spelling/grammar change.

## Proof of Testing

<img width="965" height="64" alt="Screenshot 2026-04-12 at 5 59 23 PM" src="https://github.com/user-attachments/assets/71161246-0eac-453c-8859-e2047d4f6e0c" />

## Changelog/Credits

n/a