### PR TITLE
[ENHANCE] Specify points of interest by category

### DIFF
--- a/docs/dev/writing/points-of-interest.md
+++ b/docs/dev/writing/points-of-interest.md
@@ -92,26 +92,28 @@ Points of Interests can use many different tags that denote circumstances around
 
 Patrols and Short Events now have an additional constraint that can be utilized to include either a specific Point of Interest ID or tag. 
 
-You can add this to any short event or patrol to constrain by Point of Interest. However, remember to constrain either via names or by a single tag, but not by both at once.
+You can add this to any short event or patrol to constrain by Point of Interest. However, remember to constrain either via names or by category or by a single tag, but not by multiple at once.
 
 ~~~
 "poi": {
     "name": ["name"]
     "tags": ["tag"]
+    "category": "moonplace"
     }
 ~~~
 
 ## Using the Point Of Interest in a Sentence
 
-Using a system similar to pronoun tags, Points of Interests can be mentioned in Short Events or Patrols with {POI} followed by relevant information; either the Points of Interest's IDs, or tags for a pool of Points of Interest.
+Using a system similar to pronoun tags, Points of Interests can be mentioned in Short Events or Patrols with {POI} followed by relevant information; either the Points of Interest's IDs, or tags or category for pools of points of Interest.
 
-A Point of Interest can either contain multiple names, separated by commas OR a single tag. Multiple tags cannot be used, nor should you mix tags and names.
+A Point of Interest can either contain multiple names, separated by commas OR a single tag OR a single category. Multiple tags or categories cannot be used, nor should you mix tags, names, or categories.
 
 A few examples below:
 
 ~~~
 {POI/name/moon_pool,moon_cave,gather_monster}
 {POI/tag/prey:fish}
+{POI/category/moonplace}
 ~~~
 
 Using one in a sentence should appear like this in the event itself versus the displayed result:

--- a/docs/dev/writing/points-of-interest.md
+++ b/docs/dev/writing/points-of-interest.md
@@ -104,7 +104,7 @@ You can add this to any short event or patrol to constrain by Point of Interest.
 
 ## Using the Point Of Interest in a Sentence
 
-Using a system similar to pronoun tags, Points of Interests can be mentioned in Short Events or Patrols with {POI} followed by relevant information; either the Points of Interest's IDs, or tags or category for pools of points of Interest.
+Using a system similar to pronoun tags, Points of Interest can be mentioned in Short Events or Patrols with {POI} followed by relevant information: either the Points of Interest's IDs or (for a pool of Points of Interest) category or tags.
 
 A Point of Interest can either contain multiple names, separated by commas OR a single tag OR a single category. Multiple tags or categories cannot be used, nor should you mix tags, names, or categories.
 

--- a/docs/dev/writing/points-of-interest.md
+++ b/docs/dev/writing/points-of-interest.md
@@ -106,7 +106,7 @@ You can add this to any short event or patrol to constrain by Point of Interest.
 
 Using a system similar to pronoun tags, Points of Interest can be mentioned in Short Events or Patrols with {POI} followed by relevant information: either the Points of Interest's IDs or (for a pool of Points of Interest) category or tags.
 
-A Point of Interest can either contain multiple names, separated by commas OR a single tag OR a single category. Multiple tags or categories cannot be used, nor should you mix tags, names, or categories.
+A Point of Interest can either contain multiple names separated by commas OR a single tag OR a single category. Multiple tags or categories cannot be used, nor should you mix tags, names, or categories.
 
 A few examples below:
 

--- a/resources/lang/en/events/misc/_debug.json
+++ b/resources/lang/en/events/misc/_debug.json
@@ -81,7 +81,7 @@
             "category": "gathering"
         },
         "frequency": 0,
-        "event_text": "visited moonplace - {POI/category/moonplace}"
+        "event_text": "visited gathering place - {POI/category/gathering}"
     },
     {
         "event_id": "debug_misc_poi_terrain",
@@ -95,6 +95,6 @@
             "category": "terrain"
         },
         "frequency": 0,
-        "event_text": "visited moonplace - {POI/category/moonplace}"
+        "event_text": "visited some random terrain - {POI/category/terrain}"
     }
 ]

--- a/resources/lang/en/events/misc/_debug.json
+++ b/resources/lang/en/events/misc/_debug.json
@@ -54,5 +54,47 @@
         },
         "frequency": 0,
         "event_text": "DEBUG: visited 'prey:fish' POI"
