### PR TITLE
[TWEAKS] injury events

### DIFF
--- a/resources/lang/en/events/death/wetlands.json
+++ b/resources/lang/en/events/death/wetlands.json
@@ -4,7 +4,7 @@
         "location": ["wetlands"],
         "season": ["any"],
         "tags": [],
-        "weight": 10,
+        "frequency": 2,
         "event_text": "m_c got stuck in quicksand and wasn't found in time.",
         "m_c": {
             "status": ["apprentice", "warrior", "deputy", "leader"],
@@ -22,7 +22,7 @@
         "location": ["wetlands"],
         "season": ["greenleaf", "newleaf", "leaf-fall"],
         "tags": [],
-        "weight": 20,
+        "frequency": 4,
         "event_text": "m_c was killed by a snake with a strikingly white mouth.",
         "m_c": {
             "status": ["apprentice"],

--- a/resources/lang/en/events/injury/beach.json
+++ b/resources/lang/en/events/injury/beach.json
@@ -8,7 +8,7 @@
             "any"
         ],
         "frequency": 3,
-        "event_text": "r_c had to rescue m_c from drowning after the apprentice headed out to practice alone.",
+        "event_text": "r_c rescued m_c from drowning after the apprentice headed out to practice alone.",
         "m_c": {
             "status": [
                 "apprentice"
@@ -86,7 +86,7 @@
         "event_text": "m_c's paw pads have become cracked and sore from walking through salty water.",
         "m_c": {
             "status": [
-                "apprentice"
+                "any"
             ]
         },
         "injury": [
@@ -765,8 +765,7 @@
     {
         "event_id": "bch_injury_crackedpads_any1",
         "location": [
-            "beach:camp1_camp3"
-        ],
+            "any"],
         "season": [
             "any"
         ],

--- a/resources/lang/en/events/injury/desert.json
+++ b/resources/lang/en/events/injury/desert.json
@@ -1,36 +1,5 @@
 [
     {
-        "event_id": "dst_injury_bruises_kitten1",
-        "location": [
-            "desert"
-        ],
-        "season": [
-            "any"
-        ],
-        "frequency": 4,
-        "event_text": "While batting a shiny skitter-pebble around m_c misjudged a pounce and smashed {PRONOUN/m_c/poss} tiny little snout into it.",
-        "m_c": {
-            "status": [
-                "kitten"
-            ],
-            "trait": [
-                "unruly",
-                "impulsive",
-                "fearless"
-            ]
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "bruises"
-                ]
-            }
-        ]
-    },
-    {
         "event_id": "dst_injury_heat_anykitten2",
         "location": [
             "desert"
@@ -89,14 +58,7 @@
                     "m_c"
                 ],
                 "injuries": [
-                    "bruises"
-                ]
-            },
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
+                    "bruises",
                     "dehydrated"
                 ]
             }
@@ -316,7 +278,7 @@
         "event_id": "dst_injury_bruisessore_anymultiage2",
         "location": ["desert"],
         "season": ["any"],
-        "weight": 20,
+        "frequency": 4,
         "event_text": "m_c took a bad tumble over a rock hidden by the dusty ground.",
         "m_c": {
             "age": ["adolescent", "young adult", "adult", "senior adult", "senior"]
@@ -386,65 +348,6 @@
                 "injuries": [
                     "hot_injury"
                 ]
-            }
-        ]
-    },
-    {
-        "event_id": "dst_injury_bruisessore_clankits1",
-        "location": [
-            "desert"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "clan:kitten"
-        ],
-        "frequency": 4,
-        "event_text": "m_c isn't as young as {PRONOUN/m_c/subject} used to be, and {PRONOUN/m_c/subject} {VERB/m_c/decline/declines} giving another badger ride, ready to nap off the happy soreness that comes with being the kits' favorite chew toy at the moment.",
-        "m_c": {
-            "age": [
-                "senior adult",
-                "senior"
-            ],
-            "status": [
-                "any"
-            ],
-            "skill": [
-                "KIT,1"
-            ]
-        },
-        "r_c": {
-            "status": [
-                "kitten"
-            ]
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "bruises",
-                    "sore"
-                ]
-            }
-        ],
-        "relationships": [
-            {
-                "cats_to": [
-                    "r_c"
-                ],
-                "cats_from": [
-                    "m_c"
-                ],
-                "mutual": true,
-                "values": [
-                    "like",
-                    "trust",
-                    "comfort"
-                ],
-                "amount": 10
             }
         ]
     },
