### PR TITLE
[BUGFIX] grief event suggests kit has helped their parent through past losses

### DIFF
--- a/resources/lang/en/events/death/death_reactions/child/child_comfort.json
+++ b/resources/lang/en/events/death/death_reactions/child/child_comfort.json
@@ -5,14 +5,20 @@
             "The world feels a little darker, a little smaller, a little less safe to r_c, without m_c there to look out for {PRONOUN/r_c/object}.",
             "r_c speaks softly at m_c's vigil about how {PRONOUN/r_c/subject} never felt so safe and loved as {PRONOUN/r_c/subject} did with m_c. c_n gathers to comfort r_c as {PRONOUN/r_c/subject} {VERB/r_c/trail/trails} off, at a loss.",
             "r_c tries to wrap {PRONOUN/r_c/poss} head around the idea that m_c will never again twine their tails, never again rest {PRONOUN/m_c/poss} head against r_c's, and never again brush {PRONOUN/m_c/poss} fur against {PRONOUN/r_c/inposs}... but it's just unthinkable.",
+            "In the losses r_c weathered in the past, m_c had always been there to comfort {PRONOUN/r_c/object}. Now that it's {PRONOUN/m_c/poss} death that r_c is grieving, {PRONOUN/r_c/subject} {VERB/r_c/are/is} alone.",
             "r_c can only stay at m_c's vigil for a few heartbeats — it's just too painful to see the cat r_c felt most comfort around, lying in a heap on the ground.",
             "r_c has always felt such serenity and joy in m_c's presence, and when {PRONOUN/r_c/subject} {VERB/r_c/see/sees} {PRONOUN/m_c/poss} body limp on the ground, r_c can't hold back a sob.",
+            "The loss of m_c gives r_c the flutters of anxiety and pangs of sorrow that only {PRONOUN/m_c/subject} {VERB/m_c/were/was} able to soothe. But now m_c is gone, forever.",
+            "r_c blinks back tears as the realization sinks in that {PRONOUN/r_c/subject}'ll never share a joke or a companionable silence with m_c ever again in this life.",
             "r_c's voice trembles at m_c's vigil, trying to get through a memory of how {PRONOUN/r_c/poss} parent supported {PRONOUN/r_c/object}. During the speech, {PRONOUN/r_c/subject} {VERB/r_c/realize/realizes} {PRONOUN/r_c/subject}{VERB/r_c/'re/'s} unconsciously waiting for m_c to comfort {PRONOUN/r_c/object} — and that just makes r_c break down further."
         ],
         "no_body": [
             "The world feels a little darker, a little smaller, a little less safe to r_c, without m_c there to look out for {PRONOUN/r_c/object}.",
             "r_c speaks softly at m_c's vigil about how {PRONOUN/r_c/subject} never felt so safe and loved as {PRONOUN/r_c/subject} did with m_c. c_n gathers to comfort r_c as {PRONOUN/r_c/subject} {VERB/r_c/trail/trails} off, at a loss.",
             "r_c tries to wrap {PRONOUN/r_c/poss} head around the idea that m_c will never again twine their tails, never again rest {PRONOUN/m_c/poss} head against r_c's, and never again brush {PRONOUN/m_c/poss} fur against {PRONOUN/r_c/inposs}... but it's just unthinkable.",
+            "In the losses r_c weathered in the past, m_c had always been there to comfort {PRONOUN/r_c/object}. Now that it's {PRONOUN/m_c/poss} death that r_c is grieving, {PRONOUN/r_c/subject} {VERB/r_c/are/is} alone.",
+            "The loss of m_c gives r_c the flutters of anxiety and pangs of sorrow that only {PRONOUN/m_c/subject} {VERB/m_c/were/was} able to soothe. But now m_c is gone, forever.",
+            "r_c blinks back tears as the realization sinks in that {PRONOUN/r_c/subject}'ll never share a joke or a companionable silence with m_c ever again in this life.",
             "r_c feels heartbroken that not only is {PRONOUN/r_c/poss} beloved parent gone, but r_c also can't touch {PRONOUN/r_c/poss} nose to {PRONOUN/m_c/poss} pelt or breathe in {PRONOUN/r_c/poss} parent's scent one last time.",
             "r_c prays that one day, c_n might recover m_c's body and allow r_c to gaze on {PRONOUN/r_c/poss} parent one last time and say goodbye properly."
         ]