+    },
+    {
+        "event_id": "debug_misc_poi_moonplace",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "poi": {
+            "category": "moonplace"
+        },
+        "frequency": 0,
+        "event_text": "visited moonplace - {POI/category/moonplace}"
+    },
+    {
+        "event_id": "debug_misc_poi_gathering",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "poi": {
+            "category": "gathering"
+        },
+        "frequency": 0,
+        "event_text": "visited moonplace - {POI/category/moonplace}"
+    },
+    {
+        "event_id": "debug_misc_poi_terrain",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "poi": {
+            "category": "terrain"
+        },
+        "frequency": 0,
+        "event_text": "visited moonplace - {POI/category/moonplace}"
     }
 ]

--- a/schemas/patrol.schema.json
+++ b/schemas/patrol.schema.json
@@ -402,7 +402,8 @@
         "goldenrod",
         "poppy",
         "plantain",
-        "catmint"
+        "catmint",
+        "honey"
       ],
       "title": "Herb",
       "type": "string"
@@ -1143,6 +1144,15 @@
       "title": "PermCondition",
       "type": "string"
     },
+    "PointsOfInterestCategoryEnum": {
+      "enum": [
+        "gathering",
+        "moonplace",
+        "terrain"
+      ],
+      "title": "PointsOfInterestCategoryEnum",
+      "type": "string"
+    },
     "PointsOfInterestGroup": {
       "anyOf": [
         {
@@ -1150,10 +1160,28 @@
         },
         {
           "$ref": "#/$defs/PointsOfInterestGroupByTags"
+        },
+        {
+          "$ref": "#/$defs/PointsOfInterestGroupByCategory"
         }
       ],
       "description": "Specifies Points of Interest constraints. Must use EITHER names or tags.",
       "title": "PointsOfInterestGroup"
+    },
+    "PointsOfInterestGroupByCategory": {
+      "additionalProperties": false,
+      "properties": {
+        "category": {
+          "$ref": "#/$defs/PointsOfInterestCategoryEnum",
+          "description": "The category this POI belongs to.",
+          "title": "Category"
+        }
+      },
+      "required": [
+        "category"
+      ],
+      "title": "PointsOfInterestGroupByCategory",
+      "type": "object"
     },
     "PointsOfInterestGroupByName": {
       "additionalProperties": false,

--- a/schemas/patrol.schema.json
+++ b/schemas/patrol.schema.json
@@ -1165,7 +1165,7 @@
           "$ref": "#/$defs/PointsOfInterestGroupByCategory"
         }
       ],
-      "description": "Specifies Points of Interest constraints. Must use EITHER names or tags.",
+      "description": "Specifies Points of Interest constraints. Must use names OR tags OR category (not multiple at once).",
       "title": "PointsOfInterestGroup"
     },
     "PointsOfInterestGroupByCategory": {

--- a/schemas/shortevent.schema.json
+++ b/schemas/shortevent.schema.json
@@ -997,7 +997,7 @@
           "$ref": "#/$defs/PointsOfInterestGroupByCategory"
         }
       ],
-      "description": "Specifies Points of Interest constraints. Must use EITHER names or tags.",
+      "description": "Specifies Points of Interest constraints. Must use names OR tags OR category (not multiple at once).",
       "title": "PointsOfInterestGroup"
     },
     "PointsOfInterestGroupByCategory": {

--- a/schemas/shortevent.schema.json
+++ b/schemas/shortevent.schema.json
@@ -550,7 +550,8 @@
         "goldenrod",
         "poppy",
         "plantain",
-        "catmint"
+        "catmint",
+        "honey"
       ],
       "title": "Herb",
       "type": "string"
@@ -975,6 +976,15 @@
       "title": "OutsiderRep",
       "type": "string"
     },
