### PR TITLE
[BUGFIX] Fix age filtering on groups

### DIFF
--- a/scripts/events_module/relationship/group_events.py
+++ b/scripts/events_module/relationship/group_events.py
@@ -1,15 +1,11 @@
 import os
-from collections import defaultdict
 from copy import deepcopy
-from email.policy import default
 from random import choice, shuffle
 
 import i18n.config
 
 from scripts.game_structure import constants
 from scripts.cat.cats import Cat
-from scripts.cat.enums import CatRank
-from scripts.cat.history import History
 from scripts.cat_relations.interaction import create_group_interaction, GroupInteraction
 from scripts.cat_relations.enums import RelType
 from scripts.event_class import Single_Event
@@ -190,6 +186,8 @@ class GroupEvents:
 
             if interact.status_constraint.get("m_c"):
                 main_constraint_dict["status"] = interact.status_constraint.get("m_c")
+            if interact.age_constraint.get("m_c"):
+                main_constraint_dict["age"] = interact.age_constraint.get("m_c")
             if interact.trait_constraint.get("m_c"):
                 main_constraint_dict["trait"] = interact.trait_constraint.get("m_c")
             if interact.backstory_constraint.get("m_c"):


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
ahahahaha so we weren't actually filtering m_c's age. horrific. but easy fix. also removed some unused imports while i was there, bc why not
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
fixes #4994
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
<img width="534" height="178" alt="image" src="https://github.com/user-attachments/assets/9703513a-b4ec-43ca-9a90-4f62485bed66" />
<img width="433" height="295" alt="image" src="https://github.com/user-attachments/assets/f9652b11-0e02-49dd-85c4-669ffabfff9b" />

gingerleap is, indeed, a senior adult! as required by this event
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Apprentice wrangling rel events are now properly age filtered. No more kittens planning lessons for apprentices.
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
