### PR TITLE
[DEV] Add version number to exception log

### DIFF
--- a/init.py
+++ b/init.py
@@ -71,7 +71,14 @@ def log_crash(logtype, value, tb):
     """
     Log uncaught exceptions to file
     """
-    logging.critical("Uncaught exception", exc_info=(logtype, value, tb))
+    try:
+        version_number = get_version_info().version_number
+    except:  # don't want the crash handler to crash
+        version_number = "version unknown"
+    logging.critical(
+        f"Uncaught exception (ClanGen {version_number})",
+        exc_info=(logtype, value, tb),
+    )
     sys.__excepthook__(type, value, tb)
 
 


### PR DESCRIPTION
## About The Pull Request

Adds version number to exception log.

## Why This Is Good For ClanGen

* If someone only copies the error log, it's still possible for us to retrieve the version information.

## Proof of Testing
* Open ClanGen
* Force to crash with exception (can do a keyboard interrupt with `ctrl+C` in the terminal when ClanGen is running)
* Check terminal and log files

```
Running on source code
Version Name:  unknown
Running on commit 38e11f9b82e775a7db1eaac8a50f67dcead0a57d
pygame-ce 2.5.3 (SDL 2.30.12, Python 3.12.8)
libpng warning: iCCP: known incorrect sRGB profile
[src/libmpg123/id3.c:process_extra():684] error: No extra frame text / valid description?
[src/libmpg123/id3.c:process_extra():684] error: No extra frame text / valid description?
libpng warning: iCCP: known incorrect sRGB profile
libpng warning: iCCP: known incorrect sRGB profile
libpng warning: iCCP: known incorrect sRGB profile
libpng warning: iCCP: known incorrect sRGB profile
libpng warning: iCCP: known incorrect sRGB profile
libpng warning: iCCP: known incorrect sRGB profile
^Croot - CRITICAL - init.py / log_crash / 78 - Uncaught exception (ClanGen 38e11f9b82e775a7db1eaac8a50f67dcead0a57d)
Traceback (most recent call last):
...
```


## Changelog/Credits

* Version number will now appear in crash logs