### PR TITLE
[BUGFIX] Player shouldn't hear about some old dead outsider

### DIFF
--- a/resources/lang/en/patrols/new_cat.json
+++ b/resources/lang/en/patrols/new_cat.json
@@ -336,7 +336,8 @@
                     [
                         "age:senior",
                         "dead",
-                        "loner"
+                        "loner",
+                        "unknown"
                     ],
                     [
                         "age:adult",
@@ -372,7 +373,8 @@
                     [
                         "age:senior",
                         "dead",
-                        "loner"
+                        "loner",
+                        "unknown"
                     ],
                     [
                         "age:adult",

--- a/resources/lang/en/patrols/new_cat_welcoming.json
+++ b/resources/lang/en/patrols/new_cat_welcoming.json
@@ -326,7 +326,8 @@
                     [
                         "age:senior",
                         "dead",
-                        "loner"
+                        "loner",
+                        "unknown"
                     ],
                     [
                         "age:adult",
@@ -362,7 +363,8 @@
                     [
                         "age:senior",
                         "dead",
-                        "loner"
+                        "loner",
+                        "unknown"
                     ],
                     [
                         "age:adult",


### PR DESCRIPTION
## About The Pull Request

As Vulpesua noted on Discord, one of the new patrols where a pair of siblings can join the Clan also generates a parent (in order to make them siblings). It will look weird to the player to see some random old cat's ghost start wandering, so I've added the "unknown" tag to the parent in all iterations.

## Linked Issues

https://discord.com/channels/1003759225522110524/1101276997751164948/1502744297391263955

## Proof of Testing

<img width="1045" height="796" alt="image" src="https://github.com/user-attachments/assets/1f9734ec-570c-46ff-8ce7-b8891375d5f3" />

<img width="1102" height="868" alt="image" src="https://github.com/user-attachments/assets/b1d8f921-b2c2-463e-bf43-777d895a1689" />

sibling relationship still functions