### PR TITLE
[BUGFIX] Overly high injury/death rates

### DIFF
--- a/scripts/events.py
+++ b/scripts/events.py
@@ -2101,7 +2101,10 @@ def handle_injuries_or_general_death(cat):
         Condition_Events.handle_injuries(cat)
         return
 
-    use_war_modifier = switch_get_value(Switch.war_rel_change_type) != "rel_up"
+    use_war_modifier = (
+        game.clan.war["at_war"]
+        and switch_get_value(Switch.war_rel_change_type) != "rel_up"
+    )
 
     # chance to kill leader: 1/50 by default
     leader_death_chance = get_config(game.clan, "death_related.leader_death_chance") - (

--- a/scripts/events_module/short/condition_events.py
+++ b/scripts/events_module/short/condition_events.py
@@ -353,7 +353,10 @@ class Condition_Events:
         """
         triggered = False
 
-        modify_for_war = switch_get_value(Switch.war_rel_change_type) != "rel_up"
+        modify_for_war = (
+            game.clan.war["at_war"]
+            and switch_get_value(Switch.war_rel_change_type) != "rel_up"
+        )
         path = (
             "condition_related.classic_injury_chance"
             if game.clan.game_mode == "classic"


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
This was being caused by the war modifier detection.  It was essentially always using the war mods even when there wasn't a war. I fixed it by ensuring that we first check if the clan is even at war before trying to use the war mod.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->


## Proof of Testing
<img width="1006" height="268" alt="image" src="https://github.com/user-attachments/assets/794862b2-e1b8-4d6e-9027-dbb03b0bc21b" />

clan is not at war, we're using the correct death chance.

<img width="1023" height="274" alt="image" src="https://github.com/user-attachments/assets/bb6a396d-af01-42ae-9ddb-3f1c9c52830e" />

clan IS at war and uses the modified death chance
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- fixes death/injury chances always using war modifiers, even outside of a war
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
