### PR TITLE
[BUGFIX] event container gap removed

### DIFF
--- a/scripts/screens/EventsScreen.py
+++ b/scripts/screens/EventsScreen.py
@@ -526,7 +526,7 @@ class EventsScreen(Screens):
         rect = pygame.Rect(
             ui_scale_offset((211, 275)),
             (
-                self.events_frame.rect[2] + ui_scale_value(13),
+                self.events_frame.rect[2] + ui_scale_value(13) +1, # Removes 1 Pixel gap towards the right frame
                 self.events_frame.rect[3] - ui_scale_value(19),
             ),
         )


### PR DESCRIPTION
## About The Pull Request

no more gap between the right side of the frame and the events inside the "Events" Tab, listing of all the events in the scrolling container

## Linked Issues

I just brought up the tiny fix i found and was encouraged to open a pr!
https://discord.com/channels/1003759225522110524/1003759339359699054/1517571936031477860

## Proof of Testing

Prior
<img width="585" height="247" alt="image" src="https://github.com/user-attachments/assets/6543ec1e-0ae9-41a9-a933-db5c66ca9286" />

Fixed
<img width="573" height="263" alt="image" src="https://github.com/user-attachments/assets/a79347fc-04c6-4a84-a9c7-e592ccc3b54e" />

## Changelog/Credits

I don't think i need to be credited for that?
