### PR TITLE
[BUGFIX] Resubmission of Blocked kittens from a thought 

### DIFF
--- a/resources/lang/en/thoughts/while_alive/clancat.json
+++ b/resources/lang/en/thoughts/while_alive/clancat.json
@@ -48,7 +48,6 @@
 			"Helps r_c fill a puddle in the camp with sand",
 			"Notices some of r_c's fur on {PRONOUN/m_c/poss} fresh-kill",
 			"Pretends not to see r_c cough up a hairball",
-			"Is assigned the same task as r_c",
 			"Accidentally startles r_c",
 			"Is accidentally startled by r_c",
 			"Runs into r_c at the medicine den",
@@ -96,7 +95,8 @@
             "Saw some wandering Twolegs today",
             "Saw a Twoleg kit playing with a dog",
             "Saw a Twoleg kit playing with a kittypet",
-            "Saw a kittypet rolling around a Twoleg garden"
+            "Saw a kittypet rolling around a Twoleg garden",
+			"Is assigned the same task as r_c"
         ],
         "main_status_constraint": [
             "-kitten"


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

- blocked kits from a singular thought
- 
## Linked Issues

Fixes: #4981
Closes: #5138
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->
game runs - no way to force thoughts as of right now. Edit is simply moving a string, so it should have no issue