### PR TITLE
[CONTENT] Camp-Specific Events

### DIFF
--- a/resources/lang/en/events/death/beach.json
+++ b/resources/lang/en/events/death/beach.json
@@ -686,7 +686,7 @@
       "adolescent"
     ],
     "skill": [
-      "-CLIMBER,1"
+      "-CLIMBER,0"
     ],
     "trait": [
       "unruly",

--- a/resources/lang/en/events/death/beach.json
+++ b/resources/lang/en/events/death/beach.json
@@ -668,5 +668,57 @@
                 }
             }
         ]
+    },
+    {
+  "event_id": "bch_death_kitappshipwreckfall",
+  "location": [
+    "beach:camp3"
+  ],
+  "season": [
+    "any"
+  ],
+  "tags": [],
+  "frequency": 1,
+  "event_text": "m_c climbed aboard the broken ship in camp, playing pretend as a Twoleg. No cat noticed what {PRONOUN/m_c/subject} {VERB/m_c/were/was} doing until the floorboards beneath {PRONOUN/m_c/object} gave way and {PRONOUN/m_c/subject} fell into the nothingness below.",
+  "m_c": {
+    "age": [
+      "kitten",
+      "adolescent"
+    ],
+    "skill": [
+      "-CLIMBER,1"
+    ],
+    "trait": [
+      "unruly",
+      "impulsive",
+      "attention-seeker",
+      "charming",
+      "skittish",
+      "daydreamer",
+      "fearless",
+      "bossy",
+      "troublesome",
+      "childish",
+      "playful",
+      "charismatic",
+      "bold",
+      "daring",
+      "confident",
+      "adventurous",
+      "shameless",
+      "sneaky",
+      "strange",
+      "rebellious"
+    ],
+    "dies": true
+  },
+  "history": [
+    {
+      "cats": [
+        "m_c"
+      ],
+      "death": "m_c fell through the floorboards of the broken ship."
     }
+  ]
+}
 ]

--- a/resources/lang/en/events/death/plains.json
+++ b/resources/lang/en/events/death/plains.json
@@ -64,7 +64,7 @@
     ],
     "tags": [],
     "frequency": 2,
-    "event_text": "Driven to desperation by the greenleaf heat, m_c drinks from a foul tasting puddle of water. The Clan finds {PRONOUN/m_c/object} dead in {PRONOUN/m_c/poss} nest hours later.",
+    "event_text": "Driven to desperation by the greenleaf heat, m_c drinks from a foul-tasting puddle of water. The Clan finds {PRONOUN/m_c/object} dead in {PRONOUN/m_c/poss} nest hours later.",
     "m_c": {
       "age": [
         "-kitten"

--- a/resources/lang/en/events/death/plains.json
+++ b/resources/lang/en/events/death/plains.json
@@ -1,1 +1,83 @@
-[]
+[
+  {
+    "event_id": "pln_death_trainvehicle",
+    "location": [
+      "plains:camp4"
+    ],
+    "season": [
+      "any"
+    ],
+    "tags": [
+      "all_lives"
+    ],
+    "frequency": 1,
+    "event_text": "r_c dares m_c to leap across the Silverpath in front of a Thundersnake near camp and is horrified when {PRONOUN/m_c/subject} stumbles and is struck.",
+    "m_c": {
+      "age": [
+        "-newborn",
+        "-kitten"
+      ],
+      "trait": [
+        "-strict",
+        "-gloomy",
+        "-responsible",
+        "-wise",
+        "-grumpy",
+        "-cunning",
+        "-careful",
+        "-nervous",
+        "-thoughtful",
+        "-cold",
+        "-calm"
+      ],
+      "dies": true
+    },
+    "r_c": {
+      "age": [
+        "-newborn"
+      ],
+      "trait": [
+        "childish",
+        "playful",
+        "daring",
+        "shameless",
+        "competitive"
+      ],
+      "dies": false
+    },
+    "history:": [
+      {
+        "cats": [
+          "m_c"
+        ],
+        "death": "m_c died from being struck by a Thundersnake."
+      }
+    ]
+  },
+  {
+    "event_id": "pln_death_poisonedwater",
+    "location": [
+      "plains:camp3"
+    ],
+    "season": [
+      "greenleaf"
+    ],
+    "tags": [],
+    "frequency": 2,
+    "event_text": "Driven to desperation by the greenleaf heat, m_c drinks from a foul tasting puddle of water. The Clan finds {PRONOUN/m_c/object} dead in {PRONOUN/m_c/poss} nest hours later.",
+    "m_c": {
+      "age": [
+        "-kitten"
+      ],
+      "dies": true
+    },
+    "history": [
+      {
+        "cats": [
+          "m_c"
+        ],
+        "death": "m_c died after drinking poisoned water."
+      }
+    ]
+  }
+]

--- a/resources/lang/en/events/injury/beach.json
+++ b/resources/lang/en/events/injury/beach.json
@@ -919,6 +919,28 @@
       "senior adult",
       "senior"
     ],
+      "trait": [
+"unruly",
+"impulsive",
+"attention-seeker",
+"charming",
+"skittish",
+"daydreamer",
+"fearless",
+"bossy",
+"troublesome",
+"childish",
+"playful",
+"charismatic",
+"bold",
+"daring",
+"confident",
+"adventurous",
+"shameless",
+"sneaky",
+"strange",
+"rebellious"
+],
     "skill": [
       "-CLIMBER,2"
     ],

--- a/resources/lang/en/events/injury/beach.json
+++ b/resources/lang/en/events/injury/beach.json
@@ -899,5 +899,51 @@
                 }
             }
         ]
