### PR TITLE
[BUGFIX] clearing possible_cats on clan creation

### DIFF
--- a/scripts/screens/make_clan_screens/MakeClanScreenBase.py
+++ b/scripts/screens/make_clan_screens/MakeClanScreenBase.py
@@ -245,6 +245,8 @@ class MakeClanScreenBase(Screens):
         Cat.sort_cats()
         rebuild_top_menu_buttons()
 
+        switch_set_value(Switch.possible_cats, [])
+
     def random_biome_selection(self):
         # Select a random biome and background
         possible_biomes = ["Forest", "Mountainous", "Plains", "Beach"]


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
`Switch.possible_members` just needed to be cleared after the clan was saved.  Since they weren't being cleared, if you created a clan and then tried to make *another* clan without first closing the game, the cats you had to pick from were all the same cats from that first clan.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Proof of Testing
<img width="654" height="198" alt="image" src="https://github.com/user-attachments/assets/a3a2f3af-291e-4761-855f-4ff05c0f726e" />

created a new clan, these are the members

<img width="194" height="351" alt="image" src="https://github.com/user-attachments/assets/09f485d3-1835-43dd-9edf-fd5861ef38c0" />

when to make a new clan, you can see that the cats available to choose are all different from the ones chosen for that first clan, which is what we want!
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Fixed a bug where the cats available when creating another new Clan immediately after creating an initial one could result in the cats duplicating
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
