### PR TITLE
[CLEANUP] Assorted cruel season things

### DIFF
--- a/resources/game_config.toml
+++ b/resources/game_config.toml
@@ -425,10 +425,8 @@ dev_tools = false
 
 [patrol_generation]
   # modifies success rate based on game mode. higher = more difficult.
-  # the Cruel Season difficulty modifier needs to have a space rather than an underscore 
-  # due to how it's written in the save files. So don't try to 'fix' it.
+  difficulty_modifier = 2.5
   classic_difficulty_modifier = 1
-  expanded_difficulty_modifier = 2.5
 
   # amount to modify patrol success based on patrol stats
   # increasing this value increases the NUMERATOR for success (denominator is fixed at 120)
@@ -470,7 +468,7 @@ dev_tools = false
 
   # base 1/chance a cat will die
   classic_death_chance = 500
-  expanded_death_chance = 350
+  death_chance = 350
 
   # modifiers for death chance based on if a war is going badly
   # SUBTRACTS from the denominator so higher = more likely to die
@@ -494,12 +492,12 @@ dev_tools = false
 
 [condition_related]
   # 10/chance an illness will occur
-  expanded_illness_chance = 250
+  illness_chance = 250
   classic_illness_chance = 500
 
   # 5/chance (for most personalities) or 15/chance (for some personalities) an injury will occur 
   classic_injury_chance = 450
-  expanded_injury_chance = 250
+  injury_chance = 250
 
   # 1/chance a cat will get a permanent condition from an event with that possibility 
   permanent_condition_chance = 15

--- a/scripts/clan.py
+++ b/scripts/clan.py
@@ -143,7 +143,7 @@ class Clan:
         self.other_clan_IDs = []
 
         self.starting_members = starting_members
-        if game_mode in ("expanded", "cruel season"):
+        if game_mode in ("expanded", "cruel_season"):
             self.freshkill_pile = FreshkillPile()
         else:
             self.freshkill_pile = None
@@ -492,7 +492,7 @@ class Clan:
         self.save_pregnancy(game.clan)
 
         save_clan_settings()
-        if game.clan.game_mode in ("expanded", "cruel season"):
+        if game.clan.game_mode in ("expanded", "cruel_season"):
             self.save_freshkill_pile(game.clan)
 
         safe_save(f"{get_save_dir()}/{self.name}/clan.json", clan_data)

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -2155,8 +2155,8 @@ def handle_injuries_or_general_death(cat):
             return True
 
     # final death chance and then, if not triggered, head to injuries
