### PR TITLE
[EDITS] tall tree death clarification

### DIFF
--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -5309,7 +5309,7 @@
         ],
         "tags": [],
         "frequency": 4,
-        "event_text": "m_c fell from the top branches of a tree.",
+        "event_text": "m_c fell from the top branches of a tree. {PRONOUN/m_c/subject/CAP} never get up again.",
         "m_c": {
             "age": [
                 "-kitten"

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -5309,7 +5309,7 @@
         ],
         "tags": [],
         "frequency": 4,
-        "event_text": "m_c fell from the top branches of a tree. {PRONOUN/m_c/subject/CAP} never get up again.",
+        "event_text": "m_c fell from the top branches of a tree. {PRONOUN/m_c/subject/CAP} never {VERB/m_c/get/gets} up again.",
         "m_c": {
             "age": [
                 "-kitten"

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -5314,6 +5314,38 @@
             "age": [
                 "-kitten"
             ],
+            "status": [
+            "-leader"
+          ],
+            "dies": true
+        },
+        "history": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "death": "m_c fell from a tall tree."
+            }
+        ]
+    },
+       {
+        "event_id": "gen_death_tree_any2",
+        "location": [
+            "beach",
+            "forest",
+            "mountainous",
+            "wetlands"
+        ],
+        "season": [
+            "any"
+        ],
+        "tags": [],
+        "frequency": 4,
+        "event_text": "m_c fell from the top branches of a tree. The fall was too great, and {PRONOUN/m_c/subject} could not recover.",
+        "m_c": {
+            "status": [
+            "leader"
+          ],
             "dies": true
         },
         "history": [


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

very minor edit to the "fell from the top branches of a tall tree" death event to clarify that it's fatal.

## Why This Is Good For ClanGen

for clarity's sake! i always had issues remembering this event was supposed to be a death due to the event's brevity and sort of vague wording. this makes sure the player is aware of the fact it kills the cat involved.

## Proof of Testing

<img width="514" height="98" alt="image" src="https://github.com/user-attachments/assets/89222e12-db99-42ce-b021-81d73023bb20" />


## Changelog/Credits

- Added an extra sentence to a death event to clarify that it is, in fact, a death.
