### PR TITLE
[DEV] Auto label PRs based on changed files

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,9 @@
+"PR:code":
+  - changed-files:
+    - any-glob-to-any-file: "**/*.py"
+"PR:writing":
+  - changed-files:
+    - any-glob-to-any-file: "**/*.json"
+"PR:art":
+  - changed-files:
+    - any-glob-to-any-file: "**/*.png"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,15 @@
+name: "Pull Request Labeler"
+on:
+  - pull_request_target
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - name: "Automatically label PR based on changed files"
+      uses: actions/labeler@v6
+      with:
+        sync-labels: true


### PR DESCRIPTION
## About The Pull Request

Auto labels PRs based on changed files. Might not be right 100% of the time since it's just working off of file type, but it takes a slight load off of Senior Devs for labelling the PR type.

## Why This Is Good For ClanGen

* More convenient for maintainers