+    "PointsOfInterestCategoryEnum": {
+      "enum": [
+        "gathering",
+        "moonplace",
+        "terrain"
+      ],
+      "title": "PointsOfInterestCategoryEnum",
+      "type": "string"
+    },
     "PointsOfInterestGroup": {
       "anyOf": [
         {
@@ -982,10 +992,28 @@
         },
         {
           "$ref": "#/$defs/PointsOfInterestGroupByTags"
+        },
+        {
+          "$ref": "#/$defs/PointsOfInterestGroupByCategory"
         }
       ],
       "description": "Specifies Points of Interest constraints. Must use EITHER names or tags.",
       "title": "PointsOfInterestGroup"
+    },
+    "PointsOfInterestGroupByCategory": {
+      "additionalProperties": false,
+      "properties": {
+        "category": {
+          "$ref": "#/$defs/PointsOfInterestCategoryEnum",
+          "description": "The category this POI belongs to.",
+          "title": "Category"
+        }
+      },
+      "required": [
+        "category"
+      ],
+      "title": "PointsOfInterestGroupByCategory",
+      "type": "object"
     },
     "PointsOfInterestGroupByName": {
       "additionalProperties": false,

--- a/scripts/clan_resources/point_of_interest.py
+++ b/scripts/clan_resources/point_of_interest.py
@@ -69,11 +69,12 @@ def add_poi(name, elements):
         else:
             _poi_by_tags[tag] = [name]
 
-    if name.startswith("gather_"):
+    category = elements["category"]
+    if category == "gathering":
         _poi_by_category["gathering"].add(name)
-    elif name.startswith("moon_"):
+    elif category == "moonplace":
         _poi_by_category["moonplace"].add(name)
-    elif name.startswith("terrain_"):
+    elif category == "terrain":
         _poi_by_category["terrain"].add(name)
 
 

--- a/scripts/clan_resources/point_of_interest.py
+++ b/scripts/clan_resources/point_of_interest.py
@@ -77,13 +77,7 @@ def add_poi(name, elements):
         else:
             _poi_by_tags[tag] = [name]
 
-    category = elements["category"]
-    if category == "gathering":
-        _poi_by_category["gathering"].add(name)
-    elif category == "moonplace":
-        _poi_by_category["moonplace"].add(name)
-    elif category == "terrain":
-        _poi_by_category["terrain"].add(name)
+    _poi_by_category[elements["category"]].add(name)
 
 
 def get_poi_save_dict():

--- a/scripts/clan_resources/point_of_interest.py
+++ b/scripts/clan_resources/point_of_interest.py
@@ -82,9 +82,7 @@ def add_poi(name, elements):
 
 def get_poi_save_dict():
     return {
-        "gathering": get_pois_by_category("gathering"),
-        "moonplace": get_pois_by_category("moonplace"),
-        "terrain": get_pois_by_category("terrain"),
+        k: get_pois_by_category(k) for k in ["gathering", "moonplace", "terrain"]
     }
 
 

--- a/scripts/clan_resources/point_of_interest.py
+++ b/scripts/clan_resources/point_of_interest.py
@@ -85,9 +85,7 @@ def add_poi(name, elements):
 
 
 def get_poi_save_dict():
-    return {
-        k: get_pois_by_category(k) for k in ["gathering", "moonplace", "terrain"]
-    }
+    return {k: get_pois_by_category(k) for k in ["gathering", "moonplace", "terrain"]}
 
 
 def load_pois(save_data: Dict[str, List[str]]):

--- a/scripts/clan_resources/point_of_interest.py
+++ b/scripts/clan_resources/point_of_interest.py
@@ -51,6 +51,10 @@ def get_random_poi_by_tag(tag):
     return choice(_poi_by_tags.get(tag, ["MISSING_POI"]))
 
 
+def get_random_poi_by_category(category: Literal["gathering", "moonplace", "terrain"]):
+    return choice(get_pois_by_category(category))
+
+
 def add_poi(name, elements):
     """
     Add a new POI to the Clan
@@ -84,10 +88,6 @@ def get_poi_save_dict():
         "moonplace": get_pois_by_category("moonplace"),
         "terrain": get_pois_by_category("terrain"),
     }
-
-
-def get_random_poi_by_category(category: Literal["gathering", "moonplace", "terrain"]):
-    return choice(get_pois_by_category(category))
 
 
 def load_pois(save_data: Dict[str, List[str]]):

--- a/scripts/clan_resources/point_of_interest.py
+++ b/scripts/clan_resources/point_of_interest.py
@@ -8,6 +8,11 @@ _poi_names = set()
 _poi_tags = set()
 
 _poi_by_tags = {}
+_poi_by_category = {
+    "gathering": set(),
+    "moonplace": set(),
+    "terrain": set(),
+}
 
 _undiscovered_poi_remaining = 3
 
@@ -52,6 +57,12 @@ def add_poi(name, elements):
     _poi_names.update([name])
     _poi_tags.update(elements["tags"])
     _poi_tags.update(tag.split(":", 1)[0] for tag in elements["tags"] if ":" in tag)
+    if name.startswith("gather_"):
+        _poi_by_category["gathering"].add(name)
+    elif name.startswith("moon_"):
+        _poi_by_category["gathering"].add(name)
+    elif name.startswith("terrain_"):
+        _poi_by_category["terrain"].add(name)
 
     global _poi_by_tags
     for tag in elements["tags"]:
@@ -70,13 +81,7 @@ def get_poi_save_dict():
 
 
 def get_poi_by_category(category: Literal["gathering", "moonplace", "terrain"]):
-    if category == "gathering":
-        return [name for name in _poi_names if name.startswith("gather_")]
-    elif category == "moonplace":
-        return [name for name in _poi_names if name.startswith("moon_")]
-    elif category == "terrain":
-        return [name for name in _poi_names if name.startswith("terrain_")]
-    raise Exception("Tried to get POI from a category that doesn't exist!")
+    return list(_poi_by_category[category])
 
 
 def get_random_poi_by_category(category: Literal["gathering", "moonplace", "terrain"]):

--- a/scripts/clan_resources/point_of_interest.py
+++ b/scripts/clan_resources/point_of_interest.py
@@ -26,6 +26,10 @@ class PoiType(StrEnum):
     TERRAIN = "terrain"
 
 
+def get_poi_by_category(category: Literal["gathering", "moonplace", "terrain"]):
+    return list(_poi_by_category[category])
+
+
 def get_poi_names_set():
     return _poi_names
 
@@ -57,12 +61,6 @@ def add_poi(name, elements):
     _poi_names.update([name])
     _poi_tags.update(elements["tags"])
     _poi_tags.update(tag.split(":", 1)[0] for tag in elements["tags"] if ":" in tag)
-    if name.startswith("gather_"):
-        _poi_by_category["gathering"].add(name)
-    elif name.startswith("moon_"):
-        _poi_by_category["gathering"].add(name)
-    elif name.startswith("terrain_"):
-        _poi_by_category["terrain"].add(name)
 
     global _poi_by_tags
     for tag in elements["tags"]:
@@ -71,6 +69,13 @@ def add_poi(name, elements):
         else:
             _poi_by_tags[tag] = [name]
 
+    if name.startswith("gather_"):
+        _poi_by_category["gathering"].add(name)
+    elif name.startswith("moon_"):
+        _poi_by_category["gathering"].add(name)
+    elif name.startswith("terrain_"):
+        _poi_by_category["terrain"].add(name)
+
 
 def get_poi_save_dict():
     return {
@@ -78,10 +83,6 @@ def get_poi_save_dict():
         "moonplace": get_poi_by_category("moonplace"),
         "terrain": get_poi_by_category("terrain"),
     }
-
-
-def get_poi_by_category(category: Literal["gathering", "moonplace", "terrain"]):
-    return list(_poi_by_category[category])
 
 
 def get_random_poi_by_category(category: Literal["gathering", "moonplace", "terrain"]):

--- a/scripts/clan_resources/point_of_interest.py
+++ b/scripts/clan_resources/point_of_interest.py
@@ -52,7 +52,11 @@ def get_random_poi_by_tag(tag):
 
 
 def get_random_poi_by_category(category: Literal["gathering", "moonplace", "terrain"]):
-    return choice(get_pois_by_category(category))
+    possible_pois = get_pois_by_category(category)
+    if possible_pois:
+        return choice(possible_pois)
+    # sometimes there are no possible pois during tests
+    return "MISSING_POI"
 
 
 def add_poi(name, elements):

--- a/scripts/clan_resources/point_of_interest.py
+++ b/scripts/clan_resources/point_of_interest.py
@@ -79,6 +79,10 @@ def get_poi_by_category(category: Literal["gathering", "moonplace", "terrain"]):
     raise Exception("Tried to get POI from a category that doesn't exist!")
 
 
+def get_random_poi_by_category(category: Literal["gathering", "moonplace", "terrain"]):
+    return choice(get_poi_by_category(category))
+
+
 def load_pois(save_data: Dict[str, List[str]]):
     for category, data in save_data.items():
         for poi in data:

--- a/scripts/clan_resources/point_of_interest.py
+++ b/scripts/clan_resources/point_of_interest.py
@@ -56,7 +56,7 @@ def get_random_poi_by_category(category: Literal["gathering", "moonplace", "terr
     if possible_pois:
         return choice(possible_pois)
     # sometimes there are no possible pois during tests
-    return "MISSING_POI"
+    return f"MISSING_POI (requested category: {category})"
 
 
 def add_poi(name, elements):

--- a/scripts/clan_resources/point_of_interest.py
+++ b/scripts/clan_resources/point_of_interest.py
@@ -72,7 +72,7 @@ def add_poi(name, elements):
     if name.startswith("gather_"):
         _poi_by_category["gathering"].add(name)
     elif name.startswith("moon_"):
-        _poi_by_category["gathering"].add(name)
+        _poi_by_category["moonplace"].add(name)
     elif name.startswith("terrain_"):
         _poi_by_category["terrain"].add(name)
 

--- a/scripts/clan_resources/point_of_interest.py
+++ b/scripts/clan_resources/point_of_interest.py
@@ -26,7 +26,7 @@ class PoiType(StrEnum):
     TERRAIN = "terrain"
 
 
-def get_poi_by_category(category: Literal["gathering", "moonplace", "terrain"]):
+def get_pois_by_category(category: Literal["gathering", "moonplace", "terrain"]):
     return list(_poi_by_category[category])
 
 
@@ -79,14 +79,14 @@ def add_poi(name, elements):
 
 def get_poi_save_dict():
     return {
-        "gathering": get_poi_by_category("gathering"),
-        "moonplace": get_poi_by_category("moonplace"),
-        "terrain": get_poi_by_category("terrain"),
+        "gathering": get_pois_by_category("gathering"),
+        "moonplace": get_pois_by_category("moonplace"),
+        "terrain": get_pois_by_category("terrain"),
     }
 
 
 def get_random_poi_by_category(category: Literal["gathering", "moonplace", "terrain"]):
-    return choice(get_poi_by_category(category))
+    return choice(get_pois_by_category(category))
 
 
 def load_pois(save_data: Dict[str, List[str]]):

--- a/scripts/clan_resources/point_of_interest.py
+++ b/scripts/clan_resources/point_of_interest.py
@@ -42,6 +42,10 @@ def get_poi_tags_set():
     return _poi_tags
 
 
+def get_poi_categories_set():
+    return set(_poi_by_category.keys())
+
+
 def get_random_poi_by_tag(tag):
     """
     Return a random POI name that fits the requested tag/s.

--- a/scripts/clan_resources/point_of_interest.py
+++ b/scripts/clan_resources/point_of_interest.py
@@ -56,11 +56,11 @@ def get_random_poi_by_tag(tag):
 
 
 def get_random_poi_by_category(category: Literal["gathering", "moonplace", "terrain"]):
-    possible_pois = get_pois_by_category(category)
-    if possible_pois:
-        return choice(possible_pois)
-    # sometimes there are no possible pois during tests
-    return f"MISSING_POI (requested category: {category})"
+    try:
+        return choice(get_pois_by_category(category))
+    except (KeyError, IndexError):
+        # sometimes there are no possible pois during tests
+        return f"MISSING_POI (requested category: {category})"
 
 
 def add_poi(name, elements):

--- a/scripts/clan_resources/point_of_interest.py
+++ b/scripts/clan_resources/point_of_interest.py
@@ -1,6 +1,6 @@
 from enum import StrEnum
 from random import choice
-from typing import Dict, Union, List
+from typing import Dict, Union, List, Literal
 
 import ujson
 
@@ -63,10 +63,20 @@ def add_poi(name, elements):
 
 def get_poi_save_dict():
     return {
-        "gathering": [name for name in _poi_names if name.startswith("gather_")],
-        "moonplace": [name for name in _poi_names if name.startswith("moon_")],
-        "terrain": [name for name in _poi_names if name.startswith("terrain_")],
+        "gathering": get_poi_by_category("gathering"),
+        "moonplace": get_poi_by_category("moonplace"),
+        "terrain": get_poi_by_category("terrain"),
     }
+
+
+def get_poi_by_category(category: Literal["gathering", "moonplace", "terrain"]):
+    if category == "gathering":
+        return [name for name in _poi_names if name.startswith("gather_")]
+    elif category == "moonplace":
+        return [name for name in _poi_names if name.startswith("moon_")]
+    elif category == "terrain":
+        return [name for name in _poi_names if name.startswith("terrain_")]
+    raise Exception("Tried to get POI from a category that doesn't exist!")
 
 
 def load_pois(save_data: Dict[str, List[str]]):

--- a/scripts/events_module/event_filters.py
+++ b/scripts/events_module/event_filters.py
@@ -7,7 +7,10 @@ from scripts.cat.constants import BACKSTORIES
 from scripts.cat.personality import Personality
 from scripts.cat_relations.enums import RelType, rel_type_tiers, RelTier
 from scripts.cat.enums import CatRank, CatAge, CatCompatibility, CatGroup, CatStanding
-from scripts.clan_resources.point_of_interest import get_poi_names_set, get_poi_tags_set
+from scripts.clan_resources.point_of_interest import (
+    get_poi_names_set,
+    get_poi_tags_set,
+)
 from scripts.events_module.parameter_dicts import (
     InvolvedCatDict,
     RelationshipConstraintDict,
@@ -250,6 +253,10 @@ def event_for_poi(pois: dict[str, list]) -> bool:
 
     if "tags" in pois:
         has_matching_tags = not set(pois.get("tags", [])).isdisjoint(get_poi_tags_set())
+
+    if "category" in pois:
+        return True
+
     return has_matching_name or has_matching_tags
 
 

--- a/scripts/events_module/event_filters.py
+++ b/scripts/events_module/event_filters.py
@@ -253,7 +253,11 @@ def event_for_poi(pois: dict[str, list]) -> bool:
 
     if "tags" in pois:
         has_matching_tags = not set(pois.get("tags", [])).isdisjoint(get_poi_tags_set())
-    return has_matching_name or has_matching_tags or "category" in pois
+
+    if "category" in pois:
+        return True
+
+    return has_matching_name or has_matching_tags
 
 
 def event_for_reputation(required_rep: list) -> bool:

--- a/scripts/events_module/event_filters.py
+++ b/scripts/events_module/event_filters.py
@@ -10,6 +10,7 @@ from scripts.cat.enums import CatRank, CatAge, CatCompatibility, CatGroup, CatSt
 from scripts.clan_resources.point_of_interest import (
     get_poi_names_set,
     get_poi_tags_set,
+    get_poi_categories_set,
 )
 from scripts.events_module.parameter_dicts import (
     InvolvedCatDict,
@@ -245,7 +246,7 @@ def event_for_poi(pois: dict[str, list]) -> bool:
     if not get_poi_names_set():
         return False  # we know they're requesting something
 
-    has_matching_name, has_matching_tags = False, False
+    has_matching_name, has_matching_tags, has_matching_categories = False, False, False
     if "name" in pois:
         has_matching_name = not set(pois.get("name", [])).isdisjoint(
             get_poi_names_set()
@@ -255,9 +256,9 @@ def event_for_poi(pois: dict[str, list]) -> bool:
         has_matching_tags = not set(pois.get("tags", [])).isdisjoint(get_poi_tags_set())
 
     if "category" in pois:
-        return True
+        has_matching_categories = pois["category"] in get_poi_categories_set()
 
-    return has_matching_name or has_matching_tags
+    return has_matching_name or has_matching_tags or has_matching_categories
 
 
 def event_for_reputation(required_rep: list) -> bool:

--- a/scripts/events_module/event_filters.py
+++ b/scripts/events_module/event_filters.py
@@ -253,11 +253,7 @@ def event_for_poi(pois: dict[str, list]) -> bool:
 
     if "tags" in pois:
         has_matching_tags = not set(pois.get("tags", [])).isdisjoint(get_poi_tags_set())
-
-    if "category" in pois:
-        return True
-
-    return has_matching_name or has_matching_tags
+    return has_matching_name or has_matching_tags or "category" in pois
 
 
 def event_for_reputation(required_rep: list) -> bool:

--- a/scripts/events_module/text_adjust.py
+++ b/scripts/events_module/text_adjust.py
@@ -145,12 +145,7 @@ def poi_repl(inner_details):
         )
     elif inner_details[1].upper() == "CATEGORY":
         category = inner_details[2].upper()
-        if category == "GATHERING":
-            base_string += get_random_poi_by_category("gathering")
-        elif category == "MOONPLACE":
-            base_string += get_random_poi_by_category("moonplace")
-        elif category == "TERRAIN":
-            base_string += get_random_poi_by_category("terrain")
+        base_string += get_random_poi_by_category(inner_details[2].lower())
 
     return i18n.t(base_string)
 

--- a/scripts/events_module/text_adjust.py
+++ b/scripts/events_module/text_adjust.py
@@ -143,12 +143,14 @@ def poi_repl(inner_details):
             if names.intersection(get_poi_names_set())
             else "MISSING_POI"
         )
-    elif inner_details[1].upper() == "GATHERING":
-        base_string += get_random_poi_by_category("gathering")
-    elif inner_details[1].upper() == "MOONPLACE":
-        base_string += get_random_poi_by_category("moonplace")
-    elif inner_details[1].upper() == "TERRITORY":
-        base_string += get_random_poi_by_category("terrain")
+    elif inner_details[1].upper() == "CATEGORY":
+        category = inner_details[2].upper()
+        if category == "GATHERING":
+            base_string += get_random_poi_by_category("gathering")
+        elif category == "MOONPLACE":
+            base_string += get_random_poi_by_category("moonplace")
+        elif category == "TERRITORY":
+            base_string += get_random_poi_by_category("terrain")
 
     return i18n.t(base_string)
 

--- a/scripts/events_module/text_adjust.py
+++ b/scripts/events_module/text_adjust.py
@@ -18,6 +18,7 @@ from scripts.cat.sprites.load_sprites import sprites
 from scripts.clan_package.get_clan_cats import find_alive_cats_with_rank
 from scripts.clan_resources.point_of_interest import (
     get_random_poi_by_tag,
+    get_random_poi_by_category,
     get_poi_names_set,
 )
 from scripts.game_structure import localization, game
@@ -142,6 +143,12 @@ def poi_repl(inner_details):
             if names.intersection(get_poi_names_set())
             else "MISSING_POI"
         )
+    elif inner_details[1].upper() == "GATHERING":
+        base_string += get_random_poi_by_category("gathering")
+    elif inner_details[1].upper() == "MOONPLACE":
+        base_string += get_random_poi_by_category("moonplace")
+    elif inner_details[1].upper() == "TERRITORY":
+        base_string += get_random_poi_by_category("terrain")
 
     return i18n.t(base_string)
 

--- a/scripts/events_module/text_adjust.py
+++ b/scripts/events_module/text_adjust.py
@@ -149,7 +149,7 @@ def poi_repl(inner_details):
             base_string += get_random_poi_by_category("gathering")
         elif category == "MOONPLACE":
             base_string += get_random_poi_by_category("moonplace")
-        elif category == "TERRITORY":
+        elif category == "TERRAIN":
             base_string += get_random_poi_by_category("terrain")
 
     return i18n.t(base_string)

--- a/scripts/models/common/points_of_interest.py
+++ b/scripts/models/common/points_of_interest.py
@@ -2,6 +2,7 @@ from enum import Enum
 from typing import List, Union
 
 from pydantic import BaseModel, ConfigDict, Field, RootModel
+from pydantic_core import MISSING
 
 
 class PointsOfInterestTagEnum(Enum):
@@ -29,6 +30,12 @@ class PointsOfInterestTagEnum(Enum):
     NESTS = "nests"
 
 
+class PointsOfInterestCategoryEnum(Enum):
+    GATHERING = "gathering"
+    MOONPLACE = "moonplace"
+    TERRAIN = "terrain"
+
+
 class PointsOfInterestTag(RootModel):
     root: Union[str, PointsOfInterestTagEnum]
 
@@ -47,8 +54,19 @@ class PointsOfInterestGroupByTags(BaseModel):
     )
 
 
