### PR TITLE
[TYPO] Typo fix in Ally Dissolution

### DIFF
--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -13594,7 +13594,7 @@
             "m_c"
         ],
         "frequency": 1,
-        "event_text": "A o_c_n patrol brings news to c_n that their old leader is dead... and that the new one does not consider c_n a friend.",
+        "event_text": "A o_c_n patrol brings news to c_n that their old leader is dead... and that the new one does not considers c_n a friend.",
         "m_c": {
             "age": [
                 "adolescent",


### PR DESCRIPTION
Fixes Typo in a short event.

<img width="634" height="85" alt="image" src="https://github.com/user-attachments/assets/44b387a4-0dea-4764-bb9d-e4dc94d77c11" />
