### PR TITLE
[CONTENT] New War Injury Events

### DIFF
--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -851,41 +851,6 @@
         }
     },
     {
-        "event_id": "gen_death_siege_any1",
-        "location": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "sub_type": [
-            "war"
-        ],
-        "frequency": 4,
-        "event_text": "o_c_n attempted to break into the camp. m_c and r_c are left cold on the ground in the aftermath.",
-        "m_c": {
-            "dies": true
-        },
-        "r_c": {
-            "dies": true
-        },
-        "history": [
-            {
-                "cats": [
-                    "m_c",
-                    "r_c"
-                ],
-                "death": "This cat died when o_c_n tried to break into camp."
-            }
-        ],
-        "other_clan": {
-            "current_rep": [
-                "hostile"
-            ],
-            "changed": -3
-        }
-    },
-    {
         "event_id": "gen_death_siege_any2",
         "location": [
             "any"
@@ -1776,6 +1741,454 @@
         }
     },
     {
+        "event_id": "gen_death_siege_any1",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 4,
+        "event_text": "o_c_n attempted to break into the camp. m_c and r_c are left cold on the ground in the aftermath.",
+        "m_c": {
+            "dies": true
+        },
+        "r_c": {
+            "dies": true
+        },
+        "history": [
+            {
+                "cats": [
+                    "m_c",
+                    "r_c"
+                ],
+                "death": "This cat died when o_c_n tried to break into camp."
+            }
+        ],
+        "other_clan": {
+            "current_rep": [
+                "hostile"
+            ],
+            "changed": -3
+        }
+    },
+    {
+        "event_id": "gen_death_bury_any3",
+        "location": [
+            "plains",
+            "forest"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "tags": [
+            "no_body",
+            "all_lives"
+        ],
+        "frequency": 3,
+        "event_text": "m_c was buried alive in a cramped rabbit burrow by o_c_n warriors.",
+        "m_c": {
+            "age": [
+                "-kitten",
+                "-senior"
+            ],
+            "status": [
+                "any"
+            ],
+            "dies": true
+        },
+        "history": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "death": "m_c suffocated underground."
+            }
+        ],
+        "other_clan": {
+            "current_rep": [
+                "hostile"
+            ],
+            "changed": -3
+        }
+    },
+    {
+        "event_id": "gen_death_war_any9",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "tags": [],
+        "frequency": 2,
+        "event_text": "Blinded by blood in the midst of battle, r_c fatally mistakes m_c for a foe.",
+        "m_c": {
+            "status": [
+                "warrior",
+                "deputy",
+                "leader"
+            ],
+            "trait": [
+                "fierce",
+                "bloodthirsty",
+                "bold",
+                "ambitious",
+                "arrogant",
+                "competitive"
+            ],
+            "dies": true
+        },
+        "r_c": {
+            "status": [
+                "apprentice",
+                "warrior",
+                "deputy",
+                "leader"
+            ]
+        },
+        "history": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "death": "m_c was accidentally killed by r_c in battle."
+            }
+        ],
+        "relationships": [
+            {
+                "cats_from": [
+                    "m_c"
+                ],
+                "cats_to": [
+                    "r_c"
+                ],
+                "values": [
+                    "trust",
+                    "like"
+                ],
+                "amount": -30,
+                "mutual": false,
+                "log": {
+                    "cats_from": "cat_from was accidentally killed by cat_to in battle."
+                }
+            },
+            {
+                "cats_from": [
+                    "some_clan"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "mutual": false,
+                "values": [
+                    "trust"
+                ],
+                "amount": -15,
+                "log": {
+                    "cats_from": "cat_from became suspicious of cat_to when {PRONOUN/cat_to/subject} claimed to have killed m_c in battle by accident."
+                }
+            }
+        ],
+        "other_clan": {
+            "current_rep": [
+                "hostile"
+            ],
+            "changed": -1
+        }
+    },
+    {
+        "event_id": "gen_death_war_any5",
+        "location": [
+            "mountainous",
+            "forest"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "tags": [],
+        "frequency": 2,
+        "event_text": "m_c was killed by a falling boulder that o_c_n warriors pushed from a cliff above {PRONOUN/m_c/object}.",
+        "m_c": {
+            "status": [
+                "apprentice",
+                "warrior",
+                "deputy",
+                "leader"
+            ],
+            "dies": true
+        },
+        "history": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "death": "m_c was crushed by a falling boulder."
+            }
+        ],
+        "other_clan": {
+            "current_rep": [
+                "hostile"
+            ],
+            "changed": -3
+        }
+    },
+    {
+        "event_id": "gen_death_ockill_anymed2",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "tags": [],
+        "frequency": 4,
+        "event_text": "o_c_n warriors broke into the camp and killed m_c after damaging the stockpiled prey.",
+        "m_c": {
+            "age": [
+                "-kitten"
+            ],
+            "skill": [
+                "-FIGHTER,2",
+                "-OMEN,3",
+                "-PROPHET,3"
+            ],
+            "dies": true
+        },
+        "history": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "death": "m_c was killed when o_c_n warriors broke into camp."
+            }
+        ],
+        "other_clan": {
+            "current_rep": [
+                "hostile"
+            ],
+            "changed": -3
+        },
+        "supplies": [
+            {
+                "type": "freshkill",
+                "trigger": [
+                    "always"
+                ],
+                "adjust": "reduce_half"
+            }
+        ]
+    },
+    {
+        "event_id": "gen_death_stress_anywar1",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "tags": [],
+        "frequency": 4,
+        "event_text": "m_c suffered a heart attack due to the stress of the ongoing war.",
+        "m_c": {
+            "age": [
+                "senior",
+                "adult",
+                "senior adult"
+            ],
+            "dies": true
+        },
+        "history": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "death": "m_c died of a heart attack due to stress."
+            }
+        ]
+    },
+    {
+        "event_id": "gen_death_ockill_anylead7",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "tags": [
+            "all_lives"
+        ],
+        "frequency": 4,
+        "event_text": "m_c was brutally murdered by a warrior from o_c_n, who cruelly took all {PRONOUN/m_c/poss} lives.",
+        "m_c": {
+            "status": [
+                "leader"
+            ],
+            "skill": [
+                "-FIGHTER,2"
+            ],
+            "dies": true
+        },
+        "history": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "death": "m_c was brutally murdered by a warrior from o_c_n."
+            }
+        ],
+        "other_clan": {
+            "current_rep": [
+                "hostile"
+            ],
+            "changed": -3
+        }
+    },
+    {
+        "event_id": "gen_death_ockill_anylead8",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "tags": [
+            "all_lives"
+        ],
+        "frequency": 4,
+        "event_text": "m_c was brutally murdered by the leader of o_c_n, who cruelly took all {PRONOUN/m_c/poss} lives.",
+        "m_c": {
+            "status": [
+                "leader"
+            ],
+            "skill": [
+                "-FIGHTER,3"
+            ],
+            "dies": true
+        },
+        "history": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "death": "m_c was brutally murdered by the leader of o_c_n."
+            }
+        ],
+        "other_clan": {
+            "current_rep": [
+                "hostile"
+            ],
+            "changed": -3
+        }
+    },
+    {
+        "event_id": "gen_death_ockill_anylead9",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "tags": [
+            "all_lives"
+        ],
+        "frequency": 4,
+        "event_text": "m_c was brutally murdered by the deputy of o_c_n, who cruelly took all {PRONOUN/m_c/poss} lives.",
+        "m_c": {
+            "status": [
+                "leader"
+            ],
+            "skill": [
+                "-FIGHTER,2"
+            ],
+            "dies": true
+        },
+        "history": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "death": "m_c was brutally murdered by the deputy of o_c_n."
+            }
+        ],
+        "other_clan": {
+            "current_rep": [
+                "hostile"
+            ],
+            "changed": -3
+        }
+    },
+    {
+        "event_id": "gen_death_war_onwatch",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 2,
+        "event_text": "m_c and r_c spend the night by the o_c_n border and catch a o_c_n patrol sneaking into c_n territory. While r_c gets reinforcements, m_c tries to hold them off and dies for it.",
+        "m_c": {
+            "status": [
+                "warrior",
+                "deputy",
+                "leader"
+            ],
+            "dies": true
+        },
+        "r_c": {
+            "status": [
+                "warrior",
+                "deputy",
+                "leader"
+            ]
+        },
+        "history": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "death": "m_c died while holding off an ambush."
+            }
+        ],
+        "other_clan": {
+            "current_rep": [
+                "hostile"
+            ],
+            "changed": -3
+        }
+    },
+    {
         "event_id": "gen_death_age_any1",
         "location": [
             "any"
@@ -2537,49 +2950,6 @@
         ]
     },
     {
-        "event_id": "gen_death_bury_any3",
-        "location": [
-            "plains",
-            "forest"
-        ],
-        "season": [
-            "any"
-        ],
-        "sub_type": [
-            "war"
-        ],
-        "tags": [
-            "no_body",
-            "all_lives"
-        ],
-        "frequency": 3,
-        "event_text": "m_c was buried alive in a cramped rabbit burrow by o_c_n warriors.",
-        "m_c": {
-            "age": [
-                "-kitten",
-                "-senior"
-            ],
-            "status": [
-                "any"
-            ],
-            "dies": true
-        },
-        "history": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "death": "m_c suffocated underground."
-            }
-        ],
-        "other_clan": {
-            "current_rep": [
-                "hostile"
-            ],
-            "changed": -3
-        }
-    },
-    {
         "event_id": "gen_death_skirmish_any1",
         "location": [
             "any"
@@ -2615,94 +2985,6 @@
                 "neutral"
             ],
             "changed": -3
-        }
-    },
-    {
-        "event_id": "gen_death_war_any9",
-        "location": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "sub_type": [
-            "war"
-        ],
-        "tags": [],
-        "frequency": 2,
-        "event_text": "Blinded by blood in the midst of battle, r_c fatally mistakes m_c for a foe.",
-        "m_c": {
-            "status": [
-                "warrior",
-                "deputy",
-                "leader"
-            ],
-            "trait": [
-                "fierce",
-                "bloodthirsty",
-                "bold",
-                "ambitious",
-                "arrogant",
-                "competitive"
-            ],
-            "dies": true
-        },
-        "r_c": {
-            "status": [
-                "apprentice",
-                "warrior",
-                "deputy",
-                "leader"
-            ]
-        },
-        "history": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "death": "m_c was accidentally killed by r_c in battle."
-            }
-        ],
-        "relationships": [
-            {
-                "cats_from": [
-                    "m_c"
-                ],
-                "cats_to": [
-                    "r_c"
-                ],
-                "values": [
-                    "trust",
-                    "like"
-                ],
-                "amount": -30,
-                "mutual": false,
-                "log": {
-                    "cats_from": "cat_from was accidentally killed by cat_to in battle."
-                }
-            },
-            {
-                "cats_from": [
-                    "some_clan"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "mutual": false,
-                "values": [
-                    "trust"
-                ],
-                "amount": -15,
-                "log": {
-                    "cats_from": "cat_from became suspicious of cat_to when {PRONOUN/cat_to/subject} claimed to have killed m_c in battle by accident."
-                }
-            }
-        ],
-        "other_clan": {
-            "current_rep": [
-                "hostile"
-            ],
-            "changed": -1
         }
     },
     {
@@ -3218,45 +3500,6 @@
                 }
             }
         ]
-    },
-    {
-        "event_id": "gen_death_war_any5",
-        "location": [
-            "mountainous",
-            "forest"
-        ],
-        "season": [
-            "any"
-        ],
-        "sub_type": [
-            "war"
-        ],
-        "tags": [],
-        "frequency": 2,
-        "event_text": "m_c was killed by a falling boulder that o_c_n warriors pushed from a cliff above {PRONOUN/m_c/object}.",
-        "m_c": {
-            "status": [
-                "apprentice",
-                "warrior",
-                "deputy",
-                "leader"
-            ],
-            "dies": true
-        },
-        "history": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "death": "m_c was crushed by a falling boulder."
-            }
-        ],
-        "other_clan": {
-            "current_rep": [
-                "hostile"
-            ],
-            "changed": -3
-        }
     },
     {
         "event_id": "gen_death_hawk_any1",
@@ -4055,55 +4298,6 @@
         ]
     },
     {
-        "event_id": "gen_death_ockill_anymed2",
-        "location": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "sub_type": [
-            "war"
-        ],
-        "tags": [],
-        "frequency": 4,
-        "event_text": "o_c_n warriors broke into the camp and killed m_c after damaging the stockpiled prey.",
-        "m_c": {
-            "age": [
-                "-kitten"
-            ],
-            "skill": [
-                "-FIGHTER,2",
-                "-OMEN,3",
-                "-PROPHET,3"
-            ],
-            "dies": true
-        },
-        "history": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "death": "m_c was killed when o_c_n warriors broke into camp."
-            }
-        ],
-        "other_clan": {
-            "current_rep": [
-                "hostile"
-            ],
-            "changed": -3
-        },
-        "supplies": [
-            {
-                "type": "freshkill",
-                "trigger": [
-                    "always"
-                ],
-                "adjust": "reduce_half"
-            }
-        ]
-    },
-    {
         "event_id": "gen_death_ockill_anymed3",
         "location": [
             "any"
@@ -4473,37 +4667,6 @@
                     "m_c"
                 ],
                 "death": "m_c died of greencough."
-            }
-        ]
-    },
-    {
-        "event_id": "gen_death_stress_anywar1",
-        "location": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "sub_type": [
-            "war"
-        ],
-        "tags": [],
-        "frequency": 4,
-        "event_text": "m_c suffered a heart attack due to the stress of the ongoing war.",
-        "m_c": {
-            "age": [
-                "senior",
-                "adult",
-                "senior adult"
-            ],
-            "dies": true
-        },
-        "history": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "death": "m_c died of a heart attack due to stress."
             }
         ]
     },
@@ -5596,126 +5759,6 @@
                 }
             }
         ]
-    },
-    {
-        "event_id": "gen_death_ockill_anylead7",
-        "location": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "sub_type": [
-            "war"
-        ],
-        "tags": [
-            "all_lives"
-        ],
-        "frequency": 4,
-        "event_text": "m_c was brutally murdered by a warrior from o_c_n, who cruelly took all {PRONOUN/m_c/poss} lives.",
-        "m_c": {
-            "status": [
-                "leader"
-            ],
-            "skill": [
-                "-FIGHTER,2"
-            ],
-            "dies": true
-        },
-        "history": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "death": "m_c was brutally murdered by a warrior from o_c_n."
-            }
-        ],
-        "other_clan": {
-            "current_rep": [
-                "hostile"
-            ],
-            "changed": -3
-        }
-    },
-    {
-        "event_id": "gen_death_ockill_anylead8",
-        "location": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "sub_type": [
-            "war"
-        ],
-        "tags": [
-            "all_lives"
-        ],
-        "frequency": 4,
-        "event_text": "m_c was brutally murdered by the leader of o_c_n, who cruelly took all {PRONOUN/m_c/poss} lives.",
-        "m_c": {
-            "status": [
-                "leader"
-            ],
-            "skill": [
-                "-FIGHTER,3"
-            ],
-            "dies": true
-        },
-        "history": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "death": "m_c was brutally murdered by the leader of o_c_n."
-            }
-        ],
-        "other_clan": {
-            "current_rep": [
-                "hostile"
-            ],
-            "changed": -3
-        }
-    },
-    {
-        "event_id": "gen_death_ockill_anylead9",
-        "location": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "sub_type": [
-            "war"
-        ],
-        "tags": [
-            "all_lives"
-        ],
-        "frequency": 4,
-        "event_text": "m_c was brutally murdered by the deputy of o_c_n, who cruelly took all {PRONOUN/m_c/poss} lives.",
-        "m_c": {
-            "status": [
-                "leader"
-            ],
-            "skill": [
-                "-FIGHTER,2"
-            ],
-            "dies": true
-        },
-        "history": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "death": "m_c was brutally murdered by the deputy of o_c_n."
-            }
-        ],
-        "other_clan": {
-            "current_rep": [
-                "hostile"
-            ],
-            "changed": -3
-        }
     },
     {
         "event_id": "gen_death_greencough_multilead2",
@@ -8670,48 +8713,5 @@
                 "death": "m_c was killed by a rooster defending his flock."
             }
         ]
