### PR TITLE
[CONTENT] POI Deaths, Murders, Injuries

### DIFF
--- a/resources/dicts/points_of_interest.json
+++ b/resources/dicts/points_of_interest.json
@@ -19,6 +19,11 @@
         "biome": ["any"],
         "tags": ["rocks"]
     },
+    "moon_mouth": {
+        "category": "moonplace",
+        "biome": ["any"],
+        "tags": ["rocks", "cave", "covered"]
+    },
     "moon_pool": {
         "category": "moonplace",
         "biome": ["any"],

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -663,6 +663,207 @@
         ]
     },
     {
+        "event_id": "gen_death_murder_moonpool_medonmedviolence",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "murder"
+        ],
+        "poi": {
+            "name": ["moon_pool"]
+        },
+        "tags": [],
+        "frequency": 4,
+        "event_text": "r_c waited until all the medicine cats were asleep and dreaming by the edge of {POI/name/moon_pool}. Then, {PRONOUN/r_c/subject} held m_c's head under the water until {PRONOUN/m_c/subject} stopped struggling.",
+        "m_c": {
+            "age": [
+                "any"
+            ],
+            "status": [
+                "medicine cat", "medicine cat apprentice"
+            ],
+            "dies": true
+        },
+        "r_c": {
+            "age": [
+                "any"
+            ],
+            "status": [
+                "medicine cat apprentice",
+                "medicine cat"
+            ]
+        },
+        "history": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "death": "m_c was murdered by r_c, who drowned {PRONOUN/m_c/object} in the Moonpool."
+            }
+        ],
+        "future_event": [
+            {
+                "event_type": "misc",
+                "pool": {
+                    "sub_type": [
+                        "murder_reveal"
+                    ]
+                },
+                "moon_delay": [
+                    1,
+                    12
+                ],
+                "involved_cats": {
+                    "m_c": "r_c",
+                    "mur_c": "m_c",
+                    "r_c": {
+                        "age": [
+                            "any"
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    {
+        "event_id": "gen_death_murder_mooncave_medonmedviolence",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "murder"
+        ],
+        "poi": {
+            "name": ["moon_cave"]
+        },
+        "tags": [],
+        "frequency": 4,
+        "event_text": "The ghostly murmurs of {POI/name/moon_cave} cannot drown out m_c's cries for help when r_c gets {PRONOUN/r_c/poss} claws on {PRONOUN/m_c/object} at last.",
+        "m_c": {
+            "age": [
+                "any"
+            ],
+            "status": [
+                "medicine cat", "medicine cat apprentice"
+            ],
+            "dies": true
+        },
+        "r_c": {
+            "age": [
+                "any"
+            ],
+            "status": [
+                "medicine cat apprentice",
+                "medicine cat"
+            ]
+        },
+        "history": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "death": "m_c was murdered by r_c, who cornered and killed {PRONOUN/m_c/object} in the Whispering Cave."
+            }
+        ],
+        "future_event": [
+            {
+                "event_type": "misc",
+                "pool": {
+                    "sub_type": [
+                        "murder_reveal"
+                    ]
+                },
+                "moon_delay": [
+                    1,
+                    12
+                ],
+                "involved_cats": {
+                    "m_c": "r_c",
+                    "mur_c": "m_c",
+                    "r_c": {
+                        "age": [
+                            "any"
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    {
+        "event_id": "gen_death_murder_mooncave_medonmedviolence",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "murder"
+        ],
+        "poi": {
+            "name": ["mother_mouth"]
+        },
+        "tags": [],
+        "frequency": 4,
+        "event_text": "During the half-moon, the gathered medicine cats wonder where m_c and r_c are. The moonlight flooding the Moonstone won't last all night. Outside, r_c heaps rocks on m_c's body.",
+        "m_c": {
+            "age": [
+                "any"
+            ],
+            "status": [
+                "medicine cat", "medicine cat apprentice"
+            ],
+            "dies": true
+        },
+        "r_c": {
+            "age": [
+                "any"
+            ],
+            "status": [
+                "medicine cat apprentice",
+                "medicine cat"
+            ]
+        },
+        "history": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "death": "m_c was murdered by r_c, who killed {PRONOUN/m_c/object} outside the Mothermouth during the half-moon."
+            }
+        ],
+        "future_event": [
+            {
+                "event_type": "misc",
+                "pool": {
+                    "sub_type": [
+                        "murder_reveal"
+                    ]
+                },
+                "moon_delay": [
+                    1,
+                    12
+                ],
+                "involved_cats": {
+                    "m_c": "r_c",
+                    "mur_c": "m_c",
+                    "r_c": {
+                        "age": [
+                            "any"
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    {
         "event_id": "gen_death_fox_any1",
         "location": [
             "any"
@@ -813,6 +1014,113 @@
                     "m_c"
                 ],
                 "death": "m_c went missing and was found dead."
+            }
+        ]
+    },
+    {
+        "event_id": "gen_death_fallriskPOI_any1",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "tags": [
+            "all_lives"
+        ],
+        "poi": {
+            "tags": ["fall_risk"]
+        },
+        "frequency": 4,
+        "event_text": "m_c went missing and was found dead at the bottom of {POI/tag/fall_risk}.",
+        "m_c": {
+            "dies": true
+        },
+        "history": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "death": "m_c went missing and was found dead after falling from a great height."
+            }
+        ]
+    },
+    {
+        "event_id": "gen_death_taintedPOI_any1",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "tags": [],
+        "poi": {
+            "tags": ["tainted"]
+        },
+        "frequency": 4,
+        "event_text": "m_c went missing and was found dead near {POI/tag/tainted}, a strange odor rising from {PRONOUN/m_c/poss} body.",
+        "m_c": {
+            "dies": true
+        },
+        "history": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "death": "m_c was poisoned by something near a dangerous part of the territory."
+            }
+        ]
+    },
+    {
+        "event_id": "gen_death_taintedPOI_any1",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "tags": [],
+        "poi": {
+            "tags": ["tainted"]
+        },
+        "frequency": 4,
+        "event_text": "m_c went missing and was found dead near {POI/tag/tainted}, a strange odor rising from {PRONOUN/m_c/poss} body.",
+        "m_c": {
+            "dies": true
+        },
+        "history": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "death": "m_c was poisoned by something near a dangerous part of the territory."
+            }
+        ]
+    },
+    {
+        "event_id": "gen_death_unstablePOI_any1",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "tags": [],
+        "poi": {
+            "tags": ["unstable"]
+        },
+        "frequency": 4,
+        "event_text": "m_c was killed when part of {POI/tag/unstable} collapsed.",
+        "m_c": {
+            "dies": true,
+            "status": ["-kitten", "-elder"]
+        },
+        "history": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "death": "m_c was crushed when something collapsed on {PRONOUN/m_c/object}."
             }
         ]
     },
@@ -1089,9 +1397,12 @@
         "season": [
             "any"
         ],
+        "poi": {
+            "tags": ["water:flowing"]
+        },
         "tags": [],
         "frequency": 3,
-        "event_text": "m_c fell into the river. r_c drowned alongside m_c while trying to rescue {PRONOUN/m_c/object}.",
+        "event_text": "m_c fell into {POI/tag/flowing:water}. r_c drowned alongside m_c while trying to rescue {PRONOUN/m_c/object}.",
         "m_c": {
             "age": [
                 "-kitten"
@@ -1129,7 +1440,52 @@
                     "m_c",
                     "r_c"
                 ],
-                "death": "This cat drowned alongside a Clanmate."
+                "death": "m_c drowned alongside a Clanmate."
+            }
+        ]
+    },
+    {
+        "event_id": "gen_death_horseplace",
+        "location": ["any"],
+        "season": ["any"],
+        "sub_type": [],
+        "tags": [],
+        "poi": {
+            "name": ["terrain_horseplace"]
+        },
+        "frequency": 2,
+        "event_text": "m_c is caught under a horse's hooves while hunting in {POI/name/terrain_horseplace}. {PRONOUN/m_c/poss/CAP} Clanmates can't get to {PRONOUN/m_c/object} in time.",
+        "m_c": {
+            "dies": true,
+            "status": ["leader", "deputy", "warrior", "apprentice"]
+        },
+        "history": [
+            {
+                "cats": ["m_c"],
+                "death": "m_c died when {PRONOUN/m_c/subject} got caught under a horse's hooves."
+            }
+        ]
+    },
+    {
+        "event_id": "gen_death_treesPOI",
+        "location": ["any"],
+        "season": ["any"],
+        "sub_type": [],
+        "tags": [],
+        "poi": {
+            "tags": ["trees"]
+        },
+        "frequency": 2,
+        "event_text": "m_c is hunting near {POI/tag/trees} when a branch falls on {PRONOUN/m_c/object}, killing {PRONOUN/m_c/object}.",
+        "new_accessory": [],
+        "m_c": {
+            "status": ["leader", "deputy", "warrior", "apprentice"],
+            "dies": true
+        },
+        "history": [
+            {
+                "cats": ["m_c"],
+                "death": "m_c was killed after a branch fell on {PRONOUN/m_c/object}."
             }
         ]
     },
