### PR TITLE
[CONTENT] Splash Dates

### DIFF
--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -13805,5 +13805,59 @@
             ],
             "changed": 15
         }
-    }
+    },
+    {
+    "event_id": "gen_misc_greenleaf_younglove_adolescent",
+    "location": ["any", "-desert"],
+    "season": ["greenleaf"],
+    "sub_type": [],
+    "tags": ["romance"],
+    "frequency": 4,
+    "event_text": "m_c and r_c spend sunhigh frolicking and splashing each other by {POI/tag/water:flowing} to cool off in the sweltering heat.",
+    "m_c": {
+        "age": ["adolescent"]
+    },
+    "r_c": {
+        "age": ["adolescent"]
+    },
+    "relationships": [
+        {
+            "cats_from": ["m_c"],
+            "cats_to": ["r_c"],
+            "mutual": true,
+            "values": ["romance"],
+            "amount": 10,
+            "log": {
+  "cats_from": "cat_to and cat_from enjoyed splashing each other to beat the heat."
+                }
+        }
+    ]
+},
+    {
+    "event_id": "gen_misc_greenleaf_younglove_YA",
+    "location": ["any", "-desert"],
+    "season": ["greenleaf"],
+    "sub_type": [],
+    "tags": ["romance"],
+    "frequency": 4,
+    "event_text": "m_c and r_c spend sunhigh frolicking and splashing each other by {POI/tag/water:flowing} to cool off in the sweltering heat.",
+    "m_c": {
+        "age": ["young adult"]
+    },
+    "r_c": {
+        "age": ["young adult"]
+    },
+    "relationships": [
+        {
+            "cats_from": ["m_c"],
+            "cats_to": ["r_c"],
+            "mutual": true,
+            "values": ["romance"],
+            "amount": 10,
+            "log": {
+  "cats_from": "m_c and r_c enjoyed splashing each other to beat the heat."
+                }
+        }
+    ]
+}
 ]

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -13815,10 +13815,10 @@
     "frequency": 4,
     "event_text": "m_c and r_c spend sunhigh frolicking and splashing each other by {POI/tag/water:flowing} to cool off in the sweltering heat.",
     "m_c": {
-        "age": ["adolescent"]
+        "age": ["adolescent", "young adult"]
     },
     "r_c": {
-        "age": ["adolescent"]
+        "age": ["adolescent", "young adult"]
     },
     "relationships": [
         {
@@ -13829,33 +13829,6 @@
             "amount": 10,
             "log": {
   "cats_from": "cat_to and cat_from enjoyed splashing each other to beat the heat."
-                }
-        }
-    ]
-},
-    {
-    "event_id": "gen_misc_greenleaf_younglove_YA",
-    "location": ["any", "-desert"],
-    "season": ["greenleaf"],
-    "sub_type": [],
-    "tags": ["romance"],
-    "frequency": 4,
-    "event_text": "m_c and r_c spend sunhigh frolicking and splashing each other by {POI/tag/water:flowing} to cool off in the sweltering heat.",
-    "m_c": {
-        "age": ["young adult"]
-    },
-    "r_c": {
-        "age": ["young adult"]
-    },
-    "relationships": [
-        {
-            "cats_from": ["m_c"],
-            "cats_to": ["r_c"],
-            "mutual": true,
-            "values": ["romance"],
-            "amount": 10,
-            "log": {
-  "cats_from": "m_c and r_c enjoyed splashing each other to beat the heat."
                 }
         }
     ]

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -13807,7 +13807,7 @@
         }
     },
     {
-    "event_id": "gen_misc_greenleaf_younglove_adolescent",
+    "event_id": "gen_misc_greenleaf_splashdate",
     "location": ["any", "-desert"],
     "season": ["greenleaf"],
     "sub_type": [],

--- a/resources/lang/en/points_of_interest.en.json
+++ b/resources/lang/en/points_of_interest.en.json
@@ -9,7 +9,7 @@
         "moon_cave": "the Whispering Cave",
 
         "terrain_lake": "the lake",
-        "terrain_fordriver": "Fordriver",
+        "terrain_fordriver": "the river ford",
         "terrain_carrionplace": "the carrionplace",
         "terrain_sunningrocks": "Sunningrocks",
         "terrain_well": "the Twoleg water pit",


### PR DESCRIPTION
## About The Pull Request

- Two variations, one for adolescents another for young adults, of a romance event involving flowing water Points of Interest. 
- also changes "Fordriver" to "the river ford" as per convo in discord. 

## Why This Is Good For ClanGen

- More variety
- Begins to integrate POI into more content. 

## Proof of Testing
<img width="515" height="98" alt="Screenshot 2026-05-22 at 11 36 27 AM" src="https://github.com/user-attachments/assets/d9d9a469-5664-46a5-9120-4bd09febe217" />
<img width="447" height="66" alt="Screenshot 2026-05-22 at 11 36 41 AM" src="https://github.com/user-attachments/assets/aafe7cf6-539b-4b83-abe6-60d8f6ffc011" />
