### PR TITLE
[BUGFIX] Resubmission: "formerly a loner" warrior no longer has a healer backstory

### DIFF
--- a/resources/dicts/backstories.json
+++ b/resources/dicts/backstories.json
@@ -22,11 +22,10 @@
             "loner4",
             "refugee2",
             "tragedy_survivor4",
-            "guided3",
-            "wandering_healer2"
+            "guided3"
         ],
         "rogue_backstories": [
-            "rogue1", "rogue2", "rogue3", "refugee4", "tragedy_survivor2", "guided2", "wandering_healer1"
+            "rogue1", "rogue2", "rogue3", "refugee4", "tragedy_survivor2", "guided2"
         ],
         "kittypet_backstories": [
             "kittypet1", "kittypet2", "kittypet3", "kittypet4", "refugee3", "tragedy_survivor3", "guided1", "refugee6"

--- a/resources/lang/en/patrols/new_cat_hostile.json
+++ b/resources/lang/en/patrols/new_cat_hostile.json
@@ -1737,7 +1737,8 @@
                 "new_cat": [
                     [
                         "status:medicine cat",
-                        "loner"
+                        "loner",
+                       "backstory:wandering_healer1,loner_backstories"
                     ]
                 ],
                 "relationships": [
@@ -1909,7 +1910,8 @@
                 "new_cat": [
                     [
                         "status:medicine cat",
-                        "loner"
+                        "loner",
+                       "backstory:wandering_healer1,loner_backstories"
                     ]
                 ],
                 "relationships": [
@@ -1941,7 +1943,8 @@
                     [
                         "status:medicine cat",
                         "age:has_kits",
-                        "loner"
+                        "loner",
+                        "backstory:wandering_healer1,loner_backstories"
                     ],
                     [
                         "litter",

--- a/resources/lang/en/patrols/new_cat_welcoming.json
+++ b/resources/lang/en/patrols/new_cat_welcoming.json
@@ -191,7 +191,8 @@
                 "exp": 10,
                 "new_cat": [
                     [
-                        "status:medicine cat"
+                        "status:medicine cat",
+                        "backstory:wandering_healer1,loner_backstories"
                     ],
                     [
                         "loner"
@@ -308,7 +309,8 @@
                     [
                         "age:adult",
                         "status:medicine cat",
-                        "loner"
+                        "loner",
+                       "backstory:wandering_healer1,loner_backstories"
                     ],
                     [
                         "status:apprentice",
@@ -370,7 +372,8 @@
                         "age:adult",
                         "status:medicine cat",
                         "parent:0",
-                        "loner"
+                        "loner",
+                        "backstory:wandering_healer1,loner_backstories"
                     ],
                     [
                         "age:adolescent",
@@ -3230,7 +3233,8 @@
                 "new_cat": [
                     [
                         "status:medicine cat",
-                        "loner"
+                        "loner",
+                        "backstory:wandering_healer1,wandering_healer2,loner_backstories"
                     ]
                 ],
                 "relationships": [
@@ -3288,7 +3292,7 @@
                         "status:medicine cat",
                         "meeting",
                         "loner",
-                        "backstory:wandering_healer2"
+                        "backstory:wandering_healer1,loner_backstories"
                     ]
                 ],
                 "frequency": 4
@@ -3360,7 +3364,8 @@
                 "new_cat": [
                     [
                         "status:medicine cat",
-                        "loner"
+                        "loner",
+                        "backstory:wandering_healer1,loner_backstories"
                     ]
                 ],
                 "relationships": [


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->
- Fixes a bug where a new cat would receive a wandering_healer backstory despite being a warrior

## Linked Issues

<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->
Fixes: #5104
closes: #5140

## Proof of Testing

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

Cat joining as a healer:
<img width="733" height="558" alt="Screen Shot 2026-05-19 at 09 10 32" src="https://github.com/user-attachments/assets/fa0e474d-0db8-4798-b917-5cafee478be0" />
<img width="683" height="293" alt="Screen Shot 2026-05-19 at 09 10 46" src="https://github.com/user-attachments/assets/2320c322-ddd8-42cc-aeb4-fd00e35770f6" />

Cat joining as a warrior:
Event:
<img width="517" height="110" alt="Screen Shot 2026-05-19 at 09 14 26" src="https://github.com/user-attachments/assets/414faf4b-1ec4-4c1c-b208-4f599ca9e776" />
<img width="714" height="470" alt="Screen Shot 2026-05-19 at 09 14 48" src="https://github.com/user-attachments/assets/333c2f1c-097d-49e3-91c0-5dde5f6c822e" />

Patrol:
<img width="724" height="547" alt="Screen Shot 2026-05-19 at 09 20 44" src="https://github.com/user-attachments/assets/fd9573fb-9078-4a2a-b4c0-cb80a526699e" />
<img width="770" height="642" alt="Screen Shot 2026-05-19 at 09 20 59" src="https://github.com/user-attachments/assets/d2c7ae3c-60b8-4995-a6ca-24cbf2e9c80b" />