### PR TITLE
[TYPO] Minor grammar mishap

### DIFF
--- a/resources/lang/en/patrols/general/medcat.json
+++ b/resources/lang/en/patrols/general/medcat.json
@@ -23937,7 +23937,7 @@
         "chance_of_success": 70,
         "success_outcomes": [
             {
-                "text": "The strengthening newleaf sun has tempted fat burdock leaves to start to sprout, so it's not finding them that's hard — it's trying to carry all the roots back to camp all at once that proves difficult! On the way back, {PRONOUN/p_l/subject} spot some plantain and almost drop all of {PRONOUN/p_l/poss} roots when {PRONOUN/p_l/subject} attempt to collect it.",
+                "text": "The strengthening newleaf sun has tempted fat burdock leaves to start to sprout, so it's not finding them that's hard — it's trying to carry all the roots back to camp all at once that proves difficult! On the way back, {PRONOUN/p_l/subject} spot some plantain and almost drops all of {PRONOUN/p_l/poss} roots when {PRONOUN/p_l/subject} attempt to collect it.",
                 "exp": 10,
                 "herbs": [
                     "burdock",


### PR DESCRIPTION


## About The Pull Request

Fixes gramma typo, in gen_med_gatheringburdock_newleaf1.

Should of been `drops` not `drop`

Reported here https://github.com/ClanGenOfficial/clangen/issues/1818#issuecomment-4452320968