### PR TITLE
Added death events

### DIFF
--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -8531,7 +8531,13 @@
                 "cats": ["m_c"],
                 "death": "m_c was murdered by a o_c_n patrol after trespassing."
             }
-        ]
+        ],
+        "other_clan": {
+        "current_rep": [
+            "hostile",
+            "neutral"
+        ],
+        "changed": -2
     },
     {
         "event_id": "gen_death_rooster_spur",

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -8480,7 +8480,7 @@
             "no_body"
         ],
         "frequency": 2,
-        "event_text": "A heron snatched m_c when {PRONOUN/m_c/subject} was too close to the waters edge.",
+        "event_text": "A heron snatched m_c when {PRONOUN/m_c/subject} {VERB/m_c/were/was} too close to the water's edge.",
         "m_c": {
             "age": [
                 "kitten"

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -8523,7 +8523,7 @@
         "history":[
             {   
                 "cats": ["m_c"],
-                "death": "m_c was murdered by a o_c_n patrol when trespassing."
+                "death": "m_c was murdered by a o_c_n patrol after trespassing."
             }
         ]
     },

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -8453,7 +8453,7 @@
             "all_lives"
         ],
         "frequency": 2,
-        "event_text": "Whilst on a walk of the territory, m_c vanishes. All that can be found is {PRONOUN/m_c/poss} fading scent - and lynx.  ",
+        "event_text": "While out on the territory, m_c vanishes. All that can be found is {PRONOUN/m_c/poss} fading scent and the stronger scent of lynx. ",
         "m_c": {
             "age": [
                 "-kitten"

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -8560,7 +8560,10 @@
                 "fierce",
                 "loyal",
                 "bloodthirsty",
-                "strange"
+                "strange",
+                "arrogant",
+                "rebellious",
+                "troublesome"
             ],
             "dies": true
         },

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -8433,7 +8433,7 @@
         },
         "history":[
             {   
-                "cats": "m_c",
+                "cats": ["m_c"],
                 "death": "m_c was eaten by a lynx."
             }
         ]

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -8411,7 +8411,7 @@
       }
     ]
   },
-{
+  {
         "event_id": "gen_death_lynx1",
         "location": [
             "forest:camp1_camp2", 

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -8540,7 +8540,7 @@
         "tags": [ 
         ],
         "frequency": 2,
-        "event_text": "m_c testing {PRONOUN/m_c/poss} luck entered Twoleg place and attacked a chicken - only to find a rooster eager to defend his flock.",
+        "event_text": "m_c entered a Twoleg's chicken roost and attacked the hens. {PRONOUN/m_c/subject/CAP} {VERB/m_c/were/was} killed by a rooster eager to defend his flock.",
         "m_c": {
             "age": [
                 "-kitten"

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -8489,7 +8489,7 @@
         },
         "history":[
             {   
-                "cats": "m_c",
+                "cats": ["m_c"],
                 "death": "m_c was swallowed by a heron."
             }
         ]

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -8522,7 +8522,7 @@
         },
         "history":[
             {   
-                "cats": "m_c",
+                "cats": ["m_c"],
                 "death": "m_c was murdered by a o_c_n patrol when trespassing."
             }
         ]

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -8462,7 +8462,7 @@
         },
         "history":[
             {   
-                "cats": "m_c",
+                "cats": ["m_c"],
                 "death": "m_c was eaten by a lynx."
             }
         ]

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -8458,6 +8458,12 @@
             "age": [
                 "-kitten"
             ],
+            "skill": [
+                "-FIGHTER,3",
+                "-CLAIRVOYANT,1",
+                "-DREAM,1",
+                "-PROPHET,1"
+            ]
             "dies": true
         },
         "history":[
@@ -8553,7 +8559,8 @@
                 "competitive",
                 "fierce",
                 "loyal",
-                "bloodthirsty"
+                "bloodthirsty",
+                "strange"
             ],
             "dies": true
         },

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -8410,5 +8410,157 @@
         "death": "m_c disappeared alongside a Clanmate, never to be seen again."
       }
     ]
