### PR TITLE
[UI] Anchors temper_text to clan_notice_text

### DIFF
--- a/scripts/screens/LeaderDenScreen.py
+++ b/scripts/screens/LeaderDenScreen.py
@@ -264,7 +264,7 @@ class LeaderDenScreen(Screens):
             object_id=get_text_box_theme("#text_box_30_horizcenter_spacing_95"),
             visible=False,
             manager=MANAGER,
-            anchors={"bottom_target": self.temper_target},
+            anchors={"bottom_target": self.temper_text},
             text_kwargs={
                 "m_c": game.clan.leader if not self.no_leader else None,
                 "count": 1,

--- a/scripts/screens/LeaderDenScreen.py
+++ b/scripts/screens/LeaderDenScreen.py
@@ -262,7 +262,7 @@ class LeaderDenScreen(Screens):
             relative_rect=ui_scale(pygame.Rect((68, 375), (445, -1))),
             html_text="screens.leader_den.clan_notice_text",
             object_id=get_text_box_theme("#text_box_30_horizcenter_spacing_95"),
-            anchors={"top_target":self.screen_elements["temper_text"]},
+            anchors={"top_target":"temper_text"},
             visible=False,
             manager=MANAGER,
             text_kwargs={

--- a/scripts/screens/LeaderDenScreen.py
+++ b/scripts/screens/LeaderDenScreen.py
@@ -268,7 +268,7 @@ class LeaderDenScreen(Screens):
                 "m_c": game.clan.leader if not self.no_leader else None,
                 "count": 1,
             },
-            anchors={"bottom_target":self.screen_elements["temper_text"]},
+            anchors={"bottom_target": self.screen_elements["temper_text"]},
         )
         self.screen_elements["outsider_notice_text"] = pygame_gui.elements.UITextBox(
             relative_rect=ui_scale(pygame.Rect((68, 375), (445, -1))),

--- a/scripts/screens/LeaderDenScreen.py
+++ b/scripts/screens/LeaderDenScreen.py
@@ -264,7 +264,7 @@ class LeaderDenScreen(Screens):
             object_id=get_text_box_theme("#text_box_30_horizcenter_spacing_95"),
             visible=False,
             manager=MANAGER,
-            anchors={"top_target":self.clan_temper},
+            anchors={"bottom_target": self.screen_elements["temper_text"]},
             text_kwargs={
                 "m_c": game.clan.leader if not self.no_leader else None,
                 "count": 1,

--- a/scripts/screens/LeaderDenScreen.py
+++ b/scripts/screens/LeaderDenScreen.py
@@ -333,7 +333,7 @@ class LeaderDenScreen(Screens):
         self.screen_elements["clan_notice_text"].show()
 
         self.screen_elements["temper_text"] = pygame_gui.elements.UITextBox(
-            relative_rect=ui_scale(pygame.Rect((68, -15), (445, -1))),
+            relative_rect=ui_scale(pygame.Rect((68, -12), (445, -1))),
             html_text="screens.leader_den.temper_text",
             object_id=get_text_box_theme("#text_box_30_horizcenter"),
             manager=MANAGER,

--- a/scripts/screens/LeaderDenScreen.py
+++ b/scripts/screens/LeaderDenScreen.py
@@ -264,7 +264,6 @@ class LeaderDenScreen(Screens):
             object_id=get_text_box_theme("#text_box_30_horizcenter_spacing_95"),
             visible=False,
             manager=MANAGER,
-            anchors={"bottom_target": self.temper_text},
             text_kwargs={
                 "m_c": game.clan.leader if not self.no_leader else None,
                 "count": 1,
@@ -345,6 +344,7 @@ class LeaderDenScreen(Screens):
                     second_temper=i18n.t(f"screens.leader_den.{self.clan_temper[1]}"),
                 ),
             },
+            anchors={"top_target": self.screen_elements["clan_notice_text"]},
         )
 
         # INITIAL DISPLAY - display currently chosen interaction OR first clan in list

--- a/scripts/screens/LeaderDenScreen.py
+++ b/scripts/screens/LeaderDenScreen.py
@@ -333,7 +333,7 @@ class LeaderDenScreen(Screens):
         self.screen_elements["clan_notice_text"].show()
 
         self.screen_elements["temper_text"] = pygame_gui.elements.UITextBox(
-            relative_rect=ui_scale(pygame.Rect((40, 0), (445, -1))),
+            relative_rect=ui_scale(pygame.Rect((68, 0), (445, -1))),
             html_text="screens.leader_den.temper_text",
             object_id=get_text_box_theme("#text_box_30_horizcenter"),
             manager=MANAGER,

--- a/scripts/screens/LeaderDenScreen.py
+++ b/scripts/screens/LeaderDenScreen.py
@@ -268,6 +268,7 @@ class LeaderDenScreen(Screens):
                 "m_c": game.clan.leader if not self.no_leader else None,
                 "count": 1,
             },
+            anchors={"bottom_target":self.screen_elements["temper_text"]},
         )
         self.screen_elements["outsider_notice_text"] = pygame_gui.elements.UITextBox(
             relative_rect=ui_scale(pygame.Rect((68, 375), (445, -1))),
@@ -344,7 +345,6 @@ class LeaderDenScreen(Screens):
                     second_temper=i18n.t(f"screens.leader_den.{self.clan_temper[1]}"),
                 ),
             },
