### PR TITLE
[BUGFIX] badger patrol inconsistancy

### DIFF
--- a/resources/lang/en/patrols/forest/border/any.json
+++ b/resources/lang/en/patrols/forest/border/any.json
@@ -781,7 +781,7 @@
                             "r_c"
                         ],
                         "injuries": [
-                            "battle_injury"
+                            "big_bite_injury"
                         ],
                         "scars": [
                             "SIDE"


### PR DESCRIPTION
## About The Pull Request

- The forest/border variation of a specific patrol had "battle_injury" instead of "big_bite_injury" so upon occasion, cats would receive a "cat bite" from a badger.

## Why This Is Good For ClanGen

- Consistency

## Linked Issues

## Proof of Testing

<img width="717" height="547" alt="Screenshot 2026-04-28 at 1 23 31 AM" src="https://github.com/user-attachments/assets/cec05ffd-4eab-40df-885a-773d9f953cd6" />
game & patrol loads

## Changelog/Credits