@@ -2942,7 +3298,7 @@
             "all_lives"
         ],
         "frequency": 4,
-        "event_text": "m_c met their end to the long claws of a predator. Later, c_n found only {PRONOUN/m_c/poss} blood and a foul smell.",
+        "event_text": "m_c met {PRONOUN/m_c/poss} end at the long claws of a predator. Later, c_n found only {PRONOUN/m_c/poss} blood and a foul smell.",
         "m_c": {
             "age": [
                 "-kitten"
@@ -5037,7 +5393,7 @@
                 "cats": [
                     "m_c"
                 ],
-                "death": "m_c was lead out into the territory and killed by r_c."
+                "death": "m_c was led out into the territory and killed by r_c."
             }
         ],
         "future_event": [
@@ -8090,12 +8446,15 @@
     },
     {
         "event_id": "gen_death_drownedbyaduck",
-        "location": ["beach", "forest", "wetlands"],
+        "location": ["any"],
         "season": ["-leaf-bare"],
+        "poi": {
+            "name": ["terrain_lake"]
+        },
         "sub_type": [],
         "tags": [],
         "frequency": 1,
-        "event_text": "m_c attacked a duck, intending to bring it back for the fresh-kill pile, but was knocked below the surface of the water and drowned.",
+        "event_text": "m_c attacked a duck by {POI/name/terrain_lake}, intending to bring it back for the fresh-kill pile, but was knocked below the surface of the water and drowned.",
         "m_c": {
             "status": [
                 "apprentice",
@@ -8373,6 +8732,47 @@
                 }
             }
         ]
