### PR TITLE
[CONTENT] Evil War Events

### DIFF
--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -2303,7 +2303,7 @@
         "history": [
             {
                 "cats": [
-                    "r_c"
+                    "m_c"
                 ],
                 "death": "m_c was killed in a battle with a warring Clan."
             }

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -2224,7 +2224,7 @@
         }
     },
     {
-        "event_id": "gen_death_war_appmentor",
+        "event_id": "gen_death_war_mentorapp",
         "location": [
             "any"
         ],
@@ -2235,36 +2235,36 @@
             "war"
         ],
         "frequency": 1,
-        "event_text": "r_c is killed by a o_c_n warrior in front of {PRONOUN/r_c/poss} apprentice, m_c.",
-        "m_c": {
+        "event_text": "m_c is killed by a o_c_n warrior in front of {PRONOUN/m_c/poss} apprentice, r_c.",
+        "r_c": {
             "status": [
                 "apprentice"
             ],
-            "relationship_status": ["app/mentor"],
             "dies": false
         },
-        "r_c": {
+        "m_c": {
             "status": [
                 "warrior", "deputy", "leader"
             ],
+            "relationship_status": ["mentor/app"],
             "dies": true
         },
         "injury": [
             {
-                "cats": ["m_c"],
+                "cats": ["r_c"],
                 "injuries": ["shock"]
             }
         ],
         "history": [
             {
                 "cats": [
-                    "r_c"
+                    "m_c"
                 ],
                 "death": "m_c was killed in a battle with a warring Clan."
             },
             {
                 "cats": [
-                    "m_c"
+                    "r_c"
                 ],
                 "death": "m_c could not recover from the shock of {PRONOUN/m_c/poss} mentor being killed in front of {PRONOUN/m_c/object}."
             }
@@ -2277,7 +2277,7 @@
         }
     },
     {
-        "event_id": "gen_death_war_mentorapp",
+        "event_id": "gen_death_war_appmentor",
         "location": [
             "any"
         ],
@@ -2288,16 +2288,16 @@
             "war"
         ],
         "frequency": 1,
-        "event_text": "r_c is killed by a o_c_n warrior in front of {PRONOUN/r_c/poss} mentor, m_c.",
-        "m_c": {
+        "event_text": "m_c is killed by a o_c_n warrior in front of {PRONOUN/m_c/poss} mentor, r_c.",
+        "r_c": {
             "status": [
                 "warrior", "deputy", "leader"
             ],
-            "relationship_status": ["mentor/app"],
             "dies": false
         },
-        "r_c": {
+        "m_c": {
             "status": ["apprentice"],
+            "relationship_status": ["app/mentor"],
             "dies": true
         },
         "history": [
@@ -2327,17 +2327,17 @@
             "war"
         ],
         "frequency": 1,
-        "event_text": "r_c and m_c match each other blow for blow in a fight with a o_c_n patrol. The tide of battle turns against the littermates, and r_c is killed in front of m_c.",
+        "event_text": "r_c and m_c match each other blow for blow in a fight with a o_c_n patrol. The tide of battle turns against the littermates, and m_c is killed in front of r_c.",
         "m_c": {
             "status": [
                 "warrior", "apprentice", "deputy", "leader"
             ],
             "relationship_status": ["littermates", "trusts"],
-            "dies": false
+            "dies": true
         },
         "r_c": {
             "status": ["warrior", "apprentice", "deputy", "leader"],
-            "dies": true
+            "dies": false
         },
         "injury": [
             {
@@ -2348,12 +2348,12 @@
         "history": [
             {
                 "cats": [
-                    "r_c"
+                    "m_c"
                 ],
                 "death": "m_c was killed in a battle with a warring Clan."
             },
             {
-                "cats": ["m_c"],
+                "cats": ["r_c"],
                 "death": "m_c could not recover from the shock of seeing {PRONOUN/m_c/poss} littermate die in front of {PRONOUN/m_c/object}."
             }
         ],
@@ -2376,85 +2376,36 @@
             "war"
         ],
         "frequency": 1,
-        "event_text": "m_c tries to protect {PRONOUN/m_c/poss} little sibling in a fight with o_c_n, but r_c is killed by enemy warriors.",
-        "m_c": {
+        "event_text": "r_c tries to protect {PRONOUN/r_c/poss} little sibling in a fight with o_c_n, but m_c is killed by enemy warriors.",
+        "r_c": {
             "status": [
                 "warrior", "deputy", "leader"
             ],
             "age": ["young adult", "adult", "senior adult"],
-            "relationship_status": ["siblings"],
             "dies": false
         },
-        "r_c": {
+        "m_c": {
             "status": ["apprentice"],
             "age": ["adolescent"],
+            "relationship_status": ["siblings"],
             "dies": true
         },
         "injury": [
             {
-                "cats": ["m_c"],
+                "cats": ["r_c"],
                 "injuries": ["shock"]
             }
         ],
         "history": [
             {
                 "cats": [
-                    "r_c"
+                    "m_c"
                 ],
                 "death": "m_c was killed in a battle with a warring Clan."
             },
             {
-                "cats": ["m_c"],
+                "cats": ["r_c"],
                 "death": "m_c could not recover from the shock of seeing {PRONOUN/m_c/poss} little sibling die in front of {PRONOUN/m_c/object}."
-            }
-        ],
-        "other_clan": {
-            "current_rep": [
-                "hostile"
-            ],
-            "changed": -5
-        }
-    },
-    {
-        "event_id": "gen_death_war_parentchild",
-        "location": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "sub_type": [
-            "war"
-        ],
-        "frequency": 1,
-        "event_text": "In a battle with o_c_n, m_c acts too late to save r_c and watches {PRONOUN/m_c/poss} kit die.",
-        "m_c": {
-            "status": [
-                "warrior", "deputy", "leader"
-            ],
-            "relationship_status": ["parent/child"],
-            "dies": false
-        },
-        "r_c": {
-            "status": ["warrior", "apprentice", "deputy", "leader"],
-            "dies": true
-        },
-        "injury": [
-            {
-                "cats": ["m_c"],
-                "injuries": ["shock"]
-            }
-        ],
-        "history": [
-            {
-                "cats": [
-                    "r_c"
-                ],
-                "death": "m_c was killed in a battle with a warring Clan."
-            },
-            {
-                "cats": ["m_c"],
-                "death": "m_c could not recover from the shock of seeing {PRONOUN/m_c/poss} kit die in front of {PRONOUN/m_c/object}."
             }
         ],
         "other_clan": {
@@ -2476,34 +2427,83 @@
             "war"
         ],
         "frequency": 1,
-        "event_text": "In a battle with o_c_n, m_c sees an enemy warrior kill {PRONOUN/m_c/poss} parent, r_c.",
-        "m_c": {
+        "event_text": "In a battle with o_c_n, r_c acts too late to save m_c and watches {PRONOUN/r_c/poss} kit die.",
+        "r_c": {
             "status": [
-                "apprentice", "warrior", "deputy", "leader"
+                "warrior", "deputy", "leader"
             ],
-            "relationship_status": ["child/parent"],
             "dies": false
         },
-        "r_c": {
-            "status": ["warrior", "deputy", "leader"],
+        "m_c": {
+            "status": ["apprentice", "warrior", "deputy", "leader"],
+            "relationship_status": ["child/parent"],
             "dies": true
         },
         "injury": [
             {
-                "cats": ["m_c"],
+                "cats": ["r_c"],
                 "injuries": ["shock"]
             }
         ],
         "history": [
             {
                 "cats": [
-                    "r_c"
+                    "m_c"
+                ],
+                "death": "m_c was killed in a battle with a warring Clan."
+            },
+            {
+                "cats": ["r_c"],
+                "death": "m_c could not recover from the shock of seeing {PRONOUN/m_c/poss} kit die in front of {PRONOUN/m_c/object}."
+            }
+        ],
+        "other_clan": {
+            "current_rep": [
+                "hostile"
+            ],
+            "changed": -5
+        }
+    },
+    {
+        "event_id": "gen_death_war_parentchild",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 1,
+        "event_text": "In a battle with o_c_n, r_c sees an enemy warrior kill {PRONOUN/r_c/poss} parent, m_c.",
+        "r_c": {
+            "status": [
+                "warrior", "deputy", "leader"
+            ],
+            "dies": false
+        },
+        "m_c": {
+            "status": ["apprentice", "warrior", "deputy", "leader"],
+            "relationship_status": ["parent/child"],
+            "dies": true
+        },
+        "injury": [
+            {
+                "cats": ["r_c"],
+                "injuries": ["shock"]
+            }
+        ],
+        "history": [
+            {
+                "cats": [
+                    "m_c"
                 ],
                 "death": "m_c was killed in a battle with a warring Clan."
             },
             {
                 "cats": [
-                    "m_c"
+                    "r_c"
                 ],
                 "death": "m_c could not recover from the shock of seeing {PRONOUN/m_c/poss} parent be killed in front of {PRONOUN/m_c/object}."
             }
@@ -2527,33 +2527,33 @@
             "war"
         ],
         "frequency": 1,
-        "event_text": "In the haze of battle, m_c is separated from r_c. When the dust settles, {PRONOUN/m_c/subject} {VERB/m_c/find/finds} r_c's cooling body.",
-        "m_c": {
+        "event_text": "In the haze of battle, r_c is separated from m_c. When the dust settles, {PRONOUN/r_c/subject} {VERB/r_c/find/finds} m_c's cooling body.",
+        "r_c": {
             "status": [
                 "warrior", "deputy", "leader"
             ],
-            "relationship_status": ["mates"],
             "dies": false
         },
-        "r_c": {
+        "m_c": {
             "status": ["warrior", "deputy", "leader"],
+            "relationship_status": ["mates"],
             "dies": true
         },
         "injury": [
             {
-                "cats": ["m_c"],
+                "cats": ["r_c"],
                 "injuries": ["shock"]
             }
         ],
         "history": [
             {
                 "cats": [
-                    "r_c"
+                    "m_c"
                 ],
                 "death": "m_c was killed in a battle with a warring Clan."
             },
             {
-                "cats": ["m_c"],
+                "cats": ["r_c"],
                 "death": "m_c could not recover from the shock of finding {PRONOUN/m_c/poss} mate's body after a battle with o_c_n."
             }
         ],
@@ -2576,22 +2576,20 @@
             "war"
         ],
         "frequency": 1,
-        "event_text": "As r_c leaves camp with the battle patrol, m_c pleads for {PRONOUN/r_c/object} to return to {PRONOUN/m_c/object} safely. r_c does not keep {PRONOUN/r_c/poss} promise.",
+        "event_text": "As m_c leaves camp with the battle patrol, r_c pleads for {PRONOUN/m_c/object} to return to {PRONOUN/r_c/object} safely. m_c does not keep {PRONOUN/m_c/poss} promise.",
         "m_c": {
-            "status": [
-                "any"
-            ],
+            "status": ["warrior", "deputy", "leader"],
             "relationship_status": ["mates"],
-            "dies": false
+            "dies": true
         },
         "r_c": {
-            "status": ["warrior", "deputy", "leader"],
-            "dies": true
+            "status": ["any"],
+            "dies": false
         },
         "history": [
             {
                 "cats": [
-                    "r_c"
+                    "m_c"
                 ],
                 "death": "m_c was killed in a battle with a warring Clan."
             }
@@ -2615,22 +2613,22 @@
             "war"
         ],
         "frequency": 1,
-        "event_text": "In a battle with o_c_n, m_c's mate r_c is killed. m_c vows the war will never end until o_c_n pays.",
-        "m_c": {
+        "event_text": "In a battle with o_c_n, r_c's mate m_c is killed. r_c vows the war will never end until o_c_n pays.",
+        "r_c": {
             "status": [
                 "leader"
             ],
-            "relationship_status": ["mates"],
             "dies": false
         },
-        "r_c": {
+        "m_c": {
             "status": ["warrior", "deputy"],
+            "relationship_status": ["mates"],
             "dies": true
         },
         "history": [
             {
                 "cats": [
-                    "r_c"
+                    "m_c"
                 ],
                 "death": "m_c was killed in a battle with a warring Clan."
             }
@@ -2654,34 +2652,35 @@
             "war"
         ],
         "frequency": 1,
-        "event_text": "Despite m_c's talent in battle, {PRONOUN/m_c/subject} and r_c are overwhelmed by waves of invading o_c_n warriors. Three hold m_c down as a fourth kills r_c in front of {PRONOUN/m_c/object}.",
-        "m_c": {
+        "event_text": "Despite r_c's talent in battle, {PRONOUN/r_c/subject} and m_c are overwhelmed by waves of invading o_c_n warriors. Three hold r_c down as a fourth kills m_c in front of {PRONOUN/r_c/object}.",
+        "r_c": {
             "status": [
                 "warrior", "deputy", "leader"
             ],
             "skill": ["FIGHTER,1"],
-            "relationship_status": ["mates"],
             "dies": false
         },
-        "r_c": {
+        "m_c": {
             "status": ["warrior", "deputy", "leader"],
+            "relationship_status": ["mates"],
             "dies": true
         },
         "injury": [
             {
-                "cats": ["m_c"],
+                "cats": ["r_c"],
                 "injuries": ["battle_injury", "shock"]
             }
         ],
         "history": [
             {
                 "cats": [
-                    "r_c"
+                    "m_c"
                 ],
                 "death": "m_c was killed in a battle with a warring Clan."
             },
             {
-                "cats": ["m_c"],
+                "cats": ["r_c"],
+                "scar": "m_c was scarred after a battle in which an enemy Clan's warriors killed {PRONOUN/m_c/poss} mate in front of {PRONOUN/m_c/object}.",
                 "death": "m_c died after a battle in which an enemy Clan's warriors killed {PRONOUN/m_c/poss} mate in front of {PRONOUN/m_c/object}."
             }
         ],

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -2637,7 +2637,7 @@
             "current_rep": [
                 "any"
             ],
-            "changed": -15
+            "changed": -10
         }
     },
     {

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -2536,7 +2536,7 @@
         },
         "m_c": {
             "status": ["warrior", "deputy", "leader"],
-            "relationship_status": ["mates"],
+            "relationship_status": ["adores"],
             "dies": true
         },
         "injury": [

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -2682,7 +2682,7 @@
             },
             {
                 "cats": ["m_c"],
-                "death": "m_c died after a battle in which an enemy Clan's warriors killed {RPONOUN/m_c/poss} mate in front of {PRONOUN/m_c/object}."
+                "death": "m_c died after a battle in which an enemy Clan's warriors killed {PRONOUN/m_c/poss} mate in front of {PRONOUN/m_c/object}."
             }
         ],
         "other_clan": {

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -2341,7 +2341,7 @@
         },
         "injury": [
             {
-                "cats": ["m_c"],
+                "cats": ["r_c"],
                 "injuries": ["shock"]
             }
         ],

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -2189,6 +2189,562 @@
         }
     },
     {
+        "event_id": "gen_death_war_fearlesskitten",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 2,
+        "event_text": "o_c_n raids c_n's camp. Despite orders to hide in the nursery, m_c is ready to prove {PRONOUN/m_c/self}. {PRONOUN/m_c/subject/CAP} {VERB/m_c/are/is} no match for the o_c_n warriors, who leave {PRONOUN/m_c/object} cold on the ground.",
+        "m_c": {
+            "status": [
+                "kitten"
+            ],
+            "trait": ["fearless", "bullying", "attention-seeker", "unruly"],
+            "dies": true
+        },
+        "history": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "death": "m_c died after attacking an enemy warrior during a camp raid."
+            }
+        ],
+        "other_clan": {
+            "current_rep": [
+                "hostile"
+            ],
+            "changed": -7
+        }
+    },
+    {
+        "event_id": "gen_death_war_appmentor",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 1,
+        "event_text": "r_c is killed by a o_c_n warrior in front of {PRONOUN/r_c/poss} apprentice, m_c.",
+        "m_c": {
+            "status": [
+                "apprentice"
+            ],
+            "relationship_status": ["app/mentor"],
+            "dies": false
+        },
+        "r_c": {
+            "status": [
+                "warrior", "deputy", "leader"
+            ],
+            "dies": true
+        },
+        "injury": [
+            {
+                "cats": ["m_c"],
+                "injuries": ["shock"]
+            }
+        ],
+        "history": [
+            {
+                "cats": [
+                    "r_c"
+                ],
+                "death": "m_c was killed in a battle with a warring Clan."
+            },
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "death": "m_c could not recover from the shock of {PRONOUN/m_c/poss} mentor being killed in front of {PRONOUN/m_c/object}."
+            }
+        ],
+        "other_clan": {
+            "current_rep": [
+                "hostile"
+            ],
+            "changed": -3
+        }
+    },
+    {
+        "event_id": "gen_death_war_mentorapp",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 1,
+        "event_text": "r_c is killed by a o_c_n warrior in front of {PRONOUN/r_c/poss} mentor, m_c.",
+        "m_c": {
+            "status": [
+                "warrior", "deputy", "leader"
+            ],
+            "relationship_status": ["mentor/app"],
+            "dies": false
+        },
+        "r_c": {
+            "status": ["apprentice"],
+            "dies": true
+        },
+        "history": [
+            {
+                "cats": [
+                    "r_c"
+                ],
+                "death": "m_c was killed in a battle with a warring Clan."
+            }
+        ],
+        "other_clan": {
+            "current_rep": [
+                "hostile"
+            ],
+            "changed": -5
+        }
+    },
+    {
+        "event_id": "gen_death_war_littermates",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 1,
+        "event_text": "r_c and m_c match each other blow for blow in a fight with a o_c_n patrol. The tide of battle turns against the littermates, and r_c is killed in front of m_c.",
+        "m_c": {
+            "status": [
+                "warrior", "apprentice", "deputy", "leader"
+            ],
+            "relationship_status": ["littermates", "trusts"],
+            "dies": false
+        },
+        "r_c": {
+            "status": ["warrior", "apprentice", "deputy", "leader"],
+            "dies": true
+        },
+        "injury": [
+            {
+                "cats": ["m_c"],
+                "injuries": ["shock"]
+            }
+        ],
+        "history": [
+            {
+                "cats": [
+                    "r_c"
+                ],
+                "death": "m_c was killed in a battle with a warring Clan."
+            },
+            {
+                "cats": ["m_c"],
+                "death": "m_c could not recover from the shock of seeing {PRONOUN/m_c/poss} littermate die in front of {PRONOUN/m_c/object}."
+            }
+        ],
+        "other_clan": {
+            "current_rep": [
+                "hostile"
+            ],
+            "changed": -3
+        }
+    },
+    {
+        "event_id": "gen_death_war_siblings",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 1,
+        "event_text": "m_c tries to protect {PRONOUN/m_c/poss} little sibling in a fight with o_c_n, but r_c is killed by enemy warriors.",
+        "m_c": {
+            "status": [
+                "warrior", "deputy", "leader"
+            ],
+            "age": ["young adult", "adult", "senior adult"],
+            "relationship_status": ["siblings"],
+            "dies": false
+        },
+        "r_c": {
+            "status": ["apprentice"],
+            "age": ["adolescent"],
+            "dies": true
+        },
+        "injury": [
+            {
+                "cats": ["m_c"],
+                "injuries": ["shock"]
+            }
+        ],
+        "history": [
+            {
+                "cats": [
+                    "r_c"
+                ],
+                "death": "m_c was killed in a battle with a warring Clan."
+            },
+            {
+                "cats": ["m_c"],
+                "death": "m_c could not recover from the shock of seeing {PRONOUN/m_c/poss} little sibling die in front of {PRONOUN/m_c/object}."
+            }
+        ],
+        "other_clan": {
+            "current_rep": [
+                "hostile"
+            ],
+            "changed": -5
+        }
+    },
+    {
+        "event_id": "gen_death_war_parentchild",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 1,
+        "event_text": "In a battle with o_c_n, m_c acts too late to save r_c and watches {PRONOUN/m_c/poss} kit die.",
+        "m_c": {
+            "status": [
+                "warrior", "deputy", "leader"
+            ],
+            "relationship_status": ["parent/child"],
+            "dies": false
+        },
+        "r_c": {
+            "status": ["warrior", "apprentice", "deputy", "leader"],
+            "dies": true
+        },
+        "injury": [
+            {
+                "cats": ["m_c"],
+                "injuries": ["shock"]
+            }
+        ],
+        "history": [
+            {
+                "cats": [
+                    "r_c"
+                ],
+                "death": "m_c was killed in a battle with a warring Clan."
+            },
+            {
+                "cats": ["m_c"],
+                "death": "m_c could not recover from the shock of seeing {PRONOUN/m_c/poss} kit die in front of {PRONOUN/m_c/object}."
+            }
+        ],
+        "other_clan": {
+            "current_rep": [
+                "hostile"
+            ],
+            "changed": -5
+        }
+    },
+    {
+        "event_id": "gen_death_war_childparent",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 1,
+        "event_text": "In a battle with o_c_n, m_c sees an enemy warrior kill {PRONOUN/m_c/poss} parent, r_c.",
+        "m_c": {
+            "status": [
+                "apprentice", "warrior", "deputy", "leader"
+            ],
+            "relationship_status": ["child/parent"],
+            "dies": false
+        },
+        "r_c": {
+            "status": ["warrior", "deputy", "leader"],
+            "dies": true
+        },
+        "injury": [
+            {
+                "cats": ["m_c"],
+                "injuries": ["shock"]
+            }
+        ],
+        "history": [
+            {
+                "cats": [
+                    "r_c"
+                ],
+                "death": "m_c was killed in a battle with a warring Clan."
+            },
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "death": "m_c could not recover from the shock of seeing {PRONOUN/m_c/poss} parent be killed in front of {PRONOUN/m_c/object}."
+            }
+        ],
+        "other_clan": {
+            "current_rep": [
+                "hostile"
+            ],
+            "changed": -5
+        }
+    },
+    {
+        "event_id": "gen_death_war_mates1",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 1,
+        "event_text": "In the haze of battle, m_c is separated from r_c. When the dust settles, {PRONOUN/m_c/subject} {VERB/m_c/find/finds} r_c's cooling body.",
+        "m_c": {
+            "status": [
+                "warrior", "deputy", "leader"
+            ],
+            "relationship_status": ["mates"],
+            "dies": false
+        },
+        "r_c": {
+            "status": ["warrior", "deputy", "leader"],
+            "dies": true
+        },
+        "injury": [
+            {
+                "cats": ["m_c"],
+                "injuries": ["shock"]
+            }
+        ],
+        "history": [
+            {
+                "cats": [
+                    "r_c"
+                ],
+                "death": "m_c was killed in a battle with a warring Clan."
+            },
+            {
+                "cats": ["m_c"],
+                "death": "m_c could not recover from the shock of finding {PRONOUN/m_c/poss} mate's body after a battle with o_c_n."
+            }
+        ],
+        "other_clan": {
+            "current_rep": [
+                "hostile"
+            ],
+            "changed": -5
+        }
+    },
+    {
+        "event_id": "gen_death_war_mates2",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 1,
+        "event_text": "As r_c leaves camp with the battle patrol, m_c pleads for {PRONOUN/r_c/object} to return to {PRONOUN/m_c/object} safely. r_c does not keep {PRONOUN/r_c/poss} promise.",
+        "m_c": {
+            "status": [
+                "any"
+            ],
+            "relationship_status": ["mates"],
+            "dies": false
+        },
+        "r_c": {
+            "status": ["warrior", "deputy", "leader"],
+            "dies": true
+        },
+        "history": [
+            {
+                "cats": [
+                    "r_c"
+                ],
+                "death": "m_c was killed in a battle with a warring Clan."
+            }
+        ],
+        "other_clan": {
+            "current_rep": [
+                "hostile"
+            ],
+            "changed": -5
+        }
+    },
+    {
+        "event_id": "gen_death_war_mates3",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 1,
+        "event_text": "In a battle with o_c_n, m_c's mate r_c is killed. m_c vows the war will never end until o_c_n pays.",
+        "m_c": {
+            "status": [
+                "leader"
+            ],
+            "relationship_status": ["mates"],
+            "dies": false
+        },
+        "r_c": {
+            "status": ["warrior", "deputy"],
+            "dies": true
+        },
+        "history": [
+            {
+                "cats": [
+                    "r_c"
+                ],
+                "death": "m_c was killed in a battle with a warring Clan."
+            }
+        ],
+        "other_clan": {
+            "current_rep": [
+                "any"
+            ],
+            "changed": -15
+        }
+    },
+    {
+        "event_id": "gen_death_war_mates4",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 1,
+        "event_text": "Despite m_c's talent in battle, {PRONOUN/m_c/subject} and r_c are overwhelmed by waves of invading o_c_n warriors. Three hold m_c down as a fourth kills r_c in front of {PRONOUN/m_c/object}.",
+        "m_c": {
+            "status": [
+                "warrior", "deputy", "leader"
+            ],
+            "skill": ["FIGHTER,1"],
+            "relationship_status": ["mates"],
+            "dies": false
+        },
+        "r_c": {
+            "status": ["warrior", "deputy", "leader"],
+            "dies": true
+        },
+        "injury": [
+            {
+                "cats": ["m_c"],
+                "injuries": ["battle_injury", "shock"]
+            }
+        ],
+        "history": [
+            {
+                "cats": [
+                    "r_c"
+                ],
+                "death": "m_c was killed in a battle with a warring Clan."
+            },
+            {
+                "cats": ["m_c"],
+                "death": "m_c died after a battle in which an enemy Clan's warriors killed {RPONOUN/m_c/poss} mate in front of {PRONOUN/m_c/object}."
+            }
+        ],
+        "other_clan": {
+            "current_rep": [
+                "hostile"
+            ],
+            "changed": -7
+        }
+    },
+    {
+        "event_id": "gen_death_war_mates5",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "tags": ["lives_remain"],
+        "frequency": 1,
+        "event_text": "m_c loses a life in battle with o_c_n. r_c questions whether {PRONOUN/r_c/subject} can be {PRONOUN/m_c/poss} mate, knowing that {PRONOUN/r_c/subject}'ll have to lose m_c over and over again.",
+        "m_c": {
+            "status": [
+                "leader"
+            ],
+            "relationship_status": ["mates"],
+            "dies": true
+        },
+        "r_c": {
+            "status": ["any"],
+            "dies": false
+        },
+        "history": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "death": "m_c was killed in a battle with a warring Clan."
+            }
+        ],
+        "relationships": [
+            {
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["romance"],
+                "amount": -15,
+                "mutual": false,
+                "log": {
+                    "cats_from": "cat_from seriously questioned {PRONOUN/cat_from/poss} relationship with cat_to after cat_to lost a life in battle."
+                }
+            }
+        ],
+        "other_clan": {
+            "current_rep": [
+                "hostile"
+            ],
+            "changed": -7
+        }
+    },
+    {
         "event_id": "gen_death_age_any1",
         "location": [
             "any"

--- a/resources/lang/en/events/injury/general.json
+++ b/resources/lang/en/events/injury/general.json
@@ -8354,7 +8354,7 @@
         "sub_type": [
             "war"
         ],
-        "frequency": 1,
+        "frequency": 2,
         "event_text": "When a fight breaks out between c_n and o_c_n, m_c fights to protect {PRONOUN/m_c/poss} apprentice, r_c, from the enemy Clan.",
         "m_c": {
             "status": [
@@ -8418,7 +8418,7 @@
         "sub_type": [
             "war"
         ],
-        "frequency": 1,
+        "frequency": 2,
         "event_text": "r_c and m_c match each other blow for blow in a fight with a o_c_n patrol. Though they are wounded, they protect each other.",
         "m_c": {
             "status": [
@@ -8476,7 +8476,7 @@
         "sub_type": [
             "war"
         ],
-        "frequency": 1,
+        "frequency": 2,
         "event_text": "m_c protects {PRONOUN/m_c/poss} little sibling, r_c, in a fight with o_c_n.",
         "m_c": {
             "status": [
@@ -8540,31 +8540,31 @@
         "sub_type": [
             "war"
         ],
-        "frequency": 1,
-        "event_text": "In a battle with o_c_n, m_c hauls an enemy warrior off r_c with the ferocity only a parent can show.",
+        "frequency": 2,
+        "event_text": "In a battle with o_c_n, r_c hauls an enemy warrior off m_c with the ferocity only a parent can show.",
         "m_c": {
             "status": [
-                "warrior", "deputy", "leader"
+                "warrior", "apprentice", "deputy", "leader"
             ],
-            "relationship_status": ["parent/child", "cherishes"],
+            "relationship_status": ["child/parent", "cherishes"],
             "dies": false
         },
         "r_c": {
-            "status": ["warrior", "apprentice", "deputy", "leader"],
+            "status": ["warrior", "deputy", "leader"],
             "dies": false
         },
         "injury": [
             {
                 "cats": [
-                    "r_c"
+                    "m_c"
                 ],
                 "injuries": ["minor_injury"]
             }
         ],
         "relationships": [
             {
-                "cats_from": ["r_c"],
-                "cats_to": ["m_c"],
+                "cats_from": ["m_c"],
+                "cats_to": ["r_c"],
                 "values": ["respect", "trust"],
                 "amount": 15,
                 "mutual": false,
@@ -8591,7 +8591,7 @@
         "sub_type": [
             "war"
         ],
-        "frequency": 1,
+        "frequency": 2,
         "event_text": "In a battle with o_c_n, m_c sees an enemy warrior attack {PRONOUN/m_c/poss} parent, r_c. m_c leaps to r_c's defense and saves {PRONOUN/m_c/poss} life.",
         "m_c": {
             "status": [
@@ -8642,7 +8642,7 @@
         "sub_type": [
             "war"
         ],
-        "frequency": 1,
+        "frequency": 2,
         "event_text": "In a battle with o_c_n, {PRONOUN/m_c/subject} {VERB/m_c/save/saves} r_c's life. {PRONOUN/m_c/poss/CAP} mate is amazed by {PRONOUN/m_c/poss} skill in battle, and both cats escape with barely a scratch.",
         "m_c": {
             "status": [
@@ -8694,13 +8694,13 @@
         "sub_type": [
             "war"
         ],
-        "frequency": 1,
+        "frequency": 2,
         "event_text": "m_c defends r_c in a fight with o_c_n, heedless of {PRONOUN/m_c/poss} own injuries.",
         "m_c": {
             "status": [
                 "warrior", "deputy", "leader"
             ],
-            "relationship_status": ["mates"],
+            "relationship_status": ["adores"],
             "dies": false
         },
         "r_c": {

--- a/resources/lang/en/events/injury/general.json
+++ b/resources/lang/en/events/injury/general.json
@@ -6389,7 +6389,7 @@
         ]
     },
     {
-        "event_id": "gen_death_drownedbyaduck",
+        "event_id": "gen_injury_drownedbyaduck",
         "location": ["beach", "forest", "wetlands"],
         "season": ["-leaf-bare"],
         "sub_type": [],
@@ -8340,6 +8340,397 @@
         ],
         "other_clan": {
             "current_rep": ["any"],
+            "changed": -2
+        }
+    },
+    {
+        "event_id": "gen_injury_war_minorbattle_mentorapp",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 1,
+        "event_text": "When a fight breaks out between c_n and o_c_n, m_c fights to protect {PRONOUN/m_c/poss} apprentice, r_c, from the enemy Clan.",
+        "m_c": {
+            "status": [
+                "warrior", "deputy", "leader"
+            ],
+            "relationship_status": ["mentor/app"],
+            "dies": false
+        },
+        "r_c": {
+            "status": ["apprentice"],
+            "dies": false
+        },
+        "injury": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "injuries": ["battle_injury"]
+            },
+            {
+                "cats": [
+                    "r_c"
+                ],
+                "injuries": ["minor_injury"]
+            }
+        ],
+        "relationships": [
+            {
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["respect", "trust"],
+                "amount": 15,
+                "mutual": false,
+                "log": {
+                    "cats_from": "cat_to protected cat_from in a fight with a warring Clan."
+                }
+            }
+        ],
+        "other_clan": {
+            "current_rep": [
+                "hostile"
+            ],
+            "changed": -2
+        }
+    },
+    {
+        "event_id": "gen_injury_war_minorbattle_littermates",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 1,
+        "event_text": "r_c and m_c match each other blow for blow in a fight with a o_c_n patrol. Though they are wounded, they protect each other.",
+        "m_c": {
+            "status": [
+                "warrior", "apprentice", "deputy", "leader"
+            ],
+            "relationship_status": ["littermates"],
+            "dies": false
+        },
+        "r_c": {
+            "status": ["warrior", "apprentice", "deputy", "leader"],
+            "dies": false
+        },
+        "injury": [
+            {
+                "cats": ["r_c", "m_c"],
+                "injuries": ["battle_injury", "minor_injury"]
+            }
+        ],
+        "history": [
+            {
+                "cats": [
+                    "m_c", "r_c"
+                ],
+                "scar": "m_c was scarred in a battle with a warring Clan.",
+                "death": "m_c died of {PRONOUN/m_c/poss} injuries after a battle with a warring Clan."
+            }
+        ],
+        "relationships": [
+            {
+                "cats_from": ["m_c"],
+                "cats_to": ["r_c"],
+                "mutual": true,
+                "values": ["trust"],
+                "amount": 15,
+                "log": {
+                    "cats_from": "cat_from and cat_to fought side by side in a battle against a warring Clan."
+                }
+            }
+        ],
+        "other_clan": {
+            "current_rep": [
+                "hostile"
+            ],
+            "changed": -3
+        }
+    },
+    {
+        "event_id": "gen_injury_war_siblings",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 1,
+        "event_text": "m_c protects {PRONOUN/m_c/poss} little sibling r_c in a fight with o_c_n..",
+        "m_c": {
+            "status": [
+                "warrior", "deputy", "leader"
+            ],
+            "age": ["young adult", "adult", "senior adult"],
+            "relationship_status": ["siblings"],
+            "dies": false
+        },
+        "r_c": {
+            "status": ["apprentice"],
+            "age": ["adolescent"],
+            "dies": false
+        },
+        "injury": [
+            {
+                "cats": ["m_c"],
+                "injuries": ["battle_injury"]
+            },
+            {
+                "cats": ["r_c"],
+                "injuries": ["minor_injury"]
+            }
+        ],
+        "history": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "scar": "m_c was scarred in a battle with a warring Clan",
+                "death": "m_c died of {PRONOUN/m_c/poss} injuries after a battle with a warring Clan."
+            }
+        ],
+        "relationships": [
+            {
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "mutual": false,
+                "values": ["trust", "respect"],
+                "amount": 15,
+                "log": {
+                    "cats_from": "cat_to protected cat_from in a fight with an enemy Clan."
+                }
+            }
+        ],
+        "other_clan": {
+            "current_rep": [
+                "hostile"
+            ],
+            "changed": -2
+        }
+    },
+    {
+        "event_id": "gen_injury_war_minorinjury_parentchild",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 1,
+        "event_text": "In a battle with o_c_n, m_c hauls an enemy warrior off r_c with the ferocity only a parent can show.",
+        "m_c": {
+            "status": [
+                "warrior", "deputy", "leader"
+            ],
+            "relationship_status": ["parent/child", "cherishes"],
+            "dies": false
+        },
+        "r_c": {
+            "status": ["warrior", "apprentice", "deputy", "leader"],
+            "dies": false
+        },
+        "injury": [
+            {
+                "cats": [
+                    "r_c"
+                ],
+                "injuries": ["minor_injury"]
+            }
+        ],
+        "relationships": [
+            {
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["respect", "trust"],
+                "amount": 15,
+                "mutual": false,
+                "log": {
+                    "cats_from": "cat_to saved cat_from in a fight with a warring Clan."
+                }
+            }
+        ],
+        "other_clan": {
+            "current_rep": [
+                "hostile"
+            ],
+            "changed": -5
+        }
+    },
+    {
+        "event_id": "gen_injury_war_minorbattle_childparent",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 1,
+        "event_text": "In a battle with o_c_n, m_c sees an enemy warrior attack {PRONOUN/m_c/poss} parent, r_c. m_c leaps to r_c's defense and saves {PRONOUN/m_c/poss} life.",
+        "m_c": {
+            "status": [
+                "apprentice", "warrior", "deputy", "leader"
+            ],
+            "relationship_status": ["child/parent", "cherishes"],
+            "dies": false
+        },
+        "r_c": {
+            "status": ["warrior", "deputy", "leader"],
+            "dies": false
+        },
+        "injury": [
+            {
+                "cats": [
+                    "r_c", "m_c"
+                ],
+                "injuries": ["battle_injury", "minor_injury"]
+            }
+        ],
+        "relationships": [
+            {
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["respect", "trust"],
+                "amount": 15,
+                "mutual": false,
+                "log": {
+                    "cats_from": "cat_to saved cat_from in a fight with a warring Clan."
+                }
+            }
+        ],
+        "other_clan": {
+            "current_rep": [
+                "hostile"
+            ],
+            "changed": -5
+        }
+    },
+    {
+        "event_id": "gen_injury_war_minorinjury_mates",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 1,
+        "event_text": "In a battle with o_c_n, {PRONOUN/m_c/subject} {VERB/m_c/save/saves} r_c's life. {PRONOUN/m_c/poss/CAP} mate is amazed by {PRONOUN/m_c/poss} skill in battle, and both cats escape with barely a scratch.",
+        "m_c": {
+            "status": [
+                "warrior", "deputy", "leader"
+            ],
+            "skill": ["FIGHTER,1"],
+            "relationship_status": ["mates"],
+            "dies": false
+        },
+        "r_c": {
+            "status": ["warrior", "deputy", "leader"],
+            "dies": false
+        },
+        "injury": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "injuries": ["minor_injury"]
+            }
+        ],
+        "relationships": [
+            {
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "mutual": false,
+                "values": ["trust", "romance"],
+                "amount": 15,
+                "log": {
+                    "cats_from": "cat_to's skill in battle saved {PRONOUN/cat_to/poss} mate, cat_from, from injury."
+                }
+            }
+        ],
+        "other_clan": {
+            "current_rep": [
+                "hostile"
+            ],
+            "changed": -1
+        }
+    },
+    {
+        "event_id": "gen_injury_war_battleinjury_mates",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 1,
+        "event_text": "m_c defends r_c in a fight with o_c_n, heedless of {PRONOUN/m_c/poss} own injuries.",
+        "m_c": {
+            "status": [
+                "warrior", "deputy", "leader"
+            ],
+            "relationship_status": ["mates"],
+            "dies": false
+        },
+        "r_c": {
+            "status": ["warrior", "deputy", "leader"],
+            "dies": false
+        },
+        "injury": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "injuries": ["battle_injury"]
+            }
+        ],
+        "history": [
+            {
+                "cats": ["m_c"],
+                "scar": "m_c was scarred in a battle with an enemy Clan while defending {PRONOUN/m_c/poss} mate.",
+                "death": "m_c died of injuries sustained protecting {PRONOUN/m_c/poss} mate from an enemy Clan."
+            }
+        ],
+        "relationships": [
+            {
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "mutual": false,
+                "values": ["trust", "romance"],
+                "amount": 15,
+                "log": {
+                    "cats_from": "cat_to defended cat_from in a battle with an enemy Clan."
+                }
+            }
+        ],
+        "other_clan": {
+            "current_rep": [
+                "hostile"
+            ],
             "changed": -2
         }
     },

--- a/resources/lang/en/events/injury/general.json
+++ b/resources/lang/en/events/injury/general.json
@@ -6389,7 +6389,7 @@
         ]
     },
     {
-        "event_id": "gen_death_drownedbyaduck",
+        "event_id": "gen_injury_drownedbyaduck",
         "location": ["beach", "forest", "wetlands"],
         "season": ["-leaf-bare"],
         "sub_type": [],
@@ -8074,6 +8074,397 @@
         "other_clan": {
             "current_rep": ["hostile"],
             "changed": -1
+        }
+    },
+    {
+        "event_id": "gen_injury_war_minorbattle_mentorapp",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 1,
+        "event_text": "When a fight breaks out between c_n and o_c_n, m_c fights to protect {PRONOUN/m_c/poss} apprentice, r_c, from the enemy Clan.",
+        "m_c": {
+            "status": [
+                "warrior", "deputy", "leader"
+            ],
+            "relationship_status": ["mentor/app"],
+            "dies": false
+        },
+        "r_c": {
+            "status": ["apprentice"],
+            "dies": false
+        },
+        "injury": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "injuries": ["battle_injury"]
+            },
+            {
+                "cats": [
+                    "r_c"
+                ],
+                "injuries": ["minor_injury"]
+            }
+        ],
+        "relationships": [
+            {
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["respect", "trust"],
+                "amount": 15,
+                "mutual": false,
+                "log": {
+                    "cats_from": "cat_to protected cat_from in a fight with a warring Clan."
+                }
+            }
+        ],
+        "other_clan": {
+            "current_rep": [
+                "hostile"
+            ],
+            "changed": -2
+        }
+    },
+    {
+        "event_id": "gen_injury_war_minorbattle_littermates",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 1,
+        "event_text": "r_c and m_c match each other blow for blow in a fight with a o_c_n patrol. Though they are wounded, they protect each other.",
+        "m_c": {
+            "status": [
+                "warrior", "apprentice", "deputy", "leader"
+            ],
+            "relationship_status": ["littermates"],
+            "dies": false
+        },
+        "r_c": {
+            "status": ["warrior", "apprentice", "deputy", "leader"],
+            "dies": false
+        },
+        "injury": [
+            {
+                "cats": ["r_c", "m_c"],
+                "injuries": ["battle_injury", "minor_injury"]
+            }
+        ],
+        "history": [
+            {
+                "cats": [
+                    "m_c", "r_c"
+                ],
+                "scar": "m_c was scarred in a battle with a warring Clan.",
+                "death": "m_c died of {PRONOUN/m_c/poss} injuries after a battle with a warring Clan."
+            }
+        ],
+        "relationships": [
+            {
+                "cats_from": ["m_c"],
+                "cats_to": ["r_c"],
+                "mutual": true,
+                "values": ["trust"],
+                "amount": 15,
+                "log": {
+                    "cats_from": "cat_from and cat_to fought side by side in a battle against a warring Clan."
+                }
+            }
+        ],
+        "other_clan": {
+            "current_rep": [
+                "hostile"
+            ],
+            "changed": -3
+        }
+    },
+    {
+        "event_id": "gen_injury_war_siblings",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 1,
+        "event_text": "m_c protects {PRONOUN/m_c/poss} little sibling r_c in a fight with o_c_n..",
+        "m_c": {
+            "status": [
+                "warrior", "deputy", "leader"
+            ],
+            "age": ["young adult", "adult", "senior adult"],
+            "relationship_status": ["siblings"],
+            "dies": false
+        },
+        "r_c": {
+            "status": ["apprentice"],
+            "age": ["adolescent"],
+            "dies": false
+        },
+        "injury": [
+            {
+                "cats": ["m_c"],
+                "injuries": ["battle_injury"]
+            },
+            {
+                "cats": ["r_c"],
+                "injuries": ["minor_injury"]
+            }
+        ],
+        "history": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "scar": "m_c was scarred in a battle with a warring Clan",
+                "death": "m_c died of {PRONOUN/m_c/poss} injuries after a battle with a warring Clan."
+            }
+        ],
+        "relationships": [
+            {
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "mutual": false,
+                "values": ["trust", "respect"],
+                "amount": 15,
+                "log": {
+                    "cats_from": "cat_to protected cat_from in a fight with an enemy Clan."
+                }
+            }
+        ],
+        "other_clan": {
+            "current_rep": [
+                "hostile"
+            ],
+            "changed": -2
+        }
+    },
+    {
+        "event_id": "gen_injury_war_minorinjury_parentchild",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 1,
+        "event_text": "In a battle with o_c_n, m_c hauls an enemy warrior off r_c with the ferocity only a parent can show.",
+        "m_c": {
+            "status": [
+                "warrior", "deputy", "leader"
+            ],
+            "relationship_status": ["parent/child", "cherishes"],
+            "dies": false
+        },
+        "r_c": {
+            "status": ["warrior", "apprentice", "deputy", "leader"],
+            "dies": false
+        },
+        "injury": [
+            {
+                "cats": [
+                    "r_c"
+                ],
+                "injuries": ["minor_injury"]
+            }
+        ],
+        "relationships": [
+            {
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["respect", "trust"],
+                "amount": 15,
+                "mutual": false,
+                "log": {
+                    "cats_from": "cat_to saved cat_from in a fight with a warring Clan."
+                }
+            }
+        ],
+        "other_clan": {
+            "current_rep": [
+                "hostile"
+            ],
+            "changed": -5
+        }
+    },
+    {
+        "event_id": "gen_injury_war_minorbattle_childparent",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 1,
+        "event_text": "In a battle with o_c_n, m_c sees an enemy warrior attack {PRONOUN/m_c/poss} parent, r_c. m_c leaps to r_c's defense and saves {PRONOUN/m_c/poss} life.",
+        "m_c": {
+            "status": [
+                "apprentice", "warrior", "deputy", "leader"
+            ],
+            "relationship_status": ["child/parent", "cherishes"],
+            "dies": false
+        },
+        "r_c": {
+            "status": ["warrior", "deputy", "leader"],
+            "dies": false
+        },
+        "injury": [
+            {
+                "cats": [
+                    "r_c", "m_c"
+                ],
+                "injuries": ["battle_injury", "minor_injury"]
+            }
+        ],
+        "relationships": [
+            {
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["respect", "trust"],
+                "amount": 15,
+                "mutual": false,
+                "log": {
+                    "cats_from": "cat_to saved cat_from in a fight with a warring Clan."
+                }
+            }
+        ],
+        "other_clan": {
+            "current_rep": [
+                "hostile"
+            ],
+            "changed": -5
+        }
+    },
+    {
+        "event_id": "gen_injury_war_minorinjury_mates",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 1,
+        "event_text": "In a battle with o_c_n, {PRONOUN/m_c/subject} {VERB/m_c/save/saves} r_c's life. {PRONOUN/m_c/poss/CAP} mate is amazed by {PRONOUN/m_c/poss} skill in battle, and both cats escape with barely a scratch.",
+        "m_c": {
+            "status": [
+                "warrior", "deputy", "leader"
+            ],
+            "skill": ["FIGHTER,1"],
+            "relationship_status": ["mates"],
+            "dies": false
+        },
+        "r_c": {
+            "status": ["warrior", "deputy", "leader"],
+            "dies": false
+        },
+        "injury": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "injuries": ["minor_injury"]
+            }
+        ],
+        "relationships": [
+            {
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "mutual": false,
+                "values": ["trust", "romance"],
+                "amount": 15,
+                "log": {
+                    "cats_from": "cat_to's skill in battle saved {PRONOUN/cat_to/poss} mate, cat_from, from injury."
+                }
+            }
+        ],
+        "other_clan": {
+            "current_rep": [
+                "hostile"
+            ],
+            "changed": -1
+        }
+    },
+    {
+        "event_id": "gen_injury_war_battleinjury_mates",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 1,
+        "event_text": "m_c defends r_c in a fight with o_c_n, heedless of {PRONOUN/m_c/poss} own injuries.",
+        "m_c": {
+            "status": [
+                "warrior", "deputy", "leader"
+            ],
+            "relationship_status": ["mates"],
+            "dies": false
+        },
+        "r_c": {
+            "status": ["warrior", "deputy", "leader"],
+            "dies": false
+        },
+        "injury": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "injuries": ["battle_injury"]
+            }
+        ],
+        "history": [
+            {
+                "cats": ["m_c"],
+                "scar": "m_c was scarred in a battle with an enemy Clan while defending {PRONOUN/m_c/poss} mate.",
+                "death": "m_c died of injuries sustained protecting {PRONOUN/m_c/poss} mate from an enemy Clan."
+            }
+        ],
+        "relationships": [
+            {
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "mutual": false,
+                "values": ["trust", "romance"],
+                "amount": 15,
+                "log": {
+                    "cats_from": "cat_to defended cat_from in a battle with an enemy Clan."
+                }
+            }
+        ],
+        "other_clan": {
+            "current_rep": [
+                "hostile"
+            ],
+            "changed": -2
         }
     },
     {

--- a/resources/lang/en/events/injury/general.json
+++ b/resources/lang/en/events/injury/general.json
@@ -8470,7 +8470,7 @@
             "war"
         ],
         "frequency": 1,