@@ -965,7 +868,7 @@
             "greenleaf"
         ],
         "frequency": 3,
-        "event_text": "m_c has been trying to keep {PRONOUN/m_c/poss} fluids up, but staying healthy in the oppressive heat of greenleaf was definitely easier in {PRONOUN/m_c/poss} prime. Sunstroke is the result.",
+        "event_text": "m_c has been trying to keep {PRONOUN/m_c/poss} fluids up, but staying healthy in the oppressive heat of greenleaf was definitely easier to manage in {PRONOUN/m_c/poss} prime resulting in sunstroke.",
         "m_c": {
             "age": [
                 "senior adult",
@@ -1071,7 +974,7 @@
             "greenleaf"
         ],
         "frequency": 3,
-        "event_text": "On one of the hottest days of the year r_c spends all {PRONOUN/r_c/poss} energy making sure that the older members of c_n keep drinking. Only m_c gets touched by sunstroke, and it's only a mild case of dehydration.",
+        "event_text": "On one of the hottest days of the year r_c spends all {PRONOUN/r_c/poss} energy making sure that the older members of c_n keep drinking. Only m_c gets touched by sunstroke, though luckily it's a mild case of dehydration.",
         "m_c": {
             "age": [
                 "senior adult",
@@ -3008,44 +2911,6 @@
             ],
             "changed": -3
         }
-    },
-    {
-        "event_id": "dst_injury_bruises_anyapprentice2",
-        "location": [
-            "desert"
-        ],
-        "season": [
-            "any"
-        ],
-        "frequency": 4,
-        "event_text": "m_c says {PRONOUN/m_c/poss} bruises are from battle training. m_c is lying, they're actually from a misjudged pounce.",
-        "m_c": {
-            "status": [
-                "apprentice"
-            ],
-            "trait": [
-                "ambitious",
-                "arrogant",
-                "charismatic",
-                "competitive",
-                "cunning",
-                "fierce",
-                "insecure",
-                "grumpy",
-                "shameless",
-                "sneaky"
-            ]
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "bruises"
-                ]
-            }
-        ]
     },
     {
         "event_id": "dst_injury_bruises_anyapprentice1",

--- a/resources/lang/en/events/injury/desert.json
+++ b/resources/lang/en/events/injury/desert.json
@@ -868,7 +868,7 @@
             "greenleaf"
         ],
         "frequency": 3,
-        "event_text": "m_c has been trying to keep {PRONOUN/m_c/poss} fluids up, but staying healthy in the oppressive heat of greenleaf was definitely easier to manage in {PRONOUN/m_c/poss} prime resulting in sunstroke.",
+        "event_text": "m_c tried to keep {PRONOUN/m_c/poss} fluids up, but staying healthy in the oppressive heat of greenleaf was definitely easier to manage in {PRONOUN/m_c/poss} prime, resulting in sunstroke.",
         "m_c": {
             "age": [
                 "senior adult",

--- a/resources/lang/en/events/injury/desert.json
+++ b/resources/lang/en/events/injury/desert.json
@@ -3307,7 +3307,7 @@
                 "cats": [
                     "m_c"
                 ],
-                "scar": "A snake bite from an unknown species left a momento on m_c's coat.",
+                "scar": "A snake bite from an unknown species left a memento on m_c's coat.",
                 "death": "The bite from an unknown species of snake took m_c's life."
             }
         ]

--- a/resources/lang/en/events/injury/desert.json
+++ b/resources/lang/en/events/injury/desert.json
@@ -2921,7 +2921,7 @@
             "any"
         ],
         "frequency": 4,
