### PR TITLE
[BUGFIX] Apprentices no longer kitsit littermates

### DIFF
--- a/resources/lang/en/events/relationship_events/group_interactions/5/negative.json
+++ b/resources/lang/en/events/relationship_events/group_interactions/5/negative.json
@@ -117,7 +117,7 @@
 		"age_constraint": {
 			"m_c": [
 				"senior adult",
-				"elder"
+				"senior"
 			]
 		},
 		"status_constraint": {

--- a/resources/lang/en/events/relationship_events/group_interactions/5/positive.json
+++ b/resources/lang/en/events/relationship_events/group_interactions/5/positive.json
@@ -432,9 +432,6 @@
 			"m_c": [
 				"-kitten"
 			],
-			"relationship_status": [
-				"-littermates"
-			],
 			"r_c1": [
 				"kitten"
 			],
@@ -455,16 +452,16 @@
 		},
 		"relationship_constraint": {
 			"m_c_to_r_c1": [
-				"-parent/child"
+				"-parent/child", "-littermates"
 			],
 			"m_c_to_r_c2": [
-				"-parent/child"
+				"-parent/child", "-littermates"
 			],
 			"m_c_to_r_c3": [
-				"-parent/child"
+				"-parent/child", "-littermates"
 			],
 			"m_c_to_r_c4": [
-				"-parent/child"
+				"-parent/child", "-littermates"
 			]
 		},
 		"specific_reaction": {

--- a/resources/lang/en/events/relationship_events/group_interactions/5/positive.json
+++ b/resources/lang/en/events/relationship_events/group_interactions/5/positive.json
@@ -432,7 +432,9 @@
 			"m_c": [
 				"-kitten"
 			],
-			"relationship_status": ["-littermates"],
+			"relationship_status": [
+				"-littermates"
+			],
 			"r_c1": [
 				"kitten"
 			],

--- a/resources/lang/en/events/relationship_events/group_interactions/5/positive.json
+++ b/resources/lang/en/events/relationship_events/group_interactions/5/positive.json
@@ -432,6 +432,7 @@
 			"m_c": [
 				"-kitten"
 			],
+			"relationship_status": ["-littermates"],
 			"r_c1": [
 				"kitten"
 			],


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

adds a relationship constraint for kitsitting events excluding littermates to prevent an apprentice kitsitting their kitten littermates on timeskip / switches "elder" to "senior" in a different event per conversation on discord


## Linked Issues

fixes #4993 

## Proof of Testing

bear with

## Changelog/Credits

- [BUGFIX] Apprentices no longer babysit their littermates on timeskip.
