### PR TITLE
[BUGFIX] Show non-zero neutral relationships on relationship screen

### DIFF
--- a/scripts/screens/RelationshipScreen.py
+++ b/scripts/screens/RelationshipScreen.py
@@ -682,7 +682,7 @@ class RelationshipScreen(Screens):
         if not get_clan_setting("show empty relation"):
             self.filtered_cats = list(
                 filter(
-                    lambda rel: not rel.is_empty,
+                    lambda rel: rel.total_abs_relationship_value != 0,
                     self.filtered_cats,
                 )
             )


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
Fixes non-zero neutral relationships not appearing!
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
Fixes: #4757
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
Lakestar shows on Gardeniapaw's relationship page, despite having a neutral relationship (5 like, 0 respect, 5 trust, 0 comfort)!
<img width="1135" height="833" alt="image" src="https://github.com/user-attachments/assets/23aa91c4-df6a-47d6-b70f-b26d8fb2ca2e" />
Aaand their one relationship log, jic it's needed for proof of testing
<img width="1145" height="915" alt="image" src="https://github.com/user-attachments/assets/2d72654a-9298-408f-8bb6-b64fc38ecedb" />
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Non-zero neutral relationships now appear as intended
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