-        "event_text": "m_c discovers it's <i>possible</i> to climb cacti. It's not a good idea, no, but sure, it's <i>possible</i>.",
+        "event_text": "m_c discovers it's <i>possible</i> to climb cacti. It's not a good idea, no, but it's <i>possible</i>.",
         "m_c": {
             "status": [
                 "apprentice"
@@ -3085,7 +3085,7 @@
         "event_id": "dst_injury_scrapessmallcuts_appmultitrait1",
         "location": ["desert"],
         "season": ["any"],
-        "weight": 20,
+        "frequency": 4,
         "event_text": "m_c dashes off from {PRONOUN/m_c/poss} mentor and tumbles face first into a cactus! Thankfully r_c is able to remove the spines with little difficulty.",
         "m_c": {
             "status": ["apprentice", "mediator apprentice", "medicine cat apprentice"],
@@ -3099,45 +3099,6 @@
             {
                 "cats": ["m_c"],
                 "injuries": ["scrapes", "small cut"]
-            }
-        ]
-    },
-    {
-        "event_id": "dst_injury_soreapp_clankits",
-        "location": [
-            "desert"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "clan:kitten"
-        ],
-        "frequency": 4,
-        "event_text": "m_c plays with a kit after training instead of resting. It's kind of {PRONOUN/m_c/object}, but the lack of downtime leaves {PRONOUN/m_c/object} sore and aching.",
-        "m_c": {
-            "status": [
-                "apprentice"
-            ],
-            "trait": [
-                "charismatic",
-                "childish",
-                "compassionate",
-                "flamboyant",
-                "loving",
-                "loyal",
-                "playful",
-                "sincere"
-            ]
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "sore"
-                ]
             }
         ]
     },
@@ -3245,7 +3206,7 @@
             "any"
         ],
         "frequency": 4,
-        "event_text": "Bitten by a red bellied black snake, m_c shakes off the effects of the venom, cleaning the wound carefully.",
+        "event_text": "m_c is bitten by a red bellied snake but is able to shake off the effects of the venom and cleans the wound carefully.",
         "m_c": {
             "age": [
                 "senior",
@@ -3282,7 +3243,7 @@
         "event_id": "dst_injury_snake_any1",
         "location": ["desert"],
         "season": ["any"],
-        "weight": 20,
+        "frequency": 4,
         "event_text": "A snake managed to slither into camp and bite m_c.",
         "m_c": {
             "age": ["any"]
@@ -3298,39 +3259,6 @@
                 "cats": ["m_c"],
                 "scar": "m_c was scarred by a snake bite.",
                 "death": "m_c died after {PRONOUN/m_c/subject} {VERB/m_c/were/was} bitten by a snake."
-            }
-        ]
-    },
-    {
-        "event_id": "dst_injury_bruises_anymultisage2",
-        "location": [
-            "desert"
-        ],
-        "season": [
-            "any"
-        ],
-        "frequency": 4,
-        "event_text": "m_c smacked into a rock. Ow.",
-        "m_c": {
-            "age": [
-                "senior",
-                "adolescent",
-                "young adult",
-                "adult",
-                "senior adult"
-            ],
-            "status": [
-                "any"
-            ]
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "bruises"
-                ]
             }
         ]
     },
@@ -3379,7 +3307,7 @@
                 "cats": [
                     "m_c"
                 ],
-                "scar": "A snake bite from an unknown species left a momentum on m_c's coat.",
+                "scar": "A snake bite from an unknown species left a momento on m_c's coat.",
                 "death": "The bite from an unknown species of snake took m_c's life."
             }
         ]
@@ -3705,7 +3633,7 @@
             "any"
         ],
         "frequency": 4,
