### PR TITLE
[CONTENT] forest bear patrol & mass extinction event

### DIFF
--- a/resources/lang/en/events/death/forest.json
+++ b/resources/lang/en/events/death/forest.json
@@ -218,7 +218,6 @@
     "sub_type": ["mass_death"],
     "frequency": 2,
     "event_text": "multi_cat were killed after a shelter-seeking bear lumbered into the grotto and discovered it was occupied.",
-    "exclude_involved": ["m_c"],
     "history": [
       {
         "cats": ["multi_cat"],

--- a/resources/lang/en/events/death/forest.json
+++ b/resources/lang/en/events/death/forest.json
@@ -210,5 +210,20 @@
                 "death": "m_c ate a beautiful but deadly mushroom."
             }
         ]
-    }
+    },
+    {
+    "event_id": "fst_death_extinction_bear",
+    "location": ["forest:camp3"],
+    "season": ["leaf-fall"],
+    "sub_type": ["mass_death"],
+    "frequency": 2,
+    "event_text": "multi_cat were killed after a shelter-seeking bear lumbered into the grotto and discovered it was occupied.",
+    "exclude_involved": ["m_c"],
+    "history": [
+      {
+        "cats": ["multi_cat"],
+        "death": "m_c was killed by a bear rampaging through camp."
+      }
+    ]
+}
 ]

--- a/resources/lang/en/patrols/forest/border/any.json
+++ b/resources/lang/en/patrols/forest/border/any.json
@@ -4174,7 +4174,7 @@
       ],
       "history_text": {
         "death": "m_c was killed by a brown bear.",
-        "scars": "m_c was scarred on patrol"
+        "scar": "m_c was scarred on patrol"
       },
       "art": "gen_dead_cat_ghost_EXPLICIT",
       "art_clean": "gen_dead_cat"

