### PR TITLE
[BALANCE/CONTENT] OtherClan hostile locked relationship boost events

### DIFF
--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -13684,7 +13684,7 @@
             "m_c"
         ],
         "frequency": 2,
-        "event_text": "o_c_n's deputy secretly meets with a patrol of c_n cats and talks their way out of a battle that would've caused pointless bloodshed.",
+        "event_text": "o_c_n's deputy secretly meets with m_c and a patrol of c_n cats and talks their way out of a battle that would've caused pointless bloodshed.",
         "m_c": {
             "age": [
                 "adolescent",

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -13734,7 +13734,7 @@
         ],
         "tags": [],
         "frequency": 1,
-        "event_text": "o_c_n's medicine cat meets with m_c and tells {PRONOUN/m_c/object} of an omen they received that hopefully foretells of future peace.",
+        "event_text": "o_c_n's medicine cat meets with m_c and shares an omen they received that foretells peace.",
         "m_c": {
             "status": [
                 "medicine cat"

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -13686,12 +13686,11 @@
         "frequency": 2,
         "event_text": "o_c_n's deputy secretly meets with m_c and a patrol of c_n cats and talks their way out of a battle that would've caused pointless bloodshed.",
         "m_c": {
-            "age": [
-                "adolescent",
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
+            "status": [
+                "warrior",
+                "deputy",
+                "leader",
+                "mediator"
             ]
         },
         "other_clan": {

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -13711,7 +13711,7 @@
         ],
         "tags": [],
         "frequency": 2,
-        "event_text": "m_c convenes with o_c_n's mediator to discuss peace. The meeting seems to go well, and m_c is optimistic o_c_n might end the conflict soon.",
+        "event_text": "m_c convenes with o_c_n's mediator to discuss peace. The meeting goes well, and m_c is optimistic o_c_n might end the conflict soon.",
         "m_c": {
             "status": [
                 "mediator"

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -13790,7 +13790,7 @@
             "m_c"
         ],
         "frequency": 1,
-        "event_text": "A group of cats from o_c_n make their way to c_n's camp, where they explain that they've overthrown their leader to avoid any more battles between them and c_n.",
+        "event_text": "A group of cats from o_c_n arrive in c_n's camp and announce they've overthrown their leader to end hostilities between the Clans.",
         "m_c": {
             "age": [
                 "adolescent",

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -13670,5 +13670,141 @@
             ],
             "changed": -15
         }
+    },
+    {
+        "event_id": "gen_misc_otherclanhostilerelboost1",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "tags": [],
+        "exclude_involved": [
+            "m_c"
+        ],
+        "frequency": 2,
+        "event_text": "o_c_n's deputy secretly meets with a patrol of c_n cats and talks their way out of a battle that would've caused pointless bloodshed.",
+        "m_c": {
+            "age": [
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult",
+                "senior"
+            ]
+        },
+        "other_clan": {
+            "current_rep": [
+                "hostile"
+            ],
+            "changed": 5
+        }
+    },
+    {
+        "event_id": "gen_misc_otherclanhostilerelboost2",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "tags": [],
+        "frequency": 2,
+        "event_text": "m_c convenes with o_c_n's mediator to discuss peace. The meeting seems to go well, and m_c is optimistic o_c_n might end the conflict soon.",
+        "m_c": {
+            "status": [
+                "mediator"
+            ]
+        },
+        "other_clan": {
+            "current_rep": [
+                "hostile"
+            ],
+            "changed": 5
+        }
+    },
+    {
+        "event_id": "gen_misc_otherclanhostilerelboost3",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "tags": [],
+        "frequency": 1,
+        "event_text": "o_c_n's medicine cat meets with m_c and tells {PRONOUN/m_c/object} of an omen they received that hopefully foretells of future peace.",
+        "m_c": {
+            "status": [
+                "medicine cat"
+            ]
+        },
+        "other_clan": {
+            "current_rep": [
+                "hostile"
+            ],
+            "changed": 10
+        }
+    },
+    {
+        "event_id": "gen_misc_otherclanhostilerelboost4",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "tags": [],
+        "exclude_involved": [
+            "m_c"
+        ],
+        "frequency": 1,
+        "event_text": "o_c_n's leader is killed in a battle with c_n. Their deputy takes over and promises to not follow in the pawsteps of their violent leader.",
+        "m_c": {
+            "age": [
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult",
+                "senior"
+            ]
+        },
+        "other_clan": {
+            "current_rep": [
+                "hostile"
+            ],
+            "changed": 15
+        }
+    },
+    {
+        "event_id": "gen_misc_otherclanhostilerelboost5",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "tags": [],
+        "exclude_involved": [
+            "m_c"
+        ],
+        "frequency": 1,
+        "event_text": "A group of cats from o_c_n make their way to c_n's camp, where they explain that they've overthrown their leader to avoid any more battles between them and c_n.",
+        "m_c": {
+            "age": [
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult",
+                "senior"
+            ]
+        },
+        "other_clan": {
+            "current_rep": [
+                "hostile"
+            ],
+            "changed": 15
+        }
     }
 ]

--- a/resources/lang/en/events/war.json
+++ b/resources/lang/en/events/war.json
@@ -116,6 +116,7 @@
     "The leaders of o_c_n and c_n have come to terms about the war, deciding that it would best for all the cats if it was formally settled here.",
     "Remembering all the blood that was shed in the war, o_c_n and c_n have decided to finally settle it, once and for all.",
     "After a tense parley at a Gathering, lead_name agrees to end the war with o_c_n.",
-    "med_name and o_c_n's medicine cat urge their leaders to find peace, and, grudgingly, they agree. The war has ended."
+    "med_name and o_c_n's medicine cat urge their leaders to find peace, and, grudgingly, they agree. The war has ended.",
+    "When o_c_n's leader is brutally killed in a battle with c_n, o_c_n realizes the gravity of their situation and ends the war on the spot."
   ]
 }


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

Adds 5 events (+ a bonus war resolution event) that are hostile-locked. They boost the relationship with the other Clan by either a decent amount or a bigger boost of +15. They are meant to be counterparts to the alliance disbanding events I added a while back.

## Why This Is Good For ClanGen

I'm targeting the release branch because while this is new content in a way, these events were made due to the fact I noticed my alliance disbanding events were happening too often despite their frequency being set to 1. As a result, the huge -15 relation drop (which likely sends Clan relations into hostile instead of neutral if they aren't at the max of 30 points) would often immediately plunge Clans into war, and I felt it was really imbalanced.
Also Scribble said I could do that. :3

## Proof of Testing

gen_misc_otherclanhostilerelboost1
<img width="507" height="86" alt="image" src="https://github.com/user-attachments/assets/7076f842-b77f-4506-af10-163b5027ee85" />
gen_misc_otherclanhostilerelboost2
<img width="513" height="129" alt="image" src="https://github.com/user-attachments/assets/7207d755-6049-46f1-8cdf-249252524ef0" />
gen_misc_otherclanhostilerelboost3
<img width="507" height="99" alt="image" src="https://github.com/user-attachments/assets/e60297ea-abb6-42cd-a9e9-f718e7999b02" />
gen_misc_otherclanhostilerelboost4
<img width="497" height="86" alt="image" src="https://github.com/user-attachments/assets/d2229c68-fda8-4eb6-b1ac-4afe15d958dc" />
gen_misc_otherclanhostilerelboost5
<img width="496" height="83" alt="image" src="https://github.com/user-attachments/assets/801e9ab6-98f5-48d4-a6b4-8243b764c050" />

## Changelog/Credits

- Adds 5 events for hostile OtherClan relations. Meant to balance out the "new leader" alliance disbanding events. Maybe peace can be found after all...
- Also adds one war resolution event.