### PR TITLE
[CONTENT] "gentle" mate rejection events

### DIFF
--- a/resources/lang/en/events/relationship_events/become_mates.json
+++ b/resources/lang/en/events/relationship_events/become_mates.json
@@ -50,7 +50,11 @@
         "After being rejected by r_c, m_c's barely been visible round camp. {PRONOUN/m_c/subject/CAP}{VERB/m_c/'re/'s} good at hiding when {PRONOUN/m_c/subject} {VERB/m_c/want/wants} to be.",
 		"m_c confesses {PRONOUN/m_c/poss} feelings to r_c, asking to be mates. And the answer, well, it's not yes.",
 		"Look, r_c is sorry, but {PRONOUN/r_c/subject} just {VERB/r_c/don't/doesn't} see m_c that way. m_c slinks off, rejected.",
-		"m_c's confession of love to r_c could've gone better. Actually, anything would've been better than the rejection {PRONOUN/m_c/subject} got."
+		"m_c's confession of love to r_c could've gone better. Actually, anything would've been better than the rejection {PRONOUN/m_c/subject} got.",
+		"When r_c tells m_c that {PRONOUN/r_c/subject}{VERB/r_c/'re/'s} not interested in being mates, r_c expects the worst. But surprisingly, m_c nods in understanding and says {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} fine with staying friends.",
+		"After a long moment of silence, r_c gently rejects m_c's love confession. m_c just nods and walks away.",
+		"m_c's smile fades when r_c tells {PRONOUN/m_c/object} that {PRONOUN/r_c/subject} {VERB/r_c/don't/doesn't} feel the same way. Through {PRONOUN/m_c/poss} heartbreak, m_c meows that {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} okay with staying friends if it means r_c can be happy.",
+		"r_c explains to m_c that {PRONOUN/r_c/subject} {VERB/r_c/don't/doesn't} feel ready to be in a relationship. Although {PRONOUN/m_c/subject} {VERB/m_c/are/is} sad to be rejected, {PRONOUN/m_c/subject} {VERB/m_c/take/takes} the situation better than r_c thought {PRONOUN/m_c/subject} would."
 	],
 	"makeup_fail":[
 		"m_c wants to get back with r_c, so {PRONOUN/m_c/subject} confessed {PRONOUN/m_c/poss} feelings to r_c but was rejected.",


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

Adds a bunch of mate rejection events that are less harsh. The cat is gently rejected and they take it well.

## Why This Is Good For ClanGen

All the current rejection events have an ambiguous tone or it's clear the rejection was not pleasant at all. By adding some "gentler" ones, we have more varied options to choose from.

## Proof of Testing

<img width="505" height="131" alt="image" src="https://github.com/user-attachments/assets/3d5328c3-834a-4081-8507-dcb5ba5b7542" />
<img width="509" height="100" alt="image" src="https://github.com/user-attachments/assets/def94dcb-69c7-40f2-8726-0a79192349e4" />
<img width="513" height="129" alt="image" src="https://github.com/user-attachments/assets/90c38354-370f-4735-a663-9484320cf847" />


## Changelog/Credits

- Adds "gentler" mate rejection events. Prepare to have your hearts broken! But a little more nicely this time.
