### PR TITLE
[CONTENT] guard asleep

### DIFF
--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -12135,7 +12135,7 @@
       "any"
     ],
     "frequency": 4,
-    "event_text": "m_c accidentally fell asleep when {PRONOUN/m_c/subject} {VERB/m_c/were/was} supposed to be guarding camp.",
+    "event_text": "m_c fell asleep when {PRONOUN/m_c/subject} {VERB/m_c/were/was} supposed to be guarding camp.",
     "m_c": {
         "status": [
           "warrior",

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -12125,5 +12125,43 @@
                 "vengeful"
             ]
         }
-    }
+    },
+      {
+    "event_id": "gen_misc_guardasleep",
+    "location": [
+      "any"
+    ],
+    "season": [
+      "any"
+    ],
+    "frequency": 4,
+    "event_text": "m_c accidentally fell asleep when {PRONOUN/m_c/subject} {VERB/m_c/were/was} supposed to be guarding camp.",
+    "m_c": {
+        "status": [
+          "warrior",
+          "deputy"
+        ],
+        "relationship_status": [],
+        "skill": [],
+        "trait": ["-strict", "-responsible"],
+        "backstory": [],
+        "dies": false
+    },
+    "relationships": [
+        {
+            "cats_from": [
+              "clan", "high_lawful"
+            ],
+            "cats_to": [
+              "m_c"
+            ],
+            "mutual": false,
+            "values": ["trust"],
+            "amount": -5,
+            "log": {
+              "cats_from": "cat_from heard cat_to fell asleep guarding camp."
+                }
+        }
+    ]
+}
 ]


### PR DESCRIPTION
## About The Pull Request

- Added a simple event of a warrior falling asleep on nightly guard duty. Room to expand on the concept with several variations.

## Why This Is Good For ClanGen

- More diverse events = more interesting gameplay. 

## Proof of Testing

<img width="642" height="246" alt="Screenshot 2026-04-19 at 10 11 25 AM" src="https://github.com/user-attachments/assets/32ce3a81-e421-4612-82bb-2459c196b344" />