--- a/resources/lang/en/events/death/death_reactions/child/child_trust.json
+++ b/resources/lang/en/events/death/death_reactions/child/child_trust.json
@@ -5,17 +5,21 @@
             "r_c feels like the earth beneath {PRONOUN/r_c/poss} paws has crumbled, with m_c gone. r_c deeply believed nothing bad could ever happen with m_c there, but now... ",
             "r_c can't fathom the future of c_n without m_c. r_c trusted {PRONOUN/m_c/object} more than any cat to protect {PRONOUN/r_c/object}, to protect all of c_n, and now m_c is gone.",
             "r_c had such faith in m_c's skill and spirit that {PRONOUN/r_c/subject} had convinced {PRONOUN/r_c/self} m_c would never really be gone. Looking at m_c's body, r_c feels the hard truth sink in.",
+            "r_c would have followed m_c anywhere, but this is one journey {PRONOUN/m_c/subject} must take alone.",
             "r_c is shocked to {PRONOUN/r_c/poss} bones, seeing m_c's body lying in camp. How could a cat that r_c relied on so deeply be taken away so easily?",
             "r_c trusted m_c to keep {PRONOUN/r_c/object} safe for {PRONOUN/r_c/poss} whole life, but that time together has been cruelly cut short.",
             "r_c feels like a fool for believing {PRONOUN/r_c/poss} parent would be with {PRONOUN/r_c/object} all {PRONOUN/r_c/poss} life. Now that m_c is gone, r_c curses every lost chance to cherish {PRONOUN/m_c/object}.",
-            "m_c was always the first cat r_c turned to for advice and good counsel. How will {PRONOUN/r_c/subject} continue without {PRONOUN/m_c/object}?"
+            "m_c was always the first cat r_c turned to for advice and good counsel. How will {PRONOUN/r_c/subject} continue without {PRONOUN/m_c/object}?",
+            "r_c prays m_c's spirit is somewhere watching over {PRONOUN/r_c/object} now. {PRONOUN/r_c/subject/CAP} can't imagine the rest of {PRONOUN/r_c/poss} life without {PRONOUN/m_c/poss} guidance."
         ],
         "no_body": [
             "r_c shakes {PRONOUN/r_c/poss} head when a Clanmate tells {PRONOUN/r_c/object} what happened to {PRONOUN/r_c/poss} parent. No, it's impossible. {PRONOUN/r_c/subject/CAP} {VERB/r_c/refuse/refuses} to believe m_c would leave {PRONOUN/r_c/object}.",
             "r_c feels like the earth beneath {PRONOUN/r_c/poss} paws has crumbled, with m_c gone. r_c deeply believed nothing bad could ever happen with m_c there, but now... ",
             "r_c can't fathom the future of c_n without m_c. r_c trusted {PRONOUN/m_c/object} more than any cat to protect {PRONOUN/r_c/object}, to protect all of c_n, and now m_c is gone.",
+            "r_c would have followed m_c anywhere, but this is one journey {PRONOUN/m_c/subject} must take alone.",
             "r_c had such faith in m_c's skill and spirit that {PRONOUN/r_c/subject} had convinced {PRONOUN/r_c/self} m_c would never really be gone. Now, the hard truth sinks in.",
-            "r_c feels like a fool for believing {PRONOUN/r_c/poss} parent would be with {PRONOUN/r_c/object} all {PRONOUN/r_c/poss} life. Now that m_c is gone, r_c curses every lost chance to cherish {PRONOUN/m_c/object}."
+            "r_c feels like a fool for believing {PRONOUN/r_c/poss} parent would be with {PRONOUN/r_c/object} all {PRONOUN/r_c/poss} life. Now that m_c is gone, r_c curses every lost chance to cherish {PRONOUN/m_c/object}.",
+            "r_c prays m_c's spirit is somewhere watching over {PRONOUN/r_c/object} now. {PRONOUN/r_c/subject/CAP} can't imagine the rest of {PRONOUN/r_c/poss} life without {PRONOUN/m_c/poss} guidance."
         ]
     },
     "adventurous": {

--- a/resources/lang/en/events/death/death_reactions/general/general_comfort.json
+++ b/resources/lang/en/events/death/death_reactions/general/general_comfort.json
@@ -5,22 +5,17 @@
             "r_c looks at all the cats sitting vigil for m_c and wonders how any of them will cope without m_c in their lives.",
             "It just doesn't feel real. r_c stares at m_c's body blankly, waiting for this horrible nightmare to end.",
             "r_c struggles to come to grips with the fact that m_c will no longer be part of {PRONOUN/r_c/poss} life to see {PRONOUN/r_c/object} through the hard times.",
-            "In the losses r_c weathered in the past, m_c had always been there to comfort {PRONOUN/r_c/object}. Now that it's {PRONOUN/m_c/poss} death that r_c is grieving, {PRONOUN/r_c/subject} {VERB/r_c/are/is} alone.",
             "r_c blinks back tears as the realization sinks in that {PRONOUN/r_c/subject}'ll never share a joke or a companionable silence with m_c ever again in this life.",
             "m_c was such a source of solace and peace for r_c that {PRONOUN/r_c/subject} {VERB/r_c/wonder/wonders} how {PRONOUN/r_c/subject}'ll get by without {PRONOUN/m_c/object}.",
             "r_c curls around m_c's body one last time, grooming {PRONOUN/m_c/poss} fur flat. It's the least {PRONOUN/r_c/subject} can do for a cat that gave r_c so much.",
             "r_c hides {PRONOUN/r_c/poss} face in m_c's cold fur so {PRONOUN/r_c/poss} Clanmates can't see how hard this loss has hit {PRONOUN/r_c/object}.",
-            "The loss of m_c gives r_c the flutters of anxiety and pangs of sorrow that only {PRONOUN/m_c/subject} {VERB/m_c/were/was} able to soothe. But now m_c is gone, forever.",
             "m_c is dead? r_c's heart seizes at the news, {PRONOUN/r_c/poss} mind racing as {PRONOUN/r_c/subject} {VERB/r_c/try/tries} to imagine life without {PRONOUN/m_c/object}.",
             "As r_c's Clanmates comfort {PRONOUN/r_c/object} during the vigil, {PRONOUN/r_c/subject} can't help but wonder if things will ever feel normal again without m_c in {PRONOUN/r_c/poss} life."
         ],
         "no_body": [
             "r_c looks at all the cats sitting vigil for m_c and wonders how any of them will cope without m_c in their lives.",
             "r_c struggles to come to grips with the fact that m_c will no longer be part of {PRONOUN/r_c/poss} life to see {PRONOUN/r_c/object} through the hard times.",
-            "In the losses r_c weathered in the past, m_c had always been there to comfort {PRONOUN/r_c/object}. Now that it's {PRONOUN/m_c/poss} death that r_c is grieving, {PRONOUN/r_c/subject} {VERB/r_c/are/is} alone.",
-            "r_c blinks back tears as the realization sinks in that {PRONOUN/r_c/subject}'ll never share a joke or a companionable silence with m_c ever again in this life.",
             "m_c was such a source of solace and peace for r_c that {PRONOUN/r_c/subject} {VERB/r_c/wonder/wonders} how {PRONOUN/r_c/subject}'ll get by without {PRONOUN/m_c/object}.",
-            "The loss of m_c gives r_c the flutters of anxiety and pangs of sorrow that only {PRONOUN/m_c/subject} {VERB/m_c/were/was} able to soothe. But now m_c is gone, forever.",
             "m_c is dead? r_c's heart seizes at the news, {PRONOUN/r_c/poss} mind racing as {PRONOUN/r_c/subject} {VERB/r_c/try/tries} to imagine life without {PRONOUN/m_c/object}.",
             "As r_c's Clanmates comfort {PRONOUN/r_c/object} during the vigil, {PRONOUN/r_c/subject} can't help but wonder if things will ever feel normal again without m_c in {PRONOUN/r_c/poss} life."
         ]

