### PR TITLE
[TYPOFIX] runnin up that hill fixing them typos

### DIFF
--- a/resources/lang/en/events/ceremonies/ceremony-master.json
+++ b/resources/lang/en/events/ceremonies/ceremony-master.json
@@ -3168,7 +3168,7 @@
       "general_backstory",
       "all_traits"
     ],
-    "(old_name) has proven {PRONOUN/m_c/self} skilled at handling the Clan's disputes. {PRONOUN/m_c/subject/CAP} {VERB/m_c/are/is} given the name m_c, and the Clan honors {PRONOUN/m_c/poss} new mediator."
+    "(old_name) has proven {PRONOUN/m_c/self} skilled at handling the Clan's disputes. {PRONOUN/m_c/subject/CAP} {VERB/m_c/are/is} given the name m_c, and the Clan honors their new mediator."
   ],
   "mediator_0_a": [
     [

--- a/resources/lang/en/events/lead_ceremony_sc.json
+++ b/resources/lang/en/events/lead_ceremony_sc.json
@@ -333,7 +333,7 @@
       "rank": ["warrior", "elder", "medicine cat", "mediator", "apprentice", "deputy"],
       "life_giving": [
         {
-          "text": "r_c approaches m_c with narrowed eyes, slightly unsettled by {PRONOUN/m_c/poss} aloofness. m_c is startled by the radiant warmth that surges through {PRONOUN/m_c/poss} chest as {PRONOUN/m_c/object} {VERB/r_c/are/is} granted a life for [virtue]. For the first time in a long while, a smile softens {PRONOUN/m_c/poss} cold demeanor.",
+          "text": "r_c approaches m_c with narrowed eyes, slightly unsettled by {PRONOUN/m_c/poss} aloofness. m_c is startled by the radiant warmth that surges through {PRONOUN/m_c/poss} chest as {PRONOUN/m_c/subject} {VERB/m_c/are/is} granted a life for [virtue]. For the first time in a long while, a smile softens {PRONOUN/m_c/poss} cold demeanor.",
           "virtue": ["acceptance", "empathy", "kindness", "understanding", "warmth", "patience", "open-mindedness", "respect", "tolerance", "forgiveness", "friendship", "respect", "mercy", "perspective", "unity", "benevolence"]
         }
       ]

--- a/resources/lang/en/thoughts/while_alive/clancat.json
+++ b/resources/lang/en/thoughts/while_alive/clancat.json
@@ -3095,7 +3095,7 @@
             "Has so many emotions, but doesn't know what to do with any of them",
             "Screams into moss after a long, <i>long</i> day",
             "Asks {PRONOUN/m_c/self} what the code means to {PRONOUN/m_c/object}",
-            "Struggles with the expectations on {PRONOUN/m_c/object} shoulders",
+            "Struggles with the expectations on {PRONOUN/m_c/poss} shoulders",
             "Feels too young to deal with life",
             "Wonders if {PRONOUN/m_c/subject}'d be respected if {PRONOUN/m_c/subject} admitted {PRONOUN/m_c/poss} insecurities",
             "Couldn't sleep last night because of worries",


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

fixes a few incorrect pronoun/verb tags (leader ceremony text & a thought) just to keep up with the typo issue

## Why This Is Good For ClanGen

typos begone please

## Linked Issues

https://github.com/ClanGenOfficial/clangen/issues/1818#issuecomment-4544781739
https://github.com/ClanGenOfficial/clangen/issues/1818#issuecomment-4546325203

## Proof of Testing

<img width="1155" height="125" alt="image" src="https://github.com/user-attachments/assets/dfb98a2b-1d2a-4ccb-9334-3f43bd7c6a9d" />


## Changelog/Credits

- Fixes a couple incorrect pronoun/verb tags.