### PR TITLE
[CONTENT] OtherClan Exile Events

### DIFF
--- a/resources/lang/en/events/new_cat/general.json
+++ b/resources/lang/en/events/new_cat/general.json
@@ -2260,7 +2260,7 @@
   "new_cat": [
     [
       "former clancat",
-      "status:warrior",
+      "status:medicine cat",
       "meeting",
       "unknown",
       "backstory:disgraced2, disgraced3",

--- a/resources/lang/en/events/new_cat/general.json
+++ b/resources/lang/en/events/new_cat/general.json
@@ -2147,5 +2147,173 @@
         "current_rep": ["neutral", "welcoming"],
         "changed": 2
     }
+},
+{
+  "event_id": "gen_new_cat_otherclanexile1_unknown",
+  "location": [
+    "any"
+  ],
+  "season": [
+    "any"
+  ],
+  "tags": [],
+  "exclude_involved": [
+    "m_c",
+    "r_c",
+    "n_c:0"
+  ],
+  "frequency": 2,
+  "event_text": "At the Gathering, o_c_n's leader announces they have exiled a warrior for an unforgivable crime. They advise the other Clans to keep their guards up.",
+  "m_c": {
+    "age": [
+      "adolescent",
+      "young adult",
+      "adult",
+      "senior adult",
+      "senior"
+    ]
+  },
+  "new_cat": [
+    [
+      "former clancat",
+      "status:warrior",
+      "meeting",
+      "unknown",
+      "backstory:disgraced1, disgraced2",
+      "new_name"
+    ]
+  ],
+  "other_clan": {
+    "current_rep": [
+      "any"
+    ],
+    "changed": 0
+  }
+},
+{
+  "event_id": "gen_new_cat_otherclanexile2_unknown",
+  "location": [
+    "any"
+  ],
+  "season": [
+    "any"
+  ],
+  "tags": [],
+  "exclude_involved": [
+    "m_c",
+    "r_c",
+    "n_c:0"
+  ],
+  "frequency": 1,
+  "event_text": "At the Gathering, o_c_n's deputy takes their place among the other leaders and declares the previous leader was driven out, but may still stalk the borders.",
+  "m_c": {
+    "age": [
+      "adolescent",
+      "young adult",
+      "adult",
+      "senior adult",
+      "senior"
+    ]
+  },
+  "new_cat": [
+    [
+      "former clancat",
+      "status:warrior",
+      "meeting",
+      "unknown",
+      "backstory:disgraced3",
+      "new_name"
+    ]
+  ],
+  "other_clan": {
+    "current_rep": [
+      "any"
+    ],
+    "changed": 0
+  }
+},
+{
+  "event_id": "gen_new_cat_otherclanexile3_unknown",
+  "location": [
+    "any"
+  ],
+  "season": [
+    "any"
+  ],
+  "tags": [],
+  "exclude_involved": [
+    "m_c",
+    "r_c",
+    "n_c:0"
+  ],
+  "frequency": 1,
+  "event_text": "At the Gathering, o_c_n's leader announces their medicine cat has been exiled for a terrible transgression. They warn the other Clans that the exiled cat is not to be trusted and should be killed on sight.",
+  "m_c": {
+    "age": [
+      "adolescent",
+      "young adult",
+      "adult",
+      "senior adult",
+      "senior"
+    ]
+  },
+  "new_cat": [
+    [
+      "former clancat",
+      "status:warrior",
+      "meeting",
+      "unknown",
+      "backstory:disgraced2, disgraced3",
+      "new_name"
+    ]
+  ],
+  "other_clan": {
+    "current_rep": [
+      "any"
+    ],
+    "changed": 0
+  }
+},
+{
+  "event_id": "gen_new_cat_otherclanexile4_unknown",
+  "location": [
+    "any"
+  ],
+  "season": [
+    "any"
+  ],
+  "tags": [],
+  "exclude_involved": [
+    "m_c",
+    "r_c",
+    "n_c:0"
+  ],
+  "frequency": 1,
+  "event_text": "At the Gathering, o_c_n's leader announces their deputy did something terrible and was exiled. They look mournful as they deliver the news, and advises the others to watch their borders closely.",
+  "m_c": {
+    "age": [
+      "adolescent",
+      "young adult",
+      "adult",
+      "senior adult",
+      "senior"
+    ]
+  },
+  "new_cat": [
+    [
+      "former clancat",
+      "status:warrior",
+      "meeting",
+      "unknown",
+      "backstory:disgraced3",
+      "new_name"
+    ]
+  ],
+  "other_clan": {
+    "current_rep": [
+      "any"
+    ],
+    "changed": 0
+  }
 }
 ]