--- a/resources/lang/en/events/death/death_reactions/general/general_trust.json
+++ b/resources/lang/en/events/death/death_reactions/general/general_trust.json
@@ -4,22 +4,18 @@
             "r_c will miss m_c, truly. There was no other cat {PRONOUN/r_c/subject} trusted more and {PRONOUN/r_c/subject} already {VERB/r_c/miss/misses} m_c's steady presence at {PRONOUN/r_c/poss} side.",
             "How is r_c supposed to keep going? {PRONOUN/r_c/subject/CAP} thought m_c was always going to be there, was supposed to always be by {PRONOUN/r_c/poss} side, but now...",
             "It's like losing a tail, or a limb, or {PRONOUN/r_c/poss} shadow. r_c relied on m_c, trusted {PRONOUN/m_c/object}, and contemplating moving on from the loss seems impossible.",
-            "r_c would have followed m_c anywhere, but this is one journey {PRONOUN/m_c/subject} must take alone.",
             "r_c feels unsteady at the thought of trying to pad through life without m_c to rely on.",
             "Part of r_c assumed nothing bad could ever happen to c_n when m_c was there. With {PRONOUN/m_c/object} gone, how will they carry on?",
             "r_c opened up to m_c more than almost any other cat. {PRONOUN/r_c/subject/CAP} {VERB/r_c/don't/doesn't} know how {PRONOUN/r_c/subject}'ll handle hard times without m_c.",