--- a/resources/lang/en/patrols/forest/border/any.json
+++ b/resources/lang/en/patrols/forest/border/any.json
@@ -3873,7 +3873,6 @@
     "forest"
   ],
   "season": [
-    "any",
     "-leaf-bare"
   ],
   "types": [
@@ -3883,15 +3882,18 @@
   "patrol_art": "fst_canopy",
   "min_cats": 2,
   "max_cats": 6,
+    "min_max_status": {
+        "leader": [
+            -1, -1 ]
+    },
   "frequency": 2,
   "chance_of_success": 30,
   "relationship_constraint": [],
   "pl_skill_constraint": [],
-  "intro_text": "Through a copse of narrow trees p_l sees a robust figure and flicks {PRONOUN/p_l/poss} tail to alert the patrol to stop. A bear is nearby; though what kind is unclear, its pelt color distorted by the shaded canopy.",
-  "decline_text": "The patrol retreats back to camp to report to l_n. Learning more about the predators in the territory could be useful, though not at the cost of their lives.",
+  "intro_text": "Through a copse of narrow trees p_l sees a robust figure and flicks {PRONOUN/p_l/poss} tail to alert the patrol to stop. A bear is nearby, though what kind is unclear; its pelt color is distorted by the shaded canopy.",
+  "decline_text": "The patrol retreats back to camp to report to lead_name. Learning more about the predators in the territory could be useful, though not at the cost of their lives.",
   "success_outcomes": [
     {
-      "min_max_status": {},
       "text": "r_c sneaks forward and determines it's a black bear. It should be relatively harmless as long as the Clan keeps an eye on its whereabouts.",
       "exp": 10,
       "frequency": 4,
@@ -3901,8 +3903,7 @@
       "art": "gen_warrior_crouching"
     },
     {
-      "min_max_status": {},
-      "text": "r_c's pupils dilate as a ray of sunlight illuminates the bear's russet pelt, realizing with alarm that it's a brown bear. The patrol slinks away without incident and lead_name warns patrols to stay away from the area.",
+      "text": "r_c's pupils dilate as a ray of sunlight illuminates the bear's russet pelt. r_c realizes with alarm that it's a brown bear. The patrol slinks away without incident and lead_name warns patrols to stay away from the area.",
       "exp": 10,
       "frequency": 4,
       "can_have_stat": [
@@ -3911,8 +3912,7 @@
       "art": "gen_warrior_crouching"
     },
     {
-      "min_max_status": {},
-      "text": "As the patrol decides their next move, the black bear lumbers towards them, snorting and grumbling. The patrol scatters as s_c lets out a bloodcurdling caterwaul and lunges at the beast, ducking beneath a massive swipe before raking {PRONOUN/s_c/poss} claws across its nose. Reeling back with a roar, the bear stumbles and retreats, giving s_c the chance to race back to the patrol. The cats regroup, shaken but relieved to have escaped with their pelts intact.",
+      "text": "The patrol is deciding their next move when the black bear lumbers towards them, snorting and grumbling. As the patrol scatters, s_c lets out a bloodcurdling caterwaul and lunges at the beast. {PRONOUN/s_c/subject/CAP} {VERB/s_c/duck/ducks} beneath a massive swipe and {VERB/s_c/rake/rakes} {PRONOUN/s_c/poss} claws across its nose. Reeling back with a roar, the bear stumbles and retreats, giving s_c the chance to race back to the patrol. The cats regroup, shaken but relieved to have escaped with their pelts intact.",
       "exp": 30,
       "frequency": 2,
       "stat_skill": [
@@ -3937,15 +3937,14 @@
           ],
           "amount": 10,
           "log": {
-            "cats_from": "cat_from is impressed that cat_to stood {PRONOUN/cat_to/poss} ground to run off a black bear."
+            "cats_from": "cat_from was impressed that cat_to stood {PRONOUN/cat_to/poss} ground to run off a black bear."
           }
         }
       ],
       "art": "gen_angry_cat_warrior"
     },
     {
-      "min_max_status": {},
-      "text": "As the patrol decides their next move, the brown bear suddenly charges, bellowing with fangs bared. s_c bounds forward with a howl, leaping onto the bear’s neck. The bear rears and clumsily swipes at itself as s_c clings on. Inspired by {PRONOUN/s_c/poss} courage, the patrol hisses and bristles in support. The bear starts to retreat, deciding they aren’t worth the trouble. s_c darts back to {PRONOUN/s_c/poss} Clanmates, pelt torn and a chunk of bear fur still caught in {PRONOUN/s_c/poss} teeth.",
+      "text": "As the patrol decides their next move, the brown bear suddenly charges, bellowing with fangs bared. s_c bounds forward with a howl and leaps onto the bear’s neck. The bear rears and clumsily swipes at itself as s_c clings on. Inspired by {PRONOUN/s_c/poss} courage, the patrol hisses and bristles in support. The bear starts to retreat, deciding they aren’t worth the trouble. s_c darts back to {PRONOUN/s_c/poss} Clanmates, pelt torn and a chunk of bear fur still caught in {PRONOUN/s_c/poss} teeth.",
       "exp": 40,
       "frequency": 2,
       "stat_skill": [
@@ -3984,7 +3983,7 @@
           ],
           "amount": 10,
           "log": {
-            "cats_from": "cat_from is baffled that cat_to attacked a brown bear and survived."
+            "cats_from": "cat_from was baffled that cat_to attacked a brown bear and survived."
           }
         },
         {
@@ -4003,7 +4002,7 @@
           ],
           "amount": 5,
           "log": {
-            "cats_from": "cat_from and cat_to have bonded after surviving an encounter with a brown bear."
+            "cats_from": "cat_from and cat_to bonded after surviving an encounter with a brown bear."
           }
         }
       ],
