### PR TITLE
[BUGFIX] Cat should survive assassination attempt, but they didnt

### DIFF
--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -7901,9 +7901,7 @@
         "event_text": "A warning from StarClan gave m_c enough knowledge to survive r_c's attack. r_c could not say the same.",
         "m_c": {
             "status": [
-                "leader",
-                "deputy",
-                "warrior"
+                "leader"
             ],
             "skill": [
                 "OMEN,1",


### PR DESCRIPTION
## About The Pull Request

This event was expanded to include non-leader ranks, but looking at it again, I realize that the intention of the event is that r_c DOES successfully murder m_c, but just isn't able to take all their lives. That really only works for leaders, so I've narrowed the constraints back down to "leader" only.

## Linked Issues

Fixes: #4839

## Proof of Testing

<img width="777" height="157" alt="image" src="https://github.com/user-attachments/assets/5047e8b2-fe7f-42df-8288-4f6daf587fa8" />
<img width="696" height="96" alt="image" src="https://github.com/user-attachments/assets/5d4e5cac-ba1d-4556-bef0-868bf6ac469d" />

jesus christ i went through hell generating this. ignore the first life text lmfao. I had to debug override so much