### PR TITLE
[BUGFIX] kits "go on patrol" on relationship event 

### DIFF
--- a/resources/lang/en/events/relationship_events/normal_interactions/romance/increase.json
+++ b/resources/lang/en/events/relationship_events/normal_interactions/romance/increase.json
@@ -211,18 +211,18 @@
 		"id": "rom_inc_med_patrols9",
 		"intensity": "medium",
 		"interactions": [
-            		"m_c and r_c played around during patrol and got in a bit of trouble, but still returned to camp smiling.",
-            		"m_c just barely missed a mouse, but r_c caught it right after, handing it off to {PRONOUN/m_c/object}.",
-            		"m_c and r_c got so into playing around that they got separated from the rest of the patrol, earning themselves an earful back at camp.",
+            "m_c and r_c played around during patrol and got in a bit of trouble, but still returned to camp smiling.",
+        	"m_c just barely missed a mouse, but r_c caught it right after, handing it off to {PRONOUN/m_c/object}.",
+            "m_c and r_c got so into playing around that they got separated from the rest of the patrol, earning themselves an earful back at camp.",
 			"m_c feels giddy about getting on the same patrol as r_c."
 		],
 		"main_status_constraint":[
 			"-elder",
-			"-kit"
+			"-kitten"
 		],
 		"random_status_constraint":[
 			"-elder",
-			"-kit"
+			"-kitten"
 		],
 		"reaction_random_cat": {
 			"romance": "increase",


### PR DESCRIPTION
## About The Pull Request

My goof. I put "kit" instead of "kitten" in the exclusionary for the status.

## Linked Issues

Fixes: #5046

## Proof of Testing

<img width="784" height="484" alt="image" src="https://github.com/user-attachments/assets/c78aab20-7d59-4a86-9377-91572e5b2531" />

can't ensure a relationship event, but here are some events generating between kits that aren't... patrolling.