### PR TITLE
[PERFORMANCE] Relationship event filtering

### DIFF
--- a/scripts/events_module/event_filters.py
+++ b/scripts/events_module/event_filters.py
@@ -3,7 +3,6 @@ from itertools import combinations
 from random import choice, randint
 from typing import List, Optional
 
-
 from scripts.cat.constants import BACKSTORIES
 from scripts.cat.personality import Personality
 from scripts.cat_relations.enums import RelType, rel_type_tiers, RelTier

--- a/scripts/events_module/event_filters.py
+++ b/scripts/events_module/event_filters.py
@@ -1012,13 +1012,13 @@ def filter_relationship_type(group: list, filter_types: List[str], patrol_leader
     # Filtering relationship values
     # these don't get exclusionary values because it's giving me a headache
     # each cat has to have relationships toward each other matching every level tag
+    group_ids = [cat.ID for cat in group]
     for tier in filter_types:
         for inter_cat in group:
             if len(group) == 2 and inter_cat == group[1]:
                 # if this is a two cat group, then we only look for the first cat's rel toward the second cat.
                 # groups > 2 will require that all cats feel the same way toward each other.
                 continue
-            group_ids = [cat.ID for cat in group]
 
             relevant_relationships = [
                 rel

--- a/scripts/events_module/event_filters.py
+++ b/scripts/events_module/event_filters.py
@@ -1021,11 +1021,11 @@ def filter_relationship_type(group: list, filter_types: List[str], patrol_leader
                 # groups > 2 will require that all cats feel the same way toward each other.
                 continue
 
-            relevant_relationships = []
-            for cat_id in group_ids:
-                rel = inter_cat.relationships.get(cat_id)
-                if rel:
-                    relevant_relationships.append(rel)
+            relevant_relationships = [
+                inter_cat.relationships[cat_id]
+                for cat_id in group_ids
+                if cat_id in inter_cat.relationships
+            ]
 
             # list of every cat's tier list
             group_lists: list[RelTier] = [

--- a/scripts/events_module/event_filters.py
+++ b/scripts/events_module/event_filters.py
@@ -1059,19 +1059,18 @@ def filter_relationship_type(group: list, filter_types: List[str], patrol_leader
 
                     # get the tier's index within the rel_types's list
                     index = rel_type_tiers[rel_type].index(rel_tier)
-                    allowed_tiers = []
+                    allowed_tiers = set()
                     # if it's a pos tier, we allow that index and higher
                     if rel_tier.is_any_pos:
-                        allowed_tiers = rel_type_tiers[rel_type][index:]
+                        allowed_tiers = set(rel_type_tiers[rel_type][index:])
                     # if it's a neg tier, we allow that index and lower
                     elif rel_tier.is_any_neg:
-                        allowed_tiers = rel_type_tiers[rel_type][0 : index + 1]
+                        allowed_tiers = set(rel_type_tiers[rel_type][0 : index + 1])
 
                     discard = True
-                    for _t in tier_list:
-                        if _t in allowed_tiers:
-                            discard = False
-                            break
+                    tier_set = set(tier_list)
+                    if allowed_tiers.intersection(tier_set):
+                        discard = False
                     if discard:
                         return False
 

--- a/scripts/events_module/event_filters.py
+++ b/scripts/events_module/event_filters.py
@@ -2,7 +2,6 @@ import re
 from itertools import combinations
 from random import choice, randint
 from typing import List, Optional
-from line_profiler import profile
 
 
 from scripts.cat.constants import BACKSTORIES
@@ -830,7 +829,6 @@ def _check_for_exclusionary_value(possible_values: List[str]) -> bool:
     return any(value.find("-") == 0 for value in possible_values)
 
 
-@profile
 def filter_relationship_type(group: list, filter_types: List[str], patrol_leader=None):
     """
     filters for specific types of relationships between groups of cat objects, returns bool

--- a/scripts/events_module/event_filters.py
+++ b/scripts/events_module/event_filters.py
@@ -2,6 +2,8 @@ import re
 from itertools import combinations
 from random import choice, randint
 from typing import List, Optional
+from line_profiler import profile
+
 
 from scripts.cat.constants import BACKSTORIES
 from scripts.cat.personality import Personality
@@ -828,6 +830,7 @@ def _check_for_exclusionary_value(possible_values: List[str]) -> bool:
     return any(value.find("-") == 0 for value in possible_values)
 
 
+@profile
 def filter_relationship_type(group: list, filter_types: List[str], patrol_leader=None):
     """
     filters for specific types of relationships between groups of cat objects, returns bool
@@ -1020,11 +1023,11 @@ def filter_relationship_type(group: list, filter_types: List[str], patrol_leader
                 # groups > 2 will require that all cats feel the same way toward each other.
                 continue
 
-            relevant_relationships = [
-                rel
-                for rel in inter_cat.relationships.values()
-                if rel.cat_to.ID in group_ids and rel.cat_to.ID != inter_cat.ID
-            ]
+            relevant_relationships = []
+            for cat_id in group_ids:
+                rel = inter_cat.relationships.get(cat_id)
+                if rel:
+                    relevant_relationships.append(rel)
 
             # list of every cat's tier list
             group_lists: list[RelTier] = [


### PR DESCRIPTION
## About The Pull Request

Relationship events are probably one of the biggest bottlenecks when it comes to timeskip performance. This adds some quick optimizations. Namely:
* Moves `group_ids` declaration outside of the loop because `group_ids` is used in every loop without being changed.
* Changes the `relevant_relationships` list comprehension to get associated relationships using the dictionary instead of filtering through the values. Relationships already map from `cat_to`, so there's no need to filter for `cat_to` again.
*  Changes the `allowed_tiers` check to use sets instead.

## Why This Is Good For ClanGen

Makes timeskips a little faster.

## Proof of Testing

On EmberClan, moonskip time before changes: 26s
On EmberClan, moonskip time after changes: 18s

## Changelog/Credits

* Improves performance for timeskips