-        "event_text": "m_c put a paw wrong running amongst the rocks, and {PRONOUN/m_c/poss} momentum wrenched {PRONOUN/m_c/poss} shoulder out of place.",
+        "event_text": "m_c stepped wrong running amongst the rocks, and {PRONOUN/m_c/poss} momentum wrenched {PRONOUN/m_c/poss} shoulder out of place.",
         "m_c": {
             "age": [
                 "senior",
@@ -3774,7 +3702,7 @@
             "any"
         ],
         "frequency": 4,
-        "event_text": "m_c was called in to help repair some of the dens, but {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} not good at it and end up spaining {PRONOUN/m_c/poss} muscles moving something in a stupid way.",
+        "event_text": "m_c was called in to help repair some of the dens, but {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} not good at it and end up straining {PRONOUN/m_c/poss} muscles moving something in a stupid way.",
         "m_c": {
             "age": [
                 "senior",
@@ -3918,7 +3846,7 @@
         }
     },
     {
-        "event_id": "dst_injury_mangledtail_anynotskillfighter2",
+        "event_id": "dst_injury_dingoattack_anynotskillfighter2",
         "location": [
             "desert"
         ],
@@ -3926,7 +3854,7 @@
             "any"
         ],
         "frequency": 4,
-        "event_text": "m_c is almost killed by a roving dingo, and it's only r_c tracking skills that allow c_n to find m_c's refuge before the blood loss is too great.",
+        "event_text": "m_c is almost killed by a roving dingo, and it's only r_c tracking skills that allow c_n to find m_c's refuge before {PRONOUN/m_c/subject} {VERB/m_c/bleed/bleeds} out.",
         "m_c": {
             "age": [
                 "senior",
@@ -4624,7 +4552,7 @@
         ]
     },
     {
-        "event_id": "dst_injury_mangledleg_anymultistatusnotcareful1",
+        "event_id": "dst_injury_cactus_anymultistatusnotcareful1",
         "location": [
             "desert"
         ],

--- a/resources/lang/en/events/injury/forest.json
+++ b/resources/lang/en/events/injury/forest.json
@@ -212,7 +212,7 @@
             "any"
         ],
         "frequency": 1,
-        "event_text": "m_c's tail was badly injured by a falling tree.",
+        "event_text": "m_c's tail was badly injured by a falling bough.",
         "m_c": {
             "age": [
                 "adolescent",
@@ -240,8 +240,8 @@
                 "cats": [
                     "m_c"
                 ],
-                "scar": "m_c was scarred by a falling tree.",
-                "death": "m_c died from {PRONOUN/m_c/poss} wounds after a tree fell on {PRONOUN/m_c/object}."
+                "scar": "m_c was scarred by a falling bough.",
+                "death": "m_c died from {PRONOUN/m_c/poss} wounds after a bough fell on {PRONOUN/m_c/object}."
             }
         ]
     },
@@ -378,7 +378,7 @@
             "leaf-bare"
         ],
         "frequency": 2,
-        "event_text": "m_c and r_c played on the ice-covered pond near camp. They weren't quick enough to react to the sound of cracking beneath them, but m_c managed to drag r_c out of the freezing water.",
+        "event_text": "m_c and r_c were playing on the ice-covered pond near camp. They weren't quick enough to react to the sound of cracking beneath them, but m_c managed to drag r_c out of the freezing water.",
         "m_c": {
             "status": [
                 "apprentice",
@@ -513,7 +513,7 @@
             "leaf-fall"
         ],
         "frequency": 4,
-        "event_text": "m_c was left scratched and scraped after pushing through thorny, bare undergrowth.",
+        "event_text": "m_c was left scratched and scraped after pushing through dense thorny undergrowth.",
         "m_c": {
             "age": [
                 "any",

--- a/resources/lang/en/events/injury/forest.json
+++ b/resources/lang/en/events/injury/forest.json
@@ -378,7 +378,7 @@
             "leaf-bare"
         ],
         "frequency": 2,
-        "event_text": "m_c and r_c were playing on the ice-covered pond near camp. They weren't quick enough to react to the sound of cracking beneath them, but m_c managed to drag r_c out of the freezing water.",
+        "event_text": "m_c and r_c were playing on the ice-covered pond near camp. The ice broke beneath them, but m_c managed to drag r_c out of the freezing water.",
         "m_c": {
             "status": [
                 "apprentice",

--- a/resources/lang/en/events/injury/general.json
+++ b/resources/lang/en/events/injury/general.json
@@ -295,7 +295,7 @@
             "any"
         ],
         "frequency": 3,
-        "event_text": "m_c woke up with a mild headache, but got up to play anyways, trying to ignore the nagging pain.",
+        "event_text": "m_c woke up with a mild headache, but got up to play anyway, trying to ignore the nagging pain.",
         "m_c": {
             "status": [
                 "kitten"

--- a/resources/lang/en/events/injury/general.json
+++ b/resources/lang/en/events/injury/general.json
@@ -7564,5 +7564,77 @@
                 ]
             }
         ]
+    },
+        {
+        "event_id": "gen_injury_soreapp_clankits",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "tags": [
+            "clan:kitten"
+        ],
+        "frequency": 4,
+        "event_text": "m_c plays with a kit after training instead of resting. It's kind of {PRONOUN/m_c/object}, but the lack of downtime leaves {PRONOUN/m_c/object} sore and aching.",
+        "m_c": {
+            "status": [
+                "apprentice"
+            ],
+            "trait": [
+                "charismatic",
+                "childish",
+                "compassionate",
+                "flamboyant",
+                "loving",
+                "loyal",
+                "playful",
+                "sincere"
+            ]
+        },
+        "injury": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "injuries": [
+                    "sore"
+                ]
+            }
+        ]
+    },
+        {
+        "event_id": "any_injury_bruises_anymultiage2",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "frequency": 4,
+        "event_text": "m_c smacked into a boulder. Ow.",
+        "m_c": {
+            "age": [
+                "senior",
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult"
+            ],
+            "status": [
+                "any"
+            ]
+        },
+        "injury": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "injuries": [
+                    "bruises"
+                ]
+            }
+        ]
     }
 ]