--- a/resources/lang/en/events/new_cat/general.json
+++ b/resources/lang/en/events/new_cat/general.json
@@ -2159,7 +2159,6 @@
   "tags": [],
   "exclude_involved": [
     "m_c",
-    "r_c",
     "n_c:0"
   ],
   "frequency": 2,
@@ -2183,6 +2182,22 @@
       "new_name"
     ]
   ],
+        "relationships": [
+            {
+                "cats_from": ["some_clan", "high_social"],
+                "cats_to": [
+                    "n_c:0"
+                ],
+                "mutual": false,
+                "values": [
+	        "trust"
+                ],
+                "amount": -10,
+                "log": {
+                    "cats_from": "cat_from heard n_c:0 was exiled from {PRONOUN/n_c:0/poss} old Clan for something terrible."
+                }
+            }
+        ],
   "other_clan": {
     "current_rep": [
       "any"
@@ -2201,7 +2216,6 @@
   "tags": [],
   "exclude_involved": [
     "m_c",
-    "r_c",
     "n_c:0"
   ],
   "frequency": 1,
@@ -2225,6 +2239,22 @@
       "new_name"
     ]
   ],
+        "relationships": [
+            {
+                "cats_from": ["some_clan", "high_social"],
+                "cats_to": [
+                    "n_c:0"
+                ],
+                "mutual": false,
+                "values": [
+	        "trust"
+                ],
+                "amount": -10,
+                "log": {
+                    "cats_from": "cat_from heard n_c:0 was driven out of {PRONOUN/n_c:0/poss} old Clan and is no longer its leader."
+                }
+            }
+        ],
   "other_clan": {
     "current_rep": [
       "any"
@@ -2243,7 +2273,6 @@
   "tags": [],
   "exclude_involved": [
     "m_c",
-    "r_c",
     "n_c:0"
   ],
   "frequency": 1,
@@ -2267,6 +2296,22 @@
       "new_name"
     ]
   ],
+        "relationships": [
+            {
+                "cats_from": ["some_clan", "high_social"],
+                "cats_to": [
+                    "n_c:0"
+                ],
+                "mutual": false,
+                "values": [
+	        "trust", "comfort"
+                ],
+                "amount": -10,
+                "log": {
+                    "cats_from": "cat_from heard n_c:0 was exiled from {PRONOUN/n_c:0/poss} old Clan for something terrible."
+                }
+            }
+        ],
   "other_clan": {
     "current_rep": [
       "any"
@@ -2285,7 +2330,6 @@
   "tags": [],
   "exclude_involved": [
     "m_c",
-    "r_c",
     "n_c:0"
   ],
   "frequency": 1,
@@ -2309,6 +2353,22 @@
       "new_name"
     ]
   ],
+        "relationships": [
+            {
+                "cats_from": ["some_clan", "high_social"],
+                "cats_to": [
+                    "n_c:0"
+                ],
+                "mutual": false,
+                "values": [
+	        "trust"
+                ],
+                "amount": -10,
+                "log": {
+                    "cats_from": "cat_from heard n_c:0 was exiled from {PRONOUN/n_c:0/poss} old Clan and is no longer its deputy."
+                }
+            }
+        ],
   "other_clan": {
     "current_rep": [
       "any"

--- a/resources/lang/en/events/new_cat/general.json
+++ b/resources/lang/en/events/new_cat/general.json
@@ -2289,7 +2289,7 @@
     "n_c:0"
   ],
   "frequency": 1,
-  "event_text": "At the Gathering, o_c_n's leader announces their deputy did something terrible and was exiled. They look mournful as they deliver the news, and advises the others to watch their borders closely.",
+  "event_text": "At the Gathering, o_c_n's leader announces their deputy did something terrible and was exiled. They look mournful as they deliver the news and advise the others to watch their borders closely.",
   "m_c": {
     "age": [
       "adolescent",

--- a/resources/lang/en/events/new_cat/general.json
+++ b/resources/lang/en/events/new_cat/general.json
@@ -356,7 +356,7 @@
                 }
             }
         ]
