### PR TITLE
[BUGFIX] former clancat creation

### DIFF
--- a/resources/dicts/backstories.json
+++ b/resources/dicts/backstories.json
@@ -46,7 +46,8 @@
             "medicine_cat",
             "guided4",
             "refugee5",
-            "stolenkit1"
+            "stolenkit1",
+            "stolenkit2"
         ],
         "healer_backstories": [
             "medicine_cat", "wandering_healer1", "wandering_healer2"

--- a/resources/lang/en/cat/backstories.en.json
+++ b/resources/lang/en/cat/backstories.en.json
@@ -64,6 +64,7 @@
         "outsider2": "m_c was born outside of a Clan, but at {PRONOUN/m_c/poss} birth one parent was a member of a Clan.",
         "outsider3": "m_c was born outside of a Clan, while {PRONOUN/m_c/poss} parent was lost.",
         "stolenkit1": "{PRONOUN/m_c/subject/CAP} was a victim of war, stolen from a rival Clan at a young age.",
+        "stolenkit2": "m_c's kits were stolen during war. {PRONOUN/m_c/subject/CAP} left {PRONOUN/m_c/poss} old Clan in an attempt to find them.",
         "unknown": "%{name}'s past history is unknown.",
         "cats_outside_the_clan": "This cat is a %{status} and currently resides outside of the Clans.",
         "cats_outside_the_clan_dead": "This cat was a %{status} in life.",

--- a/resources/lang/en/events/new_cat/general.json
+++ b/resources/lang/en/events/new_cat/general.json
@@ -1300,7 +1300,8 @@
                 "age:has_kits",
                 "former clancat",
                 "meeting",
-                "new_name"
+                "new_name",
+                "backstory:stolenkit2"
             ],
             [
                 "litter",

--- a/scripts/events_module/consequences.py
+++ b/scripts/events_module/consequences.py
@@ -210,7 +210,7 @@ def create_new_cat_block(
     elif rank == CatRank.MEDICINE_CAT:
         chosen_backstory = choice(["wandering_healer1", "wandering_healer2"])
     else:
-        if cat_social == CatSocial.CLANCAT:
+        if cat_social in (CatSocial.CLANCAT, "former clancat"):
             x = "former_clancat"
         else:
             x = cat_social
@@ -247,7 +247,11 @@ def create_new_cat_block(
             BACKSTORIES["backstory_categories"]["baby_clancat_backstories"]
             + BACKSTORIES["backstory_categories"]["former_clancat_backstories"]
         ):
-            cat_social = CatSocial.CLANCAT
+            cat_social = (
+                CatSocial.CLANCAT
+                if cat_social != "former clancat"
+                else "former clancat"
+            )
         elif chosen_backstory in (
             BACKSTORIES["backstory_categories"]["baby_loner_backstories"]
             + BACKSTORIES["backstory_categories"]["loner_backstories"]


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
Every time I have to fix the cat creation code I cry a little bit.
This should fix our issues with generating former clancats:
- new cats marked as former clancat but given no backstory now take an appropriate backstory
- new cats being given a former clancat backstory via backstory override, but don't join the player clan, are now correctly placed outside of the clans instead of being assigned to one of the other clans
- added a new backstory `stolenkit2` so that the parent in `gen_new_cat_war_stolenkits1` will have an appropriate backstory
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
fixes #4846
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
This cat was generated by `gen_new_cat_war_stolenkits1` and then invited into the Clan to see what the backstory would be. You can see that it's appropriate for the event. I didn't take screenshots of the profile from before the invite, but it was as expected.

<img width="710" height="479" alt="image" src="https://github.com/user-attachments/assets/204aee6d-c62c-4f99-8bb5-043866dcb5f7" />


also tested the generation of other clan cats, just to make sure my meddling didn't screw that up

<img width="544" height="130" alt="image" src="https://github.com/user-attachments/assets/a1b0033d-62ba-4952-bf60-d61379c1b82e" />
<img width="659" height="271" alt="image" src="https://github.com/user-attachments/assets/e4b9f519-800f-4cef-8a21-d15469902539" />

it works exactly as it used to! so we should be good
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- new cats marked as former clancat but given no backstory now take an appropriate backstory
- new cats being given a former clancat backstory via backstory override, but don't join the player clan, are now correctly placed outside of the clans instead of being assigned to one of the other clans
- added a new backstory `stolenkit2` so that the parent in `gen_new_cat_war_stolenkits1` will have an appropriate backstory
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
