### PR TITLE
[CONTENT] general medicine cat teaching patrol

### DIFF
--- a/resources/lang/en/patrols/general/medcat.json
+++ b/resources/lang/en/patrols/general/medcat.json
@@ -37586,5 +37586,156 @@
                 "frequency": 4
             }
         ]
+    },
+{
+  "patrol_id": "gen_med_teachingwarriorapps",
+  "biome": [
+    "-desert"
+  ],
+  "season": [
+    "-leaf-bare"
+  ],
+  "types": [
+    "herb_gathering"
+  ],
+  "tags": [],
+  "min_cats": 2,
+  "max_cats": 6,
+  "patrol_art": "gen_app_crouching_perplexed",
+  "intro_text": "p_l takes the apprentices out to learn to identify common herbs. Regardless of their role, it is important to be able to recognize what grows in c_n's territory.",
+  "decline_text": "The apprentices get called away to other duties.",
+  "min_max_status": {
+    "warrior": [
+      -1,
+      -1
+    ],
+    "normal adult": [
+      -1,
+      -1
+    ],
+    "medicine cat": [
+      1,
+      6
+    ],
+    "leader": [
+      -1,
+      -1
+    ],
+    "deputy": [
+      -1,
+      -1
+    ],
+    "apprentice": [
+      1,
+      6
+    ],
+    "all apprentices": [
+      1,
+      6
+    ]
+  },
+  "frequency": 4,
+  "chance_of_success": 50,
+  "success_outcomes": [
+    {
+      "text": "p_l leads the apprentices on through common routes through the territory, pointing out herbs along the way. The apprentices soak up the information as their pelts soak in the sun's rays. Late in the lesson, s_c even manages to find usable herbs on {PRONOUN/s_c/poss} own, bounding up to p_l with show {PRONOUN/p_l/object} catmint in paw.",
+      "exp": 20,
+      "frequency": 2,
+      "stat_skill": [
+        "SENSE,0",
+        "HEALER,0"
+      ],
+      "herbs": [
+        "random_herbs"
+      ],
+      "relationships": [
+        {
+          "cats_to": [
+            "patrol"
+          ],
+          "cats_from": [
+            "p_l"
+          ],
+          "mutual": false,
+          "values": [
+            "respect",
+            "like",
+            "trust"
+          ],
+          "amount": 10,
+          "log": {
+            "cats_from": "cat_from was impressed by cat_to's diligence and natural talent for identifying herbs."
+          }
+        }
+      ],
+      "art": "gen_med_gatheringmallow_newleaf2"
+    },
+    {
+      "text": "p_l leads the apprentices on through common routes through the territory, pointing out herbs along the way. Wild garlic, burdock root, even raspberry bunches can be found near the best hunting grounds or by the border. It is always helpful to keep one's eye out, though {PRONOUN/p_l/subject} {VERB/p_l/remind/reminds} them never to ingest anything before it is identified by a medicine cat. The apprentices remain attentive throughout the patrol, taking in the lesson p_l has to offer.",
+      "exp": 20,
+      "frequency": 4,
+      "relationships": [
+        {
+          "cats_to": ["patrol", "-p_l"],
+          "cats_from": ["p_l"],
+          "mutual": false,
+          "values": ["trust"],
+          "amount": 10,
+          "log": {
+            "cats_from": "cat_from was impressed by cat_to's focus during an herb identification lesson."
+          }
+        }
+      ],
+      "art": "gen_showing_herbs_med_one_app"
     }
+  ],
+  "fail_outcomes": [
+    {
+      "text": "p_l sighs. The patrol is going exactly how {PRONOUN/p_l/subject} expected. None of the apprentices can focus and the warrior apprentices grumble that the information is useless. StarClan's sake, it's as if they're as immature as kits!",
+      "exp": 0,
+      "frequency": 4,
+      "relationships": [
+        {
+          "cats_to": ["patrol", "-p_l"],
+          "cats_from": ["p_l"],
+          "mutual": false,
+          "values": ["like"],
+          "amount": -5,
+          "log": {
+            "cats_from": "cat_from was frustrated that cat_to seemed to dismiss {PRONOUN/cat_from/poss} advice and teaching."
+          }
+        },
+                {
+          "cats_to": ["p_l"],
+          "cats_from": ["patrol", "-p_l"],
+          "mutual": false,
+          "values": ["like"],
+          "amount": -5,
+          "log": {
+            "cats_from": "cat_from didn't understand why anything cat_to was trying to teach {PRONOUN/cat_from/object} was relevant."
+          }
+        }
+      ],
+      "art": "med_cat_looking_up"
+    },
+    {
+      "text": "As the patrol sets out a sudden rain pours from the sky. The apprentices immediately begin to whine and moan about getting their pelts wet. p_l doesn't have the patience for this and turns the patrol around.",
+      "exp": 0,
+      "frequency": 2,
+      "relationships": [
+        {
+          "cats_to": ["patrol", "-p_l"],
+          "cats_from": ["p_l"],
+          "mutual": false,
+          "values": ["like", "respect"],
+          "amount": -5,
+          "log": {
+            "cats_from": "cat_from was irritated cat_to complained until something as trivial as rain deterred their patrol."
+          }
+        }
+      ],
+      "art": "gen_med_rainygathering"
+    }
+  ]
+}
 ]

