### PR TITLE
fix: exclude driven-off cats from outsider next/prev navigation

### DIFF
--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -3438,6 +3438,18 @@ class Cat:
                 for check_cat in sorted_specific_list
                 if check_cat.status.group_ID == self.status.group_ID
             ]
+        elif (
+            self.status.is_outsider or self.status.is_other_clancat
+        ) and self.status.is_near(CatGroup.PLAYER_CLAN_ID):
+            # Mirror the Cats Outside The Clan tab: only include outsiders who
+            # are still near the player clan. Driven-off cats (near=False) are
+            # filtered out of that tab, so next/prev navigation from a cat in
+            # that tab should not walk into them either (issue #4767).
+            sorted_specific_list = [
+                check_cat
+                for check_cat in sorted_specific_list
+                if check_cat.status.is_near(CatGroup.PLAYER_CLAN_ID)
+            ]
 
         if filter_func is not None:
             sorted_specific_list = [


### PR DESCRIPTION
## Summary

#4767. Navigating next/prev from a cat in the "Cats Outside The Clan" tab could surface driven-off cats that the tab itself filters out. This change mirrors the tab's filter inside `determine_next_and_previous_cats()`.

## Root cause

`determine_next_and_previous_cats()` in `scripts/cat/cats.py` (line 3415) filtered only by `dead`, `alive_in_player_clan`, and `faded`. The Cats Outside The Clan tab (`ListScreen.get_cotc_cats()`, line 766) additionally restricts to cats that are `is_near(PLAYER_CLAN_ID)`. Driven-off cats have `near=False`, so they were excluded from the tab list but included in the navigation walk.

## Fix

When the current cat is an outsider or other-clan cat AND is still near the player clan, filter `sorted_specific_list` to also require `is_near(PLAYER_CLAN_ID)`. Dead-cat branches and the default group-ID path are untouched. One new branch, 10ish lines.

Matches the maintainer's suggestion on the issue.

## Steps to verify

1. Exile a kit, ensure at least one other outsider is near the clan
2. Drive off the kit via the leader's den
3. Skip a moon
4. Open Cats Outside The Clan tab
5. Tap any cat, hit next/prev repeatedly

Before: driven-off kit eventually appears. After: navigation stays within the visible tab list.

## Testing

Syntax check passes (`python3 -c "import ast; ast.parse(...)"`). Full test suite needs pygame which is not available in this environment; the change is a single list-comprehension filter mirroring an existing path above it.