### PR TITLE
[DEV] Label PRs being opened against stable

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -7,3 +7,5 @@
 "PR:art":
   - changed-files:
     - any-glob-to-any-file: "**/*.png"
+"target:stable":
+  - base-branch: "^release"


### PR DESCRIPTION
## About The Pull Request

PRs being opened against stable `release` branches will automatically be labeled with  `target:stable`.

## Why This Is Good For ClanGen

It's helpful knowing if a PR is being opened against stable or dev at a glance.
