### PR TITLE
[CONTENT] A Heaping Helping of Angst

### DIFF
--- a/resources/lang/en/conditions/pregnancy.json
+++ b/resources/lang/en/conditions/pregnancy.json
@@ -97,6 +97,8 @@
             "m_c gave birth to a {insert} with r_c and is looking forward to co-parenting.",
 			"After a bit of fumbling, r_c finally just blurts that {PRONOUN/r_c/subject} {VERB/r_c/don't/doesn't} want to be a parent. m_c and {PRONOUN/m_c/poss} new {insert} are left alone in the nursery.",
 			"m_c isn't cruel about it, but after r_c's done meeting {PRONOUN/r_c/poss} new {insert}, {PRONOUN/m_c/subject} {VERB/m_c/make/makes} {PRONOUN/m_c/poss} intention to be the <i>primary parent</i> clear.",
+			"r_c bluntly tells m_c that {PRONOUN/r_c/subject} {VERB/r_c/don't/doesn't} intend to help raise the {insert} that {PRONOUN/m_c/subject} just gave birth to. {PRONOUN/r_c/subject/CAP} {VERB/r_c/walk/walks} out of the nursery, leaving m_c alone and heartbroken.",
+			"m_c waits with bated breath for r_c to visit the nursery and finally meet {PRONOUN/r_c/poss} new {insert}, but {PRONOUN/r_c/subject} never {VERB/r_c/do/does}. m_c is left wondering what {PRONOUN/m_c/subject} did wrong.",
             "r_c sheepishly peeks into the nursery to see {PRONOUN/r_c/poss} {insert}. m_c looks surprised but not unhappy to see {PRONOUN/r_c/object} there, and welcomes {PRONOUN/r_c/object} in with a purr.",
             "m_c purrs loudly as r_c grooms {PRONOUN/m_c/poss} pelt. As their new {insert} squirms around m_c's belly, the two cats think about their new responsibilities together.",
             "m_c gazes lovingly at {PRONOUN/m_c/poss} new {insert}. r_c looks nervous and awkward in the nursery, but m_c calls {PRONOUN/r_c/object} forward to meet the litter.",
@@ -108,7 +110,8 @@
             "r_c goes to visit m_c in the nursery with {PRONOUN/m_c/poss} new {insert}, on a completely innocent mission to deliver food to the new parent.",
             "The newly arrived {insert} that m_c has just given birth to looks suspiciously like r_c. ",
             "No one wants to ruin such a happy occasion, but... it doesn't take a genius to notice how m_c's {insert} looks suspiciously like r_c...",
-            "Ever since the birth, rumor's gone around that m_c's {insert} belongs to r_c and, while no one wants to confirm anything, no one really has to when the evidence is mewling right there..."
+            "Ever since the birth, rumor's gone around that m_c's {insert} belongs to r_c and, while no one wants to confirm anything, no one really has to when the evidence is mewling right there...",
+			"r_c adamantly denies that m_c's newly born {insert} belongs to {PRONOUN/r_c/object} when questioned, but it's hard to believe {PRONOUN/r_c/object} when they're so similar..."
         ],
         "affair_mated": [
             "m_c's mate is such a wonderful cat, deserving of being a parent... so why does m_c's {insert} look more like r_c instead?",

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -7054,6 +7054,29 @@
             ]
         }
     },
+      {
+    "event_id": "multi_death_massdeath_mistery1",
+    "location": [
+      "any"
+    ],
+    "season": [
+      "any"
+    ],
+    "sub_type": [
+      "mass_death"
+    ],
+    "tags": [],
+    "frequency": 1,
+    "event_text": "A thick fog covers c_n for days. When it finally lifts, multi_cat are found dead out in the territory.",
+    "history": [
+      {
+        "cats": [
+          "multi_cat"
+        ],
+        "death": "m_c died after being consumed by mysterious fog."
+      }
+    ]
+  },
     {
         "event_id": "gen_death_freshkill_anyfox1",
         "location": [
@@ -8221,5 +8244,174 @@
                 "death": "m_c died after disappearing mysteriously."
             }
         ]