-    },
-    {
-        "event_id": "gen_death_war_onwatch",
-        "location": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "sub_type": [
-            "war"
-        ],
-        "frequency": 2,
-        "event_text": "m_c and r_c spend the night by the o_c_n border and catch a o_c_n patrol sneaking into c_n territory. While r_c gets reinforcements, m_c tries to hold them off and dies for it.",
-        "m_c": {
-            "status": [
-                "warrior",
-                "deputy",
-                "leader"
-            ],
-            "dies": true
-        },
-        "r_c": {
-            "status": [
-                "warrior",
-                "deputy",
-                "leader"
-            ]
-        },
-        "history": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "death": "m_c died while holding off an ambush."
-            }
-        ],
-        "other_clan": {
-            "current_rep": [
-                "hostile"
-            ],
-            "changed": -3
-        }
     }
 ]

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -2157,7 +2157,7 @@
             "war"
         ],
         "frequency": 2,
-        "event_text": "m_c and r_c spend the night by the o_c_n border and catch a o_c_n patrol sneaking into c_n territory. While r_c gets reinforcements, m_c tries to hold them off and dies for it.",
+        "event_text": "m_c and r_c spend the night by the o_c_n border and catch a o_c_n patrol sneaking into c_n territory. While r_c gets reinforcements, m_c tries to hold them off and is killed",
         "m_c": {
             "status": [
                 "warrior",

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -1680,7 +1680,7 @@
         "sub_type": [
             "war"
         ],
-        "frequency": 2,
+        "frequency": 1,
         "event_text": "m_c fell into a pit trap set by o_c_n's warriors.",
         "m_c": {
             "age": [

--- a/resources/lang/en/events/injury/general.json
+++ b/resources/lang/en/events/injury/general.json
@@ -1072,103 +1072,6 @@
         ]
     },
     {
-        "event_id": "gen_injury_war_clawwound_anymultitraitmultistatus2",
-        "location": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "sub_type": [
-            "war"
-        ],
-        "frequency": 4,
-        "event_text": "A brutal battle against o_c_n leaves m_c injured.",
-        "m_c": {
-            "status": [
-                "apprentice",
-                "warrior",
-                "deputy",
-                "leader"
-            ]
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "claw-wound"
-                ],
-                "scars": [
-                    "FACE", "LEFTBLIND", "RIGHTBLIND", "SIDE", "THREE", "THROAT"
-                ]
-            }
-        ],
-        "history": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "scar": "m_c was scarred in a fight against o_c_n.",
-                "death": "m_c died from {PRONOUN/m_c/poss} wounds after a battle with o_c_n."
-            }
-        ],
-        "other_clan": {
-            "current_rep": [
-                "hostile"
-            ],
-            "changed": -3
-        }
-    },
-    {
-        "event_id": "gen_injury_war_catbite_anymultitraitmultistatus1",
-        "location": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "sub_type": [
-            "war"
-        ],
-        "frequency": 4,
-        "event_text": "m_c came out worse for wear after a border skirmish with o_c_n.",
-        "m_c": {
-            "status": [
-                "apprentice",
-                "warrior",
-                "deputy",
-                "leader"
-            ]
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "cat bite"
-                ]
-            }
-        ],
-        "history": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "scar": "m_c was scarred in a fight against o_c_n.",
-                "death": "m_c died from {PRONOUN/m_c/poss} wounds after a battle with o_c_n."
-            }
-        ],
-        "other_clan": {
-            "current_rep": [
-                "hostile"
-            ],
-            "changed": -3
-        }
-    },
-    {
         "event_id": "gen_injury_catbite_anyotherclanhostileany1",
         "location": [
             "any"
@@ -1237,67 +1140,6 @@
                 "amount": -5,
                 "log": {
                     "cats_from": "cat_from was unimpressed to hear that cat_to impulsively attacked a o_c_n patrol."
-                }
-            }
-        ]
-    },
-    {
-        "event_id": "gen_injury_clawwound_anyclankitsmultistatus1",
-        "location": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "sub_type": [
-            "war"
-        ],
-        "tags": [
-            "clan:kitten"
-        ],
-        "frequency": 4,
-        "event_text": "While o_c_n attempted a surprise attack on the c_n camp, m_c fiercely guarded the nursery, no matter how injured {PRONOUN/m_c/subject} became.",
-        "m_c": {
-            "age": [
-                "-kitten"
-            ],
-            "status": [
-                "any"
-            ]
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "claw-wound"
-                ]
-            }
-        ],
-        "history": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "scar": "m_c was scarred in a fight against o_c_n.",
-                "death": "m_c died from {PRONOUN/m_c/poss} wounds after a battle with o_c_n."
-            }
-        ],
-        "other_clan": {
-            "current_rep": [
-                "hostile"
-            ],
-            "changed": -3
-        },
-        "relationships": [
-            {
-                "cats_from": ["clan", "high_social"],
-                "cats_to": ["m_c"],
-                "values": ["respect", "trust"],
-                "amount": 10,
-                "log": {
-                    "cats_from": "cat_from saw how fiercely cat_to defended the nursery in a battle with o_c_n."
                 }
             }
         ]
@@ -3616,121 +3458,6 @@
                 "death": "m_c died from {PRONOUN/m_c/poss} wounds after a hare scratched {PRONOUN/m_c/poss} eyes."
             }
         ]
-    },
-    {
-        "event_id": "gen_injury_sore_war_anyapprentice2",
-        "location": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "sub_type": [
-            "war"
-        ],
-        "frequency": 4,
-        "event_text": "Heightened battle training has left m_c sore and tired.",
-        "m_c": {
-            "status": [
-                "apprentice"
-            ]
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "sore"
-                ]
-            }
-        ]
-    },
-    {
-        "event_id": "gen_injury_bruises_war_anyapprentice1",
-        "location": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "sub_type": [
-            "war"
-        ],
-        "frequency": 4,
-        "event_text": "A harsh sparring session has left m_c bruised. {PRONOUN/m_c/subject/CAP} {VERB/m_c/worry/worries} that {PRONOUN/m_c/subject} will do badly in a real fight against o_c_n.",
-        "m_c": {
-            "status": [
-                "apprentice"
-            ]
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "bruises"
-                ]
-            }
-        ]
-    },
-    {
-        "event_id": "gen_injury_mangledtail_war_anyapprenticehostile1",
-        "location": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "sub_type": [
-            "war"
-        ],
-        "frequency": 4,
-        "event_text": "A horrible battle occurred between c_n and o_c_n patrols after the two patrols traded insults at the border. m_c and r_c were left badly injured.",
-        "m_c": {
-            "status": [
-                "apprentice",
-                "warrior",
-                "leader",
-                "deputy"
-            ]
-        },
-        "r_c": {
-            "status": [
-                "leader",
-                "deputy",
-                "warrior",
-                "apprentice"
-            ]
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c",
-                    "r_c"
-                ],
-                "injuries": [
-                    "battle_injury"
-                ]
-            }
-        ],
-        "history": [
-            {
-                "cats": [
-                    "m_c",
-                    "r_c"
-                ],
-                "scar": "m_c was scarred after a fight with o_c_n cats.",
-                "death": "m_c died from {PRONOUN/m_c/poss} wounds after fighting with o_c_n cats."
-            }
-        ],
-        "other_clan": {
-            "current_rep": [
-                "hostile"
-            ],
-            "changed": -1
-        }
     },
     {
         "event_id": "gen_injury_catbite_anyapprenticemultitraitappmentor4",
@@ -6690,147 +6417,6 @@
         ]
     },
     {
-        "event_id": "gen_injury_mangledleg_anymultistatusnotcareful1",
-        "location": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "sub_type": [
-            "war"
-        ],
-        "frequency": 1,
-        "event_text": "While patrolling the o_c_n borders, m_c stepped on a concealed pit trap set by what seemed to be o_c_n warriors. m_c freezes with shock as {PRONOUN/m_c/subject} {VERB/m_c/plunge/plunges} into the depths of the trap. The other cats on the patrol flank {PRONOUN/m_c/object} as {PRONOUN/m_c/subject} {VERB/m_c/limp/limps} back to the camp.",
-        "m_c": {
-            "age": [
-                "any"
-            ],
-            "status": [
-                "-kitten",
-                "-elder",
-                "-mediator",
-                "-mediator apprentice"
-            ],
-            "trait": [
-                "-careful"
-            ]
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "mangled leg"
-                ]
-            }
-        ],
-        "history": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "scar": "m_c was scarred after falling into a o_c_n trap.",
-                "death": "m_c died after falling into a o_c_n trap."
-            }
-        ],
-        "other_clan": {
-            "current_rep": [
-                "hostile"
-            ],
-            "changed": -2
-        }
-    },
-    {
-        "event_id": "gen_injury_war_clawwound_anymultitraitmultistatus1",
-        "location": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "sub_type": [
-            "war"
-        ],
-        "frequency": 4,
-        "event_text": "During a skirmish with o_c_n, m_c took a blow meant for r_c.",
-        "m_c": {
-            "status": [
-                "apprentice",
-                "warrior",
-                "leader",
-                "deputy"
-            ],
-            "trait": [
-                "fierce",
-                "bloodthirsty",
-                "charismatic",
-                "bold",
-                "daring",
-                "ambitious",
-                "confident",
-                "adventurous",
-                "vengeful",
-                "competitive",
-                "rebellious",
-                "flamboyant"
-            ]
-        },
-        "r_c": {
-            "status": [
-                "apprentice",
-                "warrior",
-                "leader",
-                "deputy"
-            ]
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "battle_injury"
-                ]
-            }
-        ],
-        "history": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "scar": "m_c was scarred in a fight against o_c_n.",
-                "death": "m_c died from {PRONOUN/m_c/poss} wounds after a battle with o_c_n."
-            }
-        ],
-        "relationships": [
-            {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "mutual": false,
-                "values": [
-                    "trust",
-                    "respect"
-                ],
-                "amount": 15,
-                "log": {
-                    "cats_from": "cat_to took a blow meant for cat_from in a fight with o_c_n."
-                }
-            }
-        ],
-        "other_clan": {
-            "current_rep": [
-                "hostile"
-            ],
-            "changed": -1
-        }
-    },
-    {
         "event_id": "gen_injury_freshkill_anyrat1",
         "location": [
             "any"
@@ -7285,48 +6871,6 @@
         ]
     },
     {
-        "event_id": "gen_injury_sprain_anyapprentice1",
-        "location": [
-            "forest",
-            "plains",
-            "mountainous",
-            "desert"
-        ],
-        "season": [
-            "any"
-        ],
-        "frequency": 4,
-        "event_text": "m_c was running around on patrol when {PRONOUN/m_c/poss} paw landed right in a rabbit hole. {PRONOUN/m_c/subject/CAP} limped the whole way home.",
-        "m_c": {
-            "status": [
-                "apprentice",
-                "medicine cat apprentice",
-                "mediator apprentice"
-            ],
-            "trait": [
-                "adventurous",
-                "bold",
-                "daring",
-                "playful",
-                "childish",
-                "ambitious",
-                "confident",
-                "competitive",
-                "oblivious"
-            ]
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "sprain"
-                ]
-            }
-        ]
-    },
-    {
         "event_id": "gen_injury_war_cliffsaved",
         "location": [
             "mountainous",
@@ -7404,38 +6948,6 @@
             }
         ]
     },
-    {
-        "event_id": "gen_injury_fireflies",
-        "location": [
-            "forest:camp2,camp4",
-            "mountainous:camp4",
-            "plains:camp1"
-        ],
-        "season": [
-            "greenleaf"
-        ],
-        "sub_type": [],
-        "tags": [],
-        "frequency": 2,
-        "event_text": "m_c got hurt while chasing fireflies through camp.",
-        "new_accessory": [],
-        "m_c": {
-            "age": [
-                "kitten",
-                "adolescent"
-            ]
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "minor_injury"
-                ]
-            }
-        ]
-    },
 {
     "event_id": "gen_injury_war_onwatch",
     "location": [
@@ -7489,6 +7001,280 @@
         "changed": -2
     }
 },
