### PR TITLE
[CONTENT] Seasonal Beach Herb-Gathering Patrols

### DIFF
--- a/resources/lang/en/patrols/beach/med/greenleaf.json
+++ b/resources/lang/en/patrols/beach/med/greenleaf.json
@@ -32,7 +32,7 @@
     "decline_text": "A warrior catches up with p_l, explaining that {PRONOUN/p_l/subject}{VERB/p_l/'re/'s} needed in camp. {PRONOUN/p_l/subject} {VERB/p_l/turn/turns} around.",
     "success_outcomes": [
         {
-    "text": "Nestled in a shaded nook next to a hillside, the magenta flowers and characteristic speckled leaves catch p_l almost by surprise. Quickly, {PRONOUN/p_l/subject} work{VERB/p_l//s} to harvest as much as {PRONOUN/p_l/subject} dare{VERB/p_l//s}, as if the lungwort could evaporate. Like dew in greenleaf.",
+    "text": "Nestled in a shaded nook next to a hillside, the magenta flowers and characteristic speckled leaves catch p_l almost by surprise. Quickly, {PRONOUN/p_l/subject} {VERB/p_l/work/works} to harvest as much as {PRONOUN/p_l/subject} {VERB/p_l/dare/dares}, as if the lungwort could evaporate like dew in greenleaf.",
     "exp": 20,
     "frequency": 4,
     "herbs": ["lungwort"],
@@ -47,7 +47,7 @@
     "art": "fst_hunt_heat_solo_medcat"
     },
      {
-    "text": "That plant is lungwort, as invaluable as it is elusive. p_l searches, without luck, until the greenleaf heat grows too oppressive. Then {PRONOUN/p_l/subject} slink{VERB/p_l//s} back to camp on unsteady paws, panting. Maybe {PRONOUN/p_l/subject} stayed out there a little too long.",
+    "text": "That plant is lungwort, as invaluable as it is elusive. p_l searches, without luck, until the greenleaf heat grows too oppressive. Then {PRONOUN/p_l/subject} {VERB/p_l/slink/slinks} back to camp on unsteady paws, panting. Maybe {PRONOUN/p_l/subject} stayed out there a little too long.",
     "exp": 0,
     "frequency": 2,
     "injury": [
@@ -79,8 +79,7 @@
         }
     ],
     "history_text": {
-        "death": "p_l died from heat stroke after searching for lungwort in the greenleaf heat.",
-        "scars": "p_l was scarred by heatstroke?"
+        "death": "p_l died from heat stroke after searching for lungwort in the greenleaf heat."
     },
     "art": "fst_hunt_heat_solo_medcat"
 }
@@ -117,7 +116,7 @@
     },
     "frequency": 3,
     "chance_of_success": 50,
-    "intro_text": "The ocean quiets to a dull murmur behind p_l as {PRONOUN/p_l/subject} trek{VERB/p_l//s} up the hill to the heathlands. app1 pants behind {PRONOUN/p_l/object} under the blazing sun. Vibrant, violet heather in full bloom surrounds them, scattered with evergreen crowberry shrubs. But p_l only has eyes for one plant today, and won't let app1 get distracted by the rare orchids or wolf's bane.",
+    "intro_text": "The ocean quiets to a dull murmur behind p_l as {PRONOUN/p_l/subject} {VERB/p_l/trek/treks} up the hill to the heathlands. app1 pants behind {PRONOUN/p_l/object} under the blazing sun. Vibrant, violet heather in full bloom surrounds them, scattered with evergreen crowberry shrubs. But p_l only has eyes for one plant today and won't let app1 get distracted by the rare orchids or wolf's bane.",
     "decline_text": "A warrior catches up with p_l, explaining that {PRONOUN/p_l/subject}{VERB/p_l/'re/'s} needed in camp. They turn around.",
     "success_outcomes": [
         {
@@ -149,7 +148,7 @@
     "art": "gen_med_and_app"
     },
      {
-    "text": "The noonday sun beats down on p_l and app1, casting a shimmer across the heath. They take more and more frequent breaks, but are unable to find any shade in the treeless expanse. At some point, p_l takes a closer look at app1 and decides they are heading back. That's a clear case of heat exhaustion.",
+    "text": "The noonday sun beats down on p_l and app1, casting a shimmer across the heath. They take more and more frequent breaks but are unable to find any shade in the treeless expanse. At some point, p_l takes a closer look at app1 and decides they are heading back. That's a clear case of heat exhaustion.",
     "exp": 0,
     "frequency": 2,
     "injury": [
@@ -161,8 +160,7 @@
         }
     ],
     "history_text": {
-        "death": "app1 died from heat exhaustion after searching for lungwort in the greenleaf heat.",
-        "scars": "app1 was scarred on patrol"
+        "death": "app1 died from heat exhaustion after searching for lungwort in the greenleaf heat."
     },
     "art": "fst_hunt_heat_app_medcat"
 }