-    }
+    },
+      {
+    "event_id": "gen_death_swiftpawreference_any1",
+    "location": [
+      "any"
+    ],
+    "season": [
+      "any"
+    ],
+    "tags": [],
+    "frequency": 1,
+    "event_text": "There have been rumors around camp that dogs are roaming the Clan's territory. m_c, frustrated at the fact {PRONOUN/m_c/subject} {VERB/m_c/have/has}n't become a warrior yet, goes out on {PRONOUN/m_c/poss} own to investigate. When the Clan discovers {PRONOUN/m_c/subject} is missing, they organize a search party — only to find m_c has been mauled by the dogs.",
+    "m_c": {
+      "age": [
+        "adolescent",
+        "young adult"
+      ],
+      "status": [
+        "apprentice"
+      ],
+      "trait": [
+        "troublesome",
+        "fierce",
+        "bloodthirsty",
+        "bold",
+        "daring",
+        "righteous",
+        "ambitious",
+        "confident",
+        "adventurous",
+        "shameless",
+        "sneaky",
+        "arrogant",
+        "competitive",
+        "cunning",
+        "rebellious"
+      ],
+      "dies": true
+    },
+    "history": [
+      {
+        "cats": [
+          "m_c"
+        ],
+        "death": "m_c was mauled by dogs after sneaking out of camp."
+      }
+    ]
+  },
+      {
+    "event_id": "gen_death_prankgonewrong_any1",
+    "location": [
+      "forest",
+      "mountainous",
+      "plains",
+      "wetlands"
+    ],
+    "season": [
+      "greenleaf",
+      "newleaf",
+      "leaf-fall"
+    ],
+    "tags": [
+      "all_lives",
+      "no_body"
+    ],
+    "frequency": 4,
+    "event_text": "While training with m_c near the river, r_c playfully shoves m_c. However, {PRONOUN/r_c/subject} {VERB/r_c/fail/fails} to measure {PRONOUN/r_c/poss} strength, and before {PRONOUN/r_c/subject} can save {PRONOUN/m_c/object}, m_c falls into the current and is swept away, never to be seen again.",
+    "m_c": {
+      "age": [
+        "-kitten"
+      ],
+      "status": [
+        "any"
+      ],
+      "dies": true
+    },
+    "r_c": {
+      "age": [
+        "adolescent",
+        "young adult",
+        "adult",
+        "senior adult"
+      ],
+      "status": [
+        "any"
+      ],
+      "trait": [
+        "childish",
+        "playful",
+        "charismatic",
+        "daring",
+        "fierce",
+        "troublesome",
+        "adventurous",
+        "shameless",
+        "sneaky",
+        "strange",
+        "competitive",
+        "cunning",
+        "flamboyant",
+        "rebellious"
+      ],
+      "skill": [
+        "FIGHTER,1"
+      ],
+      "dies": false
+    },
+    "history": [
+      {
+        "cats": [
+          "m_c"
+        ],
+        "death": "m_c was swept away by the river after a prank by r_c went horribly wrong."
+      }
+    ]
+  },
+ {
+    "event_id": "gen_death_doubledisappearance_any1",
+    "location": [
+      "any"
+    ],
+    "season": [
+      "any"
+    ],
+    "tags": [
+      "all_lives",
+      "no_body"
+    ],
+    "frequency": 2,
+    "event_text": "m_c mysteriously disappeared one night. r_c noticed before anyone else could and went looking for {PRONOUN/m_c/object} {PRONOUN/r_c/self}. c_n never saw either of them again.",
+    "m_c": {
+      "age": [
+        "-kitten"
+      ],
+      "status": [
+        "any"
+      ],
+      "dies": true
+    },
+    "r_c": {
+      "age": [
+        "young adult",
+        "adult",
+        "senior adult"
+      ],
+      "status": [
+        "any"
+      ],
+      "trait": [
+        "bold",
+        "daring",
+        "sneaky",
+        "loyal",
+        "confident",
+        "thoughtful",
+        "adventurous",
+        "responsible"
+      ],
+      "dies": true
+    },
+    "history": [
+      {
+        "cats": [
+          "m_c",
+          "r_c"
+        ],
+        "death": "This cat disappeared alongside a Clanmate, never to be seen again."
+      }
+    ]
+  }
 ]

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -8300,9 +8300,7 @@
       "wetlands"
     ],
     "season": [
-      "greenleaf",
-      "newleaf",
-      "leaf-fall"
+      "-leaf-bare"
     ],
     "tags": [
       "all_lives",

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -8255,7 +8255,7 @@
     ],
     "tags": [],
     "frequency": 1,
