### PR TITLE
[CONTENT] rogue seeking redemption event

### DIFF
--- a/resources/lang/en/events/new_cat/general.json
+++ b/resources/lang/en/events/new_cat/general.json
@@ -3635,41 +3635,6 @@
         "log": {
           "cats_from": "cat_from approved of cat_to killing an old loner who once wronged c_n."
         }
-      },
-                {
-        "cats_from": [
-          "n_c:0"
-        ],
-        "cats_to": [
-          "m_c"
-        ],
-        "mutual": false,
-        "values": [
-          "like",
-          "trust"
-        ],
-        "amount": -10,
-        "log": {
-          "cats_from": "cat_from never imagined that m_c would kill {PRONOUN/n_c:0/object} during an apology."
-        }
-      },
-        {
-        "cats_from": [
-          "n_c:0",
-            "high_aggress"
-        ],
-        "cats_to": [
-          "m_c"
-        ],
-        "mutual": false,
-        "values": [
-          "like",
-          "trust"
-        ],
-        "amount": -20,
-        "log": {
-          "cats_from": "cat_from vows to curse m_c and c_n from beyond the grave."
-        }
       }
     ]
   },
@@ -3748,41 +3713,6 @@
         "amount": 10,
         "log": {
           "cats_from": "cat_from approved of cat_to killing an old rogue who once wronged c_n."
-        }
-      },
-        {
-        "cats_from": [
-          "n_c:0"
-        ],
-        "cats_to": [
-          "m_c"
-        ],
-        "mutual": false,
-        "values": [
-          "like",
-          "trust"
-        ],
-        "amount": -10,
-        "log": {
-          "cats_from": "cat_from never imagined that m_c would kill {PRONOUN/n_c:0/object} during an apology."
-        }
-      },
-        {
-        "cats_from": [
-          "n_c:0",
-            "high_aggress"
-        ],
-        "cats_to": [
-          "m_c"
-        ],
-        "mutual": false,
-        "values": [
-          "like",
-          "trust"
-        ],
-        "amount": -20,
-        "log": {
-          "cats_from": "cat_from vows to curse m_c and c_n from beyond the grave."
         }
       }
     ]

--- a/resources/lang/en/events/new_cat/general.json
+++ b/resources/lang/en/events/new_cat/general.json
@@ -3535,7 +3535,7 @@
         ],
         "amount": -5,
         "log": {
-          "cats_from": "Though cat_from understood, {PRONOUN/n_c:0/subject} were still disappointed that cat_to shunned them."
+          "cats_from": "cat_from was disappointed that cat_to shunned {PRONOUN/cat_from/object}."
         }
       },
         {

--- a/resources/lang/en/events/new_cat/general.json
+++ b/resources/lang/en/events/new_cat/general.json
@@ -3442,7 +3442,7 @@
         ],
         "amount": -5,
         "log": {
-          "cats_from": "Though cat_from understood, {PRONOUN/n_c:0/subject} were still disappointed that cat_to shunned them."
+          "cats_from": "cat_from was disappointed that cat_to shunned {PRONOUN/cat_from/object}."
         }
       },
         {

--- a/resources/lang/en/events/new_cat/general.json
+++ b/resources/lang/en/events/new_cat/general.json
@@ -3541,7 +3541,7 @@
     "sub_type": [],
     "tags": [],
     "frequency": 1,
-    "event_text": "m_c is called to the camp's entrance where n_c:0 waits, head ducked in respect. n_c:0 meows that {PRONOUN/n_c:0/subject} {VERB/n_c:0/regret/regrets} any misdeeds, mischief, or hardship {PRONOUN/n_c:0/subject} {VERB/n_c:0/have/has} caused c_n in the past and {VERB/n_c:0/want/wants} to join the Clan. m_c ruthlessly uses the opportunity to slay the nuisance where {PRONOUN/n_c:0/subject} {VERB/n_c:0/stand/stands}.",
+    "event_text": "m_c is called to the camp's entrance where n_c:0 waits, head ducked in respect. n_c:0 apologizes for any misdeeds, mischief, or hardship {PRONOUN/n_c:0/subject}{VERB/n_c:0/'ve/'s} caused c_n in the past and asks to join the Clan. m_c ruthlessly uses the opportunity to slay the nuisance where {PRONOUN/n_c:0/subject} {VERB/n_c:0/stand/stands}.",
     "m_c": {
       "status": [
         "leader"

--- a/resources/lang/en/events/new_cat/general.json
+++ b/resources/lang/en/events/new_cat/general.json
@@ -3602,7 +3602,7 @@
         ],
         "amount": 10,
         "log": {
-          "cats_from": "cat_from approved of cat_to killing an old loner who once wronged c_n."
+          "cats_from": "cat_from approved of cat_to killing an old rogue who once wronged c_n."
         }
       }
     ]

