### PR TITLE
[TWEAKS] revising constraints on death events.

### DIFF
--- a/resources/lang/en/events/death/beach.json
+++ b/resources/lang/en/events/death/beach.json
@@ -139,7 +139,7 @@
     {
         "event_id": "bch_death_abyss_any1",
         "location": [
-            "beach:camp3"
+            "beach"
         ],
         "season": [
             "any"

--- a/resources/lang/en/events/death/desert.json
+++ b/resources/lang/en/events/death/desert.json
@@ -67,7 +67,7 @@
           "history": [
               {
               "cats": ["m_c"],
-              "death": "m_c was mislead by a mirage and died of dehydration."
+              "death": "m_c was misled by a mirage and died of dehydration."
               }
           ]
   },

--- a/resources/lang/en/events/death/desert.json
+++ b/resources/lang/en/events/death/desert.json
@@ -67,7 +67,7 @@
           "history": [
               {
               "cats": ["m_c"],
-              "death": "m_c was mislead by a mirage, thinking it was water."
+              "death": "m_c was mislead by a mirage and died of dehydration."
               }
           ]
   },

--- a/resources/lang/en/events/death/forest.json
+++ b/resources/lang/en/events/death/forest.json
@@ -40,7 +40,7 @@
         ],
         "tags": [],
         "frequency": 3,
-        "event_text": "m_c was found dead underneath an oak tree with dog scent wreathing around {PRONOUN/m_c/object}.",
+        "event_text": "m_c was found dead underneath a clawed oak tree surrounded by the stench of dog.",
         "m_c": {
             "skill": [
                 "-CLIMBER,2"

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -6868,7 +6868,7 @@
             "no_body"
         ],
         "frequency": 4,
-        "event_text": "m_c boasted about how ready {PRONOUN/m_c/subject} {VERB/m_c/were/was} for apprenticeship. {PRONOUN/m_c/subject/CAP} snuck away to prove it, the Clan finds only blood and raccoon-scent in the morning.",
+        "event_text": "m_c boasted about how ready {PRONOUN/m_c/subject} {VERB/m_c/were/was} for apprenticeship. {PRONOUN/m_c/subject/CAP} snuck away to prove it. The Clan finds only blood and raccoon-scent in the morning.",
         "m_c": {
             "status": [
                 "kitten"

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -7907,7 +7907,7 @@
             ],
             "skill": [
                 "OMEN,1",
-                "DREAM,1",
+                "CLAIRVOYANT,1",
                 "PROPHET,1",
                 "STAR,1"
             ],

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -3702,9 +3702,6 @@
                 "adolescent",
                 "elder"
             ],
-            "status": [
-                "kitten"
-            ],
             "dies": true
         },
         "history": [
@@ -4771,7 +4768,7 @@
                 "-CLEVER,2",
                 "-STAR,2",
                 "-OMEN,2",
-                "-ClAIRVOYANT,2",
+                "-CLAIRVOYANT,2",
                 "-PROPHET,2"
             ],
             "dies": true

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -126,6 +126,74 @@
         ]
     },
     {
+        "event_id": "gen_death_murder_any2trait",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "murder"
+        ],
+        "tags": [],
+        "frequency": 4,
+        "event_text": "m_c was murdered. r_c stands over {PRONOUN/m_c/object}, blood dripping from {PRONOUN/r_c/poss} pelt.",
+        "m_c": {
+            "age": [
+                "any"
+            ],
+            "status": [
+                "-leader"
+            ],
+            "skill": [
+                "-FIGHTER,2"
+            ],
+            "dies": true
+        },
+        "r_c": {
+            "age": [
+                "-kitten"
+            ],
+            "trait": [
+                "bloodthirsty",
+                "fierce",
+                "arrogant"
+            ]
+        },
+        "history": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "death": "m_c was murdered by r_c."
+            }
+        ],
+        "future_event": [
+            {
+                "event_type": "misc",
+                "pool": {
+                    "sub_type": [
+                        "murder_reveal"
+                    ]
+                },
+                "moon_delay": [
+                    1,
+                    12
+                ],
+                "involved_cats": {
+                    "m_c": "r_c",
+                    "mur_c": "m_c",
+                    "r_c": {
+                        "age": [
+                            "any"
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    {
         "event_id": "gen_death_murder_any3",
         "location": [
             "any"
@@ -461,7 +529,9 @@
         "location": [
             "forest",
             "plains",
-            "beach"
+            "beach",
+            "wetlands",
+            "mountainous"
         ],
         "season": [
             "any"
@@ -636,7 +706,7 @@
             "any"
         ],
         "season": [
-            "any"
+            "-leaf-bare"
         ],
         "tags": [],
         "frequency": 3,
@@ -659,7 +729,7 @@
     {
         "event_id": "gen_death_snake_any2",
         "location": [
-            "any"
+            "-leaf-bare"
         ],
         "season": [
             "any"
@@ -873,7 +943,7 @@
                 ],
                 "amount": 40,
                 "log": {
-                    "cats_from": "cat_to died protecting cat_from from enemy warriors in the nursery."
+                    "cats_from": "cat_to died protecting cat_from from enemy warriors invading the nursery."
                 }
             }
         ],
@@ -1139,7 +1209,11 @@
                 ],
                 "death": "m_c was killed by a gang of rogues."
             }
-        ]
+        ],
+            "outsider": {
+        "current_rep": ["any"],
+        "changed": -3
+    }
     },
     {
         "event_id": "gen_death_greencough_any1",
@@ -1274,7 +1348,7 @@
         ],
         "tags": [],
         "frequency": 2,
-        "event_text": "m_c sneaked out of camp, intending to discover more about {PRONOUN/m_c/poss} origins. After a long morning search, c_n found {PRONOUN/m_c/poss} cooling body.",
+        "event_text": "m_c snuck out of camp, intending to discover more about {PRONOUN/m_c/poss} origins. After a long morning search, c_n found {PRONOUN/m_c/poss} cooling body.",
         "m_c": {
             "age": [
                 "adolescent",
@@ -1322,6 +1396,7 @@
                 "deputy",
                 "leader"
             ],
+            "relationship_status": ["knows_of_only", "likes_only", "enjoys_only", "cherishes"],
             "dies": true
         },
         "r_c": {
@@ -1383,6 +1458,7 @@
                 "deputy",
                 "leader"
             ],
+            "relationship_status": ["knows_of_only", "likes_only", "enjoys_only", "cherishes"],
             "dies": true
         },
         "r_c": {
@@ -1444,6 +1520,7 @@
                 "deputy",
                 "leader"
             ],