--- a/resources/lang/en/patrols/beach/med/greenleaf.json
+++ b/resources/lang/en/patrols/beach/med/greenleaf.json
@@ -1,2 +1,172 @@
 [
+    {
+    "patrol_id": "bch_med_greenleaflungwort1",
+    "biome": ["beach"],
+    "season": ["greenleaf"],
+    "types": ["herb_gathering"],
+    "tags": [],
+    "patrol_art": "fst_med_herblocation2",
+    "min_cats": 1,
+    "max_cats": 1,
+    "min_max_status": {
+        "apprentice": [
+            -1,
+            -1
+        ],
+        "medicine cat apprentice": [
+            -1,
+            -1
+        ],
+        "medicine cat": [
+            1,
+            1
+        ],
+        "normal adult": [
+            -1,
+            -1
+        ]
+    },
+    "frequency": 3,
+    "chance_of_success": 50,
+    "intro_text": "The ocean quiets to a dull murmur behind p_l as {PRONOUN/p_l/subject} {VERB/p_l/trek/treks} up the hill to the heathlands under the blazing sun. Vibrant, violet heather in full bloom surrounds {PRONOUN/p_l/object}, scattered with evergreen crowberry shrubs. But p_l only has eyes for one plant today.",
+    "decline_text": "A warrior catches up with p_l, explaining that {PRONOUN/p_l/subject}{VERB/p_l/'re/'s} needed in camp. {PRONOUN/p_l/subject} {VERB/p_l/turn/turns} around.",
+    "success_outcomes": [
+        {
+    "text": "Nestled in a shaded nook next to a hillside, the magenta flowers and characteristic speckled leaves catch p_l almost by surprise. Quickly, {PRONOUN/p_l/subject} work{VERB/p_l//s} to harvest as much as {PRONOUN/p_l/subject} dare{VERB/p_l//s}, as if the lungwort could evaporate. Like dew in greenleaf.",
+    "exp": 20,
+    "frequency": 4,
+    "herbs": ["lungwort"],
+    "art": "gen_med_gatheringlungwort"
+}
+    ],
+    "fail_outcomes": [
+        {
+    "text": "There are so many flowers here, both rare and beautiful. But none they find have speckled leaves. None are lungwort. The sun has moved far when p_l finally gives up and heads home, tail drooping.",
+    "exp": 0,
+    "frequency": 4,
+    "art": "fst_hunt_heat_solo_medcat"
+    },
+     {
+    "text": "That plant is lungwort, as invaluable as it is elusive. p_l searches, without luck, until the greenleaf heat grows too oppressive. Then {PRONOUN/p_l/subject} slink{VERB/p_l//s} back to camp on unsteady paws, panting. Maybe {PRONOUN/p_l/subject} stayed out there a little too long.",
+    "exp": 0,
+    "frequency": 2,
+    "injury": [
+        {
+            "cats": ["p_l"],
+            "injuries": ["heat exhaustion"],
+            "scars": [],
+            "no_results": false
+        }
+    ],
+    "history_text": {
+        "death": "p_l died from heat exhaustion after searching for lungwort in the greenleaf heat.",
+        "scars": "p_l was scarred on patrol"
+    },
+    "art": "fst_hunt_heat_solo_medcat"
+},
+
+     {
+    "text": "That plant is lungwort, as invaluable as it is elusive. p_l searches stubbornly, without luck, even as the greenleaf heat grows ever more oppressive. It's only after {PRONOUN/p_l/poss} paws get unsteady that {PRONOUN/p_l/subject} stumble{VERB/p_l//s} back to camp, panting.",
+    "exp": 0,
+    "frequency": 2,
+    "stat_trait": ["rebellious","oblivious","flamboyant","fierce","competitive","bold","daring","adventurous","ambitious","confident","arrogant","righteous"],
+    "injury": [
+        {
+            "cats": ["p_l"],
+            "injuries": ["heat stroke"],
+            "scars": [],
+            "no_results": false
+        }
+    ],
+    "history_text": {
+        "death": "p_l died from heat stroke after searching for lungwort in the greenleaf heat.",
+        "scars": "p_l was scarred by heatstroke?"
+    },
+    "art": "fst_hunt_heat_solo_medcat"
+}
+]
+},
+
+
+    {
+    "patrol_id": "bch_med_greenleaflungwort2",
+    "biome": ["beach"],
+    "season": ["greenleaf"],
+    "types": ["herb_gathering"],
+    "tags": [],
+    "patrol_art": "gen_med_and_app",
+    "min_cats": 2,
+    "max_cats": 2,
+    "min_max_status": {
+        "apprentice": [
+            -1,
+            -1
+        ],
+        "medicine cat apprentice": [
+            1,
+            1
+        ],
+        "medicine cat": [
+            1,
+            1
+        ],
+        "normal adult": [
+            -1,
+            -1
+        ]
+    },
+    "frequency": 3,
+    "chance_of_success": 50,
+    "intro_text": "The ocean quiets to a dull murmur behind p_l as {PRONOUN/p_l/subject} trek{VERB/p_l//s} up the hill to the heathlands. app1 pants behind {PRONOUN/p_l/object} under the blazing sun. Vibrant, violet heather in full bloom surrounds them, scattered with evergreen crowberry shrubs. But p_l only has eyes for one plant today, and won't let app1 get distracted by the rare orchids or wolf's bane.",
+    "decline_text": "A warrior catches up with p_l, explaining that {PRONOUN/p_l/subject}{VERB/p_l/'re/'s} needed in camp. They turn around.",
+    "success_outcomes": [
+        {
+    "text": "They are here for lungwort, and eventually find a small patch in a large heather shrub's shade. But no matter how small it is, a medicine cat always leaves some plants untouched, p_l teaches. They ought to be able to regenerate. Else app1 will stand there, next greenleaf, without lungwort. And c_n cannot afford to be without lungwort.",
+    "exp": 20,
+    "frequency": 4,
+    "herbs": ["lungwort"],
+    
+    "relationships": [
+    { 
+    "cats_from": ["app1"],
+    "cats_to": ["p_l"],
+    "mutual": false,
+    "values": ["trust","respect"],
+    "amount": 8,
+    "log": {
+    "cats_from": "cat_from learned about the importance of leaving some plants alone to regenerate, and gained new insights into the responsibilities of a medicine cat."
+    }
+    }
+    ],
+    "art": "gen_med_gatheringlungwort"
+}
+    ],
+    "fail_outcomes": [
+        {
+    "text": "There are so many flowers here, both rare and beautiful. app1 recites their names as they pass them. But none they find have speckled leaves. None are lungwort. The sun has moved far when p_l finally gives up and they turn home, tails drooping.",
+    "exp": 0,
+    "frequency": 4,
+    "art": "gen_med_and_app"
+    },
+     {
+    "text": "The noonday sun beats down on p_l and app1, casting a shimmer across the heath. They take more and more frequent breaks, but are unable to find any shade in the treeless expanse. At some point, p_l takes a closer look at app1 and decides they are heading back. That's a clear case of heat exhaustion.",
+    "exp": 0,
+    "frequency": 2,
+    "injury": [
+        {
+            "cats": ["app1"],
+            "injuries": ["heat exhaustion"],
+            "scars": [],
+            "no_results": false
+        }
+    ],
+    "history_text": {
+        "death": "app1 died from heat exhaustion after searching for lungwort in the greenleaf heat.",
+        "scars": "app1 was scarred on patrol"
+    },
+    "art": "fst_hunt_heat_app_medcat"
+}
+]
+}
+
 ]