+
+    {
+        "event_id": "gen_injury_war_clawwound_anymultitraitmultistatus2",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 4,
+        "event_text": "A brutal battle against o_c_n leaves m_c injured.",
+        "m_c": {
+            "status": [
+                "apprentice",
+                "warrior",
+                "deputy",
+                "leader"
+            ]
+        },
+        "injury": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "injuries": [
+                    "claw-wound"
+                ],
+                "scars": [
+                    "FACE", "LEFTBLIND", "RIGHTBLIND", "SIDE", "THREE", "THROAT"
+                ]
+            }
+        ],
+        "history": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "scar": "m_c was scarred in a fight against o_c_n.",
+                "death": "m_c died from {PRONOUN/m_c/poss} wounds after a battle with o_c_n."
+            }
+        ],
+        "other_clan": {
+            "current_rep": [
+                "hostile"
+            ],
+            "changed": -3
+        }
+    },
+    {
+        "event_id": "gen_injury_war_catbite_anymultitraitmultistatus1",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 4,
+        "event_text": "m_c came out worse for wear after a border skirmish with o_c_n.",
+        "m_c": {
+            "status": [
+                "apprentice",
+                "warrior",
+                "deputy",
+                "leader"
+            ]
+        },
+        "injury": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "injuries": [
+                    "cat bite"
+                ]
+            }
+        ],
+        "history": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "scar": "m_c was scarred in a fight against o_c_n.",
+                "death": "m_c died from {PRONOUN/m_c/poss} wounds after a battle with o_c_n."
+            }
+        ],
+        "other_clan": {
+            "current_rep": [
+                "hostile"
+            ],
+            "changed": -3
+        }
+    },
+    {
+        "event_id": "gen_injury_clawwound_anyclankitsmultistatus1",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "tags": [
+            "clan:kitten"
+        ],
+        "frequency": 4,
+        "event_text": "While o_c_n attempted a surprise attack on the c_n camp, m_c fiercely guarded the nursery, no matter how injured {PRONOUN/m_c/subject} became.",
+        "m_c": {
+            "age": [
+                "-kitten"
+            ],
+            "status": [
+                "any"
+            ]
+        },
+        "injury": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "injuries": [
+                    "claw-wound"
+                ]
+            }
+        ],
+        "history": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "scar": "m_c was scarred in a fight against o_c_n.",
+                "death": "m_c died from {PRONOUN/m_c/poss} wounds after a battle with o_c_n."
+            }
+        ],
+        "other_clan": {
+            "current_rep": [
+                "hostile"
+            ],
+            "changed": -3
+        },
+        "relationships": [
+            {
+                "cats_from": ["clan", "high_social"],
+                "cats_to": ["m_c"],
+                "values": ["respect", "trust"],
+                "amount": 10,
+                "log": {
+                    "cats_from": "cat_from saw how fiercely cat_to defended the nursery in a battle with o_c_n."
+                }
+            }
+        ]
+    },
+    {
+        "event_id": "gen_injury_sore_war_anyapprentice2",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 4,
+        "event_text": "Heightened battle training has left m_c sore and tired.",
+        "m_c": {
+            "status": [
+                "apprentice"
+            ]
+        },
+        "injury": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "injuries": [
+                    "sore"
+                ]
+            }
+        ]
+    },
+    {
+        "event_id": "gen_injury_bruises_war_anyapprentice1",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 4,
+        "event_text": "A harsh sparring session has left m_c bruised. {PRONOUN/m_c/subject/CAP} {VERB/m_c/worry/worries} that {PRONOUN/m_c/subject} will do badly in a real fight against o_c_n.",
+        "m_c": {
+            "status": [
+                "apprentice"
+            ]
+        },
+        "injury": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "injuries": [
+                    "bruises"
+                ]
+            }
+        ]
+    },
+    {
+        "event_id": "gen_injury_mangledtail_war_anyapprenticehostile1",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 4,
+        "event_text": "A horrible battle occurred between c_n and o_c_n patrols after the two patrols traded insults at the border. m_c and r_c were left badly injured.",
+        "m_c": {
+            "status": [
+                "apprentice",
+                "warrior",
+                "leader",
+                "deputy"
+            ]
+        },
+        "r_c": {
+            "status": [
+                "leader",
+                "deputy",
+                "warrior",
+                "apprentice"
+            ]
+        },
+        "injury": [
+            {
+                "cats": [
+                    "m_c",
+                    "r_c"
+                ],
+                "injuries": [
+                    "battle_injury"
+                ]
+            }
+        ],
+        "history": [
+            {
+                "cats": [
+                    "m_c",
+                    "r_c"
+                ],
+                "scar": "m_c was scarred after a fight with o_c_n cats.",
+                "death": "m_c died from {PRONOUN/m_c/poss} wounds after fighting with o_c_n cats."
+            }
+        ],
+        "other_clan": {
+            "current_rep": [
+                "hostile"
+            ],
+            "changed": -1
+        }
+    },
     {
         "event_id": "gen_injury_bruises_kittensnout",
         "location": [
@@ -7618,6 +7404,147 @@
             }
         ]
     },
+    {
+        "event_id": "gen_injury_mangledleg_anymultistatusnotcareful1",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 1,
+        "event_text": "While patrolling the o_c_n borders, m_c stepped on a concealed pit trap set by what seemed to be o_c_n warriors. m_c freezes with shock as {PRONOUN/m_c/subject} {VERB/m_c/plunge/plunges} into the depths of the trap. The other cats on the patrol flank {PRONOUN/m_c/object} as {PRONOUN/m_c/subject} {VERB/m_c/limp/limps} back to the camp.",
+        "m_c": {
+            "age": [
+                "any"
+            ],
+            "status": [
+                "-kitten",
+                "-elder",
+                "-mediator",
+                "-mediator apprentice"
+            ],
+            "trait": [
+                "-careful"
+            ]
+        },
+        "injury": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "injuries": [
+                    "mangled leg"
+                ]
+            }
+        ],
+        "history": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "scar": "m_c was scarred after falling into a o_c_n trap.",
+                "death": "m_c died after falling into a o_c_n trap."
+            }
+        ],
+        "other_clan": {
+            "current_rep": [
+                "hostile"
+            ],
+            "changed": -2
+        }
+    },
+    {
+        "event_id": "gen_injury_war_clawwound_anymultitraitmultistatus1",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 4,
+        "event_text": "During a skirmish with o_c_n, m_c took a blow meant for r_c.",
+        "m_c": {
+            "status": [
+                "apprentice",
+                "warrior",
+                "leader",
+                "deputy"
+            ],
+            "trait": [
+                "fierce",
+                "bloodthirsty",
+                "charismatic",
+                "bold",
+                "daring",
+                "ambitious",
+                "confident",
+                "adventurous",
+                "vengeful",
+                "competitive",
+                "rebellious",
+                "flamboyant"
+            ]
+        },
+        "r_c": {
+            "status": [
+                "apprentice",
+                "warrior",
+                "leader",
+                "deputy"
+            ]
+        },
+        "injury": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "injuries": [
+                    "battle_injury"
+                ]
+            }
+        ],
+        "history": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "scar": "m_c was scarred in a fight against o_c_n.",
+                "death": "m_c died from {PRONOUN/m_c/poss} wounds after a battle with o_c_n."
+            }
+        ],
+        "relationships": [
+            {
+                "cats_from": [
+                    "r_c"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "mutual": false,
+                "values": [
+                    "trust",
+                    "respect"
+                ],
+                "amount": 15,
+                "log": {
+                    "cats_from": "cat_to took a blow meant for cat_from in a fight with o_c_n."
+                }
+            }
+        ],
+        "other_clan": {
+            "current_rep": [
+                "hostile"
+            ],
+            "changed": -1
+        }
+    },
         {
         "event_id": "gen_injury_soreapp_clankits",
         "location": [
@@ -7686,6 +7613,80 @@
                 ],
                 "injuries": [
                     "bruises"
+                ]
+            }
+        ]
+    },
+    {
+        "event_id": "gen_injury_sprain_anyapprentice1",
+        "location": [
+            "forest",
+            "plains",
+            "mountainous",
+            "desert"
+        ],
+        "season": [
+            "any"
+        ],
+        "frequency": 4,
+        "event_text": "m_c was running around on patrol when {PRONOUN/m_c/poss} paw landed right in a rabbit hole. {PRONOUN/m_c/subject/CAP} limped the whole way home.",
+        "m_c": {
+            "status": [
+                "apprentice",
+                "medicine cat apprentice",
+                "mediator apprentice"
+            ],
+            "trait": [
+                "adventurous",
+                "bold",
+                "daring",
+                "playful",
+                "childish",
+                "ambitious",
+                "confident",
+                "competitive",
+                "oblivious"
+            ]
+        },
+        "injury": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "injuries": [
+                    "sprain"
+                ]
+            }
+        ]
+    },
+    {
+        "event_id": "gen_injury_fireflies",
+        "location": [
+            "forest:camp2,camp4",
+            "mountainous:camp4",
+            "plains:camp1"
+        ],
+        "season": [
+            "greenleaf"
+        ],
+        "sub_type": [],
+        "tags": [],
+        "frequency": 2,
+        "event_text": "m_c got hurt while chasing fireflies through camp.",
+        "new_accessory": [],
+        "m_c": {
+            "age": [
+                "kitten",
+                "adolescent"
+            ]
+        },
+        "injury": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "injuries": [
+                    "minor_injury"
                 ]
             }
         ]

--- a/resources/lang/en/events/injury/general.json
+++ b/resources/lang/en/events/injury/general.json
@@ -7276,135 +7276,6 @@
         }
     },
     {
-        "event_id": "gen_injury_bruises_kittensnout",
-        "location": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "frequency": 4,
-        "event_text": "While batting a shiny pebble around, m_c misjudged a pounce and smashed {PRONOUN/m_c/poss} tiny little snout into it.",
-        "m_c": {
-            "status": [
-                "kitten"
-            ],
-            "trait": [
-                "unruly",
-                "impulsive",
-                "fearless"
-            ]
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "bruises"
-                ]
-            }
-        ]
-    },
-    {
-        "event_id": "gen_injury_bruisessore_clankits1",
-        "location": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "clan:kitten"
-        ],
-        "frequency": 4,
-        "event_text": "m_c isn't as young as {PRONOUN/m_c/subject} used to be, and {PRONOUN/m_c/subject} {VERB/m_c/decline/declines} giving another badger ride to nap off the happy soreness that comes with being the kits' current favorite chew toy.",
-        "m_c": {
-            "age": [
-                "senior adult",
-                "senior"
-            ],
-            "status": [
-                "any"
-            ],
-            "skill": [
-                "KIT,1"
-            ]
-        },
-        "r_c": {
-            "status": [
-                "kitten"
-            ]
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "bruises",
-                    "sore"
-                ]
-            }
-        ],
-        "relationships": [
-            {
-                "cats_to": [
-                    "r_c"
-                ],
-                "cats_from": [
-                    "m_c"
-                ],
-                "mutual": true,
-                "values": [
-                    "like",
-                    "trust",
-                    "comfort"
-                ],
-                "amount": 10,
-                "log": "m_c gave r_c the best badger rides as a kit."
-            }
-        ]
-    },
-    {
-        "event_id": "gen_injury_bruises_anyapprentice3",
-        "location": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "frequency": 4,
-        "event_text": "m_c claims {PRONOUN/m_c/poss} bruises are from battle training. m_c is lying; they're actually from a misjudged pounce.",
-        "m_c": {
-            "status": [
-                "apprentice"
-            ],
-            "trait": [
-                "ambitious",
-                "arrogant",
-                "charismatic",
-                "competitive",
-                "cunning",
-                "fierce",
-                "insecure",
-                "grumpy",
-                "shameless",
-                "sneaky"
-            ]
-        },
-                "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "bruises"
-                ]
-            }
-        ]
-    },
-    {
         "event_id": "gen_injury_mangledleg_anymultistatusnotcareful1",
         "location": [
             "any"
@@ -7544,6 +7415,135 @@
             ],
             "changed": -1
         }
+    },
+    {
+        "event_id": "gen_injury_bruises_kittensnout",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "frequency": 4,
+        "event_text": "While batting a shiny pebble around, m_c misjudged a pounce and smashed {PRONOUN/m_c/poss} tiny little snout into it.",
+        "m_c": {
+            "status": [
+                "kitten"
+            ],
+            "trait": [
+                "unruly",
+                "impulsive",
+                "fearless"
+            ]
+        },
+        "injury": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "injuries": [
+                    "bruises"
+                ]
+            }
+        ]
+    },
+    {
+        "event_id": "gen_injury_bruisessore_clankits1",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "tags": [
+            "clan:kitten"
+        ],
+        "frequency": 4,
+        "event_text": "m_c isn't as young as {PRONOUN/m_c/subject} used to be, and {PRONOUN/m_c/subject} {VERB/m_c/decline/declines} giving another badger ride to nap off the happy soreness that comes with being the kits' current favorite chew toy.",
+        "m_c": {
+            "age": [
+                "senior adult",
+                "senior"
+            ],
+            "status": [
+                "any"
+            ],
+            "skill": [
+                "KIT,1"
+            ]
+        },
+        "r_c": {
+            "status": [
+                "kitten"
+            ]
+        },
+        "injury": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "injuries": [
+                    "bruises",
+                    "sore"
+                ]
+            }
+        ],
+        "relationships": [
+            {
+                "cats_to": [
+                    "r_c"
+                ],
+                "cats_from": [
+                    "m_c"
+                ],
+                "mutual": true,
+                "values": [
+                    "like",
+                    "trust",
+                    "comfort"
+                ],
+                "amount": 10,
+                "log": "m_c gave r_c the best badger rides as a kit."
+            }
+        ]
+    },
+    {
+        "event_id": "gen_injury_bruises_anyapprentice3",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "frequency": 4,
+        "event_text": "m_c claims {PRONOUN/m_c/poss} bruises are from battle training. m_c is lying; they're actually from a misjudged pounce.",
+        "m_c": {
+            "status": [
+                "apprentice"
+            ],
+            "trait": [
+                "ambitious",
+                "arrogant",
+                "charismatic",
+                "competitive",
+                "cunning",
+                "fierce",
+                "insecure",
+                "grumpy",
+                "shameless",
+                "sneaky"
+            ]
+        },
+                "injury": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "injuries": [
+                    "bruises"
+                ]
+            }
+        ]
     },
         {
         "event_id": "gen_injury_soreapp_clankits",

--- a/resources/lang/en/events/injury/general.json
+++ b/resources/lang/en/events/injury/general.json
@@ -7580,7 +7580,7 @@
             {
                 "cats": ["m_c"],
                 "scar": "m_c was scarred after winning a duel with a o_c_n warrior.",
-                "death": "m_c died from {PRONOUN/m_c/poss} injuries after losing a duel with a o_c_n warrior."
+                "death": "m_c died from {PRONOUN/m_c/poss} injuries after winning a duel with a o_c_n warrior."
             }
         ],
         "relationships": [

--- a/resources/lang/en/events/injury/general.json
+++ b/resources/lang/en/events/injury/general.json
@@ -7158,7 +7158,7 @@
                 "values": ["respect", "trust"],
                 "amount": 10,
                 "log": {
-                    "cats_from": "cat_from saw how fiercely cat_to defended the nursery in a battle with o_c_n."
+                    "cats_from": "cat_from saw cat_to defended the nursery in a battle with o_c_n."
                 }
             }
         ]

