### PR TITLE
[MODEL] Improve schemas for Points of Interest

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,6 +21,12 @@
                 "events/new_cat/*.json",
                 "events/injury/*.json"
             ]
+        },
+        {
+            "url": "./schemas/poi.schema.json",
+            "fileMatch": [
+                "points_of_interest.json"
+            ]
         }
     ],
     "python.formatting.provider": "yapf",

--- a/schemas/patrol.schema.json
+++ b/schemas/patrol.schema.json
@@ -1212,6 +1212,8 @@
         "prey:flying",
         "prey:water",
         "prey:ground",
+        "prey:eggs",
+        "prey:fish",
         "rocks",
         "tainted",
         "trees",
@@ -1222,7 +1224,8 @@
         "water",
         "water:still",
         "water:flowing",
-        "water:ocean"
+        "water:ocean",
+        "nests"
       ],
       "title": "PointsOfInterestTagEnum",
       "type": "string"

--- a/schemas/patrol.schema.json
+++ b/schemas/patrol.schema.json
@@ -927,18 +927,9 @@
           "type": "array"
         },
         "poi": {
-          "additionalProperties": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          },
+          "$ref": "#/$defs/PointsOfInterestGroup",
           "description": "The relevant points of interest. Points of Interest never affect outcome.",
-          "propertyNames": {
-            "$ref": "#/$defs/PointsOfInterestGroup"
-          },
-          "title": "Poi",
-          "type": "object"
+          "title": "Poi"
         },
         "patrol_art": {
           "anyOf": [
@@ -1153,11 +1144,87 @@
       "type": "string"
     },
     "PointsOfInterestGroup": {
-      "enum": [
-        "name",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/PointsOfInterestGroupByName"
+        },
+        {
+          "$ref": "#/$defs/PointsOfInterestGroupByTags"
+        }
+      ],
+      "description": "Specifies Points of Interest constraints. Must use EITHER names or tags.",
+      "title": "PointsOfInterestGroup"
+    },
+    "PointsOfInterestGroupByName": {
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "description": "Points of Interest with these specific IDs will be allowed.",
+          "items": {
+            "type": "string"
+          },
+          "title": "Name",
+          "type": "array"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "PointsOfInterestGroupByName",
+      "type": "object"
+    },
+    "PointsOfInterestGroupByTags": {
+      "additionalProperties": false,
+      "properties": {
+        "tags": {
+          "description": "Points of Interest with these tags will be allowed.",
+          "items": {
+            "$ref": "#/$defs/PointsOfInterestTag"
+          },
+          "title": "Tags",
+          "type": "array"
+        }
+      },
+      "required": [
         "tags"
       ],
-      "title": "PointsOfInterestGroup",
+      "title": "PointsOfInterestGroupByTags",
+      "type": "object"
+    },
+    "PointsOfInterestTag": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/PointsOfInterestTagEnum"
+        }
+      ],
+      "title": "PointsOfInterestTag"
+    },
+    "PointsOfInterestTagEnum": {
+      "enum": [
+        "cave",
+        "covered",
+        "fall_risk",
+        "hole",
+        "prey",
+        "prey:flying",
+        "prey:water",
+        "prey:ground",
+        "rocks",
+        "tainted",
+        "trees",
+        "Twolegs",
+        "Twolegs:abandoned",
+        "Twolegs:present",
+        "unstable",
+        "water",
+        "water:still",
+        "water:flowing",
+        "water:ocean"
+      ],
+      "title": "PointsOfInterestTagEnum",
       "type": "string"
     },
     "Prey": {

--- a/schemas/poi.schema.json
+++ b/schemas/poi.schema.json
@@ -43,14 +43,7 @@
         },
         "tags": {
           "items": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/Tag"
-              },
-              {
-                "type": "string"
-              }
-            ]
+            "$ref": "#/$defs/PointsOfInterestTag"
           },
           "title": "Tags",
           "type": "array"
@@ -64,7 +57,18 @@
       "title": "PointOfInterestItem",
       "type": "object"
     },
