### PR TITLE
[ADJUSTMENT] Add Cruel Season Locked popup with mate settings for Heartless Card

### DIFF
--- a/scripts/screens/ClanSettingsScreen.py
+++ b/scripts/screens/ClanSettingsScreen.py
@@ -123,13 +123,6 @@ class ClanSettingsScreen(Screens):
                 self.checkboxes["affair"].uncheck()
                 CruelLockedAction()
                 return
-            if event.ui_element == self.checkboxes.get("affair") and not get_config(
-                "mates.allow_mating"
-            ):
-                set_clan_setting("affair", False)
-                self.checkboxes["affair"].uncheck()
-                CruelLockedAction()
-                return
             if event.ui_element == self.checkboxes.get(
                 "romantic with former mentor"
             ) and not get_config("mates.allow_mating"):

--- a/scripts/screens/ClanSettingsScreen.py
+++ b/scripts/screens/ClanSettingsScreen.py
@@ -130,16 +130,16 @@ class ClanSettingsScreen(Screens):
                 self.checkboxes["affair"].uncheck()
                 CruelLockedAction()
                 return
-            if event.ui_element == self.checkboxes.get("romantic with former mentor") and not get_config(
-                "mates.allow_mating"
-            ):
+            if event.ui_element == self.checkboxes.get(
+                "romantic with former mentor"
+            ) and not get_config("mates.allow_mating"):
                 set_clan_setting("romantic with former mentor", False)
                 self.checkboxes["romantic with former mentor"].uncheck()
                 CruelLockedAction()
                 return
-            if event.ui_element == self.checkboxes.get("first cousin mates") and not get_config(
-                "mates.allow_mating"
-            ):
+            if event.ui_element == self.checkboxes.get(
+                "first cousin mates"
+            ) and not get_config("mates.allow_mating"):
                 set_clan_setting("first cousin mates", False)
                 self.checkboxes["first cousin mates"].uncheck()
                 CruelLockedAction()

--- a/scripts/screens/ClanSettingsScreen.py
+++ b/scripts/screens/ClanSettingsScreen.py
@@ -120,7 +120,7 @@ class ClanSettingsScreen(Screens):
                 "mates.allow_mating"
             ):
                 set_clan_setting("affair", False)
-                self.checkboxes["affair"].check()
+                self.checkboxes["affair"].uncheck()
                 CruelLockedAction()
                 return
             for key, value in self.checkboxes.items():

--- a/scripts/screens/ClanSettingsScreen.py
+++ b/scripts/screens/ClanSettingsScreen.py
@@ -116,7 +116,13 @@ class ClanSettingsScreen(Screens):
                 self.checkboxes["deputy"].check()
                 CruelLockedAction()
                 return
-
+            if event.ui_element == self.checkboxes.get("affair") and not get_config(
+                "mates.allow_mating"
+            ):
+                set_clan_setting("affair", False)
+                self.checkboxes["affair"].check()
+                CruelLockedAction()
+                return
             for key, value in self.checkboxes.items():
                 if value == event.ui_element:
                     switch_clan_setting(key)

--- a/scripts/screens/ClanSettingsScreen.py
+++ b/scripts/screens/ClanSettingsScreen.py
@@ -123,6 +123,27 @@ class ClanSettingsScreen(Screens):
                 self.checkboxes["affair"].uncheck()
                 CruelLockedAction()
                 return
+            if event.ui_element == self.checkboxes.get("affair") and not get_config(
+                "mates.allow_mating"
+            ):
+                set_clan_setting("affair", False)
+                self.checkboxes["affair"].uncheck()
+                CruelLockedAction()
+                return
+            if event.ui_element == self.checkboxes.get("romantic with former mentor") and not get_config(
+                "mates.allow_mating"
+            ):
+                set_clan_setting("romantic with former mentor", False)
+                self.checkboxes["romantic with former mentor"].uncheck()
+                CruelLockedAction()
+                return
+            if event.ui_element == self.checkboxes.get("first cousin mates") and not get_config(
+                "mates.allow_mating"
+            ):
+                set_clan_setting("first cousin mates", False)
+                self.checkboxes["first cousin mates"].uncheck()
+                CruelLockedAction()
+                return
             for key, value in self.checkboxes.items():
                 if value == event.ui_element:
                     switch_clan_setting(key)

--- a/scripts/screens/ClanSettingsScreen.py
+++ b/scripts/screens/ClanSettingsScreen.py
@@ -123,20 +123,6 @@ class ClanSettingsScreen(Screens):
                 self.checkboxes["affair"].uncheck()
                 CruelLockedAction()
                 return
-            elif event.ui_element == self.checkboxes.get(
-                "romantic with former mentor"
-            ) and not get_config("mates.allow_mating"):
-                set_clan_setting("romantic with former mentor", False)
-                self.checkboxes["romantic with former mentor"].uncheck()
-                CruelLockedAction()
-                return
-            elif event.ui_element == self.checkboxes.get(
-                "first cousin mates"
-            ) and not get_config("mates.allow_mating"):
-                set_clan_setting("first cousin mates", False)
-                self.checkboxes["first cousin mates"].uncheck()
-                CruelLockedAction()
-                return
             for key, value in self.checkboxes.items():
                 if value == event.ui_element:
                     switch_clan_setting(key)

--- a/scripts/screens/ClanSettingsScreen.py
+++ b/scripts/screens/ClanSettingsScreen.py
@@ -116,21 +116,21 @@ class ClanSettingsScreen(Screens):
                 self.checkboxes["deputy"].check()
                 CruelLockedAction()
                 return
-            if event.ui_element == self.checkboxes.get("affair") and not get_config(
+            elif event.ui_element == self.checkboxes.get("affair") and not get_config(
                 "mates.allow_mating"
             ):
                 set_clan_setting("affair", False)
                 self.checkboxes["affair"].uncheck()
                 CruelLockedAction()
                 return
-            if event.ui_element == self.checkboxes.get(
+            elif event.ui_element == self.checkboxes.get(
                 "romantic with former mentor"
             ) and not get_config("mates.allow_mating"):
                 set_clan_setting("romantic with former mentor", False)
                 self.checkboxes["romantic with former mentor"].uncheck()
                 CruelLockedAction()
                 return
-            if event.ui_element == self.checkboxes.get(
+            elif event.ui_element == self.checkboxes.get(
                 "first cousin mates"
             ) and not get_config("mates.allow_mating"):
                 set_clan_setting("first cousin mates", False)


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->
- Adds a trigger for CruelLockedAction if "allow affairs", "romantic with mentor" or "romantic with cousin" is clicked in settings with the heartless card enabled

## Why This Is Good For ClanGen

<!-- If this is a bug fix, you can remove this section. -->
<!-- Please add a short description of why you think these changes would benefit the game. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->
<!-- If you have multiple features that can stand on their own, or unrelated bugfixes, please create separate PRs for them. -->
- Blocks a setting that isn't necessary with the card
Just noticed this when playing around 

## Proof of Testing

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

<img width="798" height="704" alt="Screenshot 2026-07-13 at 10 57 36" src="https://github.com/user-attachments/assets/1ff2a963-10da-47aa-ab06-7e4e5d1298e7" />
