### PR TITLE
[TYPOFIX] misc typo fixes + event rewrites

### DIFF
--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -2157,7 +2157,7 @@
             "war"
         ],
         "frequency": 2,
-        "event_text": "m_c and r_c spend the night by the o_c_n border and catch a o_c_n patrol sneaking into c_n territory. While r_c gets reinforcements, m_c tries to hold them off and is killed",
+        "event_text": "m_c and r_c spend the night by the o_c_n border and catch a o_c_n patrol sneaking into c_n territory. While r_c gets reinforcements, m_c tries to hold them off and is killed.",
         "m_c": {
             "status": [
                 "warrior",

--- a/resources/lang/en/events/relationship_events/breakup_mates.json
+++ b/resources/lang/en/events/relationship_events/breakup_mates.json
@@ -32,7 +32,7 @@
 	],
 	"chill_breakup":[
 		"m_c and r_c broke up.", 
-            	"m_c and r_c have decided that they may not be the right fit for each other after all, they decide leave off on good terms and break up.",
+            	"m_c and r_c have decided that they may not be the right fit for each other after all. They opt to leave things on good terms and break up.",
 		"After explaining {PRONOUN/m_c/poss} feelings and thoughts to r_c, m_c broke up with {PRONOUN/r_c/object}, no hard feelings."
 	]
 }

--- a/resources/lang/en/hardcoded.en.json
+++ b/resources/lang/en/hardcoded.en.json
@@ -2,7 +2,7 @@
     "en": {
         "comment": "at some point, this file should become empty and unnecessary.",
         "event_deaths": {
-            "one": "This past moon, m_c has taken {PRONOUN/m_c/poss} place in StarClan. c_n mourns their loss, and {PRONOUN/m_c/poss} Clanmates will miss where {PRONOUN/m_c/subject} had been in their lives. Moments of {PRONOUN/m_c/poss} life are shared in stories around the circle of mourners as those that were closest to {PRONOUN/m_c/object} take {PRONOUN/m_c/object} to {PRONOUN/m_c/poss} final resting place.",
+            "one": "This past moon, m_c has taken {PRONOUN/m_c/poss} place in StarClan. c_n mourns the loss of their Clanmate, and {PRONOUN/m_c/poss} Clanmates will miss where {PRONOUN/m_c/subject} had been in their lives. Moments of {PRONOUN/m_c/poss} life are shared in stories around the circle of mourners as those that were closest to {PRONOUN/m_c/object} take {PRONOUN/m_c/object} to {PRONOUN/m_c/poss} final resting place.",
             "many": "The past moon, %{insert} have taken their place in StarClan. c_n mourns their loss, and their Clanmates will miss where they had been in their lives. Moments of their lives are shared in stories around the circle of mourners as those that were closest to them take them to their final resting place."
         },
         "event_shaken_grief": {

--- a/resources/lang/en/patrols/general/border.json
+++ b/resources/lang/en/patrols/general/border.json
@@ -42,7 +42,7 @@
                 "frequency": 4
             },
             {
-                "text": "p_l wishes for something interesting to happen, but no, there was nothing to ease p_l's boredom as {PRONOUN/p_l/subject} mark the borders.",
+                "text": "p_l wishes for something interesting to happen, but no, there was nothing to ease p_l's boredom as {PRONOUN/p_l/subject} {VERB/p_l/mark/marks} the borders.",
                 "exp": 5,
                 "frequency": 4
             },

--- a/resources/lang/en/patrols/other_clan.json
+++ b/resources/lang/en/patrols/other_clan.json
@@ -1373,7 +1373,7 @@
                     "values": ["trust"],
                     "amount": -5,
                     "log": {
-                        "cats_from": "cat_from heard about cat_to starting accidentally starting a fight with a misplaced border marking."
+                        "cats_from": "cat_from heard about cat_to accidentally starting a fight because of a misplaced border marking."
                     }
                 }],
                 "exp": 0,
@@ -1407,7 +1407,7 @@
                     "values": ["trust"],
                     "amount": -5,
                     "log": {
-                        "cats_from": "cat_from heard about cat_to starting accidentally starting a fight with a misplaced border marking."
+                        "cats_from": "cat_from heard about cat_to accidentally starting a fight because of a misplaced border marking."
                     }
                 }],
                 "exp": 0,