+            "relationship_status": ["knows_of_only", "likes_only", "enjoys_only", "cherishes"],
             "dies": true
         },
         "r_c": {
@@ -1505,7 +1582,8 @@
                 "deputy",
                 "leader"
             ],
-            "dies": true
+            "dies": true,
+            "relationship_status": ["knows_of_only", "likes_only", "enjoys_only", "cherishes"]
         },
         "r_c": {
             "age": [

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -4761,7 +4761,7 @@
             "any"
         ],
         "tags": [],
-        "frequency": 4,
+        "frequency": 3,
         "event_text": "m_c failed to interpret a warning sign from StarClan and couldn't foresee the circumstances of {PRONOUN/m_c/poss} death.",
         "m_c": {
             "status": [
@@ -4771,7 +4771,7 @@
                 "-CLEVER,2",
                 "-STAR,2",
                 "-OMEN,2",
-                "-ClAIRVOYANT,2",
+                "CLAIRVOYANT",
                 "-PROPHET,2"
             ],
             "dies": true

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -1458,7 +1458,7 @@
                 "deputy",
                 "leader"
             ],
-            "relationship_status": ["knows_of_only", "likes_only", "enjoys_only", "cherishes"],
+            "relationship_status": ["knows_of_only", "likes"],
             "dies": true
         },
         "r_c": {
@@ -1520,7 +1520,7 @@
                 "deputy",
                 "leader"
             ],
-            "relationship_status": ["knows_of_only", "likes_only", "enjoys_only", "cherishes"],
+            "relationship_status": ["knows_of_only", "likes"],
             "dies": true
         },
         "r_c": {
@@ -1583,7 +1583,7 @@
                 "leader"
             ],
             "dies": true,
