### PR TITLE
[BUGFIX] Failing Eyesight from Broken Jaw

### DIFF
--- a/resources/lang/en/events/new_cat/mountainous.json
+++ b/resources/lang/en/events/new_cat/mountainous.json
@@ -23,36 +23,36 @@
         "new_cat": [
             [
                 "exists",
-		"loner"
+		    "loner"
             ]
         ],
-	"injury": [
-        {
+	      "injury": [
+            {
+                "cats": ["n_c:0"],
+                "injuries": ["blunt_force_injury"]
+            }
+        ],
+	      "history": [
+            {
             "cats": ["n_c:0"],
-            "injuries": ["blunt_force_injury"]
-        }
+            "scar": "m_c was scarred after {PRONOUN/m_c/subject} {VERB/m_c/were/was} dropped by an eagle.",
+            "death": "m_c died after {PRONOUN/m_c/subject} {VERB/m_c/were/was} dropped by an eagle."
+            }
         ],
-	"history": [
-        {
-        "cats": ["n_c:0"],
-        "scar": "m_c was scarred after {PRONOUN/m_c/subject} {VERB/m_c/were/was} dropped by an eagle.",
-        "death": "m_c died after {PRONOUN/m_c/subject} {VERB/m_c/were/was} dropped by an eagle."
-        }
-        ],
-	"relationships": [
-          {
-            "cats_from": ["m_c"],
-            "cats_to": ["n_c:0"],
-            "mutual": true,
-            "values": ["comfort", "like"],
-            "amount": 5
-          },
-          {
-            "cats_from": ["n_c:0"],
-            "cats_to": ["m_c"],
-            "values": ["trust"],
-            "amount": 10
-          }
+        "relationships": [
+            {
+              "cats_from": ["m_c"],
+              "cats_to": ["n_c:0"],
+              "mutual": true,
+              "values": ["comfort", "like"],
+              "amount": 5
+            },
+            {
+              "cats_from": ["n_c:0"],
+              "cats_to": ["m_c"],
+              "values": ["trust"],
+              "amount": 10
+            }
         ],
         "outsider": {
             "current_rep": [

--- a/resources/lang/en/events/new_cat/mountainous.json
+++ b/resources/lang/en/events/new_cat/mountainous.json
@@ -29,8 +29,7 @@
 	"injury": [
         {
             "cats": ["n_c:0"],
-            "injuries": ["blunt_force_injury"],
-            "scars": ["THREE", "FACE"]
+            "injuries": ["blunt_force_injury"]
         }
         ],
 	"history": [


### PR DESCRIPTION
## About The Pull Request

Taking the scar line away to prevent inaccurate scars (and also permanent conditions) from generating as a result of an eagle event.

## Linked Issues

Fixes: #4808

## Proof of Testing

<img width="841" height="141" alt="image" src="https://github.com/user-attachments/assets/7b18e749-8435-46e2-9c00-50f4f45d8ea6" />

<img width="1035" height="686" alt="image" src="https://github.com/user-attachments/assets/cd1e5968-ea6d-48b4-b351-ff9d0fd51f80" />

scarred by an eagle. no failing eyesight this time