### PR TITLE
[TYPOFIX] misc typo fixes

### DIFF
--- a/resources/lang/en/conditions/risk_strings/illness_risk_strings.json
+++ b/resources/lang/en/conditions/risk_strings/illness_risk_strings.json
@@ -35,7 +35,7 @@
 
         ],
         "sore throat": [
-            "m_c's congestion has left {PRONOUN/m_c/poss} throat inflammed and sore.",
+            "m_c's congestion has left {PRONOUN/m_c/poss} throat inflamed and sore.",
             "As if a running nose wasn't enough trouble, now m_c's throat is sore as well."
         ]
     },

--- a/resources/lang/en/patrols/other_clan_allies.json
+++ b/resources/lang/en/patrols/other_clan_allies.json
@@ -1253,7 +1253,7 @@
                     "r_c"
                 ],
                 "history_text": {
-                    "death": "m_c was slain by o_c_n warriors"
+                    "death": "m_c was slain by o_c_n warriors."
                 },
                 "relationships": [
                     {


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

just keeping up to date with #1818 !
- changes spelling of "inflammed" to "inflamed" for sore throat risk
- adds missing period from a death history in an otherclan allies border patrol

## Why This Is Good For ClanGen

i eated the typos

## Linked Issues

https://github.com/ClanGenOfficial/clangen/issues/1818#issuecomment-4292672040
https://github.com/ClanGenOfficial/clangen/issues/1818#issuecomment-4323220284

## Proof of Testing

<img width="1153" height="267" alt="image" src="https://github.com/user-attachments/assets/e7e7e00a-2d78-4f21-9a60-1d1ebe338b08" />
<img width="1156" height="265" alt="image" src="https://github.com/user-attachments/assets/5bf95384-58d2-470a-aff8-932b41bf743a" />


## Changelog/Credits

- Fixes some miscellaneous typos in events/patrol history text.
