### PR TITLE
[PERFORMANCE] Improve loading times

### DIFF
--- a/scripts/cat_relations/relationship.py
+++ b/scripts/cat_relations/relationship.py
@@ -65,14 +65,14 @@ class Relationship:
         """
 
         # romance operates on a 0-100 scale, 0 is no romantic interest and 100 is full romantic interest
-        self.romance = romance
+        self._romance = romance
 
         # each stat can go from -100 to 100
         # negative numbers are the negative state while positive is the positive state
-        self.like = like
-        self.respect = respect
-        self.trust = trust
-        self.comfort = comfort
+        self._like = like
+        self._respect = respect
+        self._trust = trust
+        self._comfort = comfort
 
     def to_dict(self):
         return {

--- a/scripts/cat_relations/relationship.py
+++ b/scripts/cat_relations/relationship.py
@@ -65,14 +65,14 @@ class Relationship:
         """
 
         # romance operates on a 0-100 scale, 0 is no romantic interest and 100 is full romantic interest
-        self._romance = romance
+        self._romance = min(max(romance, 0), 100)
 
         # each stat can go from -100 to 100
         # negative numbers are the negative state while positive is the positive state
-        self._like = like
-        self._respect = respect
-        self._trust = trust
-        self._comfort = comfort
+        self._like = min(max(like, -100), 100)
+        self._respect = min(max(respect, -100), 100)
+        self._trust = min(max(trust, -100), 100)
+        self._comfort = min(max(comfort, -100), 100)
 
     def to_dict(self):
         return {

--- a/scripts/game_structure/load_cat.py
+++ b/scripts/game_structure/load_cat.py
@@ -354,30 +354,12 @@ def json_load():
             )
             switch_set_value(Switch.traceback, e)
             raise
+        if constants.CONFIG["save_load"]["load_integrity_checks"]:
+            save_check()
 
     # have to load before thoughts but after cats are done
     inheritance_db.clear_stored_data()
     inheritance_db.load_inheritances(Cat, get_faded_ids)
-
-    # requires info received from inheritance
-    for cat in all_cats:
-        try:
-            # initialization of thoughts
-            cat.get_new_thought(other_clan_cats=other_clan_cats)
-        except Exception as e:
-            logger.exception(
-                f"There was an error when thoughts for cat #{cat} are created."
-            )
-            switch_set_value(
-                Switch.error_message,
-                f"There was an error when thoughts for cat #{cat} are created.",
-            )
-            switch_set_value(Switch.traceback, e)
-            raise
-
-        # Save integrety checks
-        if constants.CONFIG["save_load"]["load_integrity_checks"]:
-            save_check()
 
 
 def csv_load(all_cats):

--- a/scripts/game_structure/load_cat.py
+++ b/scripts/game_structure/load_cat.py
@@ -357,7 +357,6 @@ def json_load():
         if constants.CONFIG["save_load"]["load_integrity_checks"]:
             save_check()
 
-    # have to load before thoughts but after cats are done
     inheritance_db.clear_stored_data()
     inheritance_db.load_inheritances(Cat, get_faded_ids)
 

--- a/scripts/game_structure/load_cat.py
+++ b/scripts/game_structure/load_cat.py
@@ -320,7 +320,6 @@ def json_load():
             raise
 
     # replace cat ids with cat objects and add other needed variables
-    other_clan_cats = [c for c in Cat.all_cats_list if c.status.is_other_clancat]
     for cat in all_cats:
         if cat.status.rank in (CatRank.LEADER, CatRank.DEPUTY, CatRank.MEDICINE_CAT):
             if cat.status.group == CatGroup.STARCLAN:

--- a/scripts/screens/ProfileScreen.py
+++ b/scripts/screens/ProfileScreen.py
@@ -555,8 +555,11 @@ class ProfileScreen(Screens):
         if self.the_cat is None:
             return
 
+        # initialize thoughts if they have none
         if not self.the_cat.thought:
             if self.the_cat.status.is_other_clancat:
+                # this isn't great, but it's only being run if someone checks an
+                # other clan cat when booting the game before doing a timeskip
                 other_clan_cats = [
                     c for c in Cat.all_cats_list if c.status.is_other_clancat
                 ]

--- a/scripts/screens/ProfileScreen.py
+++ b/scripts/screens/ProfileScreen.py
@@ -555,6 +555,15 @@ class ProfileScreen(Screens):
         if self.the_cat is None:
             return
 
+        if not self.the_cat.thought:
+            if self.the_cat.status.is_other_clancat:
+                other_clan_cats = [
+                    c for c in Cat.all_cats_list if c.status.is_other_clancat
+                ]
+                self.the_cat.get_new_thought(other_clan_cats=other_clan_cats)
+            else:
+                self.the_cat.get_new_thought()
+
         # Info in string
         cat_name = str(self.the_cat.name)
         cat_name = shorten_text_to_fit(cat_name, 500, 20)


### PR DESCRIPTION
## About The Pull Request

Some more performance improvements, especially when it comes to loading.
* Thoughts are no longer generated when loading a Clan. Instead, if a cat has no thoughts, one is generated when going to their profile page.
* Tweaks `Relationship()` constructor to not use the class properties because doing it like this is apparently faster.
 
## Proof of Testing

`json_load()` according to line_profiler before the changes: 21.22 seconds
`json_load()` according to line_profiler after the changes: 4.14 seconds

Cats still have thoughts:
<img width="373" height="131" alt="image" src="https://github.com/user-attachments/assets/e253356f-95eb-4a72-ad55-b954c21a92fb" />

## Changelog/Credits

* Performance improvements for loading