+    },
+    {
+        "event_id": "gen_death_murder_sunningrocks",
+        "location": ["any"],
+        "season": ["any"],
+        "tags": [],
+        "sub_type": ["murder", "war"],
+        "poi": {
+            "name": ["terrain_sunningrocks"]
+        },
+        "frequency": 4,
+        "event_text": "In the wake of a battle with o_c_n at {POI/name/terrain_sunningrocks}, r_c claims that m_c was killed by the o_c_n deputy, and r_c killed the deputy in revenge.",
+        "m_c": {
+            "status": ["deputy"]
+        },
+        "future_event": [
+            {
+                "event_type": "misc",
+                "pool": {
+                    "sub_type": [
+                        "murder_reveal"
+                    ]
+                },
+                "moon_delay": [
+                    1,
+                    4
+                ],
+                "involved_cats": {
+                    "m_c": "r_c",
+                    "mur_c": "m_c",
+                    "r_c": {
+                        "age": [
+                            "adolescent"
+                        ]
+                    }
+                }
+            }
+        ],
+        "other_clan": {
+            "changed": -6
+        }
     },
     {
         "event_id": "gen_death_trapmurder1",
@@ -9395,5 +9795,76 @@
     ],
     "changed": -3
   }
+},
+{
+    "event_id": "gen_death_gatheringisland",
+    "location": ["any"],
+    "season": ["any"],
+    "tags": [],
+    "poi": {
+        "name": ["gather_island"]
+    },
+    "frequency": 1,
+    "event_text": "m_c is so excited to be at the Gathering that {PRONOUN/m_c/subject} {VERB/m_c/forget/forgets} to watch {PRONOUN/m_c/poss} paws on the tree bridge. No cat is able to pull {PRONOUN/m_c/object} to shore in time, and the Gathering is cut short for a vigil.",
+    "m_c": {
+        "dies": true,
+        "age": ["adolescent"],
+        "trait": ["-careful", "-calm", "-wise"],
+        "skill": ["-SWIMMER,0"]
+    },
+    "history": [
+        {
+            "cats": ["m_c"],
+            "death": "m_c died after slipping off the tree bridge at the Gathering."
+        }
+
+    ]
+},
+{
+    "event_id": "gen_death_fourtrees",
+    "location": ["any"],
+    "season": ["any"],
+    "tags": [],
+    "poi": {
+        "name": ["gather_fourtrees"]
+    },
+    "frequency": 1,
+    "event_text": "When r_c takes m_c to {POI/name/gather_fourtrees}, m_c declares {PRONOUN/m_c/poss} intention to be the first cat to climb all four trees. r_c can't stop {PRONOUN/m_c/object} in time. m_c only makes it halfway up the first when {PRONOUN/m_c/subject} {VERB/m_c/fall/falls}, never to get back up.",
+    "m_c": {
+        "dies": true,
+        "age": ["adolescent"],
+        "trait": ["arrogant", "ambitious", "confident", "rebellious"],
+        "skill": ["-CLIMBER,0"],
+        "relationship_status": ["app/mentor"]
+    },
+    "r_c": {},
+    "history": [
+        {
+            "cats": ["m_c"],
+            "death": "m_c died after falling out of one of the Fourtrees."
+        }
+
+    ]
+},
+{
+    "event_id": "gen_death_gathermonster",
+    "location": ["any"],
+    "season": ["any"],
+    "poi": {
+        "name": ["gather_monster"]
+    },
+    "tags": [],
+    "frequency": 1,
+    "event_text": "At a busy Gathering, m_c is scratched by a piece of sharp metal jutting from {POI/name/gather_monster}. {PRONOUN/m_c/subject/CAP} {VERB/m_c/succumb/succumbs} to infection only a few days later.",
+    "m_c": {
+        "dies": true,
+        "age": ["-kitten"]
+    },
+    "history": [
+        {
+        "cats": ["m_c"],
+        "death": "m_c died of infection after being scraped by rusty metal at the Gathering."
+    }
+    ]
 }
 ]

