### PR TITLE
[TYPO/TWEAKS] minor changes to a mountain thrush training patrol

### DIFF
--- a/resources/lang/en/patrols/mountainous/training/any.json
+++ b/resources/lang/en/patrols/mountainous/training/any.json
@@ -2085,7 +2085,7 @@
                         }
                     }
                 ],
-                "frequency": 1
+                "frequency": 4
             },
             {
                 "text": "s_c stops, suddenly reminded of an old tale. The thrush below is breaking a snail open on a rock. There was a prophecy about that once, although p_l can't quite remember how the story goes...",
@@ -2149,7 +2149,7 @@
         ],
         "fail_outcomes": [
             {
-                "text": "app1 rolls {PRONOUN/app1/poss} eyes and asks why {PRONOUN/app1/subject} can't just try catching it. Irritably, p_l replies that {PRONOUN/app1/subject}{VERB/app1/'re/'s} welcome to try, and the bird spots app1 coming immediately, also spoiling app2's chances.",
+                "text": "app1 rolls {PRONOUN/app1/poss} eyes and asks why {PRONOUN/app1/subject} can't just try catching it. p_l replies that {PRONOUN/app1/subject}{VERB/app1/'re/'s} welcome to try, and the bird spots app1 coming immediately, also spoiling app2's chances.",
                 "exp": 0,
                 "relationships": [
                     {
@@ -2166,7 +2166,7 @@
                         ],
                         "amount": -10,
                         "log": {
-                            "cats_from": "cat_from and cat_to squabbled during a training session when app1 wanted to actually hunt instead of practice stalking."
+                            "cats_from": "cat_from ignored cat_to's lesson during training session when app1 wanted to actually hunt instead of practice stalking."
                         }
                     },
                     {
@@ -2182,7 +2182,7 @@
                         ],
                         "amount": -10,
                         "log": {
-                            "cats_from": "cat_from was peeved that cat_to's hasty pounce ruined {PRONOUN/cat_from/poss} chance to learn about bird-hunting."
+                            "cats_from": "cat_from's hasty pounce ruined cat_to's chance to learn about bird-hunting."
                         }
                     }
                 ],

--- a/resources/lang/en/patrols/mountainous/training/any.json
+++ b/resources/lang/en/patrols/mountainous/training/any.json
@@ -2166,7 +2166,7 @@
                         ],
                         "amount": -10,
                         "log": {
-                            "cats_from": "cat_from ignored cat_to's lesson during training session when app1 wanted to actually hunt instead of practice stalking."
+                            "cats_from": "app1 ignored p_l's lesson during training session when app1 wanted to actually hunt instead of practice stalking."
                         }
                     },
                     {


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

- Increased the frequency of the second generic success to 4 as well so there's a 50/50 chance either option. In my opinion, this makes the patrol more variable instead of feeling as repetitive. 
- Removed the word 'irritably' from one outcome that was assigning emotion to the mentor's temperament instead of letting the player extrapolate on their words based on their personality in game.
- Clarified a relationship log. 

## Why This Is Good For ClanGen

- More clarity & variability in content

## Proof of Testing
Game runs locally, no changes outside of the patrol structure itself.