--- a/resources/lang/en/patrols/general/medcat.json
+++ b/resources/lang/en/patrols/general/medcat.json
@@ -37605,53 +37605,29 @@
   "intro_text": "p_l takes the apprentices out to learn to identify common herbs. Regardless of their role, it is important to be able to recognize what grows in c_n's territory.",
   "decline_text": "The apprentices get called away to other duties.",
   "min_max_status": {
-    "warrior": [
-      -1,
-      -1
-    ],
-    "normal adult": [
-      -1,
-      -1
-    ],
-    "medicine cat": [
-      1,
-      6
-    ],
-    "leader": [
-      -1,
-      -1
-    ],
-    "deputy": [
-      -1,
-      -1
-    ],
-    "apprentice": [
-      1,
-      6
-    ],
-    "all apprentices": [
-      1,
-      6
-    ]
+    "normal adult": [-1, -1],
+    "medicine cat": [1, 1],
+    "apprentice": [2, 5]
   },
   "frequency": 4,
   "chance_of_success": 50,
   "success_outcomes": [
     {
-      "text": "p_l leads the apprentices on through common routes through the territory, pointing out herbs along the way. The apprentices soak up the information as their pelts soak in the sun's rays. Late in the lesson, s_c even manages to find usable herbs on {PRONOUN/s_c/poss} own, bounding up to p_l with show {PRONOUN/p_l/object} catmint in paw.",
+      "text": "p_l leads the apprentices on through common routes through the territory, pointing out herbs along the way. The apprentices soak up the information as their pelts soak up the sun's rays. Late in the lesson, s_c even manages to find usable herbs on {PRONOUN/s_c/poss} own, bounding up to p_l to show {PRONOUN/p_l/object} the catmint clutched gently in {PRONOUN/s_c/poss} mouth.",
       "exp": 20,
-      "frequency": 2,
+      "frequency": 4,
       "stat_skill": [
         "SENSE,0",
         "HEALER,0"
       ],
+      "can_have_stat": ["app"],
       "herbs": [
         "random_herbs"
       ],
       "relationships": [
         {
           "cats_to": [
-            "patrol"
+            "s_c"
           ],
           "cats_from": [
             "p_l"
@@ -37671,12 +37647,12 @@
       "art": "gen_med_gatheringmallow_newleaf2"
     },
     {
-      "text": "p_l leads the apprentices on through common routes through the territory, pointing out herbs along the way. Wild garlic, burdock root, even raspberry bunches can be found near the best hunting grounds or by the border. It is always helpful to keep one's eye out, though {PRONOUN/p_l/subject} {VERB/p_l/remind/reminds} them never to ingest anything before it is identified by a medicine cat. The apprentices remain attentive throughout the patrol, taking in the lesson p_l has to offer.",
+      "text": "p_l leads the apprentices along common routes, pointing out herbs along the way. Wild garlic, burdock root, even raspberry bunches can be found near the best hunting grounds or by the border. One should always keep one's eye out, though p_l reminds them never to ingest anything before it is identified by a medicine cat. The apprentices remain attentive throughout the patrol, taking in the lesson p_l offers.",
       "exp": 20,
       "frequency": 4,
       "relationships": [
         {
-          "cats_to": ["patrol", "-p_l"],
+          "cats_to": ["patrol"],
           "cats_from": ["p_l"],
           "mutual": false,
           "values": ["trust"],
@@ -37691,35 +37667,26 @@
   ],
   "fail_outcomes": [
     {
-      "text": "p_l sighs. The patrol is going exactly how {PRONOUN/p_l/subject} expected. None of the apprentices can focus and the warrior apprentices grumble that the information is useless. StarClan's sake, it's as if they're as immature as kits!",
+      "text": "p_l sighs. The patrol is going exactly how {PRONOUN/p_l/subject} expected. None of the apprentices can focus and the warrior apprentices grumble that the information is useless. For StarClan's sake, they're as immature as kits!",
       "exp": 0,
       "frequency": 4,
       "relationships": [
         {
-          "cats_to": ["patrol", "-p_l"],
+          "cats_to": ["patrol"],
           "cats_from": ["p_l"],
-          "mutual": false,
+          "mutual": true,
           "values": ["like"],
           "amount": -5,
           "log": {
-            "cats_from": "cat_from was frustrated that cat_to seemed to dismiss {PRONOUN/cat_from/poss} advice and teaching."
-          }
-        },
-                {
-          "cats_to": ["p_l"],
-          "cats_from": ["patrol", "-p_l"],
-          "mutual": false,
-          "values": ["like"],
-          "amount": -5,
-          "log": {
-            "cats_from": "cat_from didn't understand why anything cat_to was trying to teach {PRONOUN/cat_from/object} was relevant."
+            "cats_from": "cat_from was frustrated that cat_to seemed to dismiss {PRONOUN/cat_from/poss} advice and teaching.",
+            "cats_to": "cat_to didn't understand why anything cat_from was trying to teach {PRONOUN/cat_to/object} was relevant."
           }
         }
       ],
       "art": "med_cat_looking_up"
     },
     {
-      "text": "As the patrol sets out a sudden rain pours from the sky. The apprentices immediately begin to whine and moan about getting their pelts wet. p_l doesn't have the patience for this and turns the patrol around.",
+      "text": "As the patrol sets out, a sudden rain pours from the sky. The apprentices whine and moan about getting their pelts wet. p_l doesn't have the patience for this and turns the patrol around.",
       "exp": 0,
       "frequency": 2,
       "relationships": [
@@ -37730,7 +37697,7 @@
           "values": ["like", "respect"],
           "amount": -5,
           "log": {
-            "cats_from": "cat_from was irritated cat_to complained until something as trivial as rain deterred their patrol."
+            "cats_from": "cat_from was irritated that cat_to was more concerned with keeping {PRONOUN/cat_to/poss} pelt dry than with cat_from's important lesson."
           }
         }
       ],

--- a/resources/lang/en/patrols/general/medcat.json
+++ b/resources/lang/en/patrols/general/medcat.json
@@ -37655,7 +37655,7 @@
           "cats_to": ["patrol"],
           "cats_from": ["p_l"],
           "mutual": false,
-          "values": ["trust"],
+          "values": ["respect"],
           "amount": 10,
           "log": {
             "cats_from": "cat_from was impressed by cat_to's focus during an herb identification lesson."


### PR DESCRIPTION
## About The Pull Request

- A new patrol for every biome (but desert) that features a medicine cat taking out either just warrior apprentices or a blend of apprentices as a whole to teach them about common herbs in the territory they might encounter.
- 2 successes (1 stat success that gives herbs) and 2 failures.

## Why This Is Good For ClanGen

- More medicine cat patrols to fill various niches in both story and patrol composition.

## Proof of Testing

<img width="709" height="546" alt="Screenshot 2026-05-02 at 12 40 15 PM" src="https://github.com/user-attachments/assets/31a1da8c-2119-4b5b-aef9-722e2816a9af" />
<img width="726" height="584" alt="Screenshot 2026-05-02 at 12 40 20 PM" src="https://github.com/user-attachments/assets/906276e4-dcaf-4d66-8a26-2bbbfe09ddfb" />
<img width="459" height="177" alt="Screenshot 2026-05-02 at 12 40 28 PM" src="https://github.com/user-attachments/assets/f43065e1-e5ab-4be0-aa63-3628cad6798e" />
<img width="430" height="116" alt="Screenshot 2026-05-02 at 12 40 30 PM" src="https://github.com/user-attachments/assets/4b83c8a0-adab-4608-b85f-b6803ff60c55" />
<img width="752" height="431" alt="Screenshot 2026-05-02 at 12 40 44 PM" src="https://github.com/user-attachments/assets/7e82cc33-7170-455c-bd7c-99bb3b819c86" />
<img width="486" height="187" alt="Screenshot 2026-05-02 at 12 40 48 PM" src="https://github.com/user-attachments/assets/807584fa-7fb1-443c-a1f0-e1197a74300a" />
