### PR TITLE
[BUGFIX] Clan ID showing up on leader's den

### DIFF
--- a/resources/lang/en/windows.en.json
+++ b/resources/lang/en/windows.en.json
@@ -26,7 +26,7 @@
         "miscellaneous": "miscellaneous",
         "editor_save_check_message": "This event will be saved to:",
         "save_check_message": "Would you like to save your game before exiting? If you don't, progress may be lost!",
-        "delete_check_message": "Do you wish to delete %{clan}? This is permanent and cannot be undone.",
+        "delete_check_message": "Do you wish to delete %{clan} (id:%clan_id)? This is permanent and cannot be undone.",
         "delete_yes": "Delete it!",
         "delete_no": "No! Go back!",
         "game_over_message": "%{clan} has died out. For now, this is where their story ends. Perhaps it's time to tell a new tale?",

--- a/scripts/screens/LeaderDenScreen.py
+++ b/scripts/screens/LeaderDenScreen.py
@@ -343,7 +343,6 @@ class LeaderDenScreen(Screens):
                     first_temper=i18n.t(f"screens.leader_den.{self.clan_temper[0]}"),
                     second_temper=i18n.t(f"screens.leader_den.{self.clan_temper[1]}"),
                 ),
-                "clan": game.clan.displayname,
             },
         )
 

--- a/scripts/screens/SwitchClanScreen.py
+++ b/scripts/screens/SwitchClanScreen.py
@@ -1,5 +1,6 @@
 import logging
 from math import ceil
+import ujson
 
 import pygame
 import pygame_gui
@@ -9,6 +10,7 @@ from pygame_gui.elements import UIImage
 import scripts.game_structure.screen_settings
 from scripts.clan import Clan
 from scripts.game_structure import game
+from scripts.housekeeping.datadir import get_save_dir
 from ..ui.elements.image_button import UIImageButton
 from ..ui.elements.surface_image_button import UISurfaceImageButton
 from scripts.ui.windows.delete_check import CheckDeletionWindow
@@ -163,6 +165,11 @@ class SwitchClanScreen(Screens):
         i = 0
         for clan in self.clan_list[1:]:
             self.clan_name[-1].append(clan)