--- a/resources/lang/en/events/new_cat/general.json
+++ b/resources/lang/en/events/new_cat/general.json
@@ -3584,7 +3584,7 @@
         ],
         "amount": -15,
         "log": {
-          "cats_from": "cat_from was stunned to see cat_to ruthlessly kill a old rogue who sought c_n's forgiveness."
+          "cats_from": "cat_from was stunned to see cat_to ruthlessly kill an old rogue who sought c_n's forgiveness."
         }
       },
       {

--- a/resources/lang/en/events/new_cat/general.json
+++ b/resources/lang/en/events/new_cat/general.json
@@ -3507,7 +3507,7 @@
         ],
         "amount": -15,
         "log": {
-          "cats_from": "cat_from was stunned to see cat_to ruthlessly kill a old rogue who sought c_n's forgiveness."
+          "cats_from": "cat_from was stunned to see cat_to ruthlessly kill an old rogue who sought c_n's forgiveness."
         }
       },
       {

--- a/resources/lang/en/events/new_cat/general.json
+++ b/resources/lang/en/events/new_cat/general.json
@@ -3222,5 +3222,389 @@
         "current_rep": ["any"],
         "changed": 1
     }
-}
+},
+ {
+    "event_id": "gen_new_cat_rogueredemption_success1",
+    "location": [
+      "any"
+    ],
+    "season": [
+      "any"
+    ],
+    "sub_type": [],
+    "tags": [],
+    "frequency": 1,
+    "event_text": "m_c is called to the camp's entrance where n_c:0 waits, head ducked in respect. n_c:0 meows that {PRONOUN/n_c:0/subject} {VERB/n_c:0/regret/regrets} any misdeeds, mischief, or hardship {PRONOUN/n_c:0/subject} {VERB/n_c:0/have/has} caused c_n in the past and {VERB/n_c:0/want/wants} to join the Clan. m_c accepts.",
+    "m_c": {
+      "status": [
+        "leader"
+      ],
+      "trait": [
+        "-bloodthirsty",
+        "-cold",
+        "-strict"
+      ],
+      "dies": false
+    },
+    "new_cat": [
+      [
+        "rogue",
+        "age:senior adult",
+        "exists"
+      ]
+    ],
+    "outsider": {
+      "current_rep": [
+        "any"
+      ],
+      "changed": 1
+    },
+    "relationships": [
+      {
+        "cats_from": [
+          "clan",
+          "high_social"
+        ],
+        "cats_to": [
+          "m_c"
+        ],
+        "mutual": false,
+        "values": [
+          "respect"
+        ],
+        "amount": 10,
+        "log": {
+          "cats_from": "cat_from is impressed that cat_from gave an old loner a chance to join the clan."
+        }
+      }
+    ]
+  },
+  {
+    "event_id": "gen_new_cat_rogueredemption_success2",
+    "location": [
+      "any"
+    ],
+    "season": [
+      "any"
+    ],
+    "sub_type": [],
+    "tags": [],
+    "frequency": 1,
+    "event_text": "m_c is called to the camp's entrance where n_c:0 waits, head ducked in respect. n_c:0 meows that {PRONOUN/n_c:0/subject} {VERB/n_c:0/regret/regrets} any misdeeds, mischief, or hardship {PRONOUN/n_c:0/subject} {VERB/n_c:0/have/has} caused c_n in the past and {VERB/n_c:0/want/wants} to join the Clan. m_c accepts.",
+    "m_c": {
+      "status": [
+        "leader"
+      ],
+      "trait": [
+        "-bloodthirsty",
+        "-cold",
+        "-strict"
+      ],
+      "dies": false
+    },
+    "new_cat": [
+      [
+        "rogue",
+        "age:senior",
+        "exists"
+      ]
+    ],
+    "outsider": {
+      "current_rep": [
+        "any"
+      ],
+      "changed": 1
+    },
+    "relationships": [
+      {
+        "cats_from": [
+          "clan",
+          "high_social"
+        ],
+        "cats_to": [
+          "m_c"
+        ],
+        "mutual": false,
+        "values": [
+          "respect"
+        ],
+        "amount": 10,
+        "log": {
+          "cats_from": "cat_from is impressed that cat_from gave an old loner a chance to join the clan."
+        }
+      }
+    ]
+  },
+  {
+    "event_id": "gen_new_cat_rogueredemption_deny1",
+    "location": [
+      "any"
+    ],
+    "season": [
+      "any"
+    ],
+    "sub_type": [],
+    "tags": [],
+    "frequency": 1,
+    "event_text": "m_c is called to the camp's entrance where n_c:0 waits, head ducked in respect. n_c:0 meows that {PRONOUN/n_c:0/subject} {VERB/n_c:0/regret/regrets} any misdeeds, mischief, or hardship {PRONOUN/n_c:0/subject} {VERB/n_c:0/have/has} caused c_n in the past and {VERB/n_c:0/want/wants} to join the Clan. m_c turns {PRONOUN/n_c:0/object} away.",
+    "m_c": {
+      "status": [
+        "leader"
+      ],
+      "trait": [
+        "-bloodthirsty",
+        "-cold",
+        "-strict"
+      ],
+      "dies": false
+    },
+    "new_cat": [
+      [
+        "rogue",
+        "age:senior adult",
+        "exists",
+         "old_name",
+          "meeting",
+          "unknown"
+      ]
+    ],
+    "outsider": {
+      "current_rep": [
+        "any"
+      ],
+      "changed": -1
+    },
+    "relationships": [
+      {
+        "cats_from": [
+          "clan",
+          "high_social"
+        ],
+        "cats_to": [
+          "m_c"
+        ],
+        "mutual": false,
+        "values": [
+          "respect"
+        ],
+        "amount": -5,
+        "log": {
+          "cats_from": "cat_from thought cat_from should've given a old loner a chance to join the clan."
+        }
+      }
+    ]
+  },
+  {
+    "event_id": "gen_new_cat_rogueredemption_deny2",
+    "location": [
+      "any"
+    ],
+    "season": [
+      "any"
+    ],
+    "sub_type": [],
+    "tags": [],
+    "frequency": 1,
+    "event_text": "m_c is called to the camp's entrance where n_c:0 waits, head ducked in respect. n_c:0 meows that {PRONOUN/n_c:0/subject} {VERB/n_c:0/regret/regrets} any misdeeds, mischief, or hardship {PRONOUN/n_c:0/subject} {VERB/n_c:0/have/has} caused c_n in the past and {VERB/n_c:0/want/wants} to join the Clan. m_c turns {PRONOUN/n_c:0/object} away.",
+    "m_c": {
+      "status": [
+        "leader"
+      ],
+      "trait": [
+        "-bloodthirsty",
+        "-cold",
+        "-strict"
+      ],
+      "dies": false
+    },
+    "new_cat": [
+      [
+        "rogue",
+        "age:senior",
+        "exists",
+        "old_name",
+          "meeting",
+          "unknown"
+      ]
+    ],
+    "outsider": {
+      "current_rep": [
+        "any"
+      ],
+      "changed": -1
+    },
+    "relationships": [
+      {
+        "cats_from": [
+          "clan",
+          "high_social"
+        ],
+        "cats_to": [
+          "m_c"
+        ],
+        "mutual": false,
+        "values": [
+          "respect"
+        ],
+        "amount": -5,
+        "log": {
+          "cats_from": "cat_from thought cat_from should've given a old loner a chance to join the clan."
+        }
+      }
+    ]
+  },
+  {
+    "event_id": "gen_new_cat_rogueredemption_kill1",
+    "location": [
+      "any"
+    ],
+    "season": [
+      "any"
+    ],
+    "sub_type": [],
+    "tags": [],
+    "frequency": 1,
+    "event_text": "m_c is called to the camp's entrance where n_c:0 waits, head ducked in respect. n_c:0 meows that {PRONOUN/n_c:0/subject} {VERB/n_c:0/regret/regrets} any misdeeds, mischief, or hardship {PRONOUN/n_c:0/subject} {VERB/n_c:0/have/has} caused c_n in the past and {VERB/n_c:0/want/wants} to join the Clan. m_c ruthlessly uses the opportunity to slay the nuisance where {PRONOUN/n_c:0/subject} {VERB/n_c:0/stand/stands}.",
+    "m_c": {
+      "status": [
+        "leader"
+      ],
+      "trait": [
+        "bloodthirsty"
+      ],
+      "dies": false
+    },
+    "new_cat": [
+      [
+        "rogue",
+        "age:senior adult",
+        "exists",
+        "dead",
+          "old_name"
+      ]
+    ],
+    "outsider": {
+      "current_rep": [
+        "any"
+      ],
+      "changed": -3
+    },
+    "relationships": [
+      {
+        "cats_from": [
+          "clan",
+          "high_social",
+          "low_aggress"
+        ],
+        "cats_to": [
+          "m_c"
+        ],
+        "mutual": false,
+        "values": [
+          "like",
+          "comfort",
+          "trust"
+        ],
+        "amount": -15,
+        "log": {
+          "cats_from": "cat_from was stunned to see cat_to ruthlessly kill a old rogue who sought c_n's forgiveness."
+        }
+      },
+      {
+        "cats_from": [
+          "clan",
+          "high_aggress"
+        ],
+        "cats_to": [
+          "m_c"
+        ],
+        "mutual": false,
+        "values": [
+          "like",
+          "respect"
+        ],
+        "amount": 10,
+        "log": {
+          "cats_from": "cat_from approved of cat_to killing an old loner who once wronged c_n."
+        }
+      }
+    ]
+  },
+  {
+    "event_id": "gen_new_cat_rogueredemption_kill2",
+    "location": [
+      "any"
+    ],
+    "season": [
+      "any"
+    ],
+    "sub_type": [],
+    "tags": [],
+    "frequency": 1,
+    "event_text": "m_c is called to the camp's entrance where n_c:0 waits, head ducked in respect. n_c:0 meows that {PRONOUN/n_c:0/subject} {VERB/n_c:0/regret/regrets} any misdeeds, mischief, or hardship {PRONOUN/n_c:0/subject} {VERB/n_c:0/have/has} caused c_n in the past and {VERB/n_c:0/want/wants} to join the Clan. m_c ruthlessly uses the opportunity to slay the nuisance where {PRONOUN/n_c:0/subject} {VERB/n_c:0/stand/stands}.",
+    "m_c": {
+      "status": [
+        "leader"
+      ],
+      "trait": [
+        "bloodthirsty"
+      ],
+      "dies": false
+    },
+    "new_cat": [
+      [
+        "rogue",
+        "age:senior",
+        "exists",
+        "dead",
+          "old_name"
+      ]
+    ],
+    "outsider": {
+      "current_rep": [
+        "any"
+      ],
+      "changed": -3
+    },
+    "relationships": [
+      {
+        "cats_from": [
+          "clan",
+          "high_social",
+          "low_aggress"
+        ],
+        "cats_to": [
+          "m_c"
+        ],
+        "mutual": false,
+        "values": [
+          "like",
+          "comfort",
+          "trust"
+        ],
+        "amount": -15,
+        "log": {
+          "cats_from": "cat_from was stunned to see cat_to ruthlessly kill a old rogue who sought c_n's forgiveness."
+        }
+      },
+      {
+        "cats_from": [
+          "clan",
+          "high_aggress"
+        ],
+        "cats_to": [
+          "m_c"
+        ],
+        "mutual": false,
+        "values": [
+          "like",
+          "respect"
+        ],
+        "amount": 10,
+        "log": {
+          "cats_from": "cat_from approved of cat_to killing an old loner who once wronged c_n."
+        }
+      }
+    ]
+  }
 ]