-        "event_text": "m_c protects {PRONOUN/m_c/poss} little sibling r_c in a fight with o_c_n..",
+        "event_text": "m_c protects {PRONOUN/m_c/poss} little sibling r_c in a fight with o_c_n.",
         "m_c": {
             "status": [
                 "warrior", "deputy", "leader"

--- a/resources/lang/en/events/injury/general.json
+++ b/resources/lang/en/events/injury/general.json
@@ -8381,6 +8381,13 @@
                 "injuries": ["minor_injury"]
             }
         ],
+        "history": [
+            {
+                "cats": ["m_c"],
+                "scar": "m_c was scarred after defending {PRONOUN/m_c/poss} apprentice in a battle with an enemy Clan.",
+                "death": "m_c died of {PRONOUN/m_c/poss} injuries after defending {PRONOUN/m_c/poss} apprentice in a battle with an enemy Clan."
+            }
+        ],
         "relationships": [
             {
                 "cats_from": ["r_c"],

--- a/resources/lang/en/events/injury/general.json
+++ b/resources/lang/en/events/injury/general.json
@@ -8477,7 +8477,7 @@
             "war"
         ],
         "frequency": 1,
-        "event_text": "m_c protects {PRONOUN/m_c/poss} little sibling r_c in a fight with o_c_n.",
+        "event_text": "m_c protects {PRONOUN/m_c/poss} little sibling, r_c, in a fight with o_c_n.",
         "m_c": {
             "status": [
                 "warrior", "deputy", "leader"

--- a/resources/lang/en/events/injury/general.json
+++ b/resources/lang/en/events/injury/general.json
@@ -8192,7 +8192,7 @@
         }
     },
     {
-        "event_id": "gen_injury_war_siblings",
+        "event_id": "gen_injury_war_battleinjury_siblings",
         "location": [
             "any"
         ],
@@ -8203,7 +8203,7 @@
             "war"
         ],
         "frequency": 1,
-        "event_text": "m_c protects {PRONOUN/m_c/poss} little sibling r_c in a fight with o_c_n..",
+        "event_text": "m_c protects {PRONOUN/m_c/poss} little sibling r_c in a fight with o_c_n.",
         "m_c": {
             "status": [
                 "warrior", "deputy", "leader"

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -11422,7 +11422,7 @@
             "relationship_status": ["parent/child"]
         },
         "r_c": {
-            "status": ["apprentice"]
+            "status": ["apprentice", "kitten"]
         },
         "relationships": [
             {

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -11329,6 +11329,155 @@
         }
     },
     {
+        "event_id": "gen_misc_war_leadermate",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "exclude_involved": ["r_c"],
+        "frequency": 1,
+        "event_text": "Resentment builds as the Clan notices that m_c is almost never assigned to battle patrols.",
+        "m_c": {
+            "status": ["warrior", "deputy"],
+            "relationship_status": ["mates"]
+        },
+        "r_c": {
+            "status": ["leader"],
+            "trait": ["-wise", "-compassionate", "-responsible", "-strict", "-righteous"]
+        },
+        "relationships": [
+            {
+                "cats_from": ["clan", "high_aggress"],
+                "cats_to": ["m_c"],
+                "values": ["respect"],
+                "amount": -15,
+                "log": {
+                    "cats_from": "cat_from suspected cat_to was being spared from battle patrols because {PRONOUN/cat_to/subject}{VERB/cat_to/'re/'s} the leader's mate."
+                }
+            },
+            {
+                "cats_from": ["clan", "high_aggress"],
+                "cats_to": ["r_c"],
+                "values": ["respect"],
+                "amount": -15,
+                "log": {
+                    "cats_from": "cat_from suspected cat_to was sparing {PRONOUN/cat_to/poss} mate from battle patrols."
+                }
+            }
+        ]
+    },
+    {
+        "event_id": "gen_misc_war_matesworried",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 3,
+        "event_text": "m_c and r_c fear for each other and their shared future as the war with o_c_n rages on.",
+        "m_c": {
+            "status": ["any"],
+            "relationship_status": ["mates"]
+        },
+        "r_c": {
+            "status": ["any"]
+        },
+        "relationships": [
+            {
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["romance"],
+                "mutual": true,
+                "amount": 10,
+                "log": {
+                    "cats_from": "cat_from and cat_to feared for each other during a war."
+                }
+            }
+        ]
+    },
+    {
+        "event_id": "gen_misc_war_parentchild",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 3,
+        "event_text": "m_c promises r_c that {PRONOUN/m_c/subject} will protect {PRONOUN/r_c/object} from o_c_n.",
+        "m_c": {
+            "status": ["any"],
+            "relationship_status": ["parent/child"]
+        },
+        "r_c": {
+            "status": ["apprentice"]
+        },
+        "relationships": [
+            {
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["trust"],
+                "mutual": false,
+                "amount": 15,
+                "log": {
+                    "cats_from": "cat_to promised to protect cat_from from o_c_n."
+                }
+            }
+        ]
+    },
+    {
+        "event_id": "gen_misc_war_bloodthirstykitmurderer",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 1,
+        "event_text": "m_c returns from a raid on o_c_n's camp with kit-blood on {PRONOUN/m_c/poss} claws.",
+        "m_c": {
+            "status": ["warrior", "deputy", "leader"],
+            "trait": ["bloodthirsty"]
+        },
+        "relationships": [
+            {
+                "cats_from": ["clan", "high_social"],
+                "cats_to": ["m_c"],
+                "values": ["comfort"],
+                "mutual": false,
+                "amount": -20,
+                "log": {
+                    "cats_from": "cat_from was disturbed by the extreme lengths cat_to went to during a war."
+                }
+            },
+            {
+                "cats_from": ["clan", "high_aggress", "low_lawful", "low_stable", "low_social"],
+                "cats_to": ["m_c"],
+                "values": ["respect"],
+                "mutual": true,
+                "amount": 10,
+                "log": {
+                    "cats_from": "cat_from defended cat_to's extreme actions during a war with o_c_n."
+                }
+            }
+        ]
+    },
+    {
         "event_id": "gen_misc_failedmurder1",
         "location": [
             "any"

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -11475,7 +11475,11 @@
                     "cats_from": "cat_from defended cat_to's extreme actions during a war with o_c_n."
                 }
             }
-        ]
+        ],
+        "other_clan": {
+            "current_rep": ["hostile"],
+            "changed": -8
+        }
     },
     {
         "event_id": "gen_misc_failedmurder1",


### PR DESCRIPTION
## About The Pull Request

Tug on those heart strings in 23 new ways:

gen_injury_war_minorbattle_mentorapp
gen_injury_war_minorbattle_littermates
gen_injury_war_battleinjury_siblings
gen_injury_war_minorinjury_parentchild
gen_injury_war_minorbattle_childparent
gen_injury_war_minorinjury_mates
gen_injury_war_battleinjury_mates
gen_misc_war_leadermate
gen_misc_war_matesworried
gen_misc_war_parentchild
gen_misc_war_bloodthirstykitmurderer
gen_death_war_fearlesskitten
gen_death_war_appmentor
gen_death_war_mentorapp
gen_death_war_littermates
gen_death_war_siblings
gen_death_war_parentchild
gen_death_war_childparent
gen_death_war_mates1
gen_death_war_mates2
gen_death_war_mates3
gen_death_war_mates4
gen_death_war_mates5

## Why This Is Good For ClanGen

Spruces up war. Also, I can't believe we haven't been using the relationship tags for pathos.

## Proof of Testing

<img width="775" height="152" alt="image" src="https://github.com/user-attachments/assets/8dbdd0c9-3eca-4c02-b76a-9ae94bd22145" />

<img width="776" height="157" alt="image" src="https://github.com/user-attachments/assets/e1405f22-7f6f-414d-8f5d-d07ff0746ffd" />

<img width="772" height="154" alt="image" src="https://github.com/user-attachments/assets/ee5cc92a-538a-4942-86ca-1fb37be7254e" />

<img width="771" height="191" alt="image" src="https://github.com/user-attachments/assets/3dc8ea9f-2a90-421e-9bb0-3948d9b7b95f" />
