### PR TITLE
[TYPOFIX] missing verb tags

### DIFF
--- a/resources/lang/en/patrols/general/medcat.json
+++ b/resources/lang/en/patrols/general/medcat.json
@@ -31282,7 +31282,7 @@
         "chance_of_success": 70,
         "success_outcomes": [
             {
-                "text": "The rains have made the soil loose and good for digging. While finding burdock plants is starting to become harder, at least it's easy to harvest the roots when p_l comes across some. On the way home, {PRONOUN/p_l/subject} {VERB/p_l/spot/spots} some straggly-looking plantain near the path. {PRONOUN/p_l/subject/CAP} pick it, as well. The more herbs they have before leaf-bare, the better.",
+                "text": "The rains have made the soil loose and good for digging. While finding burdock plants is starting to become harder, at least it's easy to harvest the roots when p_l comes across some. On the way home, {PRONOUN/p_l/subject} {VERB/p_l/spot/spots} some straggly-looking plantain near the path. {PRONOUN/p_l/subject/CAP} {VERB/p_l/pick/picks} it, as well. The more herbs they have before leaf-bare, the better.",
                 "exp": 10,
                 "herbs": [
                     "burdock",

--- a/resources/lang/en/patrols/plains/border/any.json
+++ b/resources/lang/en/patrols/plains/border/any.json
@@ -3417,7 +3417,7 @@
                 "frequency": 4
             },
             {
-                "text": "Careful, p_l warns. But {PRONOUN/p_l/subject} {VERB/p_l/don't/doesn't} need to warn app1, app1 takes safety seriously. {PRONOUN/app1/subject/CAP} want to know how p_l spotted this new burrow, what makes p_l think that there's nothing dangerous inside, how to check without running face first into a badger. p_l appreciates app1's caution.",
+                "text": "Careful, p_l warns. But {PRONOUN/p_l/subject} {VERB/p_l/don't/doesn't} need to warn app1, app1 takes safety seriously. {PRONOUN/app1/subject/CAP} {VERB/app1/want/wants} to know how p_l spotted this new burrow, what makes p_l think that there's nothing dangerous inside, how to check without running face first into a badger. p_l appreciates app1's caution.",
                 "exp": 30,
                 "art": "gen_hunt_mentor_app",
                 "can_have_stat": [


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

adds two missing verb tags to two different patrols.

## Why This Is Good For ClanGen

no more typo :3

## Linked Issues

https://github.com/ClanGenOfficial/clangen/issues/1818#issuecomment-4424323899
https://github.com/ClanGenOfficial/clangen/issues/1818#issuecomment-4433499053

## Proof of Testing

<img width="1159" height="480" alt="image" src="https://github.com/user-attachments/assets/dd747cdd-6c78-4749-9049-6ed7b2c08f84" />

## Changelog/Credits

- Adds two missing verb tags in patrols. Typos begone!