--- a/resources/lang/en/events/new_cat/general.json
+++ b/resources/lang/en/events/new_cat/general.json
@@ -3234,7 +3234,7 @@
     "sub_type": [],
     "tags": [],
     "frequency": 1,
-    "event_text": "m_c is called to the camp's entrance where n_c:0 waits, head ducked in respect. n_c:0 meows that {PRONOUN/n_c:0/subject} {VERB/n_c:0/regret/regrets} any misdeeds, mischief, or hardship {PRONOUN/n_c:0/subject} {VERB/n_c:0/have/has} caused c_n in the past and {VERB/n_c:0/want/wants} to join the Clan. m_c accepts.",
+    "event_text": "m_c is called to the camp's entrance where n_c:0 waits, head ducked in respect. n_c:0 apologizes for any misdeeds, mischief, or hardship {PRONOUN/n_c:0/subject}{VERB/n_c:0/'ve/'s} caused c_n in the past and asks to join the Clan. m_c accepts.",
     "m_c": {
       "status": [
         "leader"
@@ -3242,7 +3242,8 @@
       "trait": [
         "-bloodthirsty",
         "-cold",
-        "-strict"
+        "-strict",
+        "-vengeful"  
       ],
       "dies": false
     },
@@ -3274,7 +3275,25 @@
         ],
         "amount": 10,
         "log": {
-          "cats_from": "cat_from is impressed that cat_from gave an old loner a chance to join the clan."
+          "cats_from": "cat_from was impressed that cat_to gave an old rogue a chance to join the clan."
+        }
+      },
+     {
+        "cats_from": [
+          "n_c:0"
+        ],
+        "cats_to": [
+          "m_c",
+            "some_clan"
+        ],
+        "mutual": false,
+        "values": [
+          "like",
+            "comfort"
+        ],
+        "amount": 5,
+        "log": {
+          "cats_from": "cat_from was grateful to be welcomed into c_n by cat_to."
         }
       }
     ]