-    "Tag": {
+    "PointsOfInterestTag": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/PointsOfInterestTagEnum"
+        }
+      ],
+      "title": "PointsOfInterestTag"
+    },
+    "PointsOfInterestTagEnum": {
       "enum": [
         "cave",
         "covered",
@@ -86,7 +90,7 @@
         "water:flowing",
         "water:ocean"
       ],
-      "title": "Tag",
+      "title": "PointsOfInterestTagEnum",
       "type": "string"
     }
   },

--- a/schemas/poi.schema.json
+++ b/schemas/poi.schema.json
@@ -1,0 +1,98 @@
+{
+  "$defs": {
+    "BiomeNoExclusions": {
+      "enum": [
+        "mountainous",
+        "plains",
+        "forest",
+        "beach",
+        "wetlands",
+        "desert"
+      ],
+      "title": "BiomeNoExclusions",
+      "type": "string"
+    },
+    "PointOfInterestItem": {
+      "additionalProperties": false,
+      "properties": {
+        "category": {
+          "description": "Category the Point of Interest belongs to.",
+          "enum": [
+            "gathering",
+            "moonplace",
+            "terrain"
+          ],
+          "title": "Category",
+          "type": "string"
+        },
+        "biome": {
+          "description": "Biomes the Point of Interest belongs to.",
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/BiomeNoExclusions"
+              },
+              {
+                "const": "any",
+                "type": "string"
+              }
+            ]
+          },
+          "title": "Biome",
+          "type": "array"
+        },
+        "tags": {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/Tag"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          },
+          "title": "Tags",
+          "type": "array"
+        }
+      },
+      "required": [
+        "category",
+        "biome",
+        "tags"
+      ],
+      "title": "PointOfInterestItem",
+      "type": "object"
+    },
+    "Tag": {
+      "enum": [
+        "cave",
+        "covered",
+        "fall_risk",
+        "hole",
+        "prey",
+        "prey:flying",
+        "prey:water",
+        "prey:ground",
+        "rocks",
+        "tainted",
+        "trees",
+        "Twolegs",
+        "Twolegs:abandoned",
+        "Twolegs:present",
+        "unstable",
+        "water",
+        "water:still",
+        "water:flowing",
+        "water:ocean"
+      ],
+      "title": "Tag",
+      "type": "string"
+    }
+  },
+  "additionalProperties": {
+    "$ref": "#/$defs/PointOfInterestItem"
+  },
+  "title": "PointsOfInterestSchema",
+  "type": "object"
+}

--- a/schemas/poi.schema.json
+++ b/schemas/poi.schema.json
@@ -78,6 +78,8 @@
         "prey:flying",
         "prey:water",
         "prey:ground",
+        "prey:eggs",
+        "prey:fish",
         "rocks",
         "tainted",
         "trees",
@@ -88,7 +90,8 @@
         "water",
         "water:still",
         "water:flowing",
-        "water:ocean"
+        "water:ocean",
+        "nests"
       ],
       "title": "PointsOfInterestTagEnum",
       "type": "string"

--- a/schemas/shortevent.schema.json
+++ b/schemas/shortevent.schema.json
@@ -976,11 +976,87 @@
       "type": "string"
     },
     "PointsOfInterestGroup": {
-      "enum": [
-        "name",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/PointsOfInterestGroupByName"
+        },
+        {
+          "$ref": "#/$defs/PointsOfInterestGroupByTags"
+        }
+      ],
+      "description": "Specifies Points of Interest constraints. Must use EITHER names or tags.",
+      "title": "PointsOfInterestGroup"
+    },
+    "PointsOfInterestGroupByName": {
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "description": "Points of Interest with these specific IDs will be allowed.",
+          "items": {
+            "type": "string"
+          },
+          "title": "Name",
+          "type": "array"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "PointsOfInterestGroupByName",
+      "type": "object"
+    },
+    "PointsOfInterestGroupByTags": {
+      "additionalProperties": false,
+      "properties": {
+        "tags": {
+          "description": "Points of Interest with these tags will be allowed.",
+          "items": {
+            "$ref": "#/$defs/PointsOfInterestTag"
+          },
+          "title": "Tags",
+          "type": "array"
+        }
+      },
+      "required": [
         "tags"
       ],
-      "title": "PointsOfInterestGroup",
+      "title": "PointsOfInterestGroupByTags",
+      "type": "object"
+    },
+    "PointsOfInterestTag": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/PointsOfInterestTagEnum"
+        }
+      ],
+      "title": "PointsOfInterestTag"
+    },
+    "PointsOfInterestTagEnum": {
+      "enum": [
+        "cave",
+        "covered",
+        "fall_risk",
+        "hole",
+        "prey",
+        "prey:flying",
+        "prey:water",
+        "prey:ground",
+        "rocks",
+        "tainted",
+        "trees",
+        "Twolegs",
+        "Twolegs:abandoned",
+        "Twolegs:present",
+        "unstable",
+        "water",
+        "water:still",
+        "water:flowing",
+        "water:ocean"
+      ],
+      "title": "PointsOfInterestTagEnum",
       "type": "string"
     },
     "RC": {
@@ -1408,18 +1484,9 @@
           "type": "array"
         },
         "poi": {
-          "additionalProperties": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          },
+          "$ref": "#/$defs/PointsOfInterestGroup",
           "description": "The relevant points of interest. Points of Interest never affect outcome.",