--- a/resources/lang/en/patrols/beach/med/greenleaf.json
+++ b/resources/lang/en/patrols/beach/med/greenleaf.json
@@ -122,7 +122,7 @@
     "success_outcomes": [
         {
     "text": "They are here for lungwort, and eventually find a small patch in a large heather shrub's shade. But no matter how small it is, a medicine cat always leaves some plants untouched, p_l teaches. They ought to be able to regenerate. Else app1 will stand there, next greenleaf, without lungwort. And c_n cannot afford to be without lungwort.",
-    "exp": 20,
+    "exp": 25,
     "frequency": 4,
     "herbs": ["lungwort"],
     

--- a/resources/lang/en/patrols/beach/med/greenleaf.json
+++ b/resources/lang/en/patrols/beach/med/greenleaf.json
@@ -29,7 +29,7 @@
     "frequency": 3,
     "chance_of_success": 50,
     "intro_text": "The ocean quiets to a dull murmur behind p_l as {PRONOUN/p_l/subject} {VERB/p_l/trek/treks} up the hill to the heathlands under the blazing sun. Vibrant, violet heather in full bloom surrounds {PRONOUN/p_l/object}, scattered with evergreen crowberry shrubs. But p_l only has eyes for one plant today.",
-    "decline_text": "A warrior catches up with p_l, explaining that {PRONOUN/p_l/subject}{VERB/p_l/'re/'s} needed in camp. {PRONOUN/p_l/subject} {VERB/p_l/turn/turns} around.",
+    "decline_text": "A warrior catches up with p_l, explaining that {PRONOUN/p_l/subject}{VERB/p_l/'re/'s} needed in camp. {PRONOUN/p_l/subject/CAP} {VERB/p_l/turn/turns} around.",
     "success_outcomes": [
         {
     "text": "Nestled in a shaded nook next to a hillside, the magenta flowers and characteristic speckled leaves catch p_l almost by surprise. Quickly, {PRONOUN/p_l/subject} {VERB/p_l/work/works} to harvest as much as {PRONOUN/p_l/subject} {VERB/p_l/dare/dares}, as if the lungwort could evaporate like dew in greenleaf.",

--- a/resources/lang/en/patrols/beach/med/leaf-fall.json
+++ b/resources/lang/en/patrols/beach/med/leaf-fall.json
@@ -34,7 +34,7 @@
     "decline_text": "Actually, ragwort can wait, because the storm won't. p_l heads directly back to camp.",
     "success_outcomes": [
     {
-    "text": "It still flowers late into the season, when most trees have already shed their leaves. Tall and bright yellow, it's also easy to identify by an unpleasant scent. Ragwort is a vital herb for joint pain and general strength, p_l reminds {PRONOUN/p_l/self}, but that doesn't quite lessen the foul taste of the leaf-covered stems in {PRONOUN/p_l/poss} mouth. Nonetheless, p_l has them safely stored away by the time the thunder growls overhead.",
+    "text": "It still flowers late into the season, when most trees have already shed their leaves. Tall and bright yellow, it's also easy to identify by an unpleasant scent. Ragwort is a vital herb for joint pain and general strength, p_l reminds {PRONOUN/p_l/self}, but that doesn't quite lessen the foul taste of the leaf-covered stems in {PRONOUN/p_l/poss} mouth. By the time the thunder growls overhead, p_l has it safely stored away.",
     "exp": 20,
     "frequency": 4,
     "herbs": ["ragwort"],
@@ -148,7 +148,7 @@
     "decline_text": "Actually, ragwort can wait, because the storm won't. p_l and r_c turn back to camp.",
     "success_outcomes": [
     {
-    "text": "Ragwort still flowers late into the season, when most trees have already shed their leaves, p_l explains. Tall and bright yellow, it's also easy to identify by an unpleasant scent. It's a vital herb for joint pain and general strength, p_l reminds r_c (and {PRONOUN/p_l/self}), but that doesn't quite lessen the foul taste of the leaf-covered stems as they hurry back to camp. Nevertheless, p_l has it safely stored away by the time the thunder growls overhead.",
+    "text": "Thankfully, ragwort still flowers late into the season. It's a vital herb for joint pain and general strength, p_l reminds r_c (and {PRONOUN/p_l/self}), but that doesn't quite lessen the foul taste of the leaf-covered stems as they hurry back to camp. By the time the thunder growls overhead, p_l has it safely stored away.",
     "exp": 25,
     "frequency": 4,
     "herbs": ["ragwort"],

--- a/resources/lang/en/patrols/beach/med/leaf-fall.json
+++ b/resources/lang/en/patrols/beach/med/leaf-fall.json
@@ -1,2 +1,179 @@
 [
+{
+    "patrol_id": "bch_med_leaffallragwort1",
+    "biome": ["beach"],
+    "season": ["leaf-fall"],
+    "types": ["herb_gathering"],
+    "tags": [],
+    "patrol_art": "med_cat_looking_up",
+    "min_cats": 1,
+    "max_cats": 1,
+    "min_max_status": {
+        "apprentice": [
+            -1,
+            -1
+        ],
+        "medicine cat apprentice": [
+            -1,
+            -1
+        ],
+        "medicine cat": [
+            1,
+            1
+        ],
+        "normal adult": [
+            -1,
+            -1
+        ]
+    },
+    "frequency": 3,
+    "chance_of_success": 50,
+    "relationship_constraint": [],
+    "pl_skill_constraint": [],
+    "intro_text": "Dark clouds gather on the seaward horizon. p_l walks through the sand, weaving from dune to dune, eager to be back before the storm hits. But not without ragwort.",
+    "decline_text": "Actually, ragwort can wait, because the storm won't. p_l heads directly back to camp.",
+    "success_outcomes": [
+    {
+    "text": "It still flowers late into the season, when most trees have already shed their leaves. Tall and bright yellow, it's also easy to identify by an unpleasant scent. Ragwort is a vital herb for joint pain and general strength, p_l reminds {PRONOUN/p_l/self}, but that doesn't quite lessen the foul taste of the leaf-covered stems in {PRONOUN/p_l/poss} mouth. Nonetheless, p_l has them safely stored away by the time the thunder growls overhead.",
+    "exp": 20,
+    "frequency": 4,
+    "herbs": ["ragwort"],
+    "art": "running_med2"
+    }
+    ],
+    "fail_outcomes": [
+    {
+    "text": "It should be here, its bright yellow flowers like little suns lightening the gloom. But Patrol Leader can't seem to find any ragwort, and the gusts of wind are whipping away any scent {PRONOUN/p_l/subject} could follow. Lightning flashes behind {PRONOUN/p_l/object} as {PRONOUN/p_l/subject} {VERB/p_l/sprint/sprints} for camp, returning half-drenched and ragwortless.",
+    "exp": 0,
+    "frequency": 4,
+    "art": "gen_med_rainygathering"
+    }
+    ]
+},
+
+{
+    "patrol_id": "bch_med_leaffallragwort2",
+    "biome": ["beach"],
+    "season": ["leaf-fall"],
+    "types": ["herb_gathering"],
+    "tags": [],
+    "patrol_art": "gen_train_talkingAM",
+    "min_cats": 2,
+    "max_cats": 2,
+    "min_max_status": {
+        "apprentice": [
+            -1,
+            -1
+        ],
+        "medicine cat apprentice": [
+            1,
+            1
+        ],
+        "medicine cat": [
+            1,
+            1
+        ],
+        "normal adult": [
+            -1,
+            -1
+        ]
+    },
+    "frequency": 3,
+    "chance_of_success": 50,
+    "relationship_constraint": [],
+    "pl_skill_constraint": [],
+    "intro_text": "Dark clouds gather on the seaward horizon. p_l walks through the sand, weaving from dune to dune, eager to be back before the storm hits. app1 tails {PRONOUN/p_l/object} attentively, and p_l quizzes {PRONOUN/app1/object} on the identification and notable properties of ragwort.",
+    "decline_text": "Actually, ragwort can wait, because the storm won't. p_l leads app1 back to camp.",
+    "success_outcomes": [
+    {
+    "text": "It still flowers late into the season, when most trees have already shed their leaves. Tall and bright yellow, it's also easy to identify by its unpleasant scent. Ragwort is a vital herb for joint pain and general strength, app1 concludes. p_l purrs and directs {PRONOUN/app1/object} on its harvest. Ignoring the noxious taste, they have it safely stored away by the time the thunder growls overhead.",
+    "exp": 25,
+    "frequency": 4,
+    "herbs": ["ragwort"],
+    "relationships": [
+    { 
+    "cats_from": ["p_l"],
+    "cats_to": ["app1"],
+    "mutual": true,
+    "values": ["trust","respect"],
+    "amount": 6,
+    "log": {
+    "cats_from": "Sharing the burden of ragwort's foul taste brought cat_from and cat_to closer together, and led cat_from to make note of their apprentice's dutifulness."
+    }
+    }
+    ],
+    "art": "running_med_app"
+    }
+    ],
+    "fail_outcomes": [
+    {
+    "text": "It should be here, its bright yellow flowers like little suns lightening the gloom. But p_l can't seem to find any ragwort, and the gusts of wind are whipping away any scent {PRONOUN/p_l/subject} could follow. Thunder growls and the first scattering of raindrops hits app1's coat. {PRONOUN/p_l/poss/CAP} eyes widen. Lightning flashes behind the two cats as they sprint for camp, returning half-drenched and ragwortless.",
+    "exp": 0,
+    "frequency": 4,
+    "art": "gen_med_rainygathering"
+    }
+    ]
+},
+
+{
+    "patrol_id": "bch_med_leaffallragwort3",
+    "biome": ["beach"],
+    "season": ["leaf-fall"],
+    "types": ["herb_gathering"],
+    "tags": [],
+    "patrol_art": "gen_bord_flashflood",
+    "min_cats": 2,
+    "max_cats": 2,
+    "min_max_status": {
+        "apprentice": [
+            -1,
+            -1
+        ],
+        "medicine cat apprentice": [
+            -1,
+            -1
+        ],
+        "medicine cat": [
+            1,
+            1
+        ],
+        "warrior": [
+            1,
+            1
+        ]
+    },
+    "frequency": 3,
+    "chance_of_success": 50,
+    "intro_text": "Dark clouds gather on the seaward horizon. p_l walks through the sand, weaving from dune to dune, eager to be back before the storm hits. But not without ragwort. {PRONOUN/p_l/poss/CAP} warrior companion pads along behind, warily glancing at the sky and p_l in turns.",
+    "decline_text": "Actually, ragwort can wait, because the storm won't. p_l and r_c turn back to camp.",
+    "success_outcomes": [
+    {
+    "text": "Ragwort still flowers late into the season, when most trees have already shed their leaves, p_l explains. Tall and bright yellow, it's also easy to identify by an unpleasant scent. It's a vital herb for joint pain and general strength, p_l reminds r_c (and {PRONOUN/p_l/self}), but that doesn't quite lessen the foul taste of the leaf-covered stems as they hurry back to camp. Nevertheless, p_l has it safely stored away by the time the thunder growls overhead.",
+    "exp": 25,
+    "frequency": 4,
+    "herbs": ["ragwort"],
+    "relationships": [
+    { 
+    "cats_from": ["p_l"],
+    "cats_to": ["r_c"],
+    "mutual": true,
+    "values": ["comfort","respect"],
+    "amount": 6,
+    "log": {
+    "cats_from": "Sharing the burden of ragwort's foul taste brought cat_from and cat_to closer together and gave them a new appreciation for each other's roles in c_n."
+    }
+    }
+    ],
+    "art": "running_med_warrior"
+    }
+    ],
+    "fail_outcomes": [
+    {
+    "text": "It should be here, its bright yellow flowers like little suns lightening the gloom. But p_l can't seem to find any ragwort, and the gusts of wind are whipping away any scent {PRONOUN/p_l/subject} could follow. Lightning flashes behind the two of them as they sprint for camp, returning half-drenched and ragwortless.",
+    "exp": 0,
+    "frequency": 4,
+    "art": "gen_med_rainygathering"
+    }
+    ]
+}
 ]

--- a/resources/lang/en/patrols/beach/med/leaf-fall.json
+++ b/resources/lang/en/patrols/beach/med/leaf-fall.json
@@ -43,7 +43,7 @@
     ],
     "fail_outcomes": [
     {
-    "text": "It should be here, its bright yellow flowers like little suns lightening the gloom. But Patrol Leader can't seem to find any ragwort, and the gusts of wind are whipping away any scent {PRONOUN/p_l/subject} could follow. Lightning flashes behind {PRONOUN/p_l/object} as {PRONOUN/p_l/subject} {VERB/p_l/sprint/sprints} for camp, returning half-drenched and ragwortless.",
+    "text": "It should be here, its bright yellow flowers like little suns brightening the gloom. But p_l can't seem to find any ragwort, and the gusts of wind whip away any scent {PRONOUN/p_l/subject} could follow. Lightning flashes behind {PRONOUN/p_l/object} as {PRONOUN/p_l/subject} {VERB/p_l/sprint/sprints} for camp, returning half-drenched and ragwortless.",
     "exp": 0,
     "frequency": 4,
     "art": "gen_med_rainygathering"
@@ -98,7 +98,7 @@
     "values": ["trust","respect"],
     "amount": 6,
     "log": {
-    "cats_from": "Sharing the burden of ragwort's foul taste brought cat_from and cat_to closer together, and led cat_from to make note of their apprentice's dutifulness."
+    "cats_from": "Sharing the burden of ragwort's foul taste brought cat_from and cat_to closer together, and cat_from noted {PRONOUN/cat_from/poss} apprentice's dutifulness."
     }
     }
     ],
@@ -107,7 +107,7 @@
     ],
     "fail_outcomes": [
     {
-    "text": "It should be here, its bright yellow flowers like little suns lightening the gloom. But p_l can't seem to find any ragwort, and the gusts of wind are whipping away any scent {PRONOUN/p_l/subject} could follow. Thunder growls and the first scattering of raindrops hits app1's coat. {PRONOUN/p_l/poss/CAP} eyes widen. Lightning flashes behind the two cats as they sprint for camp, returning half-drenched and ragwortless.",
+    "text": "It should be here, its bright yellow flowers like little suns brightening the gloom. But p_l can't seem to find any ragwort, and the gusts of wind whip away any scent {PRONOUN/p_l/subject} could follow. Thunder growls, and the first scattering of raindrops hits app1's coat. p_l's eyes widen. Lightning flashes behind the two cats as they sprint for camp, returning half-drenched and ragwortless.",
     "exp": 0,
     "frequency": 4,
     "art": "gen_med_rainygathering"
@@ -169,7 +169,7 @@
     ],
     "fail_outcomes": [
     {
-    "text": "It should be here, its bright yellow flowers like little suns lightening the gloom. But p_l can't seem to find any ragwort, and the gusts of wind are whipping away any scent {PRONOUN/p_l/subject} could follow. Lightning flashes behind the two of them as they sprint for camp, returning half-drenched and ragwortless.",
+    "text": "It should be here, its bright yellow flowers like little suns brightening the gloom. But p_l can't seem to find any ragwort, and the gusts of wind whip away any scent {PRONOUN/p_l/subject} could follow. Lightning flashes behind the two of them as they sprint for camp, returning half-drenched and ragwortless.",
     "exp": 0,
     "frequency": 4,
     "art": "gen_med_rainygathering"

--- a/resources/lang/en/patrols/beach/med/newleaf.json
+++ b/resources/lang/en/patrols/beach/med/newleaf.json
@@ -33,7 +33,7 @@
     "success_outcomes": [
         {
     "text": "The long, pointed narrow leaves, the characteristic brown bulbs with tiny white flowers... sea plantain isn't hard to recognize, once newleaf arrives. p_l is relieved to find it nonetheless, and chews off as many leaves as {PRONOUN/p_l/subject} can fit in {PRONOUN/p_l/poss} mouth. ",
-    "exp": 15,
+    "exp": 20,
     "frequency": 4,
     "herbs": ["plantain"],
     "art": "gen_med_gatheringplantain_greenleaf1"
@@ -117,7 +117,7 @@
     "success_outcomes": [
         {
     "text": "Plantain is especially good against the insect bites common in greenleaf. The days are still lengthening, but a medicine cat always has to look toward the next season as well as the Clan's present needs. app1 can only twitch an ear in agreement, carrying the bulk of the leaves home while p_l teaches.",
-    "exp": 20,
+    "exp": 25,
     "frequency": 4,
     "herbs": ["plantain"],
     "relationships": [

--- a/resources/lang/en/patrols/beach/med/newleaf.json
+++ b/resources/lang/en/patrols/beach/med/newleaf.json
@@ -28,11 +28,11 @@
     },
     "frequency": 3,
     "chance_of_success": 50,
-    "intro_text": "Sea-scented mist blows across the salt meadow in damp gusts. p_l's whiskers are beading with water as {PRONOUN/p_l/subject} stalk{VERB/p_l//s} through the growing grass, fixating plant by plant, scanning for the right herb.",
-    "decline_text": "The fog quickly gets much worse, and p_l turns right around. {PRONOUN/p_l/subject/CAP} won't find any herbs like this.",
+    "intro_text": "Sea-scented mist blows across the salt meadow in damp gusts. p_l's whiskers bead with water as {PRONOUN/p_l/subject} {VERB/p_l/stalk/stalks} through the growing grass, fixating on each plant in turn, scanning for the right herb.",
+    "decline_text": "The fog thickens, and p_l turns right around. {PRONOUN/p_l/subject/CAP} won't find any herbs like this.",
     "success_outcomes": [
         {
-    "text": "The long, pointed narrow leaves, the characteristic brown bulbs with tiny white flowers... sea plantain isn't hard to recognize, once newleaf arrives. p_l is relieved to find it nonetheless, and chews off as many leaves as {PRONOUN/p_l/subject} can fit in {PRONOUN/p_l/poss} mouth. ",
+    "text": "The long, pointed narrow leaves, the characteristic brown bulbs with tiny white flowers... Sea plantain isn't hard to recognize, once newleaf arrives. p_l is relieved to find it nonetheless and chews off as many leaves as {PRONOUN/p_l/subject} can fit in {PRONOUN/p_l/poss} mouth. ",
     "exp": 20,
     "frequency": 4,
     "herbs": ["plantain"],
@@ -112,8 +112,8 @@
     },
     "frequency": 3,
     "chance_of_success": 50,
-    "intro_text": "Sea-scented mist blows across the salt meadow in damp gusts. p_l and app1's whiskers are beading with water as they stalk through the growing grass, fixating plant by plant, scanning for the right herb.",
-    "decline_text": "The fog quickly gets much worse, and p_l turns right around. They won't find any herbs like this.",
+    "intro_text": "Sea-scented mist blows across the salt meadow in damp gusts. p_l and app1's whiskers bead with water as they stalk through the growing grass, fixating on each plant in turn, scanning for the right herb.",
+    "decline_text": "The fog thickens, and p_l turns right around. They won't find any herbs like this.",
     "success_outcomes": [
         {
     "text": "Plantain is especially good against the insect bites common in greenleaf. The days are still lengthening, but a medicine cat always has to look toward the next season as well as the Clan's present needs. app1 can only twitch an ear in agreement, carrying the bulk of the leaves home while p_l teaches.",
@@ -128,7 +128,7 @@
     "values": ["like","trust","respect"],
     "amount": 5,
     "log": {
-    "cats_from": "cat_to listened attentively to cat_from, and carried most of the plantain for {PRONOUN/cat_from/object}."
+    "cats_from": "cat_to listened attentively to cat_from and carried most of the plantain for {PRONOUN/cat_from/object}."
     }
     }
     ],
@@ -143,7 +143,7 @@
     "art": "gen_app_med_meadow"
     },
      {
-    "text": "Not long into their search, the fog thickens, obscuring their own paws and dappling their pelts. In the haze, the two of them drift apart and p_l doesn't see it coming. Hooves crunching fresh grass are the only warning before a flock of sheep push and jostle against app1 on all sides. {PRONOUN/app1/subject/CAP}{VERB/app1/'re/'s} bruised and panicked by the time {PRONOUN/app1/subject} {VERB/app1/get/gets} away.",
+    "text": "Not long into their search, the fog thickens, obscuring their own paws and dappling their pelts. In the haze, the two of them drift apart. Hooves crunching fresh grass are their only warning before a flock of sheep push and jostle against app1 on all sides. {PRONOUN/app1/subject/CAP}{VERB/app1/'re/'s} bruised and panicked by the time {PRONOUN/app1/subject} {VERB/app1/get/gets} away.",
     "exp": 0,
     "frequency": 3,
     "injury": [

--- a/resources/lang/en/patrols/beach/med/newleaf.json
+++ b/resources/lang/en/patrols/beach/med/newleaf.json
@@ -1,1 +1,195 @@
-[]
+[
+    {
+    "patrol_id": "bch_med_newleafplantain1",
+    "biome": ["beach"],
+    "season": ["newleaf"],
+    "types": ["herb_gathering"],
+    "tags": [],
+    "patrol_art": "pln_med_herblocation2",
+    "min_cats": 1,
+    "max_cats": 1,
+    "min_max_status": {
+        "medicine cat apprentice": [
+            -1,
+            -1
+        ],
+        "medicine cat": [
+            1,
+            1
+        ],
+        "normal adult": [
+            -1,
+            -1
+        ]
+    },
+    "frequency": 3,
+    "chance_of_success": 50,
+    "intro_text": "Sea-scented mist blows across the salt meadow in damp gusts. p_l's whiskers are beading with water as {PRONOUN/p_l/subject} stalk{VERB/p_l//s} through the growing grass, fixating plant by plant, scanning for the right herb.",
+    "decline_text": "The fog quickly gets much worse, and p_l turns right around. {PRONOUN/p_l/subject/CAP} won't find any herbs like this.",
+    "success_outcomes": [
+        {
+    "text": "The long, pointed narrow leaves, the characteristic brown bulbs with tiny white flowers... sea plantain isn't hard to recognize, once newleaf arrives. p_l is relieved to find it nonetheless, and chews off as many leaves as {PRONOUN/p_l/subject} can fit in {PRONOUN/p_l/poss} mouth. ",
+    "exp": 15,
+    "frequency": 4,
+    "herbs": ["plantain"],
+    "art": "gen_med_gatheringplantain_greenleaf1"
+}
+    ],
+    "fail_outcomes": [
+        {
+    "text": "Not long into {PRONOUN/p_l/poss} search, the fog thickens, obscuring p_l's own paws and dappling {PRONOUN/p_l/poss} pelt. Last night's rain, caught in the meadow, rises into haze under the strengthening newleaf sun. p_l can't see anything like this, and sea plantain only has a faint smell. Best to wait for the sun to burn the fog away.",
+    "exp": 0,
+    "frequency": 4,
+    "art": "pln_med_herblocation2"
+    },
+     {
+    "text": "Not long into {PRONOUN/p_l/poss} search, the fog thickens, obscuring p_l's own paws and dappling {PRONOUN/p_l/poss} pelt. In the haze, {PRONOUN/p_l/subject} {VERB/p_l/don't/doesn't} see them coming. Hooves crunching fresh grass are the only warning before a flock of sheep push and jostle against p_l on all sides. {PRONOUN/p_l/subject/CAP}{VERB/p_l/'re/'s} bruised and disoriented by the time {PRONOUN/p_l/subject} {VERB/p_l/get/gets} away.",
+    "exp": 0,
+    "frequency": 3,
+    "injury": [
+        {
+            "cats": ["p_l"],
+            "injuries": ["bruises"],
+            "scars": [],
+            "no_results": false
+        }
+    ],
+    "art": "running_med"
+},
+
+     {
+    "text": "Not long into {PRONOUN/p_l/poss} search, the fog thickens, obscuring p_l's own paws and dappling {PRONOUN/p_l/poss} pelt. In the haze, {PRONOUN/p_l/subject} {VERB/p_l/don't/doesn't} see them coming. Hooves crunching fresh grass are the only warning before a flock of sheep envelop p_l, trampling {PRONOUN/p_l/object} underhoof. {PRONOUN/p_l/subject/CAP}{VERB/p_l/'re/'s} battered and panicked by the time {PRONOUN/p_l/subject} finally {VERB/p_l/get/gets} away.",
+    "exp": 0,
+    "frequency": 1,
+    "injury": [
+        {
+            "cats": ["p_l"],
+            "injuries": ["blunt_force_injury"],
+            "scars": [],
+            "no_results": false
+        }
+    ],
+    "history_text": {
+        "death": "p_l died from {PRONOUN/app1/poss} injuries after being trampled by a flock of sheep.",
+        "scars": "p_l was scarred after being trampled by a flock of sheep."
+    },
+    "art": "running_med2"
+}
+    ]
+},
+    
+    
+    {
+    "patrol_id": "bch_med_newleafplantain2",
+    "biome": ["beach"],
+    "season": ["newleaf"],
+    "types": ["herb_gathering"],
+    "tags": [],
+    "patrol_art": "gen_app_med_meadow",
+    "min_cats": 2,
+    "max_cats": 2,
+    "min_max_status": {
+        "medicine cat apprentice": [
+            1,
+            1
+        ],
+        "medicine cat": [
+            1,
+            1
+        ],
+        "normal adult": [
+            -1,
+            -1
+        ]
+    },
+    "frequency": 3,
+    "chance_of_success": 50,
+    "intro_text": "Sea-scented mist blows across the salt meadow in damp gusts. p_l and app1's whiskers are beading with water as they stalk through the growing grass, fixating plant by plant, scanning for the right herb.",
+    "decline_text": "The fog quickly gets much worse, and p_l turns right around. They won't find any herbs like this.",
+    "success_outcomes": [
+        {
+    "text": "Plantain is especially good against the insect bites common in greenleaf. The days are still lengthening, but a medicine cat always has to look toward the next season as well as the Clan's present needs. app1 can only twitch an ear in agreement, carrying the bulk of the leaves home while p_l teaches.",
+    "exp": 20,
+    "frequency": 4,
+    "herbs": ["plantain"],
+    "relationships": [
+    { 
+    "cats_from": ["p_l"],
+    "cats_to": ["app1"],
+    "mutual": false,
+    "values": ["like","trust","respect"],
+    "amount": 5,
+    "log": {
+    "cats_from": "cat_to listened attentively to cat_from, and carried most of the plantain for {PRONOUN/cat_from/object}."
+    }
+    }
+    ],
+    "art": "gen_med_gatheringplantain_greenleaf1"
+}
+    ],
+    "fail_outcomes": [
+        {
+    "text": "Not long into their search, the fog thickens, obscuring their own paws and dappling their pelts. Last night's rain, caught in the meadow, rises into haze under the strengthening newleaf sun. p_l can't see anything like this, and sea plantain only has a faint smell. Best to wait for the sun to burn the fog away.",
+    "exp": 0,
+    "frequency": 4,
+    "art": "gen_app_med_meadow"
+    },
+     {
+    "text": "Not long into their search, the fog thickens, obscuring their own paws and dappling their pelts. In the haze, the two of them drift apart and p_l doesn't see it coming. Hooves crunching fresh grass are the only warning before a flock of sheep push and jostle against app1 on all sides. {PRONOUN/app1/subject/CAP}{VERB/app1/'re/'s} bruised and panicked by the time {PRONOUN/app1/subject} {VERB/app1/get/gets} away.",
+    "exp": 0,
+    "frequency": 3,
+    "injury": [
+        {
+            "cats": ["app1"],
+            "injuries": ["bruises"],
+            "scars": [],
+            "no_results": false
+        }
+    ],
+    "relationships": [
+    { 
+    "cats_from": ["app1"],
+    "cats_to": ["p_l"],
+    "mutual": false,
+    "values": ["trust"],
+    "amount": -10,
+    "log": {
+    "cats_from": "The bruises from the sheep flock were a painful reminder for cat_from that {PRONOUN/cat_from/subject} couldn't rely on cat_to to warn {PRONOUN/cat_from/object}."
+    }
+    }
+    ],
+    "art": "running_med_app"
+},
+     {
+    "text": "Not long into their search, the fog thickens, obscuring their own paws and dappling their pelts. In the haze, the two of them drift apart and p_l doesn't see it coming. Hooves crunching fresh grass are the only warning before a flock of sheep envelop app1, trampling {PRONOUN/app1/object} underhoof. {PRONOUN/app1/subject/CAP}{VERB/app1/'re/'s} battered and panicked by the time {PRONOUN/app1/subject} finally {VERB/app1/get/gets} away.",
+    "exp": 0,
+    "frequency": 1,
+    "injury": [
+        {
+            "cats": ["app1"],
+            "injuries": ["blunt_force_injury"],
+            "scars": [],
+            "no_results": false
+        }
+    ],
+    "history_text": {
+        "death": "app1 died from {PRONOUN/app1/poss} injuries after being trampled by a flock of sheep.",
+        "scars": "app1 was scarred after being trampled by a flock of sheep."
+    },
+    "relationships": [
+    { 
+    "cats_from": ["app1"],
+    "cats_to": ["p_l"],
+    "mutual": false,
+    "values": ["trust"],
+    "amount": -16,
+    "log": {
+    "cats_from": "The injury from being trampled by a flock of sheep was a painful reminder for cat_from that {PRONOUN/cat_from/subject} couldn't rely on cat_to to warn {PRONOUN/cat_from/object}."
+    }
+    }
+    ],
+    "art": "gen_train_patrolapprenticesessionfail"
+}
+]
+}
+]

--- a/resources/lang/en/patrols/beach/med/newleaf.json
+++ b/resources/lang/en/patrols/beach/med/newleaf.json
@@ -9,6 +9,10 @@
     "min_cats": 1,
     "max_cats": 1,
     "min_max_status": {
+        "apprentice": [
+            -1,
+            -1
+        ],
         "medicine cat apprentice": [
             -1,
             -1
@@ -89,6 +93,10 @@
     "min_cats": 2,
     "max_cats": 2,
     "min_max_status": {
+        "apprentice": [
+            -1,
+            -1
+        ],
         "medicine cat apprentice": [
             1,
             1


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
Part two of the seasonal beach patrol collection, these are three herb gathering patrols (corresponding to newleaf, greenleaf & leaf-fall) with 2-3 variants each, which account for solo medicine cats, a meddie and one med apprentice, or a meddie and one warrior assistant. 
I tried to mimic the real locations certain herbs are found when close to seashores - ragwort among sand dunes, lungwort on heather heathlands, and sea plantain on salt meadows. Additionally, I included fitting seasonal hazards: fog, heat, thunderstorms, and grazing sheep.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Why This Is Good For ClanGen
As part of the ongoing Season & Biome-Specific Patrols project, this PR adds specific patrols for three previously missing combinations of biome, season, and patrol type.
<!-- If this is a bug fix, you can remove this section. -->
<!-- Please add a short description of why you think these changes would benefit the game. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->
<!-- If you have multiple features that can stand on their own, or unrelated bugfixes, please create separate PRs for them. -->

## Proof of Testing
<img width="467" height="187" alt="grafik" src="https://github.com/user-attachments/assets/bc705fb8-4822-4046-b78e-41125e01e5c2" />
<img width="472" height="226" alt="grafik" src="https://github.com/user-attachments/assets/022fd5fe-9b10-4113-b500-c2987562254b" />
<img width="473" height="202" alt="grafik" src="https://github.com/user-attachments/assets/e1a4254a-c9fe-4a2c-91d1-d270bef5b8e9" />
<img width="466" height="279" alt="grafik" src="https://github.com/user-attachments/assets/add8c362-0d7f-4a7f-b96d-93e805d4a672" />

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
Changelog: Added three (+variants) new season-specific herb-gathering patrols for beach-dwelling Clans
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