+    },
+    {
+  "event_id": "bch_injury_shipwreckfall_anymultiage1",
+  "location": [
+    "beach:camp3"
+  ],
+  "season": [
+    "any"
+  ],
+  "frequency": 1,
+  "event_text": "While trying to climb the broken ship in camp, m_c's paw slipped and {PRONOUN/m_c/subject} fell to the ground with a nasty thump.",
+  "m_c": {
+    "age": [
+      "kitten",
+      "adolescent",
+      "young adult",
+      "adult",
+      "senior adult",
+      "senior"
+    ],
+    "skill": [
+      "-CLIMBER,2"
+    ],
+    "status": [
+      "any"
+    ]
+  },
+  "injury": [
+    {
+      "cats": [
+        "m_c"
+      ],
+      "injuries": [
+        "broken bone"
+      ]
     }
+  ],
+  "history": [
+    {
+      "cats": [
+        "m_c"
+      ],
+      "death": "m_c died from {PRONOUN/m_c/poss} wounds after failing to climb the broken ship.",
+      "scar": "m_c was scarred after failing to climb the broken ship."
+    }
+  ]
+}
 ]

--- a/resources/lang/en/events/misc/mountainous.json
+++ b/resources/lang/en/events/misc/mountainous.json
@@ -182,7 +182,7 @@
     "any"
   ],
   "frequency": 2,
-  "event_text": "For the tiniest moment, m_c thought the reflection staring back at {PRONOUN/m_c/object} in the crystals around camp was not {PRONOUN/m_c/poss} own.",
+  "event_text": "For a heartbeat, m_c thought the reflection staring back at {PRONOUN/m_c/object} in the crystals around camp was not {PRONOUN/m_c/poss} own.",
   "m_c": {
     "age": [
       "any"

--- a/resources/lang/en/events/misc/mountainous.json
+++ b/resources/lang/en/events/misc/mountainous.json
@@ -172,5 +172,31 @@
                 "sincere"
             ]
         }
