### PR TITLE
[CONTENT] Train & Stalactite Death Events

### DIFF
--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -8223,7 +8223,6 @@
         ]
     },
     {
-  {
         "event_id": "gen_death_stalactite",
         "location": [
             "mountainous_camp2",

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -8223,12 +8223,13 @@
         ]
     },
     {
-        {
+  {
         "event_id": "gen_death_stalactite",
         "location": [
-            "mountainous_camp2_camp3",
-            "beach_camp2",
-            "forest_camp3"
+            "mountainous_camp2",
+            "mountainous_camp3",
+            "forest_camp3",
+            "beach_camp2"
         ],
         "season": [
             "any"
@@ -8251,5 +8252,5 @@
                 "death": "m_c was killed by stalactite."
             }
         ]
-    } 
+    }
 ]

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -8225,10 +8225,7 @@
     {
         "event_id": "gen_death_stalactite",
         "location": [
-            "mountainous_camp2",
-            "mountainous_camp3",
-            "forest_camp3",
-            "beach_camp2"
+            "mountainous:camp2_camp3",
         ],
         "season": [
             "any"
@@ -8236,7 +8233,7 @@
         "sub_type": [],
         "tags": [],
         "frequency": 2,
-        "event_text": "m_c was killed by a falling stalactite in the middle of camp.",
+        "event_text": "m_c was killed by a stalactite falling in the middle of camp.",
         "m_c": {
             "status": [
                 "any"

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -8221,5 +8221,32 @@
                 "death": "m_c died after disappearing mysteriously."
             }
         ]
-    }
+    },
+    {
+        "event_id": "gen_death_stalactite",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [],
+        "tags": [],
+        "frequency": 2,
+        "event_text": "m_c was killed by a falling stalactite in the middle of camp.",
+        "m_c": {
+            "status": [
+                "any"
+            ],
+            "dies": true
+        },
+        "history": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "death": "m_c was killed by stalactite."
+            }
+        ]
+    } 
 ]

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -8221,32 +8221,5 @@
                 "death": "m_c died after disappearing mysteriously."
             }
         ]
-    },
-    {
-        "event_id": "gen_death_stalactite",
-        "location": [
-            "mountainous:camp2_camp3"
-        ],
-        "season": [
-            "any"
-        ],
-        "sub_type": [],
-        "tags": [],
-        "frequency": 2,
-        "event_text": "m_c was killed by a stalactite falling in the middle of camp.",
-        "m_c": {
-            "status": [
-                "any"
-            ],
-            "dies": true
-        },
-        "history": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "death": "m_c was killed by stalactite."
-            }
-        ]
     }
 ]

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -8225,7 +8225,7 @@
     {
         "event_id": "gen_death_stalactite",
         "location": [
-            "mountainous:camp2_camp3",
+            "mountainous:camp2_camp3"
         ],
         "season": [
             "any"

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -8223,9 +8223,12 @@
         ]
     },
     {
+        {
         "event_id": "gen_death_stalactite",
         "location": [
-            "any"
+            "mountainous_camp2_camp3",
+            "beach_camp2",
+            "forest_camp3"
         ],
         "season": [
             "any"

--- a/resources/lang/en/events/death/mountainous.json
+++ b/resources/lang/en/events/death/mountainous.json
@@ -37,5 +37,33 @@
                 "death": "m_c was eaten by a mountain weasel when {PRONOUN/m_c/subject} tried to sneak out of camp."
             }
         ]
+    },
+        },
+    {
+        "event_id": "mnt_death_stalactite",
+        "location": [
+            "mountainous:camp2_camp3"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [],
+        "tags": [],
+        "frequency": 2,
+        "event_text": "m_c was killed by a stalactite falling in the middle of camp.",
+        "m_c": {
+            "status": [
+                "any"
+            ],
+            "dies": true
+        },
+        "history": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "death": "m_c was killed by stalactite."
+            }
+        ]
     }
 ]

--- a/resources/lang/en/events/death/mountainous.json
+++ b/resources/lang/en/events/death/mountainous.json
@@ -38,7 +38,6 @@
             }
         ]
     },
-        },
     {
         "event_id": "mnt_death_stalactite",
         "location": [

--- a/resources/lang/en/events/death/mountainous.json
+++ b/resources/lang/en/events/death/mountainous.json
@@ -61,7 +61,7 @@
                 "cats": [
                     "m_c"
                 ],
-                "death": "m_c was killed by stalactite."
+                "death": "m_c was killed by a stalactite."
             }
         ]
     }

--- a/resources/lang/en/events/death/plains.json
+++ b/resources/lang/en/events/death/plains.json
@@ -24,7 +24,7 @@
         "-wise",
         "-grumpy",
         "-cunning",
-        "-careful"
+        "-careful",
         "-nervous",
         "-thoughtful",
         "-cold",