--- a/resources/lang/en/events/injury/general.json
+++ b/resources/lang/en/events/injury/general.json
@@ -7666,7 +7666,7 @@
             "any"
         ],
         "frequency": 4,
-        "event_text": "m_c smacked into a boulder. Ow.",
+        "event_text": "m_c walked into a boulder. Ow.",
         "m_c": {
             "age": [
                 "senior",

--- a/resources/lang/en/events/injury/general.json
+++ b/resources/lang/en/events/injury/general.json
@@ -347,7 +347,7 @@
             "any"
         ],
         "frequency": 4,
-        "event_text": "m_c had a bad fall while taking a walk through the territory, returning to camp sore and bruised.",
+        "event_text": "m_c had a bad fall while taking a walk through the territory and returned to camp sore and bruised.",
         "m_c": {
             "age": [
                 "adolescent",
@@ -1177,7 +1177,7 @@
             "any"
         ],
         "frequency": 3,
-        "event_text": "On a border patrol near the o_c_n border, m_c could no longer take o_c_n's jeers and smirks. {PRONOUN/m_c/subject/CAP} lashed out at the first jeering cat {PRONOUN/m_c/subject} saw, although the hotheaded move wasn't smart as m_c couldn't escape the skirmish without injury.",
+        "event_text": "On a border patrol near the o_c_n border, m_c could no longer take o_c_n's jeers and smirks. {PRONOUN/m_c/subject/CAP} lashed out at the first jeering cat {PRONOUN/m_c/subject} saw, although the hotheaded move ensured {PRONOUN/m_c/subject} didn't escape the skirmish without injury.",
         "m_c": {
             "age": [
                 "-kitten"
@@ -1256,7 +1256,7 @@
             "clan:kitten"
         ],
         "frequency": 4,
-        "event_text": "While o_c_n attempted a surprise attack on the c_n camp, m_c fiercely guarded the nursery. However, it didn't end with m_c unscathed.",
+        "event_text": "While o_c_n attempted a surprise attack on the c_n camp, m_c fiercely guarded the nursery, no matter how injured {PRONOUN/m_c/subject} became.",
         "m_c": {
             "age": [
                 "-kitten"
@@ -1560,7 +1560,9 @@
         "event_id": "multi_injury_anybrokenbone1",
         "location": [
             "plains",
-            "mountainous"
+            "mountainous",
+            "beach",
+            "desert"
         ],
         "season": [
             "any"
@@ -1596,7 +1598,8 @@
         "location": [
             "beach",
             "mountainous",
-            "forest"
+            "forest",
+            "wetlands"
         ],
         "season": [
             "any"
@@ -1624,7 +1627,8 @@
         "location": [
             "beach",
             "mountainous",
-            "forest"
+            "forest",
+            "wetlands"
         ],
         "season": [
             "any"
@@ -1652,7 +1656,8 @@
         "location": [
             "beach",
             "forest",
-            "mountainous"
+            "mountainous",
+            "wetlands"
         ],
         "season": [
             "any"
@@ -1838,7 +1843,9 @@
         "event_id": "gen_injury_sprain_anymultiage6",
         "location": [
             "forest:camp1_camp2_camp4",
-            "plains:camp1_camp3"
+            "plains:camp1_camp3_camp4",
+            "mountainous:camp1_camp4",
+            "wetlands"
         ],
         "season": [
             "newleaf",
@@ -5255,35 +5262,6 @@
         ]
     },
     {
-        "event_id": "gen_injury_crackedpads_anymultiage1",
-        "location": [
-            "beach"
-        ],
-        "season": [
-            "any"
-        ],
-        "frequency": 4,
-        "event_text": "m_c stepped on some sharp stones while walking along the shoreline.",
-        "m_c": {
-            "age": [
-                "-kitten"
-            ],
-            "status": [
-                "any"
-            ]
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "cracked pads"
-                ]
-            }
-        ]
-    },
-    {
         "event_id": "gen_injury_snakebite_anymultiage1",
         "location": [
             "any"
@@ -5330,7 +5308,7 @@
             "any"
         ],
         "frequency": 4,
-        "event_text": "m_c wasn't looking where {PRONOUN/m_c/subject} {VERB/m_c/were/was} going and tripped over a small trunk, gaining a few bruises.",
+        "event_text": "m_c wasn't looking where {PRONOUN/m_c/subject} {VERB/m_c/were/was} going and tripped over a small stump, gaining a few bruises.",
         "m_c": {
             "age": [
                 "-kitten"
@@ -5504,7 +5482,7 @@
             "any"
         ],
         "frequency": 4,
-        "event_text": "m_c wasn't looking where {PRONOUN/m_c/subject} {VERB/m_c/were/was} going and tripped over a small trunk, spraining {PRONOUN/m_c/poss} paw.",
+        "event_text": "m_c wasn't looking where {PRONOUN/m_c/subject} {VERB/m_c/were/was} going and tripped over a small stump, spraining {PRONOUN/m_c/poss} paw.",
         "m_c": {
             "age": [
                 "-kitten"
@@ -5833,7 +5811,7 @@
         ]
     },
     {
-        "event_id": "gen_injury_mangledtail_any1",
+        "event_id": "gen_injury_mangledleg_any1",
         "location": [
             "any"
         ],
@@ -6507,7 +6485,7 @@
             "newleaf"
         ],
         "frequency": 4,
-        "event_text": "The day is so nice out today that m_c decided to sneak out of camp and go play in the flowers without anyone noticing. {PRONOUN/m_c/subject/CAP} come back with a swollen paw, having stepped on a bee.",
+        "event_text": "The day is so nice out today that m_c decided to sneak out of camp and go play in the flowers without anyone noticing. {PRONOUN/m_c/subject/CAP} come back with a swollen paw after stepping on a bee.",
         "m_c": {
             "age": [
                 "kitten"
@@ -7457,5 +7435,134 @@
       ]
     }
   ]
-}
+},
+    {
+        "event_id": "gen_injury_bruises_kittensnout",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "frequency": 4,
+        "event_text": "While batting a shiny pebble around, m_c misjudged a pounce and smashed {PRONOUN/m_c/poss} tiny little snout into it.",
+        "m_c": {
+            "status": [
+                "kitten"
+            ],
+            "trait": [
+                "unruly",
+                "impulsive",
+                "fearless"
+            ]
+        },
+        "injury": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "injuries": [
+                    "bruises"
+                ]
+            }
+        ]
+    },
+    {
+        "event_id": "gen_injury_bruisessore_clankits1",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "tags": [
+            "clan:kitten"
+        ],
+        "frequency": 4,
+        "event_text": "m_c isn't as young as {PRONOUN/m_c/subject} used to be, and {PRONOUN/m_c/subject} {VERB/m_c/decline/declines} giving another badger ride, ready to nap off the happy soreness that comes with being the kits' favorite chew toy at the moment.",
+        "m_c": {
+            "age": [
+                "senior adult",
+                "senior"
+            ],
+            "status": [
+                "any"
+            ],
+            "skill": [
+                "KIT,1"
+            ]
+        },
+        "r_c": {
+            "status": [
+                "kitten"
+            ]
+        },
+        "injury": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "injuries": [
+                    "bruises",
+                    "sore"
+                ]
+            }
+        ],
+        "relationships": [
+            {
+                "cats_to": [
+                    "r_c"
+                ],
+                "cats_from": [
+                    "m_c"
+                ],
+                "mutual": true,
+                "values": [
+                    "like",
+                    "trust",
+                    "comfort"
+                ],
+                "amount": 10,
+                "log": "m_c gives r_c the best badger rides."
+            }
+        ]
+    },
+    {
+        "event_id": "gen_injury_bruises_anyapprentice3",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "frequency": 4,
+        "event_text": "m_c says {PRONOUN/m_c/poss} bruises are from battle training. m_c is lying, they're actually from a misjudged pounce.",
+        "m_c": {
+            "status": [
+                "apprentice"
+            ],
+            "trait": [
+                "ambitious",
+                "arrogant",
+                "charismatic",
+                "competitive",
+                "cunning",
+                "fierce",
+                "insecure",
+                "grumpy",
+                "shameless",
+                "sneaky"
+            ]
+        },
+                "injury": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "injuries": [
+                    "bruises"
+                ]
+            }
+        ]
+    }
 ]