-          "propertyNames": {
-            "$ref": "#/$defs/PointsOfInterestGroup"
-          },
-          "title": "Poi",
-          "type": "object"
+          "title": "Poi"
         },
         "frequency": {
           "description": "Controls how common an event is. 4 == Common, 3 == Uncommon, 2 == Rare, 3 == Very Rare. Consider this in the terms of 'If an event of this type happened every moon for 10 moons, on how many of those moons should this sort of event appear?'",

--- a/schemas/shortevent.schema.json
+++ b/schemas/shortevent.schema.json
@@ -1044,6 +1044,8 @@
         "prey:flying",
         "prey:water",
         "prey:ground",
+        "prey:eggs",
+        "prey:fish",
         "rocks",
         "tainted",
         "trees",
@@ -1054,7 +1056,8 @@
         "water",
         "water:still",
         "water:flowing",
-        "water:ocean"
+        "water:ocean",
+        "nests"
       ],
       "title": "PointsOfInterestTagEnum",
       "type": "string"

--- a/scripts/dump_model_schemas.py
+++ b/scripts/dump_model_schemas.py
@@ -8,6 +8,9 @@ from scripts.models.common.common_schema import CommonSchema
 from scripts.models.patrol.patrol_schema import PatrolSchema
 from scripts.models.shortevent.short_event_schema import ShortEventSchema
 from scripts.models.thought.thought_schema import ThoughtSchema
