### PR TITLE
[BUGFIX] Crash when switching Clans

### DIFF
--- a/scripts/game_structure/load_cat.py
+++ b/scripts/game_structure/load_cat.py
@@ -25,7 +25,11 @@ from scripts.game_structure import game
 from ..cat.personality import Personality
 from ..cat.skills import CatSkills
 from ..cat.status import StatusDict
-from ..clan_resources.point_of_interest import clear_pois, generate_and_add_new_poi, PoiType
+from ..clan_resources.point_of_interest import (
+    clear_pois,
+    generate_and_add_new_poi,
+    PoiType,
+)
 from ..housekeeping.datadir import get_save_dir
 
 logger = logging.getLogger(__name__)

--- a/scripts/game_structure/load_cat.py
+++ b/scripts/game_structure/load_cat.py
@@ -25,7 +25,7 @@ from scripts.game_structure import game
 from ..cat.personality import Personality
 from ..cat.skills import CatSkills
 from ..cat.status import StatusDict
-from ..clan_resources.point_of_interest import generate_and_add_new_poi, PoiType
+from ..clan_resources.point_of_interest import clear_pois, generate_and_add_new_poi, PoiType
 from ..housekeeping.datadir import get_save_dir
 
 logger = logging.getLogger(__name__)
@@ -705,6 +705,9 @@ def version_convert(version_info):
 
     # generate points of interest
     if version < 5:
+        # remove any already loaded points of interest
+        clear_pois()
+
         generate_and_add_new_poi(biome=game.clan.biome, category=PoiType.GATHERING)
         generate_and_add_new_poi(biome=game.clan.biome, category=PoiType.MOONPLACE)
 


### PR DESCRIPTION
## About The Pull Request

* Fixes an issue where the game would crash when switching between old save files without Points of Interests multiple times.

## Linked Issues

Fixes #5182 

## Proof of Testing

* Have Clans that are old saves without Points of Interest
* Switch between them three times
* No crash