### PR TITLE
[CONTENT] negative group relationship events

### DIFF
--- a/resources/lang/en/events/relationship_events/group_interactions/3/negative.json
+++ b/resources/lang/en/events/relationship_events/group_interactions/3/negative.json
@@ -318,5 +318,101 @@
 				"respect": "decrease"
 			}
 		}
-	}
+	},
+	{
+  "id": "muddypaws3cat_warrior",
+  "intensity": "medium",
+  "cat_amount": 3,
+  "interactions": [
+"m_c tracked a trail of muddy pawprints into the warrior's den, straight through the nests of r_c1 and r_c2.",
+    "m_c returned to the warrior's den dripping mud everywhere and managed to ruin r_c1 and r_c2's nests.",
+    "m_c tromped into the warrior's den with muddy paws, trailing muck straight through r_c1 and r_c2's nests."
+  ],
+  		"specific_reaction": {
+			"r_c1_to_m_c": {
+				"respect": "decrease",
+				"like": "decrease"
+			},
+			"r_c2_to_m_c": {
+				"respect": "decrease",
+				"like": "decrease"
+			}
+		},
+    		"status_constraint": {
+			"m_c": [
+			"warrior",
+              "deputy"
+			],
+			"r_c1": [
+			"warrior",
+              "deputy"
+			],
+			"r_c2": [
+			"warrior",
+              "deputy"
+			]
+		}
+},
+	{
+  "id": "muddypaws3cat_elder",
+  "intensity": "medium",
+  "cat_amount": 3,
+  "interactions": [
+"m_c tracked a trail of muddy pawprints into the elder's den, straight through the nests of r_c1 and r_c2.",
+    "m_c returned to the elder's den dripping mud everywhere and managed to ruin r_c1 and r_c2's nests.",
+    "m_c tromped into the elder's den with muddy paws, trailing muck straight through r_c1 and r_c2's nests."
+  ],
+  		"specific_reaction": {
+			"r_c1_to_m_c": {
+				"respect": "decrease",
+				"like": "decrease"
+			},
+			"r_c2_to_m_c": {
+				"respect": "decrease",
+				"like": "decrease"
+			}
+		},
+    		"status_constraint": {
+			"m_c": [
+			"elder"
+			],
+			"r_c1": [
+			"elder"
+			],
+			"r_c2": [
+			"elder"
+			]
+		}
+},
+		{
+  "id": "muddypaws3cat_apprentice",
+  "intensity": "medium",
+  "cat_amount": 3,
+  "interactions": [
+"m_c tracked a trail of muddy pawprints into the apprentice's den, straight through the nests of r_c1 and r_c2.",
+    "m_c returned to the apprentice's den dripping mud everywhere and managed to ruin r_c1 and r_c2's nests.",
+    "m_c tromped into the apprentice's den with muddy paws, trailing muck straight through r_c1 and r_c2's nests."
+  ],
+  		"specific_reaction": {
+			"r_c1_to_m_c": {
+				"respect": "decrease",
+				"like": "decrease"
+			},
+			"r_c2_to_m_c": {
+				"respect": "decrease",
+				"like": "decrease"
+			}
+		},
+    		"status_constraint": {
+			"m_c": [
+			"apprentice"
+			],
+			"r_c1": [
+			"apprentice"
+			],
+			"r_c2": [
+			"apprentice"
+			]
+		}
+}
 ]

