### PR TITLE
resubmit: [BUGFIX/STREAMLINING] Filter Error regarding UR in Cat Thoughts / shorten sections of thought jsons

### DIFF
--- a/resources/lang/en/thoughts/while_dead/starclan/apprentice.json
+++ b/resources/lang/en/thoughts/while_dead/starclan/apprentice.json
@@ -10,10 +10,6 @@
             "Is glad that elders don't get ticks in StarClan",
             "Wonders if the water ever freezes in StarClan",
             "Sneaks close to the border of the Dark Forest but dares not go in"
-        ],
-        "random_living_status":[
-            "living",
-            "starclan"
         ]
     },
     {

--- a/resources/lang/en/thoughts/while_dead/starclan/elder.json
+++ b/resources/lang/en/thoughts/while_dead/starclan/elder.json
@@ -21,6 +21,9 @@
         ],
         "random_living_status": [
             "starclan"
+        ],
+        "random_status_constraint": [
+            "-elder"
         ]
     }
 ]

--- a/resources/lang/en/thoughts/while_dead/starclan/general.json
+++ b/resources/lang/en/thoughts/while_dead/starclan/general.json
@@ -37,12 +37,6 @@
             "Is chasing rabbits in StarClan",
             "Can feel some cat forgetting {PRONOUN/m_c/object}...",
             "Is judging a codebreaker"
-        ],
-        "random_living_status":[
-            "living",
-            "starclan",
-            "darkforest",
-            "unknownresidence"
         ]
     },
     {
@@ -74,11 +68,8 @@
             "Is telling other StarClan cats about the ambitions, hopes, and dreams {PRONOUN/m_c/subject} had for c_n"
         ],
         "main_age_constraint": [
-            "adolescent",
-            "young adult",
-            "adult",
-            "senior adult",
-            "senior"
+            "-kitten",
+            "-newborn"
         ],
         "main_backstory_constraint": ["clan_founder"],
         "random_living_status": [
@@ -153,11 +144,8 @@
             "Is watching over the newest additions to {PRONOUN/m_c/poss} Clan"
         ],
         "main_age_constraint": [
-            "adolescent",
-            "young adult",
-            "adult",
-            "senior adult",
-            "senior"
+            "-kitten",
+            "-newborn"
         ],
         "main_backstory_constraint": ["clan_founder"],
         "random_status_constraint": [
@@ -256,7 +244,7 @@
             "Is feeling guilty watching r_c miss {PRONOUN/m_c/object}",
             "Deeply regrets leaving r_c without {PRONOUN/m_c/object}"
         ],
-        "random_living_status": [
+        "main_status_constraint": [
             "starclan",
             "darkforest",
             "unknownresidence"
@@ -264,7 +252,7 @@
         "relationship_constraint": [
             "parent/child"
         ],
-        "main_status_constraint": [
+        "random_living_status": [
             "living"
         ]
     },
@@ -275,9 +263,7 @@
             "Visited r_c's dream to tell {PRONOUN/r_c/object} just how immensely proud {PRONOUN/m_c/subject} {VERB/m_c/are/is} of {PRONOUN/r_c/object}"
         ],
         "random_living_status": [
-            "starclan",
-            "darkforest",
-            "unknownresidence"
+            "living"
         ],
         "main_skill_constraint": [
             "STAR,1",
@@ -287,31 +273,9 @@
             "parent/child"
         ],
         "main_status_constraint": [
-            "living"
-        ]
-    },
-    {
-        "id": "dead_outsider_parent_to_alive_child",
-        "thoughts": [
-            "Regrets not joining a Clan if it meant being able to raise r_c",
-            "Still doesn't trust Clan cats, but is happy r_c is safe",
-            "Is just glad r_c was saved from meeting the same fate {PRONOUN/m_c/subject} did",
-            "Is so grateful to c_n for saving r_c"
-        ],
-        "random_backstory_constraint": [
-            "orphaned1",
-            "orphaned2",
-            "orphaned4",
-            "orphaned5"
-        ],
-        "main_status_constraint": [
-            "unknownresidence"
-        ],
-        "relationship_constraint": [
-            "parent/child"
-        ],
-        "random_living_status": [
-            "living"
+            "starclan",
+            "unknownresidence",
+            "darkforest"
         ]
     },
     {
@@ -398,7 +362,12 @@
         ],
         "random_living_status": [
             "starclan"
-        ]
+        ],
+         "random_age_constraint": [
+            "-kitten",
+            "-newborn",
+            "-adolescent"
+         ]
     },
     {
         "id": "dead_app_to_alive_app_sibling",

--- a/resources/lang/en/thoughts/while_dead/starclan/kitten.json
+++ b/resources/lang/en/thoughts/while_dead/starclan/kitten.json
@@ -23,11 +23,8 @@
             "starclan"
         ],
         "random_age_constraint": [
-            "adolescent",
-            "young adult",
-            "adult",
-            "senior adult",
-            "senior"
+            "-kitten",
+            "-newborn"
         ]
     },
     {

--- a/resources/lang/en/thoughts/while_dead/unknown_residence/general.json
+++ b/resources/lang/en/thoughts/while_dead/unknown_residence/general.json
@@ -89,5 +89,29 @@
             "leader",
             "elder"
         ]