@@ -4012,7 +4011,6 @@
   ],
   "fail_outcomes": [
     {
-      "min_max_status": {},
       "text": "r_c fails to identify its scent before the bear disappears further into the woods.",
       "exp": 0,
       "frequency": 4,
@@ -4032,14 +4030,13 @@
           ],
           "amount": -5,
           "log": {
-            "cats_from": "cat_to wishes cat_from had the guts to at least identify a bear on patrol."
+            "cats_from": "cat_to wished cat_from had the guts to at least identify a bear on patrol."
           }
         }
       ],
       "art": "gen_found_scent_dangerous"
     },
     {
-      "min_max_status": {},
       "text": "r_c freezes at the sight of the enormous bear and cannot tell what kind it is before it moves on.",
       "exp": 0,
       "frequency": 4,
@@ -4059,15 +4056,14 @@
           ],
           "amount": -5,
           "log": {
-            "cats_from": "cat_to wishes cat_from had the guts to at least identify a bear on patrol."
+            "cats_from": "cat_to wished cat_from had the guts to at least identify a bear on patrol."
           }
         }
       ],
       "art": "gen_anxious1"
     },
     {
-      "min_max_status": {},
-      "text": "r_c creeps closer to identify the beast but is spotted. With a roar, the black bear swipes at {PRONOUN/r_c/object}, sending r_c tumbling across the leaf litter. {PRONOUN/r_c/subject/CAP} scramble to {PRONOUN/r_c/poss} feet and p_l rushes to help them to safety. Thankfully, the bear is uninterested in finishing the job and lumbers away.",
+      "text": "r_c creeps closer to identify the beast but is spotted. With a roar, the black bear swipes at {PRONOUN/r_c/object}, sending r_c tumbling across the leaf litter. {PRONOUN/r_c/subject/CAP} {VERB/r_c/scramble/scrambles} to {PRONOUN/r_c/poss} feet, and p_l rushes to help {PRONOUN/r_c/object} to safety. Thankfully, the bear is uninterested in finishing the job and lumbers away..",
       "exp": 0,
       "frequency": 3,
       "injury": [
@@ -4082,12 +4078,12 @@
             "torn pelt",
             "broken bone"
           ],
-          "scars": [],
           "no_results": false
         }
       ],
       "history_text": {
-        "scar": "m_c was scarred after being mauled by a black bear."
+        "scar": "m_c was scarred after being mauled by a black bear.",
+        "death": "m_c was killed by their injuries after being mauled by a black bear."
       },
       "relationships": [
         {
@@ -4104,14 +4100,13 @@
           ],
           "amount": 10,
           "log": {
-            "cats_from": "cat_from is grateful that cat_to helped {PRONOUN/cat_from/object} flee from a black bear."
+            "cats_from": "cat_from was grateful that cat_to helped {PRONOUN/cat_from/object} flee from a black bear."
           }
         }
       ],
       "art": "gen_scared_cat_warrior"
     },
     {
-      "min_max_status": {},
       "text": "r_c sneaks towards the bear to try to identify it. Before {PRONOUN/r_c/subject} {VERB/r_c/know/knows} it, {PRONOUN/r_c/subject} {VERB/r_c/are/is} snout to snout with an angry, slobbering brown bear who swings its massive paw toward {PRONOUN/r_c/object}. r_c wails as {PRONOUN/r_c/subject} {VERB/r_c/are/is} mauled and tossed to the side, attempting to scrabble to safety when p_l grabs {PRONOUN/r_c/poss} scruff and pulls them both to safety. Luckily the bear is uninterested in finishing the job. ",
       "exp": 0,
       "frequency": 3,
@@ -4127,12 +4122,12 @@
             "torn pelt",
             "broken bone"
           ],
-          "scars": [],
           "no_results": false
         }
       ],
       "history_text": {
-        "scar": "m_c was scarred after being mauled by a brown bear."
+        "scar": "m_c was scarred after being mauled by a brown bear.",
+        "death": "m_c was killed by their injuries after being mauled by a brown bear."
       },
       "relationships": [
         {
@@ -4149,38 +4144,27 @@
           ],
           "amount": 10,
           "log": {
-            "cats_from": "cat_from is grateful that cat_to helped {PRONOUN/cat_from/object} escape a brown bear."
+            "cats_from": "cat_from was grateful that cat_to helped {PRONOUN/cat_from/object} escape a brown bear."
           }
         }
       ],
       "art": "gen_scared_cat_warrior"
     },
     {
-      "min_max_status": {},
       "text": "r_c sneaks towards the bear to try to identify it. Before {PRONOUN/r_c/subject} {VERB/r_c/know/knows} it, {PRONOUN/r_c/subject} {VERB/r_c/are/is} snout to snout with an angry, slobbering brown bear who swings its massive paw toward {PRONOUN/r_c/object} batting {PRONOUN/r_c/object} effortlessly into a nearby tree. The patrol scatters when they see r_c is no longer moving.",
       "exp": 0,
       "frequency": 3,
       "dead_cats": [
         "r_c"
       ],
-      "injury": [
-        {
-          "cats": [],
-          "injuries": [],
-          "scars": [],
-          "no_results": false
-        }
-      ],
       "history_text": {
-        "death": "m_c was killed by a brown bear.",
-        "scar": "m_c was scarred on patrol"
+        "death": "m_c was killed by a brown bear."
       },
       "art": "gen_dead_cat_ghost_EXPLICIT",
       "art_clean": "gen_dead_cat"
     },
     {
-      "min_max_status": {},
-      "text": "While the patrol decides what to do, the black bear scents them, charging through the undergrowth toward them. The horrible beast lashes out wildly, leaving multiple injured before the patrol manages to escape.",
+      "text": "While the patrol decides what to do, the black bear scents them, charging through the undergrowth toward them. The beast lashes out wildly, leaving multiple injured before the patrol manages to escape.",
       "exp": 0,
       "frequency": 2,
       "injury": [
@@ -4195,19 +4179,16 @@
             "torn pelt",
             "broken bone"
           ],
-          "scars": [],
           "no_results": false
         }
       ],
       "history_text": {
-        "death": "m_c died from injuries of a black bear attack.",
+        "death": "m_c died of {PRONOUN/m_c/poss} injuries after a black bear attack.",
         "scar": "m_c was scarred on patrol by a black bear."
       },
