### PR TITLE
[BUGFIX] herb supply status on load

### DIFF
--- a/scripts/clan.py
+++ b/scripts/clan.py
@@ -1111,7 +1111,8 @@ class Clan:
             # else just start us with an empty herb supply
             else:
                 clan.herb_supply = HerbSupply()
-            clan.herb_supply.required_herb_count = get_living_clan_cat_count(Cat) * 2
+                
+            clan.herb_supply.set_required_herb_count = get_living_clan_cat_count(Cat)
         except:
             clan.herb_supply = HerbSupply()
 

--- a/scripts/clan.py
+++ b/scripts/clan.py
@@ -1111,8 +1111,8 @@ class Clan:
             # else just start us with an empty herb supply
             else:
                 clan.herb_supply = HerbSupply()
-                
-            clan.herb_supply.set_required_herb_count = get_living_clan_cat_count(Cat)
+
+            clan.herb_supply.set_required_herb_count(get_living_clan_cat_count(Cat))
         except:
             clan.herb_supply = HerbSupply()
 


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
Herb supply status messages were changing supply status types between saving and loading! The reason for that was that we set the required herb count upon load and weren't using the up-to-date `set_required_herb_count` func.  It was still using an out-dated calc, which made it mismatched compared to the supply state that would have been determined just before saving and closing the game.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
fixes #4909
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
<img width="466" height="70" alt="image" src="https://github.com/user-attachments/assets/235216e3-a2f7-4365-8e32-cd017af621b4" />

Status message for "Full" supply

<img width="502" height="56" alt="image" src="https://github.com/user-attachments/assets/0aa4cf3d-7887-4996-b4a0-0b94b7d48cae" />

upon save and reload, still have a "Full" supply message

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Medicine den supply status no longer calculates incorrectly upon loading a save
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
