### PR TITLE
[CRASHFIX] Fix no ambiance list found

### DIFF
--- a/scripts/game_structure/audio/ambiance.py
+++ b/scripts/game_structure/audio/ambiance.py
@@ -285,14 +285,16 @@ class Ambiance:
         if not self.camp_overlay_playlist or camp != self.camp_playing:
             self.camp_playing = camp
             camp_name = camp.casefold().replace(" ", "_")
-            self.camp_overlay_playlist = self.overlay_dict.get(camp_name)
+            self.camp_overlay_playlist = self.overlay_dict.get(camp_name, [])
             for each in self.camp_overlay_playlist:
                 each.set_volume(self.overlay_volume)
 
         # then grab season specific sounds
         if not self.season_overlay_playlist or season != self.season_playing:
             self.season_playing = season
-            self.season_overlay_playlist = self.overlay_dict.get(f"{season.casefold()}")
+            self.season_overlay_playlist = self.overlay_dict.get(
+                f"{season.casefold()}", []
+            )
             for each in self.camp_overlay_playlist:
                 each.set_volume(self.overlay_volume)
 


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
Just needed to make the .get default to an empty list
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Proof of Testing
<img width="782" height="691" alt="image" src="https://github.com/user-attachments/assets/255c66e2-3db2-42af-a401-7665152cd5ee" />

the crash would happen for camps without a camp ambiance, this is one of those camps! as you can see, audio isn't muted and it hasn't crashed

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Fix audio crash that could occur on camps that have no camp overlays
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