--- a/resources/lang/en/events/injury/general.json
+++ b/resources/lang/en/events/injury/general.json
@@ -7417,6 +7417,593 @@
         }
     },
     {
+        "event_id": "gen_injury_war_battleinjury_outnumbered1",
+        "location": ["any"],
+        "season": ["any"],
+        "sub_type": ["war"],
+        "tags": [],
+        "frequency": 2,
+        "event_text": "m_c is badly outnumbered in a fight with a o_c_n patrol and sustains grave injuries.",
+        "m_c": {
+            "status": ["warrior", "deputy", "leader"],
+            "dies": false
+        },
+        "injury": [
+            {
+                "cats": ["m_c"],
+                "injuries": ["battle_injury"]
+            }
+        ],
+        "history": [
+            {
+                "cats": ["m_c"],
+                "scar": "m_c was scarred after being outnumbered in a fight with o_c_n.",
+                "death": "m_c died from {PRONOUN/m_c/poss} injuries after being outnumbered in a fight with o_c_n."
+            }
+        ],
+        "other_clan": {
+            "current_rep": ["hostile"],
+            "changed": -1
+        }
+    },
+    {
+        "event_id": "gen_injury_war_battleinjury_outnumbered2",
+        "location": ["any"],
+        "season": ["any"],
+        "sub_type": ["war"],
+        "tags": [],
+        "frequency": 2,
+        "event_text": "m_c and r_c are badly outnumbered in a fight with a o_c_n patrol and sustain grave injuries.",
+        "m_c": {
+            "status": ["warrior", "deputy", "leader"],
+            "dies": false
+        },
+        "r_c": {
+            "status": ["warrior", "deputy", "leader"],
+            "dies": false
+        },
+        "injury": [
+            {
+                "cats": ["m_c", "r_c"],
+                "injuries": ["battle_injury"]
+            }
+        ],
+        "history": [
+            {
+                "cats": ["m_c", "r_c"],
+                "scar": "m_c was scarred after being outnumbered in a fight with o_c_n.",
+                "death": "m_c died from {PRONOUN/m_c/poss} injuries after being outnumbered in a fight with o_c_n."
+            }
+        ],
+        "other_clan": {
+            "current_rep": ["hostile"],
+            "changed": -1
+        }
+    },
+    {
+        "event_id": "gen_injury_war_battleinjury_surpriseskirmish",
+        "location": ["any"],
+        "season": ["any"],
+        "sub_type": ["war"],
+        "tags": [],
+        "frequency": 2,
+        "event_text": "lead_name sends m_c to strengthen the markings along the border with o_c_n, but o_c_n had the same idea. m_c and r_c are injured in the ensuing fight.",
+        "m_c": {
+            "status": ["deputy"],
+            "dies": false
+        },
+        "r_c": {
+            "status": ["warrior"],
+            "dies": false
+        },
+        "injury": [
+            {
+                "cats": ["m_c", "r_c"],
+                "injuries": ["battle_injury"]
+            }
+        ],
+        "history": [
+            {
+                "cats": ["m_c", "r_c"],
+                "scar": "m_c was scarred after a fight with o_c_n.",
+                "death": "m_c died from {PRONOUN/m_c/poss} injuries after a fight with o_c_n."
+            }
+        ],
+        "other_clan": {
+            "current_rep": ["hostile"],
+            "changed": -1
+        }
+    },
+    {
+        "event_id": "gen_injury_war_battleinjury_mudfuradderfangduel1",
+        "location": ["any"],
+        "season": ["any"],
+        "sub_type": ["war"],
+        "tags": [],
+        "frequency": 1,
+        "event_text": "To settle a piece of disputed land in the ongoing war with o_c_n, m_c is chosen to fight one o_c_n warrior. m_c loses the duel, and the strip of territory goes to o_c_n.",
+        "m_c": {
+            "status": ["warrior", "deputy"],
+            "skill": ["-FIGHTER,2"],
+            "dies": false
+        },
+        "injury": [
+            {
+                "cats": ["m_c"],
+                "injuries": ["battle_injury"]
+            }
+        ],
+        "history": [
+            {
+                "cats": ["m_c"],
+                "scar": "m_c was scarred after losing a duel with a o_c_n warrior.",
+                "death": "m_c died from {PRONOUN/m_c/poss} injuries after losing a duel with a o_c_n warrior."
+            }
+        ],
+        "relationships": [
+            {
+                "cats_from": ["clan", "high_aggress"],
+                "cats_to": ["m_c"],
+                "values": ["respect"],
+                "amount": -10,
+                "mutual": false,
+                "log": {
+                    "cats_from": "cat_from lost respect for cat_to after cat_to lost a piece of c_n territory in a one-on-one duel with an enemy Clan's warrior."
+                }
+            }
+        ],
+        "other_clan": {
+            "current_rep": ["hostile"],
+            "changed": -1
+        }
+    },
+    {
+        "event_id": "gen_injury_war_battleinjury_mudfuradderfangduel2",
+        "location": ["any"],
+        "season": ["any"],
+        "sub_type": ["war"],
+        "tags": [],
+        "frequency": 2,
+        "event_text": "To settle a piece of disputed land in the ongoing war with o_c_n, m_c is chosen to fight one o_c_n warrior. m_c wins the duel, and the strip of territory goes to c_n.",
+        "m_c": {
+            "status": ["warrior", "deputy"],
+            "skill": ["FIGHTER,2"],
+            "dies": false
+        },
+        "injury": [
+            {
+                "cats": ["m_c"],
+                "injuries": ["small_bite_injury"]
+            }
+        ],
+        "history": [
+            {
+                "cats": ["m_c"],
+                "scar": "m_c was scarred after winning a duel with a o_c_n warrior.",
+                "death": "m_c died from {PRONOUN/m_c/poss} injuries after losing a duel with a o_c_n warrior."
+            }
+        ],
+        "relationships": [
+            {
+                "cats_from": ["clan", "high_aggress"],
+                "cats_to": ["m_c"],
+                "values": ["respect"],
+                "amount": 10,
+                "mutual": false,
+                "log": {
+                    "cats_from": "cat_from gained respect for cat_to after cat_to won a piece of territory for c_n in a one-on-one duel with an enemy Clan's warrior."
+                }
+            }
+        ],
+        "other_clan": {
+            "current_rep": ["hostile"],
+            "changed": -2
+        }
+    },
+    {
+        "event_id": "gen_injury_war_battleinjury_campraid",
+        "location": ["any"],
+        "season": ["any"],
+        "sub_type": ["war"],
+        "tags": [],
+        "frequency": 1,
+        "event_text": "m_c leads a raid on o_c_n's camp. r_c is badly injured in the fight.",
+        "m_c": {
+            "status": ["warrior", "deputy", "leader"],
+            "age": ["senior adult"],
+            "dies": false
+        },
+        "r_c": {
+            "status": ["apprentice", "warrior"],
+            "dies": false
+        },
+        "injury": [
+            {
+                "cats": ["r_c"],
+                "injuries": ["battle_injury"]
+            }
+        ],
+        "history": [
+            {
+                "cats": ["r_c"],
+                "scar": "m_c was scarred during a raid on o_c_n's camp.",
+                "death": "m_c died from {PRONOUN/m_c/poss} injuries after a raid on o_c_n's camp."
+            }
+        ],
+        "other_clan": {
+            "current_rep": ["hostile"],
+            "changed": -3
+        }
+    },
+    {
+        "event_id": "gen_injury_war_battleinjury_infamouswarrior",
+        "location": ["any"],
+        "season": ["any"],
+        "sub_type": ["war"],
+        "tags": [],
+        "frequency": 3,
+        "event_text": "m_c battles one of o_c_n's most feared warriors and winds up in the medicine den.",
+        "m_c": {
+            "status": ["warrior", "deputy", "leader"],
+            "trait": ["confident", "daring", "bold", "arrogant", "fierce", "bloodthirsty", "ambitious", "arrogant", "shameless", "adventurous", "loyal", "rebellious", "troublesome", "vengeful"],
+            "dies": false
+        },
+        "injury": [
+            {
+                "cats": ["m_c"],
+                "injuries": ["battle_injury"]
+            }
+        ],
+        "history": [
+            {
+                "cats": ["m_c"],
+                "scar": "m_c was scarred after taking on one of o_c_n's most feared warriors in a fight.",
+                "death": "m_c died from {PRONOUN/m_c/poss} injuries after taking on one of o_c_n's most feared warriors in a fight."
+            }
+        ],
+        "other_clan": {
+            "current_rep": ["hostile"],
+            "changed": -1
+        }
+    },
+    {
+        "event_id": "gen_injury_war_minorinjury_nervoustrait",
+        "location": ["any"],
+        "season": ["any"],
+        "sub_type": ["war"],
+        "tags": [],
+        "frequency": 4,
+        "event_text": "m_c is relieved to sustain only minor injuries in a fight with o_c_n.",
+        "m_c": {
+            "status": ["apprentice", "warrior", "deputy", "leader"],
+            "trait": ["nervous", "careful", "wise", "calm", "insecure", "gloomy", "thoughtful", "sincere", "compassionate"],
+            "dies": false
+        },
+        "injury": [
+            {
+                "cats": ["m_c"],
+                "injuries": ["minor_injury"]
+            }
+        ],
+        "other_clan": {
+            "current_rep": ["hostile"],
+            "changed": -1
+        }
+    },
+    {
+        "event_id": "gen_injury_war_tornear_fighterskill",
+        "location": ["any"],
+        "season": ["any"],
+        "sub_type": ["war"],
+        "tags": [],
+        "frequency": 3,
+        "event_text": "m_c leads a patrol to skirmish with o_c_n at the border. When o_c_n's patrol retreats, {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} unscathed, save for {PRONOUN/m_c/poss} torn ear.",
+        "m_c": {
+            "status": ["warrior", "deputy", "leader"],
+            "skill": ["FIGHTER,1"],
+            "dies": false
+        },
+        "injury": [
+            {
+                "cats": ["m_c"],
+                "injuries": ["torn ear"]
+            }
+        ],
+        "history": [
+            {
+                "cats": ["m_c"],
+                "scar": "m_c was scarred after winning a skirmish against o_c_n.",
+                "death": "m_c died from {PRONOUN/m_c/poss} injuries sustained in a battle {PRONOUN/m_c/subject} won."
+            }
+        ],
+        "other_clan": {
+            "current_rep": ["hostile"],
+            "changed": -2
+        }
+    },
+    {
+        "event_id": "gen_injury_war_minorinjury_senseskill",
+        "location": ["any"],
+        "season": ["any"],
+        "sub_type": ["war"],
+        "tags": [],
+        "frequency": 3,
+        "event_text": "m_c's sharp reflexes while patrolling the o_c_n border save {PRONOUN/m_c/object} and r_c from an ambush. They escape with only minor injuries.",
+        "m_c": {
+            "status": ["warrior", "deputy", "leader"],
+            "skill": ["SENSE,1"],
+            "dies": false
+        },
+        "r_c": {
+            "status": ["warrior", "deputy", "leader"],
+            "dies": false
+        },
+        "injury": [
+            {
+                "cats": ["m_c", "r_c"],
+                "injuries": ["minor_injury", "torn ear"]
+            }
+        ],
+        "history": [
+            {
+                "cats": ["m_c"],
+                "scar": "m_c was scarred after o_c_n attempted to ambush {PRONOUN/m_c/object}."
+            }
+        ],
+        "other_clan": {
+            "current_rep": ["hostile"],
+            "changed": -1
+        }
+    },
+    {
+        "event_id": "gen_injury_war_battleinjury_ocnambush",
+        "location": ["any"],
+        "season": ["any"],
+        "sub_type": ["war"],
+        "tags": [],
+        "frequency": 2,
+        "event_text": "A o_c_n patrol ambushes c_n's patrol when they renew the border markings. r_c and m_c are badly wounded in the fight.",
+        "m_c": {
+            "status": ["apprentice", "warrior", "deputy", "leader"],
+            "dies": false
+        },
+        "r_c": {
+            "status": ["apprentice", "warrior", "deputy", "leader"],
+            "dies": false
+        },
+        "injury": [
+            {
+                "cats": ["m_c", "r_c"],
+                "injuries": ["battle_injury"]
+            }
+        ],
+        "history": [
+            {
+                "cats": ["m_c"],
+                "scar": "m_c was scarred after o_c_n ambushed {PRONOUN/m_c/object}.",
+                "death": "m_c died of {PRONOUN/m_c/poss} injuries after o_c_n attempted to ambush {PRONOUN/m_c/object}."
+            }
+        ],
+        "other_clan": {
+            "current_rep": ["hostile"],
+            "changed": -1
+        }
+    },
+    {
+        "event_id": "gen_injury_war_battleinjury_cnambush",
+        "location": ["any"],
+        "season": ["any"],
+        "sub_type": ["war"],
+        "tags": [],
+        "frequency": 2,
+        "event_text": "c_n lies in wait at the o_c_n border, waiting for a patrol to appear. When they do, c_n ambushes them. m_c and r_c are injured in the battle.",
+        "m_c": {
+            "status": ["apprentice", "warrior", "deputy", "leader"],
+            "dies": false
+        },
+        "r_c": {
+            "status": ["apprentice", "warrior", "deputy", "leader"],
+            "dies": false
+        },
+        "injury": [
+            {
+                "cats": ["m_c", "r_c"],
+                "injuries": ["battle_injury", "minor_injury"]
+            }
+        ],
+        "history": [
+            {
+                "cats": ["m_c"],
+                "scar": "m_c was scarred after ambushing a o_c_n patrol.",
+                "death": "m_c died of {PRONOUN/m_c/poss} injuries after ambushing a o_c_n patrol."
+            }
+        ],
+        "other_clan": {
+            "current_rep": ["hostile"],
+            "changed": -2
+        }
+    },
+    {
+        "event_id": "gen_injury_war_tornear_fighterskill",
+        "location": ["any"],
+        "season": ["any"],
+        "sub_type": ["war"],
+        "tags": [],
+        "frequency": 3,
+        "event_text": "m_c sneaks onto o_c_n territory to poach prey. o_c_n catches {PRONOUN/m_c/object} and claws at {PRONOUN/m_c/poss} tail as {PRONOUN/m_c/subject} {VERB/m_c/flee/flees}.",
+        "m_c": {
+            "status": ["warrior", "deputy", "leader"],
+            "trait": ["rebellious", "troublesome", "vengeful"],
+            "dies": false
+        },
+        "injury": [
+            {
+                "cats": ["m_c"],
+                "injuries": ["mangled tail"]
+            }
+        ],
+        "history": [
+            {
+                "cats": ["m_c"],
+                "scar": "m_c was scarred after a o_c_n patrol caught {PRONOUN/m_c/object} poaching prey.",
+                "death": "m_c died of {PRONOUN/m_c/poss} injuries after a o_c_n patrol caught {PRONOUN/m_c/object} poaching prey."
+            }
+        ],
+        "relationships": [
+            {
+                "cats_from": ["clan", "high_aggress", "low_lawful"],
+                "cats_to": ["m_c"],
+                "values": ["respect"],
+                "amount": 10,
+                "mutual": false,
+                "log": {
+                    "cats_from": "cat_from approved of cat_to stealing an enemy Clan's prey during a war."
+                }
+            },
+            {
+                "cats_from": ["clan", "low_aggress", "high_lawful"],
+                "cats_to": ["m_c"],
+                "values": ["respect"],
+                "amount": -10,
+                "mutual": false,
+                "log": {
+                    "cats_from": "cat_from disapproved of cat_to stealing an enemy Clan's prey during a war."
+                }
+            }
+        ],
+        "other_clan": {
+            "current_rep": ["hostile"],
+            "changed": -2
+        }
+    },
+    {
+        "event_id": "gen_injury_war_battleinjury_leadervsleader1",
+        "location": ["any"],
+        "season": ["any"],
+        "sub_type": ["war"],
+        "tags": [],
+        "frequency": 3,
+        "event_text": "m_c confronts o_c_n's leader in battle. The warring Clans hold their breath as the leaders battle, and c_n is aggrieved when m_c is defeated.",
+        "m_c": {
+            "status": ["leader"],
+            "skill": ["-FIGHTER,1"],
+            "dies": false
+        },
+        "injury": [
+            {
+                "cats": ["m_c"],
+                "injuries": ["battle_injury"]
+            }
+        ],
+        "history": [
+            {
+                "cats": ["m_c"],
+                "scar": "m_c was scarred after fighting o_c_n's leader.",
+                "death": "m_c died of {PRONOUN/m_c/poss} injuries after fighting o_c_n's leader."
+            }
+        ],
+        "relationships": [
+            {
+                "cats_from": ["clan", "high_aggress"],
+                "cats_to": ["m_c"],
+                "values": ["respect", "trust"],
+                "amount": -10,
+                "mutual": false,
+                "log": {
+                    "cats_from": "cat_from doubted cat_to after {PRONOUN/cat_to/subject} lost in a one-on-one fight with an enemy Clan's leader."
+                }
+            }
+        ],
+        "other_clan": {
+            "current_rep": ["hostile"],
+            "changed": -1
+        }
+    },
+    {
+        "event_id": "gen_injury_war_battleinjury_leadervsleader2",
+        "location": ["any"],
+        "season": ["any"],
+        "sub_type": ["war"],
+        "tags": [],
+        "frequency": 2,
+        "event_text": "m_c confronts o_c_n's leader in battle. The warring Clans hold their breath as the leaders battle, and c_n is elated when m_c emerges victorious.",
+        "m_c": {
+            "status": ["leader"],
+            "dies": false
+        },
+        "injury": [
+            {
+                "cats": ["m_c"],
+                "injuries": ["small_bite_injury"]
+            }
+        ],
+        "history": [
+            {
+                "cats": ["m_c"],
+                "scar": "m_c was scarred after fighting o_c_n's leader.",
+                "death": "m_c died of {PRONOUN/m_c/poss} injuries after fighting o_c_n's leader."
+            }
+        ],
+        "relationships": [
+            {
+                "cats_from": ["clan", "high_aggress"],
+                "cats_to": ["m_c"],
+                "values": ["respect", "trust"],
+                "amount": 10,
+                "mutual": false,
+                "log": {
+                    "cats_from": "cat_from felt more confident in cat_to's leadership after {PRONOUN/cat_to/subject} defeated an enemy Clan's leader in a fight."
+                }
+            }
+        ],
+        "other_clan": {
+            "current_rep": ["hostile"],
+            "changed": -1
+        }
+    },
+    {
+        "event_id": "gen_injury_war_battleinjury_leadervsleader3",
+        "location": ["any"],
+        "season": ["any"],
+        "sub_type": ["war"],
+        "tags": [],
+        "frequency": 3,
+        "event_text": "m_c confronts o_c_n's leader in battle. The warring Clans hold their breath as the leaders battle, and c_n is elated when m_c emerges victorious.",
+        "m_c": {
+            "status": ["leader"],
+            "skill": ["FIGHTER,1"],
+            "dies": false
+        },
+        "injury": [
+            {
+                "cats": ["m_c"],
+                "injuries": ["torn ear"]
+            }
+        ],
+        "history": [
+            {
+                "cats": ["m_c"],
+                "scar": "m_c was scarred after fighting o_c_n's leader."
+            }
+        ],
+        "relationships": [
+            {
+                "cats_from": ["clan", "high_aggress"],
+                "cats_to": ["m_c"],
+                "values": ["respect", "trust"],
+                "amount": 10,
+                "mutual": false,
+                "log": {
+                    "cats_from": "cat_from felt more confident in cat_to's leadership after {PRONOUN/cat_to/subject} defeated an enemy Clan's leader in a fight."
+                }
+            }
+        ],
+        "other_clan": {
+            "current_rep": ["hostile"],
+            "changed": -1
+        }
+    },
+    {
         "event_id": "gen_injury_bruises_kittensnout",
         "location": [
             "any"

--- a/resources/lang/en/events/injury/general.json
+++ b/resources/lang/en/events/injury/general.json
@@ -7567,7 +7567,7 @@
         "sub_type": ["war"],
         "tags": [],
         "frequency": 2,
-        "event_text": "To settle a piece of disputed land in the ongoing war with o_c_n, m_c is chosen to fight one o_c_n warrior. m_c wins the duel, and the strip of territory goes to c_n.",
+        "event_text": "To settle a piece of disputed land in the ongoing war with o_c_n, m_c is chosen to fight one-on-one with a o_c_n warrior. m_c wins the duel, and the strip of territory goes to c_n.",
         "m_c": {
             "status": ["warrior", "deputy"],
             "skill": ["FIGHTER,2"],

--- a/resources/lang/en/events/injury/general.json
+++ b/resources/lang/en/events/injury/general.json
@@ -7791,13 +7791,47 @@
         }
     },
     {
-        "event_id": "gen_injury_war_battleinjury_cnambush",
+        "event_id": "gen_injury_war_battleinjury_cnambushfail",
         "location": ["any"],
         "season": ["any"],
         "sub_type": ["war"],
         "tags": [],
         "frequency": 2,
-        "event_text": "c_n lies in wait at the o_c_n border, waiting for a patrol to appear. When they do, c_n ambushes them. m_c and r_c are injured in the battle.",
+        "event_text": "c_n tries to ambush o_c_n at the border, but o_c_n is prepared. c_n loses the element of surprise and must retreat, m_c and r_c wounded.",
+        "m_c": {
+            "status": ["apprentice", "warrior", "deputy", "leader"],
+            "dies": false
+        },
+        "r_c": {
+            "status": ["apprentice", "warrior", "deputy", "leader"],
+            "dies": false
+        },
+        "injury": [
+            {
+                "cats": ["m_c", "r_c"],
+                "injuries": ["battle_injury"]
+            }
+        ],
+        "history": [
+            {
+                "cats": ["m_c"],
+                "scar": "m_c was scarred after ambushing a o_c_n patrol.",
+                "death": "m_c died of {PRONOUN/m_c/poss} injuries after ambushing a o_c_n patrol."
+            }
+        ],
+        "other_clan": {
+            "current_rep": ["hostile"],
+            "changed": -2
+        }
+    },
+    {
+        "event_id": "gen_injury_war_battleinjury_cnambushstruggle",
+        "location": ["any"],
+        "season": ["any"],
+        "sub_type": ["war"],
+        "tags": [],
+        "frequency": 2,
+        "event_text": "c_n ambushes o_c_n at the border. Though they drive off the patrol, m_c and r_c are injured in the battle.",
         "m_c": {
             "status": ["apprentice", "warrior", "deputy", "leader"],
             "dies": false
@@ -7810,6 +7844,40 @@
             {
                 "cats": ["m_c", "r_c"],
                 "injuries": ["battle_injury", "minor_injury"]
+            }
+        ],
+        "history": [
+            {
+                "cats": ["m_c"],
+                "scar": "m_c was scarred after ambushing a o_c_n patrol.",
+                "death": "m_c died of {PRONOUN/m_c/poss} injuries after ambushing a o_c_n patrol."
+            }
+        ],
+        "other_clan": {
+            "current_rep": ["hostile"],
+            "changed": -2
+        }
+    },
+    {
+        "event_id": "gen_injury_war_battleinjury_cnambushsuccess",
+        "location": ["any"],
+        "season": ["any"],
+        "sub_type": ["war"],
+        "tags": [],
+        "frequency": 2,
+        "event_text": "c_n ambushes o_c_n at the border. m_c and r_c sustain minor injuries in the fight, but the o_c_n patrol is driven off successfully.",
+        "m_c": {
+            "status": ["apprentice", "warrior", "deputy", "leader"],
+            "dies": false
+        },
+        "r_c": {
+            "status": ["apprentice", "warrior", "deputy", "leader"],
+            "dies": false
+        },
+        "injury": [
+            {
+                "cats": ["m_c", "r_c"],
+                "injuries": ["minor_injury"]
             }
         ],
         "history": [

--- a/resources/lang/en/events/injury/general.json
+++ b/resources/lang/en/events/injury/general.json
@@ -7488,7 +7488,7 @@
         "location": ["any"],
         "season": ["any"],
         "sub_type": ["war"],
-        "tags": [],
+        "tags": ["clan:leader"],
         "frequency": 2,
         "event_text": "lead_name sends m_c to strengthen the markings along the border with o_c_n, but o_c_n had the same idea. m_c and r_c are injured in the ensuing fight.",
         "m_c": {

--- a/resources/lang/en/events/injury/general.json
+++ b/resources/lang/en/events/injury/general.json
@@ -7747,7 +7747,8 @@
         "history": [
             {
                 "cats": ["m_c"],
-                "scar": "m_c was scarred after o_c_n attempted to ambush {PRONOUN/m_c/object}."
+                "scar": "m_c was scarred after o_c_n attempted to ambush {PRONOUN/m_c/object}.",
+                "death": "m_c died of {PRONOUN/m_c/poss} injuries after a o_c_n patrol attempted to ambush {PRONOUN/m_c/object}."
             }
         ],
         "other_clan": {
@@ -7983,7 +7984,8 @@
         "history": [
             {
                 "cats": ["m_c"],
-                "scar": "m_c was scarred after fighting o_c_n's leader."
+                "scar": "m_c was scarred after fighting o_c_n's leader.",
+                "death": "m_c died of {PRONOUN/m_c/poss} injuries after fighting o_c_n's leader."
             }
         ],
         "relationships": [

--- a/resources/lang/en/events/injury/general.json
+++ b/resources/lang/en/events/injury/general.json
@@ -7114,7 +7114,7 @@
             "clan:kitten"
         ],
         "frequency": 4,
-        "event_text": "While o_c_n attempted a surprise attack on the c_n camp, m_c fiercely guarded the nursery, no matter how injured {PRONOUN/m_c/subject} became.",
+        "event_text": "While o_c_n attempted a surprise attack on the c_n camp, m_c guarded the nursery, no matter how injured {PRONOUN/m_c/subject} became.",
         "m_c": {
             "age": [
                 "-kitten"

--- a/resources/lang/en/events/injury/general.json
+++ b/resources/lang/en/events/injury/general.json
@@ -7158,7 +7158,7 @@
                 "values": ["respect", "trust"],
                 "amount": 10,
                 "log": {
-                    "cats_from": "cat_from saw cat_to defended the nursery in a battle with o_c_n."
+                    "cats_from": "cat_from saw cat_to defend the nursery in a battle with o_c_n."
                 }
             }
         ]

--- a/resources/lang/en/events/injury/general.json
+++ b/resources/lang/en/events/injury/general.json
@@ -7222,7 +7222,7 @@
         ]
     },
     {
-        "event_id": "gen_injury_mangledtail_war_anyapprenticehostile1",
+        "event_id": "gen_injury_war_battleinjury1",
         "location": [
             "any"
         ],
@@ -7279,7 +7279,7 @@
         }
     },
     {
-        "event_id": "gen_injury_mangledleg_anymultistatusnotcareful1",
+        "event_id": "gen_injury_war_pittrap",
         "location": [
             "any"
         ],
@@ -7557,7 +7557,7 @@
         ],
         "other_clan": {
             "current_rep": ["hostile"],
-            "changed": -1
+            "changed": 1
         }
     },
     {
@@ -7600,7 +7600,7 @@
         ],
         "other_clan": {
             "current_rep": ["hostile"],
-            "changed": -2
+            "changed": -1
         }
     },
     {

--- a/resources/lang/en/events/injury/general.json
+++ b/resources/lang/en/events/injury/general.json
@@ -7524,7 +7524,7 @@
         "sub_type": ["war"],
         "tags": [],
         "frequency": 1,
-        "event_text": "To settle a piece of disputed land in the ongoing war with o_c_n, m_c is chosen to fight one o_c_n warrior. m_c loses the duel, and the strip of territory goes to o_c_n.",
+        "event_text": "To settle a piece of disputed land in the ongoing war with o_c_n, m_c is chosen to fight one-on-one with a o_c_n warrior. m_c loses the duel, and the strip of territory goes to o_c_n.",
         "m_c": {
             "status": ["warrior", "deputy"],
             "skill": ["-FIGHTER,2"],

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -3730,58 +3730,6 @@
         ]
     },
     {
-        "event_id": "gen_misc_war_any_kitparent1",
-        "location": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "sub_type": [
-            "war"
-        ],
-        "frequency": 4,
-        "event_text": "m_c was comforted by r_c after having nightmares about the big, bad o_c_n cats.",
-        "m_c": {
-            "status": [
-                "kitten"
-            ],
-            "relationship_status": [
-                "child/parent"
-            ]
-        },
-        "r_c": {
-            "status": [
-                "any"
-            ]
-        },
-        "relationships": [
-            {
-                "cats_from": [
-                    "m_c"
-                ],
-                "cats_to": [
-                    "r_c"
-                ],
-                "mutual": false,
-                "values": [
-                    "comfort",
-                    "trust"
-                ],
-                "amount": 30,
-                "log": {
-                    "cats_from": "cat_from was comforted by cat_to after a nightmare about o_c_n."
-                }
-            }
-        ],
-        "other_clan": {
-            "current_rep": [
-                "hostile"
-            ],
-            "changed": 0
-        }
-    },
-    {
         "event_id": "gen_misc_any_accessorykit1",
         "location": [
             "any"
@@ -4763,60 +4711,6 @@
                 }
             }
         ]
