### PR TITLE
[BUGFIX] name property shenanigans again

### DIFF
--- a/scripts/clan_package/clan_symbols.py
+++ b/scripts/clan_package/clan_symbols.py
@@ -14,7 +14,7 @@ def clan_symbol_sprite(clan, return_string=False, force_light=False):
         possible_sprites = []
         for sprite in sprites.clan_symbols:
             name = sprite.strip("1234567890")
-            if f"symbol{clan.name.upper()}" == name:
+            if f"symbol{clan.prefix.upper()}" == name:
                 possible_sprites.append(sprite)
         if possible_sprites:
             clan.chosen_symbol = choice(possible_sprites)

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -1203,7 +1203,7 @@ def check_war():
             ):
                 enemy_clan = other_clan
                 game.clan.war["at_war"] = True
-                game.clan.war["enemy"] = other_clan.name
+                game.clan.war["enemy"] = other_clan.prefix
                 war_events = WAR_TXT["trigger_events"]
                 switch_set_value(Switch.war_rel_change_type, "rel_down")
 

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -1155,7 +1155,7 @@ def check_war():
     if game.clan.war["at_war"]:
         # Grab the enemy clan object
         for other_clan in game.clan.all_other_clans:
-            if other_clan.name == game.clan.war["enemy"]:
+            if other_clan.prefix == game.clan.war["enemy"]:
                 enemy_clan = other_clan
                 break
 

--- a/scripts/screens/ProfileScreen.py
+++ b/scripts/screens/ProfileScreen.py
@@ -1358,7 +1358,7 @@ class ProfileScreen(Screens):
             and self.the_cat != game.clan.instructor
         ):
             clan = [
-                clan
+                clan.name
                 for clan in game.clan.all_other_clans
                 if clan.group_ID == self.the_cat.status.get_last_living_group()
             ]

--- a/scripts/screens/WarriorDenScreen.py
+++ b/scripts/screens/WarriorDenScreen.py
@@ -308,9 +308,7 @@ class WarriorDenScreen(Screens):
         if self.original_focus_code in self.other_clan_settings:
             desc = i18n.t(
                 "screens.warrior_den.involved_clans",
-                clans=adjust_list_text(
-                    [f"{clan}clan" for clan in game.clan.clans_in_focus]
-                ),
+                clans=adjust_list_text(game.clan.clans_in_focus),
             )
         last_change_text = ""
         next_change = ""

--- a/scripts/ui/windows/select_focus_clans.py
+++ b/scripts/ui/windows/select_focus_clans.py
@@ -40,7 +40,7 @@ class SelectFocusClansWindow(GameWindow):
         n = 0
         for clan in game.clan.all_other_clans:
             self.texts[clan.name] = pygame_gui.elements.UITextBox(
-                clan.name + "clan",
+                clan.name,
                 ui_scale(pygame.Rect(107, n * 27 + 38, -1, 25)),
                 object_id="#text_box_30_horizleft_pad_0_8",
                 container=self,


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
Fixed a variety of name property issues. 
- Fixed weird name display in other clan cat histories
- Change symbol search to check `prefix` instead of `name`
- Fixed enemy clans to save their `prefix` instead of `name`
- Fixed variety of displays relating to other clans and warrior focus. There was some weird hardcoded text in these that was causing the issue.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
fixes #5352
fixes #5355
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
<img width="316" height="259" alt="image" src="https://github.com/user-attachments/assets/5122c97e-d9cd-4bc7-b9df-7631e28b0543" />
<img width="330" height="130" alt="image" src="https://github.com/user-attachments/assets/4891c190-d30c-40b7-a8cc-c9d26a7a08d3" />
<img width="233" height="61" alt="image" src="https://github.com/user-attachments/assets/3f216e43-4fc2-4f9c-8b4f-2764be893346" />

<img width="141" height="212" alt="image" src="https://github.com/user-attachments/assets/d44495c0-1c56-4f57-80a7-46a861dcb5ca" />

(new save, it found a matching symbol just fine for this other clan)

<img width="205" height="124" alt="image" src="https://github.com/user-attachments/assets/62f42015-e690-4816-bec8-cd0aab8955d5" />

war saving correctly
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Fixed weird name display in other clan cat histories
- Change symbol search to check `prefix` instead of `name`
- Fixed enemy clans to save their `prefix` instead of `name`
- Fixed variety of displays relating to other clans and warrior focus. There was some weird hardcoded text in these that was causing the issue.
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
