### PR TITLE
[BUGFIX] add missing "war" tag for war-only event + renaming

### DIFF
--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -6943,7 +6943,7 @@
         ]
     },
     {
-        "event_id": "gen_misc_any_medicinecatdream1",
+        "event_id": "gen_misc_any_mediatorwar1",
         "location": [
             "any"
         ],

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -6950,6 +6950,9 @@
         "season": [
             "any"
         ],
+        "sub_type": [
+            "war"
+        ],
         "frequency": 2,
         "event_text": "m_c is conversing with r_c about ways to potentially end this war — though not without bloodshed.",
         "m_c": {


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

gen_misc_any_medicinecatdream1 was missing the "war" sub_type tag even though it talks about cats conversing about "potentially ending this war," leading to players being able to get this event when the clan is not in a war. this adds the missing tag so it generates in the proper context. also, this event is actually tagged for mediators and not medicine cats despite the event ID suggesting otherwise, so i also renamed it to fit the actual requirements.

## Why This Is Good For ClanGen

the event will now appear appropiately!

## Linked Issues

reported on the discord:
https://discord.com/channels/1003759225522110524/1104122948706635778/1510742129486463246

## Proof of Testing

<img width="1159" height="286" alt="image" src="https://github.com/user-attachments/assets/1d6abd80-bc6d-4fd3-a252-46fb174d3362" />


## Changelog/Credits

- Adds a missing "war" tag to an event. Now your mediators won't converse with the leader about ending a war when there is no war.