-  }
+  },
+{
+        "event_id": "gen_death_lynx1",
+        "location": [
+            "forest:camp1_camp2", 
+            "plains:camp1_camp3_camp_4", 
+            "mountain:camp1_camp2_camp4"],
+        "season": [
+            "any"
+        ],
+        "tags": [  
+            "no_body"
+        ],
+        "frequency": 1,
+        "event_text": "m_c snuck out of camp, none the wiser. Only Lynx scent is found by c_n after {PRONOUN/m_c/subject} disappeared.",
+        "m_c": {
+            "age": [
+                "kitten"
+            ],
+            "dies": true
+        },
+        "history":[
+            {   
+                "cats": "m_c",
+                "death": "m_c was eaten by a Lynx."
+            }
+        ]
+    },
+        {
+        "event_id": "gen_death_lynx2",
+        "location": [
+            "forest:camp1_camp2", 
+            "plains:camp1_camp3_camp_4", 
+            "mountain:camp1_camp2_camp4"],
+        "season": [
+            "any"
+        ],
+        "tags": [  
+            "no_body",
+            "low_lives"
+        ],
+        "frequency": 2,
+        "event_text": "Whilst on a walk of the territory, m_c vanishes. All that can be found is {PRONOUN/m_c/poss} fading scent - and Lynx.  ",
+        "m_c": {
+            "age": [
+                "-kitten"
+            ],
+            "dies": true
+        },
+        "history":[
+            {   
+                "cats": "m_c",
+                "death": "m_c was eaten by a Lynx."
+            }
+        ]
+    },
+    {
+        "event_id": "gen_death_heron",
+        "location": [
+            "forest:camp_4",
+            "wetlands"
+        ],
+        "season": [
+            "any"
+        ],
+        "tags": [  
+            "no_body"
+        ],
+        "frequency": 2,
+        "event_text": "A Heron snatched m_c when {PRONOUN/m_c/subject} was too close to the water's edge.",
+        "m_c": {
+            "age": [
+                "kitten"
+            ],
+            "dies": true
+        },
+        "history":[
+            {   
+                "cats": "m_c",
+                "death": "m_c was swallowed by a Heron."
+            }
+        ]
+    },
+    {
+        "event_id": "gen_death_dare_kit",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "tags": [   ],
+        "frequency": 1,
+        "event_text": "m_c slips out of camp on a dare - c_n finds m_c cooling body encircled by o_c_n scent.",
+        "m_c": {
+            "age": [
+                "kitten"
+            ],
+            "trait": [
+                "attention-seeker",
+                "self-conscious",
+                "unruly",
+                "know-it-all",
+                "noisy",
+                "fearless",
+                "daydreamer"
+            ],
+            "dies": true
+        },
+        "history":[
+            {   
+                "cats": "m_c",
+                "death": "m_c was murdered by a o_c_n patrol trespassing."
+            }
+        ]
+    },
+    {
+        "event_id": "gen_death_rooster_spur.",
+        "location": [
+            "forest", 
+            "plains"
+            ],
+        "season": [
+            "leaf-fall",
+            "leaf-bare"
+        ],
+        "tags": [ 
+        ],
+        "frequency": 2,
+        "event_text": "m_c testing {PRONOUN/m_c/poss} luck entered Twoleg, and attacked a chicken - only to find a rooster eager to defend his flock.",
+        "m_c": {
+            "age": [
+                "-kitten"
+            ],
+            "trait": [
+                "adventurous",
+                "ambitious",
+                "bold",
+                "daring",
+                "competitive",
+                "fierce",
+                "loyal",
+                "bloodthirsty"
+            ],
+            "dies": true
+        },
+        "history":[
+            {   
+                "cats": "m_c",
+                "death": "m_c was killed by a Rooster defending his flock."
+            }
+        ]
+    }
 ]

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -8504,7 +8504,7 @@
         ],
         "tags": [   ],
         "frequency": 1,
