### PR TITLE
[TYPOFIX] relationship event typo fixes

### DIFF
--- a/resources/lang/en/events/new_cat/general.json
+++ b/resources/lang/en/events/new_cat/general.json
@@ -242,7 +242,7 @@
                 "amount": 30,
                 "mutual": false,
                 "log": {
-                    "cats_from": "n_c:0 left {PRONOUN/n_c:0/poss} kit to the m_c, trusting {PRONOUN/m_c/object} to raise {PRONOUN/n_c:1/object}."
+                    "cats_from": "n_c:0 left {PRONOUN/n_c:0/poss} kit to m_c, trusting {PRONOUN/m_c/object} to raise {PRONOUN/n_c:1/object}."
                 }
             },
             {
@@ -296,7 +296,7 @@
                 "amount": 30,
                 "mutual": false,
                 "log": {
-                    "cats_from": "n_c:0 left {PRONOUN/n_c:0/poss} kit to the m_c, trusting {PRONOUN/m_c/object} to raise {PRONOUN/n_c:1/object}."
+                    "cats_from": "n_c:0 left {PRONOUN/n_c:0/poss} kit to m_c, trusting {PRONOUN/m_c/object} to raise {PRONOUN/n_c:1/object}."
                 }
             },
             {
@@ -342,7 +342,7 @@
                 "amount": 30,
                 "mutual": false,
                 "log": {
-                    "cats_from": "n_c:0 left {PRONOUN/n_c:0/poss} kit to the m_c, trusting {PRONOUN/m_c/object} to raise {PRONOUN/n_c:1/object}."
+                    "cats_from": "n_c:0 left {PRONOUN/n_c:0/poss} kit to m_c, trusting {PRONOUN/m_c/object} to raise {PRONOUN/n_c:1/object}."
                 }
             },
             {

--- a/resources/lang/en/events/relationship_events/group_interactions/5/positive.json
+++ b/resources/lang/en/events/relationship_events/group_interactions/5/positive.json
@@ -667,7 +667,7 @@
 		"interactions": [
 			"Late into the evening, m_c invites r_c1, r_c2, r_c3, and r_c4 to stretch with {PRONOUN/m_c/object} and enjoy each other's company.",
 			"m_c convinces r_c1, r_c2, r_c3, and r_c4 to wind down and stretch with {PRONOUN/m_c/object}.",
-			"m_c's eagerness to do early morning stretches rubs off on r_c1, r_c2, and r_c4.",
+			"m_c's eagerness to do early morning stretches rubs off on r_c1, r_c2, r_c3, and r_c4.",
 			"m_c appreciates r_c1, r_c2, r_c3, and r_c4 joining {PRONOUN/m_c/object} to stretch late into the night so {PRONOUN/m_c/subject} wouldn't be alone.",
 			"m_c, r_c1, r_c2, r_c3, and r_c4 hang out while stretching.",
 			"m_c, r_c1, r_c2, r_c3, and r_c4 blow off steam by stretching with and venting to each other.",


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

fixes two instances of minor typos:
- in the event where an outsider leaves one singular kitten to a cat to raise them, the event was worded as "left their kit to the m_c" where "the" is completely unneeded. this extra "the" was removed from 3 variations of the same event
- included r_c3 that was missing in one of the positive 5 cat group relationship event outcomes

## Why This Is Good For ClanGen

typo fixing good :3

## Linked Issues

https://github.com/ClanGenOfficial/clangen/issues/1818#issuecomment-4260739917
https://github.com/ClanGenOfficial/clangen/issues/1818#issuecomment-4211791694 (does not fix the parent and kit not being pronoun tagged, as that appears to be a code issue rather than a typo in the event text)

## Proof of Testing

<img width="878" height="88" alt="image" src="https://github.com/user-attachments/assets/727b9be8-6899-4252-9702-5f27aee2b173" />
<img width="1059" height="101" alt="image" src="https://github.com/user-attachments/assets/c4a042e9-b9c1-41e1-b7d6-5f4cc46fab11" />

## Changelog/Credits

- Fixes two miscellaneous typos in relationship events.