### PR TITLE
[BUGFIX] Switch clan error

### DIFF
--- a/main.py
+++ b/main.py
@@ -185,7 +185,8 @@ while 1:
 
     if switch_get_value(Switch.switch_clan):
         load_game()
-        game.all_screens[GameScreen.START].reload_error()
+        # have to manually reload errors because it only happens when screen is switched to
+        game.all_screens[GameScreen.START].reload_errors()
 
     # Draw screens
     # This occurs before events are handled to stop pygame_gui buttons from blinking.

--- a/main.py
+++ b/main.py
@@ -185,6 +185,7 @@ while 1:
 
     if switch_get_value(Switch.switch_clan):
         load_game()
+        game.all_screens[GameScreen.START].reload_error()
 
     # Draw screens
     # This occurs before events are handled to stop pygame_gui buttons from blinking.

--- a/scripts/screens/StartScreen.py
+++ b/scripts/screens/StartScreen.py
@@ -134,6 +134,41 @@ class StartScreen(Screens):
         for btn in self.social_buttons:
             self.social_buttons[btn].kill()
 
+    def reload_error(self):
+        if switch_get_value(Switch.error_message):
+            error_text = "screens.start.error_text"
+            traceback_text = ""
+            if switch_get_value(Switch.traceback):
+                print("Traceback:")
+                print(switch_get_value(Switch.traceback))
+                traceback_text = "<br><br>" + escape(
+                    "".join(
+                        traceback.format_exception(
+                            switch_get_value(Switch.traceback),
+                            switch_get_value(Switch.traceback),
+                            switch_get_value(Switch.traceback).__traceback__,
+                        )
+                    )
+                )  # pylint: disable=line-too-long
+            self.error_label.set_text(
+                error_text,
+                text_kwargs={
+                    "error": str(switch_get_value(Switch.error_message)),
+                    Switch.traceback: traceback_text,
+                },
+            )
+            self.error_box.show()
+            self.error_label.show()
+            self.error_gethelp.show()
+            self.open_data_directory_button.show()
+
+            if get_version_info().is_sandboxed:
+                self.open_data_directory_button.hide()
+
+            self.closebtn.show()
+
+            self.error_open = True
+
     def screen_switches(self):
         """
         TODO: DOCS
@@ -374,39 +409,7 @@ class StartScreen(Screens):
         else:
             self.switch_clan_button.disable()
 
-        if switch_get_value(Switch.error_message):
-            error_text = "screens.start.error_text"
-            traceback_text = ""
-            if switch_get_value(Switch.traceback):
-                print("Traceback:")
-                print(switch_get_value(Switch.traceback))
-                traceback_text = "<br><br>" + escape(
-                    "".join(
-                        traceback.format_exception(
-                            switch_get_value(Switch.traceback),
-                            switch_get_value(Switch.traceback),
-                            switch_get_value(Switch.traceback).__traceback__,
-                        )
-                    )
-                )  # pylint: disable=line-too-long
-            self.error_label.set_text(
-                error_text,
-                text_kwargs={
-                    "error": str(switch_get_value(Switch.error_message)),
-                    Switch.traceback: traceback_text,
-                },
-            )
-            self.error_box.show()
-            self.error_label.show()
-            self.error_gethelp.show()
-            self.open_data_directory_button.show()
-
-            if get_version_info().is_sandboxed:
-                self.open_data_directory_button.hide()
-
-            self.closebtn.show()
-
-            self.error_open = True
+        self.reload_error()
 
         if game.clan is not None:
             key_copy = tuple(Cat.all_cats.keys())

--- a/scripts/screens/StartScreen.py
+++ b/scripts/screens/StartScreen.py
@@ -136,6 +136,7 @@ class StartScreen(Screens):
 
     def reload_error(self):
         if switch_get_value(Switch.error_message):
+            self.continue_button.disable()
             error_text = "screens.start.error_text"
             traceback_text = ""
             if switch_get_value(Switch.traceback):
@@ -168,6 +169,19 @@ class StartScreen(Screens):
             self.closebtn.show()
 
             self.error_open = True
+        else:
+            self.continue_button.enable()
+            self.error_box.hide()
+            self.error_label.hide()
+            self.error_gethelp.hide()
+            self.open_data_directory_button.hide()
+
+            if get_version_info().is_sandboxed:
+                self.open_data_directory_button.hide()
+
+            self.closebtn.hide()
+
+            self.error_open = False
 
     def screen_switches(self):
         """

--- a/scripts/screens/StartScreen.py
+++ b/scripts/screens/StartScreen.py
@@ -134,7 +134,7 @@ class StartScreen(Screens):
         for btn in self.social_buttons:
             self.social_buttons[btn].kill()
 
-    def reload_error(self):
+    def reload_errors(self):
         if switch_get_value(Switch.error_message):
             self.continue_button.disable()
             error_text = "screens.start.error_text"
@@ -423,7 +423,7 @@ class StartScreen(Screens):
         else:
             self.switch_clan_button.disable()
 
-        self.reload_error()
+        self.reload_errors()
 
         if game.clan is not None:
             key_copy = tuple(Cat.all_cats.keys())


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

This bug is caused because the order of things is:
1. The button to switch Clans is clicked in `SwitchClanScreen.py`
2. ClanGen goes to the title screen
3. Clan is switched in code (this is where any errors would be raised)

The problem is that the error message on the title screen is updated in step 2, which happens before the Clan is loaded. This makes the state of the error message on the title screen out of sync with the actual raised error. Therefore, I manually reload the error part of the title screen after the Clan is switched in the code.


## Linked Issues

Fixes #4824

## Proof of Testing

1. Create multiple Clans and save them
2. Close game
3. Go into save files and make one Clan broken so it fails to load (easy to do by just butchering a JSON)
4. Open game and switch Clans
