### PR TITLE
[BUGFIX] Same age rel events

### DIFF
--- a/scripts/events_module/relationship/relation_events.py
+++ b/scripts/events_module/relationship/relation_events.py
@@ -145,9 +145,12 @@ class Relation_Events:
         if not Relation_Events.can_trigger_events(cat):
             return
 
+        # gets cats who are within an age range. range is either 40% their current moon age OR 40 moons, whichever is smaller
         same_age_cats = get_cats_same_age(
-            Cat, cat, constants.CONFIG["mates"]["age_range"]
+            Cat, cat, min(constants.CONFIG["mates"]["age_range"], int(cat.moons * 0.4))
         )
+        if [c for c in same_age_cats if c.age == CatAge.NEWBORN]:
+            pass
         if len(same_age_cats) > 0:
             random_cat = choice(same_age_cats)
             if (
@@ -226,7 +229,9 @@ class Relation_Events:
             return
 
         for new_cat in new_cats:
-            same_age_cats = get_cats_same_age(Cat, new_cat)
+            same_age_cats = get_cats_same_age(
+            Cat, new_cat, min(constants.CONFIG["mates"]["age_range"], int(new_cat.moons * 0.4))
+        )
             alive_cats = [
                 i for i in new_cat.all_cats.values() if i.status.alive_in_player_clan
             ]

--- a/scripts/events_module/relationship/relation_events.py
+++ b/scripts/events_module/relationship/relation_events.py
@@ -230,8 +230,10 @@ class Relation_Events:
 
         for new_cat in new_cats:
             same_age_cats = get_cats_same_age(
-            Cat, new_cat, min(constants.CONFIG["mates"]["age_range"], int(new_cat.moons * 0.4))
-        )
+                Cat,
+                new_cat,
+                min(constants.CONFIG["mates"]["age_range"], int(new_cat.moons * 0.4)),
+            )
             alive_cats = [
                 i for i in new_cat.all_cats.values() if i.status.alive_in_player_clan
             ]


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
I already talked abt this at length in the discord. But the short of it is that the way we went about finding "same age" cats for these relationship events was inherently flawed on a logical level and could result in newborns and young adults being considered the same age.

I've fixed this by making the age range a percentage of the target cat's age. So now a cat can have "same age" events with cats who are within 40% of their own age (i.e. a 100 moon old cat can have an event with cats who are up to 40 moons older or younger, but a 5 moon old cat can only have events with cats who are up to 2 moons older or younger.) This is additionally capped at 40, which was the original range, in order to prevent our elderly cats from having massive age ranges for their events.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
fixes #4969
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
<img width="547" height="138" alt="image" src="https://github.com/user-attachments/assets/60a5cc5c-6763-4fa9-b370-60a477fc53f3" />

this is a same age event

<img width="249" height="266" alt="image" src="https://github.com/user-attachments/assets/14f7671e-41f2-4222-8c82-2e4038b4b52e" />
<img width="227" height="220" alt="image" src="https://github.com/user-attachments/assets/d67150f0-16a5-470f-89ed-80b92e954874" />

involved cats are appropriately aged

<img width="772" height="592" alt="image" src="https://github.com/user-attachments/assets/b950704b-ffcf-4ea7-9950-6a7cbfff7638" />
<img width="765" height="591" alt="image" src="https://github.com/user-attachments/assets/7253b43a-f6b4-4693-bf9b-f6a4f302db6a" />

additionally, newborns born this moon only have their intended familial relationships

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- kicked newborns out of rel events AGAIN! More seriously: the retrieval of "same-age" cats was logically flawed and could result in things like newborns and young adults being considered the same age. This has been fixed so that the "same age" range is 40% of the target cat's age OR 40 moons, whichever is smaller.
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