-            "r_c stares at m_c's body, unable to look away. {PRONOUN/m_c/subject/CAP} {VERB/m_c/were/was} a steady, rock-solid presence in r_c's life, and death has rendered {PRONOUN/m_c/object} so small and feeble.",
-            "r_c prays m_c's spirit is somewhere watching over {PRONOUN/r_c/object} now. {PRONOUN/r_c/subject/CAP} can't imagine the rest of {PRONOUN/r_c/poss} life without {PRONOUN/m_c/poss} guidance."
+            "r_c stares at m_c's body, unable to look away. {PRONOUN/m_c/subject/CAP} {VERB/m_c/were/was} a steady, rock-solid presence in r_c's life, and death has rendered {PRONOUN/m_c/object} so small and feeble."
         ],
         "no_body": [
             "r_c will miss m_c, truly. There was no other cat {PRONOUN/r_c/subject} trusted more and {PRONOUN/r_c/subject} already {VERB/r_c/miss/misses} m_c's steady presence at {PRONOUN/r_c/poss} side.",
             "How is r_c supposed to keep going? {PRONOUN/r_c/subject/CAP} thought m_c was always going to be there, was supposed to always be by {PRONOUN/r_c/poss} side, but now...",
             "It's like losing a tail, or a limb, or {PRONOUN/r_c/poss} shadow. r_c relied on m_c, trusted {PRONOUN/m_c/object}, and contemplating moving on from the loss seems impossible.",
-            "r_c would have followed m_c anywhere, but this is one journey {PRONOUN/m_c/subject} must take alone.",
             "r_c feels unsteady at the thought of trying to pad through life without m_c to rely on.",
             "Part of r_c assumed nothing bad could ever happen to c_n when m_c was there. With {PRONOUN/m_c/object} gone, how will they carry on?",
-            "r_c opened up to m_c more than almost any other cat. {PRONOUN/r_c/subject/CAP} {VERB/r_c/don't/doesn't} know how {PRONOUN/r_c/subject}'ll handle hard times without m_c.",
-            "r_c prays m_c's spirit is somewhere watching over {PRONOUN/r_c/object} now. {PRONOUN/r_c/subject/CAP} can't imagine the rest of {PRONOUN/r_c/poss} life without {PRONOUN/m_c/poss} guidance."
+            "r_c opened up to m_c more than almost any other cat. {PRONOUN/r_c/subject/CAP} {VERB/r_c/don't/doesn't} know how {PRONOUN/r_c/subject}'ll handle hard times without m_c."
         ]
     },
     "adventurous": {

--- a/resources/lang/en/events/death/death_reactions/mate/mate_comfort.json
+++ b/resources/lang/en/events/death/death_reactions/mate/mate_comfort.json
@@ -4,6 +4,7 @@
         "m_c's vigil is doubly hard for r_c, who took such comfort in {PRONOUN/r_c/poss} mate's steady presence that {PRONOUN/r_c/subject} {VERB/r_c/don't/doesn't} know how {PRONOUN/r_c/subject}'ll face this loss without {PRONOUN/m_c/object}.",
         "Who can r_c turn to for comfort in the wake of m_c's death? {PRONOUN/r_c/subject/CAP} relied on m_c more than any other cat, but now m_c is gone.",
         "r_c is inconsolable in the wake of m_c's death. {PRONOUN/r_c/poss/CAP} mate was such a source of strength and peace. What will r_c do without {PRONOUN/m_c/object}?",
+        "r_c blinks back tears as the realization sinks in that {PRONOUN/r_c/subject}'ll never share a joke or a companionable silence with m_c ever again in this life.",
         "r_c would give anything to press {PRONOUN/r_c/poss} muzzle against m_c's one last time and breathe in {PRONOUN/m_c/poss} sweet scent. Now, the only scent on m_c is that of death.",
         "r_c tries to take comfort in {PRONOUN/r_c/poss} Clanmates during m_c's vigil, but it just isn't the same as {PRONOUN/r_c/poss} mate."
     ],
@@ -11,6 +12,7 @@
       "m_c's vigil is doubly hard for r_c, who took such comfort in {PRONOUN/r_c/poss} mate's steady presence that {PRONOUN/r_c/subject} {VERB/r_c/don't/doesn't} know how {PRONOUN/r_c/subject}'ll face this loss without {PRONOUN/m_c/object}.",
       "Who can r_c turn to for comfort in the wake of m_c's death? {PRONOUN/r_c/subject/CAP} relied on m_c more than any other cat, but now m_c is gone.",
       "r_c is inconsolable in the wake of m_c's death. {PRONOUN/r_c/poss/CAP} mate was such a source of strength and peace. What will r_c do without {PRONOUN/m_c/object}?",
