### PR TITLE
[FREQFIX] transient outsider event frequency

### DIFF
--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -4720,7 +4720,7 @@
         "season": [
             "any"
         ],
-        "frequency": 3,
+        "frequency": 2,
         "event_text": "A stranger limped into camp this moon, knowing c_n was friendly, and requested a few nights of shelter while {PRONOUN/n_c:0/poss} wounds healed. c_n obliged.",
         "m_c": {
             "age": [
@@ -4733,6 +4733,7 @@
         },
         "new_cat": [
             [
+	     "exists",
                 "meeting",
                 "loner",
                 "rogue"
@@ -4756,7 +4757,7 @@
         "season": [
             "any"
         ],
-        "frequency": 4,
+        "frequency": 2,
         "event_text": "A wandering healer was found on the border, hoping to learn from Clan medicine cats. {PRONOUN/n_c:0/subject/CAP} left a moon later, grateful and armed with new knowledge.",
         "m_c": {
             "status": [
@@ -4765,6 +4766,7 @@
         },
         "new_cat": [
             [
+	     "exists",
                 "meeting",
                 "loner",
                 "rogue",
@@ -4810,7 +4812,7 @@
         "season": [
             "any"
         ],
-        "frequency": 3,
+        "frequency": 2,
         "event_text": "A stranger requested a few days of shelter in c_n's sturdy camp while the incoming storm blew over. c_n obliged.",
         "m_c": {
             "age": [
@@ -4823,6 +4825,7 @@
         },
         "new_cat": [
             [
+	     "exists",
                 "meeting",
                 "loner",
                 "rogue"
@@ -4847,7 +4850,7 @@
         "season": [
             "any"
         ],
-        "frequency": 2,
+        "frequency": 1,
         "event_text": "A o_c_n apprentice asked to join c_n after having apparently forsaken {PRONOUN/n_c:0/poss} original Clan loyalties. {PRONOUN/n_c:0/subject/CAP} {VERB/n_c:0/stay/stays} for only a few days before sheepishly requesting to return home.",
         "m_c": {
             "age": [
@@ -4884,7 +4887,7 @@
         "season": [
             "any"
         ],
-        "frequency": 3,
+        "frequency": 2,
         "event_text": "A kittypet asked to join c_n but returned to Twolegplace after only a few days, realizing {PRONOUN/n_c:0/poss} distaste for outdoor living.",
         "m_c": {
             "age": [
@@ -4897,6 +4900,7 @@
         },
         "new_cat": [
             [
+	     "exists",
                 "meeting",
                 "kittypet"
             ]


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

reduces the frequency of transient outsider events (ie, events where a cat temporarily requests shelter, or a kittypet joining but finding out clan life isn't their thing, etc) as it was reported that they were happening too often and generating too many outsiders in one moon. all of these events had their frequency reduced by 1 or 2 and the "exists" tag added (minus the otherclan apprentice event)

## Why This Is Good For ClanGen

listening to feedback! i also personally agree that these events were too common and they often flooded my outsiders tab in the span of a couple moons.

## Linked Issues

https://github.com/ClanGenOfficial/clangen/issues/3896#issuecomment-4316305256

## Proof of Testing

game boots + moonskips work fine
<br>
<img width="790" height="690" alt="image" src="https://github.com/user-attachments/assets/417b2b39-b5a5-4816-a4c7-fb8d30ee19a9" />
<img width="786" height="686" alt="image" src="https://github.com/user-attachments/assets/7f5afb8b-7ad2-466f-a301-c7a10462a5e8" />

## Changelog/Credits

- Reduced frequency of the transient outsider events and added an "exists" requirement to most of them, in response to player feedback that they were happening too often and flooding the outsiders tab.