-        "event_text": "m_c slips out of camp on a dare - c_n finds m_c's cooling body encircled by o_c_n scent.",
+        "event_text": "m_c slips out of camp on a dare. c_n finds m_c's cooling body encircled by o_c_n scent.",
         "m_c": {
             "age": [
                 "kitten"

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -8424,7 +8424,7 @@
             "no_body"
         ],
         "frequency": 1,
-        "event_text": "m_c snuck out of camp, none the wiser to lay outside. Only Lynx scent is found by c_n after {PRONOUN/m_c/subject} disappeared.",
+        "event_text": "m_c sneaks out of camp. c_n's search parties find the scent of lynx and no sign of the missing kit.",
         "m_c": {
             "age": [
                 "kitten"

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -8528,7 +8528,7 @@
         ]
     },
     {
-        "event_id": "gen_death_rooster_spur.",
+        "event_id": "gen_death_rooster_spur",
         "location": [
             "forest", 
             "plains"

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -8424,7 +8424,7 @@
             "no_body"
         ],
         "frequency": 1,
-        "event_text": "m_c snuck out of camp, none the wiser. Only Lynx scent is found by c_n after {PRONOUN/m_c/subject} disappeared.",
+        "event_text": "m_c snuck out of camp, none the wiser to lay outside. Only Lynx scent is found by c_n after {PRONOUN/m_c/subject} disappeared.",
         "m_c": {
             "age": [
                 "kitten"
@@ -8434,7 +8434,7 @@
         "history":[
             {   
                 "cats": "m_c",
-                "death": "m_c was eaten by a Lynx."
+                "death": "m_c was eaten by a lynx."
             }
         ]
     },
@@ -8449,10 +8449,11 @@
         ],
         "tags": [  
             "no_body",
-            "low_lives"
+            "low_lives",
+            "all_lives"
         ],
         "frequency": 2,
-        "event_text": "Whilst on a walk of the territory, m_c vanishes. All that can be found is {PRONOUN/m_c/poss} fading scent - and Lynx.  ",
+        "event_text": "Whilst on a walk of the territory, m_c vanishes. All that can be found is {PRONOUN/m_c/poss} fading scent - and lynx.  ",
         "m_c": {
             "age": [
                 "-kitten"
@@ -8462,7 +8463,7 @@
         "history":[
             {   
                 "cats": "m_c",
-                "death": "m_c was eaten by a Lynx."
+                "death": "m_c was eaten by a lynx."
             }
         ]
     },
@@ -8479,7 +8480,7 @@
             "no_body"
         ],
         "frequency": 2,
-        "event_text": "A Heron snatched m_c when {PRONOUN/m_c/subject} was too close to the water's edge.",
+        "event_text": "A heron snatched m_c when {PRONOUN/m_c/subject} was too close to the waters edge.",
         "m_c": {
             "age": [
                 "kitten"
@@ -8489,7 +8490,7 @@
         "history":[
             {   
                 "cats": "m_c",
-                "death": "m_c was swallowed by a Heron."
+                "death": "m_c was swallowed by a heron."
             }
         ]
     },
@@ -8503,7 +8504,7 @@
         ],
         "tags": [   ],
         "frequency": 1,
-        "event_text": "m_c slips out of camp on a dare - c_n finds m_c cooling body encircled by o_c_n scent.",
+        "event_text": "m_c slips out of camp on a dare - c_n finds m_c's cooling body encircled by o_c_n scent.",
         "m_c": {
             "age": [
                 "kitten"
@@ -8522,7 +8523,7 @@
         "history":[
             {   
                 "cats": "m_c",
-                "death": "m_c was murdered by a o_c_n patrol trespassing."
+                "death": "m_c was murdered by a o_c_n patrol when trespassing."
             }
         ]
     },
@@ -8539,7 +8540,7 @@
         "tags": [ 
         ],
         "frequency": 2,
-        "event_text": "m_c testing {PRONOUN/m_c/poss} luck entered Twoleg, and attacked a chicken - only to find a rooster eager to defend his flock.",
+        "event_text": "m_c testing {PRONOUN/m_c/poss} luck entered Twoleg place and attacked a chicken - only to find a rooster eager to defend his flock.",
         "m_c": {
             "age": [
                 "-kitten"
@@ -8559,7 +8560,7 @@
         "history":[
             {   
                 "cats": "m_c",
-                "death": "m_c was killed by a Rooster defending his flock."
+                "death": "m_c was killed by a rooster defending his flock."
             }
         ]
     }


### PR DESCRIPTION


## About The Pull Request

Adds more death events

- Two Lynx based deaths, one for kits and one for older cats.

- A chicken hunt gone wrong, rooster takes action.

-A kit Heron death limited to the Lakeside camp. 

- A kit dared to leave camp winds them on other clans borders (this one is inspired by the patrol where you find other clan kits)


## Why This Is Good For ClanGen

More flavour in death types for clangen.

## Proof of 
<img width="515" height="105" alt="Screenshot 2026-04-15 at 03 04 47" src="https://github.com/user-attachments/assets/4e5d01fd-fac9-4509-9790-579ad15bdbf9" />
Testing

<img width="506" height="105" alt="Screenshot 2026-04-15 at 03 17 48" src="https://github.com/user-attachments/assets/62c18a4a-4547-4763-821f-e48a107f87ed" />

<img width="520" height="102" alt="Screenshot 2026-04-15 at 00 57 25" src="https://github.com/user-attachments/assets/370b1b5f-0e35-42bb-be41-0a581e6da892" />
<img width="513" height="102" alt="Screenshot 2026-04-15 at 01 06 45" src="https://github.com/user-attachments/assets/2cdea404-cf2c-4007-966f-3ed5f494e59f" />
<img width="504" height="99" alt="Screenshot 2026-04-15 at 01 56 09" src="https://github.com/user-attachments/assets/3468a326-9961-4b77-b5d8-c19836b74139" />



## Changelog/Credits

<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
