### PR TITLE
[BUGFIXES] Rel log mismatch, Leader's den mismatch, Missing verb tag

### DIFF
--- a/resources/lang/en/events/leader_den/success/other_clan.json
+++ b/resources/lang/en/events/leader_den/success/other_clan.json
@@ -261,7 +261,7 @@
   {
     "interaction_type": "offend",
     "event_text": "m_c is intentional with {PRONOUN/m_c/poss} comments during the Gathering. {PRONOUN/m_c/subject/CAP} {VERB/m_c/manage/manages} to make it clear to o_c_n that c_n is no longer their ally — without being outright insulting.",
-    "rel_change": -7,
+    "rel_change": -10,
     "m_c": {
       "trait": ["wise", "sincere", "cunning", "calm", "careful", "loving", "responsible", "righteous", "strict", "compassionate", "thoughtful"]
     },

--- a/resources/lang/en/patrols/forest/hunting/greenleaf.json
+++ b/resources/lang/en/patrols/forest/hunting/greenleaf.json
@@ -555,7 +555,7 @@
                 "relationships": [
                     {
                         "cats_to": [
-                            "s_c"
+                            "r_c"
                         ],
                         "cats_from": [
                             "patrol"
@@ -565,6 +565,34 @@
                         "amount": 10,
                         "log": {
                             "cats_from": "cat_from was highly impressed by cat_to's genius idea for baiting squirrels."
+                        }
+                    },
+                    {
+                        "cats_to": [
+                            "s_c"
+                        ],
+                        "cats_from": [
+                            "patrol", "high_stable"
+                        ],
+                        "mutual": false,
+                        "values": ["respect"],
+                        "amount": 10,
+                        "log": {
+                            "cats_from": "cat_from was amazed by cat_to's hunting skill on patrol."
+                        }
+                    },
+                    {
+                        "cats_to": [
+                            "s_c"
+                        ],
+                        "cats_from": [
+                            "patrol", "low_stable"
+                        ],
+                        "mutual": false,
+                        "values": ["respect"],
+                        "amount": -10,
+                        "log": {
+                            "cats_from": "cat_from envied cat_to's hunting skill on patrol."
                         }
                     }
                 ],

--- a/resources/lang/en/patrols/forest/hunting/leaf-bare.json
+++ b/resources/lang/en/patrols/forest/hunting/leaf-bare.json
@@ -1564,7 +1564,7 @@
                 "relationships": [
                     {
                         "cats_to": [
-                            "s_c"
+                            "r_c"
                         ],
                         "cats_from": [
                             "patrol"
@@ -1574,6 +1574,34 @@
                         "amount": 10,
                         "log": {
                             "cats_from": "cat_from was highly impressed by cat_to's genius idea for baiting squirrels."
+                        }
+                    },
+                    {
+                        "cats_to": [
+                            "s_c"
+                        ],
+                        "cats_from": [
+                            "patrol", "high_stable"
+                        ],
+                        "mutual": false,
+                        "values": ["respect"],
+                        "amount": 10,
+                        "log": {
+                            "cats_from": "cat_from was amazed by cat_to's hunting skill on patrol."
+                        }
+                    },
+                    {
+                        "cats_to": [
+                            "s_c"
+                        ],
+                        "cats_from": [
+                            "patrol", "low_stable"
+                        ],
+                        "mutual": false,
+                        "values": ["respect"],
+                        "amount": -10,
+                        "log": {
+                            "cats_from": "cat_from envied cat_to's hunting skill on patrol."
                         }
                     }
                 ],

--- a/resources/lang/en/patrols/forest/hunting/leaf-fall.json
+++ b/resources/lang/en/patrols/forest/hunting/leaf-fall.json
@@ -542,7 +542,7 @@
                 "relationships": [
                     {
                         "cats_to": [
-                            "s_c"
+                            "r_c"
                         ],
                         "cats_from": [
                             "patrol"
@@ -552,6 +552,34 @@
                         "amount": 10,
                         "log": {
                             "cats_from": "cat_from was highly impressed by cat_to's genius idea for baiting squirrels."
+                        }
+                    },
+                    {
+                        "cats_to": [
+                            "s_c"
+                        ],
+                        "cats_from": [
+                            "patrol", "high_stable"
+                        ],
+                        "mutual": false,
+                        "values": ["respect"],
+                        "amount": 10,
+                        "log": {
+                            "cats_from": "cat_from was amazed by cat_to's hunting skill on patrol."
+                        }
+                    },
+                    {
+                        "cats_to": [
+                            "s_c"
+                        ],
+                        "cats_from": [
+                            "patrol", "low_stable"
+                        ],
+                        "mutual": false,
+                        "values": ["respect"],
+                        "amount": -10,
+                        "log": {
+                            "cats_from": "cat_from envied cat_to's hunting skill on patrol."
                         }
                     }
                 ],

--- a/resources/lang/en/patrols/forest/hunting/newleaf.json
+++ b/resources/lang/en/patrols/forest/hunting/newleaf.json
@@ -542,7 +542,7 @@
                 "relationships": [
                     {
                         "cats_to": [
-                            "s_c"
+                            "r_c"
                         ],
                         "cats_from": [
                             "patrol"
@@ -552,6 +552,34 @@
                         "amount": 10,
                         "log": {
                             "cats_from": "cat_from was highly impressed by cat_to's genius idea for baiting squirrels."
+                        }
+                    },
+                    {
+                        "cats_to": [
+                            "s_c"
+                        ],
+                        "cats_from": [
+                            "patrol", "high_stable"
+                        ],
+                        "mutual": false,
+                        "values": ["respect"],
+                        "amount": 10,
+                        "log": {
+                            "cats_from": "cat_from was amazed by cat_to's hunting skill on patrol."
+                        }
+                    },
+                    {
+                        "cats_to": [
+                            "s_c"
+                        ],
+                        "cats_from": [
+                            "patrol", "low_stable"
+                        ],
+                        "mutual": false,
+                        "values": ["respect"],
+                        "amount": -10,
+                        "log": {
+                            "cats_from": "cat_from envied cat_to's hunting skill on patrol."
                         }
                     }
                 ],

--- a/resources/lang/en/patrols/general/medcat.json
+++ b/resources/lang/en/patrols/general/medcat.json
@@ -14300,6 +14300,7 @@
                 "stat_skill": [
                     "SENSE,2"
                 ],
+                "can_have_stat": ["p_l"],
                 "herbs": [
                     "many_herbs",
                     "dandelion",
@@ -25302,6 +25303,7 @@
                 "stat_skill": [
                     "SENSE,2"
                 ],
+                "can_have_stat": ["p_l"],
                 "herbs": [
                     "many_herbs",
                     "dandelion",
@@ -32648,6 +32650,7 @@
                 "stat_skill": [
                     "SENSE,2"
                 ],
+                "can_have_stat": ["p_l"],
                 "herbs": [
                     "many_herbs",
                     "dandelion",

--- a/resources/lang/en/patrols/general/medcat.json
+++ b/resources/lang/en/patrols/general/medcat.json
@@ -14295,7 +14295,7 @@
                 "frequency": 1
             },
             {
-                "text": "With warmth in the air and ground, s_c doesn't need to try very hard to find an excellent haul of dandelions and plentiful wild garlic to bring back to camp. {PRONOUN/p_l/subject/CAP} help the warriors carefully pluck fluffy dandelions heads to bring back for the nursery, and don't even have the heart to get annoyed when the warriors decline to help carry the wild garlic.",
+                "text": "With warmth in the air and ground, s_c doesn't need to try very hard to find an excellent haul of dandelions and plentiful wild garlic to bring back to camp. {PRONOUN/p_l/subject/CAP} {VERB/p_l/help/helps} the warriors pluck fluffy dandelions heads to bring back for the nursery and {VERB/p_l/do/does}n't even have the heart to get annoyed when the warriors decline to help carry the wild garlic.",
                 "exp": 10,
                 "stat_skill": [
                     "SENSE,2"

--- a/resources/lang/en/patrols/mountainous/hunting/greenleaf.json
+++ b/resources/lang/en/patrols/mountainous/hunting/greenleaf.json
@@ -657,7 +657,7 @@
                 "relationships": [
                     {
                         "cats_to": [
-                            "s_c"
+                            "r_c"
                         ],
                         "cats_from": [
                             "patrol"
@@ -667,6 +667,34 @@
                         "amount": 10,
                         "log": {
                             "cats_from": "cat_from was highly impressed by cat_to's genius idea for baiting squirrels."
+                        }
+                    },
+                    {
+                        "cats_to": [
+                            "s_c"
+                        ],
+                        "cats_from": [
+                            "patrol", "high_stable"
+                        ],
+                        "mutual": false,
+                        "values": ["respect"],
+                        "amount": 10,
+                        "log": {
+                            "cats_from": "cat_from was amazed by cat_to's hunting skill on patrol."
+                        }
+                    },
+                    {
+                        "cats_to": [
+                            "s_c"
+                        ],
+                        "cats_from": [
+                            "patrol", "low_stable"
+                        ],
+                        "mutual": false,
+                        "values": ["respect"],
+                        "amount": -10,
+                        "log": {
+                            "cats_from": "cat_from envied cat_to's hunting skill on patrol."
                         }
                     }
                 ],

--- a/resources/lang/en/patrols/mountainous/hunting/leaf-bare.json
+++ b/resources/lang/en/patrols/mountainous/hunting/leaf-bare.json
@@ -1411,7 +1411,7 @@
                 "relationships": [
                     {
                         "cats_to": [
-                            "s_c"
+                            "r_c"
                         ],
                         "cats_from": [
                             "patrol"
@@ -1421,6 +1421,34 @@
                         "amount": 10,
                         "log": {
                             "cats_from": "cat_from was highly impressed by cat_to's genius idea for baiting squirrels."
+                        }
+                    },
+                    {
+                        "cats_to": [
+                            "s_c"
+                        ],
+                        "cats_from": [
+                            "patrol", "high_stable"
+                        ],
+                        "mutual": false,
+                        "values": ["respect"],
+                        "amount": 10,
+                        "log": {
+                            "cats_from": "cat_from was amazed by cat_to's hunting skill on patrol."
+                        }
+                    },
+                    {
+                        "cats_to": [
+                            "s_c"
+                        ],
+                        "cats_from": [
+                            "patrol", "low_stable"
+                        ],
+                        "mutual": false,
+                        "values": ["respect"],
+                        "amount": -10,
+                        "log": {
+                            "cats_from": "cat_from envied cat_to's hunting skill on patrol."
                         }
                     }
                 ],

--- a/resources/lang/en/patrols/mountainous/hunting/leaf-fall.json
+++ b/resources/lang/en/patrols/mountainous/hunting/leaf-fall.json
@@ -1287,7 +1287,7 @@
                 "relationships": [
                     {
                         "cats_to": [
-                            "s_c"
+                            "r_c"
                         ],
                         "cats_from": [
                             "patrol"
@@ -1297,6 +1297,34 @@
                         "amount": 10,
                         "log": {
                             "cats_from": "cat_from was highly impressed by cat_to's genius idea for baiting squirrels."
+                        }
+                    },
+                    {
+                        "cats_to": [
+                            "s_c"
+                        ],
+                        "cats_from": [
+                            "patrol", "high_stable"
+                        ],
+                        "mutual": false,
+                        "values": ["respect"],
+                        "amount": 10,
+                        "log": {
+                            "cats_from": "cat_from was amazed by cat_to's hunting skill on patrol."
+                        }
+                    },
+                    {
+                        "cats_to": [
+                            "s_c"
+                        ],
+                        "cats_from": [
+                            "patrol", "low_stable"
+                        ],
+                        "mutual": false,
+                        "values": ["respect"],
+                        "amount": -10,
+                        "log": {
+                            "cats_from": "cat_from envied cat_to's hunting skill on patrol."
                         }
                     }
                 ],

--- a/resources/lang/en/patrols/mountainous/hunting/newleaf.json
+++ b/resources/lang/en/patrols/mountainous/hunting/newleaf.json
@@ -952,7 +952,7 @@
                 "relationships": [
                     {
                         "cats_to": [
-                            "s_c"
+                            "r_c"
                         ],
                         "cats_from": [
                             "patrol"
@@ -962,6 +962,34 @@
                         "amount": 10,
                         "log": {
                             "cats_from": "cat_from was highly impressed by cat_to's genius idea for baiting squirrels."
+                        }
+                    },
+                    {
+                        "cats_to": [
+                            "s_c"
+                        ],
+                        "cats_from": [
+                            "patrol", "high_stable"
+                        ],
+                        "mutual": false,
+                        "values": ["respect"],
+                        "amount": 10,
+                        "log": {
+                            "cats_from": "cat_from was amazed by cat_to's hunting skill on patrol."
+                        }
+                    },
+                    {
+                        "cats_to": [
+                            "s_c"
+                        ],
+                        "cats_from": [
+                            "patrol", "low_stable"
+                        ],
+                        "mutual": false,
+                        "values": ["respect"],
+                        "amount": -10,
+                        "log": {
+                            "cats_from": "cat_from envied cat_to's hunting skill on patrol."
                         }
                     }
                 ],


### PR DESCRIPTION
## About The Pull Request

* Adds relationship logs to the reported patrol to make it clear that r_c came up with the idea and s_c's hunting talent is being spotlighted. Just for fun, I added some low stable envy results
* Increased the negative change in the leader's den event from -7 to -10. Any more and it would be possible for c_n to leapfrog neutral and go straight to hostile.
* Typo reported -- just missing verb tags.

## Linked Issues

Fixes: #4906 
Fixes: #4908 
addresses #1818

## Proof of Testing

<img width="554" height="471" alt="image" src="https://github.com/user-attachments/assets/27493086-c560-4914-89c6-47b4c3dcbe76" />
<img width="622" height="219" alt="image" src="https://github.com/user-attachments/assets/f85a6014-733a-4c1f-a7eb-7ef8d49af43c" />
<img width="713" height="186" alt="image" src="https://github.com/user-attachments/assets/0d6b74c2-be95-4ebd-b13b-bf4abc4ece7a" />

<img width="589" height="476" alt="image" src="https://github.com/user-attachments/assets/de3035b1-4da0-4295-bb84-ac57174f6d0e" />
verb tag being correct (although I've realized this is another case where the "can_have_stat" is missing)

<img width="739" height="179" alt="image" src="https://github.com/user-attachments/assets/65265f0e-0463-4393-b66f-ec688b3b1891" />
<img width="258" height="324" alt="image" src="https://github.com/user-attachments/assets/c9306f7c-4464-43f1-8b13-e3739005162e" />

actually neutral