@@ -1837,7 +1837,7 @@
                     "values": ["trust"],
                     "amount": -5,
                     "log": {
-                        "cats_from": "cat_from heard about cat_to starting accidentally starting a fight with a misplaced border marking."
+                        "cats_from": "cat_from heard about cat_to accidentally starting a fight because of a misplaced border marking."
                     }
                 }],
                 "exp": 0,
@@ -1871,7 +1871,7 @@
                     "values": ["trust"],
                     "amount": -5,
                     "log": {
-                        "cats_from": "cat_from heard about cat_to starting accidentally starting a fight with a misplaced border marking."
+                        "cats_from": "cat_from heard about cat_to accidentally starting a fight because of a misplaced border marking."
                     }
                 }],
                 "exp": 0,
@@ -2301,7 +2301,7 @@
                     "values": ["trust"],
                     "amount": -5,
                     "log": {
-                        "cats_from": "cat_from heard about cat_to starting accidentally starting a fight with a misplaced border marking."
+                        "cats_from": "cat_from heard about cat_to accidentally starting a fight because of a misplaced border marking."
                     }
                 }],
                 "exp": 0,
@@ -2335,7 +2335,7 @@
                     "values": ["trust"],
                     "amount": -5,
                     "log": {
-                        "cats_from": "cat_from heard about cat_to starting accidentally starting a fight with a misplaced border marking."
+                        "cats_from": "cat_from heard about cat_to accidentally starting a fight because of a misplaced border marking."
                     }
                 }],
                 "exp": 0,
@@ -2765,7 +2765,7 @@
                     "values": ["trust"],
                     "amount": -5,
                     "log": {
-                        "cats_from": "cat_from heard about cat_to starting accidentally starting a fight with a misplaced border marking."
+                        "cats_from": "cat_from heard about cat_to accidentally starting a fight because of a misplaced border marking."
                     }
                 }],
                 "exp": 0,
@@ -2799,7 +2799,7 @@
                     "values": ["trust"],
                     "amount": -5,
                     "log": {
-                        "cats_from": "cat_from heard about cat_to starting accidentally starting a fight with a misplaced border marking."
+                        "cats_from": "cat_from heard about cat_to accidentally starting a fight because of a misplaced border marking."
                     }
                 }],
                 "exp": 0,
@@ -3253,7 +3253,7 @@
                     "values": ["trust"],
                     "amount": -5,
                     "log": {
-                        "cats_from": "cat_from heard about cat_to starting accidentally starting a fight with a misplaced border marking."
+                        "cats_from": "cat_from heard about cat_to accidentally starting a fight because of a misplaced border marking."
                     }
                 }],
                 "exp": 0,

--- a/resources/lang/en/patrols/other_clan.json
+++ b/resources/lang/en/patrols/other_clan.json
@@ -1399,7 +1399,7 @@
                 "min_max_status": {
                     "warrior": [-1,-1]
                 },