--- a/resources/lang/en/events/injury/general.json
+++ b/resources/lang/en/events/injury/general.json
@@ -6393,12 +6393,15 @@
     },
     {
         "event_id": "gen_injury_drownedbyaduck",
-        "location": ["beach", "forest", "wetlands"],
+        "location": ["any"],
         "season": ["-leaf-bare"],
+        "poi": {
+            "name": ["POI/name/terrain_lake"]
+        },
         "sub_type": [],
         "tags": [],
         "frequency": 1,
-        "event_text": "m_c fought with a duck in the water, trying to kill it for the fresh-kill pile, but was knocked below the surface of the water and inhaled a lot of water.",
+        "event_text": "m_c fought with a duck in the water, trying to kill it for the fresh-kill pile, but was knocked below the surface of {POI/name/terrain_lake} and inhaled a lot of water.",
         "m_c": {
             "status": [
                 "apprentice",
@@ -6556,6 +6559,262 @@
                 "log": {
                     "cats_from": "cat_from saw cat_to defend the fresh-kill pile from a horde of rats."
                 }
+            }
+        ]
+    },
+    {
+        "event_id": "gen_injury_waterinlungs_gatheringisland",
+        "location": ["any"],
+        "season": ["any"],
+    "tags": [],
+        "poi": {
+            "name": ["gather_island"]
+        },
+        "frequency": 1,
+        "event_text": "m_c is so excited to be at the Gathering that {PRONOUN/m_c/subject} {VERB/m_c/forget/forgets} to watch {PRONOUN/m_c/poss} paws on the tree bridge. r_c has to jump in the water to rescue {PRONOUN/m_c/object}.",
+        "m_c": {
+            "age": ["adolescent"],
+            "trait": ["-careful", "-calm", "-wise"],
+            "skill": ["-SWIMMER,0"]
+        },
+        "r_c": {
+            "age": ["young adult", "adult", "senior adult"],
+            "status": ["-elder"],
+            "skill": ["SWIMMER,1"]
+        },
+        "injury": [
+            {
+                "cats": ["m_c"],
+                "injuries": ["water in their lungs"]
+            }
+
+        ],
+        "history": [
+            {
+                "cats": ["m_c"],
+                "death": "m_c died of the water in {PRONOUN/m_c/poss} lungs after falling off the tree bridge at the Gathering."
+            }
+        ],
+        "relationships": [
+            {
+                "cats_from": ["m_c"],
+                "cats_to": ["r_c"],
+                "values": ["respect", "like"],
+                "amount": -10,
+                "mutual": false,
+                "log": {
+                    "cats_from": "cat_from was humiliated when cat_to needed to rescue {PRONOUN/cat_from/object} from the water at the Gathering."
+                }
+            }
+        ]
+    },
+    {
+        "event_id": "gen_injury_bluntforce_fourtrees",
+        "location": ["any"],
+        "season": ["any"],
+    "tags": [],
+        "poi": {
+            "name": ["gather_fourtrees"]
+        },
+        "frequency": 1,
+        "event_text": "When r_c takes m_c to {POI/name/gather_fourtrees}, m_c declares {PRONOUN/m_c/poss} intention to be the first cat to climb all four trees. r_c can't stop {PRONOUN/m_c/object} in time. m_c is leaping from the first tree to the second when {PRONOUN/m_c/subject} {VERB/m_c/fall/falls}. While {PRONOUN/m_c/subject} {VERB/m_c/land/lands} on {PRONOUN/m_c/poss} feet, {PRONOUN/m_c/poss} leg snaps under {PRONOUN/m_c/object}.",
+        "m_c": {
+            "age": ["adolescent"],
+            "trait": ["arrogant", "ambitious", "confident", "rebellious"],
+            "skill": ["CLIMBER,0"],
+            "relationship_status": ["app/mentor"]
+        },
+        "r_c": {},
+        "injury": [
+            {
+                "cats": ["m_c"],
+                "injuries": ["broken bone"]
+            }
+        ],
+        "history": [
+            {
+                "cats": ["m_c"],
+                "scar": "m_c was scarred after trying to climb all of the Fourtrees as an apprentice.",
+                "death": "m_c died of {PRONOUN/m_c/poss} injuries after falling out of one of the Fourtrees."
+            }
+
+        ]
+    },
+    {
+        "event_id": "gen_injury_poison_carrion",
+        "location": ["any"],
+        "season": ["any"],
+        "sub_type": [],
+        "tags": [],
+        "poi": {
+            "name": ["terrain_carrionplace", "terrain_carrionbeach"]
+        },
+        "frequency": 2,
+        "event_text": "m_c and r_c become poisoned after hunting near {POI/name/terrain_carrionplace,terrain_carrionbeach}.",
+        "new_accessory": [],
+        "m_c": {
+            "status": ["warrior", "apprentice"],
+            "relationship_status": ["considers"]
+        },
+        "r_c": {
+            "status": ["warrior", "apprentice"]
+        },
+        "injury": [
+            {
+                "cats": ["r_c", "m_c"],
+                "injuries": ["poisoned"]
+            }
+        ],
+        "history": [
+            {
+                "cats": ["m_c", "r_c"],
+                "death": "m_c died after eating rotting prey."
+            }
+        ]
+    },
+    {
+        "event_id": "gen_injury_battleinjury_twolegplace",
+        "location": ["any"],
+        "season": ["any"],
+        "sub_type": [],
+        "tags": [],
+        "poi": {
+            "name": ["terrain_twolegplace"]
+        },
+        "frequency": 2,
+        "event_text": "m_c and r_c go on an adventure in the Twolegplace, but they barely escape with their lives after encountering a group of alleycats.",
+        "new_accessory": [],
+        "m_c": {
+            "status": ["apprentice"],
+            "relationship_status": ["considers"]
+        },
+        "r_c": {
+            "status": ["apprentice"]
+        },
+        "injury": [
+            {
+                "cats": ["r_c", "m_c"],
+                "injuries": ["battle_injury"]
+            }
+        ],
+        "history": [
+            {
+                "cats": ["m_c", "r_c"],
+                "scar": "m_c was scarred in a fight with alleycats.",
+                "death": "m_c died of {PRONOUN/m_c/poss} injuries after getting into a fight with alleycats."
+            }
+        ],
+        "new_cat": [
+            [
+                "rogue",
+                "meeting",
+                "unknown"
+            ],
+            [
+                "rogue",
+                "meeting",
+                "unknown"
+            ],
+            [
+                "rogue",
+                "meeting",
+                "unknown"
+            ]
+        ],
+        "relationships": [
+            {
+                "cats_from": ["m_c", "r_c"],
+                "cats_to": ["n_c:0", "n_c:1", "n_c:2"],
+                "mutual": false,
+                "values": ["comfort"],
+                "amount": -15,
+                "log": {
+                    "cats_from": "cat_from was chased out of the Twolegplace by cat_to."
+                }
+            },
+            {
+                "cats_from": ["m_c", "r_c"],
+                "cats_to": ["n_c:0", "n_c:1", "n_c:2"],
+                "mutual": true,
+                "values": ["like"],
+                "amount": -15,
+                "log": {
+                    "cats_from": "cat_from and cat_to got into a vicious fight."
+                }
+            }
+        ]
+    },
+    {
+        "event_id": "gen_injury_bluntforce_horseplace",
+        "location": ["any"],
+        "season": ["any"],
+        "sub_type": [],
+        "tags": [],
+        "poi": {
+            "name": ["terrain_horseplace"]
+        },
+        "frequency": 2,
+        "event_text": "m_c is caught under a horse's hooves while hunting in {POI/name/terrain_horseplace}. r_c helps {PRONOUN/m_c/object} back to camp",
+        "new_accessory": [],
+        "m_c": {
+            "status": ["leader", "deputy", "warrior", "apprentice"],
+            "relationship_status": ["acknowledges"]
+        },
+        "r_c": {
+            "status": ["leader", "deputy", "warrior", "apprentice"]
+        },
+        "injury": [
+            {
+                "cats": ["m_c"],
+                "injuries": ["blunt_force_injury"]
+            }
+        ],
+        "history": [
+            {
+                "cats": ["m_c"],
+                "scar": "m_c was scarred after being caught under a horse's hooves.",
+                "death": "m_c died after being injured by a horse's hooves."
+            }
+        ],
+        "relationships": [
+            {
+                "cats_from": ["m_c"],
+                "cats_to": ["r_c"],
+                "values": ["respect", "trust"],
+                "amount": 10,
+                "mutual": false,
+                "log": {
+                    "cats_from": "cat_from was grateful that cat_to helped {PRONOUN/cat_from/object} back to camp after {PRONOUN/cat_from/subject} was struck by a horse's hooves."
+                }
+            }
+        ]
+    },
+    {
+        "event_id": "gen_injury_bluntforce_trees",
+        "location": ["any"],
+        "season": ["any"],
+        "sub_type": [],
+        "tags": [],
+        "poi": {
+            "tags": ["trees"]
+        },
+        "frequency": 2,
+        "event_text": "m_c is hunting near {POI/tag/trees} when a branch falls on {PRONOUN/m_c/object}, injuring {PRONOUN/m_c/object}.",
+        "new_accessory": [],
+        "m_c": {
+            "status": ["leader", "deputy", "warrior", "apprentice"]
+        },
+        "injury": [
+            {
+                "cats": ["m_c"],
+                "injuries": ["blunt_force_injury", "bruises"]
+            }
+        ],
+        "history": [
+            {
+                "cats": ["m_c"],
+                "scar": "m_c was scarred after a branch fell on {PRONOUN/m_c/object}.",
+                "death": "m_c died of {PRONOUN/m_c/poss} injuries after a branch fell on {PRONOUN/m_c/object}."
             }
         ]
     },

--- a/resources/lang/en/points_of_interest.en.json
+++ b/resources/lang/en/points_of_interest.en.json
@@ -5,9 +5,9 @@
         "gather_monster": "the Monster Carcass",
 
         "moon_meteor": "the Silverpelt Stone",
+        "moon_mouth": "the Mothermouth",
         "moon_pool": "the Moonpool",
         "moon_cave": "the Whispering Cave",
-
         "terrain_lake": "the lake",
         "terrain_fordriver": "the river ford",
         "terrain_carrionplace": "the carrionplace",


### PR DESCRIPTION
## About The Pull Request

Adding deaths and injuries for most of the POIs.

Also adding Mothermouth as a POI. I know we were discussing adding it in wave 2 but it would be more of a pain rn for me to remove the event I already wrote for it and hide it away in a branch until that happens, so I want to just add it now.

## Why This Is Good For ClanGen

Hopefully self-evident

## Proof of Testing

