### PR TITLE
[TYPOFIX] adding missing periods in death histories

### DIFF
--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -4168,7 +4168,7 @@
                 "cats": [
                     "m_c"
                 ],
-                "death": "m_c died defending r_c from a hawk"
+                "death": "m_c died defending r_c from a hawk."
             }
         ],
         "relationships": [
@@ -5547,7 +5547,7 @@
                 "cats": [
                     "m_c"
                 ],
-                "death": "m_c died defending r_c from a dog"
+                "death": "m_c died defending r_c from a dog."
             }
         ],
         "relationships": [
@@ -5944,7 +5944,7 @@
                 "cats": [
                     "m_c"
                 ],
-                "death": "m_c died defending the kits from o_c_n warriors"
+                "death": "m_c died defending the kits from o_c_n warriors."
             }
         ],
         "other_clan": {
@@ -6158,7 +6158,7 @@
                 "cats": [
                     "m_c"
                 ],
-                "death": "m_c succumbed to old age"
+                "death": "m_c succumbed to old age."
             }
         ]
     },
@@ -6192,7 +6192,7 @@
                 "cats": [
                     "m_c"
                 ],
-                "death": "m_c succumbed to old age"
+                "death": "m_c succumbed to old age."
             }
         ]
     },
@@ -8652,7 +8652,7 @@
         "history": [
             {
                 "cats": ["m_c"],
-                "death": "m_c died when a rogue attacked {PRONOUN/m_c/object} on r_c's orders"
+                "death": "m_c died when a rogue attacked {PRONOUN/m_c/object} on r_c's orders."
             }
         ],
         "relationships": [


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

noticed a missing period in my leader's death history, so i combed through deaths > general.json and found a bunch of events that were missing periods in the death history line. added 'em back!

## Why This Is Good For ClanGen

typos begone

## Proof of Testing

<img width="1150" height="587" alt="image" src="https://github.com/user-attachments/assets/59d042e8-6e0f-4c33-a31f-53a2a7919a0c" />


## Changelog/Credits

- Added missing periods in death history text for multiple events.