--- a/resources/lang/en/events/injury/general.json
+++ b/resources/lang/en/events/injury/general.json
@@ -7436,60 +7436,58 @@
             }
         ]
     },
-    {
-        "event_id": "gen_injury_war_onwatch",
-        "location": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "sub_type": [
-            "war"
-        ],
-        "frequency": 3,
-        "event_text": "m_c and r_c spend the night by the o_c_n border and catch a o_c_n patrol sneaking into c_n territory. While r_c gets reinforcements, m_c keeps them occupied.",
-        "m_c": {
-            "status": [
-                "warrior",
-                "deputy",
-                "leader"
-            ]
-        },
-        "r_c": {
-            "status": [
-                "warrior",
-                "deputy",
-                "leader"
-            ]
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "battle_injury"
-                ]
-            }
-        ],
-        "history": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "scar": "m_c gained a scar from holding off an ambush.",
-                "death": "m_c died of {PRONOUN/m_c/poss} injuries after holding off o_c_n's ambush."
-            }
-        ],
-        "other_clan": {
-            "current_rep": [
-                "hostile"
+{
+    "event_id": "gen_injury_war_onwatch",
+    "location": [
+        "any"
+    ],
+    "season": [
+        "any"
+    ],
+    "sub_type": [
+        "war"
+    ],
+    "frequency": 3,
+    "event_text": "m_c and r_c spend the night by the o_c_n border and catch a o_c_n patrol sneaking into c_n territory. While r_c gets reinforcements, m_c keeps them occupied.",
+    "m_c": {
+        "status": [
+            "warrior",
+            "deputy",
+            "leader"
+        ]
+    },
+    "r_c": {
+        "status": [
+            "warrior",
+            "deputy",
+            "leader"
+        ]
+    },
+    "injury": [
+        {
+            "cats": [
+                "m_c"
             ],
-            "changed": -2
+            "injuries": [
+                "battle_injury"
+            ]
         }
+    ],
+    "history": [
+        {
+            "cats": [
+                "m_c"
+            ],
+            "scar": "m_c gained a scar from holding off an ambush.",
+            "death": "m_c died of {PRONOUN/m_c/poss} injuries after holding off o_c_n's ambush."
+        }
+    ],
+    "other_clan": {
+        "current_rep": [
+            "hostile"
+        ],
+        "changed": -2
     }
-  ]
 },
     {
         "event_id": "gen_injury_bruises_kittensnout",

--- a/resources/lang/en/events/injury/general.json
+++ b/resources/lang/en/events/injury/general.json
@@ -7591,7 +7591,7 @@
             "any"
         ],
         "frequency": 4,
-        "event_text": "m_c says {PRONOUN/m_c/poss} bruises are from battle training. m_c is lying, they're actually from a misjudged pounce.",
+        "event_text": "m_c claims {PRONOUN/m_c/poss} bruises are from battle training. m_c is lying; they're actually from a misjudged pounce.",
         "m_c": {
             "status": [
                 "apprentice"

--- a/resources/lang/en/events/injury/general.json
+++ b/resources/lang/en/events/injury/general.json
@@ -7534,7 +7534,7 @@
             "clan:kitten"
         ],
         "frequency": 4,
-        "event_text": "m_c isn't as young as {PRONOUN/m_c/subject} used to be, and {PRONOUN/m_c/subject} {VERB/m_c/decline/declines} giving another badger ride, ready to nap off the happy soreness that comes with being the kits' favorite chew toy at the moment.",
+        "event_text": "m_c isn't as young as {PRONOUN/m_c/subject} used to be, and {PRONOUN/m_c/subject} {VERB/m_c/decline/declines} giving another badger ride to nap off the happy soreness that comes with being the kits' current favorite chew toy.",
         "m_c": {
             "age": [
                 "senior adult",

--- a/resources/lang/en/events/injury/general.json
+++ b/resources/lang/en/events/injury/general.json
@@ -7632,7 +7632,7 @@
             "clan:kitten"
         ],
         "frequency": 4,
-        "event_text": "m_c plays with a kit after training instead of resting. It's kind of {PRONOUN/m_c/object}, but the lack of downtime leaves {PRONOUN/m_c/object} sore and aching.",
+        "event_text": "m_c plays with a kit after training instead of resting. The lack of downtime leaves {PRONOUN/m_c/object} sore and aching.",
         "m_c": {
             "status": [
                 "apprentice"

--- a/resources/lang/en/events/injury/general.json
+++ b/resources/lang/en/events/injury/general.json
@@ -7578,7 +7578,7 @@
                     "comfort"
                 ],
                 "amount": 10,
-                "log": "m_c gives r_c the best badger rides."
+                "log": "m_c gave r_c the best badger rides as a kit."
             }
         ]
     },

--- a/resources/lang/en/events/injury/mountainous.json
+++ b/resources/lang/en/events/injury/mountainous.json
@@ -8,7 +8,7 @@
             "leaf-fall",
             "leaf-bare"
         ],