-      "art": "gen_scared_cat_warrior",
-      "art_clean": " "
+      "art": "gen_scared_cat_warrior"
     },
     {
-      "min_max_status": {},
       "text": "While the patrol decides what to do, the brown bear scents them, charging through the undergrowth toward them with a mighty roar. The terrible beast mauls the patrol, razing their bodies with claw and fang before they are able to escape.",
       "exp": 0,
       "frequency": 2,
@@ -4223,19 +4204,16 @@
             "torn pelt",
             "broken bone"
           ],
-          "scars": [],
           "no_results": false
         }
       ],
       "history_text": {
-        "death": "m_c died from injuries of a brown bear attack.",
+        "death": "m_c died of {PRONOUN/m_c/poss} injuries after a brown bear attack.",
         "scar": "m_c was scarred on patrol by a brown bear."
       },
-      "art": "gen_scared_cat_warrior",
-      "art_clean": " "
+      "art": "gen_scared_cat_warrior"
     },
     {
-      "min_max_status": {},
       "text": "While the patrol decides what to do, the brown bear scents them, charging through the undergrowth toward them with a mighty roar. The carnage is instant as the massive creature's teeth crunch down on poor r_c and its paws raze p_l. The survivors return to camp harrowed.",
       "exp": 0,
       "frequency": 2,

--- a/resources/lang/en/patrols/forest/border/any.json
+++ b/resources/lang/en/patrols/forest/border/any.json
@@ -3866,5 +3866,404 @@
                 }
             }
         ]
