### PR TITLE
[BUGFIX] tadpole patrol typo

### DIFF
--- a/resources/lang/en/patrols/general/training.json
+++ b/resources/lang/en/patrols/general/training.json
@@ -22034,7 +22034,7 @@
     "patrol_id": "gen_train_newleaf_tadpole",
     "biome": ["-desert"],
     "season": ["newleaf"],
-    "types": ["hunting"],
+    "types": ["training"],
     "tags": [],
     "patrol_art": "train_general_intro",
     "min_cats": 2,


### PR DESCRIPTION
## About The Pull Request

- Was incorrectly tagged as a hunting patrol despite being a training patrol in a training file, thus likely causing the patrol to not generate. 

## Why This Is Good For ClanGen

- Lets the patrol generate

## Proof of Testing

- Game runs smoothly, patrol generates with the patrol ID game config tool, should hopefully generate organically now too. 