+    },
+    {
+        "id": "dead_outsider_parent_to_alive_child",
+        "thoughts": [
+            "Regrets not joining a Clan if it meant being able to raise r_c",
+            "Still doesn't trust Clan cats, but is happy r_c is safe",
+            "Is just glad r_c was saved from meeting the same fate {PRONOUN/m_c/subject} did",
+            "Is so grateful to c_n for saving r_c"
+        ],
+        "random_backstory_constraint": [
+            "orphaned1",
+            "orphaned2",
+            "orphaned4",
+            "orphaned5"
+        ],
+        "main_status_constraint": [
+            "unknownresidence"
+        ],
+        "relationship_constraint": [
+            "parent/child"
+        ],
+        "random_living_status": [
+            "living"
+        ]
     }
 ]

--- a/scripts/events_module/thoughts/generate_thoughts.py
+++ b/scripts/events_module/thoughts/generate_thoughts.py
@@ -366,11 +366,14 @@ def _constraints_fulfilled(main_cat: "Cat", random_cat: "Cat", thought) -> bool:
             if random_cat.dead:
                 if random_cat.status.group == CatGroup.DARK_FOREST:
                     living_status = "darkforest"
-                else:
+                if random_cat.status.group == CatGroup.STARCLAN:
                     living_status = "starclan"
+                else:
+                    living_status = "unknownresidence"
             else:
                 living_status = "living"
         else:
+            # left this here as a failsafe since otherwise it causes a 'placed before declared' error
             living_status = "unknownresidence"
         if living_status and living_status not in thought["random_living_status"]:
             return False


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->
- Streamlines thought JSON files
- Fixes a filtering issue with how the game checks living status for thoughts


## Linked Issues

<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->
Fixes: #5207
Closes: #5214

## Proof of Testing
- Game Runs

``` test_not_working_thought_illness_major (tests.test_thoughts.TestNotWorkingThoughts.test_not_working_thought_illness_major) ... ok
test_not_working_thought_illness_minor (tests.test_thoughts.TestNotWorkingThoughts.test_not_working_thought_illness_minor) ... ok
test_not_working_thought_injury_major (tests.test_thoughts.TestNotWorkingThoughts.test_not_working_thought_injury_major) ... ok
test_not_working_thought_injury_minor (tests.test_thoughts.TestNotWorkingThoughts.test_not_working_thought_injury_minor) ... ok
test_not_working_thought_null (tests.test_thoughts.TestNotWorkingThoughts.test_not_working_thought_null) ... ok

----------------------------------------------------------------------
Ran 5 tests in 0.017s

OK
PROJECT_ROOT_PATH is set, using /Users/shadowdiamondfire/Documents/clangen-development as cwd for execution payload
pygame-ce 2.5.3 (SDL 2.30.12, Python 3.12.3)
Finished running tests!

test_exiled_thoughts (tests.test_thoughts.TestsGetStatusThought.test_exiled_thoughts) ... ok
test_lost_thoughts (tests.test_thoughts.TestsGetStatusThought.test_lost_thoughts) ... ok
test_medicine_thought (tests.test_thoughts.TestsGetStatusThought.test_medicine_thought) ... ok

----------------------------------------------------------------------
Ran 3 tests in 0.032s

OK
PROJECT_ROOT_PATH is set, using /Users/shadowdiamondfire/Documents/clangen-development as cwd for execution payload
pygame-ce 2.5.3 (SDL 2.30.12, Python 3.12.3)
Finished running tests!
```
<img width="672" height="290" alt="Screen Shot 2026-05-27 at 09 34 13" src="https://github.com/user-attachments/assets/ef38a2b7-6500-4519-8273-46ccc289b935" />
<img width="714" height="307" alt="Screen Shot 2026-05-27 at 09 34 21" src="https://github.com/user-attachments/assets/3ce19642-2d0f-4758-a3c0-42128929ae79" />


## Changelog/Credits

<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
- Fixed a filtering issue with how the game checks living status for thoughts