+class PointsOfInterestGroupByCategory(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    category: Union[PointsOfInterestCategoryEnum, MISSING] = Field(
+        ..., description="The category this POI belongs to."
+    )
+
+
 class PointsOfInterestGroup(RootModel):
-    root: Union[PointsOfInterestGroupByName, PointsOfInterestGroupByTags] = Field(
+    root: Union[
+        PointsOfInterestGroupByName,
+        PointsOfInterestGroupByTags,
+        PointsOfInterestGroupByCategory,
+    ] = Field(
         ...,
         description="Specifies Points of Interest constraints. Must use EITHER names or tags.",
     )

--- a/scripts/models/common/points_of_interest.py
+++ b/scripts/models/common/points_of_interest.py
@@ -68,5 +68,5 @@ class PointsOfInterestGroup(RootModel):
         PointsOfInterestGroupByCategory,
     ] = Field(
         ...,
-        description="Specifies Points of Interest constraints. Must use EITHER names or tags.",
+        description="Specifies Points of Interest constraints. Must use names OR tags OR category (not multiple at once).",
     )

--- a/tests/test_event_filters.py
+++ b/tests/test_event_filters.py
@@ -363,7 +363,7 @@ class TestPointsOfInterest(unittest.TestCase):
             "empty all": {"name": [], "tags": [], "category": None},
             "empty name": {"name": [], "tags": ["water"]},
             "empty tags": {"name": ["test_name"], "tags": []},
-            "None category": {"category": None},
+            "None category": {"name": ["test_name"], "category": None},
         }
 
         for title, event_poi in combinations.items():