-        "frequency": 1,
+        "frequency": 2,
         "event_text": "m_c thought {PRONOUN/m_c/subject} {VERB/m_c/were/was} walking on a snowdrift until it gave way and {PRONOUN/m_c/subject} fell down the mountain, breaking {PRONOUN/m_c/poss} leg.",
         "m_c": {
             "age": [
@@ -47,7 +47,7 @@
         "season": [
             "any"
         ],
-        "frequency": 1,
+        "frequency": 2,
         "event_text": "m_c's tail was badly injured by falling rocks.",
         "m_c": {
             "age": [

--- a/resources/lang/en/events/injury/mountainous.json
+++ b/resources/lang/en/events/injury/mountainous.json
@@ -8,7 +8,7 @@
             "leaf-fall",
             "leaf-bare"
         ],
-        "frequency": 2,
+        "frequency": 1,
         "event_text": "m_c thought {PRONOUN/m_c/subject} {VERB/m_c/were/was} walking on a snowdrift until it gave way and {PRONOUN/m_c/subject} fell down the mountain, breaking {PRONOUN/m_c/poss} leg.",
         "m_c": {
             "age": [
@@ -47,7 +47,7 @@
         "season": [
             "any"
         ],
-        "frequency": 2,
+        "frequency": 1,
         "event_text": "m_c's tail was badly injured by falling rocks.",
         "m_c": {
             "age": [

--- a/resources/lang/en/events/injury/wetlands.json
+++ b/resources/lang/en/events/injury/wetlands.json
@@ -3,7 +3,7 @@
         "event_id": "wtlnd_injury_sore_anymultiage1",
         "location": ["wetlands"],
         "season": ["any"],
-        "weight": 20,
+        "frequency": 4,
         "event_text": "m_c woke up sore after walking through an especially muddy and dense part of the territory.",
         "m_c": {
             "age": ["adolescent", "young adult", "adult", "senior adult", "senior"]
@@ -19,7 +19,7 @@
         "event_id": "wtlnd_injury_poisoned_app1",
         "location": ["wetlands"],
         "season": ["any"],
-        "weight": 20,
+        "frequency": 4,
         "event_text": "m_c ate some red berries out in the territory and was rushed back to camp by r_c.",
         "m_c": {
             "age": ["adolescent"],
@@ -39,7 +39,7 @@
         "event_id": "wtlnd_injury_smallcut_anymultiage1",
         "location": ["wetlands"],
         "season": ["any"],
-        "weight": 20,
+        "frequency": 4,
         "event_text": "m_c nicked {PRONOUN/m_c/self} on the low branches of a spiky tree.",
         "m_c": {
             "age": ["adolescent", "young adult", "adult", "senior adult"]
@@ -58,7 +58,7 @@
         "event_id": "wtlnd_injury_snakebite_anymultiage1",
         "location": ["wetlands"],
         "season": ["any"],
-        "weight": 20,
+        "frequency": 4,
         "event_text": "m_c was bitten by a hidden snake whilst hunting in the marsh.",
         "m_c": {
             "age": ["adolescent", "young adult", "adult", "senior adult"]


### PR DESCRIPTION
## About The Pull Request

- Spelling/grammar changes
- Frequency tweaks
- Event constraint changes

## Why This Is Good For ClanGen

- Moves events to files where the event text itself indicates it belongs in, removing region-locked constraints.
- Removing a duplicate event in multiple files
- Miscellaneous changes to spelling/grammar and frequency. 

## Proof of Testing

Moonskipped roughly 100 moons in a pure vanilla test clan with these changes without error.

<img width="415" height="206" alt="Screenshot 2026-04-18 at 6 27 23 PM" src="https://github.com/user-attachments/assets/604a5360-d600-4dd4-a8f7-b3f7dc6e7cd5" />