### PR TITLE
[BUGFIX] Other Clan cat rank progression

### DIFF
--- a/scripts/events.py
+++ b/scripts/events.py
@@ -984,7 +984,7 @@ def one_moon_outside_cat(cat, other_clan_cats: list = None):
             if cat.status.rank == CatRank.MEDIATOR_APPRENTICE:
                 cat.status._change_rank(CatRank.MEDIATOR)
         # cat to elder
-        if cat.moon >= cat_class.age_moons[CatAge.SENIOR][0]:
+        if cat.moons >= cat_class.age_moons[CatAge.SENIOR][0]:
             # exclude the roles that don't really retire
             if cat.status.rank not in (CatRank.LEADER, CatRank.MEDICINE_CAT):
                 cat.status._change_rank(CatRank.ELDER)

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -965,6 +965,30 @@ def one_moon_outside_cat(cat, other_clan_cats: list = None):
     cat.skills.progress_skill(cat)
     Pregnancy_Events.handle_having_kits(cat, clan=game.clan)
 
+    # handling the rank changes for Other Clan cats
+    # this is SUPER rudimentary rn, really just a temp patch to handle our current little edge-cases
+    if cat.status.is_other_clancat:
+        # kitten to apprentice - for now it's going to be limited to warrior apprentices
+        if cat.moons == cat_class.age_moons[CatAge.ADOLESCENT][0]:
+            cat.status._change_rank(CatRank.APPRENTICE)
+            # we aren't going to worry about sourcing a mentor, we're gonna pretend it's "hidden" from the player
+        # apprentice to full
+        if cat.moons >= cat_class.age_moons[CatAge.YOUNG_ADULT][0]:
+            # warrior
+            if cat.status.rank == CatRank.APPRENTICE:
+                cat.status._change_rank(CatRank.WARRIOR)
+            # med cat
+            if cat.status.rank == CatRank.MEDICINE_APPRENTICE:
+                cat.status._change_rank(CatRank.MEDICINE_CAT)
+            # mediator (just in case)
+            if cat.status.rank == CatRank.MEDIATOR_APPRENTICE:
+                cat.status._change_rank(CatRank.MEDIATOR)
+        # cat to elder
+        if cat.moon >= cat_class.age_moons[CatAge.SENIOR][0]:
+            # exclude the roles that don't really retire
+            if cat.status.rank not in (CatRank.LEADER, CatRank.MEDICINE_CAT):
+                cat.status._change_rank(CatRank.ELDER)
+
     if not cat.dead:
         OutsiderEvents.killing_outsiders(cat)
 

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -962,9 +962,6 @@ def one_moon_outside_cat(cat, other_clan_cats: list = None):
 
     handle_outside_EX(cat)
 
-    cat.skills.progress_skill(cat)
-    Pregnancy_Events.handle_having_kits(cat, clan=game.clan)
-
     # handling the rank changes for Other Clan cats
     # this is SUPER rudimentary rn, really just a temp patch to handle our current little edge-cases
     if cat.status.is_other_clancat:
@@ -988,6 +985,10 @@ def one_moon_outside_cat(cat, other_clan_cats: list = None):
             # exclude the roles that don't really retire
             if cat.status.rank not in (CatRank.LEADER, CatRank.MEDICINE_CAT):
                 cat.status._change_rank(CatRank.ELDER)
+
+    # skill progression needs to be after rank progression
+    cat.skills.progress_skill(cat)
+    Pregnancy_Events.handle_having_kits(cat, clan=game.clan)
 
     if not cat.dead:
         OutsiderEvents.killing_outsiders(cat)


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
Turns out we just didn't handle Other Clan rank progressions at all. Understandable, considering how little we've fleshed that part of the game out and how little we currently generate those cats.

To fix this I've added a rudimentary rank progression section to other clan cat moonskips. I didn't make this very complex. It's really just meant to be a temp measure until we're able to get more complex with it. For now, kittens will progress to warrior apps only and we don't try to assign a mentor.  All apprentice types will progress to their mature rank right when they hit young adult, no dependence on exp points.  All cats (excluding meddies and leaders) will retire to elder upon becoming seniors.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
fixes #4863
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
<img width="607" height="276" alt="image" src="https://github.com/user-attachments/assets/1bf55bd8-fd1d-4230-82d3-13cc078c8722" />

our Other Clan app

<img width="600" height="303" alt="image" src="https://github.com/user-attachments/assets/7ffcc36d-86cb-4f5f-9f7a-3be23c5d4a60" />

Aged up and made a warrior!
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Other Clan cats will now correctly progress their rank as they age
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
