### PR TITLE
[BUGFIX] incorrect permanent conditions

### DIFF
--- a/resources/lang/en/patrols/disaster.json
+++ b/resources/lang/en/patrols/disaster.json
@@ -921,7 +921,7 @@
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c was badly scarred when rogues ambushed their patrol.",
+                    "scar": "m_c was badly scarred when rogues ambushed {PRONOUN/m_c/poss} patrol.",
                     "death": "m_c died of wounds sustained in a rogue ambush."
                 },
                 "frequency": 4

--- a/resources/lang/en/patrols/forest/border/any.json
+++ b/resources/lang/en/patrols/forest/border/any.json
@@ -96,7 +96,6 @@
                     "multi"
                 ],
                 "history_text": {
-                    "scar": "This cat was badly scarred when rogues ambushed {PRONOUN/m_c/poss} patrol.",
                     "death": "This cat was killed when rogues ambushed {PRONOUN/m_c/poss} patrol."
                 },
                 "relationships": [
@@ -127,14 +126,10 @@
                         ],
                         "injuries": [
                             "battle_injury"
-                        ],
-                        "scars": [
-                            "THROAT"
                         ]
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c was badly scarred when rogues ambushed {PRONOUN/m_c/poss} patrol.",
                     "death": "m_c died of an injury sustained in a rogue ambush."
                 },
                 "relationships": [

--- a/resources/lang/en/patrols/forest/border/any.json
+++ b/resources/lang/en/patrols/forest/border/any.json
@@ -96,6 +96,7 @@
                     "multi"
                 ],
                 "history_text": {
+                    "scar": "This cat was badly scarred when rogues ambushed {PRONOUN/m_c/poss} patrol.",
                     "death": "This cat was killed when rogues ambushed {PRONOUN/m_c/poss} patrol."
                 },
                 "relationships": [
@@ -130,6 +131,7 @@
                     }
                 ],
                 "history_text": {
+                    "scar": "This cat was badly scarred when rogues ambushed {PRONOUN/m_c/poss} patrol.",
                     "death": "m_c died of an injury sustained in a rogue ambush."
                 },
                 "relationships": [

--- a/resources/lang/en/patrols/forest/border/any.json
+++ b/resources/lang/en/patrols/forest/border/any.json
@@ -96,7 +96,6 @@
                     "multi"
                 ],
                 "history_text": {
-                    "scar": "This cat was badly scarred when rogues ambushed {PRONOUN/m_c/poss} patrol.",
                     "death": "This cat was killed when rogues ambushed {PRONOUN/m_c/poss} patrol."
                 },
                 "relationships": [

--- a/resources/lang/en/patrols/forest/border/any.json
+++ b/resources/lang/en/patrols/forest/border/any.json
@@ -3575,12 +3575,10 @@
                 "injury": [
                     {
                         "cats": ["r_c"],
-                        "injuries": ["minor_injury"],
-                        "scars": ["LEFTEAR"]
+                        "injuries": ["minor_injury"]
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c carries a scar from a fox fight.",
                     "death": "m_c died of an injury inflicted by a fox."
                 }
             },
@@ -3742,12 +3740,10 @@
                 "injury": [
                     {
                         "cats": ["s_c"],
-                        "injuries": ["minor_injury"],
-                        "scars": ["LEFTEAR"]
+                        "injuries": ["minor_injury"]
                     }
                 ],
                 "history_text": {
-                    "scar": "m_c carries a scar from a fox fight.",
                     "death": "m_c died of an injury inflicted by a fox."
             },
                 "relationships": [


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

removes scarring lists from two patrols that also utilize a list of injuries, as it could result in the cat gaining a permanent condition that doesn't make sense (ie, a torn ear can also cause partial hearing loss, but the patrol selected a sprain as the injury)
also fixes a missing pronoun tag in a disaster border patrol.

## Why This Is Good For ClanGen

yummy bug fix

## Linked Issues

fixes #5015 
other patrol and pronoun tag were reported in dev chat on the discord

## Proof of Testing

<img width="930" height="436" alt="image" src="https://github.com/user-attachments/assets/17b7160a-1495-43a7-b1b9-6d7563662efc" />
the "scar" lines were removed for this patrol, both for the actual injuries and the history text

## Changelog/Credits

- Removes scars from two patrols to avoid them giving cats permanent conditions that don't make sense. No more damaged throats because of mangled legs!
- Also adds a missing pronoun tag in another patrol.