--- a/resources/lang/en/events/death/plains.json
+++ b/resources/lang/en/events/death/plains.json
@@ -2,7 +2,7 @@
   {
     "event_id": "pln_death_trainvehicle",
     "location": [
-      "plains_camp4"
+      "plains:camp4"
     ],
     "season": [
       "any"

--- a/resources/lang/en/events/death/plains.json
+++ b/resources/lang/en/events/death/plains.json
@@ -1,1 +1,53 @@
-[]
+[
+  {
+    "event_id": "pln_death_trainvehicle",
+    "location": [
+      "plains_camp4"
+    ],
+    "season": [
+      "any"
+    ],
+    "tags": [
+      "all_lives"
+    ],
+    "frequency": 1,
+    "event_text": "r_c dares m_c to leap across the Silverpath in front of the Thundersnake near camp and is horrified when {PRONOUN/m_c/subject} stumbles and is struck.",
+    "m_c": {
+      "age": [
+        "-newborn",
+        "-kitten"
+      ],
+      "status": [
+        "-newborn",
+        "-kitten"
+      ],
+      "dies": true
+    },
+    "r_c": {
+      "age": [
+        "-newborn",
+        "-kitten"
+      ],
+      "status": [
+        "-newborn",
+        "-kitten"
+      ],
+      "trait": [
+        "childish",
+        "playful",
+        "daring",
+        "shameless",
+        "competitive"
+      ],
+      "dies": false
+    },
+    "history:": [
+      {
+        "cats": [
+          "m_c"
+        ],
+        "death": "m_c died from being struck by a Thundersnake."
+      }
+    ]
+  }
+]

--- a/resources/lang/en/events/death/plains.json
+++ b/resources/lang/en/events/death/plains.json
@@ -25,6 +25,10 @@
         "-grumpy",
         "-cunning",
         "-careful"
+        "-nervous",
+        "-thoughtful",
+        "-cold",
+        "-calm"
       ],
       "dies": true
     },

--- a/resources/lang/en/events/death/plains.json
+++ b/resources/lang/en/events/death/plains.json
@@ -11,7 +11,7 @@
       "all_lives"
     ],
     "frequency": 1,
-    "event_text": "r_c dares m_c to leap across the Silverpath in front of the Thundersnake near camp and is horrified when {PRONOUN/m_c/subject} stumbles and is struck.",
+    "event_text": "r_c dares m_c to leap across the Silverpath in front of a Thundersnake near camp and is horrified when {PRONOUN/m_c/subject} stumbles and is struck.",
     "m_c": {
       "age": [
         "-newborn",

--- a/resources/lang/en/events/death/plains.json
+++ b/resources/lang/en/events/death/plains.json
@@ -17,18 +17,10 @@
         "-newborn",
         "-kitten"
       ],
-      "status": [
-        "-newborn",
-        "-kitten"
-      ],
       "dies": true
     },
     "r_c": {
       "age": [
-        "-newborn",
-        "-kitten"
-      ],
-      "status": [
         "-newborn",
         "-kitten"
       ],

--- a/resources/lang/en/events/death/plains.json
+++ b/resources/lang/en/events/death/plains.json
@@ -17,6 +17,15 @@
         "-newborn",
         "-kitten"
       ],
+       "trait": [
+        "-strict",
+        "-gloomy",
+        "-responsible",
+        "-wise",
+        "-grumpy",
+        "-cunning",
+        "-careful"
+      ],
       "dies": true
     },
     "r_c": {

--- a/resources/lang/en/events/death/plains.json
+++ b/resources/lang/en/events/death/plains.json
@@ -30,7 +30,7 @@
     },
     "r_c": {
       "age": [
-        "-newborn",
+        "-newborn"
       ],
       "trait": [
         "childish",

--- a/resources/lang/en/events/death/plains.json
+++ b/resources/lang/en/events/death/plains.json
@@ -31,7 +31,6 @@
     "r_c": {
       "age": [
         "-newborn",
-        "-kitten"
       ],
       "trait": [
         "childish",


### PR DESCRIPTION
Choo Choo! Two new death events for ClanGen. One specifically for the new Bridge camp in the plains and the other for cave-based camps across regions. 

## About The Pull Request

Two new death events. RE: Stalactite, I chose to have it available for the Grotto and Sea Cave camp as well but I can see how cutting them might be more realistic as well. 

## Why This Is Good For ClanGen

More death events themed to specific areas, diversifying the type of events and stories that can be told based on each individual camp. 

## Proof of Testing

<img width="521" height="124" alt="Screenshot 2026-04-14 at 10 40 54 AM" src="https://github.com/user-attachments/assets/46bc1255-d283-4aaf-a2ea-ff3df1c6d58d" />
<img width="520" height="348" alt="Screenshot 2026-04-14 at 10 30 44 AM" src="https://github.com/user-attachments/assets/03e07517-aa4f-4369-9d9d-023076553f79" />
<img width="517" height="130" alt="Screenshot 2026-04-14 at 10 52 11 AM" src="https://github.com/user-attachments/assets/aa33d0fd-bd6f-4690-8470-4a6ab42149d9" />

