### PR TITLE
Fix: use game_config values for new cat relationship initialization

### DIFF
--- a/scripts/events_module/consequences.py
+++ b/scripts/events_module/consequences.py
@@ -398,6 +398,10 @@ def create_new_cat_block(
         # add mates
         # THIS DOES NOT ADD RELATIONS TO CATS IN THE EVENT, those are added within the relationships block of the event
 
+        # Read relationship buff values from game_config.toml so they stay in sync with the config.
+        _sib_cfg = constants.CONFIG["new_cat"]["sib_buff"]
+        _par_cfg = constants.CONFIG["new_cat"]["parent_buff"]
+
         for n_c in new_cats:
             # SET MATES
             for inter_cat in give_mates:
@@ -415,10 +419,10 @@ def create_new_cat_block(
 
                 y = randrange(0, 20)
                 start_relation = Relationship(n_c, inter_cat, False, True)
-                start_relation.like += 40 + y
-                start_relation.comfort = 40 + y
-                start_relation.respect = 10 + y
-                start_relation.trust = 30 + y
+                start_relation.like += _sib_cfg["cat1_to_cat2"]["like"] + y
+                start_relation.comfort = _sib_cfg["cat1_to_cat2"]["comfort"] + y
+                start_relation.respect = _sib_cfg["cat1_to_cat2"]["respect"] + y
+                start_relation.trust = _sib_cfg["cat1_to_cat2"]["trust"] + y
                 n_c.relationships[inter_cat.ID] = start_relation
 
             # BIO PARENTS
@@ -428,18 +432,18 @@ def create_new_cat_block(
 
                 y = randrange(0, 20)
                 start_relation = Relationship(par, n_c, False, True)
-                start_relation.like += 60 + y
-                start_relation.comfort = 40 + y
-                start_relation.respect = 30 + y
-                start_relation.trust = 30 + y
+                start_relation.like += _par_cfg["parent_to_kit"]["like"] + y
+                start_relation.comfort = _par_cfg["parent_to_kit"]["comfort"] + y
+                start_relation.respect = _par_cfg["parent_to_kit"]["respect"] + y
+                start_relation.trust = _par_cfg["parent_to_kit"]["trust"] + y
                 par.relationships[n_c.ID] = start_relation
 
                 y = randrange(0, 20)
                 start_relation = Relationship(n_c, par, False, True)
-                start_relation.like += 40 + y
-                start_relation.comfort = 70 + y
-                start_relation.respect = 30 + y
-                start_relation.trust = 60 + y
+                start_relation.like += _par_cfg["kit_to_parent"]["like"] + y
+                start_relation.comfort = _par_cfg["kit_to_parent"]["comfort"] + y
+                start_relation.respect = _par_cfg["kit_to_parent"]["respect"] + y
+                start_relation.trust = _par_cfg["kit_to_parent"]["trust"] + y
                 n_c.relationships[par.ID] = start_relation
 
             # ADOPTIVE PARENTS
@@ -451,18 +455,18 @@ def create_new_cat_block(
 
                 y = randrange(0, 20)
                 start_relation = Relationship(par, n_c, False, True)
-                start_relation.like += 60 + y
-                start_relation.comfort = 40 + y
-                start_relation.respect = 30 + y
-                start_relation.trust = 30 + y
+                start_relation.like += _par_cfg["parent_to_kit"]["like"] + y
+                start_relation.comfort = _par_cfg["parent_to_kit"]["comfort"] + y
+                start_relation.respect = _par_cfg["parent_to_kit"]["respect"] + y
+                start_relation.trust = _par_cfg["parent_to_kit"]["trust"] + y
                 par.relationships[n_c.ID] = start_relation
 
                 y = randrange(0, 20)
                 start_relation = Relationship(n_c, par, False, True)
-                start_relation.like += 40 + y
-                start_relation.comfort = 70 + y
-                start_relation.respect = 30 + y
-                start_relation.trust = 60 + y
+                start_relation.like += _par_cfg["kit_to_parent"]["like"] + y
+                start_relation.comfort = _par_cfg["kit_to_parent"]["comfort"] + y
+                start_relation.respect = _par_cfg["kit_to_parent"]["respect"] + y
+                start_relation.trust = _par_cfg["kit_to_parent"]["trust"] + y
                 n_c.relationships[par.ID] = start_relation
 
             # UPDATE INHERITANCE


### PR DESCRIPTION
## Summary

The `create_new_cat_block()` function in `scripts/events_module/consequences.py` was using **hardcoded values** when initializing relationships for littermates, bio parents, and adoptive parents. This caused a silent discrepancy — edits to `resources/game_config.toml` under `[new_cat.sib_buff]` and `[new_cat.parent_buff]` had no effect on these initial relationships.

## What Changed

Replaced four blocks of hardcoded relationship assignments:

```python
# BEFORE — hardcoded, ignores game_config.toml
start_relation.like += 40 + y
start_relation.comfort = 40 + y
start_relation.respect = 10 + y
start_relation.trust = 30 + y
```

With config-driven lookups:

```python
# AFTER — reads from constants.CONFIG, stays in sync with game_config.toml
_sib_cfg = constants.CONFIG["new_cat"]["sib_buff"]
_par_cfg = constants.CONFIG["new_cat"]["parent_buff"]

start_relation.like += _sib_cfg["cat1_to_cat2"]["like"] + y
start_relation.comfort = _sib_cfg["cat1_to_cat2"]["comfort"] + y
start_relation.respect = _sib_cfg["cat1_to_cat2"]["respect"] + y
start_relation.trust = _sib_cfg["cat1_to_cat2"]["trust"] + y
```

This applies to:
- **Littermates** → reads `[new_cat.sib_buff.cat1_to_cat2]`
- **Bio parent → kit** → reads `[new_cat.parent_buff.parent_to_kit]`
- **Kit → bio parent** → reads `[new_cat.parent_buff.kit_to_parent]`
- **Adoptive parent / adoptive kid** → same `parent_buff` keys as bio parents

## Side Effects of the Old Hardcoded Values

Notably, the old hardcoded `comfort = 40` for parent relationships was **half** the configured value of `comfort = 70` in `game_config.toml`. This fix also corrects that discrepancy.

## Testing

- Verified `constants.CONFIG` is the standard access path used elsewhere in the codebase for `game_config.toml` values
- Default config values match the previously hardcoded values (except `comfort` for parents, which was wrong)
- No new imports needed; `constants` is already imported in this file

## Related

No issue number — this is a consistency/correctness fix discovered during a code audit.