### PR TITLE
[BUGFIX] reset group IDs on load

### DIFF
--- a/scripts/clan.py
+++ b/scripts/clan.py
@@ -499,6 +499,7 @@ class Clan:
         """
 
         version_info = None
+        game.reset_used_group_IDs()
         if os.path.exists(
             get_save_dir() + "/" + switch_get_value(Switch.clan_list)[0] + "clan.json"
         ):


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
Reset group IDs on loading a new clan. Since we weren't doing this before, other_clan IDs were sometimes getting inflated if loading up an old save.

Ideally, used_group_IDs would be held in `Clan`. unfortunately, in pondering why I didn't code it like that in the first place and then trying to fix it, I discovered past-me's reasoning. Which is that we can't do that. Because of how cat loading works in the order of operations and the dependancy cat loading has on accessing the group ID list. It's hell in there and requires a much greater "refactor how Clan works in general. oh boy" project.

For now, this one line addition fixes the problem and serves as a decent stopgap imo
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
fixes #5072, kinda. Doesn't retroactively fix the problem, but prevents it in the future.
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
<img width="561" height="273" alt="image" src="https://github.com/user-attachments/assets/56d6ea90-f876-4df3-a57c-0f86ed368257" />

normal and expected number of other clan IDs instead of the inflated amount i would get when replicating the problem.
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- fixes other_clan group ID bloat that would occur when loading old saves
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
