### PR TITLE
[BUGFIX] Fixes Self-interaction in training patrol

### DIFF
--- a/resources/lang/en/patrols/general/training.json
+++ b/resources/lang/en/patrols/general/training.json
@@ -5840,7 +5840,7 @@
                     "TEACHER,1"
                 ],
                 "can_have_stat": [
-                    "not_rc"
+                    "p_l"
                 ],
                 "relationships": [
                     {

--- a/resources/lang/en/patrols/general/training.json
+++ b/resources/lang/en/patrols/general/training.json
@@ -5840,7 +5840,7 @@
                     "TEACHER,1"
                 ],
                 "can_have_stat": [
-                    "any"
+                    "not_rc"
                 ],
                 "relationships": [
                     {


### PR DESCRIPTION


## About The Pull Request

Fixes the self-interaction with the `s_c` in the patrol provided below. Changes who the stat cat can be to stop cat from moaning at themselves 

<img width="827" height="368" alt="image" src="https://github.com/user-attachments/assets/18986678-3807-4d77-8b0d-4b54a3a6aed1" />


