### PR TITLE
[BUGFIX] curlew tags

### DIFF
--- a/resources/dicts/clan_symbols.json
+++ b/resources/dicts/clan_symbols.json
@@ -467,7 +467,7 @@
   }, 
   "Curlew": {
       "variants": 1,
-      "tags0": ["plant", "flower"]
+      "tags0": ["animal", "bird"]
   }, 
   "Curly": {
     "variants": 1,


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
fixes incorrect tags on the curlew symbol
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->


## Linked Issues
fixes #4960
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
<img width="395" height="540" alt="image" src="https://github.com/user-attachments/assets/d6e607c4-7d99-4236-8aad-346d3c960586" />
<img width="714" height="558" alt="image" src="https://github.com/user-attachments/assets/a0b6519f-71d9-412b-b487-9a3a1cea94f2" />

CURLEW0 previously showed up right before the cypress symbol
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- there's no longer a bird in the plants (CURLEW0 symbol filter tags fixed)
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
