### PR TITLE
[FIX] changed maim event frequencies to 1

### DIFF
--- a/resources/lang/en/events/injury/general.json
+++ b/resources/lang/en/events/injury/general.json
@@ -5586,7 +5586,7 @@
         "season": [
             "any"
         ],
-        "frequency": 2,
+        "frequency": 1,
         "event_text": "m_c was maimed by r_c for questioning {PRONOUN/r_c/poss} leadership.",
         "m_c": {
             "age": [
@@ -5757,7 +5757,7 @@
         "season": [
             "any"
         ],
-        "frequency": 2,
+        "frequency": 1,
         "event_text": "m_c was hurt by r_c for disobeying orders.",
         "m_c": {
             "status": [
@@ -5914,7 +5914,7 @@
         "season": [
             "any"
         ],
-        "frequency": 2,
+        "frequency": 1,
         "event_text": "m_c was hurt by r_c to make an example out of {PRONOUN/m_c/object}.",
         "m_c": {
             "age": [


### PR DESCRIPTION
## About The Pull Request

- As discussed in dev chats, frequency for a leader or deputy maiming their clanmates feels too frequent. All were previously at 2 and are now changed to one. I also proposed possibly constraining who the MC could be based on high relationship values but for now opted to just see whether the frequency change will suffice. 

## Why This Is Good For ClanGen

- Better balance

## Linked Issues

https://github.com/ClanGenOfficial/clangen/issues/3896#issuecomment-4384244000

## Proof of Testing

- Game runs locally. Nothing changed other than frequency values. 
