### PR TITLE
[BUGFIX] Relationship values too high for newborn relatives

### DIFF
--- a/resources/game_config.toml
+++ b/resources/game_config.toml
@@ -164,8 +164,9 @@ dev_tools = false
   # number of welcoming events to add when a new cat joins
   cat_amount_welcoming = 3
 
-  # this is the amount to divide a relative's relation toward the parent when deciding on a relative's initial relationship toward a kit
-  ext_relative_modifier = 4
+  # ext_relative_modifer * parents(len) is what will a relative's relation toward the parent 
+  # will by divided by when deciding on a relative's initial relationship toward a kit
+  ext_relative_modifier = 2
   # relationship buffs represent "default" relationship values that are then lightly randomized
   # in order to create initial relationship values for cats
 

--- a/scripts/events_module/relationship/pregnancy_events.py
+++ b/scripts/events_module/relationship/pregnancy_events.py
@@ -1087,7 +1087,10 @@ class Pregnancy_Events:
 
         for kit in all_kitten:
             for c in all_relatives:
-                rel_reflection = constants.CONFIG["new_cat"]["ext_relative_modifier"]
+                ext_relative_modifier = constants.CONFIG["new_cat"][
+                    "ext_relative_modifier"
+                ]
+                rel_reflection = ext_relative_modifier * len(parents)
                 y = random.randrange(-10, 10)
 
                 # this finds what the relative's relationship is toward each parent and applies a reflection of that

--- a/scripts/events_module/relationship/pregnancy_events.py
+++ b/scripts/events_module/relationship/pregnancy_events.py
@@ -3,6 +3,7 @@ from random import choice, randint
 from typing import Dict, List, Union, Optional
 
 import i18n
+import math
 
 from scripts.cat.cats import Cat
 from scripts.cat.enums import (
@@ -1091,7 +1092,8 @@ class Pregnancy_Events:
                     "ext_relative_modifier"
                 ]
                 rel_reflection = ext_relative_modifier * len(parents)
-                y = random.randrange(-10, 10)
+                variation_range = math.ceil(20 / len(parents))
+                y = random.randrange(-variation_range, variation_range)
 
                 # this finds what the relative's relationship is toward each parent and applies a reflection of that
                 # relationship to the kit. reflection values will be divided by 4 by default and then modified


### PR DESCRIPTION
## About The Pull Request

Fixes issue where relatives could have relationship values with newborn kits that were too high.

Relationships with newborns will take the relative’s relationships with each parent and divide them 4, then add that to their relationship values towards the kit. If the kit has a lot of parents and/or the relative has strong relationships with them, then the relative may end up having high relationship values towards the kit. The random ranges can also impact the final relationships very strongly if there are a lot of parents, since they can all be from -10 to 10.

I assumed that the numbers were previously balanced around exactly 2 parents and:
* Changed relationships to divide by `2 *  number of parents`
* Random range depends on the amount of parents

## Linked Issues
Fixes: #4857

## Proof of Testing

Downblotch has five mates:
<img width="750" height="408" alt="image" src="https://github.com/user-attachments/assets/0743b1a8-6f90-4d8f-a310-9de66d1b3b84" />

Heatherpaw (adopted by one of Downblotch's mates) has very high like with everyone (edited):
<img width="791" height="698" alt="image" src="https://github.com/user-attachments/assets/5666f865-35b9-494b-97f2-c355d7a7b97c" />

Previously, her relationships with her siblings would generate like this:
<img width="796" height="694" alt="image" src="https://github.com/user-attachments/assets/df9e341e-63a1-4d07-a320-282f0b829421" />

But after this PR, Heatherpaw will generate more normal relationships with siblings:
<img width="766" height="635" alt="image" src="https://github.com/user-attachments/assets/56880ed9-3e3d-4bdc-92ee-41fb8e0008fc" />
