### PR TITLE
[BUGFIX]  o_c_n text adjustment not working properly for vowels

### DIFF
--- a/scripts/events_module/text_adjust.py
+++ b/scripts/events_module/text_adjust.py
@@ -562,8 +562,9 @@ def _replace_clan_name(text, abbreviation, clan_name):
                     if f"{abbreviation}." in modify:
                         pos = modify.index(f"{abbreviation}.")
                     if modify[pos - 1] == "a":
-                        modify.remove("a")
-                        modify.insert(pos - 1, "an")
+                        modify[pos - 1] = "an"
+                    if modify[pos - 1] == "A":
+                        modify[pos - 1] = "An"
                     text = " ".join(modify)
                     break
 


### PR DESCRIPTION
## About The Pull Request

* Fixes issue where o_c_n text adjustment was not working for `A o_c_n`
* Fixes issue where o_c_n text adjustment was not working for `a [more text goes here] a o_c_n`

## Linked Issues

Fixes #4828

## Proof of Testing

<img width="704" height="321" alt="image" src="https://github.com/user-attachments/assets/ea2e6e73-1889-4f54-b4a9-cad67e59f059" />
Edited patrol to have construction that causes text replacement to fail.
<br/><br/>
<img width="696" height="343" alt="image" src="https://github.com/user-attachments/assets/33919e00-ffe0-40c9-8874-2cc609cd990b" />
Works with capital letters.