+from scripts.models.points_of_interest.points_of_interest_schema import (
+    PointsOfInterestSchema,
+)
 from scripts.models.util import (
     create_generate_json_schema_with_externals,
     get_defs_from_pydantic_model,
@@ -70,6 +73,7 @@ def main():
     dump_model_schema(PatrolSchema, "schemas/patrol.schema.json")
     dump_model_schema(ShortEventSchema, "schemas/shortevent.schema.json")
     dump_model_schema(ThoughtSchema, "schemas/thought.schema.json")
+    dump_model_schema(PointsOfInterestSchema, "schemas/poi.schema.json")
 
 
 if __name__ == "__main__":

--- a/scripts/models/common/biome.py
+++ b/scripts/models/common/biome.py
@@ -16,3 +16,12 @@ class Biome(Enum):
     not_wetlands = "-wetlands"
     desert = "desert"
     not_desert = "-desert"
+
+
+class BiomeNoExclusions(Enum):
+    mountainous = "mountainous"
+    plains = "plains"
+    forest = "forest"
+    beach = "beach"
+    wetlands = "wetlands"
+    desert = "desert"

--- a/scripts/models/common/points_of_interest.py
+++ b/scripts/models/common/points_of_interest.py
@@ -45,4 +45,7 @@ class PointsOfInterestGroupByTags(BaseModel):
 
 
 class PointsOfInterestGroup(RootModel):
-    root: Union[PointsOfInterestGroupByName, PointsOfInterestGroupByTags]
+    root: Union[PointsOfInterestGroupByName, PointsOfInterestGroupByTags] = Field(
+        ...,
+        description="Specifies Points of Interest constraints. Must use EITHER names or tags.",
+    )

--- a/scripts/models/common/points_of_interest.py
+++ b/scripts/models/common/points_of_interest.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import List, Union
 
-from pydantic import BaseModel, RootModel
+from pydantic import BaseModel, Field, RootModel
 
 
 class PointsOfInterestTagEnum(Enum):
@@ -31,11 +31,15 @@ class PointsOfInterestTag(RootModel):
 
 
 class PointsOfInterestGroupByName(BaseModel):
-    name: List[str]
+    name: List[str] = Field(
+        ..., description="Points of Interest with these specific IDs will be allowed."
+    )
 
 
 class PointsOfInterestGroupByTags(BaseModel):
-    tags: List[PointsOfInterestTag]
+    tags: List[PointsOfInterestTag] = Field(
+        ..., description="Points of Interest with these tags will be allowed."
+    )
 
 
 class PointsOfInterestGroup(RootModel):

--- a/scripts/models/common/points_of_interest.py
+++ b/scripts/models/common/points_of_interest.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import List, Union
 
-from pydantic import BaseModel, Field, RootModel
+from pydantic import BaseModel, ConfigDict, Field, RootModel
 
 
 class PointsOfInterestTagEnum(Enum):
@@ -31,12 +31,14 @@ class PointsOfInterestTag(RootModel):
 
 
 class PointsOfInterestGroupByName(BaseModel):
+    model_config = ConfigDict(extra="forbid")
     name: List[str] = Field(
         ..., description="Points of Interest with these specific IDs will be allowed."
     )
 
 
 class PointsOfInterestGroupByTags(BaseModel):
+    model_config = ConfigDict(extra="forbid")
     tags: List[PointsOfInterestTag] = Field(
         ..., description="Points of Interest with these tags will be allowed."
     )

--- a/scripts/models/common/points_of_interest.py
+++ b/scripts/models/common/points_of_interest.py
@@ -13,6 +13,8 @@ class PointsOfInterestTagEnum(Enum):
     PREY_FLYING = "prey:flying"
     PREY_WATER = "prey:water"
     PREY_GROUND = "prey:ground"
+    PREY_EGGS = "prey:eggs"
+    PREY_FISH = "prey:fish"
     ROCKS = "rocks"
     TAINTED = "tainted"
     TREES = "trees"
@@ -24,6 +26,7 @@ class PointsOfInterestTagEnum(Enum):
     WATER_STILL = "water:still"
     WATER_FLOWING = "water:flowing"
     WATER_OCEAN = "water:ocean"
+    NESTS = "nests"
 
 
 class PointsOfInterestTag(RootModel):

--- a/scripts/models/common/points_of_interest.py
+++ b/scripts/models/common/points_of_interest.py
@@ -1,6 +1,28 @@
 from enum import Enum
 
 
+class PointsOfInterestTagEnum(Enum):
+    CAVE = "cave"
+    COVERED = "covered"
+    FALL_RISK = "fall_risk"
+    HOLE = "hole"
+    PREY = "prey"
+    PREY_FLYING = "prey:flying"
+    PREY_WATER = "prey:water"
+    PREY_GROUND = "prey:ground"
+    ROCKS = "rocks"
+    TAINTED = "tainted"
+    TREES = "trees"
+    TWOLEGS = "Twolegs"
+    TWOLEGS_ABANDONED = "Twolegs:abandoned"
+    TWOLEGS_PRESENT = "Twolegs:present"
+    UNSTABLE = "unstable"
+    WATER = "water"
+    WATER_STILL = "water:still"
+    WATER_FLOWING = "water:flowing"
+    WATER_OCEAN = "water:ocean"
+
+
 class PointsOfInterestGroup(Enum):
     name = "name"
     tags = "tags"

--- a/scripts/models/common/points_of_interest.py
+++ b/scripts/models/common/points_of_interest.py
@@ -1,4 +1,7 @@
 from enum import Enum
+from typing import List, Union
+
+from pydantic import BaseModel, RootModel
 
 
 class PointsOfInterestTagEnum(Enum):
@@ -23,6 +26,17 @@ class PointsOfInterestTagEnum(Enum):
     WATER_OCEAN = "water:ocean"
 
 
-class PointsOfInterestGroup(Enum):
-    name = "name"
-    tags = "tags"
+class PointsOfInterestTag(RootModel):
+    root: Union[str, PointsOfInterestTagEnum]
+
+
+class PointsOfInterestGroupByName(BaseModel):
+    name: List[str]
+
+
+class PointsOfInterestGroupByTags(BaseModel):
+    tags: List[PointsOfInterestTag]
+
+
+class PointsOfInterestGroup(RootModel):
+    root: Union[PointsOfInterestGroupByName, PointsOfInterestGroupByTags]

--- a/scripts/models/patrol/patrol_schema_item.py
+++ b/scripts/models/patrol/patrol_schema_item.py
@@ -32,7 +32,7 @@ class PatrolSchemaItem(BaseModel):
         ...,
         description="Tags are used for some filtering purposes, and some odd-and-ends. Tags never affect outcome.",
     )
