### PR TITLE
[BUGFIX] Rest and Recover

### DIFF
--- a/resources/game_config.toml
+++ b/resources/game_config.toml
@@ -628,7 +628,7 @@ dev_tools = false
       "running nose" = 5
       whitecough = 1
 
-  [focus."rest_and_recover"]
+  [focus.rest_and_recover]
     # roughly 1/chance injuries will be prevented
     injury_prevent = 4
 

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -1662,7 +1662,7 @@ class Cat:
         moons_with = game.clan.age - self.illnesses[illness]["moon_start"]
 
         # focus buff
-        moons_prior = constants.CONFIG["focus"]["rest_and_recover"][
+        recovery_buff = constants.CONFIG["focus"]["rest_and_recover"][
             "moons_earlier_healed"
         ]
 
@@ -1673,7 +1673,7 @@ class Cat:
         # CLAN FOCUS! - if the focus 'rest_and_recover' is selected
         elif (
             get_clan_setting("rest_and_recover")
-            and self.illnesses[illness]["duration"] + moons_prior - moons_with <= 0
+            and self.illnesses[illness]["duration"] - recovery_buff - moons_with <= 0
         ):
             self.healed_condition = True
             return False
@@ -1704,7 +1704,7 @@ class Cat:
         moons_with = game.clan.age - self.injuries[injury]["moon_start"]
 
         # focus buff
-        moons_prior = constants.CONFIG["focus"]["rest_and_recover"][
+        recovery_buff = constants.CONFIG["focus"]["rest_and_recover"][
             "moons_earlier_healed"
         ]
 
@@ -1720,7 +1720,7 @@ class Cat:
         elif (
             not self.injuries[injury]["complication"]
             and get_clan_setting("rest_and_recover")
-            and self.injuries[injury]["duration"] + moons_prior - moons_with <= 0
+            and self.injuries[injury]["duration"] - recovery_buff - moons_with <= 0
         ):
             self.healed_condition = True
             return False

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -648,7 +648,7 @@ def handle_focus():
         - raid other clans
         - hoarding
     Focus which are not able to be handled here:
-        rest and recover - handled in:
+        rest_and_recover - handled in:
             - 'handle_outbreaks'
             - 'condition_events.handle_injuries'
             - 'condition_events.handle_illnesses'
@@ -2341,8 +2341,8 @@ def handle_outbreaks(cat):
             ):
                 continue
 
-            if get_clan_setting("rest and recover"):
-                stopping_chance = constants.CONFIG["focus"]["rest and recover"][
+            if get_clan_setting("rest_and_recover"):
+                stopping_chance = constants.CONFIG["focus"]["rest_and_recover"][
                     "outbreak_prevention"
                 ]
                 if not int(random.random() * stopping_chance):

--- a/scripts/events_module/short/condition_events.py
+++ b/scripts/events_module/short/condition_events.py
@@ -284,8 +284,8 @@ class Condition_Events:
                 and not event_string
             ):
                 # CLAN FOCUS!
-                if get_clan_setting("rest and recover"):
-                    stopping_chance = constants.CONFIG["focus"]["rest and recover"][
+                if get_clan_setting("rest_and_recover"):
+                    stopping_chance = constants.CONFIG["focus"]["rest_and_recover"][
                         "illness_prevent"
                     ]
                     if not int(random.random() * stopping_chance):
@@ -410,8 +410,8 @@ class Condition_Events:
 
             if triggered:
                 # CLAN FOCUS!
-                if get_clan_setting("rest and recover"):
-                    stopping_chance = constants.CONFIG["focus"]["rest and recover"][
+                if get_clan_setting("rest_and_recover"):
+                    stopping_chance = constants.CONFIG["focus"]["rest_and_recover"][
                         "injury_prevent"
                     ]
                     if not int(random.random() * stopping_chance):


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
ahahahaha so this wasn't even a balancing problem. rest and recover was just fully bugged. 

- The recovery_buff (renamed to such) was *adding* to the duration instead of *subtracting*, which resulted in longer recovery times instead of shorter
- A bunch of mentions of `"rest and recover"` had never been changed to the new underscored version: `"rest_and_recover"`. This means that *none* of those buffs were being applied.  I've fixed all of these to be correctly underscored. I double checked all the other focus settings and it seems that all of those are using the correctly updated names, this was the only one that got missed.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Proof of Testing
debugging view

<img width="573" height="162" alt="image" src="https://github.com/user-attachments/assets/425d8e94-89f0-4139-a2e6-d212850e7740" />

yay! we actually made it to the part of code that will try and stop an illness. this was previously inaccessible

<img width="666" height="177" alt="image" src="https://github.com/user-attachments/assets/29e4ed91-c2aa-429a-9602-70ca25497219" />

healed one moon earlier, which is what should happen with this focus! Duration was 2, recovery_buff was 1, and moons_with was 1. 
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Resting and Recovering focus no longer incorrectly *adds* to condition durations instead of subtracting
- Some Resting and Recovering buffs were inaccessible to the code due to incorrect name shenanigans, this has been fixed and all buffs now apply correctly.
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