-    "event_text": "There have been rumors around camp that dogs are roaming the Clan's territory. m_c, frustrated at the fact {PRONOUN/m_c/subject} {VERB/m_c/have/has}n't become a warrior yet, goes out on {PRONOUN/m_c/poss} own to investigate. The c_n search party discovers m_c's mauled body the next day.",
+    "event_text": "There have been rumors around camp that dogs are roaming the Clan's territory. m_c goes out on {PRONOUN/m_c/poss} own to investigate. The c_n search party discovers m_c's mauled body the next day.",
     "m_c": {
       "age": [
         "young adult"

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -8255,7 +8255,7 @@
     ],
     "tags": [],
     "frequency": 1,
-    "event_text": "There have been rumors around camp that dogs are roaming the Clan's territory. m_c, frustrated at the fact {PRONOUN/m_c/subject} {VERB/m_c/have/has}n't become a warrior yet, goes out on {PRONOUN/m_c/poss} own to investigate. When the Clan discovers {PRONOUN/m_c/subject} is missing, they organize a search party — only to find m_c has been mauled by the dogs.",
+    "event_text": "There have been rumors around camp that dogs are roaming the Clan's territory. m_c, frustrated at the fact {PRONOUN/m_c/subject} {VERB/m_c/have/has}n't become a warrior yet, goes out on {PRONOUN/m_c/poss} own to investigate. The c_n search party discovers m_c's mauled body the next day.",
     "m_c": {
       "age": [
         "adolescent",

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -8409,7 +8409,7 @@
           "m_c",
           "r_c"
         ],
-        "death": "This cat disappeared alongside a Clanmate, never to be seen again."
+        "death": "m_c disappeared alongside a Clanmate, never to be seen again."
       }
     ]
   }

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -8309,7 +8309,7 @@
       "no_body"
     ],
     "frequency": 1,
