### PR TITLE
[CRASHFIX] Dead cats persisting across Clans

### DIFF
--- a/scripts/screens/MakeClanScreen.py
+++ b/scripts/screens/MakeClanScreen.py
@@ -2136,6 +2136,8 @@ class MakeClanScreen(Screens):
     def save_clan(self):
         game.mediated.clear()
         game.patrolled.clear()
+        game.just_died.clear()
+        game.dead_cats_to_grieve.clear()
         save_load.faded_ids.clear()
         Cat.outside_cats.clear()
         Patrol.used_patrols.clear()


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
This was being caused by dead cat list info persisting when a new clan is made. Solution was just to clear those lists upon clan creation like we do with similar lists (i.e. patrolled_cats)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
fixes #4830
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
<img width="794" height="696" alt="image" src="https://github.com/user-attachments/assets/f9e1566d-1a42-401a-ba21-a78e19aed50d" />

Followed the replication method from the bug report: killed a cat, saved, created a new clan, then timeskipped. When I tested before my fix, the dead cat from the prior clan would receive a grief message in the new clan upon timeskipping. The screenshot is from after my fix and you can see that the clan has been timeskipped once and doesn't display a grief event.
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- newly created Clans no longer attempt to grieve cats who had just died in the prior save (save files already affected by this will not be retroactively fixed. if you want to stop it from crashing, edit the clan json to clear the `dead_cats_to_grieve` list)
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
