### PR TITLE
[BUGFIX] exiled newborn return

### DIFF
--- a/scripts/cat/status.py
+++ b/scripts/cat/status.py
@@ -544,6 +544,8 @@ class Status:
         # adding a cat who has been in a clan in the past, they will take their old rank if possible
         elif self.is_former_clancat and not self.group.is_afterlife():
             new_rank = self.find_prior_clan_rank()
+            if new_rank == CatRank.NEWBORN and not age == CatAge.NEWBORN:
+                new_rank = CatRank.KITTEN
             # we don't need to change leaders and deps if they're going to an afterlife
             if (
                 new_rank in (CatRank.LEADER, CatRank.DEPUTY)
@@ -712,7 +714,7 @@ class Status:
         # if no group given
         if not group_ID:
             for entry in self.standing_history:
-                if CatStanding.EXILED in entry["standing"]:
+                if CatStanding.EXILED == entry["standing"][-1]:
                     return True
             return False
 


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
This was being caused by us just assigning a cat their "last" clan rank when they return to a clan. For newborns exiled as newborns, this means their last rank was newborn. Regardless of their current age, they would be assigned the newborn rank. Our code then gets confused as it doesn't expect a newborn to be so old and has no clue how to handle it. 

The fix is just to check if the rank is newborn and change it to kitten. From there, our typical code (which was already set up to check if a cat needed a ceremony of some sort upon returning) takes over just fine.

I also noticed that the exiled cats who return would still be noted as exiled, this was due to our func for checking if a cat is exiled not properly checking *only* their last standing with the group. So I fixed that as well.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
fixes #5148
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
<img width="580" height="135" alt="image" src="https://github.com/user-attachments/assets/fcc50d53-3834-4fb1-9ffc-d3f1b5cc5de0" />

Rosykit (the legendary exiled newborn) returns

<img width="676" height="294" alt="image" src="https://github.com/user-attachments/assets/de0cf08a-256d-42d7-9ba3-8b2185f0c1ae" />

She has the correct rank! And is no longer noted as an exile

<img width="589" height="290" alt="image" src="https://github.com/user-attachments/assets/27f6f7eb-6a33-496e-b504-9dfaaa92c4c1" />

Other exiled cats still note as such correctly on their profiles

<img width="557" height="170" alt="image" src="https://github.com/user-attachments/assets/3373ead2-6484-4419-a230-aec791efe1cc" />
<img width="648" height="332" alt="image" src="https://github.com/user-attachments/assets/d3913a9f-8586-4197-a7f4-83d8e7d8e6f2" />

Rosypaw is aging and progressing correctly

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Newborns who are exiled and then return to the Clan are no longer perpetually stuck at the newborn rank for their entire life.
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
