### PR TITLE
[TYPOFIX] death history r_c eradication

### DIFF
--- a/resources/lang/en/patrols/general/training.json
+++ b/resources/lang/en/patrols/general/training.json
@@ -17105,7 +17105,7 @@
                     "app1"
                 ],
                 "history_text": {
-                    "death": "r_c died when {PRONOUN/r_c/subject} distractedly ran onto the Thunderpath as an apprentice."
+                    "death": "m_c died when {PRONOUN/m_c/subject} distractedly ran onto the Thunderpath as an apprentice."
                 },
                 "relationships": [
                     {


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

Changes an incorrect use of an r_c tag in the death history for a training patrol and switches it to use m_c instead so the text displays correctly.

## Why This Is Good For ClanGen

typo gone!! no more {PRONOUN/r_c/subject} where it shouldn't be

## Linked Issues

was brought up in an external discord server!

## Proof of Testing

how it originally displayed:
<img width="674" height="83" alt="image" src="https://github.com/user-attachments/assets/7d3fcb17-e746-4542-8878-7268fab08aa9" />
how it looks now:
<img width="748" height="537" alt="image" src="https://github.com/user-attachments/assets/237cefb3-e716-4eb1-8a03-5415420fde8a" />


## Changelog/Credits

- Fixes an incorrect r_c tag in the death history for a training patrol.