### PR TITLE
[EDIT] Adds "exists" tag to nosy outsider war events

### DIFF
--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -12124,7 +12124,7 @@
             "status": ["leader","deputy","warrior","apprentice"]
         },
         "new_cat": [
-            ["meeting","loner"]
+            ["exists","meeting","loner"]
         ],
         "other_clan": {
             "current_rep": ["any"],
@@ -12154,7 +12154,7 @@
             "status": ["leader", "deputy", "warrior", "apprentice"]
         },
         "new_cat": [
-            ["meeting","loner"]
+            ["exists","meeting","loner"]
         ],
         "other_clan": {
             "current_rep": ["any"],
@@ -12184,7 +12184,7 @@
             "status": ["leader", "deputy", "warrior", "apprentice"]
         },
         "new_cat": [
-            ["meeting","kittypet"]
+            ["exists","meeting","kittypet"]
         ],
         "other_clan": {
             "current_rep": ["any"],
@@ -12214,7 +12214,7 @@
             "status": ["leader", "deputy", "warrior", "apprentice"]
         },
         "new_cat": [
-            ["meeting","loner"]
+            ["exists","meeting","loner"]
         ],
         "other_clan": {
             "current_rep": ["any"],
@@ -12243,7 +12243,7 @@
         "m_c": { "status": ["leader","deputy","warrior","apprentice"]
             },
         "new_cat": [
-        ["meeting","kittypet"]
+        ["exists","meeting","kittypet"]
         ],
         "other_clan": {
             "current_rep": ["any"],


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

This has been bugging me since I wrote these, since during testing for them I ended up with over 6 pages of outsider cats. No longer! Now the game can choose an existing outsider instead of forcing it to make a new one. Huzzah!

## Why This Is Good For ClanGen

Gives game the option to choose an existing cat over forcing it to make a new one, allowing for more variety of interactions from these specific events.

## Proof of Testing

Bear with me, I will try to get a screenshot here shortly