-    poi: Union[Dict[PointsOfInterestGroup, List[str]], MISSING] = Field(
+    poi: Union[PointsOfInterestGroup, MISSING] = Field(
         MISSING,
         description="The relevant points of interest. Points of Interest never affect outcome.",
     )

--- a/scripts/models/points_of_interest/points_of_interest_schema.py
+++ b/scripts/models/points_of_interest/points_of_interest_schema.py
@@ -1,33 +1,11 @@
 from __future__ import annotations
 
-from enum import Enum
 from typing import Dict, List, Literal, Union
 
 from pydantic import BaseModel, ConfigDict, Field, RootModel
 
+from scripts.models.common.points_of_interest import PointsOfInterestTag
 from scripts.models.common.biome import BiomeNoExclusions
-
-
-class Tag(Enum):
-    CAVE = "cave"
-    COVERED = "covered"
-    FALL_RISK = "fall_risk"
-    HOLE = "hole"
-    PREY = "prey"
-    PREY_FLYING = "prey:flying"
-    PREY_WATER = "prey:water"
-    PREY_GROUND = "prey:ground"
-    ROCKS = "rocks"
-    TAINTED = "tainted"
-    TREES = "trees"
-    TWOLEGS = "Twolegs"
-    TWOLEGS_ABANDONED = "Twolegs:abandoned"
-    TWOLEGS_PRESENT = "Twolegs:present"
-    UNSTABLE = "unstable"
-    WATER = "water"
-    WATER_STILL = "water:still"
-    WATER_FLOWING = "water:flowing"
-    WATER_OCEAN = "water:ocean"
 
 
 class PointOfInterestItem(BaseModel):
@@ -40,7 +18,7 @@ class PointOfInterestItem(BaseModel):
         ..., description="Biomes the Point of Interest belongs to."
     )
     # tags seem able to be kind of arbitrary, so this is just for autocomplete
-    tags: List[Union[Tag, str]]
+    tags: List[PointsOfInterestTag]
 
 
 class PointsOfInterestSchema(RootModel):

