### PR TITLE
[TYPOFIX] resubmission: even more typo fixes

### DIFF
--- a/resources/lang/en/events/death/death_reactions/general/general_neg_comfort.json
+++ b/resources/lang/en/events/death/death_reactions/general/general_neg_comfort.json
@@ -4,7 +4,7 @@
             "r_c can't help but feel grateful that m_c is gone.",
             "r_c isn't <i>glad</i> m_c is dead, but {PRONOUN/r_c/subject} {VERB/r_c/do/does} feel some relief at the news.",
             "From this day forward, r_c can go about {PRONOUN/r_c/poss} day with ease, now that {PRONOUN/r_c/subject} no longer {VERB/r_c/have/has} to see m_c every day and be reminded of how uncomfortable {PRONOUN/m_c/subject} made {PRONOUN/r_c/object}.",
-            "r_c can’t stay at m_c’s vigil for long — even the presence of {PRONOUN/m_c/poss} dead body in the clearing makes {PRONOUN/r_c/poss} feel uncomfortable."
+            "r_c can’t stay at m_c’s vigil for long — even the presence of {PRONOUN/m_c/poss} dead body in the clearing makes {PRONOUN/r_c/object} feel uncomfortable."
         ],
         "no_body": [
             "r_c can't help but feel grateful that m_c is gone.",

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -13313,7 +13313,7 @@
     "any"
   ],
   "frequency": 3,
-  "event_text": "m_c caught r_c trying to sneak out of camp while on guard duty.",
+  "event_text": "While on guard duty, m_c caught r_c trying to sneak out of camp.",
   "m_c": {
     "status": [
       "warrior",

--- a/resources/lang/en/events/new_cat/general.json
+++ b/resources/lang/en/events/new_cat/general.json
@@ -2158,8 +2158,7 @@
   ],
   "tags": [],
   "exclude_involved": [
-    "m_c",
-    "n_c:0"
+    "m_c"
   ],
   "frequency": 2,
   "event_text": "At the Gathering, o_c_n's leader announces they have exiled a warrior for an unforgivable crime. They advise the other Clans to keep their guards up.",
@@ -2215,8 +2214,7 @@
   ],
   "tags": [],
   "exclude_involved": [
-    "m_c",
-    "n_c:0"
+    "m_c"
   ],
   "frequency": 1,
   "event_text": "At the Gathering, o_c_n's deputy takes their place among the other leaders and declares the previous leader was driven out, but may still stalk the borders.",
@@ -2272,8 +2270,7 @@
   ],
   "tags": [],
   "exclude_involved": [
-    "m_c",
-    "n_c:0"
+    "m_c"
   ],
   "frequency": 1,
   "event_text": "At the Gathering, o_c_n's leader announces their medicine cat has been exiled for a terrible transgression. They warn the other Clans that the exiled cat is not to be trusted and should be killed on sight.",
@@ -2329,8 +2326,7 @@
   ],
   "tags": [],
   "exclude_involved": [
-    "m_c",
-    "n_c:0"
+    "m_c"
   ],
   "frequency": 1,
   "event_text": "At the Gathering, o_c_n's leader announces their deputy did something terrible and was exiled. They look mournful as they deliver the news and advise the others to watch their borders closely.",

--- a/resources/lang/en/patrols/beach/hunting/any.json
+++ b/resources/lang/en/patrols/beach/hunting/any.json
@@ -5966,7 +5966,7 @@
         },
         {
             "min_max_status": {"normal adult": [4,6]},
-            "text": "r_c spots a lone egg in an unattended kelp nest, but as {PRONOUN/r_c/subject} {VERB/r_c/clamber/clambers} over, wingbeats buffet and a huge gannet lands right on it. p_l and {PRONOUN/p_l/poss} Clanmates react quickly, backing r_c up. r_c distracts the gannet, and p_l pounces, sinking {PRONOUN/s_c/poss} teeth into the back of its neck. It writhes and struggles, then lies still. That piece of fresh-kill is so big, r_c and p_l have to carry it together!",
+            "text": "r_c spots a lone egg in an unattended kelp nest, but as {PRONOUN/r_c/subject} {VERB/r_c/clamber/clambers} over, wingbeats buffet and a huge gannet lands right on it. p_l and {PRONOUN/p_l/poss} Clanmates react quickly, backing r_c up. r_c distracts the gannet, and p_l pounces, sinking {PRONOUN/p_l/poss} teeth into the back of its neck. It writhes and struggles, then lies still. That piece of fresh-kill is so big, r_c and p_l have to carry it together!",
             "exp": 40,
             "frequency": 2,
             "prey": ["huge"],

--- a/resources/lang/en/patrols/other_clan.json
+++ b/resources/lang/en/patrols/other_clan.json
@@ -232,7 +232,7 @@
                         ],
                         "amount": -5,
                         "log": {
-                            "cats_from": "cat_from was frustrated when cat_to was openly aggressive another Clan's patrol."
+                            "cats_from": "cat_from was frustrated when cat_to was openly aggressive towards another Clan's patrol."
                         }
                     }
                 ]

--- a/resources/lang/en/thoughts/while_dead/dark_forest/general.json
+++ b/resources/lang/en/thoughts/while_dead/dark_forest/general.json
@@ -116,7 +116,7 @@
             "Is cleaning the blood from {PRONOUN/m_c/poss} claws",
             "Is the first to volunteer for training",
             "Is trying to lure living cats to train in the Dark Forest",
-            "Is itching to dig {PRONOUN/m_c/poss} claws into the first cat {PRONOUN/m_c/object} sees",
+            "Is itching to dig {PRONOUN/m_c/poss} claws into the first cat {PRONOUN/m_c/subject} {VERB/m_c/see/sees}",
             "Has taken a living visitor under {PRONOUN/m_c/poss} wing",
             "Has begun to grow quite fond of the muck",
             "Has allied {PRONOUN/m_c/self} with the strongest cats {PRONOUN/m_c/subject} could find",


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

- fixes a missing word in a relationship log for an otherclan patrol
- changes an incorrect pronoun tag in a negative vigil reaction
- removes n_c:0 from the "exclude_involved" list in my otherclan exile events due to player feedback that finding the newly generated outsider wasn't immediately obvious and could be confusing
- changes an incorrect pronoun tag and adds a missing verb tag in a dark forest thought
- rewords my guard duty sneakout event for clarity
- changes "s_c" into "p_l" for a pronoun tag in a patrol as it was displaying the pronoun tag as raw text

## Why This Is Good For ClanGen

i am in typofixing hell and accidentally updated a PR going into stable with dev's files so i had to close and re-submit. im so smart

## Linked Issues

https://github.com/ClanGenOfficial/clangen/issues/1818#issuecomment-4512445645
all other typos i noticed myself or were sent to me outside of github

## Proof of Testing

<img width="1044" height="82" alt="image" src="https://github.com/user-attachments/assets/bdddb6a5-7485-4db4-933d-7e24bee73210" />
<img width="953" height="42" alt="image" src="https://github.com/user-attachments/assets/5da2a460-bcfb-4200-8449-241a4b3e3297" />


## Changelog/Credits

- Even more typo/pronoun tag fixes because I am never free.
- Made the "otherclan exile" events actually show the newly generated outsider in the involved cats list in response to player feedback that it was difficult/confusing to find them.
- Rewords an event for clarity.
