### PR TITLE
[CONTENT] high negative rel flags

### DIFF
--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -14871,21 +14871,18 @@
     "location": ["any"],
     "season": ["any"],
     "frequency": 1,
-    "event_text": "m_c pretends not to notice when r_c stumbles during a patrol.",
+    "event_text": "m_c hopes r_c gets horribly wounded.",
     "m_c": {
-        "status": ["-kitten", "-elder"],
         "relationship_status": ["loathes_only"]
     },
-    "r_c": {
-    "status": ["-newborn", "-kitten", "-elder"]
-    }
+    "r_c": {}
 },
     {
     "event_id": "gen_rel_loathes3",
     "location": ["any"],
     "season": ["any"],
     "frequency": 1,
-    "event_text": "m_c's cannot stomach that fox-hearted r_c.",
+    "event_text": "m_c cannot stomach that fox-hearted r_c.",
     "m_c": {
         "relationship_status": ["loathes_only"]
     },
@@ -14920,7 +14917,7 @@
     "frequency": 1,
     "event_text": "m_c thinks {PRONOUN/m_c/subject} would be a better deputy than r_c.",
     "m_c": {
-        "status": ["-kitten", "-deputy", "-leader"],
+        "status": ["-kitten", "-deputy", "-leader", "-medicine cat apprentice", "-medicine cat"],
         "relationship_status": ["resents_only"]
     },
     "r_c": {

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -14904,7 +14904,7 @@
     "location": ["any"],
     "season": ["any"],
     "frequency": 1,
-    "event_text": "m_c can tastes mousebile every time {PRONOUN/m_c/subject} {VERB/m_c/think/thinks} about r_c.",
+    "event_text": "m_c tastes mouse-bile every time {PRONOUN/m_c/subject} {VERB/m_c/think/thinks} about r_c.",
     "m_c": {
         "relationship_status": ["resents_only"]
     },
@@ -14981,7 +14981,8 @@
     "frequency": 1,
     "event_text": "m_c refuses to socialize or patrol with r_c.",
     "m_c": {
-        "relationship_status": ["runs_from_only"]
+        "relationship_status": ["runs_from_only"],
+        "status": ["-kitten", "-elder"]
     },
     "r_c": {
         "status": ["-kitten", "-elder"]

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -14854,5 +14854,162 @@
                 }
         }
     ]