-    "event_text": "While training with m_c near the river, r_c playfully shoves m_c. However, {PRONOUN/r_c/subject} {VERB/r_c/fail/fails} to measure {PRONOUN/r_c/poss} strength, and before {PRONOUN/r_c/subject} can save {PRONOUN/m_c/object}, m_c falls into the current and is swept away, never to be seen again.",
+    "event_text": "While training with m_c near the river, r_c playfully shoves m_c. However, {PRONOUN/r_c/subject} {VERB/r_c/push/pushes} too hard and m_c loses {PRONOUN/m_c/poss} balance. Before r_c can save {PRONOUN/m_c/object}, the current sweeps m_c away.",
     "m_c": {
       "age": [
         "-kitten"

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -8327,7 +8327,7 @@
         "senior adult"
       ],
       "status": [
-        "any"
+        "-elder"
       ],
       "trait": [
         "childish",

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -8372,7 +8372,7 @@
       "no_body"
     ],
     "frequency": 2,
-    "event_text": "m_c mysteriously disappeared one night. r_c noticed before anyone else could and went looking for {PRONOUN/m_c/object} {PRONOUN/r_c/self}. c_n never saw either of them again.",
+    "event_text": "m_c mysteriously disappeared one night. r_c noticed before anyone else and went looking for {PRONOUN/m_c/object} {PRONOUN/r_c/self}. c_n never saw either of them again.",
     "m_c": {
       "age": [
         "-kitten"

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -8315,7 +8315,7 @@
         "-kitten"
       ],
       "status": [
-        "any"
+        "-elder"
       ],
       "dies": true
     },

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -8375,7 +8375,7 @@
     "event_text": "m_c mysteriously disappeared one night. r_c noticed before anyone else and went looking for {PRONOUN/m_c/object} {PRONOUN/r_c/self}. c_n never saw either of them again.",
     "m_c": {
       "age": [
-        "-kitten"
+        "any"
       ],
       "status": [
         "any"

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -8258,7 +8258,6 @@
     "event_text": "There have been rumors around camp that dogs are roaming the Clan's territory. m_c, frustrated at the fact {PRONOUN/m_c/subject} {VERB/m_c/have/has}n't become a warrior yet, goes out on {PRONOUN/m_c/poss} own to investigate. The c_n search party discovers m_c's mauled body the next day.",
     "m_c": {
       "age": [
-        "adolescent",
         "young adult"
       ],
       "status": [

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -8309,7 +8309,7 @@
       "all_lives",
       "no_body"
     ],
-    "frequency": 4,
+    "frequency": 1,
     "event_text": "While training with m_c near the river, r_c playfully shoves m_c. However, {PRONOUN/r_c/subject} {VERB/r_c/fail/fails} to measure {PRONOUN/r_c/poss} strength, and before {PRONOUN/r_c/subject} can save {PRONOUN/m_c/object}, m_c falls into the current and is swept away, never to be seen again.",
     "m_c": {
       "age": [


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

baby's first PR... ^^"
this PR aims to add a couple angsty short events. specifically; general death events and negative birth reactions.
inspired by #4680 !!
<br>
full details include:
- a reference to swiftpaw's death in the books, where an apprentice who's bitter about not being made a warrior hears that dogs may be roaming the territory and goes looking out for them themself... which leads to their demise.
- an accidental death where one cat shoves another a little too hard while training, making them fall into a river and be carried away by the current.
- a more ambiguous death where a cat randomly disappears one night, and another cat goes out looking for them. neither of them ever return...
- a mass_death version of the "mistery" deaths written by tobes! that thick fog will getcha
- negative birth reactions (that don't affect relationships due to the current nature of how birth events work) where the other parent makes it clear they don't want to co-parent
- an affair event where the other parent denies the new litter is theirs even though it's obvious it is


## Why This Is Good For ClanGen

more event variety! recent additions have been very angsty, and i wanted to add onto it. tobes' writing is what mostly inspired me, and cats can afford to be a bit meaner. the death events i wrote are all at 1/2 frequency, and some have specific trait/skill requirements, so they won't show up often, but they'll be a shock if they do!

## Proof of Testing

all of these events were tested individually by editing death chances in game_config, temporarily increasing their frequency, and turning on every extra kit setting to pray for kit booms!
here are screenshots of the events generating correctly: (they don't only generate for leaders, they're just the screenshots i happen to have on me, lol)
<img width="508" height="183" alt="image" src="https://github.com/user-attachments/assets/29267d87-231a-426f-be15-6b89324edb57" />
<img width="512" height="177" alt="image" src="https://github.com/user-attachments/assets/ed1c7acf-36bc-436a-bb34-5c036206284e" />
<img width="510" height="129" alt="image" src="https://github.com/user-attachments/assets/f242f560-b196-4248-a4a7-c26a5cbf8da8" />
<img width="512" height="155" alt="image" src="https://github.com/user-attachments/assets/65489107-6f95-4872-aaaa-b71875b6f83b" />
<img width="511" height="127" alt="image" src="https://github.com/user-attachments/assets/69d228eb-4c39-4b29-b335-60b800c8f437" />
<img width="510" height="203" alt="image" src="https://github.com/user-attachments/assets/8065a73d-23d1-4b63-ac4a-9bd4ebf9da57" />
<img width="510" height="132" alt="image" src="https://github.com/user-attachments/assets/da32374b-4e80-4137-bd24-a0ff58467eb5" />

## Changelog/Credits

- New general death events and one new mass extinction event. Accidental killing? Mysterious disappearances? An unfortunate fate for an apprentice that seems all too familiar? It's all here!
- New affair text and "negative" birth events. Sometimes cats just don't want to co-parent... and they may get cruel about it.