-            "relationship_status": ["knows_of_only", "likes_only", "enjoys_only", "cherishes"]
+            "relationship_status": ["knows_of_only", "likes"],
         },
         "r_c": {
             "age": [

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -1583,7 +1583,7 @@
                 "leader"
             ],
             "dies": true,
-            "relationship_status": ["knows_of_only", "likes"],
+            "relationship_status": ["knows_of_only", "likes"]
         },
         "r_c": {
             "age": [

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -4762,7 +4762,8 @@
         "event_text": "m_c failed to interpret a warning sign from StarClan and couldn't foresee the circumstances of {PRONOUN/m_c/poss} death.",
         "m_c": {
             "status": [
-                "-kitten"
+                "leader",
+                "medicine cat"
             ],
             "skill": [
                 "-CLEVER,2",
@@ -7908,7 +7909,6 @@
                 "OMEN,1",
                 "DREAM,1",
                 "PROPHET,1",
-                "GHOST,2",
                 "STAR,1"
             ],
             "dies": true

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -1396,7 +1396,7 @@
                 "deputy",
                 "leader"
             ],
-            "relationship_status": ["knows_of_only", "likes_only", "enjoys_only", "cherishes"],
+            "relationship_status": ["knows_of_only", "likes"],
             "dies": true
         },
         "r_c": {

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -3700,7 +3700,7 @@
             "age": [
                 "kitten",
                 "adolescent",
-                "elder"
+                "senior"
             ],
             "dies": true
         },

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -2374,7 +2374,8 @@
         "location": [
             "beach",
             "plains",
-            "forest"
+            "forest",
+            "desert"
         ],
         "season": [
             "any"
@@ -2401,7 +2402,8 @@
         "location": [
             "plains",
             "forest",
-            "beach"
+            "beach",
+            "desert"
         ],
         "season": [
             "any"
@@ -2946,7 +2948,7 @@
         ],
         "tags": [],
         "frequency": 4,
-        "event_text": "m_c and r_c are killed in a border skirmish against o_c_n.",
+        "event_text": "m_c and r_c are killed in a border skirmish with o_c_n.",
         "m_c": {
             "status": [
                 "apprentice",
@@ -3095,7 +3097,7 @@
         ],
         "tags": [],
         "frequency": 3,
-        "event_text": "m_c slipped off a cliff onto the sharp rocks at the bottom.",
+        "event_text": "m_c slipped off a cliff onto the sharp rocks below.",
         "m_c": {
             "age": [
                 "-kitten"
@@ -3132,7 +3134,7 @@
             "all_lives"
         ],
         "frequency": 3,
-        "event_text": "m_c slipped off a cliff onto the sharp rocks at the bottom and couldn't recover.",
+        "event_text": "m_c slipped off a cliff onto the sharp rocks below and couldn't recover.",
         "m_c": {
             "status": [
                 "leader"
@@ -3163,7 +3165,7 @@
         ],
         "tags": [],
         "frequency": 4,
-        "event_text": "m_c was pushed off a cliff onto the sharp rocks at the bottom.",
+        "event_text": "m_c was pushed off a cliff onto the sharp rocks below.",
         "m_c": {
             "status": [
                 "-leader",
@@ -3259,8 +3261,8 @@
     {
         "event_id": "gen_death_hawk_any1",
         "location": [
-            "forest:camp1_camp4",
-            "plains:camp1_camp3",
+            "forest:camp1_camp2_camp4",
+            "plains:camp1_camp3_camp4",
             "mountainous:camp1_camp4",
             "beach:camp1_camp3"
         ],
@@ -3321,8 +3323,8 @@
     {
         "event_id": "gen_death_hawk_any2",
         "location": [
-            "forest:camp1_camp4",
-            "plains:camp1_camp3",
+            "forest:camp1_camp2_camp4",
+            "plains:camp1_camp3_camp4",
             "mountainous:camp1_camp4",
             "beach:camp1_camp3"
         ],
@@ -3394,8 +3396,8 @@
     {
         "event_id": "gen_death_eagle_anylead3",
         "location": [
-            "forest:camp1_camp4",
-            "plains:camp1_camp3",
+            "forest:camp1_camp2_camp4",
+            "plains:camp1_camp3_camp4",
             "mountainous:camp1_camp4",
             "beach:camp1_camp3"
         ],
@@ -3523,7 +3525,8 @@
         "location": [
             "plains",
             "forest",
-            "mountainous"
+            "mountainous",
+            "wetlands"
         ],
         "season": [
             "leaf-fall",
@@ -3556,7 +3559,8 @@
         "location": [
             "plains",
             "forest",
-            "mountainous"
+            "mountainous",
+            "wetlands"
         ],
         "season": [
             "leaf-fall",
@@ -3694,7 +3698,9 @@
         "event_text": "m_c was killed in {PRONOUN/m_c/poss} sleep by a snake that had snuck into camp.",
         "m_c": {
             "age": [
-                "kitten"
+                "kitten",
+                "adolescent",
+                "elder"
             ],
             "status": [
                 "kitten"
@@ -3953,7 +3959,7 @@
         ],
         "tags": [],
         "frequency": 4,
-        "event_text": "m_c sneaked out of camp and misjudged the jump across a stream. r_c watched without concern as {PRONOUN/m_c/subject} disappeared under the water.",
+        "event_text": "m_c snuck out of camp and misjudged the jump across a stream. r_c watched without concern as {PRONOUN/m_c/subject} disappeared under the water.",
         "m_c": {
             "age": [
                 "kitten"
@@ -4580,7 +4586,8 @@
         "location": [
             "beach",
             "forest",
-            "mountainous"
+            "mountainous",
+            "wetlands"
         ],
         "season": [
             "any"
@@ -4613,7 +4620,7 @@
         ],
         "tags": [],
         "frequency": 4,
-        "event_text": "m_c died in a fight with a dog.",
+        "event_text": "m_c died fighting a dog.",
         "m_c": {
             "status": [
                 "apprentice",
@@ -4645,7 +4652,7 @@
         ],
         "tags": [],
         "frequency": 4,
-        "event_text": "m_c died in a fight with a badger.",
+        "event_text": "m_c died fighting a badger.",
         "m_c": {
             "status": [
                 "apprentice",
@@ -4677,7 +4684,7 @@
         ],
         "tags": [],
         "frequency": 4,
-        "event_text": "m_c died in a fight with a rogue.",
+        "event_text": "m_c died fighting a rogue.",
         "m_c": {
             "status": [
                 "apprentice",
@@ -4758,11 +4765,14 @@
         "event_text": "m_c failed to interpret a warning sign from StarClan and couldn't foresee the circumstances of {PRONOUN/m_c/poss} death.",
         "m_c": {
             "status": [
-                "leader"
+                "-kitten"
             ],
             "skill": [
                 "-CLEVER,2",
-                "-STAR,2"
+                "-STAR,2",
+                "-OMEN,2",
+                "-ClAIRVOYANT,2",
+                "-PROPHET,2"
             ],
             "dies": true
         },

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -8463,7 +8463,7 @@
                 "-CLAIRVOYANT,1",
                 "-DREAM,1",
                 "-PROPHET,1"
-            ]
+            ],
             "dies": true
         },
         "history":[
@@ -8533,11 +8533,12 @@
             }
         ],
         "other_clan": {
-        "current_rep": [
-            "hostile",
-            "neutral"
-        ],
-        "changed": -2
+            "current_rep": [
+                "hostile",
+                "neutral"
+            ],
+            "changed": -2
+        }
     },
     {
         "event_id": "gen_death_rooster_spur",

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -6230,7 +6230,9 @@
         "event_text": "m_c and r_c were ambushed by a pack of dogs, but r_c was nowhere to be found when m_c looked for help.",
         "m_c": {
             "status": [
-                "leader"
+                "leader",
+                "deputy",
+                "warrior"
             ],
             "skill": [
                 "-FIGHTER,3"
@@ -6711,7 +6713,7 @@
         ],
         "tags": [],
         "frequency": 4,
-        "event_text": "m_c disappeared from the nursery and was later found dead, not far from camp.",
+        "event_text": "m_c disappeared from the nursery and was later found frozen not far from camp.",
         "m_c": {
             "status": [
                 "kitten"
@@ -6869,7 +6871,7 @@
             "no_body"
         ],
         "frequency": 4,
-        "event_text": "m_c boasted about how ready {PRONOUN/m_c/subject} {VERB/m_c/were/was} for apprenticeship. {PRONOUN/m_c/subject/CAP} snuck away to prove it and the Clan finds only blood and raccoon-scent in the morning.",
+        "event_text": "m_c boasted about how ready {PRONOUN/m_c/subject} {VERB/m_c/were/was} for apprenticeship. {PRONOUN/m_c/subject/CAP} snuck away to prove it, the Clan finds only blood and raccoon-scent in the morning.",
         "m_c": {
             "status": [
                 "kitten"
@@ -6890,7 +6892,8 @@
         "location": [
             "forest",
             "beach",
-            "plains"
+            "plains",
+            "wetlands"
         ],
         "season": [
             "newleaf"
@@ -6914,7 +6917,7 @@
         "event_id": "multi_death_massdeath_fire1",
         "location": [
             "forest:camp1_camp2",
-            "plains:camp1_camp3",
+            "plains:camp1_camp3_camp4",
             "beach:camp1_camp3",
             "mountainous:camp4"
         ],
@@ -7580,7 +7583,7 @@
         ],
         "tags": [],
         "frequency": 4,
-        "event_text": "r_c claimed the haze of battle and blood lust were the reason {PRONOUN/r_c/subject} killed m_c.",
+        "event_text": "r_c claimed the haze of battle and bloodlust were the reason {PRONOUN/r_c/subject} killed m_c.",
         "m_c": {
             "status": [
                 "warrior",
@@ -7900,7 +7903,9 @@
         "event_text": "A warning from StarClan gave m_c enough knowledge to survive r_c's attack. r_c could not say the same.",
         "m_c": {
             "status": [
-                "leader"
+                "leader",
+                "deputy",
+                "warrior"
             ],
             "skill": [
                 "OMEN,1",
@@ -7929,7 +7934,7 @@
                 "cats": [
                     "r_c"
                 ],
-                "death": "r_c died after launching a failed assassination attempt on the Clan's leader."
+                "death": "r_c died after launching a failed assassination attempt."
             }
         ],
         "future_event": [
@@ -7963,7 +7968,7 @@
                 "amount": -30,
                 "mutual": false,
                 "log": {
-                    "cats_from": "cat_to attempted to take all of cat_from's lives, but cat_from had forewarning."
+                    "cats_from": "cat_to attempted to take cat_from's life, but cat_from had forewarning."
                 }
             }
         ]

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -4771,7 +4771,7 @@
                 "-CLEVER,2",
                 "-STAR,2",
                 "-OMEN,2",
-                "-ClAIRVOYANT,2",
+                "-CLAIRVOYANT,2",
                 "-PROPHET,2"
             ],
             "dies": true

--- a/resources/lang/en/events/injury/desert.json
+++ b/resources/lang/en/events/injury/desert.json
@@ -1640,7 +1640,7 @@
             "greenleaf"
         ],
         "frequency": 4,
-        "event_text": "m_c sneaked out of camp and was later found wandering in the full noon sun, confused and disoriented.",
+        "event_text": "m_c snuck out of camp and was later found wandering in the full noon sun, confused and disoriented.",
         "m_c": {
             "status": [
                 "kitten"
@@ -1667,7 +1667,7 @@
                 "cats": [
                     "m_c"
                 ],
-                "death": "m_c died after {PRONOUN/m_c/subject} sneaked out of camp and got sunstroke."
+                "death": "m_c died after {PRONOUN/m_c/subject} snuck out of camp and got sunstroke."
             }
         ]
     },


### PR DESCRIPTION
## About The Pull Request
- Revising constraints on death events to make them more broadly applicable or more constrained depending on the context.
- Minor tweaks to word choice and changes to typos.

## Why This Is Good For ClanGen

- allows events that otherwise might not be seen as often 
- limit events to the proper parties
- typo fixes
- smoother writing flow
- uniform sneaked/snuck

## Proof of Testing

Game loads perfectly fine and can moonskip 50 moons without crashing.

<img width="428" height="129" alt="Screenshot 2026-04-16 at 8 54 23 PM" src="https://github.com/user-attachments/assets/15fcfebb-e2e2-45d5-99ee-eff0f2a6382b" />
