### PR TITLE
[BUGFIX] Patrol adds new cat to playerclan when the text does not imply they were joining the clan

### DIFF
--- a/resources/lang/en/events/injury/general.json
+++ b/resources/lang/en/events/injury/general.json
@@ -8304,7 +8304,8 @@
             [
                 "clancat",
                 "exists",
-                "age:young adult"
+                "age:young adult",
+                "meeting"
             ]
         ],
         "injury": [


### PR DESCRIPTION
## About The Pull Request

Easy fix. Just missing the "meeting" tag to prevent them from actually joining the Clan.

## Linked Issues

Fixes: #5047

## Proof of Testing

<img width="774" height="229" alt="image" src="https://github.com/user-attachments/assets/0d4857e8-90fe-4cc5-919f-883abdfadafe" />

<img width="928" height="405" alt="image" src="https://github.com/user-attachments/assets/9eee422d-1372-4546-89af-831ad8f9683a" />
