### PR TITLE
[BUGFIX] No r_c in condition/injury/illness events

### DIFF
--- a/resources/lang/en/conditions/condition_got_strings/gain_congenital_condition_strings.json
+++ b/resources/lang/en/conditions/condition_got_strings/gain_congenital_condition_strings.json
@@ -73,14 +73,14 @@
         "When m_c is anxious, {PRONOUN/m_c/poss} voice freezes up, no matter how strongly {PRONOUN/m_c/subject} {VERB/m_c/want/wants} to speak up."
     ],
     "strange lump": [
-            "m_c developed a new lump on {PRONOUN/m_c/poss} body. It doesn't look good.",
             "r_c isn't sure where this lump on {PRONOUN/m_c/poss} body came from, but m_c isn't sure it's good news.",
             "m_c complains about being unable to sleep properly, leading r_c to find a strange lump on {PRONOUN/m_c/object}. It's not good news.",
-            "m_c won't let r_c see the new lump that appeared on {PRONOUN/m_c/poss} body."
+            "m_c won't let r_c see the new lump that appeared on {PRONOUN/m_c/poss} body.",
+            "m_c developed a new lump on {PRONOUN/m_c/poss} body. It doesn't look good."
         ],
     "absent": [
-            "m_c has been getting more and more forgetful lately. {PRONOUN/m_c/subject/CAP} is starting to fade.",
             "r_c has to repeat m_c's name several times to get {PRONOUN/m_c/poss} attention, quietly concerned about how long it takes {PRONOUN/m_c/object} to respond.",
-            "m_c has trouble remembering where {PRONOUN/m_c/poss} nest is. r_c takes note — m_c has been fading fast."
+            "m_c has trouble remembering where {PRONOUN/m_c/poss} nest is. r_c takes note — m_c has been fading fast.",
+            "m_c has been getting more and more forgetful lately. {PRONOUN/m_c/subject/CAP} is starting to fade."
         ]
 }

