### PR TITLE
[DOCS] expanded on EXP documentation

### DIFF
--- a/docs/dev/writing/patrols.md
+++ b/docs/dev/writing/patrols.md
@@ -609,7 +609,15 @@ What each parameter does, and what the options are for outcomes.
 
 #### exp: int
 >The amount of exp cats receive (sorta). The exact amount also depends on the number of cats and current EXP levels, but in general, a higher number here means more exp. If exp is 0, no exp will be given. 
+> 
+> There are a few things to keep in mind when determining patrol EXP. First is that the EXP per outcome is split between every cat in the patrol. Second is the difficulty of the patrol itself. If it involves dangerous scenarios (outsiders, predators, or risk of death) and has a lower success rate, the higher the EXP gain typically is. Likewise, failure outcomes typically result in 0 EXP gained, though there are some border patrols and training patrols that will still grant 5 EXP depending on the circumstance. The EXP granted by failed patrols, average successes, and uncommon extreme successes for each patrol type is as follows:
 >
+|          | failure | average success | extreme scenarios |
+|:--------:|:-------:|:---------------:|:-----------------:|
+|  hunting |    0    |      10-20      |        40         |
+|  border  |   0-5   |      0-15       |       20-40       |
+|  medcat  |    0    |      10-20      |        30         |
+| training |   0-5   |       30        |        40         |
 
 ***
 

--- a/docs/dev/writing/patrols.md
+++ b/docs/dev/writing/patrols.md
@@ -617,7 +617,7 @@ What each parameter does, and what the options are for outcomes.
 |  hunting |    0    |      10-20      |        40         |
 |  border  |   0-5   |      0-15       |       20-40       |
 |  medcat  |    0    |      10-20      |        30         |
-| training |   0-5   |       30        |        40         |
+| training |   0-5   |       20        |        40         |
 
 ***
 


### PR DESCRIPTION
## About The Pull Request

- Adds more documentation on the amount of EXP granted on various types of patrols from failures to average to extreme scenarios. 

## Why This Is Good For ClanGen

- Very helpful for writers to have on hand for balancing patrols.

## Proof of Testing

- ClanGen does not crash / the formatting for docs is not messed up by it. 

<img width="976" height="779" alt="Screenshot 2026-04-27 at 4 01 53 PM" src="https://github.com/user-attachments/assets/78c22e80-e5d0-4288-aaa2-db07e6de26ed" />
