### PR TITLE
[BUGFIX] Add unconstrained success outcome to pln_train_training_loreteacherinsightfullocked1

### DIFF
--- a/resources/lang/en/patrols/plains/training/any.json
+++ b/resources/lang/en/patrols/plains/training/any.json
@@ -4006,7 +4006,7 @@
             "INSIGHTFUL,1"
         ],
         "intro_text": "Don't get too close, p_l warns the apprentices, well before they can even smell the tacky stink of the Thunderpath on the air. They're here to learn, <i>not</i> to take risks. Does every cat understand that?",
-        "decline_text": "p_l, worried that the apprentices aren't giving the patrol the focus it requires, calls it off early.",
+        "decline_text": "Worried that the apprentices aren't giving the patrol the focus it requires, p_l calls it off early.",
         "success_outcomes": [
             {
                 "text": "With plain, somber words, s_c recites the cats {PRONOUN/s_c/subject} {VERB/s_c/know/knows} who've been hurt by the Thunderpath, killed by the monsters, bodies twisted and broken, thrown about by inconceivable impacts. It's not to frighten. The apprentices need to know the realities of the danger of monsters. Only knowledge can protect them.",
@@ -4097,6 +4097,63 @@
                     }
                 ],
                 "frequency": 4
+            },
+            {
+                "text": "app1 doesn't quite understand, and {PRONOUN/app1/subject} {VERB/app1/ask/asks} why {PRONOUN/app1/subject} {VERB/app1/have/has} to stay so far back. p_l snaps back that {PRONOUN/app1/subject} just {VERB/app1/do/does}, and an argument breaks out. It lasts so long that everyone's pawpads crack from walking on the asphalt.",
+                "exp": 15,
+                "frequency": 4,
+                "injury": {
+                    "cats": [
+                        "patrol"
+                    ],
+                    "injuries": "cracked pads",
+                    "scars": [],
+                    "no_results": false
+                },
+                "relationships": [
+                    {
+                        "cats_from": [
+                            "app1",
+                            "app2",
+                            "app3",
+                            "app4",
+                            "app5"
+                        ],
+                        "cats_to": [
+                            "p_l"
+                        ],
+                        "mutual": false,
+                        "values": [
+                            "like",
+                            "trust"
+                        ],
+                        "amount": -10,
+                        "log": {
+                            "cats_from": "cat_from is disappointed that cat_to didn't explain why thunderpaths are dangerous."
+                        }
+                    },
+                    {
+                        "cats_from": [
+                            "p_l"
+                        ],
+                        "cats_to": [
+                            "app1",
+                            "app2",
+                            "app3",
+                            "app4",
+                            "app5"
+                        ],
+                        "mutual": false,
+                        "values": [
+                            "like"
+                        ],
+                        "amount": -10,
+                        "log": {
+                            "cats_from": "cat_from is upset that cat_to wouldn't listen to {PRONOUN/cat_from/poss} instructions during a patrol."
+                        }
+                    }
+                    ],
+                "art": "gen_train_argueWAA"
             }
         ],
         "fail_outcomes": [

--- a/resources/lang/en/patrols/plains/training/any.json
+++ b/resources/lang/en/patrols/plains/training/any.json
@@ -4102,14 +4102,14 @@
                 "text": "app1 doesn't quite understand, and {PRONOUN/app1/subject} {VERB/app1/ask/asks} why {PRONOUN/app1/subject} {VERB/app1/have/has} to stay so far back. p_l snaps back that {PRONOUN/app1/subject} just {VERB/app1/do/does}, and an argument breaks out. It lasts so long that everyone's pawpads crack from walking on the asphalt.",
                 "exp": 15,
                 "frequency": 4,
-                "injury": {
+                "injury": [
+                    {
                     "cats": [
                         "patrol"
                     ],
-                    "injuries": "cracked pads",
-                    "scars": [],
-                    "no_results": false
-                },
+                    "injuries": ["cracked pads"]
+                }
+            ],
                 "relationships": [
                     {
                         "cats_from": [

--- a/resources/lang/en/patrols/plains/training/any.json
+++ b/resources/lang/en/patrols/plains/training/any.json
@@ -4099,7 +4099,7 @@
                 "frequency": 4
             },
             {
-                "text": "app1 doesn't quite understand, and {PRONOUN/app1/subject} {VERB/app1/ask/asks} why {PRONOUN/app1/subject} {VERB/app1/have/has} to stay so far back. p_l snaps back that {PRONOUN/app1/subject} just {VERB/app1/do/does}, and an argument breaks out. It lasts so long that everyone's pawpads crack from walking on the asphalt.",
+                "text": "app1 doesn't quite understand, and {PRONOUN/app1/subject} {VERB/app1/ask/asks} why {PRONOUN/app1/subject} {VERB/app1/have/has} to stay so far back. p_l snaps back that {PRONOUN/app1/subject} just {VERB/app1/do/does}. app1 stubbornly decides to walk onto the thunderpath and stay there, and an argument breaks out. It lasts so long that everyone's pawpads crack from standing on the asphalt.",
                 "exp": 15,
                 "frequency": 4,
                 "injury": [

--- a/resources/lang/en/patrols/plains/training/any.json
+++ b/resources/lang/en/patrols/plains/training/any.json
@@ -4137,11 +4137,7 @@
                             "p_l"
                         ],
                         "cats_to": [
-                            "app1",
-                            "app2",
-                            "app3",
-                            "app4",
-                            "app5"
+                            "app1"
                         ],
                         "mutual": false,
                         "values": [


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

Adds a new unconstrained success outcome to pln_train_training_loreteacherinsightfullocked1

## Linked Issues

fixes #4952

## Proof of Testing
<img width="1183" height="1033" alt="Screenshot 2026-05-03 135122" src="https://github.com/user-attachments/assets/7b407187-5e13-4eb6-bcaa-be5f5d9af852" />