--- a/resources/lang/en/conditions/condition_got_strings/gain_permanent_condition_strings.json
+++ b/resources/lang/en/conditions/condition_got_strings/gain_permanent_condition_strings.json
@@ -123,8 +123,8 @@
             "m_c jumps, then realizes that it was just a leaf blowing in the wind. {PRONOUN/m_c/subject/CAP} {VERB/m_c/feel/feels} exhausted, {PRONOUN/m_c/poss} memories like a trap that rears up to bite {PRONOUN/m_c/object} whenever {PRONOUN/m_c/subject} {VERB/m_c/relax/relaxes}."
         ],
         "absent": [
-            "m_c never really came around again after going into shock.",
-            "m_c fails to respond to r_c yet again, leading {PRONOUN/r_c/subject} to accept m_c is never really coming back."
+            "m_c fails to respond to r_c yet again, leading {PRONOUN/r_c/subject} to accept m_c is never really coming back.",
+            "m_c never really came around again after going into shock."
         ],
         "selective mutism": [
             "m_c's nerves seem to have eased, until {PRONOUN/m_c/poss} voice gets caught in {PRONOUN/m_c/poss} chest.",
@@ -160,10 +160,10 @@
             "m_c begrudgingly accepts that the horrible headaches {PRONOUN/m_c/subject}{VERB/m_c/'ve/'s} been having might be a permanent side effect of {PRONOUN/m_c/poss} head damage."
         ],
         "absent": [
-            "m_c hasn't been the same since the head injury. {PRONOUN/m_c/subject/CAP} {VERB/m_c/seem/seems} like {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} living in a daze.",
             "r_c has to repeat m_c's name several times to get {PRONOUN/m_c/poss} attention, worried about {PRONOUN/m_c/poss} head injury.",
             "m_c has trouble remembering where {PRONOUN/m_c/poss} nest is. r_c takes note — m_c has been fading fast since the head injury.",
-            "m_c got lost in the camp too many times. r_c wants to keep {PRONOUN/m_c/object} at camp for much longer."
+            "m_c got lost in the camp too many times. r_c wants to keep {PRONOUN/m_c/object} at camp for much longer.",
+            "m_c hasn't been the same since the head injury. {PRONOUN/m_c/subject/CAP} {VERB/m_c/seem/seems} like {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} living in a daze."
         ]
     },
     "damaged eyes": {
@@ -225,9 +225,9 @@
     },
     "a festering wound": {
         "strange lump": [
-            "A lump has appeared under m_c's wound. {PRONOUN/m_c/subject/CAP} {VERB/m_c/aren't/isn't} sure that's a good sign.",
             "m_c complains about being unable to sleep properly, leading r_c to find a strange lump under the wound.",
-            "m_c won't let r_c see the new lump that appeared on {PRONOUN/m_c/poss} body."
+            "m_c won't let r_c see the new lump that appeared on {PRONOUN/m_c/poss} body.",
+            "A lump has appeared under m_c's wound. {PRONOUN/m_c/subject/CAP} {VERB/m_c/aren't/isn't} sure that's a good sign."
         ]
     },
     "sore throat": {

--- a/resources/lang/en/conditions/risk_strings/injuries_risk_strings.json
+++ b/resources/lang/en/conditions/risk_strings/injuries_risk_strings.json
@@ -48,7 +48,7 @@
         "r_c worries over m_c, looking for any tick-heads an apprentice might have left, but {PRONOUN/r_c/subject} can only find a distinctive rash. m_c knows what it means — tick fever.",
         "m_c's heart sinks as {PRONOUN/m_c/poss} fur starts falling out. The apprentices must have missed a tick — r_c confirms it's tick fever.",
         "m_c complains about a new rash, going silent when r_c finds a tick-head. {PRONOUN/m_c/subject/CAP} has tick fever.",
-        "m_c is caught scratching at a rash, pulling out small clumps of loose fur. It seems {PRONOUN/m_c/subject} {VERB/have/has} developed tick fever."
+        "m_c is caught scratching at a rash, pulling out small clumps of loose fur. It seems {PRONOUN/m_c/subject} {VERB/m_c/have/has} developed tick fever."
     ]
     },
     "broken jaw": {

--- a/resources/lang/en/conditions/risk_strings/injuries_risk_strings.json
+++ b/resources/lang/en/conditions/risk_strings/injuries_risk_strings.json
@@ -47,7 +47,8 @@
         "tick fever": [
         "r_c worries over m_c, looking for any tick-heads an apprentice might have left, but {PRONOUN/r_c/subject} can only find a distinctive rash. m_c knows what it means — tick fever.",
         "m_c's heart sinks as {PRONOUN/m_c/poss} fur starts falling out. The apprentices must have missed a tick — r_c confirms it's tick fever.",
-        "m_c complains about a new rash, going silent when r_c finds a tick-head. {PRONOUN/m_c/subject/CAP} has tick fever."
+        "m_c complains about a new rash, going silent when r_c finds a tick-head. {PRONOUN/m_c/subject/CAP} has tick fever.",
+        "m_c is caught scratching at a rash, pulling out small clumps of loose fur. It seems {PRONOUN/m_c/subject} {VERB/have/has} developed tick fever."
     ]
     },
     "broken jaw": {
@@ -159,8 +160,8 @@
             "m_c pants, helplessly searching for a cooler place to lie and nap. {PRONOUN/m_c/subject/CAP} {VERB/m_c/feel/feels} utterly exhausted by this heat."
         ],
         "sore throat": [
-            "The lack of water has left m_c's throat dry and sore.",
-            "r_c has tried to get some water into m_c, but {PRONOUN/m_c/poss} thirst has left {PRONOUN/m_c/poss} throat dry and scratchy."
+            "r_c has tried to get some water into m_c, but {PRONOUN/m_c/poss} thirst has left {PRONOUN/m_c/poss} throat dry and scratchy.",
+            "The lack of water has left m_c's throat dry and sore."
         ]
     },
     "damaged eyes": {

--- a/resources/lang/en/conditions/risk_strings/permanent_condition_risk_strings.json
+++ b/resources/lang/en/conditions/risk_strings/permanent_condition_risk_strings.json
@@ -18,8 +18,8 @@
     },
     "damaged throat": {
         "sore throat": [
-            "m_c overexerted {PRONOUN/m_c/poss} voice and now can hardly speak at all, with how horribly sore {PRONOUN/m_c/poss} throat is.",
-            "m_c mimes the motions for numbing herbs to r_c, who understands and supplies them swiftly. Something must have irritated m_c's damaged throat."
+            "m_c mimes the motions for numbing herbs to r_c, who understands and supplies them swiftly. Something must have irritated m_c's damaged throat.",
+            "m_c overexerted {PRONOUN/m_c/poss} voice and now can hardly speak at all, with how horribly sore {PRONOUN/m_c/poss} throat is."
         ]
     },
     "born without a leg": {
@@ -86,8 +86,8 @@
             "m_c's weak lungs have left {PRONOUN/m_c/object} coughing and wheezing this moon, unable to resist potential sickness."
         ],
         "breathless fit": [
-            "m_c is used to being breathless, but today {PRONOUN/m_c/subject} can hardly walk a few fox-lengths before growing faint. Something in the air must have irritated {PRONOUN/m_c/poss} lungs.",
-            "m_c wheezes to r_c that it feels like a cat is sitting on {PRONOUN/m_c/poss} chest. r_c waves fragrant herbs beneath m_c's nose, praying this breathlessness will not progress to suffocation."
+            "m_c wheezes to r_c that it feels like a cat is sitting on {PRONOUN/m_c/poss} chest. r_c waves fragrant herbs beneath m_c's nose, praying this breathlessness will not progress to suffocation.",
+            "m_c is used to being breathless, but today {PRONOUN/m_c/subject} can hardly walk a few fox-lengths before growing faint. Something in the air must have irritated {PRONOUN/m_c/poss} lungs."
         ]
     },
     "wasting disease": {
@@ -185,15 +185,16 @@
     "strange lump": {
         "seizure": [
             "m_c had a seizure recently. r_c says the lump looks different.",
-            "Nobody expected m_c to have a seizure out of the blue like that. r_c worries it's due to {PRONOUN/m_c/poss} lump."
+            "Nobody expected m_c to have a seizure out of the blue like that. r_c worries it's due to {PRONOUN/m_c/poss} lump.",
+            "m_c falters during {PRONOUN/m_c/poss} tasks, collapsing into a seizure. {PRONOUN/m_c/poss/CAP} Clanmates suspect that the culprit is the lump on m_c's body."
         ],
         "paralysis": [
             "m_c woke up and realized {PRONOUN/m_c/object} can't move {PRONOUN/m_c/poss} legs anymore...",
             "m_c reports a strange buzzing and severe weakness of {PRONOUN/m_c/poss} legs."
         ],
         "redcough": [
-            "m_c has finally started coughing up blood. The Clan has seen this before — that lump was poison.",
-            "r_c braces for the inevitable when m_c finally contracts redcough. It's just a matter of moons now."
+            "r_c braces for the inevitable when m_c finally contracts redcough. It's just a matter of moons now.",
+            "m_c has finally started coughing up blood. The Clan has seen this before — that lump was poison."
         ]
     }
 }


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->
- Moved around some strings in illness/condition/injury events to make sure the last string option doesn't have r_c, as the final string is the default in situations where no medicine cat is present
- Added some new strings where the above was not possible due to all possibilities containing r_c

## Linked Issues

<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->
fix: #5283


## Proof of Testing

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->
<img width="522" height="106" alt="Screen Shot 2026-06-04 at 10 32 02" src="https://github.com/user-attachments/assets/ef1b2213-0251-4065-b831-c16740d43b01" />
<img width="519" height="71" alt="Screen Shot 2026-06-04 at 10 38 56" src="https://github.com/user-attachments/assets/3a4adb96-cfc9-4e3b-b5b9-19a4e1faebe6" />
(Game runs, events dont crash / events like this are hell to test lol)