@@ -3290,7 +3309,7 @@
     "sub_type": [],
     "tags": [],
     "frequency": 1,
-    "event_text": "m_c is called to the camp's entrance where n_c:0 waits, head ducked in respect. n_c:0 meows that {PRONOUN/n_c:0/subject} {VERB/n_c:0/regret/regrets} any misdeeds, mischief, or hardship {PRONOUN/n_c:0/subject} {VERB/n_c:0/have/has} caused c_n in the past and {VERB/n_c:0/want/wants} to join the Clan. m_c accepts.",
+    "event_text": "m_c is called to the camp's entrance where n_c:0 waits, head ducked in respect. n_c:0 apologizes for any misdeeds, mischief, or hardship {PRONOUN/n_c:0/subject}{VERB/n_c:0/'ve/'s} caused c_n in the past and asks to join the Clan. m_c accepts.",
     "m_c": {
       "status": [
         "leader"
@@ -3298,7 +3317,8 @@
       "trait": [
         "-bloodthirsty",
         "-cold",
-        "-strict"
+        "-strict", 
+        "-vengeful"
       ],
       "dies": false
     },
@@ -3330,7 +3350,25 @@
         ],
         "amount": 10,
         "log": {
-          "cats_from": "cat_from is impressed that cat_from gave an old loner a chance to join the clan."
+          "cats_from": "cat_from was impressed that cat_to gave an old rogue a chance to join the clan."
+        }
+      },
+      {
+        "cats_from": [
+          "n_c:0"
+        ],
+        "cats_to": [
+          "m_c",
+            "some_clan"
+        ],
+        "mutual": false,
+        "values": [
+          "like",
+            "comfort"
+        ],
+        "amount": 5,
+        "log": {
+          "cats_from": "cat_from was grateful to be welcomed into c_n by cat_to."
         }
       }
     ]
