### PR TITLE
[BUGFIX] Fix PoIs getting transferred when switching Clans

### DIFF
--- a/scripts/clan.py
+++ b/scripts/clan.py
@@ -774,6 +774,9 @@ class Clan:
         else:
             displayname = clan_data["clanname"]
 
+        # remove any already loaded points of interest
+        clear_pois()
+
         load_pois(clan_data.get("poi", {"empty": []}))
 
         game.clan = Clan(


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
Fixes the PoIs of the previous Clan getting tacked onto the PoIs of the Clan you're switching to when switching Clans.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
Fixes: #5248
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
_Display of two Clans' PoIs, at the start and after switching Clans._
OneClan
```
    "poi": {
        "gathering": [
            "gather_monster"
        ],
        "moonplace": [
            "moon_meteor"
        ],
        "terrain": [
            "terrain_deepforest",
            "terrain_sunningrocks",
            "terrain_batcaves"
        ]
    }
```
TwoClan
```
    "poi": {
        "gathering": [
            "gather_island"
        ],
        "moonplace": [
            "moon_cave"
        ],
        "terrain": [
            "terrain_rookery",
            "terrain_deepforest",
            "terrain_twolegplace"
        ]
    }
```
OneClan after switching from TwoClan
```
    "poi": {
        "gathering": [
            "gather_monster"
        ],
        "moonplace": [
            "moon_meteor"
        ],
        "terrain": [
            "terrain_deepforest",
            "terrain_sunningrocks",
            "terrain_batcaves"
        ]
    }
```
TwoClan after switching from OneClan
```
    "poi": {
        "gathering": [
            "gather_island"
        ],
        "moonplace": [
            "moon_cave"
        ],
        "terrain": [
            "terrain_rookery",
            "terrain_deepforest",
            "terrain_twolegplace"
        ]
    }
```
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Fixed PoIs getting transferred when switching Clans
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
