### PR TITLE
[CRASHFIX] Clan names

### DIFF
--- a/resources/lang/en/screens/switch_clan.en.json
+++ b/resources/lang/en/screens/switch_clan.en.json
@@ -2,7 +2,7 @@
     "en": {
         "current_clan": {
             "zero": "There is no Clan currently loaded.",
-            "one": "The currently loaded Clan is %{clan}Clan\n(id: %{clan_id})."
+            "one": "The currently loaded Clan is %{clan}\n(id: %{clan_id})."
         }
     }
 }

--- a/scripts/clan.py
+++ b/scripts/clan.py
@@ -173,11 +173,11 @@ class Clan:
 
     @property
     def name(self):
-        return i18n.t("general.clan", name=self._name)
+        return i18n.t("general.clan", name=self.prefix)
 
     @name.setter
     def name(self, value):
-        self._name = value
+        self.prefix = value
 
     # The clan couldn't save itself in time due to issues arising, for example, from this function: "if deputy is not
     # None: self.deputy.status_change('deputy') -> game.clan.remove_med_cat(self)"
@@ -424,7 +424,7 @@ class Clan:
 
         clan_data = {
             "save_id": self.save_id,
-            "displayname": self._name,
+            "displayname": self.prefix,
             "clanage": self.age,
             "biome": self.biome,
             "camp_bg": self.camp_bg,

--- a/scripts/clan.py
+++ b/scripts/clan.py
@@ -424,7 +424,7 @@ class Clan:
 
         clan_data = {
             "save_id": self.save_id,
-            "displayname": self.name,
+            "displayname": self._name,
             "clanage": self.age,
             "biome": self.biome,
             "camp_bg": self.camp_bg,
@@ -856,7 +856,7 @@ class Clan:
                     ID = other_clan["group_ID"]
                 game.clan.all_other_clans.append(
                     OtherClan(
-                        name=other_clan["name"],
+                        name=other_clan.get("prefix", other_clan.get("name")),
                         relations=int(other_clan["relations"]),
                         temperament=other_clan["temperament"],
                         chosen_symbol=other_clan["chosen_symbol"],
@@ -1424,11 +1424,11 @@ class OtherClan:
 
     @property
     def name(self):
-        return i18n.t("general.clan", name=self._name)
+        return i18n.t("general.clan", name=self.prefix)
 
     @name.setter
     def name(self, value):
-        self._name = value
+        self.prefix = value
 
     def __repr__(self):
         # has indicators that this is unlocalized, just in case


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
- There was a localized string still including "Clan", so I fixed that.
- Clan display names were being saved with the "Clan" appended instead of saving just the prefix. Fixed this by changing the save to pull `self.prefix`.  `self.prefix` is the same thing as `self._name`, I've just renamed it to make it more clear what exactly it is and how it differs from `self.name`.
- Now for the actual problems causing saves to crash:
  - Other clans were being saved with `"_name"` as a key due to how the save function pulls other clan info.  I've made the same change here as for the player clan save, the `self._name` attr is now called `self.prefix` for clarity.
  - To fix the crash I've updated the loading func to check for `"prefix"` first, then `"name"` to catch any older saves.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
fixes #5336
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
<img width="792" height="697" alt="image" src="https://github.com/user-attachments/assets/31446ec7-e623-4409-8211-890b19cab836" />

One of the affected Clans, it now loads without crashing.

<img width="797" height="695" alt="image" src="https://github.com/user-attachments/assets/fcae6ccc-79e4-4472-b280-c1998db140bc" />

An older Clan that also loads without issue to demonstrate that older saves still load properly.
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Fixed a localized string that still manually appended "Clan"
- Clan display names were being saved with the "Clan" appended instead of saving just the prefix. Fixed this by changing the save to pull `self.prefix`.  `self.prefix` is the same thing as `self._name`, I've just renamed it to make it more clear what exactly it is and how it differs from `self.name`.
- Now for the actual problems causing saves to crash:
  - Other clans were being saved with `"_name"` as a key due to how the save function pulls other clan info.  I've made the same change here as for the player clan save, the `self._name` attr is now called `self.prefix` for clarity.
  - To fix the crash I've updated the loading func to check for `"prefix"` first, then `"name"` to catch any older saves.
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
