### PR TITLE
[BUGFIX] dropdown xpos assignment

### DIFF
--- a/scripts/ui/elements/dropdown.py
+++ b/scripts/ui/elements/dropdown.py
@@ -78,9 +78,7 @@ class UIDropDown(UIDropDownContainer):
             open_on_hover=open_on_hover,
         )
 
-        rect = pygame.Rect(
-            (relative_rect.x, 0), (relative_rect.width, relative_rect.height)
-        )
+        rect = pygame.Rect((0, 0), (relative_rect.width, relative_rect.height))
 
         # create parent button
         if not parent_override:
@@ -98,9 +96,9 @@ class UIDropDown(UIDropDownContainer):
             self.parent_button.set_container(self)
 
         if center_children:
-            x_pos = -int(child_dimensions[0] / 2 - relative_rect.width / 2)
+            x_pos = -int(child_dimensions[0] / 2 - rect.width / 2)
         else:
-            x_pos = relative_rect.x
+            x_pos = rect.x
         dropdown_rect = ((x_pos, 0), (0, 0))
 
         self.child_button_container = UIAutoResizingContainer(


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
Buggy behavior with the dropdowns was brought to my attention.  Essentially we were applying the x positioning to both the base container and all of the contained elements, resulting in inconsistent positioning when applying an x pos over 0.  This hadn't been noticed before simply because we haven't utilized any dropdowns with an x pos over 0.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Proof of Testing
<img width="440" height="171" alt="image" src="https://github.com/user-attachments/assets/b8f70bff-ef54-4d1b-adee-a12c2211263f" />

test dropdown to check if it worked as expected.  This dropdown has an x pos over 0, so if the problem still persisted then it would be very obvious.

<img width="394" height="224" alt="image" src="https://github.com/user-attachments/assets/9cb40eee-1255-46c2-8c88-7301a26f186d" />

other dropdown still works fine
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Fixed inconsistent behavior in dropdown positioning when utilizing x positions over 0
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
