### PR TITLE
[BUGFIX] Patrol relationships exclusion tags

### DIFF
--- a/resources/lang/en/patrols/general/training.json
+++ b/resources/lang/en/patrols/general/training.json
@@ -18955,7 +18955,7 @@
             "normal adult": [1, 1],
             "apprentice": [1, 1]
         },
-        "relationship_status": [
+        "relationship_constraint": [
             "-mentor/app",
             "-parent/child"
         ],

--- a/schemas/patrol.schema.json
+++ b/schemas/patrol.schema.json
@@ -304,6 +304,7 @@
       "type": "string"
     },
     "PatrolSchemaItem": {
+      "additionalProperties": false,
       "properties": {
         "patrol_id": {
           "description": "Unique string used to identify the patrol.",
@@ -417,12 +418,12 @@
           "title": "Chance Of Success",
           "type": "integer"
         },
-        "relationship_status": {
+        "relationship_constraint": {
           "description": "Dictates what relationships m_c must have towards r_c. Do not use this section if there is no r_c in the event.",
           "items": {
             "$ref": "common.schema.json#/$defs/RelationshipStatus"
           },
-          "title": "Relationship Status",
+          "title": "Relationship Constraint",
           "type": "array"
         },
         "pl_skill_constraint": {

--- a/scripts/events_module/event_filters.py
+++ b/scripts/events_module/event_filters.py
@@ -870,6 +870,7 @@ def filter_relationship_type(group: list, filter_types: List[str], patrol_leader
     qualifies = False
 
     if "strangers" in filter_types:
+        qualifies = False
         if any([inter_cat.ID in test_cat.relationships for inter_cat in testing_cats]):
             if "strangers" in exclusionary_values:
                 qualifies = True
@@ -883,6 +884,7 @@ def filter_relationship_type(group: list, filter_types: List[str], patrol_leader
         filter_types.remove("strangers")
 
     if "siblings" in filter_types:
+        qualifies = False
         if not all([test_cat.is_sibling(inter_cat) for inter_cat in testing_cats]):
             if "siblings" in exclusionary_values:
                 qualifies = True
@@ -893,6 +895,7 @@ def filter_relationship_type(group: list, filter_types: List[str], patrol_leader
         filter_types.remove("siblings")
 
     if "littermates" in filter_types:
+        qualifies = False
         if not all([test_cat.is_littermate(inter_cat) for inter_cat in testing_cats]):
             if "littermates" in exclusionary_values:
                 qualifies = True
@@ -908,6 +911,7 @@ def filter_relationship_type(group: list, filter_types: List[str], patrol_leader
             return False
 
         # then if cats don't have the needed number of mates
+        qualifies = False
         if not all(len(i.mate) >= (len(group) - 1) for i in group):
             if "mates" in exclusionary_values:
                 qualifies = True
@@ -934,6 +938,7 @@ def filter_relationship_type(group: list, filter_types: List[str], patrol_leader
             return False
 
         # Check each cat to see if it is mates with the patrol leader
+        qualifies = False
         for cat in group:
             if cat.ID == patrol_leader.ID:
                 continue
@@ -952,6 +957,7 @@ def filter_relationship_type(group: list, filter_types: List[str], patrol_leader
         if len(group) != 2:
             return False
         # test for parentage
+        qualifies = False
         if not group[0].is_parent(group[1]):
             if "parent/child" in exclusionary_values:
                 qualifies = True
@@ -966,6 +972,7 @@ def filter_relationship_type(group: list, filter_types: List[str], patrol_leader
         if len(group) != 2:
             return False
         # test for parentage
+        qualifies = False
         if not group[1].is_parent(group[0]):
             if "child/parent" in exclusionary_values:
                 qualifies = True
@@ -977,6 +984,7 @@ def filter_relationship_type(group: list, filter_types: List[str], patrol_leader
 
     if "mentor/app" in filter_types:
         # It should be exactly two cats for a "mentor/app" event
+        qualifies = False
         if len(group) != 2:
             return False
         # test for parentage
@@ -994,6 +1002,7 @@ def filter_relationship_type(group: list, filter_types: List[str], patrol_leader
         if len(group) != 2:
             return False
         # test for parentage
+        qualifies = False
         if not group[0].ID in group[1].apprentice:
             if "app/mentor" in exclusionary_values:
                 qualifies = True

--- a/scripts/events_module/event_filters.py
+++ b/scripts/events_module/event_filters.py
@@ -980,7 +980,7 @@ def filter_relationship_type(group: list, filter_types: List[str], patrol_leader
         if len(group) != 2:
             return False
         # test for parentage
-        if not group[0].ID in group[1].apprentice:
+        if not group[1].ID in group[0].apprentice:
             if "mentor/app" in exclusionary_values:
                 qualifies = True
             else:

--- a/scripts/events_module/event_filters.py
+++ b/scripts/events_module/event_filters.py
@@ -980,7 +980,7 @@ def filter_relationship_type(group: list, filter_types: List[str], patrol_leader
         if len(group) != 2:
             return False
         # test for parentage
-        if not group[1].ID in group[0].apprentice:
+        if not group[0].ID in group[1].apprentice:
             if "mentor/app" in exclusionary_values:
                 qualifies = True
             else:

--- a/scripts/models/patrol/patrol_schema_item.py
+++ b/scripts/models/patrol/patrol_schema_item.py
@@ -59,7 +59,7 @@ class PatrolSchemaItem(BaseModel):
         ...,
         description="Controls chance to succeed. Higher number is higher chance to succeed.",
     )
-    relationship_status: Union[List[RelationshipStatus], MISSING] = Field(
+    relationship_constraint: Union[List[RelationshipStatus], MISSING] = Field(
         MISSING,
         description="Dictates what relationships m_c must have towards r_c. Do not use this section if there is no r_c in the event.",
     )

--- a/scripts/models/patrol/patrol_schema_item.py
+++ b/scripts/models/patrol/patrol_schema_item.py
@@ -16,7 +16,7 @@ from scripts.models.patrol.patrol_type import PatrolType
 
 
 class PatrolSchemaItem(BaseModel):
-    model_config = ConfigDict(extra='forbid')
+    model_config = ConfigDict(extra="forbid")
     patrol_id: str = Field(
         ..., description="Unique string used to identify the patrol."
     )

--- a/scripts/models/patrol/patrol_schema_item.py
+++ b/scripts/models/patrol/patrol_schema_item.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import Dict, List, Literal, Optional, Tuple, Union
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ConfigDict
 from pydantic_core import MISSING
 from scripts.models.common.biome import Biome
 from scripts.models.common.min_max_status import MinMaxStatusDictKey
@@ -16,6 +16,7 @@ from scripts.models.patrol.patrol_type import PatrolType
 
 
 class PatrolSchemaItem(BaseModel):
+    model_config = ConfigDict(extra='forbid')
     patrol_id: str = Field(
         ..., description="Unique string used to identify the patrol."
     )

--- a/tests/test_event_filters.py
+++ b/tests/test_event_filters.py
@@ -538,7 +538,9 @@ class TestInterpersonalRelationshipConstraints(unittest.TestCase):
         )
 
         app.update_mentor(new_mentor=mentor.ID)
-        with self.subTest("are mentor/app, expected not mentor/app and not parent/child"):
+        with self.subTest(
+            "are mentor/app, expected not mentor/app and not parent/child"
+        ):
             self.assertFalse(
                 event_for_cat(
                     cat_info={"relationship_status": ["-mentor/app", "-parent/child"]},
@@ -546,6 +548,7 @@ class TestInterpersonalRelationshipConstraints(unittest.TestCase):
                     cat_group=[mentor, app],
                 )
             )
+
 
 class TestRelationshipTiers(unittest.TestCase):
     @classmethod

--- a/tests/test_event_filters.py
+++ b/tests/test_event_filters.py
@@ -531,6 +531,21 @@ class TestInterpersonalRelationshipConstraints(unittest.TestCase):
                 )
             )
 
+    def test_multiple(self):
+        app = Cat(moons=8, disable_random=True)
+        mentor = Cat(
+            moons=26, status_dict=StatusDict(rank=CatRank.WARRIOR), disable_random=True
+        )
+
+        app.update_mentor(new_mentor=mentor.ID)
+        with self.subTest("are mentor/app, expected not mentor/app and not parent/child"):
+            self.assertFalse(
+                event_for_cat(
+                    cat_info={"relationship_status": ["-mentor/app", "-parent/child"]},
+                    cat=mentor,
+                    cat_group=[mentor, app],
+                )
+            )
 
 class TestRelationshipTiers(unittest.TestCase):
     @classmethod


### PR DESCRIPTION
## About The Pull Request

* Updates Pydantic model and JSON schema to have the correct `relationship_constraint` value
* Makes the Pydantic patrol model check against properties more strictly (i.e. it won't allow "additional" properties not specified in the model)
* Fixes issue where a patrol had the incorrect field name, causing it to be filtered incorrectly
* Fixes issue where multiple exclusions for relationships weren't working properly. If a single exclusion filter was fulfilled, `qualifies` would be set to `True`, allowing other exclusion filters through even when they shouldn't be allowed
* Adds test for multiple relationship event filters at once

## Linked Issues

Fixes #4811

## Proof of Testing

Set the debug patrol ID to `gen_train_notmentor` and it was filtered out when they were apprentice and mentor:
<img width="554" height="81" alt="image" src="https://github.com/user-attachments/assets/7582ad66-4671-4451-ac24-1aba8e40fc32" />

But allowed when they weren't:
<img width="588" height="80" alt="image" src="https://github.com/user-attachments/assets/0bb87164-e34f-467a-82ee-f7dec595dd1d" />