--- a/resources/lang/en/events/relationship_events/group_interactions/4/negative.json
+++ b/resources/lang/en/events/relationship_events/group_interactions/4/negative.json
@@ -50,7 +50,7 @@
   "interactions": [
     "m_c eats as ravenously as a wolverine and by the time {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} done, r_c1, r_c2, and r_c3 barely have the stomach to finish their own meals.",
     "While m_c gorges on {PRONOUN/m_c/poss} piece of fresh kill, r_c1, r_c2, and r_c3 find that eating is suddenly less appealing.",
-    "Spittle and flecks of bone fly while m_c guzzles down prey, reminding r_c1, rc_2, and r_c3 to seek out better mealtime companionship next time."
+    "Spittle and flecks of bone fly while m_c gobbles down prey, reminding r_c1, rc_2, and r_c3 to seek out better mealtime companionship next time."
   ],
   		"specific_reaction": {
 			"r_c1_to_m_c": {
@@ -72,7 +72,7 @@
   "intensity": "medium",
   "cat_amount": 4,
   "interactions": [
-"m_c spends the Gathering whispering to r_c1, r_c2, and r_c3 making it nearly impossible for anyone nearby to hear the leaders speak.",
+"m_c spends the Gathering whispering to r_c1, r_c2, and r_c3, making it nearly impossible for anyone nearby to hear the leaders speak.",
     "m_c won't keep {PRONOUN/m_c/poss} mouth shut during the Gathering. r_c1, r_c2, and r_c3 can barely hear the leader's announcements!",
     "No matter how many warning looks r_c1, r_c2, and r_c3 send {PRONOUN/m_c/object}, m_c keeps talking over the Gathering announcements."
   ],
@@ -114,9 +114,9 @@
   "intensity": "low",
   "cat_amount": 4,
   "interactions": [
-"m_c shares a suspiciously exaggerated tale with r_c1, r_c2, and r_c3 who seem far from convinced of its veracity.",
+"m_c shares a suspiciously exaggerated tale with r_c1, r_c2, and r_c3, who seem far from convinced of its veracity.",
     "m_c tells r_c1, r_c2, and r_c3 a story that seems to grow less believable every meow.",
-    "m_c tells r_c1, r_c2, and r_c3, a story that earns more skepticism than admiration."
+    "m_c tells r_c1, r_c2, and r_c3 a story that earns more skepticism than admiration."
   ],
   		"specific_reaction": {
 			"r_c1_to_m_c": {
@@ -158,7 +158,9 @@
     		"status_constraint": {
 			"m_c": [
 			"-kitten",
-              "-elder"
+            "-elder",
+			"-leader",
+			"-deputy"
 			],
 			"r_c1": [
 			"-kitten",

--- a/resources/lang/en/events/relationship_events/group_interactions/4/negative.json
+++ b/resources/lang/en/events/relationship_events/group_interactions/4/negative.json
@@ -42,5 +42,254 @@
 				"comfort": "decrease"
 			}
 		}
-	}
+	},
+	{
+  "id": "glutton4cat",
+  "intensity": "low",
+  "cat_amount": 4,
+  "interactions": [
+    "m_c eats as ravenously as a wolverine and by the time {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} done, r_c1, r_c2, and r_c3 barely have the stomach to finish their own meals.",
+    "While m_c gorges on {PRONOUN/m_c/poss} piece of fresh kill, r_c1, r_c2, and r_c3 find that eating is suddenly less appealing.",
+    "Spittle and flecks of bone fly while m_c guzzles down prey, reminding r_c1, rc_2, and r_c3 to seek out better mealtime companionship next time."
+  ],
+  		"specific_reaction": {
+			"r_c1_to_m_c": {
+				"comfort": "decrease",
+				"like": "decrease"
+			},
+			"r_c2_to_m_c": {
+				"comfort": "decrease",
+				"like": "decrease"
+			},
+			"r_c3_to_m_c": {
+				"comfort": "decrease",
+				"like": "decrease"
+			}
+		}
+},
+	{
+  "id": "chattygathering4cat",
+  "intensity": "medium",
+  "cat_amount": 4,
+  "interactions": [
+"m_c spends the Gathering whispering to r_c1, r_c2, and r_c3 making it nearly impossible for anyone nearby to hear the leaders speak.",
+    "m_c won't keep {PRONOUN/m_c/poss} mouth shut during the Gathering. r_c1, r_c2, and r_c3 can barely hear the leader's announcements!",
+    "No matter how many warning looks r_c1, r_c2, and r_c3 send {PRONOUN/m_c/object}, m_c keeps talking over the Gathering announcements."
+  ],
+  		"specific_reaction": {
+			"r_c1_to_m_c": {
+				"respect": "decrease",
+				"like": "decrease"
+			},
+			"r_c2_to_m_c": {
+				"respect": "decrease",
+				"like": "decrease"
+			},
+			"r_c3_to_m_c": {
+				"respect": "decrease",
+				"like": "decrease"
+			}
+		},
+  		"status_constraint": {
+			"m_c": [
+				"warrior",
+              "apprentice"
+			],
+			"r_c1": [
+				"warrior",
+              "apprentice"
+			],
+			"r_c2": [
+				"warrior",
+              "apprentice"
+			],
+			"r_c3": [
+				"warrior",
+              "apprentice"
+			]
+		}
+},
+	{
+  "id": "badstory4cat",
+  "intensity": "low",
+  "cat_amount": 4,
+  "interactions": [
+"m_c shares a suspiciously exaggerated tale with r_c1, r_c2, and r_c3 who seem far from convinced of its veracity.",
+    "m_c tells r_c1, r_c2, and r_c3 a story that seems to grow less believable every meow.",
+    "m_c tells r_c1, r_c2, and r_c3, a story that earns more skepticism than admiration."
+  ],
+  		"specific_reaction": {
+			"r_c1_to_m_c": {
+				"trust": "decrease",
+				"like": "decrease"
+			},
+			"r_c2_to_m_c": {
+				"trust": "decrease",
+				"like": "decrease"
+			},
+			"r_c3_to_m_c": {
+				"trust": "decrease",
+				"like": "decrease"
+			}
+		}
+},
+	{
+  "id": "patrolcomplainer5cat",
+  "intensity": "low",
+  "cat_amount": 4,
+  "interactions": [
+"m_c complained about {PRONOUN/m_c/poss} patrol assignment all day, much to the annoyance of r_c1, r_c2, and r_c3.",
+    "m_c complained so relentlessly about {PRONOUN/m_c/poss} patrol assignment that r_c1, r_c2, and r_c3 could only sigh and bear it."
+  ],
+  		"specific_reaction": {
+			"r_c1_to_m_c": {
+				"respect": "decrease",
+				"like": "decrease"
+			},
+			"r_c2_to_m_c": {
+				"respect": "decrease",
+				"like": "decrease"
+			},
+			"r_c3_to_m_c": {
+				"respect": "decrease",
+				"like": "decrease"
+			}
+		},
+    		"status_constraint": {
+			"m_c": [
+			"-kitten",
+              "-elder"
+			],
+			"r_c1": [
+			"-kitten",
+              "-elder"
+			],
+			"r_c2": [
+			"-kitten",
+              "-elder"
+			],
+			"r_c3": [
+			"-kitten",
+              "-elder"
+			]
+		}
+},
+	{
+  "id": "muddypaws4cat_warrior",
+  "intensity": "medium",
+  "cat_amount": 4,
+  "interactions": [
+"m_c tracked a trail of muddy pawprints into the warrior's den, straight through the nests of r_c1, r_c2, and r_c3.",
+    "m_c returned to the warrior's den dripping mud everywhere and managed to ruin r_c1, r_c2, and r_c3’s nests.",
+    "m_c tromped into the warrior's den with muddy paws, trailing muck straight through r_c1, r_c2, and r_c3’s nests."
+  ],
+  		"specific_reaction": {
+			"r_c1_to_m_c": {
+				"respect": "decrease",
+				"like": "decrease"
+			},
+			"r_c2_to_m_c": {
+				"respect": "decrease",
+				"like": "decrease"
+			},
+			"r_c3_to_m_c": {
+				"respect": "decrease",
+				"like": "decrease"
+			}
+		},
+    		"status_constraint": {
+			"m_c": [
+			"warrior",
+              "deputy"
+			],
+			"r_c1": [
+			"warrior",
+              "deputy"
+			],
+			"r_c2": [
+			"warrior",
+              "deputy"
+			],
+			"r_c3": [
+			"warrior",
+              "deputy"
+			]
+		}
+},
+	{
+  "id": "muddypaws4cat_elder",
+  "intensity": "medium",
+  "cat_amount": 4,
+  "interactions": [
+"m_c tracked a trail of muddy pawprints into the elder's den, straight through the nests of r_c1, r_c2, and r_c3.",
+    "m_c returned to the elder's den dripping mud everywhere and managed to ruin r_c1, r_c2, and r_c3’s nests.",
+    "m_c tromped into the elder's den with muddy paws, trailing muck straight through r_c1, r_c2, and r_c3’s nests."
+  ],
+  		"specific_reaction": {
+			"r_c1_to_m_c": {
+				"respect": "decrease",
+				"like": "decrease"
+			},
+			"r_c2_to_m_c": {
+				"respect": "decrease",
+				"like": "decrease"
+			},
+			"r_c3_to_m_c": {
+				"respect": "decrease",
+				"like": "decrease"
+			}
+		},
+    		"status_constraint": {
+			"m_c": [
+			"elder"
+			],
+			"r_c1": [
+			"elder"
+			],
+			"r_c2": [
+			"elder"
+			],
+			"r_c3": [
+			"elder"
+			]
+		}
+},
+		{
+  "id": "muddypaws4cat_apprentice",
+  "intensity": "medium",
+  "cat_amount": 4,
+  "interactions": [
+"m_c tracked a trail of muddy pawprints into the apprentice's den, straight through the nests of r_c1, r_c2, and r_c3.",
+    "m_c returned to the apprentice's den dripping mud everywhere and managed to ruin r_c1, r_c2, and r_c3’s nests.",
+    "m_c tromped into the apprentice's den with muddy paws, trailing muck straight through r_c1, r_c2, and r_c3’s nests."
+  ],
+  		"specific_reaction": {
+			"r_c1_to_m_c": {
+				"respect": "decrease",
+				"like": "decrease"
+			},
+			"r_c2_to_m_c": {
+				"respect": "decrease",
+				"like": "decrease"
+			},
+			"r_c3_to_m_c": {
+				"respect": "decrease",
+				"like": "decrease"
+			}
+		},
+    		"status_constraint": {
+			"m_c": [
+			"apprentice"
+			],
+			"r_c1": [
+			"apprentice"
+			],
+			"r_c2": [
+			"apprentice"
+			],
+			"r_c3": [
+			"apprentice"
+			]
+		}
+}
 ]

--- a/resources/lang/en/events/relationship_events/group_interactions/5/negative.json
+++ b/resources/lang/en/events/relationship_events/group_interactions/5/negative.json
@@ -583,7 +583,7 @@
   "interactions": [
     "m_c eats as ravenously as a wolverine and by the time {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} done, r_c1, r_c2, r_c3, and r_c4 barely have the stomach to finish their own meals.",
     "While m_c gorges on {PRONOUN/m_c/poss} piece of fresh kill, r_c1, r_c2, r_c3, and r_c4 find that eating is suddenly less appealing.",
-    "Spittle and flecks of bone fly while m_c guzzles down prey, reminding r_c1, rc_2, r_c3, and r_c4 to seek out better mealtime companionship next time."
+    "Spittle and flecks of bone fly while m_c gobbles down prey, reminding r_c1, rc_2, r_c3, and r_c4 to seek out better mealtime companionship next time."
   ],
   		"specific_reaction": {
 			"r_c1_to_m_c": {
@@ -711,7 +711,9 @@
     		"status_constraint": {
 			"m_c": [
 			"-kitten",
-              "-elder"
+            "-elder",
+			"-leader",
+			"-deputy"
 			],
 			"r_c1": [
 			"-kitten",

--- a/resources/lang/en/events/relationship_events/group_interactions/5/negative.json
+++ b/resources/lang/en/events/relationship_events/group_interactions/5/negative.json
@@ -575,5 +575,160 @@
 				"comfort": "decrease"
 			}
 		}
-	}
+	},
+	{
+  "id": "glutton5cat",
+  "intensity": "low",
+  "cat_amount": 5,
+  "interactions": [
+    "m_c eats as ravenously as a wolverine and by the time {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} done, r_c1, r_c2, r_c3, and r_c4 barely have the stomach to finish their own meals.",
+    "While m_c gorges on {PRONOUN/m_c/poss} piece of fresh kill, r_c1, r_c2, r_c3, and r_c4 find that eating is suddenly less appealing.",
+    "Spittle and flecks of bone fly while m_c guzzles down prey, reminding r_c1, rc_2, r_c3, and r_c4 to seek out better mealtime companionship next time."
+  ],
+  		"specific_reaction": {
+			"r_c1_to_m_c": {
+				"comfort": "decrease",
+				"like": "decrease"
+			},
+			"r_c2_to_m_c": {
+				"comfort": "decrease",
+				"like": "decrease"
+			},
+			"r_c3_to_m_c": {
+				"comfort": "decrease",
+				"like": "decrease"
+			},
+			"r_c4_to_m_c": {
+				"comfort": "decrease",
+				"like": "decrease"
+			}
+		}
+},
+	{
+  "id": "chattygathering5cat",
+  "intensity": "medium",
+  "cat_amount": 5,
+  "interactions": [
+"m_c spends the Gathering whispering to r_c1, r_c2, r_c3, and r_c4, making it nearly impossible for anyone nearby to hear the leaders speak.",
+    "m_c won't keep {PRONOUN/m_c/poss} mouth shut during the Gathering. r_c1, r_c2, r_c3, and r_c4 can barely hear the leader's announcements!",
+    "No matter how many warning looks r_c1, r_c2, r_c3, and r_c4 send {PRONOUN/m_c/object}, m_c keeps talking over the Gathering announcements."
+  ],
+  		"specific_reaction": {
+			"r_c1_to_m_c": {
+				"respect": "decrease",
+				"like": "decrease"
+			},
+			"r_c2_to_m_c": {
+				"respect": "decrease",
+				"like": "decrease"
+			},
+			"r_c3_to_m_c": {
+				"respect": "decrease",
+				"like": "decrease"
+			},
+			"r_c4_to_m_c": {
+				"respect": "decrease",
+				"like": "decrease"
+			}
+		},
+  		"status_constraint": {
+			"m_c": [
+				"warrior",
+              "apprentice"
+			],
+			"r_c1": [
+				"warrior",
+              "apprentice"
+			],
+			"r_c2": [
+				"warrior",
+              "apprentice"
+			],
+			"r_c3": [
+				"warrior",
+              "apprentice"
+			],
+			"r_c4": [
+				"warrior",
+              "apprentice"
+			]
+		}
+},
+	{
+  "id": "badstory5cat",
+  "intensity": "low",
+  "cat_amount": 5,
+  "interactions": [
+"m_c shares a suspiciously exaggerated tale with r_c1, r_c2, r_c3, and r_c4, who seem far from convinced of its veracity.",
+    "m_c tells r_c1, r_c2, r_c3, and r_c4 a story that seems to grow less believable every meow.",
+    "m_c tells r_c1, r_c2, r_c3, and r_c4 a story that earns more skepticism than admiration."
+  ],
+  		"specific_reaction": {
+			"r_c1_to_m_c": {
+				"trust": "decrease",
+				"like": "decrease"
+			},
+			"r_c2_to_m_c": {
+				"trust": "decrease",
+				"like": "decrease"
+			},
+			"r_c3_to_m_c": {
+				"trust": "decrease",
+				"like": "decrease"
+			},
+			"r_c4_to_m_c": {
+				"trust": "decrease",
+				"like": "decrease"
+			}
+		}
+},
+	{
+  "id": "patrolcomplainer5cat",
+  "intensity": "low",
+  "cat_amount": 5,
+  "interactions": [
+"m_c complained about {PRONOUN/m_c/poss} patrol assignment all day, much to the annoyance of r_c1, r_c2, r_c3, and r_c4.",
+    "m_c complained so relentlessly about {PRONOUN/m_c/poss} patrol assignment that r_c1, r_c2, r_c3, and r_c4 could only sigh and bear it."
+  ],
+  		"specific_reaction": {
+			"r_c1_to_m_c": {
+				"respect": "decrease",
+				"like": "decrease"
+			},
+			"r_c2_to_m_c": {
+				"respect": "decrease",
+				"like": "decrease"
+			},
+			"r_c3_to_m_c": {
+				"respect": "decrease",
+				"like": "decrease"
+			},
+			"r_c4_to_m_c": {
+				"respect": "decrease",
+				"like": "decrease"
+			}
+		},
+    		"status_constraint": {
+			"m_c": [
+			"-kitten",
+              "-elder"
+			],
+			"r_c1": [
+			"-kitten",
+              "-elder"
+			],
+			"r_c2": [
+			"-kitten",
+              "-elder"
+			],
+			"r_c3": [
+			"-kitten",
+              "-elder"
+			],
+            "r_c4": [
+			"-kitten",
+              "-elder"
+			]
+		}
+}
 ]


### PR DESCRIPTION
## About The Pull Request

- Adds more variety to the negative large group relationship events that are loosely constrained, making them appear more frequently.

## Why This Is Good For ClanGen

- More variety
- May help fix [#3896](https://github.com/ClanGenOfficial/clangen/issues/3896#issuecomment-4456686367). (specifically the linked comment)

## Proof of Testing

- Game loads without error and I immediately found my events in the relationship events tag upon a moonskip in a large clan.
<img width="521" height="136" alt="Screenshot 2026-05-15 at 12 46 33 PM" src="https://github.com/user-attachments/assets/4834c636-d6c6-4e24-8984-bfba73affe78" />
<img width="524" height="137" alt="Screenshot 2026-05-15 at 12 46 13 PM" src="https://github.com/user-attachments/assets/9deaf071-1eff-4f4c-bd17-51b5d9536e9a" />
<img width="514" height="130" alt="Screenshot 2026-05-15 at 12 45 49 PM" src="https://github.com/user-attachments/assets/9340f644-0887-47b2-af08-0c05c9d2214d" />
<img width="522" height="133" alt="Screenshot 2026-05-15 at 12 45 27 PM" src="https://github.com/user-attachments/assets/d965eb35-b86d-400f-a127-a77ca1b0e259" />