### PR TITLE
[BUGFIX] certain traits no longer 'merge' with "related:" on relationships screen

### DIFF
--- a/scripts/screens/RelationshipScreen.py
+++ b/scripts/screens/RelationshipScreen.py
@@ -549,7 +549,7 @@ class RelationshipScreen(Screens):
             # Column One Details:
             self.inspect_cat_elements["col1"] = pygame_gui.elements.UITextBox(
                 self.inspect_cat.get_info_block(relationship=True),
-                ui_scale(pygame.Rect((10, 185), (100, 70))),
+                ui_scale(pygame.Rect((9, 185), (100, 70))),
                 object_id="#text_box_22_horizleft_spacing_95",
                 manager=MANAGER,
                 container=self.selected_cat_container,

--- a/scripts/screens/RelationshipScreen.py
+++ b/scripts/screens/RelationshipScreen.py
@@ -549,7 +549,7 @@ class RelationshipScreen(Screens):
             # Column One Details:
             self.inspect_cat_elements["col1"] = pygame_gui.elements.UITextBox(
                 self.inspect_cat.get_info_block(relationship=True),
-                ui_scale(pygame.Rect((9, 185), (100, 70))),
+                ui_scale(pygame.Rect((7, 185), (100, 70))),
                 object_id="#text_box_22_horizleft_spacing_95",
                 manager=MANAGER,
                 container=self.selected_cat_container,


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

Bumps text box size from (10,185) down to (7,185) to prevent 'merging' of traits with the "related:" text on relationships screen.

## Linked Issues

fixes #4744

## Proof of Testing

<img width="365" height="596" alt="image" src="https://github.com/user-attachments/assets/0a70f1cb-c808-4dbf-9d1e-a17997978e1b" />
<img width="382" height="607" alt="image" src="https://github.com/user-attachments/assets/68d97ff1-084f-4f4f-b202-1ff5057a89b2" />
