### PR TITLE
[BUGFIX] rogue no longer gets positive relation after attacking leader

### DIFF
--- a/resources/lang/en/events/injury/general.json
+++ b/resources/lang/en/events/injury/general.json
@@ -2658,7 +2658,7 @@
                     "m_c", "r_c"
                 ],
                 "values": [ "like" ],
-                "amount": 10,
+                "amount": -10,
                 "mutual": true,
                 "log": {
                     "cats_from": "n_c:0 attacked r_c, but m_c fought {PRONOUN/n_c:0/object} off."

--- a/scripts/screens/RelationshipScreen.py
+++ b/scripts/screens/RelationshipScreen.py
@@ -549,7 +549,7 @@ class RelationshipScreen(Screens):
             # Column One Details:
             self.inspect_cat_elements["col1"] = pygame_gui.elements.UITextBox(
                 self.inspect_cat.get_info_block(relationship=True),
-                ui_scale(pygame.Rect((10, 185), (100, 70))),
+                ui_scale(pygame.Rect((9, 185), (100, 70))),
                 object_id="#text_box_22_horizleft_spacing_95",
                 manager=MANAGER,
                 container=self.selected_cat_container,

--- a/scripts/screens/RelationshipScreen.py
+++ b/scripts/screens/RelationshipScreen.py
@@ -549,7 +549,7 @@ class RelationshipScreen(Screens):
             # Column One Details:
             self.inspect_cat_elements["col1"] = pygame_gui.elements.UITextBox(
                 self.inspect_cat.get_info_block(relationship=True),
-                ui_scale(pygame.Rect((9, 185), (100, 70))),
+                ui_scale(pygame.Rect((7, 185), (100, 70))),
                 object_id="#text_box_22_horizleft_spacing_95",
                 manager=MANAGER,
                 container=self.selected_cat_container,


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

Changes the positive relationship change to a negative one between nc:0 and r_c in the rel log so that after attacking the leader, the rogue and the leader don't like eachother.


## Linked Issues

fixes #4942
## Proof of Testing
<img width="656" height="608" alt="image" src="https://github.com/user-attachments/assets/d4b120fa-e857-4521-986e-9ee2a47a4fe9" />
<img width="1160" height="929" alt="image" src="https://github.com/user-attachments/assets/0a1b0e46-e298-40b3-8c73-dc1ec93db779" />