### PR TITLE
[EDITS] removal of "poopy" outsider name

### DIFF
--- a/resources/dicts/names/names.json
+++ b/resources/dicts/names/names.json
@@ -372,7 +372,7 @@
     "Osiris", "Pachirisu", "Paimon", "Pallas", "Papyrus", "Para", "Parhelion", "Pawmi", "Peanut Butter", "Peanut Wigglebutt", "Peeta", "Pekhult", "Pepsi",
     "Periodic Table", "Periodic Trend", "Perrserker", "Peter Pan", "Peter Parker", "Pharah", "Phasmo", "Photon", "Pichu", "Pikachu", "Pina Colada",
     "Ping Pong", "Pinkie Pie", "Pinkie", "Pipkin", "Pippin", "Pisces", "Pistol Star", "Pizza Place", "Plato", "Playstation", "Plentiful Leaves", 
-    "Plot Twist", "Pluto", "Pokey", "Poki", "Pokotho", "Polaris", "Polka", "Polyatomic", "Polyatomic Ion", "Pompompurin", "Ponyboy", "Poopy", "Pork Belly",
+    "Plot Twist", "Pluto", "Pokey", "Poki", "Pokotho", "Polaris", "Polka", "Polyatomic", "Polyatomic Ion", "Pompompurin", "Ponyboy", "Pork Belly",
     "Porsche", "Pot Roast", "Pouncival", "President Blanket", "Primm Slim", "Pringle", "Private Eye", "Procyon", "Proton", "Pumbaa", "Purdy", "Purri", "Pusheen", 
     "Quantum Mechanics", "Quarter Pounder", "Quartermaster", "Quasar", "Qubo", "Queso Ruby", "Quicky", "Rafiki", "Ramattra", "Rambley", "Rapunzel", 
     "Ratau", "Ratoo", "Razzle", "Reeses Puff", "Ribosome", "Rick Astley", "Rigel", "Righteous Bread Pudding", "Ringo Starr", "Riolu", "Rizz", "Rizzo", "Rolo", 


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

per discussion in the dev chat, this PR removes "poopy" from the pool of outsider names to keep that file more appropiate.

## Why This Is Good For ClanGen

multiple devs agreed that this name reaches into gross-out humor and doesn't set a good precedent for other outsider names potentially being "gross", so in the spirit of fairness we concluded it was better to remove it.

## Linked Issues

discord discussion starts here:
https://discord.com/channels/1003759225522110524/1244700946269995018/1501667629205815347

## Proof of Testing

<img width="1131" height="101" alt="image" src="https://github.com/user-attachments/assets/5c97ac54-0379-4d37-87cd-f1ecd31568e9" />
gone

## Changelog/Credits

- Slight edit to the names.json file to keep it more appropiate.