--- a/scripts/models/points_of_interest/points_of_interest_schema.py
+++ b/scripts/models/points_of_interest/points_of_interest_schema.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Dict, List, Literal, Union
+
+from pydantic import BaseModel, ConfigDict, Field, RootModel
+
+from scripts.models.common.biome import BiomeNoExclusions
+
+
+class Tag(Enum):
+    CAVE = "cave"
+    COVERED = "covered"
+    FALL_RISK = "fall_risk"
+    HOLE = "hole"
+    PREY = "prey"
+    PREY_FLYING = "prey:flying"
+    PREY_WATER = "prey:water"
+    PREY_GROUND = "prey:ground"
+    ROCKS = "rocks"
+    TAINTED = "tainted"
+    TREES = "trees"
+    TWOLEGS = "Twolegs"
+    TWOLEGS_ABANDONED = "Twolegs:abandoned"
+    TWOLEGS_PRESENT = "Twolegs:present"
+    UNSTABLE = "unstable"
+    WATER = "water"
+    WATER_STILL = "water:still"
+    WATER_FLOWING = "water:flowing"
+    WATER_OCEAN = "water:ocean"
+
+
+class PointOfInterestItem(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    category: Literal["gathering", "moonplace", "terrain"] = Field(
+        ..., description="Category the Point of Interest belongs to."
+    )
+    biome: List[Union[BiomeNoExclusions, Literal["any"]]] = Field(
+        ..., description="Biomes the Point of Interest belongs to."
+    )
+    # tags seem able to be kind of arbitrary, so this is just for autocomplete
+    tags: List[Union[Tag, str]]
+
+
+class PointsOfInterestSchema(RootModel):
+    root: Dict[str, PointOfInterestItem]

--- a/scripts/models/points_of_interest/points_of_interest_schema.py
+++ b/scripts/models/points_of_interest/points_of_interest_schema.py
@@ -17,7 +17,6 @@ class PointOfInterestItem(BaseModel):
     biome: List[Union[BiomeNoExclusions, Literal["any"]]] = Field(
         ..., description="Biomes the Point of Interest belongs to."
     )
-    # tags seem able to be kind of arbitrary, so this is just for autocomplete
     tags: List[PointsOfInterestTag]
 
 

--- a/scripts/models/shortevent/short_event_schema_item.py
+++ b/scripts/models/shortevent/short_event_schema_item.py
@@ -41,7 +41,7 @@ class ShortEventSchemaItem(BaseModel):
         List[Tag],
         MISSING,
     ] = Field(MISSING, description="Used for some filtering purposes")
-    poi: Union[Dict[PointsOfInterestGroup, List[str]], MISSING] = Field(
+    poi: Union[PointsOfInterestGroup, MISSING] = Field(
         MISSING,
         description="The relevant points of interest. Points of Interest never affect outcome.",
     )

--- a/tests/test_json_model_compliance.py
+++ b/tests/test_json_model_compliance.py
@@ -91,6 +91,6 @@ def test_shortevents(shortevent_file: Path):
 
 
 def test_points_of_interest():
-    """Test that all shortevent JSONs are correct according to the Pydantic models"""
+    """Test that the Points of Interest JSON is correct according to the Pydantic models"""
     poi_file = RESOURCES_DIR / "dicts/points_of_interest.json"
     PointsOfInterestSchema.model_validate_json(poi_file.read_text())

--- a/tests/test_json_model_compliance.py
+++ b/tests/test_json_model_compliance.py
@@ -12,6 +12,9 @@ os.environ["SDL_AUDIODRIVER"] = "dummy"
 from scripts.models.patrol.patrol_schema import PatrolSchema
 from scripts.models.shortevent.short_event_schema import ShortEventSchema
 from scripts.models.thought.thought_schema import ThoughtSchema
+from scripts.models.points_of_interest.points_of_interest_schema import (
+    PointsOfInterestSchema,
+)
 
 
 ROOT_DIR = Path(__file__).parent.parent
@@ -85,3 +88,9 @@ def test_patrols(patrol_file: Path):
 def test_shortevents(shortevent_file: Path):
     """Test that all shortevent JSONs are correct according to the Pydantic models"""
     ShortEventSchema.model_validate_json(shortevent_file.read_text())
+
+
+def test_points_of_interest():
+    """Test that all shortevent JSONs are correct according to the Pydantic models"""
+    poi_file = RESOURCES_DIR / "dicts/points_of_interest.json"
+    PointsOfInterestSchema.model_validate_json(poi_file.read_text())


### PR DESCRIPTION
## About The Pull Request

* Adds a schema for `points_of_interest.json`.
* Improves `poi` property schema to have better documentation and validation.

### Differences from documentation
* `category` uses `terrain` instead of `territory`, since `terrain` is what is used in the files.
* Includes tags for `prey:eggs`, `prey:fish`, and `nests`, which are used for some POIs.

## Proof of Testing

Tests are passing.

Autocomplete:
<img width="659" height="222" alt="image" src="https://github.com/user-attachments/assets/2552eefa-18d8-43fe-96e9-a1142e65471b" />