### PR TITLE
[BALANCE] remove passive buff

### DIFF
--- a/resources/game_config.toml
+++ b/resources/game_config.toml
@@ -22,9 +22,6 @@ dev_tools = false
   # sets the positive or negative effect that interactions will have on other cats based on personality compatibility
   compatibility_effect = 5
 
-  # Adds a passive buff to relationship events. We divide the value change by passive_influence_div and apply it to all other relationship values.
-  passive_influence_div = 3
-
   # base 1/chance of a romance interaction with another cat, when a cat has a mate
   chance_romance_not_mate = 15
 

--- a/scripts/events_module/relationship/generate_pair_event.py
+++ b/scripts/events_module/relationship/generate_pair_event.py
@@ -391,36 +391,11 @@ def _apply_base_influence(
         intensity=intensity,
         relationship=relationship,
     )
-    # only high intensity gives passive buffs
-    if intensity == "high":
-        passive_buff = int(amount / get_config("relationship.passive_influence_div"))
-        # just adding a teeny bit of variety
-        buffs = [passive_buff - 1, passive_buff, passive_buff + 1]
-        # the passive buff creates a cascade effect
-        # so a negative interaction will affect all values to a negative degree
-        # and a positive interaction will affect all values to a positive degree
-
-        if type_of_interaction == RelType.ROMANCE:
-            relationship.romance += amount
-
-        for rel_out in (
-            RelType.LIKE,
-            RelType.RESPECT,
-            RelType.TRUST,
-            RelType.COMFORT,
-        ):
-            setattr(
-                relationship,
-                rel_out,
-                getattr(relationship, rel_out)
-                + (choice(buffs) if type_of_interaction != rel_out else amount),
-            )
-    else:
-        setattr(
-            relationship,
-            type_of_interaction,
-            getattr(relationship, type_of_interaction) + amount,
-        )
+    setattr(
+        relationship,
+        type_of_interaction,
+        getattr(relationship, type_of_interaction) + amount,
+    )
 
     relationship.log.append(
         i18n.t(


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
Removes the passive influence that relationship events could apply to all rel values.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Why This Is Good For ClanGen
Twas discussed in the discord that this might be a factor in how often cat relationships end up being one note.
<!-- If this is a bug fix, you can remove this section. -->
<!-- Please add a short description of why you think these changes would benefit the game. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->
<!-- If you have multiple features that can stand on their own, or unrelated bugfixes, please create separate PRs for them. -->

## Proof of Testing
<img width="552" height="368" alt="image" src="https://github.com/user-attachments/assets/3c67fdd8-85d3-422e-aed7-27de6f5d60db" />

rel events still work!
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Removes the passive influence that relationship events could apply to all rel values.
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