@@ -3346,15 +3384,13 @@
     "sub_type": [],
     "tags": [],
     "frequency": 1,
-    "event_text": "m_c is called to the camp's entrance where n_c:0 waits, head ducked in respect. n_c:0 meows that {PRONOUN/n_c:0/subject} {VERB/n_c:0/regret/regrets} any misdeeds, mischief, or hardship {PRONOUN/n_c:0/subject} {VERB/n_c:0/have/has} caused c_n in the past and {VERB/n_c:0/want/wants} to join the Clan. m_c turns {PRONOUN/n_c:0/object} away.",
+    "event_text": "m_c is called to the camp's entrance where n_c:0 waits, head ducked in respect. n_c:0 apologizes for any misdeeds, mischief, or hardship {PRONOUN/n_c:0/subject}{VERB/n_c:0/'ve/'s} caused c_n in the past and asks to join the Clan. m_c turns {PRONOUN/n_c:0/object} away.",
     "m_c": {
       "status": [
         "leader"
       ],
       "trait": [
-        "-bloodthirsty",
-        "-cold",
-        "-strict"
+        "-bloodthirsty"
       ],
       "dies": false
     },
@@ -3389,7 +3425,43 @@
         ],
         "amount": -5,
         "log": {
-          "cats_from": "cat_from thought cat_from should've given a old loner a chance to join the clan."
+          "cats_from": "cat_from thought cat_to should've given an old rogue a chance to join the clan."
+        }
+      },
+                        {
+        "cats_from": [
+          "n_c:0"
+        ],
+        "cats_to": [
+          "m_c"
+        ],
+        "mutual": false,
+        "values": [
+          "like",
+          "trust"
+        ],
+        "amount": -5,
+        "log": {
+          "cats_from": "Though cat_from understood, {PRONOUN/n_c:0/subject} were still disappointed that cat_to shunned them."
+        }
+      },
+        {
+        "cats_from": [
+          "n_c:0",
+            "high_aggress",
+            "low_stable"
+        ],
+        "cats_to": [
+          "m_c"
+        ],
+        "mutual": false,
+        "values": [
+          "like",
+          "trust"
+        ],
+        "amount": -15,
+        "log": {
+          "cats_from": "cat_from regretted ever offering c_n their forgiveness."
         }
       }
     ]