+    },
+{
+  "patrol_id": "fst_bord_notleafbare_bear",
+  "biome": [
+    "forest"
+  ],
+  "season": [
+    "any",
+    "-leaf-bare"
+  ],
+  "types": [
+    "border"
+  ],
+  "tags": [],
+  "patrol_art": "fst_canopy",
+  "patrol_art_clean": null,
+  "min_cats": 2,
+  "max_cats": 6,
+  "frequency": 2,
+  "chance_of_success": 30,
+  "relationship_constraint": [],
+  "pl_skill_constraint": [],
+  "intro_text": "Through a copse of narrow trees p_l sees a robust figure and flicks {PRONOUN/p_l/poss} tail to alert the patrol to stop. A bear is nearby; though what kind is unclear, its pelt color distorted by the shaded canopy.",
+  "decline_text": "The patrol retreats back to camp to report to l_n. Learning more about the predators in the territory could be useful, though not at the cost of their lives.",
+  "success_outcomes": [
+    {
+      "min_max_status": {},
+      "text": "r_c sneaks forward and determines it's a black bear. It should be relatively harmless as long as the Clan keeps an eye on its whereabouts.",
+      "exp": 10,
+      "frequency": 4,
+      "can_have_stat": [
+        "any"
+      ],
+      "art": "gen_warrior_crouching"
+    },
+    {
+      "min_max_status": {},
+      "text": "r_c's pupils dilate as a ray of sunlight illuminates the bear's russet pelt, realizing with alarm that it's a brown bear. The patrol slinks away without incident and lead_name warns patrols to stay away from the area.",
+      "exp": 10,
+      "frequency": 4,
+      "can_have_stat": [
+        "any"
+      ],
+      "art": "gen_warrior_crouching"
+    },
+    {
+      "min_max_status": {},
+      "text": "As the patrol decides their next move, the black bear lumbers towards them, snorting and grumbling. The patrol scatters as s_c lets out a bloodcurdling caterwaul and lunges at the beast, ducking beneath a massive swipe before raking {PRONOUN/s_c/poss} claws across its nose. Reeling back with a roar, the bear stumbles and retreats, giving s_c the chance to race back to the patrol. The cats regroup, shaken but relieved to have escaped with their pelts intact.",
+      "exp": 30,
+      "frequency": 2,
+      "stat_skill": [
+        "FIGHTER,2"
+      ],
+      "can_have_stat": [
+        "any"
+      ],
+      "relationships": [
+        {
+          "cats_to": [
+            "s_c"
+          ],
+          "cats_from": [
+            "patrol",
+            "some_clan"
+          ],
+          "mutual": false,
+          "values": [
+            "trust",
+            "like"
+          ],
+          "amount": 10,
+          "log": {
+            "cats_from": "cat_from is impressed that cat_to stood {PRONOUN/cat_to/poss} ground to run off a black bear."
+          }
+        }
+      ],
+      "art": "gen_angry_cat_warrior"
+    },
+    {
+      "min_max_status": {},
+      "text": "As the patrol decides their next move, the brown bear suddenly charges, bellowing with fangs bared. s_c bounds forward with a howl, leaping onto the bear’s neck. The bear rears and clumsily swipes at itself as s_c clings on. Inspired by {PRONOUN/s_c/poss} courage, the patrol hisses and bristles in support. The bear starts to retreat, deciding they aren’t worth the trouble. s_c darts back to {PRONOUN/s_c/poss} Clanmates, pelt torn and a chunk of bear fur still caught in {PRONOUN/s_c/poss} teeth.",
+      "exp": 40,
+      "frequency": 2,
+      "stat_skill": [
+        "FIGHTER,3"
+      ],
+      "can_have_stat": [
+        "any"
+      ],
+      "injury": [
+        {
+          "cats": [
+            "s_c"
+          ],
+          "injuries": [
+            "torn pelt"
+          ],
+          "no_results": false
+        }
+      ],
+      "history_text": {
+        "scar": "s_c was scarred by a brown bear."
+      },
+      "relationships": [
+        {
+          "cats_to": [
+            "s_c"
+          ],
+          "cats_from": [
+            "patrol",
+            "some_clan"
+          ],
+          "mutual": false,
+          "values": [
+            "trust",
+            "like"
+          ],
+          "amount": 10,
+          "log": {
+            "cats_from": "cat_from is baffled that cat_to attacked a brown bear and survived."
+          }
+        },
+        {
+          "cats_to": [
+            "patrol"
+          ],
+          "cats_from": [
+            "patrol"
+          ],
+          "mutual": false,
+          "values": [
+            "trust",
+            "like",
+            "comfort",
+            "respect"
+          ],
+          "amount": 5,
+          "log": {
+            "cats_from": "cat_from and cat_to have bonded after surviving an encounter with a brown bear."
+          }
+        }
+      ],
+      "art": "gen_angry_cat_warrior"
     }
-]
+  ],
+  "fail_outcomes": [
+    {
+      "min_max_status": {},
+      "text": "r_c fails to identify its scent before the bear disappears further into the woods.",
+      "exp": 0,
+      "frequency": 4,
+      "relationships": [
+        {
+          "cats_to": [
+            "r_c"
+          ],
+          "cats_from": [
+            "some_clan",
+            "high_aggress"
+          ],
+          "mutual": false,
+          "values": [
+            "like",
+            "respect"
+          ],
+          "amount": -5,
+          "log": {
+            "cats_from": "cat_to wishes cat_from had the guts to at least identify a bear on patrol."
+          }
+        }
+      ],
+      "art": "gen_found_scent_dangerous"
+    },
+    {
+      "min_max_status": {},
+      "text": "r_c freezes at the sight of the enormous bear and cannot tell what kind it is before it moves on.",
+      "exp": 0,
+      "frequency": 4,
+      "relationships": [
+        {
+          "cats_to": [
+            "r_c"
+          ],
+          "cats_from": [
+            "some_clan",
+            "high_aggress"
+          ],
+          "mutual": false,
+          "values": [
+            "like",
+            "respect"
+          ],
+          "amount": -5,
+          "log": {
+            "cats_from": "cat_to wishes cat_from had the guts to at least identify a bear on patrol."
+          }
+        }
+      ],
+      "art": "gen_anxious1"
+    },
+    {
+      "min_max_status": {},
+      "text": "r_c creeps closer to identify the beast but is spotted. With a roar, the black bear swipes at {PRONOUN/r_c/object}, sending r_c tumbling across the leaf litter. {PRONOUN/r_c/subject/CAP} scramble to {PRONOUN/r_c/poss} feet and p_l rushes to help them to safety. Thankfully, the bear is uninterested in finishing the job and lumbers away.",
+      "exp": 0,
+      "frequency": 3,
+      "injury": [
+        {
+          "cats": [
+            "r_c"
+          ],
+          "injuries": [
+            "claw-wound",
+            "mangled leg",
+            "mangled tail",
+            "torn pelt",
+            "broken bone"
+          ],
+          "scars": [],
+          "no_results": false
+        }
+      ],
+      "history_text": {
+        "scar": "m_c was scarred after being mauled by a black bear."
+      },
+      "relationships": [
+        {
+          "cats_to": [
+            "p_l"
+          ],
+          "cats_from": [
+            "r_c"
+          ],
+          "mutual": false,
+          "values": [
+            "comfort",
+            "trust"
+          ],
+          "amount": 10,
+          "log": {
+            "cats_from": "cat_from is grateful that cat_to helped {PRONOUN/cat_from/object} flee from a black bear."
+          }
+        }
+      ],
+      "art": "gen_scared_cat_warrior"
+    },
+    {
+      "min_max_status": {},
+      "text": "r_c sneaks towards the bear to try to identify it. Before {PRONOUN/r_c/subject} {VERB/r_c/know/knows} it, {PRONOUN/r_c/subject} {VERB/r_c/are/is} snout to snout with an angry, slobbering brown bear who swings its massive paw toward {PRONOUN/r_c/object}. r_c wails as {PRONOUN/r_c/subject} {VERB/r_c/are/is} mauled and tossed to the side, attempting to scrabble to safety when p_l grabs {PRONOUN/r_c/poss} scruff and pulls them both to safety. Luckily the bear is uninterested in finishing the job. ",
+      "exp": 0,
+      "frequency": 3,
+      "injury": [
+        {
+          "cats": [
+            "r_c"
+          ],
+          "injuries": [
+            "claw-wound",
+            "mangled leg",
+            "mangled tail",
+            "torn pelt",
+            "broken bone"
+          ],
+          "scars": [],
+          "no_results": false
+        }
+      ],
+      "history_text": {
+        "scar": "m_c was scarred after being mauled by a brown bear."
+      },
+      "relationships": [
+        {
+          "cats_to": [
+            "p_l"
+          ],
+          "cats_from": [
+            "r_c"
+          ],
+          "mutual": false,
+          "values": [
+            "comfort",
+            "trust"
+          ],
+          "amount": 10,
+          "log": {
+            "cats_from": "cat_from is grateful that cat_to helped {PRONOUN/cat_from/object} escape a brown bear."
+          }
+        }
+      ],
+      "art": "gen_scared_cat_warrior"
+    },
+    {
+      "min_max_status": {},
+      "text": "r_c sneaks towards the bear to try to identify it. Before {PRONOUN/r_c/subject} {VERB/r_c/know/knows} it, {PRONOUN/r_c/subject} {VERB/r_c/are/is} snout to snout with an angry, slobbering brown bear who swings its massive paw toward {PRONOUN/r_c/object} batting {PRONOUN/r_c/object} effortlessly into a nearby tree. The patrol scatters when they see r_c is no longer moving.",
+      "exp": 0,
+      "frequency": 3,
+      "dead_cats": [
+        "r_c"
+      ],
+      "injury": [
+        {
+          "cats": [],
+          "injuries": [],
+          "scars": [],
+          "no_results": false
+        }
+      ],
+      "history_text": {
+        "death": "m_c was killed by a brown bear.",
+        "scars": "m_c was scarred on patrol"
+      },
+      "art": "gen_dead_cat_ghost_EXPLICIT",
+      "art_clean": "gen_dead_cat"
+    },
+    {
+      "min_max_status": {},
+      "text": "While the patrol decides what to do, the black bear scents them, charging through the undergrowth toward them. The horrible beast lashes out wildly, leaving multiple injured before the patrol manages to escape.",
+      "exp": 0,
+      "frequency": 2,
+      "injury": [
+        {
+          "cats": [
+            "multi"
+          ],
+          "injuries": [
+            "claw-wound",
+            "mangled leg",
+            "mangled tail",
+            "torn pelt",
+            "broken bone"
+          ],
+          "scars": [],
+          "no_results": false
+        }
+      ],
+      "history_text": {
+        "death": "m_c died from injuries of a black bear attack.",
+        "scar": "m_c was scarred on patrol by a black bear."
+      },
+      "art": "gen_scared_cat_warrior",
+      "art_clean": " "
+    },
+    {
+      "min_max_status": {},
+      "text": "While the patrol decides what to do, the brown bear scents them, charging through the undergrowth toward them with a mighty roar. The terrible beast mauls the patrol, razing their bodies with claw and fang before they are able to escape.",
+      "exp": 0,
+      "frequency": 2,
+      "injury": [
+        {
+          "cats": [
+            "patrol"
+          ],
+          "injuries": [
+            "claw-wound",
+            "mangled leg",
+            "mangled tail",
+            "torn pelt",
+            "broken bone"
+          ],
+          "scars": [],
+          "no_results": false
+        }
+      ],
+      "history_text": {
+        "death": "m_c died from injuries of a brown bear attack.",
+        "scar": "m_c was scarred on patrol by a brown bear."
+      },
+      "art": "gen_scared_cat_warrior",
+      "art_clean": " "
+    },
+    {
+      "min_max_status": {},
+      "text": "While the patrol decides what to do, the brown bear scents them, charging through the undergrowth toward them with a mighty roar. The carnage is instant as the massive creature's teeth crunch down on poor r_c and its paws raze p_l. The survivors return to camp harrowed.",
+      "exp": 0,
+      "frequency": 2,
+      "dead_cats": [
+        "r_c",
+        "p_l"
+      ],
+      "injury": [
+        {
+          "cats": [
+            "patrol",
+            "-r_c",
+            "-p_l"
+          ],
+          "injuries": [
+            "shock"
+          ],
+          "scars": [],
+          "no_results": false
+        }
+      ],
+      "history_text": {
+        "death": "m_c was killed by a brown bear."
+      },
+      "art": "gen_dead_cat_ghost_EXPLICIT",
+      "art_clean": "gen_dead_cat"
+    }
+  ]
+}
+  ]

