### PR TITLE
[BUGFIX] Changed Text Box Size For Other Clans in Leader's Den

### DIFF
--- a/scripts/screens/LeaderDenScreen.py
+++ b/scripts/screens/LeaderDenScreen.py
@@ -259,7 +259,7 @@ class LeaderDenScreen(Screens):
         self.clan_temper = game.clan.temperament
 
         self.screen_elements["clan_notice_text"] = pygame_gui.elements.UITextBox(
-            relative_rect=ui_scale(pygame.Rect((68, 375), (445, -1))),
+            relative_rect=ui_scale(pygame.Rect((68, 375), (445, -2))),
             html_text="screens.leader_den.clan_notice_text",
             object_id=get_text_box_theme("#text_box_30_horizcenter_spacing_95"),
             visible=False,

--- a/scripts/screens/LeaderDenScreen.py
+++ b/scripts/screens/LeaderDenScreen.py
@@ -259,7 +259,7 @@ class LeaderDenScreen(Screens):
         self.clan_temper = game.clan.temperament
 
         self.screen_elements["clan_notice_text"] = pygame_gui.elements.UITextBox(
-            relative_rect=ui_scale(pygame.Rect((68, 375), (445, -3))),
+            relative_rect=ui_scale(pygame.Rect((68, 365), (445, -1))),
             html_text="screens.leader_den.clan_notice_text",
             object_id=get_text_box_theme("#text_box_30_horizcenter_spacing_95"),
             visible=False,

--- a/scripts/screens/LeaderDenScreen.py
+++ b/scripts/screens/LeaderDenScreen.py
@@ -259,7 +259,7 @@ class LeaderDenScreen(Screens):
         self.clan_temper = game.clan.temperament
 
         self.screen_elements["clan_notice_text"] = pygame_gui.elements.UITextBox(
-            relative_rect=ui_scale(pygame.Rect((68, 365), (445, -1))),
+            relative_rect=ui_scale(pygame.Rect((68, 350), (445, -1))),
             html_text="screens.leader_den.clan_notice_text",
             object_id=get_text_box_theme("#text_box_30_horizcenter_spacing_95"),
             visible=False,

--- a/scripts/screens/LeaderDenScreen.py
+++ b/scripts/screens/LeaderDenScreen.py
@@ -506,7 +506,7 @@ class LeaderDenScreen(Screens):
             self.other_clan_selection_elements[
                 f"clan_rel{i}"
             ] = pygame_gui.elements.UILabel(
-                ui_scale(pygame.Rect((0, 2), (133, -1))),
+                ui_scale(pygame.Rect((0, 1), (133, -1))),
                 text=f"screens.leader_den.{other_clan.get_standing().strip()}",
                 object_id=get_text_box_theme("#text_box_22_horizcenter"),
                 container=self.other_clan_selection_elements[f"container{i}"],

--- a/scripts/screens/LeaderDenScreen.py
+++ b/scripts/screens/LeaderDenScreen.py
@@ -506,7 +506,7 @@ class LeaderDenScreen(Screens):
             self.other_clan_selection_elements[
                 f"clan_rel{i}"
             ] = pygame_gui.elements.UILabel(
-                ui_scale(pygame.Rect((0, 0), (133, -1))),
+                ui_scale(pygame.Rect((0, 2), (133, -1))),
                 text=f"screens.leader_den.{other_clan.get_standing().strip()}",
                 object_id=get_text_box_theme("#text_box_22_horizcenter"),
                 container=self.other_clan_selection_elements[f"container{i}"],

--- a/scripts/screens/LeaderDenScreen.py
+++ b/scripts/screens/LeaderDenScreen.py
@@ -472,7 +472,7 @@ class LeaderDenScreen(Screens):
             self.other_clan_selection_elements[
                 f"clan_name{i}"
             ] = pygame_gui.elements.UILabel(
-                ui_scale(pygame.Rect((0, 20), (133, -1))),
+                ui_scale(pygame.Rect((0, 10), (133, -1))),
                 text=f"{other_clan.name}Clan",
                 object_id=get_text_box_theme("#text_box_30_horizcenter"),
                 container=self.other_clan_selection_elements[f"container{i}"],

--- a/scripts/screens/LeaderDenScreen.py
+++ b/scripts/screens/LeaderDenScreen.py
@@ -506,7 +506,7 @@ class LeaderDenScreen(Screens):
             self.other_clan_selection_elements[
                 f"clan_rel{i}"
             ] = pygame_gui.elements.UILabel(
-                ui_scale(pygame.Rect((0, 1), (133, -1))),
+                ui_scale(pygame.Rect((0, 2), (133, -1))),
                 text=f"screens.leader_den.{other_clan.get_standing().strip()}",
                 object_id=get_text_box_theme("#text_box_22_horizcenter"),
                 container=self.other_clan_selection_elements[f"container{i}"],

--- a/scripts/screens/LeaderDenScreen.py
+++ b/scripts/screens/LeaderDenScreen.py
@@ -259,7 +259,7 @@ class LeaderDenScreen(Screens):
         self.clan_temper = game.clan.temperament
 
         self.screen_elements["clan_notice_text"] = pygame_gui.elements.UITextBox(
-            relative_rect=ui_scale(pygame.Rect((68, 350), (445, -1))),
+            relative_rect=ui_scale(pygame.Rect((68, 375), (445, -1))),
             html_text="screens.leader_den.clan_notice_text",
             object_id=get_text_box_theme("#text_box_30_horizcenter_spacing_95"),
             visible=False,

--- a/scripts/screens/LeaderDenScreen.py
+++ b/scripts/screens/LeaderDenScreen.py
@@ -333,7 +333,7 @@ class LeaderDenScreen(Screens):
         self.screen_elements["clan_notice_text"].show()
 
         self.screen_elements["temper_text"] = pygame_gui.elements.UITextBox(
-            relative_rect=ui_scale(pygame.Rect((68, 410), (445, -1))),
+            relative_rect=ui_scale(pygame.Rect((68, 385), (445, -1))),
             html_text="screens.leader_den.temper_text",
             object_id=get_text_box_theme("#text_box_30_horizcenter"),
             manager=MANAGER,

--- a/scripts/screens/LeaderDenScreen.py
+++ b/scripts/screens/LeaderDenScreen.py
@@ -508,7 +508,7 @@ class LeaderDenScreen(Screens):
             ] = pygame_gui.elements.UILabel(
                 ui_scale(pygame.Rect((0, 2), (133, -1))),
                 text=f"screens.leader_den.{other_clan.get_standing().strip()}",
-                object_id=get_text_box_theme("#text_box_22_horizcenter"),
+                object_id=get_text_box_theme("#text_box_22_horizcenter_spacing_95"),
                 container=self.other_clan_selection_elements[f"container{i}"],
                 manager=MANAGER,
                 anchors={

--- a/scripts/screens/LeaderDenScreen.py
+++ b/scripts/screens/LeaderDenScreen.py
@@ -259,7 +259,7 @@ class LeaderDenScreen(Screens):
         self.clan_temper = game.clan.temperament
 
         self.screen_elements["clan_notice_text"] = pygame_gui.elements.UITextBox(
-            relative_rect=ui_scale(pygame.Rect((68, 375), (445, -2))),
+            relative_rect=ui_scale(pygame.Rect((68, 375), (445, -3))),
             html_text="screens.leader_den.clan_notice_text",
             object_id=get_text_box_theme("#text_box_30_horizcenter_spacing_95"),
             visible=False,

--- a/scripts/screens/LeaderDenScreen.py
+++ b/scripts/screens/LeaderDenScreen.py
@@ -506,7 +506,7 @@ class LeaderDenScreen(Screens):
             self.other_clan_selection_elements[
                 f"clan_rel{i}"
             ] = pygame_gui.elements.UILabel(
-                ui_scale(pygame.Rect((0, 2), (133, -1))),
+                ui_scale(pygame.Rect((0, 0), (133, -1))),
                 text=f"screens.leader_den.{other_clan.get_standing().strip()}",
                 object_id=get_text_box_theme("#text_box_22_horizcenter_spacing_95"),
                 container=self.other_clan_selection_elements[f"container{i}"],

--- a/scripts/screens/LeaderDenScreen.py
+++ b/scripts/screens/LeaderDenScreen.py
@@ -333,7 +333,7 @@ class LeaderDenScreen(Screens):
         self.screen_elements["clan_notice_text"].show()
 
         self.screen_elements["temper_text"] = pygame_gui.elements.UITextBox(
-            relative_rect=ui_scale(pygame.Rect((68, 385), (445, -1))),
+            relative_rect=ui_scale(pygame.Rect((68, 410), (445, -1))),
             html_text="screens.leader_den.temper_text",
             object_id=get_text_box_theme("#text_box_30_horizcenter"),
             manager=MANAGER,

--- a/scripts/screens/LeaderDenScreen.py
+++ b/scripts/screens/LeaderDenScreen.py
@@ -506,7 +506,7 @@ class LeaderDenScreen(Screens):
             self.other_clan_selection_elements[
                 f"clan_rel{i}"
             ] = pygame_gui.elements.UILabel(
-                ui_scale(pygame.Rect((0, 2), (133, -1))),
+                ui_scale(pygame.Rect((0, 0), (133, -1))),
                 text=f"screens.leader_den.{other_clan.get_standing().strip()}",
                 object_id=get_text_box_theme("#text_box_22_horizcenter"),
                 container=self.other_clan_selection_elements[f"container{i}"],


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

Moved the clan rel text box up two pixels and the clan name text box up ten pixels so that the border no longer interferes with the clan rel text.

## Linked Issues

fixes #4978 

## Proof of Testing

before
<img width="239" height="288" alt="image" src="https://github.com/user-attachments/assets/090f7266-7d69-4e19-ac73-d00572059b74" />
after
<img width="206" height="270" alt="image" src="https://github.com/user-attachments/assets/1adaf9f1-03de-4e91-969c-eee8dc8b1f89" />
## Changelog/Credits

- Other Clan relationship in Leader's Den menu no longer covered by border if Clan has two long temperament names.
