### PR TITLE
[TASK] Handle Card Save Data

### DIFF
--- a/scripts/clan.py
+++ b/scripts/clan.py
@@ -72,7 +72,7 @@ class Clan:
         camp_bg=None,
         symbol=None,
         game_mode="classic",
-        cruel_cards=[],
+        cruel_cards: list[str]=[],
         starting_members=None,
         starting_season="Newleaf",
         self_run_init_functions=True,

--- a/scripts/clan.py
+++ b/scripts/clan.py
@@ -761,7 +761,7 @@ class Clan:
             biome=clan_data["biome"],
             camp_bg=clan_data["camp_bg"],
             game_mode=clan_data["gamemode"],
-            cruel_cards=clan_data["cruel_cards"],
+            cruel_cards=clan_data.get("cruel_cards", []),
             self_run_init_functions=False,
         )
         game.clan.post_initialization_functions()

--- a/scripts/clan.py
+++ b/scripts/clan.py
@@ -118,7 +118,7 @@ class Clan:
         self.camp_bg = camp_bg
         self.chosen_symbol = symbol
         self.game_mode = game_mode
-        self.cruel_cards = cruel_cards
+        self.cruel_cards: list[str] = cruel_cards
         self.pregnancy_data = {}
         self.inheritance = {}
         self.custom_pronouns = {}

--- a/scripts/clan.py
+++ b/scripts/clan.py
@@ -72,6 +72,7 @@ class Clan:
         camp_bg=None,
         symbol=None,
         game_mode="classic",
+        cruel_cards=[],
         starting_members=None,
         starting_season="Newleaf",
         self_run_init_functions=True,
@@ -117,10 +118,7 @@ class Clan:
         self.camp_bg = camp_bg
         self.chosen_symbol = symbol
         self.game_mode = game_mode
-        if game_mode == "cruel season":
-            self.cruel_cards = []
-        else:
-            self.cruel_cards = None
+        self.cruel_cards = cruel_cards
         self.pregnancy_data = {}
         self.inheritance = {}
         self.custom_pronouns = {}
@@ -426,6 +424,7 @@ class Clan:
             "camp_bg": self.camp_bg,
             "clan_symbol": self.chosen_symbol,
             "gamemode": self.game_mode,
+            "cruel_cards": self.cruel_cards,
             "used_group_IDs": game.used_group_IDs,
             "last_focus_change": self.last_focus_change,
             "clans_in_focus": self.clans_in_focus,
@@ -441,7 +440,6 @@ class Clan:
             "version_commit": get_version_info().version_number,
             "source_build": get_version_info().is_source_build,
             "custom_pronouns": self.custom_pronouns,
-            "cruel_card_IDs": self.cruel_cards,
         }
 
         # LEADER DATA
@@ -490,11 +488,6 @@ class Clan:
         save_clan_settings()
         if game.clan.game_mode in ("expanded", "cruel season"):
             self.save_freshkill_pile(game.clan)
-
-        if game.clan.game_mode == "cruel season":
-            clan_data["cruel_card_IDs"] = self.cruel_cards
-        else:
-            clan_data["cruel_card_IDs"] = {}
 
         safe_save(f"{get_save_dir()}/{self.name}clan.json", clan_data)
 
@@ -768,6 +761,7 @@ class Clan:
             biome=clan_data["biome"],
             camp_bg=clan_data["camp_bg"],
             game_mode=clan_data["gamemode"],
+            cruel_cards=clan_data["cruel_cards"],
             self_run_init_functions=False,
         )
         game.clan.post_initialization_functions()

--- a/scripts/clan.py
+++ b/scripts/clan.py
@@ -138,6 +138,10 @@ class Clan:
             self.freshkill_pile = FreshkillPile()
         else:
             self.freshkill_pile = None
+        if game_mode in "cruel season":
+            self.cruel_season_cards = CruelSeasonCards()
+        else:
+            self.cruel_season_cards = None
         self.herb_supply = HerbSupply()
         self.primary_disaster = None
         self.secondary_disaster = None

--- a/scripts/clan.py
+++ b/scripts/clan.py
@@ -72,7 +72,7 @@ class Clan:
         camp_bg=None,
         symbol=None,
         game_mode="classic",
-        cruel_cards: list[str]=[],
+        cruel_cards: list[str] = [],
         starting_members=None,
         starting_season="Newleaf",
         self_run_init_functions=True,

--- a/scripts/clan.py
+++ b/scripts/clan.py
@@ -117,6 +117,10 @@ class Clan:
         self.camp_bg = camp_bg
         self.chosen_symbol = symbol
         self.game_mode = game_mode
+        if game_mode == "cruel season":
+            self.cruel_cards = []
+        else:
+            self.cruel_cards = None
         self.pregnancy_data = {}
         self.inheritance = {}
         self.custom_pronouns = {}
@@ -138,10 +142,6 @@ class Clan:
             self.freshkill_pile = FreshkillPile()
         else:
             self.freshkill_pile = None
-        if game_mode in "cruel season":
-            self.cruel_season_cards = CruelSeasonCards()
-        else:
-            self.cruel_season_cards = None
         self.herb_supply = HerbSupply()
         self.primary_disaster = None
         self.secondary_disaster = None
@@ -441,6 +441,7 @@ class Clan:
             "version_commit": get_version_info().version_number,
             "source_build": get_version_info().is_source_build,
             "custom_pronouns": self.custom_pronouns,
+            "cruel_card_IDs": self.cruel_cards,
         }
 
         # LEADER DATA
@@ -489,6 +490,11 @@ class Clan:
         save_clan_settings()
         if game.clan.game_mode in ("expanded", "cruel season"):
             self.save_freshkill_pile(game.clan)
+
+        if game.clan.game_mode == "cruel season":
+            clan_data["cruel_card_IDs"] = self.cruel_cards
+        else:
+            clan_data["cruel_card_IDs"] = {}
 
         safe_save(f"{get_save_dir()}/{self.name}clan.json", clan_data)
 


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->
added cruel_cards attribute to clan.py & handles storing card IDs as clan_data
## Why This Is Good For ClanGen

<!-- If this is a bug fix, you can remove this section. -->
<!-- Please add a short description of why you think these changes would benefit the game. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->
Fixes: #5082 
<!-- If you have multiple features that can stand on their own, or unrelated bugfixes, please create separate PRs for them. -->

## Linked Issues

<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits

<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
