### PR TITLE
[BUGFIX] Version number is now visible

### DIFF
--- a/scripts/screens/screens_core/screens_core.py
+++ b/scripts/screens/screens_core/screens_core.py
@@ -60,18 +60,16 @@ def rebuild_core(*, should_rebuild_bgs=True):
     rebuild_mute("default")
 
     version_number = pygame_gui.elements.UILabel(
-        ui_scale(pygame.Rect((50, 50), (-1, -1))),
+        ui_scale(pygame.Rect((0, 0), (-1, -1))),
         get_version_info().version_number[0:8],
-        object_id=get_text_box_theme(),
+        object_id="#dev_watermark",
         anchors={"bottom": "bottom", "right": "right"},
     )
     # Adjust position
     version_number.set_relative_position(
-        ui_scale_offset(
-            (
-                800 - version_number.get_relative_rect()[2],
-                700 - version_number.get_relative_rect()[3],
-            )
+        (
+            -version_number.relative_rect[2] - ui_scale_value(10),
+            -version_number.relative_rect[3],
         )
     )
 

--- a/scripts/screens/screens_core/screens_core.py
+++ b/scripts/screens/screens_core/screens_core.py
@@ -73,7 +73,7 @@ def rebuild_core(*, should_rebuild_bgs=True):
         )
     )
 
-    if get_version_info().is_source_build or get_version_info().is_dev():
+    if get_version_info().is_source_build:
         dev_watermark = pygame_gui.elements.UILabel(
             ui_scale(pygame.Rect((525, 660), (300, 50))),
             "screens.core.dev_watermark",


### PR DESCRIPTION
## About The Pull Request

* Makes version text not get pushed off-screen for release builds
* Changes the version text appear to on all non-source versions of the game so errors with the text are easier to catch
* Makes the version text use the same font style as the Dev Build text so it's more visible

## Linked Issues

Fixes #5027

## Proof of Testing

Windowed:
<img width="797" height="699" alt="image" src="https://github.com/user-attachments/assets/ff1d694b-b3c6-4980-a874-9bc346d45479" />

Fullscreen:
<img width="1470" height="919" alt="image" src="https://github.com/user-attachments/assets/d4527a42-4a07-4ca5-b257-f421d90a4cb8" />

We know that this is the "version" text because it doesn't say "Dev Build".

Here's one where the version.ini is used so we know it works for the shorter strings too:
<img width="791" height="693" alt="image" src="https://github.com/user-attachments/assets/ae66080b-c733-46f8-8c2d-0a70f6ecf149" />