-            anchors={"top_target": self.screen_elements["clan_notice_text"]},
         )
 
         # INITIAL DISPLAY - display currently chosen interaction OR first clan in list

--- a/scripts/screens/LeaderDenScreen.py
+++ b/scripts/screens/LeaderDenScreen.py
@@ -333,7 +333,7 @@ class LeaderDenScreen(Screens):
         self.screen_elements["clan_notice_text"].show()
 
         self.screen_elements["temper_text"] = pygame_gui.elements.UITextBox(
-            relative_rect=ui_scale(pygame.Rect((68, -12), (445, -1))),
+            relative_rect=ui_scale(pygame.Rect((68, -13), (445, -1))),
             html_text="screens.leader_den.temper_text",
             object_id=get_text_box_theme("#text_box_30_horizcenter"),
             manager=MANAGER,

--- a/scripts/screens/LeaderDenScreen.py
+++ b/scripts/screens/LeaderDenScreen.py
@@ -264,7 +264,7 @@ class LeaderDenScreen(Screens):
             object_id=get_text_box_theme("#text_box_30_horizcenter_spacing_95"),
             visible=False,
             manager=MANAGER,
-            anchors={"bottom_target": self.screen_elements["temper_text"]},
+            anchors={"bottom_target": self.temper_target},
             text_kwargs={
                 "m_c": game.clan.leader if not self.no_leader else None,
                 "count": 1,

--- a/scripts/screens/LeaderDenScreen.py
+++ b/scripts/screens/LeaderDenScreen.py
@@ -262,6 +262,7 @@ class LeaderDenScreen(Screens):
             relative_rect=ui_scale(pygame.Rect((68, 375), (445, -1))),
             html_text="screens.leader_den.clan_notice_text",
             object_id=get_text_box_theme("#text_box_30_horizcenter_spacing_95"),
+            anchors={"top_target":self.screen_elements["temper_text"]},
             visible=False,
             manager=MANAGER,
             text_kwargs={

--- a/scripts/screens/LeaderDenScreen.py
+++ b/scripts/screens/LeaderDenScreen.py
@@ -333,7 +333,7 @@ class LeaderDenScreen(Screens):
         self.screen_elements["clan_notice_text"].show()
 
         self.screen_elements["temper_text"] = pygame_gui.elements.UITextBox(
-            relative_rect=ui_scale(pygame.Rect((68, -20), (445, -1))),
+            relative_rect=ui_scale(pygame.Rect((68, -15), (445, -1))),
             html_text="screens.leader_den.temper_text",
             object_id=get_text_box_theme("#text_box_30_horizcenter"),
             manager=MANAGER,

--- a/scripts/screens/LeaderDenScreen.py
+++ b/scripts/screens/LeaderDenScreen.py
@@ -264,7 +264,7 @@ class LeaderDenScreen(Screens):
             object_id=get_text_box_theme("#text_box_30_horizcenter_spacing_95"),
             visible=False,
             manager=MANAGER,
-            anchors={"top_target":self.screen_elements["temper_text"]},
+            anchors={"top_target":self.clan_temper},
             text_kwargs={
                 "m_c": game.clan.leader if not self.no_leader else None,
                 "count": 1,

--- a/scripts/screens/LeaderDenScreen.py
+++ b/scripts/screens/LeaderDenScreen.py
@@ -333,7 +333,7 @@ class LeaderDenScreen(Screens):
         self.screen_elements["clan_notice_text"].show()
 
         self.screen_elements["temper_text"] = pygame_gui.elements.UITextBox(
-            relative_rect=ui_scale(pygame.Rect((10, 0), (445, -1))),
+            relative_rect=ui_scale(pygame.Rect((40, 0), (445, -1))),
             html_text="screens.leader_den.temper_text",
             object_id=get_text_box_theme("#text_box_30_horizcenter"),
             manager=MANAGER,

--- a/scripts/screens/LeaderDenScreen.py
+++ b/scripts/screens/LeaderDenScreen.py
@@ -262,9 +262,9 @@ class LeaderDenScreen(Screens):
             relative_rect=ui_scale(pygame.Rect((68, 375), (445, -1))),
             html_text="screens.leader_den.clan_notice_text",
             object_id=get_text_box_theme("#text_box_30_horizcenter_spacing_95"),
-            anchors={"top_target":"temper_text"},
             visible=False,
             manager=MANAGER,
+            anchors={"top_target":self.screen_elements["temper_text"]},
             text_kwargs={
                 "m_c": game.clan.leader if not self.no_leader else None,
                 "count": 1,

--- a/scripts/screens/LeaderDenScreen.py
+++ b/scripts/screens/LeaderDenScreen.py
@@ -268,7 +268,6 @@ class LeaderDenScreen(Screens):
                 "m_c": game.clan.leader if not self.no_leader else None,
                 "count": 1,
             },
-            anchors={"bottom_target": self.screen_elements["temper_text"]},
         )
         self.screen_elements["outsider_notice_text"] = pygame_gui.elements.UITextBox(
             relative_rect=ui_scale(pygame.Rect((68, 375), (445, -1))),
@@ -334,7 +333,7 @@ class LeaderDenScreen(Screens):
         self.screen_elements["clan_notice_text"].show()
 
         self.screen_elements["temper_text"] = pygame_gui.elements.UITextBox(
-            relative_rect=ui_scale(pygame.Rect((68, 410), (445, -1))),
+            relative_rect=ui_scale(pygame.Rect((10, 0), (445, -1))),
             html_text="screens.leader_den.temper_text",
             object_id=get_text_box_theme("#text_box_30_horizcenter"),
             manager=MANAGER,
@@ -345,6 +344,7 @@ class LeaderDenScreen(Screens):
                     second_temper=i18n.t(f"screens.leader_den.{self.clan_temper[1]}"),
                 ),
             },
+            anchors={"top_target": self.screen_elements["clan_notice_text"]},
         )
 
         # INITIAL DISPLAY - display currently chosen interaction OR first clan in list

--- a/scripts/screens/LeaderDenScreen.py
+++ b/scripts/screens/LeaderDenScreen.py
@@ -333,7 +333,7 @@ class LeaderDenScreen(Screens):
         self.screen_elements["clan_notice_text"].show()
 
         self.screen_elements["temper_text"] = pygame_gui.elements.UITextBox(
-            relative_rect=ui_scale(pygame.Rect((68, 20), (445, -1))),
+            relative_rect=ui_scale(pygame.Rect((68, -20), (445, -1))),
             html_text="screens.leader_den.temper_text",
             object_id=get_text_box_theme("#text_box_30_horizcenter"),
             manager=MANAGER,

--- a/scripts/screens/LeaderDenScreen.py
+++ b/scripts/screens/LeaderDenScreen.py
@@ -333,7 +333,7 @@ class LeaderDenScreen(Screens):
         self.screen_elements["clan_notice_text"].show()
 
         self.screen_elements["temper_text"] = pygame_gui.elements.UITextBox(
-            relative_rect=ui_scale(pygame.Rect((68, 0), (445, -1))),
+            relative_rect=ui_scale(pygame.Rect((68, 20), (445, -1))),
             html_text="screens.leader_den.temper_text",
             object_id=get_text_box_theme("#text_box_30_horizcenter"),
             manager=MANAGER,


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

adds an anchors arg anchoring temper_text to clan_notice_text

## Why This Is Good For ClanGen

As discussed in the discord, this makes the text in the leader's den much more appealing to look at, as it isn't squished.

## Linked Issues

fixes #4985

## Proof of Testing

before
<img width="852" height="762" alt="image" src="https://github.com/user-attachments/assets/6555797e-e49b-4cdf-88d5-7a5ebbe01123" />
after
<img width="663" height="123" alt="image" src="https://github.com/user-attachments/assets/5494de19-b321-4481-b015-b4bbda1ee939" />

## Changelog/Credits

- text in leader's den unsqueezed
