### PR TITLE
[BUGFIX] Add in missing age:has_kits

### DIFF
--- a/resources/lang/en/events/new_cat/general.json
+++ b/resources/lang/en/events/new_cat/general.json
@@ -2107,7 +2107,8 @@
         "status": ["medicine cat"]
     },
     "new_cat": [
-        ["can_birth",
+        ["age:has_kits",
+        "can_birth",
         "meeting",
         "exists",
         "old_name",
@@ -2382,7 +2383,8 @@
         "status": ["medicine cat"]
     },
     "new_cat": [
-        ["can_birth",
+        ["age:has_kits",
+        "can_birth",
         "meeting",
         "exists",
         "old_name",
@@ -2462,7 +2464,8 @@
         "status": ["medicine cat"]
     },
     "new_cat": [
-        ["can_birth",
+        ["age:has_kits",
+        "can_birth",
         "meeting",
         "exists",
         "old_name",
@@ -2504,7 +2507,8 @@
         "trait": ["bloodthirsty", "cold", "cunning", "sneaky"]
     },
     "new_cat": [
-        ["can_birth",
+        ["age:has_kits",
+        "can_birth",
         "meeting",
         "exists",
         "old_name",
@@ -2548,7 +2552,8 @@
         "age": ["young adult", "adult", "senior adult"]
     },
     "new_cat": [
-        ["can_birth",
+        ["age:has_kits",
+        "can_birth",
         "meeting",
         "exists",
         "old_name",
@@ -2614,7 +2619,8 @@
         "trait": ["bloodthirsty", "fierce", "cold", "cunning", "shameless"]
     },
     "new_cat": [
-        ["can_birth",
+        ["age:has_kits",
+        "can_birth",
         "meeting",
         "exists",
         "old_name",
@@ -2698,7 +2704,8 @@
         "trait": ["bloodthirsty", "fierce", "cold", "cunning", "shameless"]
     },
     "new_cat": [
-        ["can_birth",
+        ["age:has_kits",
+        "can_birth",
         "meeting",
         "exists",
         "old_name",
@@ -2799,7 +2806,8 @@
         "trait": ["shameless", "arrogant", "bold", "cold", "ambitious", "cunning", "sneaky"]
     },
     "new_cat": [
-        ["can_birth",
+        ["age:has_kits",
+        "can_birth",
         "meeting",
         "exists",
         "old_name",
@@ -2895,7 +2903,8 @@
         "trait": ["shameless", "arrogant", "bold", "cold", "ambitious", "cunning", "sneaky"]
     },
     "new_cat": [
-        ["can_birth",
+        ["age:has_kits",
+        "can_birth",
         "meeting",
         "exists",
         "old_name",
@@ -3003,7 +3012,8 @@
         "age": ["young adult", "adult", "senior adult"]
     },
     "new_cat": [
-        ["can_birth",
+        ["age:has_kits",
+        "can_birth",
         "meeting",
         "exists",
         "old_name",
@@ -3074,7 +3084,8 @@
         "status": ["leader"]
     },
     "new_cat": [
-        ["can_birth",
+        ["age:has_kits",
+        "can_birth",
         "meeting",
         "exists",
         "old_name",
@@ -3169,7 +3180,8 @@
         "gender": ["male"]
     },
     "new_cat": [
-        ["can_birth",
+        ["age:has_kits",
+        "can_birth",
         "meeting",
         "exists",
         "old_name",


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
Adds in missing age:has_kits to a bunch of events missing them.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
Fixes: #5250
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
Forced gen_new_cat_queenhelpgiantlitter to occur (that was a mistake), and got cats whose ages were between 29 and 118 - so, within age:has_kits's range. No adols.
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Fixed adolescents being able to have kits in a bunch of events.
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