--- a/tests/test_event_filters.py
+++ b/tests/test_event_filters.py
@@ -359,10 +359,11 @@ class TestPointsOfInterest(unittest.TestCase):
             "match tag generic to generic": {"tags": ["water"]},
             "match tag exact to exact": {"tags": ["prey:fish"]},
             "match tag generic to exact": {"tags": ["prey"]},
-            "empty all": {"name": [], "tags": []},
+            "match category": {"category": "gathering"},
+            "empty all": {"name": [], "tags": [], "category": None},
             "empty name": {"name": [], "tags": ["water"]},
             "empty tags": {"name": ["test_name"], "tags": []},
-            "match category": {"category": "gathering"},
+            "None category": {"category": None},
         }
 
         for title, event_poi in combinations.items():
@@ -374,6 +375,7 @@ class TestPointsOfInterest(unittest.TestCase):
             "no name": {"name": ["something_else", "aint_it_chief"]},
             "no tag": {"tags": ["Twolegs", "cave"]},
             "match generic tag but not exact": {"tags": ["prey:bird"]},
+            "invalid category": {"category": "not found"},
         }
 
         for title, event_poi in bad_combinations.items():

--- a/tests/test_event_filters.py
+++ b/tests/test_event_filters.py
@@ -11,6 +11,7 @@ from scripts.clan_resources.point_of_interest import (
     get_poi_tags_set,
     clear_pois,
     generate_and_add_new_poi,
+    get_pois_by_category,
 )
 
 try:
@@ -232,6 +233,10 @@ class TestPointsOfInterest(unittest.TestCase):
         self.assertIn("prey", get_poi_tags_set())
         self.assertNotIn("fish", get_poi_tags_set())
 
+        self.assertIn("test_name", get_pois_by_category("gathering"))
+        self.assertNotIn("test_name", get_pois_by_category("moonplace"))
+        self.assertNotIn("test_name", get_pois_by_category("terrain"))
+
     def test_clear_pois(self):
         poi_to_add = {
             "test_name": {
@@ -357,6 +362,7 @@ class TestPointsOfInterest(unittest.TestCase):
             "empty all": {"name": [], "tags": []},
             "empty name": {"name": [], "tags": ["water"]},
             "empty tags": {"name": ["test_name"], "tags": []},
+            "match category": {"category": "gathering"},
         }
 
         for title, event_poi in combinations.items():


### PR DESCRIPTION

## About The Pull Request

* Adds support for `category` when specifying points of interest for events and patrols.
* Doesn't add support for `category` at the same time as `tags` because I think that might require more substantial rewrites?

## Why This Is Good For ClanGen

* Can refer to the Clan's specific moonplace and gathering locations (and also to random unspecified terrain with no other qualifiers if you wanted to do that for some reason)

## Linked Issues

* Fixes #5164
  * (but not #5171)

## Proof of Testing

`debug_misc_poi_terrain`
<img width="733" height="443" alt="image" src="https://github.com/user-attachments/assets/585d6ba6-f94f-4811-a000-673d383c3d83" />

`debug_misc_poi_moonplace`
<img width="733" height="448" alt="image" src="https://github.com/user-attachments/assets/8b21b643-2e3e-4549-bf82-81892d78efc4" />

`debug_misc_poi_gathering`
<img width="723" height="393" alt="image" src="https://github.com/user-attachments/assets/1fc2e1ea-0b48-4031-bc32-f9f32ade248c" />