### PR TITLE
[BUGFIXES] cat_to and cat_from swapped in patrol rel log & Herb patrol with tagging issues 

### DIFF
--- a/resources/lang/en/events/injury/general.json
+++ b/resources/lang/en/events/injury/general.json
@@ -6667,7 +6667,7 @@
         "frequency": 1,
         "event_text": "m_c fought with a duck in the water, trying to kill it for the fresh-kill pile, but was knocked below the surface of the water and inhaled a lot of water.",
         "m_c": {
-            "rank": [
+            "status": [
                 "apprentice",
                 "warrior",
                 "deputy",

--- a/resources/lang/en/patrols/general/medcat.json
+++ b/resources/lang/en/patrols/general/medcat.json
@@ -17815,6 +17815,7 @@
             {
                 "text": "s_c uses the bright flowers to find the plants quickly, determined to bring back as many poppy seeds as possible. The rest of the patrol, knowing how important poppy seeds are as a painkiller, work hard, both for s_c and all of c_n.",
                 "exp": 10,
+                "can_have_stat": ["p_l"],
                 "stat_skill": [
                     "SENSE,2"
                 ],
@@ -28841,6 +28842,7 @@
             {
                 "text": "s_c uses the bright red flowers to find the plants quickly, determined to bring back as many poppy seeds as possible. The rest of the patrol, knowing how important poppy seeds are as a painkiller, work hard, both for s_c and all of c_n.",
                 "exp": 10,
+                "can_have_stat": ["p_l"],
                 "stat_skill": [
                     "SENSE,2"
                 ],

--- a/resources/lang/en/patrols/general/medcat.json
+++ b/resources/lang/en/patrols/general/medcat.json
@@ -16329,6 +16329,7 @@
                 "stat_skill": [
                     "SENSE,2"
                 ],
+                "can_have_stat": ["p_l"],
                 "herbs": [
                     "many_herbs",
                     "tansy",
@@ -16431,6 +16432,7 @@
                 "stat_skill": [
                     "SENSE,2"
                 ],
+                "can_have_stat": ["p_l"],
                 "herbs": [
                     "many_herbs",
                     "tansy",
@@ -16554,6 +16556,7 @@
                 "stat_skill": [
                     "SENSE,2"
                 ],
+                "can_have_stat": ["p_l"],
                 "herbs": [
                     "many_herbs",
                     "tansy",
@@ -27326,6 +27329,7 @@
                 "stat_skill": [
                     "SENSE,2"
                 ],
+                "can_have_stat": ["p_l"],
                 "herbs": [
                     "many_herbs",
                     "tansy",
@@ -27430,6 +27434,7 @@
                 "stat_skill": [
                     "SENSE,2"
                 ],
+                "can_have_stat": ["p_l"],
                 "herbs": [
                     "many_herbs",
                     "tansy",
@@ -27553,6 +27558,7 @@
                 "stat_skill": [
                     "SENSE,2"
                 ],
+                "can_have_stat": ["p_l"],
                 "herbs": [
                     "many_herbs",
                     "tansy",
@@ -34689,6 +34695,7 @@
                 "stat_skill": [
                     "SENSE,2"
                 ],
+                "can_have_stat": ["p_l"],
                 "herbs": [
                     "many_herbs",
                     "tansy",
@@ -34774,6 +34781,7 @@
                 "stat_skill": [
                     "SENSE,2"
                 ],
+                "can_have_stat": ["p_l"],
                 "herbs": [
                     "many_herbs",
                     "tansy",
@@ -34897,6 +34905,7 @@
                 "stat_skill": [
                     "SENSE,2"
                 ],
+                "can_have_stat": ["p_l"],
                 "herbs": [
                     "many_herbs",
                     "tansy",

--- a/resources/lang/en/patrols/general/training.json
+++ b/resources/lang/en/patrols/general/training.json
@@ -17294,7 +17294,7 @@
                         "amount": -10,
                         "log": {
                             "cats_from": "cat_from wasn't impressed by cat_to's failure on a tracking assessment.",
-                            "cats_to": "cat_from spotted cat_to looking amused by cat_from's failure on a tracking assessment."
+                            "cats_to": "cat_to spotted cat_from looking amused by cat_to's failure on a tracking assessment."
                         }
                     }
                 ],


### PR DESCRIPTION
## About The Pull Request

Two easy fixes. The former had the tags swapped due to a change in how mutual rel logs function midway through the process. The latter needed to require s_c to be p_l in order to choose a medicine cat. Similar problem on another med patrol. I also found in my own event that I'd mistakenly put "rank" instead of "status", which was causing a short event to generate for the wrong ranks.

## Linked Issues

Fixes: #4816 
Fixes: #4827

## Proof of Testing

<img width="921" height="256" alt="image" src="https://github.com/user-attachments/assets/240a82d3-9666-4773-badb-726b7107ca2e" />

Log generating correctly

<img width="704" height="182" alt="image" src="https://github.com/user-attachments/assets/3b9626b3-acd0-46cd-8371-a54242665406" />

<img width="1091" height="547" alt="image" src="https://github.com/user-attachments/assets/5e98fb0b-1c23-48f0-90fc-79b09ea4d48f" />

p_l is Batsoar, the medicine cat. Logs correctly generate targeting Batsoar