-    }
+    },
+    {
+  "event_id": "mtn_misc_crystalreflection_supernaturalskills",
+  "location": [
+    "mountainous:camp3"
+  ],
+  "season": [
+    "any"
+  ],
+  "frequency": 2,
+  "event_text": "For the tiniest moment, m_c thought the reflection staring back at {PRONOUN/m_c/object} in the crystals around camp was not {PRONOUN/m_c/poss} own.",
+  "m_c": {
+    "age": [
+      "any"
+    ],
+    "status": [
+      "any"
+    ],
+    "skill": [
+      "GHOST,2",
+      "CLAIRVOYANT,1",
+      "OMEN,1",
+      "DARK,2",
+      "STAR,2"
+    ]
+  }
+}
 ]

--- a/resources/lang/en/events/new_cat/mountainous.json
+++ b/resources/lang/en/events/new_cat/mountainous.json
@@ -107,7 +107,67 @@
             ],
             "changed": 1
         }
+    },
+{
+  "event_id": "mtn_new_cat_cliffrescue",
+  "location": [
+    "mountainous:camp1"
+  ],
+  "season": [
+    "any"
+  ],
+  "frequency": 2,
+  "event_text": "Hearing yowls of distress, m_c rescues a loner who was close to falling off a cliff. The grateful cat decides to join the Clan.",
+  "m_c": {
+    "age": [
+      "young adult",
+      "adult",
+      "senior adult",
+      "senior"
+    ],
+    "status": [
+      "any"
+    ]
+  },
+  "new_cat": [
+    [
+      "exists",
+      "loner"
+    ]
+  ],
+  "relationships": [
+    {
+      "cats_from": [
+        "m_c"
+      ],
+      "cats_to": [
+        "n_c:0"
+      ],
+      "mutual": true,
+      "values": [
+        "comfort",
+        "like"
+      ],
+      "amount": 10
+    },
+    {
+      "cats_from": [
+        "n_c:0"
+      ],
+      "cats_to": [
+        "m_c"
+      ],
+      "values": [
+        "trust"
+      ],
+      "amount": 10
     }
-
-
+  ],
+  "outsider": {
+    "current_rep": [
+      "welcoming"
+    ],
+    "changed": 1
+  }
+}
 ]

--- a/resources/lang/en/events/new_cat/mountainous.json
+++ b/resources/lang/en/events/new_cat/mountainous.json
@@ -161,6 +161,9 @@
       "cats_to": [
         "m_c"
       ],
+		"log": {
+			"cats_from": "m_c is curious about n_c:0 now that {PRONOUN/n_c:0/subject} {VERB/n_c:0/have/has} joined the Clan."
+		},
       "values": [
         "trust"
       ],

--- a/resources/lang/en/events/new_cat/mountainous.json
+++ b/resources/lang/en/events/new_cat/mountainous.json
@@ -117,7 +117,7 @@
     "any"
   ],
   "frequency": 2,