-    },
-    {
-        "event_id": "gen_misc_war_any_apprentice1",
-        "location": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "sub_type": [
-            "war"
-        ],
-        "frequency": 2,
-        "event_text": "m_c is struggling to cope with the violence and chaos of war surrounding {PRONOUN/m_c/object}, finding it difficult to wake up in the morning due to the stress and strain of constant battle training.",
-        "m_c": {
-            "status": [
-                "apprentice"
-            ],
-            "trait": [
-                "nervous",
-                "lonesome",
-                "playful",
-                "careful",
-                "compassionate",
-                "loving",
-                "insecure"
-            ]
-        }
-    },
-    {
-        "event_id": "gen_misc_war_any_apprentice2",
-        "location": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "sub_type": [
-            "war"
-        ],
-        "frequency": 4,
-        "event_text": "m_c feels like {PRONOUN/m_c/subject} might be growing up too fast in the midst of war.",
-        "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "trait": [
-                "-fierce",
-                "-bloodthirsty",
-                "-cold",
-                "-ambitious",
-                "-arrogant"
-            ]
-        }
     },
     {
         "event_id": "gen_misc_any_welcoming_strangermeeting1",
@@ -6391,143 +6285,6 @@
         ]
     },
     {
-        "event_id": "gen_misc_any_wartraitmediator1",
-        "location": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "sub_type": [
-            "war"
-        ],
-        "frequency": 4,
-        "event_text": "m_c goes to o_c_n in an attempt to ease the tension of war between the Clans. It goes well, and o_c_n begins to draw back from c_n's territory.",
-        "m_c": {
-            "age": [
-                "any"
-            ],
-            "status": [
-                "mediator",
-                "mediator apprentice"
-            ],
-            "skill": [
-                "MEDIATOR,2"
-            ]
-        },
-        "other_clan": {
-            "changed": 4
-        },
-        "relationships": [
-            {
-                "cats_from": ["clan", "high_social"],
-                "cats_to": ["m_c"],
-                "values": ["respect"],
-                "amount": 10,
-                "mutual": false,
-                "log": {
-                    "cats_from": "cat_from approved of how cat_to persuaded o_c_n to withdraw from c_n's territory."
-                }
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_any_wartraitmediator2",
-        "location": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "sub_type": [
-            "war"
-        ],
-        "frequency": 4,
-        "event_text": "m_c is checking in on every cat in the camp to make sure everyone is staying healthy in the midst of war.",
-        "m_c": {
-            "age": [
-                "any"
-            ],
-            "status": [
-                "mediator",
-                "mediator apprentice"
-            ],
-            "trait": [
-                "calm",
-                "careful",
-                "insecure",
-                "lonesome",
-                "loyal",
-                "nervous",
-                "compassionate",
-                "faithful",
-                "loving",
-                "responsible",
-                "thoughtful",
-                "wise",
-                "childish",
-                "playful"
-            ]
-        },
-        "relationships": [
-            {
-                "cats_from": [
-                    "some_clan"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "mutual": false,
-                "values": [
-                    "trust",
-                    "comfort"
-                ],
-                "amount": 5,
-                "log": {
-                    "cats_from": "cat_from appreciated cat_to checking in on {PRONOUN/cat_from/object} in the midst of the war."
-                }
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_any_warmediator1",
-        "location": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "sub_type": [
-            "war"
-        ],
-        "frequency": 3,
-        "event_text": "m_c goes to o_c_n in an attempt to ease the tension of war between the Clans. It doesn't go well, and o_c_n further advances in c_n's territory.",
-        "m_c": {
-            "age": [
-                "any"
-            ],
-            "status": [
-                "mediator",
-                "mediator apprentice"
-            ]
-        },
-        "other_clan": {
-            "changed": -2
-        },
-        "relationships": [
-            {
-                "cats_from": ["clan", "high_aggress"],
-                "cats_to": ["m_c"],
-                "values": ["respect"],
-                "amount": -10,
-                "mutual": false,
-                "log": {
-                    "cats_from": "cat_from thought cat_to's mediation efforts in the war with o_c_n were a waste of time."
-                }
-            }
-        ]
-    },
-    {
         "event_id": "gen_misc_any_mediatortoadult",
         "location": [
             "any"
@@ -6612,191 +6369,6 @@
                 "amount": 10,
                 "log": {
                     "cats_from": "cat_from was grateful that cat_to let {PRONOUN/cat_from/object} tag along and watch {PRONOUN/cat_to/object} do {PRONOUN/cat_to/poss} duties."
-                }
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_any_war_mediatorleader1",
-        "location": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "sub_type": [
-            "war"
-        ],
-        "frequency": 4,
-        "event_text": "m_c is giving r_c advice on the war, though it's unclear how helpful it really is.",
-        "m_c": {
-            "status": [
-                "mediator",
-                "mediator apprentice"
-            ],
-            "relationship_status": [
-                "dislikes"
-            ],
-            "trait": [
-                "cunning"
-            ]
-        },
-        "r_c": {
-            "status": [
-                "leader"
-            ],
-            "trait": [
-                "bold",
-                "charismatic",
-                "confident",
-                "daring",
-                "righteous",
-                "ambitious",
-                "bloodthirsty",
-                "cold",
-                "fierce",
-                "shameless",
-                "strict",
-                "troublesome",
-                "vengeful",
-                "sneaky",
-                "strange"
-            ]
-        },
-        "relationships": [
-            {
-                "cats_to": [
-                    "m_c"
-                ],
-                "cats_from": [
-                    "r_c"
-                ],
-                "mutual": true,
-                "values": [
-                    "trust"
-                ],
-                "amount": -20,
-                "log": {
-                    "cats_from": "cat_from suspected that cat_to intentionally gave {PRONOUN/cat_from/object} bad advice about an ongoing war."
-                }
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_any_war_mediatorleader2",
-        "location": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "sub_type": [
-            "war"
-        ],
-        "frequency": 2,
-        "event_text": "m_c is conversing with r_c about ways to potentially end this war without bloodshed.",
-        "m_c": {
-            "status": [
-                "mediator",
-                "mediator apprentice"
-            ]
-        },
-        "r_c": {
-            "status": [
-                "leader"
-            ],
-            "trait": [
-                "calm",
-                "careful",
-                "insecure",
-                "lonesome",
-                "loyal",
-                "nervous",
-                "compassionate",
-                "faithful",
-                "loving",
-                "responsible",
-                "thoughtful",
-                "wise",
-                "childish",
-                "playful"
-            ]
-        },
-        "relationships": [
-            {
-                "cats_from": [
-                    "m_c"
-                ],
-                "cats_to": [
-                    "r_c"
-                ],
-                "mutual": true,
-                "values": [
-                    "trust"
-                ],
-                "amount": 20,
-                "log": {
-                    "cats_from": "cat_from consulted cat_to about how to end the war with o_c_n."
-                }
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_any_war_mediatorleader3",
-        "location": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "sub_type": [
-            "war"
-        ],
-        "frequency": 2,
-        "event_text": "m_c is conversing with r_c about ways to potentially end this war — though not without bloodshed.",
-        "m_c": {
-            "status": [
-                "mediator",
-                "mediator apprentice"
-            ]
-        },
-        "r_c": {
-            "status": [
-                "leader"
-            ],
-            "trait": [
-                "bold",
-                "charismatic",
-                "confident",
-                "daring",
-                "righteous",
-                "ambitious",
-                "bloodthirsty",
-                "cold",
-                "fierce",
-                "shameless",
-                "strict",
-                "troublesome",
-                "vengeful",
-                "sneaky",
-                "strange"
-            ]
-        },
-        "relationships": [
-            {
-                "cats_from": [
-                    "m_c"
-                ],
-                "cats_to": [
-                    "r_c"
-                ],
-                "mutual": true,
-                "values": [
-                    "trust"
-                ],
-                "amount": 20,
-                "log": {
-                    "cats_from": "cat_from consulted cat_to about how to end the war with o_c_n."
                 }
             }
         ]
@@ -7203,140 +6775,6 @@
                 "log": {
                     "cats_from": "cat_from and cat_to discussed something when they met each other on the border."
                 }
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_any_medicinecatwar1",
-        "location": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "sub_type": [
-            "war"
-        ],
-        "frequency": 2,
-        "event_text": "m_c's knowledge of herbs and healing is put to the test by the severe injuries sustained in the war.",
-        "m_c": {
-            "status": [
-                "medicine cat",
-                "medicine cat apprentice"
-            ]
-        }
-    },
-    {
-        "event_id": "gen_misc_any_medicinecatwar2",
-        "location": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "sub_type": [
-            "war"
-        ],
-        "frequency": 4,
-        "event_text": "m_c watches every little thing around {PRONOUN/m_c/object} for any omen that indicates what the Clan should do in the war. The losses weigh heavy on the hearts of every cat.",
-        "m_c": {
-            "status": [
-                "medicine cat apprentice",
-                "medicine cat"
-            ],
-            "skill": [
-                "OMEN,1"
-            ]
-        }
-    },
-    {
-        "event_id": "gen_misc_any_medicinecatwar3",
-        "location": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "sub_type": [
-            "war"
-        ],
-        "frequency": 2,
-        "event_text": "m_c preps battle herbs into small bundles to rush to the battlefield in case of severe injuries.",
-        "m_c": {
-            "age": [
-                "any"
-            ],
-            "status": [
-                "medicine cat apprentice",
-                "medicine cat"
-            ]
-        },
-        "relationships": [
-            {
-                "cats_from": ["clan", "high_aggress"],
-                "cats_to": ["m_c"],
-                "values": ["respect", "trust"],
-                "amount": 10,
-                "mutual": false,
-                "log": {
-                    "cats_from": "cat_from appreciated cat_to's foresight in preparing small bundles of herbs for use during battle."
-                }
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_any_medcatwar4",
-        "location": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "sub_type": [
-            "war"
-        ],
-        "frequency": 2,
-        "event_text": "c_n is in a badly need of herbs, and m_c knows it, but {PRONOUN/m_c/subject} can't bring {PRONOUN/m_c/self} to leave {PRONOUN/m_c/poss} patients' side.",
-        "m_c": {
-            "status": [
-                "medicine cat",
-                "medicine cat apprentice"
-            ]
-        }
-    },
-    {
-        "event_id": "multi_misc_leafbare_medicinecatwar1",
-        "location": [
-            "forest",
-            "plains",
-            "beach",
-            "mountainous",
-            "wetlands"
-        ],
-        "season": [
-            "leaf-bare"
-        ],
-        "sub_type": [
-            "war"
-        ],
-        "frequency": 2,
-        "event_text": "m_c hopes to find the herbs that c_n needs in the war and goes to look for them even in this leaf-bare's harsh weather.",
-        "m_c": {
-            "age": [
-                "any"
-            ],
-            "status": [
-                "medicine cat apprentice",
-                "medicine cat"
-            ]
-        },
-        "supplies": [
-            {
-                "type": "any_herb",
-                "trigger": [
-                    "low"
-                ],
-                "adjust": "increase_5"
             }
         ]
     },
@@ -7748,172 +7186,6 @@
         }
     },
     {
-        "event_id": "gen_misc_any_wardeputy1",
-        "location": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "sub_type": [
-            "war"
-        ],
-        "frequency": 2,
-        "event_text": "As the deputy, m_c is doing {PRONOUN/m_c/poss} best to prepare for leadership in the case the worst happens.",
-        "m_c": {
-            "status": [
-                "deputy"
-            ]
-        }
-    },
-    {
-        "event_id": "gen_misc_any_warmultitraitdeputyleader1",
-        "location": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "sub_type": [
-            "war"
-        ],
-        "tags": [
-            "low_lives"
-        ],
-        "frequency": 1,
-        "event_text": "m_c is struggling to accept the fact that {PRONOUN/m_c/subject} may have to step up as leader if r_c loses {PRONOUN/r_c/poss} last life.",
-        "m_c": {
-            "age": [
-                "any"
-            ],
-            "status": [
-                "deputy"
-            ],
-            "trait": [
-                "insecure",
-                "lonesome",
-                "nervous"
-            ]
-        },
-        "r_c": {
-            "age": [
-                "any"
-            ],
-            "status": [
-                "leader"
-            ]
-        }
-    },
-    {
-        "event_id": "gen_misc_any_warmultitraitdeputyleader2",
-        "location": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "sub_type": [
-            "war"
-        ],
-        "tags": [
-            "low_lives"
-        ],
-        "frequency": 2,
-        "event_text": "m_c is struggling to accept the fact that {PRONOUN/m_c/subject} may have to step up as leader if r_c loses {PRONOUN/r_c/poss} last life. How could {PRONOUN/m_c/subject} {VERB/m_c/go/goes} on without {PRONOUN/m_c/poss} beloved leader? How difficult will it to be to lead in {PRONOUN/r_c/poss} stead?",
-        "m_c": {
-            "status": [
-                "deputy"
-            ],
-            "trait": [
-                "insecure",
-                "lonesome",
-                "nervous"
-            ]
-        },
-        "r_c": {
-            "status": [
-                "leader"
-            ]
-        },
-        "relationships": [
-            {
-                "cats_from": [
-                    "m_c"
-                ],
-                "cats_to": [
-                    "r_c"
-                ],
-                "mutual": false,
-                "values": [
-                    "respect",
-                    "trust"
-                ],
-                "amount": 15,
-                "log": {
-                    "cats_from": "Knowing the war might take cat_to away from {PRONOUN/cat_from/object}, cat_from realized what an incredible leader cat_to is."
-                }
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_any_wardeputyelder1",
-        "location": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "sub_type": [
-            "war"
-        ],
-        "tags": [
-            "clan:elder"
-        ],
-        "frequency": 2,
-        "event_text": "m_c is heavily relying on the tactical advice and experience of the elders, namely r_c.",
-        "m_c": {
-            "status": [
-                "deputy",
-                "leader"
-            ],
-            "trait": [
-                "insecure",
-                "lonesome",
-                "nervous"
-            ]
-        },
-        "r_c": {
-            "status": [
-                "elder"
-            ],
-            "skill": [
-                "INSIGHTFUL,1",
-                "TEACHER,3",
-                "CLEVER,3",
-                "CAMP,3"
-            ]
-        },
-        "relationships": [
-            {
-                "cats_from": [
-                    "m_c"
-                ],
-                "cats_to": [
-                    "r_c"
-                ],
-                "mutual": false,
-                "values": [
-                    "respect",
-                    "trust"
-                ],
-                "amount": 15,
-                "log": {
-                    "cats_from": "During a war, cat_from relied heavily on the wisdom of cat_to."
-                }
-            }
-        ]
-    },
-    {
         "event_id": "gen_misc_any_lowlivesleader1",
         "location": [
             "any"
@@ -7982,95 +7254,6 @@
                 "leader"
             ]
         }
-    },
-    {
-        "event_id": "gen_misc_any_warleader1",
-        "location": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "sub_type": [
-            "war"
-        ],
-        "frequency": 4,
-        "event_text": "m_c feels burdened with the weight of {PRONOUN/m_c/poss} decisions, knowing that every choice {PRONOUN/m_c/subject} {VERB/m_c/make/makes} could mean the difference between victory and defeat.",
-        "m_c": {
-            "status": [
-                "leader"
-            ]
-        }
-    },
-    {
-        "event_id": "gen_misc_any_warleader2",
-        "location": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "sub_type": [
-            "war"
-        ],
-        "frequency": 4,
-        "event_text": "m_c's relationships with {PRONOUN/m_c/poss} Clanmates are strained, with some questioning {PRONOUN/m_c/poss} decisions and others relying on {PRONOUN/m_c/object} more heavily than ever.",
-        "m_c": {
-            "status": [
-                "leader"
-            ]
-        },
-        "relationships": [
-            {
-                "cats_from": ["clan", "high_stable"],
-                "cats_to": ["m_c"],
-                "values": ["trust", "respect"],
-                "amount": 20,
-                "log": {
-                    "cats_from": "During a war, cat_from put all {PRONOUN/cat_from/poss} faith in m_c."
-                }
-            },
-            {
-                "cats_from": ["clan", "low_stable"],
-                "cats_to": ["m_c"],
-                "values": ["trust", "respect"],
-                "amount": -20,
-                "log": {
-                    "cats_from": "During a war, cat_from seriously reconsidered whether cat_to was the right cat to lead the Clan."
-                }
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_any_warleader3",
-        "location": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "sub_type": [
-            "war"
-        ],
-        "frequency": 4,
-        "event_text": "m_c is forced to be a symbol of strength and unity for {PRONOUN/m_c/poss} Clan, even in the face of {PRONOUN/m_c/poss} own doubts and fears.",
-        "m_c": {
-            "status": [
-                "leader"
-            ]
-        },
-        "relationships": [
-            {
-                "cats_from": ["clan", "high_social"],
-                "cats_to": ["m_c"],
-                "values": ["respect"],
-                "amount": 20,
-                "mutual": false,
-                "log": {
-                    "cats_from": "cat_from recognized how hard m_c worked to be a symbol of strength and unity for c_n during a war."
-                }
-            }
-        ]
     },
     {
         "event_id": "gen_misc_any_leaderapprentice1",
@@ -8629,143 +7812,6 @@
             ],
             "changed": 1
         }
-    },
-    {
-        "event_id": "gen_misc_herb_anywarsteal1",
-        "location": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "sub_type": [
-            "war"
-        ],
-        "exclude_involved": [
-            "m_c",
-            "r_c"
-        ],
-        "frequency": 1,
-        "event_text": "o_c_n breaks into the camp and ravages the herb stores, taking some for themselves and attempting to destroy the rest. The Clan manages to recover some of the herbs, but the store was still badly damaged.",
-        "supplies": [
-            {
-                "type": "all_herb",
-                "trigger": [
-                    "adequate",
-                    "full",
-                    "excess"
-                ],
-                "adjust": "reduce_half"
-            }
-        ],
-        "other_clan": {
-            "current_rep": [
-                "hostile"
-            ],
-            "changed": -2
-        }
-    },
-    {
-        "event_id": "gen_misc_herb_anywarsteal1",
-        "location": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "sub_type": [
-            "war"
-        ],
-        "exclude_involved": [
-            "m_c",
-            "r_c"
-        ],
-        "frequency": 1,
-        "event_text": "o_c_n breaks into the camp and ravages the herb stores, taking some for themselves and destroying the rest.",
-        "supplies": [
-            {
-                "type": "all_herb",
-                "trigger": [
-                    "adequate",
-                    "full",
-                    "excess"
-                ],
-                "adjust": "reduce_full"
-            }
-        ],
-        "other_clan": {
-            "current_rep": [
-                "hostile"
-            ],
-            "changed": -2
-        }
-    },
-    {
-        "event_id": "gen_misc_herb_anywarsteal2",
-        "location": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "sub_type": [
-            "war"
-        ],
-        "exclude_involved": [
-            "m_c",
-            "r_c"
-        ],
-        "frequency": 1,
-        "event_text": "c_n breaks into the o_c_n camp and steals precious herbs from their medicine cat den.",
-        "m_c": {
-            "status": [
-                "leader"
-            ],
-            "trait": [
-                "arrogant",
-                "bloodthirsty",
-                "vengeful",
-                "competitive",
-                "bold",
-                "troublesome",
-                "fierce",
-                "cold",
-                "righteous",
-                "daring",
-                "shameless",
-                "sneaky",
-                "cunning",
-                "rebellious"
-            ]
-        },
-        "supplies": [
-            {
-                "type": "all_herb",
-                "trigger": [
-                    "low",
-                    "adequate"
-                ],
-                "adjust": "increase_5"
-            }
-        ],
-        "other_clan": {
-            "current_rep": [
-                "hostile"
-            ],
-            "changed": -2
-        },
-        "relationships": [
-            {
-                "cats_from": ["clan", "high_stable"],
-                "cats_to": ["m_c"],
-                "values": ["respect"],
-                "amount": -20,
-                "mutual": false,
-                "log": {
-                    "cats_from": "cat_from thought it was fox-hearted of cat_to to order {PRONOUN/cat_from/object} to steal from o_c_n's herb stores."
-                }
-            }
-        ]
     },
     {
         "event_id": "gen_misc_herb_anydestruction1",
@@ -11083,6 +10129,1186 @@
         }
     },
     {
+        "event_id": "gen_misc_war_any_kitparent1",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 4,
+        "event_text": "m_c was comforted by r_c after having nightmares about the big, bad o_c_n cats.",
+        "m_c": {
+            "status": [
+                "kitten"
+            ],
+            "relationship_status": [
+                "child/parent"
+            ]
+        },
+        "r_c": {
+            "status": [
+                "any"
+            ]
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "m_c"
+                ],
+                "cats_to": [
+                    "r_c"
+                ],
+                "mutual": false,
+                "values": [
+                    "comfort",
+                    "trust"
+                ],
+                "amount": 30,
+                "log": {
+                    "cats_from": "cat_from was comforted by cat_to after a nightmare about o_c_n."
+                }
+            }
+        ],
+        "other_clan": {
+            "current_rep": [
+                "hostile"
+            ],
+            "changed": 0
+        }
+    },
+    {
+        "event_id": "gen_misc_war_any_kitparent1",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 4,
+        "event_text": "m_c was comforted by r_c after having nightmares about the big, bad o_c_n cats.",
+        "m_c": {
+            "status": [
+                "kitten"
+            ],
+            "relationship_status": [
+                "child/parent"
+            ]
+        },
+        "r_c": {
+            "status": [
+                "any"
+            ]
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "m_c"
+                ],
+                "cats_to": [
+                    "r_c"
+                ],
+                "mutual": false,
+                "values": [
+                    "comfort",
+                    "trust"
+                ],
+                "amount": 30,
+                "log": {
+                    "cats_from": "cat_from was comforted by cat_to after a nightmare about o_c_n."
+                }
+            }
+        ],
+        "other_clan": {
+            "current_rep": [
+                "hostile"
+            ],
+            "changed": 0
+        }
+    },
+    {
+        "event_id": "gen_misc_war_any_apprentice1",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 2,
+        "event_text": "m_c is struggling to cope with the violence and chaos of war surrounding {PRONOUN/m_c/object}, finding it difficult to wake up in the morning due to the stress and strain of constant battle training.",
+        "m_c": {
+            "status": [
+                "apprentice"
+            ],
+            "trait": [
+                "nervous",
+                "lonesome",
+                "playful",
+                "careful",
+                "compassionate",
+                "loving",
+                "insecure"
+            ]
+        }
+    },
+    {
+        "event_id": "gen_misc_war_any_apprentice2",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 4,
+        "event_text": "m_c feels like {PRONOUN/m_c/subject} might be growing up too fast in the midst of war.",
+        "m_c": {
+            "age": [
+                "adolescent"
+            ],
+            "trait": [
+                "-fierce",
+                "-bloodthirsty",
+                "-cold",
+                "-ambitious",
+                "-arrogant"
+            ]
+        }
+    },
+    {
+        "event_id": "gen_misc_any_wartraitmediator1",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 4,
+        "event_text": "m_c goes to o_c_n in an attempt to ease the tension of war between the Clans. It goes well, and o_c_n begins to draw back from c_n's territory.",
+        "m_c": {
+            "age": [
+                "any"
+            ],
+            "status": [
+                "mediator",
+                "mediator apprentice"
+            ],
+            "skill": [
+                "MEDIATOR,2"
+            ]
+        },
+        "other_clan": {
+            "changed": 4
+        },
+        "relationships": [
+            {
+                "cats_from": ["clan", "high_social"],
+                "cats_to": ["m_c"],
+                "values": ["respect"],
+                "amount": 10,
+                "mutual": false,
+                "log": {
+                    "cats_from": "cat_from approved of how cat_to persuaded o_c_n to withdraw from c_n's territory."
+                }
+            }
+        ]
+    },
+    {
+        "event_id": "gen_misc_any_wartraitmediator2",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 4,
+        "event_text": "m_c is checking in on every cat in the camp to make sure everyone is staying healthy in the midst of war.",
+        "m_c": {
+            "age": [
+                "any"
+            ],
+            "status": [
+                "mediator",
+                "mediator apprentice"
+            ],
+            "trait": [
+                "calm",
+                "careful",
+                "insecure",
+                "lonesome",
+                "loyal",
+                "nervous",
+                "compassionate",
+                "faithful",
+                "loving",
+                "responsible",
+                "thoughtful",
+                "wise",
+                "childish",
+                "playful"
+            ]
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "some_clan"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "mutual": false,
+                "values": [
+                    "trust",
+                    "comfort"
+                ],
+                "amount": 5,
+                "log": {
+                    "cats_from": "cat_from appreciated cat_to checking in on {PRONOUN/cat_from/object} in the midst of the war."
+                }
+            }
+        ]
+    },
+    {
+        "event_id": "gen_misc_any_warmediator1",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 3,
+        "event_text": "m_c goes to o_c_n in an attempt to ease the tension of war between the Clans. It doesn't go well, and o_c_n further advances in c_n's territory.",
+        "m_c": {
+            "age": [
+                "any"
+            ],
+            "status": [
+                "mediator",
+                "mediator apprentice"
+            ]
+        },
+        "other_clan": {
+            "changed": -2
+        },
+        "relationships": [
+            {
+                "cats_from": ["clan", "high_aggress"],
+                "cats_to": ["m_c"],
+                "values": ["respect"],
+                "amount": -10,
+                "mutual": false,
+                "log": {
+                    "cats_from": "cat_from thought cat_to's mediation efforts in the war with o_c_n were a waste of time."
+                }
+            }
+        ]
+    },
+    {
+        "event_id": "gen_misc_any_war_mediatorleader1",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 4,
+        "event_text": "m_c is giving r_c advice on the war, though it's unclear how helpful it really is.",
+        "m_c": {
+            "status": [
+                "mediator",
+                "mediator apprentice"
+            ],
+            "relationship_status": [
+                "dislikes"
+            ],
+            "trait": [
+                "cunning"
+            ]
+        },
+        "r_c": {
+            "status": [
+                "leader"
+            ],
+            "trait": [
+                "bold",
+                "charismatic",
+                "confident",
+                "daring",
+                "righteous",
+                "ambitious",
+                "bloodthirsty",
+                "cold",
+                "fierce",
+                "shameless",
+                "strict",
+                "troublesome",
+                "vengeful",
+                "sneaky",
+                "strange"
+            ]
+        },
+        "relationships": [
+            {
+                "cats_to": [
+                    "m_c"
+                ],
+                "cats_from": [
+                    "r_c"
+                ],
+                "mutual": true,
+                "values": [
+                    "trust"
+                ],
+                "amount": -20,
+                "log": {
+                    "cats_from": "cat_from suspected that cat_to intentionally gave {PRONOUN/cat_from/object} bad advice about an ongoing war."
+                }
+            }
+        ]
+    },
+    {
+        "event_id": "gen_misc_any_war_mediatorleader2",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 2,
+        "event_text": "m_c is conversing with r_c about ways to potentially end this war without bloodshed.",
+        "m_c": {
+            "status": [
+                "mediator",
+                "mediator apprentice"
+            ]
+        },
+        "r_c": {
+            "status": [
+                "leader"
+            ],
+            "trait": [
+                "calm",
+                "careful",
+                "insecure",
+                "lonesome",
+                "loyal",
+                "nervous",
+                "compassionate",
+                "faithful",
+                "loving",
+                "responsible",
+                "thoughtful",
+                "wise",
+                "childish",
+                "playful"
+            ]
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "m_c"
+                ],
+                "cats_to": [
+                    "r_c"
+                ],
+                "mutual": true,
+                "values": [
+                    "trust"
+                ],
+                "amount": 20,
+                "log": {
+                    "cats_from": "cat_from consulted cat_to about how to end the war with o_c_n."
+                }
+            }
+        ]
+    },
+    {
+        "event_id": "gen_misc_any_war_mediatorleader3",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 2,
+        "event_text": "m_c is conversing with r_c about ways to potentially end this war — though not without bloodshed.",
+        "m_c": {
+            "status": [
+                "mediator",
+                "mediator apprentice"
+            ]
+        },
+        "r_c": {
+            "status": [
+                "leader"
+            ],
+            "trait": [
+                "bold",
+                "charismatic",
+                "confident",
+                "daring",
+                "righteous",
+                "ambitious",
+                "bloodthirsty",
+                "cold",
+                "fierce",
+                "shameless",
+                "strict",
+                "troublesome",
+                "vengeful",
+                "sneaky",
+                "strange"
+            ]
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "m_c"
+                ],
+                "cats_to": [
+                    "r_c"
+                ],
+                "mutual": true,
+                "values": [
+                    "trust"
+                ],
+                "amount": 20,
+                "log": {
+                    "cats_from": "cat_from consulted cat_to about how to end the war with o_c_n."
+                }
+            }
+        ]
+    },
+    {
+        "event_id": "gen_misc_any_medicinecatwar1",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 2,
+        "event_text": "m_c's knowledge of herbs and healing is put to the test by the severe injuries sustained in the war.",
+        "m_c": {
+            "status": [
+                "medicine cat",
+                "medicine cat apprentice"
+            ]
+        }
+    },
+    {
+        "event_id": "gen_misc_any_medicinecatwar2",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 4,
+        "event_text": "m_c watches every little thing around {PRONOUN/m_c/object} for any omen that indicates what the Clan should do in the war. The losses weigh heavy on the hearts of every cat.",
+        "m_c": {
+            "status": [
+                "medicine cat apprentice",
+                "medicine cat"
+            ],
+            "skill": [
+                "OMEN,1"
+            ]
+        }
+    },
+    {
+        "event_id": "gen_misc_any_medicinecatwar3",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 2,
+        "event_text": "m_c preps battle herbs into small bundles to rush to the battlefield in case of severe injuries.",
+        "m_c": {
+            "age": [
+                "any"
+            ],
+            "status": [
+                "medicine cat apprentice",
+                "medicine cat"
+            ]
+        },
+        "relationships": [
+            {
+                "cats_from": ["clan", "high_aggress"],
+                "cats_to": ["m_c"],
+                "values": ["respect", "trust"],
+                "amount": 10,
+                "mutual": false,
+                "log": {
+                    "cats_from": "cat_from appreciated cat_to's foresight in preparing small bundles of herbs for use during battle."
+                }
+            }
+        ]
+    },
+    {
+        "event_id": "gen_misc_any_medcatwar4",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 2,
+        "event_text": "c_n is in a badly need of herbs, and m_c knows it, but {PRONOUN/m_c/subject} can't bring {PRONOUN/m_c/self} to leave {PRONOUN/m_c/poss} patients' side.",
+        "m_c": {
+            "status": [
+                "medicine cat",
+                "medicine cat apprentice"
+            ]
+        }
+    },
+    {
+        "event_id": "multi_misc_leafbare_medicinecatwar1",
+        "location": [
+            "forest",
+            "plains",
+            "beach",
+            "mountainous",
+            "wetlands"
+        ],
+        "season": [
+            "leaf-bare"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 2,
+        "event_text": "m_c hopes to find the herbs that c_n needs in the war and goes to look for them even in this leaf-bare's harsh weather.",
+        "m_c": {
+            "age": [
+                "any"
+            ],
+            "status": [
+                "medicine cat apprentice",
+                "medicine cat"
+            ]
+        },
+        "supplies": [
+            {
+                "type": "any_herb",
+                "trigger": [
+                    "low"
+                ],
+                "adjust": "increase_5"
+            }
+        ]
+    },
+    {
+        "event_id": "gen_misc_any_wardeputy1",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 2,
+        "event_text": "As the deputy, m_c is doing {PRONOUN/m_c/poss} best to prepare for leadership in the case the worst happens.",
+        "m_c": {
+            "status": [
+                "deputy"
+            ]
+        }
+    },
+    {
+        "event_id": "gen_misc_any_warmultitraitdeputyleader1",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "tags": [
+            "low_lives"
+        ],
+        "frequency": 1,
+        "event_text": "m_c is struggling to accept the fact that {PRONOUN/m_c/subject} may have to step up as leader if r_c loses {PRONOUN/r_c/poss} last life.",
+        "m_c": {
+            "age": [
+                "any"
+            ],
+            "status": [
+                "deputy"
+            ],
+            "trait": [
+                "insecure",
+                "lonesome",
+                "nervous"
+            ]
+        },
+        "r_c": {
+            "age": [
+                "any"
+            ],
+            "status": [
+                "leader"
+            ]
+        }
+    },
+    {
+        "event_id": "gen_misc_any_warmultitraitdeputyleader2",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "tags": [
+            "low_lives"
+        ],
+        "frequency": 2,
+        "event_text": "m_c is struggling to accept the fact that {PRONOUN/m_c/subject} may have to step up as leader if r_c loses {PRONOUN/r_c/poss} last life. How could {PRONOUN/m_c/subject} {VERB/m_c/go/goes} on without {PRONOUN/m_c/poss} beloved leader? How difficult will it to be to lead in {PRONOUN/r_c/poss} stead?",
+        "m_c": {
+            "status": [
+                "deputy"
+            ],
+            "trait": [
+                "insecure",
+                "lonesome",
+                "nervous"
+            ]
+        },
+        "r_c": {
+            "status": [
+                "leader"
+            ]
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "m_c"
+                ],
+                "cats_to": [
+                    "r_c"
+                ],
+                "mutual": false,
+                "values": [
+                    "respect",
+                    "trust"
+                ],
+                "amount": 15,
+                "log": {
+                    "cats_from": "Knowing the war might take cat_to away from {PRONOUN/cat_from/object}, cat_from realized what an incredible leader cat_to is."
+                }
+            }
+        ]
+    },
+    {
+        "event_id": "gen_misc_any_wardeputyelder1",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "tags": [
+            "clan:elder"
+        ],
+        "frequency": 2,
+        "event_text": "m_c is heavily relying on the tactical advice and experience of the elders, namely r_c.",
+        "m_c": {
+            "status": [
+                "deputy",
+                "leader"
+            ],
+            "trait": [
+                "insecure",
+                "lonesome",
+                "nervous"
+            ]
+        },
+        "r_c": {
+            "status": [
+                "elder"
+            ],
+            "skill": [
+                "INSIGHTFUL,1",
+                "TEACHER,3",
+                "CLEVER,3",
+                "CAMP,3"
+            ]
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "m_c"
+                ],
+                "cats_to": [
+                    "r_c"
+                ],
+                "mutual": false,
+                "values": [
+                    "respect",
+                    "trust"
+                ],
+                "amount": 15,
+                "log": {
+                    "cats_from": "During a war, cat_from relied heavily on the wisdom of cat_to."
+                }
+            }
+        ]
+    },
+    {
+        "event_id": "gen_misc_any_warleader1",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 4,
+        "event_text": "m_c feels burdened with the weight of {PRONOUN/m_c/poss} decisions, knowing that every choice {PRONOUN/m_c/subject} {VERB/m_c/make/makes} could mean the difference between victory and defeat.",
+        "m_c": {
+            "status": [
+                "leader"
+            ]
+        }
+    },
+    {
+        "event_id": "gen_misc_any_warleader2",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 4,
+        "event_text": "m_c's relationships with {PRONOUN/m_c/poss} Clanmates are strained, with some questioning {PRONOUN/m_c/poss} decisions and others relying on {PRONOUN/m_c/object} more heavily than ever.",
+        "m_c": {
+            "status": [
+                "leader"
+            ]
+        },
+        "relationships": [
+            {
+                "cats_from": ["clan", "high_stable"],
+                "cats_to": ["m_c"],
+                "values": ["trust", "respect"],
+                "amount": 20,
+                "log": {
+                    "cats_from": "During a war, cat_from put all {PRONOUN/cat_from/poss} faith in m_c."
+                }
+            },
+            {
+                "cats_from": ["clan", "low_stable"],
+                "cats_to": ["m_c"],
+                "values": ["trust", "respect"],
+                "amount": -20,
+                "log": {
+                    "cats_from": "During a war, cat_from seriously reconsidered whether cat_to was the right cat to lead the Clan."
+                }
+            }
+        ]
+    },
+    {
+        "event_id": "gen_misc_any_warleader3",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 4,
+        "event_text": "m_c is forced to be a symbol of strength and unity for {PRONOUN/m_c/poss} Clan, even in the face of {PRONOUN/m_c/poss} own doubts and fears.",
+        "m_c": {
+            "status": [
+                "leader"
+            ]
+        },
+        "relationships": [
+            {
+                "cats_from": ["clan", "high_social"],
+                "cats_to": ["m_c"],
+                "values": ["respect"],
+                "amount": 20,
+                "mutual": false,
+                "log": {
+                    "cats_from": "cat_from recognized how hard m_c worked to be a symbol of strength and unity for c_n during a war."
+                }
+            }
+        ]
+    },
+    {
+        "event_id": "gen_misc_herb_anywarsteal1",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "exclude_involved": [
+            "m_c",
+            "r_c"
+        ],
+        "frequency": 1,
+        "event_text": "o_c_n breaks into the camp and ravages the herb stores, taking some for themselves and destroying the rest.",
+        "supplies": [
+            {
+                "type": "all_herb",
+                "trigger": [
+                    "adequate",
+                    "full",
+                    "excess"
+                ],
+                "adjust": "reduce_full"
+            }
+        ],
+        "other_clan": {
+            "current_rep": [
+                "hostile"
+            ],
+            "changed": -2
+        }
+    },
+    {
+        "event_id": "gen_misc_herb_anywarsteal2",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "exclude_involved": [
+            "m_c",
+            "r_c"
+        ],
+        "frequency": 1,
+        "event_text": "c_n breaks into the o_c_n camp and steals precious herbs from their medicine cat den.",
+        "m_c": {
+            "status": [
+                "leader"
+            ],
+            "trait": [
+                "arrogant",
+                "bloodthirsty",
+                "vengeful",
+                "competitive",
+                "bold",
+                "troublesome",
+                "fierce",
+                "cold",
+                "righteous",
+                "daring",
+                "shameless",
+                "sneaky",
+                "cunning",
+                "rebellious"
+            ]
+        },
+        "supplies": [
+            {
+                "type": "all_herb",
+                "trigger": [
+                    "low",
+                    "adequate"
+                ],
+                "adjust": "increase_5"
+            }
+        ],
+        "other_clan": {
+            "current_rep": [
+                "hostile"
+            ],
+            "changed": -2
+        },
+        "relationships": [
+            {
+                "cats_from": ["clan", "high_stable"],
+                "cats_to": ["m_c"],
+                "values": ["respect"],
+                "amount": -20,
+                "mutual": false,
+                "log": {
+                    "cats_from": "cat_from thought it was fox-hearted of cat_to to order {PRONOUN/cat_from/object} to steal from o_c_n's herb stores."
+                }
+            }
+        ]
+    },
+    {
+        "event_id": "gen_misc_war_onwatch1",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 4,
+        "event_text": "m_c and r_c spend the night by the o_c_n border, on watch for an attack that never comes.",
+        "m_c": {
+            "status": [
+                "warrior",
+                "deputy",
+                "leader"
+            ]
+        },
+       "r_c": {
+            "status": [
+                "warrior",
+                "deputy",
+                "leader"
+            ]
+        },
+        "relationships": [
+            {
+                "cats_from": [ "m_c" ],
+                "cats_to": [ "r_c" ],
+                "mutual": true,
+                "values": [ "trust" ],
+                "amount": 10,
+                "log": {
+                    "cats_from": "cat_from and cat_to spent the night on watch for a potential attack."
+                }
+            }
+        ],
+        "other_clan": {
+            "current_rep": [
+                "hostile"
+            ]
+        }
+    },
+    {
+        "event_id": "gen_misc_war_onwatch2",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 2,
+        "event_text": "m_c and r_c spend the night by the o_c_n border. They confront a passing o_c_n patrol, but they're more keen on a conversation than a fight.",
+        "m_c": {
+            "status": [
+                "warrior",
+                "deputy",
+                "leader"
+            ]
+        },
+        "r_c": {
+            "status": [
+                "warrior",
+                "deputy",
+                "leader"
+            ]
+        },
+        "other_clan": {
+            "current_rep": [
+                "hostile"
+            ],
+            "changed": 1
+        }
+    },
+    {
+        "event_id": "gen_misc_war_onwatch3",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 1,
+        "event_text": "m_c and r_c spend the night by the o_c_n border. They confront a passing o_c_n patrol, but they're more keen on a conversation than a fight and offer to keep them company instead.",
+        "m_c": {
+            "status": [
+                "warrior",
+                "deputy",
+                "leader"
+            ]
+        },
+        "r_c": {
+            "status": [
+                "warrior",
+                "deputy",
+                "leader"
+            ]
+        },
+        "other_clan": {
+            "current_rep": [
+                "hostile"
+            ],
+            "changed": 2
+        }
+    },
+    {
+        "event_id": "gen_misc_war_onwatch4",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 3,
+        "event_text": "m_c and r_c spend the night by the o_c_n border. They confront a passing o_c_n patrol, but they're more keen to trade insults than blows.",
+        "m_c": {
+            "status": [
+                "warrior",
+                "deputy",
+                "leader"
+            ]
+        },
+        "r_c": {
+            "status": [
+                "warrior",
+                "deputy",
+                "leader"
+            ]
+        },
+        "other_clan": {
+            "current_rep": [
+                "hostile"
+            ],
+            "changed": -1
+        }
+    },
+    {
+        "event_id": "gen_misc_waraggro",
+        "location": [ "any" ],
+        "season": [ "any" ],
+        "sub_type": [ "war" ],
+        "tags": [ ],
+        "frequency": 2,
+        "event_text": "m_c is eager to sink {PRONOUN/m_c/poss} claws into o_c_n during the next skirmish.",
+        "m_c": {
+            "status": [
+                "apprentice",
+                "warrior",
+                "deputy",
+                "leader"
+            ],
+            "trait": [
+                "ambitious",
+                "arrogant",
+                "bloodthirsty",
+                "bold",
+                "cold",
+                "confident",
+                "daring",
+                "vengeful"
+            ]
+        }
+    },
+    {
+        "event_id": "gen_misc_herb_anywarsteal1",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "exclude_involved": [
+            "m_c",
+            "r_c"
+        ],
+        "frequency": 1,
+        "event_text": "o_c_n breaks into the camp and ravages the herb stores, taking some for themselves and attempting to destroy the rest. The Clan manages to recover some of the herbs, but the store was still badly damaged.",
+        "supplies": [
+            {
+                "type": "all_herb",
+                "trigger": [
+                    "adequate",
+                    "full",
+                    "excess"
+                ],
+                "adjust": "reduce_half"
+            }
+        ],
+        "other_clan": {
+            "current_rep": [
+                "hostile"
+            ],
+            "changed": -2
+        }
+    },
+    {
         "event_id": "gen_misc_failedmurder1",
         "location": [
             "any"
@@ -11951,180 +12177,6 @@
             }
         }
     ]