--- a/resources/lang/en/patrols/forest/border/any.json
+++ b/resources/lang/en/patrols/forest/border/any.json
@@ -3881,7 +3881,6 @@
   ],
   "tags": [],
   "patrol_art": "fst_canopy",
-  "patrol_art_clean": null,
   "min_cats": 2,
   "max_cats": 6,
   "frequency": 2,


### PR DESCRIPTION
## About The Pull Request

- Adds a deadly forest border patrol featuring either a brown or black bear with a 30% chance of success, 4 success options, and 8 failures
- Adds a unique mass extinction event for the Grotto camp featuring a bear seeking hibernation.

## Why This Is Good For ClanGen

- More diversity between biomes. Gives me the legwork to build bear-related patrols for the mountains and beach as well (hello salmon run). 


## Proof of Testing

Bear Patrol Intro + two of the extreme outcomes

<img width="695" height="550" alt="patrolstart" src="https://github.com/user-attachments/assets/a0abc52e-e6d9-43d6-82f8-774d66cfc9a7" />
<img width="694" height="471" alt="ult fail" src="https://github.com/user-attachments/assets/6e48e284-6366-43e5-8332-ea352c67c11d" />
<img width="679" height="408" alt="ult success" src="https://github.com/user-attachments/assets/6f441c7b-a764-4631-9869-9b455d7fd650" />


Extinction Event Test (Note: Mass extinctions are bugged in event generation so it was generated as a regular death. The missing names are because multi_cat was still in the event text instead of m_c.)

<img width="516" height="179" alt="Screenshot 2026-04-27 at 9 42 13 PM" src="https://github.com/user-attachments/assets/f31c861a-564b-4fb6-9a50-a3e93255fc8e" />