-                "text": "r_c is having trouble focusing today and puts a mark in the wrong place — and at the worst possible moment, because a o_c_n patrol sees them doing it! The diplomatic incident spirals into a full blown conflict, and r_c hauls {PRONOUN/r_c/self} back to camp wounded and bleeding.",
+                "text": "r_c is having trouble focusing today and puts a mark in the wrong place — and at the worst possible moment, because a o_c_n patrol sees {PRONOUN/r_c/object} doing it! The diplomatic incident spirals into a full blown conflict, and r_c hauls {PRONOUN/r_c/self} back to camp wounded and bleeding.",
                 "relationships": [{
                     "cats_from": ["some_clan"],
                     "cats_to": ["r_c"],
@@ -1863,7 +1863,7 @@
                 "min_max_status": {
                     "warrior": [-1,-1]
                 },
-                "text": "r_c is having trouble focusing today and puts a mark in the wrong place — and at the worst possible moment, because a o_c_n patrol sees them doing it! The diplomatic incident spirals into a full blown conflict, and r_c hauls {PRONOUN/r_c/self} back to camp wounded and bleeding.",
+                "text": "r_c is having trouble focusing today and puts a mark in the wrong place — and at the worst possible moment, because a o_c_n patrol sees {PRONOUN/r_c/object} doing it! The diplomatic incident spirals into a full blown conflict, and r_c hauls {PRONOUN/r_c/self} back to camp wounded and bleeding.",
                 "relationships": [{
                     "cats_from": ["some_clan"],
                     "cats_to": ["r_c"],
@@ -2327,7 +2327,7 @@
                 "min_max_status": {
                     "warrior": [-1,-1]
                 },
-                "text": "r_c is having trouble focusing today and puts a mark in the wrong place — and at the worst possible moment, because a o_c_n patrol sees them doing it! The diplomatic incident spirals into a full blown conflict, and r_c hauls {PRONOUN/r_c/self} back to camp wounded and bleeding.",
+                "text": "r_c is having trouble focusing today and puts a mark in the wrong place — and at the worst possible moment, because a o_c_n patrol sees {PRONOUN/r_c/object} doing it! The diplomatic incident spirals into a full blown conflict, and r_c hauls {PRONOUN/r_c/self} back to camp wounded and bleeding.",
                 "relationships": [{
                     "cats_from": ["some_clan"],
                     "cats_to": ["r_c"],
@@ -2791,7 +2791,7 @@
                 "min_max_status": {
                     "warrior": [-1,-1]
                 },
-                "text": "r_c is having trouble focusing today and puts a mark in the wrong place — and at the worst possible moment, because a o_c_n patrol sees them doing it! The diplomatic incident spirals into a full blown conflict, and r_c hauls {PRONOUN/r_c/self} back to camp wounded and bleeding.",
+                "text": "r_c is having trouble focusing today and puts a mark in the wrong place — and at the worst possible moment, because a o_c_n patrol sees {PRONOUN/r_c/object} doing it! The diplomatic incident spirals into a full blown conflict, and r_c hauls {PRONOUN/r_c/self} back to camp wounded and bleeding.",
                 "relationships": [{
                     "cats_from": ["some_clan"],
                     "cats_to": ["r_c"],
@@ -3245,7 +3245,7 @@
                 "min_max_status": {
                     "warrior": [-1,-1]
                 },
-                "text": "r_c is having trouble focusing today and puts a mark in the wrong place — and at the worst possible moment, because a o_c_n patrol sees them doing it! The diplomatic incident spirals into a full blown conflict, and r_c hauls {PRONOUN/r_c/self} back to camp wounded and bleeding.",
+                "text": "r_c is having trouble focusing today and puts a mark in the wrong place — and at the worst possible moment, because a o_c_n patrol sees {PRONOUN/r_c/object} doing it! The diplomatic incident spirals into a full blown conflict, and r_c hauls {PRONOUN/r_c/self} back to camp wounded and bleeding.",
                 "relationships": [{
                     "cats_from": ["some_clan"],
                     "cats_to": ["r_c"],

--- a/resources/lang/en/patrols/other_clan_allies.json
+++ b/resources/lang/en/patrols/other_clan_allies.json
@@ -950,7 +950,7 @@
             },
             {
                 "min_max_status": {"warrior": [1, 1]},
-                "text": "r_c is having trouble focusing today and puts a mark in the wrong place — at the worst possible moment, because a o_c_n patrol sees them doing it! {PRONOUN/r_c/subject/CAP} immediately {VERB/r_c/apologize/apologizes} to the o_c_n patrol for the diplomatic incident {PRONOUN/r_c/subject}{VERB/r_c/'ve/'s} inadvertently caused.",
+                "text": "r_c is having trouble focusing today and puts a mark in the wrong place — at the worst possible moment, because a o_c_n patrol sees {PRONOUN/r_c/object} doing it! {PRONOUN/r_c/subject/CAP} immediately {VERB/r_c/apologize/apologizes} to the o_c_n patrol for the diplomatic incident {PRONOUN/r_c/subject}{VERB/r_c/'ve/'s} inadvertently caused.",
                 "exp": 0,
                 "stat_trait": [
                     "ambitious",


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

- slightly rewords the clan mourning message when one cat dies because of pronoun confusion.
- adds a bunch of missing pronoun tags in patrols (i had to look through 20 copies of the same text and 5 had the missing tag. it was hell on earth)
- adds a missing period in a death event.
- rewords a chill breakup string because it was missing a word and it felt kind of clunky with the way the sentence was structured.

## Why This Is Good For ClanGen

:3 no typos!!!

## Linked Issues

https://github.com/ClanGenOfficial/clangen/issues/1818#issuecomment-4434376677
https://github.com/ClanGenOfficial/clangen/issues/1818#issuecomment-4436785373

## Proof of Testing

<img width="980" height="87" alt="image" src="https://github.com/user-attachments/assets/22bc0876-6f14-4251-92b3-ec9d12d4f2c8" />
<img width="1025" height="129" alt="image" src="https://github.com/user-attachments/assets/0ee76f85-557a-49e5-a5be-7ceee6d6bef0" />


## Changelog/Credits

- A couple typo fixes and mild rewrites to events for clarity.