### PR TITLE
[BUGFIX] Invited Outsiders "bringing their kittens" that were already adopted into the clan

### DIFF
--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -939,6 +939,7 @@ class Cat:
                 not child.dead
                 and not child.status.is_exiled(CatGroup.PLAYER_CLAN_ID)
                 and child.moons < 12
+                and not child.status.alive_in_player_clan
             ):
                 child.status.add_to_group(
                     new_group_ID=CatGroup.PLAYER_CLAN_ID, age=child.age


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

Adds an additional check to add_to_clan() that checks if the outsider's kits already exist in the clan

## Linked Issues
#4749 

## Proof of Testing
<img width="408" height="49" alt="image" src="https://github.com/user-attachments/assets/a0d731ce-92b5-4f3f-a2f0-6f3d69c15ab2" />
<img width="735" height="181" alt="DebugStep" src="https://github.com/user-attachments/assets/1575c640-9888-47ab-bc3e-4fea0d53572a" />


## Changelog/Credits
- Outsiders that have kits in the clan will no longer try to bring them un upon being invited to the clan
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