@@ -3405,15 +3477,13 @@
     "sub_type": [],
     "tags": [],
     "frequency": 1,
-    "event_text": "m_c is called to the camp's entrance where n_c:0 waits, head ducked in respect. n_c:0 meows that {PRONOUN/n_c:0/subject} {VERB/n_c:0/regret/regrets} any misdeeds, mischief, or hardship {PRONOUN/n_c:0/subject} {VERB/n_c:0/have/has} caused c_n in the past and {VERB/n_c:0/want/wants} to join the Clan. m_c turns {PRONOUN/n_c:0/object} away.",
+    "event_text": "m_c is called to the camp's entrance where n_c:0 waits, head ducked in respect. n_c:0 apologizes for any misdeeds, mischief, or hardship {PRONOUN/n_c:0/subject}{VERB/n_c:0/'ve/'s} caused c_n in the past and asks to join the Clan. m_c turns {PRONOUN/n_c:0/object} away.",
     "m_c": {
       "status": [
         "leader"
       ],
       "trait": [
-        "-bloodthirsty",
-        "-cold",
-        "-strict"
+        "-bloodthirsty"
       ],
       "dies": false
     },
@@ -3448,7 +3518,43 @@
         ],
         "amount": -5,
         "log": {
-          "cats_from": "cat_from thought cat_from should've given a old loner a chance to join the clan."
+          "cats_from": "cat_from thought cat_from should've given an old rogue a chance to join the clan."
+        }
+      },
+                {
+        "cats_from": [
+          "n_c:0"
+        ],
+        "cats_to": [
+          "m_c"
+        ],
+        "mutual": false,
+        "values": [
+          "like",
+          "trust"
+        ],
+        "amount": -5,
+        "log": {
+          "cats_from": "Though cat_from understood, {PRONOUN/n_c:0/subject} were still disappointed that cat_to shunned them."
+        }
+      },
+        {
+        "cats_from": [
+          "n_c:0",
+            "high_aggress",
+            "low_stable"
+        ],
+        "cats_to": [
+          "m_c"
+        ],
+        "mutual": false,
+        "values": [
+          "like",
+          "trust"
+        ],
+        "amount": -15,
+        "log": {
+          "cats_from": "cat_from regretted ever offering c_n their forgiveness."
         }
       }
     ]