+},
+      {
+    "event_id": "gen_rel_loathes1",
+    "location": ["any"],
+    "season": ["any"],
+    "frequency": 1,
+    "event_text": "m_c's claws unsheathe whenever r_c is near.",
+    "m_c": {
+        "relationship_status": ["loathes_only"]
+    },
+    "r_c": {}
+},
+    {
+    "event_id": "gen_rel_loathes2",
+    "location": ["any"],
+    "season": ["any"],
+    "frequency": 1,
+    "event_text": "m_c pretends not to notice when r_c stumbles during a patrol.",
+    "m_c": {
+        "status": ["-kitten", "-elder"],
+        "relationship_status": ["loathes_only"]
+    },
+    "r_c": {
+    "status": ["-newborn", "-kitten", "-elder"]
+    }
+},
+    {
+    "event_id": "gen_rel_loathes3",
+    "location": ["any"],
+    "season": ["any"],
+    "frequency": 1,
+    "event_text": "m_c's cannot stomach that fox-hearted r_c.",
+    "m_c": {
+        "relationship_status": ["loathes_only"]
+    },
+    "r_c": {}
+},
+      {
+    "event_id": "gen_rel_resents1",
+    "location": ["any"],
+    "season": ["any"],
+    "frequency": 1,
+    "event_text": "m_c thinks the praise r_c receives is a load of mouse-dung.",
+    "m_c": {
+        "relationship_status": ["resents_only"]
+    },
+    "r_c": {}
+},
+      {
+    "event_id": "gen_rel_resents2",
+    "location": ["any"],
+    "season": ["any"],
+    "frequency": 1,
+    "event_text": "m_c can tastes mousebile every time {PRONOUN/m_c/subject} {VERB/m_c/think/thinks} about r_c.",
+    "m_c": {
+        "relationship_status": ["resents_only"]
+    },
+    "r_c": {}
+},
+      {
+    "event_id": "gen_rel_resents3",
+    "location": ["any"],
+    "season": ["any"],
+    "frequency": 1,
+    "event_text": "m_c thinks {PRONOUN/m_c/subject} would be a better deputy than r_c.",
+    "m_c": {
+        "status": ["-kitten", "-deputy", "-leader"],
+        "relationship_status": ["resents_only"]
+    },
+    "r_c": {
+        "status": ["deputy"]
+    }
+},
+      {
+    "event_id": "gen_rel_discredits1",
+    "location": ["any"],
+    "season": ["any"],
+    "frequency": 1,
+    "event_text": "m_c is convinced r_c is influenced by the Dark Forest.",
+    "m_c": {
+        "relationship_status": ["discredits_only"]
+    },
+    "r_c": {}
+},
+          {
+    "event_id": "gen_rel_discredits2",
+    "location": ["any"],
+    "season": ["any"],
+    "frequency": 1,
+    "event_text": "m_c knows r_c is plotting against {PRONOUN/m_c/object}.",
+    "m_c": {
+        "relationship_status": ["discredits_only"]
+    },
+    "r_c": {}
+},
+      {
+    "event_id": "gen_rel_discredits3",
+    "location": ["any"],
+    "season": ["any"],
+    "frequency": 1,
+    "event_text": "m_c thinks r_c lets Clanmates {PRONOUN/r_c/subject} {VERB/r_c/don't/doesn't} like die intentionally.",
+    "m_c": {
+        "relationship_status": ["discredits_only"]
+    },
+    "r_c": {
+        "age": [],
+        "status": ["medicine cat", "medicine cat apprentice"]
+    }
+},
+          {
+    "event_id": "gen_rel_discredits4",
+    "location": ["any"],
+    "season": ["any"],
+    "frequency": 1,
+    "event_text": "m_c whispers to {PRONOUN/m_c/poss} friends doubts about r_c's leadership.",
+    "m_c": {
+        "relationship_status": ["discredits_only"],
+         "status": ["-deputy", "-leader"]
+    },
+    "r_c": {
+        "status": ["leader", "deputy"]
+    }
+},
+    {
+    "event_id": "gen_rel_runsfrom1",
+    "location": ["any"],
+    "season": ["any"],
+    "frequency": 1,
+    "event_text": "m_c refuses to socialize or patrol with r_c.",
+    "m_c": {
+        "relationship_status": ["runs_from_only"]
+    },
+    "r_c": {
+        "status": ["-kitten", "-elder"]
+    }
+},
+      {
+    "event_id": "gen_rel_runsfrom2",
+    "location": ["any"],
+    "season": ["any"],
+    "frequency": 1,
+    "event_text": "m_c thinks if they were alone together r_c would hurt them.",
+    "m_c": {
+        "relationship_status": ["runs_from_only"]
+    },
+    "r_c": {}
+},
+          {
+    "event_id": "gen_rel_runsfrom3",
+    "location": ["any"],
+    "season": ["any"],
+    "frequency": 1,
+    "event_text": "m_c isn't sure {PRONOUN/m_c/subject} {VERB/m_c/feel/feels} safe in c_n... not with r_c around.",
+    "m_c": {
+        "relationship_status": ["runs_from_only"]
+    },
+    "r_c": {}
 }
 ]

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -14995,7 +14995,7 @@
     "location": ["any"],
     "season": ["any"],
     "frequency": 1,
-    "event_text": "m_c thinks if they were alone together r_c would hurt them.",
+    "event_text": "m_c thinks if they were alone together r_c would hurt {PRONOUN/m_c/object}.",
     "m_c": {
         "relationship_status": ["runs_from_only"]
     },


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

- Adds a few relationship flags for each high negative relationship value. 

## Why This Is Good For ClanGen

- Discussed at length here (https://github.com/ClanGenOfficial/clangen/pull/5064)

## Proof of Testing
Turned Hollyhockhop into the ultimate hater to test each event. Here are a selection of my favorites.
<img width="511" height="69" alt="Screenshot 2026-06-03 at 11 21 58 PM" src="https://github.com/user-attachments/assets/8c184474-977a-40f5-bb1f-19b8ca995dd5" />
<img width="509" height="98" alt="Screenshot 2026-06-03 at 11 24 20 PM" src="https://github.com/user-attachments/assets/2bd44651-1ad3-4510-bb05-edfa7fbbf30a" />
<img width="517" height="99" alt="Screenshot 2026-06-03 at 11 25 34 PM" src="https://github.com/user-attachments/assets/7b3d6b59-2549-4ced-a578-34814283bd76" />
<img width="514" height="75" alt="Screenshot 2026-06-03 at 11 25 53 PM" src="https://github.com/user-attachments/assets/a50eddce-2ab2-430c-aba1-8ca7e3e71c99" />
<img width="512" height="175" alt="Screenshot 2026-06-03 at 11 26 24 PM" src="https://github.com/user-attachments/assets/3130c330-891c-4733-8132-adf0d4c1c5d4" />
<img width="513" height="101" alt="Screenshot 2026-06-03 at 11 27 11 PM" src="https://github.com/user-attachments/assets/ce24dbee-d31c-4e67-bf8f-2649cb6b6571" />
<img width="517" height="100" alt="Screenshot 2026-06-03 at 11 29 15 PM" src="https://github.com/user-attachments/assets/0ac4d9ed-e7ed-4a92-9ca5-fdc16331f76c" />
