### PR TITLE
[FREQFIX/EDITS] Overly Common Hunting Patrols

### DIFF
--- a/resources/lang/en/patrols/beach/hunting/any.json
+++ b/resources/lang/en/patrols/beach/hunting/any.json
@@ -154,7 +154,7 @@
         "min_cats": 2,
         "max_cats": 6,
         "min_max_status": {},
-        "frequency": 3,
+        "frequency": 2,
         "intro_text": "The patrol looks around for something to disguise their scent while hunting.",
         "decline_text": "On second thought, maybe not.",
         "chance_of_success": 50,

--- a/resources/lang/en/patrols/forest/hunting/any.json
+++ b/resources/lang/en/patrols/forest/hunting/any.json
@@ -1513,7 +1513,7 @@
         "min_cats": 2,
         "max_cats": 6,
         "min_max_status": {},
-        "frequency": 3,
+        "frequency": 2,
         "intro_text": "The patrol looks around for something to disguise their scent while hunting.",
         "decline_text": "On second thought, maybe not.",
         "chance_of_success": 50,

--- a/resources/lang/en/patrols/general/hunting.json
+++ b/resources/lang/en/patrols/general/hunting.json
@@ -2710,7 +2710,7 @@
             "any"
         ],
         "season": [
-            "any"
+            "-leaf-bare"
         ],
         "types": [
             "hunting"
@@ -2722,7 +2722,7 @@
         "min_max_status": {
             "normal adult": [
                 1,
-                6
+                3
             ]
         },
         "frequency": 1,
@@ -2731,7 +2731,7 @@
         "chance_of_success": 50,
         "success_outcomes": [
             {
-                "text": "It's the perfect time of day, the cats melting in and out of their territory's shadowy cover as their successes begin to pile up. At first there's only a couple pieces of prey, then more, and more, and more, until finally p_l calls off the patrol: not because the prey has escaped them, but because they're going to have trouble carrying it all home.",
+                "text": "It's the perfect time of day, the cats melting in and out of the shadows, piling up fresh-kill. Finally, p_l calls off the patrol: not because the prey has escaped them, but because they're going to have trouble carrying it all home.",
                 "exp": 30,
                 "relationships": [
                     {
@@ -2751,7 +2751,7 @@
                 "frequency": 3
             },
             {
-                "text": "With their diurnal prey tired and headed to their homes, their crepuscular counterparts come out in full force! As their nocturnal prey still blinks away the sleep in their eyes, the patrol has a truly premium number of opportunities to catch food, enough so that the entire Clan comes to comment on the patrol's success when they return.",
+                "text": "As the day's prey heads home, the evening's prey awakens. The patrol capitalizes on the animals' sleepiness, so much so that the entire Clan comes to comment on the patrol's success when they return.",
                 "exp": 30,
                 "relationships": [
                     {
@@ -2762,6 +2762,16 @@
                         "amount": 5,
                         "log": {
                             "cats_from": "cat_from and cat_to had a successful hunt together."
+                        }
+                    },
+                    {
+                        "cats_to": ["patrol"],
+                        "cats_from": ["clan"],
+                        "mutual": false,
+                        "values": ["respect"],
+                        "amount": 3,
+                        "log": {
+                            "cats_from": "cat_from noticed how successful cat_to's hunting patrol was."
                         }
                     }
                 ],

--- a/resources/lang/en/patrols/mountainous/hunting/any.json
+++ b/resources/lang/en/patrols/mountainous/hunting/any.json
@@ -75,7 +75,7 @@
         "min_cats": 2,
         "max_cats": 6,
         "min_max_status": {},
-        "frequency": 3,
+        "frequency": 2,
         "intro_text": "The patrol looks around for something to disguise their scent while hunting.",
         "decline_text": "On second thought, maybe not.",
         "chance_of_success": 40,

--- a/resources/lang/en/patrols/plains/hunting/any.json
+++ b/resources/lang/en/patrols/plains/hunting/any.json
@@ -1173,7 +1173,7 @@
         "min_cats": 2,
         "max_cats": 6,
         "min_max_status": {},
-        "frequency": 3,
+        "frequency": 2,
         "intro_text": "The patrol looks around for something to disguise their scent while hunting.",
         "decline_text": "On second thought, maybe not.",
         "chance_of_success": 50,


### PR DESCRIPTION
## About The Pull Request

Two fixes:
1) addressing the "diurnal prey" patrol feeling too frequent by editing its text down and making it a little less... sesquipedalian. 
2) addressing the "disguise scent" patrol by bumping its frequency down to 2. (Because we condensed a lot of patrols, including some hunting patrols, it may have become artificially more common as a result)

I also added a relationship log to acknowledge the outcome text saying that the whole Clan notices their success.

## Linked Issues

https://discord.com/channels/1003759225522110524/1023072143560429598/1500171205649367291
my brief message about it

## Proof of Testing

<img width="1042" height="739" alt="image" src="https://github.com/user-attachments/assets/23bdc3e1-9438-4bfe-9ff9-e8d918c16b1f" />
<img width="875" height="152" alt="image" src="https://github.com/user-attachments/assets/a7488c30-78e2-48ac-9242-ccac37c76820" />
<img width="720" height="131" alt="image" src="https://github.com/user-attachments/assets/0579dc99-e51a-4b7e-b634-ed05b9db14fb" />