-  "event_text": "Hearing yowls of distress, m_c rescues a loner who was close to falling off a cliff. The grateful cat decides to join the Clan.",
+  "event_text": "Hearing yowls of distress, m_c rescues a loner from falling off a cliff. The grateful cat decides to join the Clan.",
   "m_c": {
     "age": [
       "young adult",

--- a/resources/lang/en/events/new_cat/mountainous.json
+++ b/resources/lang/en/events/new_cat/mountainous.json
@@ -144,6 +144,10 @@
         "n_c:0"
       ],
       "mutual": true,
+		"log": {
+			"cats_to": "n_c:0 was thankful that m_c saved {PRONOUN/n_c:0/object} from falling off a cliff.",
+"cats_from": "m_c saved n_c:0 from falling off a cliff and offered {PRONOUN/n_c:0/object} a place in the Clan."
+		},
       "values": [
         "comfort",
         "like"

--- a/resources/lang/en/events/new_cat/mountainous.json
+++ b/resources/lang/en/events/new_cat/mountainous.json
@@ -145,7 +145,7 @@
       ],
       "mutual": true,
 		"log": {
-			"cats_to": "n_c:0 was thankful that m_c saved {PRONOUN/n_c:0/object} from falling off a cliff.",
+			"cats_to": "m_c is curious about n_c:0 now that {PRONOUN/n_c:0/subject} {VERB/n_c:0/have/has} joined the Clan.",
 "cats_from": "m_c saved n_c:0 from falling off a cliff and offered {PRONOUN/n_c:0/object} a place in the Clan."
 		},
       "values": [
@@ -162,7 +162,7 @@
         "m_c"
       ],
 		"log": {
-			"cats_from": "m_c is curious about n_c:0 now that {PRONOUN/n_c:0/subject} {VERB/n_c:0/have/has} joined the Clan."
+			"cats_from": "n_c:0 was thankful that m_c saved {PRONOUN/n_c:0/object} from falling off a cliff."
 		},
       "values": [
         "trust"


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

Adds a variety of events that are specific to certain camps. Includes death, injury, new_cat and miscellaneous.
Specifically:
- new_cat event in cliff camp (mountainous) where a loner is rescued after almost falling off the cliff
- misc event in crystal river (mountainous) where a cat's reflection is not what it seems... [locked to cats with supernatural skills]
- injury event in shipwreck (beach) where a cat fails to climb the shipwreck and breaks their bone [climber skill cats are excluded]
- death event in shipwreck (beach) where a kitten/apprentice climbs the shipwreck to play pretend as a twoleg, but the wood below them breaks and they fall [climber skill cats are excluded]
- death event in wastelands (plains) specific to greenleaf, where a cat drinks poisoned water out of thirst and desperation

## Why This Is Good For ClanGen

Event variety! Part of an ongoing project where camp-specific events of all kinds are being written.


## Proof of Testing

**mtn_new_cat_cliffrescue**
<img width="516" height="107" alt="image" src="https://github.com/user-attachments/assets/886078bb-6996-4ab8-9016-c1e2e42b39c5" />
<img width="767" height="531" alt="image" src="https://github.com/user-attachments/assets/ccd2ee36-d30b-45b9-8f5c-4ca6a2fb9499" />
<br>
**mtn_misc_crystalreflection_supernaturalskills**
<img width="513" height="101" alt="image" src="https://github.com/user-attachments/assets/d883d5e2-8508-4ded-b1bb-95ee8abee7b8" />
<br>
**bch_injury_shipwreckfall_anymultiage1**
<img width="510" height="104" alt="image" src="https://github.com/user-attachments/assets/c938cc94-4346-479f-b490-7b411f998bbf" />
<img width="739" height="537" alt="image" src="https://github.com/user-attachments/assets/47eb31ec-4c6c-4bbd-b746-5fc57721fb2c" />
<img width="720" height="541" alt="image" src="https://github.com/user-attachments/assets/0bd3333a-c8ef-41cf-8b04-f9bbab895da6" />
<img width="765" height="656" alt="image" src="https://github.com/user-attachments/assets/095fe0dc-0564-4d18-b49a-8b54e13e6046" />
<br>
**bch_death_kitappshipwreckfall**
<img width="509" height="122" alt="image" src="https://github.com/user-attachments/assets/804acbe1-28dd-4723-83d6-956ea389208a" />
<img width="730" height="551" alt="image" src="https://github.com/user-attachments/assets/7b33ff3b-aacd-46cf-9cc2-bc017a03b9ed" />
<br>
**pln_death_poisonedwater**
<img width="511" height="124" alt="image" src="https://github.com/user-attachments/assets/1e2c84db-b83f-4257-810b-8bf639b35784" />
<img width="743" height="544" alt="image" src="https://github.com/user-attachments/assets/7f226288-b2d2-40ce-8661-93385769f65d" />


## Changelog/Credits

- New events of all kinds that are camp-specific (not just biome!) Includes death, injury, new_cat and misc. Specific camps affected by this PR are Wastelands, Shipwreck, Crystal River and Cliff.

(For credits: Vickarooni - writing shortevents :3)