+            try:
+                with open(f"{get_save_dir()}/{clan}clan.json") as f:
+                    clan_button_name = ujson.load(f).get("displayname", clan)
+            except (FileNotFoundError, ujson.JSONDecodeError):
+                clan_button_name = clan
             self.clan_buttons[-1].append(
                 UISurfaceImageButton(
                     pygame.Rect(
@@ -173,7 +180,7 @@ class SwitchClanScreen(Screens):
                         ),
                         (ui_scale_value(200), item_height),
                     ),
-                    clan + "Clan",
+                    clan_button_name,
                     get_button_dict(
                         ButtonStyles.DROPDOWN,
                         (

--- a/scripts/screens/SwitchClanScreen.py
+++ b/scripts/screens/SwitchClanScreen.py
@@ -54,6 +54,7 @@ class SwitchClanScreen(Screens):
                         CheckDeletionWindow(
                             self.change_screen,
                             self.clan_name[self.page][page.index(event.ui_element)],
+                            self.clan_display_names[self.page][page.index(event.ui_element)],
                         )
 
                         return
@@ -143,6 +144,7 @@ class SwitchClanScreen(Screens):
 
         self.clan_buttons = [[]]
         self.clan_name = [[]]
+        self.clan_display_names = [[]]
         self.delete_buttons = [[]]
 
         # cursed math o clock!
@@ -170,6 +172,7 @@ class SwitchClanScreen(Screens):
                     clan_button_name = ujson.load(f).get("displayname", clan)
             except (FileNotFoundError, ujson.JSONDecodeError):
                 clan_button_name = clan
+            self.clan_display_names[-1].append(clan_button_name)
             self.clan_buttons[-1].append(
                 UISurfaceImageButton(
                     pygame.Rect(

--- a/scripts/screens/SwitchClanScreen.py
+++ b/scripts/screens/SwitchClanScreen.py
@@ -54,7 +54,9 @@ class SwitchClanScreen(Screens):
                         CheckDeletionWindow(
                             self.change_screen,
                             self.clan_name[self.page][page.index(event.ui_element)],
-                            self.clan_display_names[self.page][page.index(event.ui_element)],
+                            self.clan_display_names[self.page][
+                                page.index(event.ui_element)
+                            ],
                         )
 
                         return

--- a/scripts/ui/windows/delete_check.py
+++ b/scripts/ui/windows/delete_check.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 
+import i18n
 import pygame
 import pygame_gui
 
@@ -27,7 +28,10 @@ class CheckDeletionWindow(GameWindow):
             line_spacing=1,
             object_id="#text_box_30_horizcenter",
             container=self,
-            text_kwargs={"clan": str(clan_display_name + "Clan"), "clan_id": clan_id},
+            text_kwargs={
+                "clan": i18n.t("general.clan", name=clan_display_name),
+                "clan_id": clan_id,
+            },
         )
 
         self.delete_it_button = UISurfaceImageButton(

--- a/scripts/ui/windows/delete_check.py
+++ b/scripts/ui/windows/delete_check.py
@@ -14,11 +14,11 @@ from scripts.ui.scale import ui_scale
 
 
 class CheckDeletionWindow(GameWindow):
-    def __init__(self, reloadscreen, clan_name):
+    def __init__(self, reloadscreen, clan_id, clan_display_name):
         super().__init__(
             ui_scale(pygame.Rect((250, 200), (300, 180))),
         )
-        self.clan_name = clan_name
+        self.clan_name = clan_id
         self.reloadscreen = reloadscreen
 
         self.delete_check_message = UITextBoxTweaked(
@@ -27,7 +27,7 @@ class CheckDeletionWindow(GameWindow):
             line_spacing=1,
             object_id="#text_box_30_horizcenter",
             container=self,
-            text_kwargs={"clan": str(self.clan_name + "Clan")},
+            text_kwargs={"clan": str(clan_display_name + "Clan"), "clan_id": clan_id},
         )
 
         self.delete_it_button = UISurfaceImageButton(

--- a/scripts/ui/windows/delete_check.py
+++ b/scripts/ui/windows/delete_check.py
@@ -16,7 +16,7 @@ from scripts.ui.scale import ui_scale
 class CheckDeletionWindow(GameWindow):
     def __init__(self, reloadscreen, clan_id, clan_display_name):
         super().__init__(
-            ui_scale(pygame.Rect((250, 200), (300, 180))),
+            ui_scale(pygame.Rect((250, 200), (300, 250))),
         )
         self.clan_name = clan_id
         self.reloadscreen = reloadscreen
@@ -31,14 +31,14 @@ class CheckDeletionWindow(GameWindow):
         )
 
         self.delete_it_button = UISurfaceImageButton(
-            ui_scale(pygame.Rect((71, 100), (153, 30))),
+            ui_scale(pygame.Rect((71, 125), (153, 30))),
             "windows.delete_yes",
             get_button_dict(ButtonStyles.SQUOVAL, (153, 30)),
             object_id="@buttonstyles_squoval",
             container=self,
         )
         self.go_back_button = UISurfaceImageButton(
-            ui_scale(pygame.Rect((71, 145), (153, 30))),
+            ui_scale(pygame.Rect((71, 170), (153, 30))),
             "windows.delete_no",
             get_button_dict(ButtonStyles.SQUOVAL, (153, 30)),
             object_id="@buttonstyles_squoval",


### PR DESCRIPTION
## About The Pull Request

* No clue what was happening on the leader's den, but removing this line causes the ID to stop showing up
* Makes some slight tweaks to make the ID not show up on the Switch Clan screen buttons
* Makes the deletion window look better for Clans with IDs

## Linked Issues

Fixes #5096

## Proof of Testing

<img width="457" height="412" alt="image" src="https://github.com/user-attachments/assets/53d79d40-a455-4edf-bbba-67954338f673" />
<img width="384" height="534" alt="image" src="https://github.com/user-attachments/assets/6f4b1974-02ee-4112-ba9f-ef6ce79b5e8a" />
<img width="447" height="539" alt="image" src="https://github.com/user-attachments/assets/1b9dc9ab-5fea-46a5-8b40-a131aa7431d4" />
<img width="493" height="521" alt="image" src="https://github.com/user-attachments/assets/09e1f206-fb75-47d0-b270-c5f029d970c5" />


## Changelog/Credits

* Fixes issue where Clan ID was showing up on leader's den and switch clan screens