+      "r_c blinks back tears as the realization sinks in that {PRONOUN/r_c/subject}'ll never share a joke or a companionable silence with m_c ever again in this life.",
       "r_c would give anything to press {PRONOUN/r_c/poss} muzzle against m_c's one last time and breathe in {PRONOUN/m_c/poss} sweet scent, but there is no body to bury.",
       "r_c tries to take comfort in {PRONOUN/r_c/poss} Clanmates during m_c's vigil, but it just isn't the same as {PRONOUN/r_c/poss} mate."
     ]

--- a/resources/lang/en/events/death/death_reactions/mate/mate_trust.json
+++ b/resources/lang/en/events/death/death_reactions/mate/mate_trust.json
@@ -5,6 +5,7 @@
       "r_c sits at m_c's vigil, unable to speak of the cat that meant everything to {PRONOUN/r_c/object}. There was no cat r_c trusted more.",
       "m_c was r_c's rock, cutting through the wild currents of life. r_c doesn't know who or what {PRONOUN/r_c/subject}'ll cling to without {PRONOUN/r_c/poss} mate.",
       "r_c is choked with grief, standing over m_c's still body. {PRONOUN/r_c/poss/CAP} mate was the steadiest presence in {PRONOUN/r_c/poss} life, and now {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} gone.",
+      "r_c would have followed m_c anywhere, but this is one journey {PRONOUN/m_c/subject} must take alone.",
       "There were so many things that r_c could only trust m_c to understand. Now, without {PRONOUN/r_c/poss} mate, r_c has no idea what {PRONOUN/r_c/subject}'ll do.",
       "r_c spends longer than any other cat at m_c's vigil, {PRONOUN/r_c/poss} muzzle buried in the cold fur of the cat on whom {PRONOUN/r_c/subject} relied so much."
     ],
@@ -12,6 +13,7 @@
       "No cat will ever be what m_c was to r_c. {PRONOUN/m_c/subject/CAP} meant something to {PRONOUN/r_c/object} that {PRONOUN/r_c/subject} will never be able to put into words.",
       "r_c sits at m_c's vigil, unable to speak of the cat that meant everything to {PRONOUN/r_c/object}. There was no cat r_c trusted more.",
       "m_c was r_c's rock, cutting through the wild currents of life. r_c doesn't know who or what {PRONOUN/r_c/subject}'ll cling to without {PRONOUN/r_c/poss} mate.",
+      "r_c would have followed m_c anywhere, but this is one journey {PRONOUN/m_c/subject} must take alone.",
       "r_c is choked with grief at m_c's vigil. {PRONOUN/r_c/poss/CAP} mate was the steadiest presence in {PRONOUN/r_c/poss} life, and now {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} gone.",
       "There were so many things that r_c could only trust m_c to understand. Now, without {PRONOUN/r_c/poss} mate, r_c has no idea what {PRONOUN/r_c/subject}'ll do.",
       "r_c can't stand m_c's vigil. In the absence of a body, {PRONOUN/r_c/subject} {VERB/r_c/convince/convinces} {PRONOUN/r_c/self} that m_c will come home to {PRONOUN/r_c/object} one day, just as {PRONOUN/m_c/subject} always promised."


### PR DESCRIPTION
## About The Pull Request

I moved some of the grief events that imply a long-term relationship between cats into files for relationships that require that -- mainly parent/child and mates. This is a band-aid solution on a current limitation of the grief system. Currently, writers have little control over what circumstances a grief event will trigger under -- we cannot constrain for age or rank, which means a parent will grieve their newborn kit with the same messages that they would grieve their adult warrior kit.

## Linked Issues

Fixes: #4825 
or at least addresses it in the short-term. Long-term, we need to bring the grief event code up to speed with that of short events etc to allow writers the flexibility to write events that account for specifics of age (and other such constraints).

## Proof of Testing

<img width="809" height="113" alt="image" src="https://github.com/user-attachments/assets/085ede9e-417c-4c18-9920-5dcbcaba0218" />

<img width="777" height="159" alt="image" src="https://github.com/user-attachments/assets/c3ee65b9-6f58-46f2-9763-f3f719a64224" />

tested by murdering some newborns. We're not getting the really overt "i have known this cat for many seasons" type grief events. They still feel like weird grieving messages because the game cannot acknowledge that we're talking about a little baby kitty cat 0 seconds old, but again, that's a limitation currently.