### PR TITLE
[BUGFIX] some_clan relationship tag crashes the game with only 1 Clan member

### DIFF
--- a/scripts/events_module/consequences.py
+++ b/scripts/events_module/consequences.py
@@ -839,14 +839,17 @@ def gather_cat_objects(
             if getattr(event, "patrol_cats", None):
                 found_cat_list.difference_update(set(event.patrol_cats))
         elif abbr == "some_clan":  # 1 / 8 of clan cats are affected
-            found_cat_list.update(
-                sample(clan_cats, randint(1, max(1, round(len(clan_cats) / 8))))
-            )
-            # exclude cats involved in the event
-            found_cat_list.discard(getattr(event, "main_cat", None))
-            found_cat_list.discard(getattr(event, "random_cat", None))
-            if getattr(event, "patrol_cats", None):
-                found_cat_list.difference_update(set(event.patrol_cats))
+            if len(
+                clan_cats
+            ):  # to prevent crash if every cat in the clan died just before this
+                found_cat_list.update(
+                    sample(clan_cats, randint(1, max(1, round(len(clan_cats) / 8))))
+                )
+                # exclude cats involved in the event
+                found_cat_list.discard(getattr(event, "main_cat", None))
+                found_cat_list.discard(getattr(event, "random_cat", None))
+                if getattr(event, "patrol_cats", None):
+                    found_cat_list.difference_update(set(event.patrol_cats))
 
         # add/remove cats if found and then continue for loop
         if is_exclusionary and found_cat_list:


### PR DESCRIPTION
## About The Pull Request

Fixes issue where the `some_clan` relationship tag would cause a crash if every cat in the Clan died before the relationships could be changed.

## Linked Issues

Fixes #4902

## Proof of Testing

No crash on outcome.
<img width="793" height="693" alt="image" src="https://github.com/user-attachments/assets/fc4b271f-6905-446a-87d5-34506bca6a61" />
