### PR TITLE
[BUGFIX] Cat interacts with self on patrol

### DIFF
--- a/resources/lang/en/patrols/forest/hunting/leaf-fall.json
+++ b/resources/lang/en/patrols/forest/hunting/leaf-fall.json
@@ -2596,6 +2596,7 @@
                 "text": "s_c bounds up to get a closer look at what the squirrel is doing and inadvertently scares it off. p_l is none too pleased.",
                 "exp": 0,
                 "frequency": 3,
+                "can_have_stat": ["r_c"],
                 "stat_trait": ["-calm", "-careful", "-wise", "-thoughtful", "-sneaky", "-cunning"],
                 "relationships": [
                     {


### PR DESCRIPTION
## About The Pull Request

Fixing my own patrol. I guess I've been labouring under the mistaken assumption that with a two cat patrol, r_c will always be chosen as s_c. That was leading to p_l interacting with themself on my squirrel subterfuge patrol. I've added a constraint to make sure that s_c is always chosen as r_c.

## Linked Issues

Just encountered it in my own save

## Proof of Testing

<img width="1036" height="602" alt="image" src="https://github.com/user-attachments/assets/da439d7f-db72-4a70-9900-60cea88829c6" />

two cat patrol. s_c is correctly chosen as r_c instead of p_l.