### PR TITLE
[BUGFIX] bear patrol fixes

### DIFF
--- a/resources/lang/en/patrols/forest/border/any.json
+++ b/resources/lang/en/patrols/forest/border/any.json
@@ -3880,7 +3880,7 @@
   ],
   "tags": [],
   "patrol_art": "fst_canopy",
-  "min_cats": 2,
+  "min_cats": 3,
   "max_cats": 6,
     "min_max_status": {
         "leader": [
@@ -3891,7 +3891,7 @@
   "relationship_constraint": [],
   "pl_skill_constraint": [],
   "intro_text": "Through a copse of narrow trees p_l sees a robust figure and flicks {PRONOUN/p_l/poss} tail to alert the patrol to stop. A bear is nearby, though what kind is unclear; its pelt color is distorted by the shaded canopy.",
-  "decline_text": "The patrol retreats back to camp to report to lead_name. Learning more about the predators in the territory could be useful, though not at the cost of their lives.",
+  "decline_text": "The patrol retreats back to camp to report to their leader. Learning more about the predators in the territory could be useful, though not at the cost of their lives.",
   "success_outcomes": [
     {
       "text": "r_c sneaks forward and determines it's a black bear. It should be relatively harmless as long as the Clan keeps an eye on its whereabouts.",
@@ -3903,7 +3903,7 @@
       "art": "gen_warrior_crouching"
     },
     {
-      "text": "r_c's pupils dilate as a ray of sunlight illuminates the bear's russet pelt. r_c realizes with alarm that it's a brown bear. The patrol slinks away without incident and lead_name warns patrols to stay away from the area.",
+      "text": "r_c's pupils dilate as a ray of sunlight illuminates the bear's russet pelt. r_c realizes with alarm that it's a brown bear. The patrol slinks away without incident and c_n's leader warns patrols to stay away from the area.",
       "exp": 10,
       "frequency": 4,
       "can_have_stat": [
@@ -4063,7 +4063,7 @@
       "art": "gen_anxious1"
     },
     {
-      "text": "r_c creeps closer to identify the beast but is spotted. With a roar, the black bear swipes at {PRONOUN/r_c/object}, sending r_c tumbling across the leaf litter. {PRONOUN/r_c/subject/CAP} {VERB/r_c/scramble/scrambles} to {PRONOUN/r_c/poss} feet, and p_l rushes to help {PRONOUN/r_c/object} to safety. Thankfully, the bear is uninterested in finishing the job and lumbers away..",
+      "text": "r_c creeps closer to identify the beast but is spotted. With a roar, the black bear swipes at {PRONOUN/r_c/object}, sending r_c tumbling across the leaf litter. {PRONOUN/r_c/subject/CAP} {VERB/r_c/scramble/scrambles} to {PRONOUN/r_c/poss} feet, and p_l rushes to help {PRONOUN/r_c/object} to safety. Thankfully, the bear is uninterested in finishing the job and lumbers away.",
       "exp": 0,
       "frequency": 3,
       "injury": [
@@ -4107,7 +4107,7 @@
       "art": "gen_scared_cat_warrior"
     },
     {
-      "text": "r_c sneaks towards the bear to try to identify it. Before {PRONOUN/r_c/subject} {VERB/r_c/know/knows} it, {PRONOUN/r_c/subject} {VERB/r_c/are/is} snout to snout with an angry, slobbering brown bear who swings its massive paw toward {PRONOUN/r_c/object}. r_c wails as {PRONOUN/r_c/subject} {VERB/r_c/are/is} mauled and tossed to the side, attempting to scrabble to safety when p_l grabs {PRONOUN/r_c/poss} scruff and pulls them both to safety. Luckily the bear is uninterested in finishing the job. ",
+      "text": "r_c sneaks towards the bear to try to identify it. Before {PRONOUN/r_c/subject} {VERB/r_c/know/knows} it, {PRONOUN/r_c/subject} {VERB/r_c/are/is} snout to snout with an angry, slobbering brown bear who swings its massive paw toward {PRONOUN/r_c/object}. r_c wails as {PRONOUN/r_c/subject} {VERB/r_c/are/is} mauled and tossed to the side, attempting to scrabble to safety when p_l grabs {PRONOUN/r_c/poss} scruff and pulls them both to safety. Luckily the bear is uninterested in finishing the job.",
       "exp": 0,
       "frequency": 3,
       "injury": [
@@ -4170,6 +4170,7 @@
       "injury": [
         {
           "cats": [
+              "r_c",
             "multi"
           ],
           "injuries": [
@@ -4229,7 +4230,8 @@
             "-p_l"
           ],
           "injuries": [
-            "shock"
+            "shock",
+              "non_lethal"
           ],
           "scars": [],
           "no_results": false

--- a/resources/lang/en/patrols/forest/border/any.json
+++ b/resources/lang/en/patrols/forest/border/any.json
@@ -3878,7 +3878,7 @@
   "types": [
     "border"
   ],
-  "tags": [],
+  "tags": ["clan:leader"],
   "patrol_art": "fst_canopy",
   "min_cats": 3,
   "max_cats": 6,


### PR DESCRIPTION
## About The Pull Request

- Removed lead_name so the patrol no longer crashes the game if the clan has no leader.
- Changed min cats to 3 instead of 2
- Made shock non-lethal so cats can't die of shock and be "killed by a bear"
- Made one failure option that mentions "multiple injuries" actually guaranteed to have at least two injuries.

## Why This Is Good For ClanGen

- Clans without leaders can now enjoy the patrol.
- Consistency between code + patrol writing

## Linked Issues

- #4898

## Proof of Testing
patrol functions in game
<img width="727" height="562" alt="Screenshot 2026-04-28 at 11 14 40 PM" src="https://github.com/user-attachments/assets/0096c101-54b8-477a-9e6b-d88a38342960" />

A clan without a leader can now decline the patrol without crashing
<img width="762" height="583" alt="Screenshot 2026-04-28 at 11 13 23 PM" src="https://github.com/user-attachments/assets/fe73ed61-3d99-45e3-a2f2-496b1b36af5e" />