-    },
-    {
-        "event_id": "gen_misc_war_onwatch1",
-        "location": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "sub_type": [
-            "war"
-        ],
-        "frequency": 4,
-        "event_text": "m_c and r_c spend the night by the o_c_n border, on watch for an attack that never comes.",
-        "m_c": {
-            "status": [
-                "warrior",
-                "deputy",
-                "leader"
-            ]
-        },
-       "r_c": {
-            "status": [
-                "warrior",
-                "deputy",
-                "leader"
-            ]
-        },
-        "relationships": [
-            {
-                "cats_from": [ "m_c" ],
-                "cats_to": [ "r_c" ],
-                "mutual": true,
-                "values": [ "trust" ],
-                "amount": 10,
-                "log": {
-                    "cats_from": "cat_from and cat_to spent the night on watch for a potential attack."
-                }
-            }
-        ],
-        "other_clan": {
-            "current_rep": [
-                "hostile"
-            ]
-        }
-    },
-    {
-        "event_id": "gen_misc_war_onwatch2",
-        "location": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "sub_type": [
-            "war"
-        ],
-        "frequency": 2,
-        "event_text": "m_c and r_c spend the night by the o_c_n border. They confront a passing o_c_n patrol, but they're more keen on a conversation than a fight.",
-        "m_c": {
-            "status": [
-                "warrior",
-                "deputy",
-                "leader"
-            ]
-        },
-        "r_c": {
-            "status": [
-                "warrior",
-                "deputy",
-                "leader"
-            ]
-        },
-        "other_clan": {
-            "current_rep": [
-                "hostile"
-            ],
-            "changed": 1
-        }
-    },
-    {
-        "event_id": "gen_misc_war_onwatch3",
-        "location": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "sub_type": [
-            "war"
-        ],
-        "frequency": 1,
-        "event_text": "m_c and r_c spend the night by the o_c_n border. They confront a passing o_c_n patrol, but they're more keen on a conversation than a fight and offer to keep them company instead.",
-        "m_c": {
-            "status": [
-                "warrior",
-                "deputy",
-                "leader"
-            ]
-        },
-        "r_c": {
-            "status": [
-                "warrior",
-                "deputy",
-                "leader"
-            ]
-        },
-        "other_clan": {
-            "current_rep": [
-                "hostile"
-            ],
-            "changed": 2
-        }
-    },
-    {
-        "event_id": "gen_misc_war_onwatch4",
-        "location": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "sub_type": [
-            "war"
-        ],
-        "frequency": 3,
-        "event_text": "m_c and r_c spend the night by the o_c_n border. They confront a passing o_c_n patrol, but they're more keen to trade insults than blows.",
-        "m_c": {
-            "status": [
-                "warrior",
-                "deputy",
-                "leader"
-            ]
-        },
-        "r_c": {
-            "status": [
-                "warrior",
-                "deputy",
-                "leader"
-            ]
-        },
-        "other_clan": {
-            "current_rep": [
-                "hostile"
-            ],
-            "changed": -1
-        }
-    },
-    {
-        "event_id": "gen_misc_waraggro",
-        "location": [ "any" ],
-        "season": [ "any" ],
-        "sub_type": [ "war" ],
-        "tags": [ ],
-        "frequency": 2,
-        "event_text": "m_c is eager to sink {PRONOUN/m_c/poss} claws into o_c_n during the next skirmish.",
-        "m_c": {
-            "status": [
-                "apprentice",
-                "warrior",
-                "deputy",
-                "leader"
-            ],
-            "trait": [
-                "ambitious",
-                "arrogant",
-                "bloodthirsty",
-                "bold",
-                "cold",
-                "confident",
-                "daring",
-                "vengeful"
-            ]
-        }
     },
       {
     "event_id": "gen_misc_guardasleep",

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -10057,7 +10057,7 @@
         }
     },
     {
-        "event_id": "gen_misc_war_kill",
+        "event_id": "gen_misc_war_kill1",
         "location": [
             "any"
         ],
@@ -10096,7 +10096,7 @@
         }
     },
     {
-        "event_id": "gen_misc_war_kill",
+        "event_id": "gen_misc_war_kill2",
         "location": [
             "any"
         ],
@@ -10571,7 +10571,9 @@
         "m_c": {
             "status": [
                 "mediator",
-                "mediator apprentice"
+                "mediator apprentice",
+                "deputy",
+                "elder"
             ]
         },
         "r_c": {
@@ -10881,7 +10883,11 @@
             "trait": [
                 "insecure",
                 "lonesome",
-                "nervous"
+                "nervous",
+                "wise",
+                "thoughtful",
+                "sincere",
+                "responsible"
             ]
         },
         "r_c": {
@@ -10890,8 +10896,8 @@
             ],
             "skill": [
                 "INSIGHTFUL,1",
-                "TEACHER,3",
-                "CLEVER,3",
+                "TEACHER,1",
+                "CLEVER,2",
                 "CAMP,3"
             ]
         },
@@ -11095,7 +11101,7 @@
         },
         "relationships": [
             {
-                "cats_from": ["clan", "high_stable"],
+                "cats_from": ["clan", "high_stable", "high_lawful"],
                 "cats_to": ["m_c"],
                 "values": ["respect"],
                 "amount": -20,


### PR DESCRIPTION
## About The Pull Request

More than doubles our current pool of injury events. Some constrained, but some very general.

## Why This Is Good For ClanGen

Hopefully self-evident

## Linked Issues

Trying to address feedback on certain injury events feeling extremely repetitive in war. This is just a starting point. I was still generating the long-ass o_c_n warrior sparing m_c from a killing blow event 10000 times per moon, despite its 1 frequency

## Proof of Testing

<img width="740" height="130" alt="image" src="https://github.com/user-attachments/assets/aee1840b-bffe-4182-a021-134468a2f462" />

<img width="749" height="129" alt="image" src="https://github.com/user-attachments/assets/172732ca-244e-43da-a41c-08865b81c6ef" />

ignore the article problem. that is NOT my fault I swear!!!!!!!!!!!!!!! I reported it in another issue

<img width="764" height="127" alt="image" src="https://github.com/user-attachments/assets/b68a5865-7d89-4803-8c66-e2f433c22f18" />