@@ -3464,13 +3570,14 @@
     "sub_type": [],
     "tags": [],
     "frequency": 1,
-    "event_text": "m_c is called to the camp's entrance where n_c:0 waits, head ducked in respect. n_c:0 meows that {PRONOUN/n_c:0/subject} {VERB/n_c:0/regret/regrets} any misdeeds, mischief, or hardship {PRONOUN/n_c:0/subject} {VERB/n_c:0/have/has} caused c_n in the past and {VERB/n_c:0/want/wants} to join the Clan. m_c ruthlessly uses the opportunity to slay the nuisance where {PRONOUN/n_c:0/subject} {VERB/n_c:0/stand/stands}.",
+    "event_text": "m_c is called to the camp's entrance where n_c:0 waits, head ducked in respect. n_c:0 apologizes for any misdeeds, mischief, or hardship {PRONOUN/n_c:0/subject}{VERB/n_c:0/'ve/'s} caused c_n in the past and asks to join the Clan. m_c ruthlessly uses the opportunity to slay the nuisance where {PRONOUN/n_c:0/subject} {VERB/n_c:0/stand/stands}.",
     "m_c": {
       "status": [
         "leader"
       ],
       "trait": [
-        "bloodthirsty"
+        "bloodthirsty",
+          "vengeful"
       ],
       "dies": false
     },
@@ -3513,7 +3620,25 @@
       {
         "cats_from": [
           "clan",
-          "high_aggress"
+          "high_aggress",
+            "low_lawful"
+        ],
+        "cats_to": [
+          "m_c"
+        ],
+        "mutual": false,
+        "values": [
+          "trust",
+          "respect"
+        ],
+        "amount": 10,
+        "log": {
+          "cats_from": "cat_from approved of cat_to killing an old loner who once wronged c_n."
+        }
+      },
+                {
+        "cats_from": [
+          "n_c:0"
         ],
         "cats_to": [
           "m_c"
@@ -3521,11 +3646,29 @@
         "mutual": false,
         "values": [
           "like",
-          "respect"
+          "trust"
         ],
-        "amount": 10,
+        "amount": -10,
         "log": {
-          "cats_from": "cat_from approved of cat_to killing an old loner who once wronged c_n."
+          "cats_from": "cat_from never imagined that m_c would kill {PRONOUN/n_c:0/object} during an apology."
+        }
+      },
+        {
+        "cats_from": [
+          "n_c:0",
+            "high_aggress"
+        ],
+        "cats_to": [
+          "m_c"
+        ],
+        "mutual": false,
+        "values": [
+          "like",
+          "trust"
+        ],
+        "amount": -20,
+        "log": {
+          "cats_from": "cat_from vows to curse m_c and c_n from beyond the grave."
         }
       }
     ]