-    mode = "expanded" if game.clan.game_mode == "cruel_season" else game.clan.game_mode
-    death_chance = get_config(game.clan, f"death_related.{mode}_death_chance") - (
+    path = "death_related.classic_death_chance" if game.clan.game_mode == "classic" else "death_related.death_chance"
+    death_chance = get_config(game.clan, path) - (
         get_config(game.clan, "death_related.war_death_modifier")
         if use_war_modifier
         else 0

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -114,7 +114,7 @@ def one_moon():
     Pregnancy_Events.handle_pregnancy_age(game.clan)
     check_war()
 
-    if game.clan.game_mode in ("expanded", "cruel season") and game.clan.freshkill_pile:
+    if game.clan.game_mode in ("expanded", "cruel_season") and game.clan.freshkill_pile:
         # feed the cats and update the nutrient status
         relevant_cats = list(
             filter(
@@ -252,7 +252,7 @@ def one_moon():
             )
         game.dead_cats_to_grieve.clear()
 
-    if game.clan.game_mode in ("expanded", "cruel season") and game.clan.freshkill_pile:
+    if game.clan.game_mode in ("expanded", "cruel_season") and game.clan.freshkill_pile:
         # make a notification if the Clan does not have enough prey
         if (
             FRESHKILL_EVENT_ACTIVE
@@ -275,7 +275,7 @@ def one_moon():
         ),
     )
 
-    if game.clan.game_mode in ("expanded", "cruel season"):
+    if game.clan.game_mode in ("expanded", "cruel_season"):
         amount_per_med = get_amount_cat_for_one_medic(game.clan)
         med_fulfilled = medicine_cats_can_cover_clan(
             Cat.all_cats.values(), amount_per_med
@@ -1036,7 +1036,7 @@ def one_moon_cat(cat):
 
     # handle nutrition amount
     # (CARE: the cats have to be fed before this happens - should be handled in "one_moon" function)
-    if game.clan.game_mode in ("expanded", "cruel season") and game.clan.freshkill_pile:
+    if game.clan.game_mode in ("expanded", "cruel_season") and game.clan.freshkill_pile:
         Condition_Events.handle_nutrient(cat, game.clan.freshkill_pile.nutrition_info)
 
         if cat.dead:
@@ -2155,7 +2155,7 @@ def handle_injuries_or_general_death(cat):
             return True
 
     # final death chance and then, if not triggered, head to injuries
-    mode = "expanded" if game.clan.game_mode == "cruel season" else game.clan.game_mode
+    mode = "expanded" if game.clan.game_mode == "cruel_season" else game.clan.game_mode
     death_chance = get_config(game.clan, f"death_related.{mode}_death_chance") - (
         get_config(game.clan, "death_related.war_death_modifier")
         if use_war_modifier

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -2155,7 +2155,11 @@ def handle_injuries_or_general_death(cat):
             return True
 
     # final death chance and then, if not triggered, head to injuries
-    path = "death_related.classic_death_chance" if game.clan.game_mode == "classic" else "death_related.death_chance"
+    path = (
+        "death_related.classic_death_chance"
+        if game.clan.game_mode == "classic"
+        else "death_related.death_chance"
+    )
     death_chance = get_config(game.clan, path) - (
         get_config(game.clan, "death_related.war_death_modifier")
         if use_war_modifier

--- a/scripts/events_module/patrol/patrol.py
+++ b/scripts/events_module/patrol/patrol.py
@@ -947,9 +947,14 @@ class Patrol:
 
         patrol_size = len(self.patrol_cats)
         total_exp = sum([x.experience for x in self.patrol_cats])
-        gm_modifier = constants.CONFIG["patrol_generation"][
-            f"{game.clan.game_mode}_difficulty_modifier"
-        ]
+        if game.clan.game_mode == "classic":
+            gm_modifier = constants.CONFIG["patrol_generation"][
+                f"classic_difficulty_modifier"
+            ]
+        else:
+            gm_modifier = constants.CONFIG["patrol_generation"][
+                f"difficulty_modifier"
+            ]
 
         exp_adustment = (
             (1 + 0.10 * patrol_size) * total_exp / (patrol_size * gm_modifier * 2)

--- a/scripts/events_module/patrol/patrol.py
+++ b/scripts/events_module/patrol/patrol.py
@@ -952,9 +952,7 @@ class Patrol:
                 f"classic_difficulty_modifier"
             ]
         else:
-            gm_modifier = constants.CONFIG["patrol_generation"][
-                f"difficulty_modifier"
-            ]
+            gm_modifier = constants.CONFIG["patrol_generation"][f"difficulty_modifier"]
 
         exp_adustment = (
             (1 + 0.10 * patrol_size) * total_exp / (patrol_size * gm_modifier * 2)

--- a/scripts/events_module/patrol/patrol.py
+++ b/scripts/events_module/patrol/patrol.py
@@ -15,6 +15,7 @@ from scripts.cat_relations.enums import RelType
 from scripts.cat.enums import CatAge, CatRank, CatCompatibility
 from scripts.clan import Clan
 from scripts.clan_package.settings import get_clan_setting
+from scripts.config import get_config
 from scripts.events_module.event_filters import (
     event_for_tags,
     get_frequency,
@@ -947,12 +948,13 @@ class Patrol:
 
         patrol_size = len(self.patrol_cats)
         total_exp = sum([x.experience for x in self.patrol_cats])
-        if game.clan.game_mode == "classic":
-            gm_modifier = constants.CONFIG["patrol_generation"][
-                f"classic_difficulty_modifier"
-            ]
-        else:
-            gm_modifier = constants.CONFIG["patrol_generation"][f"difficulty_modifier"]
+        path = (
+            "patrol_generation.classic_difficulty_modifier"
+            if game.clan.game_mode == "classic"
+            else "patrol_generation.difficulty_modifier"
+        )
+
+        gm_modifier = get_config(game.clan, path)
 
         exp_adustment = (
             (1 + 0.10 * patrol_size) * total_exp / (patrol_size * gm_modifier * 2)

--- a/scripts/events_module/short/condition_events.py
+++ b/scripts/events_module/short/condition_events.py
@@ -272,16 +272,15 @@ class Condition_Events:
             # ---------------------------------------------------------------------------- #
             #                              make cats sick                                  #
             # ---------------------------------------------------------------------------- #
-            mode = (
-                "expanded"
-                if game.clan.game_mode == "cruel_season"
-                else game.clan.game_mode
+
+            path = (
+                "condition_related.classic_illness_chance"
+                if game.clan.game_mode == "classic"
+                else "condition_related.illness_chance"
             )
             random_number = int(
                 random.random()
-                * get_config(
-                    "condition_related", f"{mode}_illness_chance"
-                )
+                * get_config(game.clan, path)
             )
             if (
                 not cat.dead
@@ -361,8 +360,14 @@ class Condition_Events:
         mode = (
             "expanded" if game.clan.game_mode == "cruel_season" else game.clan.game_mode
         )
+        path = (
+            "condition_related.classic_injury_chance"
+            if game.clan.game_mode == "classic"
+            else "condition_related.injury_chance"
+        )
+
         injury_chance = get_config(
-            game.clan, f"condition_related.{mode}_injury_chance"
+            game.clan, path
         ) - (
             get_config(game.clan, "condition_related.war_injury_modifier")
             if modify_for_war

--- a/scripts/events_module/short/condition_events.py
+++ b/scripts/events_module/short/condition_events.py
@@ -278,10 +278,7 @@ class Condition_Events:
                 if game.clan.game_mode == "classic"
                 else "condition_related.illness_chance"
             )
-            random_number = int(
-                random.random()
-                * get_config(game.clan, path)
-            )
+            random_number = int(random.random() * get_config(game.clan, path))
             if (
                 not cat.dead
                 and not cat.is_ill()
@@ -366,9 +363,7 @@ class Condition_Events:
             else "condition_related.injury_chance"
         )
 
-        injury_chance = get_config(
-            game.clan, path
-        ) - (
+        injury_chance = get_config(game.clan, path) - (
             get_config(game.clan, "condition_related.war_injury_modifier")
             if modify_for_war
             else 0

--- a/scripts/events_module/short/condition_events.py
+++ b/scripts/events_module/short/condition_events.py
@@ -272,10 +272,15 @@ class Condition_Events:
             # ---------------------------------------------------------------------------- #
             #                              make cats sick                                  #
             # ---------------------------------------------------------------------------- #
+            mode = (
+                "expanded"
+                if game.clan.game_mode == "cruel_season"
+                else game.clan.game_mode
+            )
             random_number = int(
                 random.random()
-                * game.get_config_value(
-                    "condition_related", f"{game.clan.game_mode}_illness_chance"
+                * get_config(
+                    "condition_related", f"{mode}_illness_chance"
                 )
             )
             if (

--- a/scripts/events_module/short/condition_events.py
+++ b/scripts/events_module/short/condition_events.py
@@ -354,9 +354,6 @@ class Condition_Events:
         triggered = False
 
         modify_for_war = switch_get_value(Switch.war_rel_change_type) != "rel_up"
-        mode = (
-            "expanded" if game.clan.game_mode == "cruel_season" else game.clan.game_mode
-        )
         path = (
             "condition_related.classic_injury_chance"
             if game.clan.game_mode == "classic"

--- a/scripts/events_module/short/condition_events.py
+++ b/scripts/events_module/short/condition_events.py
@@ -131,7 +131,7 @@ class Condition_Events:
     def handle_nutrient(cat: Cat, nutrition_info: dict) -> None:
         """
         Handles gaining conditions or death for cats with low nutrient.
-        This function should only be called if the game is in 'expanded' or 'cruel season' mode.
+        This function should only be called if the game is in 'expanded' or 'cruel_season' mode.
 
         Starvation and malnutrtion must be handled separately from other illnesses due to their distinct death triggers.
 
@@ -354,7 +354,7 @@ class Condition_Events:
 
         modify_for_war = switch_get_value(Switch.war_rel_change_type) != "rel_up"
         mode = (
-            "expanded" if game.clan.game_mode == "cruel season" else game.clan.game_mode
+            "expanded" if game.clan.game_mode == "cruel_season" else game.clan.game_mode
         )
         injury_chance = get_config(
             game.clan, f"condition_related.{mode}_injury_chance"

--- a/scripts/game_structure/game/__init__.py
+++ b/scripts/game_structure/game/__init__.py
@@ -201,65 +201,6 @@ def load_events():
         pass
 
 
-def get_config_value(*args):
-    """Fetches a value from the config dictionary. Pass each key as a
-    separate argument, in the same order you would access the dictionary.
-    This function will apply war modifiers if the clan is currently at war."""
-
-    global clan
-
-    war_effected = {
-        ("death_related", "leader_death_chance"): (
-            "death_related",
-            "war_death_modifier_leader",
-        ),
-        ("death_related", "classic_death_chance"): (
-            "death_related",
-            "war_death_modifier",
-        ),
-        ("death_related", "expanded_death_chance"): (
-            "death_related",
-            "war_death_modifier",
-        ),
-        ("death_related", "cruel season_death_chance"): (
-            "death_related",
-            "war_death_modifier",
-        ),
-        ("condition_related", "classic_injury_chance"): (
-            "condition_related",
-            "war_injury_modifier",
-        ),
-        ("condition_related", "expanded_injury_chance"): (
-            "condition_related",
-            "war_injury_modifier",
-        ),
-        ("condition_related", "cruel season_injury_chance"): (
-            "condition_related",
-            "war_injury_modifier",
-        ),
-    }
-
-    # Get Value
-    config_value = constants.CONFIG
-    for key in args:
-        config_value = config_value[key]
-
-    # Apply war if needed
-    if clan and clan.war.get("at_war", False) and args in war_effected:
-        rel_change_type = switch_get_value(Switch.war_rel_change_type)
-        # if the war was positively affected this moon, we don't apply war modifier
-        # this way we only see increased death/injury when the war is going badly or is neutral
-        if rel_change_type != "rel_up":
-            # Grabs the modifier
-            mod = constants.CONFIG
-            for key in war_effected[args]:
-                mod = mod[key]
-
-            config_value -= mod
-
-    return config_value
-
-
 def get_free_group_ID(group_type: CatGroup) -> str:
     """
     Find the next free group ID, adds it to the used_group_ID dict, and then returns the ID.

--- a/scripts/screens/ProfileScreen.py
+++ b/scripts/screens/ProfileScreen.py
@@ -1050,7 +1050,7 @@ class ProfileScreen(Screens):
 
         # NUTRITION INFO (if the game is in the correct mode)
         if (
-            game.clan.game_mode in ["expanded", "cruel season"]
+            game.clan.game_mode in ["expanded", "cruel_season"]
             and the_cat.is_alive()
             and FRESHKILL_ACTIVE
         ):

--- a/scripts/screens/make_clan_screens/ChooseModeScreen.py
+++ b/scripts/screens/make_clan_screens/ChooseModeScreen.py
@@ -120,7 +120,7 @@ class ChooseModeScreen(MakeClanScreenBase):
                 self.game_mode = "expanded"
                 self.refresh_text_and_buttons()
             elif event.ui_element == self.elements["cruel_season_mode_button"]:
-                self.game_mode = "cruel season"
+                self.game_mode = "cruel_season"
                 self.refresh_text_and_buttons()
 
             # Logic for when to quick-start clan
@@ -150,7 +150,7 @@ class ChooseModeScreen(MakeClanScreenBase):
         elif self.game_mode == "expanded":
             display_text = "screens.make_clan.expanded_info"
             display_name = "screens.make_clan.expanded_label"
-        elif self.game_mode == "cruel season":
+        elif self.game_mode == "cruel_season":
             display_text = "screens.make_clan.cruel_season_info"
             display_name = "screens.make_clan.cruel_season_label"
         else:
@@ -169,7 +169,7 @@ class ChooseModeScreen(MakeClanScreenBase):
             self.elements["classic_mode_button"].enable()
             self.elements["expanded_mode_button"].disable()
             self.elements["cruel_season_mode_button"].enable()
-        elif self.game_mode == "cruel season":
+        elif self.game_mode == "cruel_season":
             self.elements["classic_mode_button"].enable()
             self.elements["expanded_mode_button"].enable()
             self.elements["cruel_season_mode_button"].disable()


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
- Changed code references to cruel season from `cruel season` to `cruel_season` 
- Changed all configs that reference `expanded` to instead be treated as the "default" config, with `classic` being treated as an exception.
- Killed the old `get_config` func that was still hanging around
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Why This Is Good For ClanGen
I wanted to clean up a few little odds and ends before we move deeper into cruel season coding.
- Changing to `cruel_season` is just good for semantics
- My logic for the change to our `expanded` configs is that we first created the whole idea of game mode config separation because we expected cruel season to have set difficulty changes in the same way we change the difficulty between classic and expanded. This is no longer the case and cruel season is essentially going to continue using the expanded configs as a base. For the sake of clarity, then, I feel it wise that we being treating our `expanded` configs as simply the "default", with `classic` being the exception.  This way we don't deal with any confusion from coders on if they should be making cruel cards modify the "expanded" or the "classic" versions of configs.

fixes #5197
<!-- If this is a bug fix, you can remove this section. -->
<!-- Please add a short description of why you think these changes would benefit the game. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->
<!-- If you have multiple features that can stand on their own, or unrelated bugfixes, please create separate PRs for them. -->

## Proof of Testing
<img width="762" height="201" alt="image" src="https://github.com/user-attachments/assets/91db1f5e-a397-4f58-ad80-4a304ee5efcd" />

classic game mode correctly identified and correct config retrieved

<img width="695" height="258" alt="image" src="https://github.com/user-attachments/assets/b86e8596-ce08-4158-9366-9cac5c77fe33" />
same here

<img width="599" height="178" alt="image" src="https://github.com/user-attachments/assets/88e9333c-39a2-4ea0-902d-91e07cd6d968" />

expanded mode using correct config

<img width="677" height="310" alt="image" src="https://github.com/user-attachments/assets/bd0330f9-8d41-46e3-a0f5-45bebbadb46d" />
same here (with war modifier applied)

<img width="794" height="693" alt="image" src="https://github.com/user-attachments/assets/6e070cf1-5996-46eb-b04d-c9b18d35b08d" />

cruel season clan successfully made
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Removed outdated `get_config()` function
- Changed code identifier from `cruel season` to `cruel_season`. This does mean any cruel season saves likely won't load correctly unless the save file is edited to use `cruel_season`.
- Changed all configs that reference `expanded` to instead be treated as the "default" config, with `classic` being treated as an exception. This also means that cruel season clans should no longer have crashes when timeskipping or patrolling.
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
