### PR TITLE
[BUGFIX] other clan prefix assignment

### DIFF
--- a/scripts/clan.py
+++ b/scripts/clan.py
@@ -1375,7 +1375,7 @@ class OtherClan:
         game.clan.other_clan_IDs.append(self.group_ID)
 
         self.name = name
-        if not self.name:  # find name if clan has no name yet
+        if not self.prefix:  # find name if clan has no name yet
             used_names = [str(i.name) for i in game.clan.all_other_clans] + [
                 game.clan.name
             ]


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
ahahahaha turns out name assignment was also broken for other clans. gonna scream.

easy fix at least
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Proof of Testing
<img width="794" height="695" alt="image" src="https://github.com/user-attachments/assets/3ccf9a7f-a82a-42f6-960a-d960e4d81bb0" />

created a new clan, previously all the other clans would have just been named "Clan" with no prefix. now they're created correctly!
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Fixed other clans generating with no name
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