-    },  
+    },
     {
         "event_id": "gen_new_cat_anypolymate1",
         "location": ["any"],
@@ -1103,8 +1103,8 @@
         },
         "new_cat": [
           [
-            "old_name", 
-            "backstory:ostracized_warrior,disgraced1,disgraced2,otherclan", 
+            "old_name",
+            "backstory:ostracized_warrior,disgraced1,disgraced2,otherclan",
             "status:warrior"
           ]
         ],
@@ -1149,8 +1149,8 @@
         },
         "new_cat": [
           [
-            "old_name", 
-            "backstory:ostracized_warrior,disgraced1,disgraced2,disgraced3,otherclan", 
+            "old_name",
+            "backstory:ostracized_warrior,disgraced1,disgraced2,disgraced3,otherclan",
             "status:warrior"
           ]
         ],
@@ -1195,8 +1195,8 @@
         },
         "new_cat": [
           [
-            "old_name", 
-            "backstory:medicine_cat", 
+            "old_name",
+            "backstory:medicine_cat",
             "status:medicine_cat"
           ]
         ],
@@ -2149,7 +2149,6 @@
     }
 },
 {
-<<<<<<< otherclan-exile-events
   "event_id": "gen_new_cat_otherclanexile1_unknown",
   "location": [
     "any"
@@ -2315,7 +2314,7 @@
       "any"
     ],
     "changed": 0
-  },
+  }},
     {
     "event_id": "gen_new_cat_queenhelpabandon",
     "location": ["any"],

--- a/resources/lang/en/events/new_cat/general.json
+++ b/resources/lang/en/events/new_cat/general.json
@@ -2315,8 +2315,8 @@
       "any"
     ],
     "changed": 0
-  }
-=======
+  },
+    {
     "event_id": "gen_new_cat_queenhelpabandon",
     "location": ["any"],
     "season": ["any"],
@@ -3163,6 +3163,5 @@
         "current_rep": ["any"],
         "changed": 1
     }
->>>>>>> development
 }
 ]


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

Adds 4 events where an OtherClan leader announces someone from their ranks has been exiled! All of them generate an outsider with a disgraced backstory and a clan name. Includes a generic warrior variant, as well as rarer versions for an exiled leader, deputy, and medicine cat (plus a little nod to Yellowfang!)

## Why This Is Good For ClanGen

Event variety!! The former clancat status was giving us trouble so I wasn't able to code these events properly before, but now that it's been fixed I can include them as god intended.


## Proof of Testing

gen_new_cat_otherclanexile1_unknown
<img width="506" height="81" alt="image" src="https://github.com/user-attachments/assets/10e7c028-68be-4437-a6d5-2ac3c389a1ce" />
<img width="739" height="542" alt="image" src="https://github.com/user-attachments/assets/8c1da053-a8cf-4ac4-9adb-a88a95fefe35" />
<br>
gen_new_cat_otherclanexile2_unknown
<img width="490" height="82" alt="image" src="https://github.com/user-attachments/assets/69819a0d-11a1-4712-98c7-486ac6f713c0" />
<img width="743" height="550" alt="image" src="https://github.com/user-attachments/assets/b4157a1e-51b5-4200-9bbc-2c9a11b14ff4" />
<br>
gen_new_cat_otherclanexile3_unknown
<img width="509" height="80" alt="image" src="https://github.com/user-attachments/assets/929f3fcf-1457-428a-8401-e7f1bff396e7" />
<img width="754" height="563" alt="image" src="https://github.com/user-attachments/assets/fdce97ad-6ce5-4154-8ed2-412a0328a3c1" />
<br>
gen_new_cat_otherclanexile4_unknown
<img width="501" height="109" alt="image" src="https://github.com/user-attachments/assets/807c33e6-2bd5-46cc-8e86-9f7e083ccb36" />
<img width="738" height="549" alt="image" src="https://github.com/user-attachments/assets/3114290f-b935-4bf2-82eb-3c61001355bb" />

## Changelog/Credits

- Adds 4 events where a rival Clan leader announces someone from their ranks has been exiled. Will you invite them in out of compassion and hospitality, or heed their warnings of how dangerous these cats are?
