### PR TITLE
[BUGFIX] get the newborns out of rel events

### DIFF
--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -1616,7 +1616,9 @@ class Cat:
         cats_to_choose = [
             iter_cat
             for iter_cat in Cat.all_cats.values()
-            if iter_cat.ID != self.ID and iter_cat.status.alive_in_player_clan
+            if iter_cat.ID != self.ID
+            and iter_cat.status.alive_in_player_clan
+            and iter_cat.age != CatAge.NEWBORN
         ]
         # if there are no cats to interact, stop
         if not cats_to_choose:

--- a/scripts/clan_package/get_clan_cats.py
+++ b/scripts/clan_package/get_clan_cats.py
@@ -87,29 +87,30 @@ def get_living_clan_cat_count(Cat):
     return count
 
 
-def get_cats_same_age(Cat, cat, age_range=10):
+def get_cats_same_age(Cat, cat_to_match, age_range=10):
     """
     Look for all cats in the Clan and returns a list of cats which are in the same age range as the given cat.
     :param Cat: Cat class
-    :param cat: the given cat
+    :param cat_to_match: the given cat
     :param int age_range: The allowed age difference between the two cats, default 10
     """
     cats = []
     for inter_cat in Cat.all_cats.values():
         if not inter_cat.status.alive_in_player_clan:
             continue
-        if inter_cat.ID == cat.ID:
+        if inter_cat.ID == cat_to_match.ID:
             continue
 
-        if inter_cat.ID not in cat.relationships:
-            cat.create_one_relationship(inter_cat)
-            if cat.ID not in inter_cat.relationships:
-                inter_cat.create_one_relationship(cat)
+        if inter_cat.ID not in cat_to_match.relationships:
+            cat_to_match.create_one_relationship(inter_cat)
+            if cat_to_match.ID not in inter_cat.relationships:
+                inter_cat.create_one_relationship(cat_to_match)
             continue
 
         if (
-            inter_cat.moons <= cat.moons + age_range
-            and inter_cat.moons <= cat.moons - age_range
+            cat_to_match.moons + age_range
+            >= inter_cat.moons
+            >= cat_to_match.moons - age_range
         ):
             cats.append(inter_cat)
 

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -1071,7 +1071,6 @@ def one_moon_cat(cat):
 
     # newborns don't do much
     if cat.status.rank == CatRank.NEWBORN:
-        cat.relationship_interaction()
         return
 
     handle_apprentice_EX(cat)  # This must be before perform_ceremonies!
@@ -1091,10 +1090,9 @@ def one_moon_cat(cat):
     if cat.dead:
         return
 
-    cat.relationship_interaction()
-
     # relationships have to be handled separately, because of the ceremony name change
     if cat.status.alive_in_player_clan:
+        cat.relationship_interaction()
         Relation_Events.handle_relationships(cat)
 
     # now we make sure ill and injured cats don't get interactions they shouldn't

--- a/scripts/events_module/relationship/relation_events.py
+++ b/scripts/events_module/relationship/relation_events.py
@@ -42,7 +42,7 @@ class Relation_Events:
         Returns
         -------
         """
-        if not cat.relationships:
+        if not cat.relationships or cat.age == CatAge.NEWBORN:
             return
         Relation_Events.had_one_event = False
 


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
Implemented a variety of measures to keep newborns out of relationship events. Though, I believe the biggest problem we were having was with the `get_cats_same_age()` func, as it was bugged to only return cats *younger* than the given cat.  When creating rel events we essentially try to trigger 4 of them: 1 general 'anyone" interaction, 1 group interaction, 1 "same age" interaction, and 1 romance interaction. What we were seeing with newborns is that they would consistently end up as the second cat in that "same age" interaction, due to the func only returning younger cats.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Why This Is Good For ClanGen
This is basically a blanket ban on newborns showing up in rel events. Technically we used to let them trigger a single interaction, but imo this doesn't make a ton of sense. We don't have *any* newborn specific relationship events. And since they're newborns, why would *they* be triggering any kind of rel change?

I could see us implementing some rel events specifically geared towards cats changing their relationships *toward* newborns, but I don't see the use in newborns changing *their* relationships towards others.
<!-- If this is a bug fix, you can remove this section. -->
<!-- Please add a short description of why you think these changes would benefit the game. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->
<!-- If you have multiple features that can stand on their own, or unrelated bugfixes, please create separate PRs for them. -->

## Linked Issues
twas reported in the dev channels
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
<img width="553" height="403" alt="image" src="https://github.com/user-attachments/assets/7a1ccfaa-bd1f-42f3-912c-561704b1d975" />

searched through 12 pages of rel events and saw no newborns involved! conversely, did see a lot of successful "same age" events actually triggering as they should.
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- banned newborns from relationship events
- fixed the bugged `get_cats_same_age()` func, which had actually been returning only cats who were younger than the given age range.
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
