### PR TITLE
[ENHANCEMENT] update "Gather for backstories.json" section of events.py

### DIFF
--- a/resources/lang/en/events/ceremonies/ceremony-master.json
+++ b/resources/lang/en/events/ceremonies/ceremony-master.json
@@ -3158,6 +3158,18 @@
     ],
     "Together (old_name) and (previous_mentor) have torn claws and taken names, and as (old_name) is honored for {PRONOUN/m_c/poss} r_h and named m_c, they're not planning on stopping any time soon!"
   ],
+  "warrior_83": [
+    [
+      "warrior",
+      "prepared",
+      "alive_mentor",
+      "general_parents",
+      "yes_leader",
+      "outsider",
+      "all_traits"
+    ],
+    "(old_name), despite having begun their live outside of the clan, puffs out {PRONOUN/m_c/poss} chest as {PRONOUN/m_c/subject} receive {PRONOUN/m_c/poss} full name: m_c, and are honoured for {PRONOUN/m_c/poss} r_h."
+  ],
   "mediator_0": [
     [
       "mediator",

--- a/resources/lang/en/events/ceremonies/ceremony-master.json
+++ b/resources/lang/en/events/ceremonies/ceremony-master.json
@@ -3168,7 +3168,7 @@
       "outsider",
       "all_traits"
     ],
-    "(old_name), despite having begun their live outside of the clan, puffs out {PRONOUN/m_c/poss} chest as {PRONOUN/m_c/subject} receive {PRONOUN/m_c/poss} full name: m_c, and are honoured for {PRONOUN/m_c/poss} r_h."
+    "(old_name), despite having begun their life outside of the clan, puffs out {PRONOUN/m_c/poss} chest as {PRONOUN/m_c/subject} receive {PRONOUN/m_c/poss} full name: m_c, and are honoured for {PRONOUN/m_c/poss} r_h."
   ],
   "mediator_0": [
     [

--- a/resources/lang/en/events/ceremonies/ceremony-master.json
+++ b/resources/lang/en/events/ceremonies/ceremony-master.json
@@ -3158,18 +3158,6 @@
     ],
     "Together (old_name) and (previous_mentor) have torn claws and taken names, and as (old_name) is honored for {PRONOUN/m_c/poss} r_h and named m_c, they're not planning on stopping any time soon!"
   ],
-  "warrior_83": [
-    [
-      "warrior",
-      "prepared",
-      "alive_mentor",
-      "general_parents",
-      "yes_leader",
-      "outsider",
-      "all_traits"
-    ],
-    "(old_name), despite having begun their life outside of the clan, puffs out {PRONOUN/m_c/poss} chest as {PRONOUN/m_c/subject} receive {PRONOUN/m_c/poss} full name: m_c, and are honoured for {PRONOUN/m_c/poss} r_h."
-  ],
   "mediator_0": [
     [
       "mediator",

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -1754,7 +1754,7 @@ def ceremony(cat, promoted_to, preparedness="prepared"):
 
         # Gather for backstories.json ----------------------------------------------------
         tags = []
-        if cat.backstory in ["backstory_categories"]["abandoned_backstories"]:
+        if cat.backstory in BACKSTORIES["backstory_categories"]["abandoned_backstories"]:
             tags.append("abandoned")
         elif cat.backstory == "clanborn":
             tags.append("clanborn")

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -1758,8 +1758,6 @@ def ceremony(cat, promoted_to, preparedness="prepared"):
             tags.append("abandoned")
         elif cat.backstory == "clanborn":
             tags.append("clanborn")
-        elif cat.backstory in BACKSTORIES["backstory_categories"]["loner_backstories", "rogue_backstories", "kittypet_backstories"]:
-            tags.append("outsider")
         temp = possible_ceremonies.intersection(ceremony_id_by_tag["general_backstory"])
 
         for t in tags:

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -1754,7 +1754,7 @@ def ceremony(cat, promoted_to, preparedness="prepared"):
 
         # Gather for backstories.json ----------------------------------------------------
         tags = []
-        if cat.backstory == ["abandoned1", "abandoned2", "abandoned3"]:
+        if cat.backstory in ["backstory_categories"]["abandoned_backstories"]:
             tags.append("abandoned")
         elif cat.backstory == "clanborn":
             tags.append("clanborn")

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -1758,7 +1758,8 @@ def ceremony(cat, promoted_to, preparedness="prepared"):
             tags.append("abandoned")
         elif cat.backstory == "clanborn":
             tags.append("clanborn")
-
+        elif cat.backstory in BACKSTORIES["backstory_categories"]["loner_backstories", "rogue_backstories", "kittypet_backstories"]:
+            tags.append("outsider")
         temp = possible_ceremonies.intersection(ceremony_id_by_tag["general_backstory"])
 
         for t in tags:

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -1754,7 +1754,10 @@ def ceremony(cat, promoted_to, preparedness="prepared"):
 
         # Gather for backstories.json ----------------------------------------------------
         tags = []
-        if cat.backstory in BACKSTORIES["backstory_categories"]["abandoned_backstories"]:
+        if (
+            cat.backstory
+            in BACKSTORIES["backstory_categories"]["abandoned_backstories"]
+        ):
             tags.append("abandoned")
         elif cat.backstory == "clanborn":
             tags.append("clanborn")


### PR DESCRIPTION
## About The Pull Request

- Streamlines "abandoned" backstory-related ceremonies and fixes an oversight where abandoned4 was not counted for the abandoned ceremony tag
## Why This Is Good For ClanGen

- Better code organisation
- Allows for new "abandoned" backstories to be written without having to edit events.py for ceremonies

## Linked Issues

fixes: #5098 

## Proof of Testing

<img width="649" height="179" alt="Screenshot 2026-05-16 at 22 38 27" src="https://github.com/user-attachments/assets/844df37e-5cc5-4879-ad5f-288ef8eef74d" />