@@ -3541,13 +3684,14 @@
     "sub_type": [],
     "tags": [],
     "frequency": 1,
-    "event_text": "m_c is called to the camp's entrance where n_c:0 waits, head ducked in respect. n_c:0 meows that {PRONOUN/n_c:0/subject} {VERB/n_c:0/regret/regrets} any misdeeds, mischief, or hardship {PRONOUN/n_c:0/subject} {VERB/n_c:0/have/has} caused c_n in the past and {VERB/n_c:0/want/wants} to join the Clan. m_c ruthlessly uses the opportunity to slay the nuisance where {PRONOUN/n_c:0/subject} {VERB/n_c:0/stand/stands}.",
+    "event_text": "m_c is called to the camp's entrance where n_c:0 waits, head ducked in respect. n_c:0 apologizes for any misdeeds, mischief, or hardship {PRONOUN/n_c:0/subject}{VERB/n_c:0/'ve/'s} caused c_n in the past and asks to join the Clan. m_c ruthlessly uses the opportunity to slay the nuisance where {PRONOUN/n_c:0/subject} {VERB/n_c:0/stand/stands}.",
     "m_c": {
       "status": [
         "leader"
       ],
       "trait": [
-        "bloodthirsty"
+        "bloodthirsty",
+          "vengeful"
       ],
       "dies": false
     },
@@ -3590,7 +3734,8 @@
       {
         "cats_from": [
           "clan",
-          "high_aggress"
+          "high_aggress",
+            "low_lawful"
         ],
         "cats_to": [
           "m_c"
@@ -3603,6 +3748,41 @@
         "amount": 10,
         "log": {
           "cats_from": "cat_from approved of cat_to killing an old loner who once wronged c_n."
+        }
+      },
+        {
+        "cats_from": [
+          "n_c:0"
+        ],
+        "cats_to": [
+          "m_c"
+        ],
+        "mutual": false,
+        "values": [
+          "like",
+          "trust"
+        ],
+        "amount": -10,
+        "log": {
+          "cats_from": "cat_from never imagined that m_c would kill {PRONOUN/n_c:0/object} during an apology."
+        }
+      },
+        {
+        "cats_from": [
+          "n_c:0",
+            "high_aggress"
+        ],
+        "cats_to": [
+          "m_c"
+        ],
+        "mutual": false,
+        "values": [
+          "like",
+          "trust"
+        ],
+        "amount": -20,
+        "log": {
+          "cats_from": "cat_from vows to curse m_c and c_n from beyond the grave."
         }
       }
     ]


### PR DESCRIPTION
## About The Pull Request

- Adds six variations of an event where a senior or senior adult rogue known to the clan seeks them out to apologize for past actions and hopefully seek a place in the clan. Options include acceptance, denial, and for the bloodthirsty, murder.

## Why This Is Good For ClanGen

- More new_cat events, especially for an age bracket where there are fewer options. 

## Proof of Testing

<img width="508" height="181" alt="Screenshot 2026-04-28 at 8 56 24 PM" src="https://github.com/user-attachments/assets/9fdf2252-f119-4dd4-85ce-39e5b262ab7d" />
<img width="504" height="153" alt="Screenshot 2026-04-28 at 8 52 44 PM" src="https://github.com/user-attachments/assets/bc277d55-d08b-4c65-a6dd-46826f0f9b5f" />
<img width="511" height="155" alt="Screenshot 2026-04-28 at 8 48 01 PM" src="https://github.com/user-attachments/assets/f64f74ae-e7f9-44b1-a53b-815fbe4edf6b" />