### PR TITLE
[TYPO/FREQFIX] typo fixes + frequency adjustments

### DIFF
--- a/resources/lang/en/events/injury/forest.json
+++ b/resources/lang/en/events/injury/forest.json
@@ -570,7 +570,7 @@
     "event_id": "fst_mushroom_injury",
     "location": ["forest:camp1"],
     "season": ["newleaf", "greenleaf"],
-    "frequency": 2,
+    "frequency": 1,
     "event_text": "m_c finds a curious azure mushroom. Surely one bite wouldn't hurt... {PRONOUN/m_c/subject/CAP} {VERB/m_c/fall/falls} ill later that evening.",
         "m_c": {
             "age": [

--- a/resources/lang/en/events/relationship_events/breakup_mates.json
+++ b/resources/lang/en/events/relationship_events/breakup_mates.json
@@ -28,7 +28,7 @@
 		"Out of the blue, m_c bluntly tells r_c that {PRONOUN/m_c/subject} {VERB/m_c/aren't/isn't} interested in {PRONOUN/r_c/object} anymore, so {PRONOUN/m_c/subject} {VERB/m_c/call/calls} off their relationship and r_c walks away heartbroken and confused.",
             	"Some relationships turn out good, some don't, but for m_c and r_c's relationship, things really didn't turn out so well. They've broken up.", 
             	"Things have become tense and sour in m_c and r_c’s relationship. They decided to break up before any fight breaks out between them.",
-		"r_c broke up with m_c and m_c has taken it very hard. {PRONOUN/m_c/subject/CAP} seem to be avoiding r_c as much as possible."
+		"r_c broke up with m_c and m_c has taken it very hard. {PRONOUN/m_c/subject/CAP} {VERB/m_c/seem/seems} to be avoiding r_c as much as possible."
 	],
 	"chill_breakup":[
 		"m_c and r_c broke up.", 

--- a/resources/lang/en/patrols/plains/border/greenleaf.json
+++ b/resources/lang/en/patrols/plains/border/greenleaf.json
@@ -93,7 +93,7 @@
         "min_cats": 2,
         "max_cats": 6,
         "min_max_status": {},
-        "frequency": 2,
+        "frequency": 1,
         "intro_text": "Here on the plains, the reaches of c_n's territory is vast, particularly in the direction p_l and {PRONOUN/p_l/poss} patrol are heading, where there is endless grass but no permanent water sources. The greenleaf sun beats down strongly.",
         "decline_text": "The patrol is interrupted by a hunting patrol that needs help carrying prey back to camp — border marking will wait til later.",
         "chance_of_success": 40,

--- a/resources/lang/en/patrols/plains/training/any.json
+++ b/resources/lang/en/patrols/plains/training/any.json
@@ -1920,7 +1920,7 @@
             "apprentice": [1, 1],
             "normal adult": [1, 1]
         },
-        "frequency": 4,
+        "frequency": 2,
         "intro_text": "On this dry morning, p_l and app1 head out to practice tunnel navigation. There's an old, long abandoned badger sett that's perfect for apprentices, big enough to not be claustrophobic, but with plenty of crisscrossed, overlapping tunnels.",
         "decline_text": "When they get there, the tunnels look muddier than p_l expected, and the training is called off until the cats can be sure they're safe.",
         "chance_of_success": 60,
@@ -2204,7 +2204,7 @@
             "apprentice": [2, 5],
             "normal adult": [1, 4]
         },
-        "frequency": 4,
+        "frequency": 2,
         "intro_text": "On this dry morning, the patrol heads out to practice tunnel navigation. There's an old, long abandoned badger sett that's perfect for apprentices, big enough to not be claustrophobic but with plenty of crisscrossing, overlapping tunnels.",
         "decline_text": "When they get there, the tunnels look muddier than p_l expected, and the training is called off until the cats can be sure they're safe.",
         "chance_of_success": 60,


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

originally this PR was mostly gonna be another batch of typofixes, but i decided to go through #3896 and lower the frequency of events and patrols that were reported as too common, including:
- fst_mushroom_injury
- pln_train_sett
- pln_train_tunnels4
- pln_bord_greenleaf_longdistancemarking_group1
<br>
also adds a missing verb tag in a breakup event.

## Why This Is Good For ClanGen

keeping up w/ typofixing and listening to feedback!

## Linked Issues

https://github.com/ClanGenOfficial/clangen/issues/3896#issuecomment-4427083211
https://github.com/ClanGenOfficial/clangen/issues/3896#issuecomment-4469365506
https://github.com/ClanGenOfficial/clangen/issues/3896#issuecomment-4526949036

## Proof of Testing

<img width="1132" height="249" alt="image" src="https://github.com/user-attachments/assets/2b1437df-43c9-43fb-b0a8-750c75075723" />
<img width="1157" height="209" alt="image" src="https://github.com/user-attachments/assets/ae48ee7d-6bef-4b09-93dc-dfd9304b9f1a" />


## Changelog/Credits

- Fixes a missing verb tag.
- Also reduces the frequency of a couple events and patrols in response to player feedback that they were too common.
