### PR TITLE
Bugfix: Crash when searching for lost cats

### DIFF
--- a/scripts/events_module/event_filters.py
+++ b/scripts/events_module/event_filters.py
@@ -501,7 +501,7 @@ def _check_cat_status(cat, statuses: list) -> bool:
 
     if (cat.status.rank in statuses) or (
         "clancat" in statuses and cat.status.is_clancat
-    ):
+    ) or ("lost" in statuses and cat.status.is_lost()):
         return True
 
     is_exclusionary = _check_for_exclusionary_value(statuses)
@@ -511,7 +511,7 @@ def _check_cat_status(cat, statuses: list) -> bool:
 
     if (cat.status.rank in statuses) or (
         "clancat" in statuses and cat.status.is_clancat
-    ):
+    ) or ("lost" in statuses and cat.status.is_lost()):
         return False
 
     return is_exclusionary

--- a/scripts/events_module/event_filters.py
+++ b/scripts/events_module/event_filters.py
@@ -499,9 +499,11 @@ def _check_cat_status(cat, statuses: list) -> bool:
     if not statuses or "any" in statuses:
         return True
 
-    if (cat.status.rank in statuses) or (
-        "clancat" in statuses and cat.status.is_clancat
-    ) or ("lost" in statuses and cat.status.is_lost()):
+    if (
+        (cat.status.rank in statuses)
+        or ("clancat" in statuses and cat.status.is_clancat)
+        or ("lost" in statuses and cat.status.is_lost())
+    ):
         return True
 
     is_exclusionary = _check_for_exclusionary_value(statuses)
@@ -509,9 +511,11 @@ def _check_cat_status(cat, statuses: list) -> bool:
     if is_exclusionary:
         statuses = [x.replace("-", "") for x in statuses]
 
-    if (cat.status.rank in statuses) or (
-        "clancat" in statuses and cat.status.is_clancat
-    ) or ("lost" in statuses and cat.status.is_lost()):
+    if (
+        (cat.status.rank in statuses)
+        or ("clancat" in statuses and cat.status.is_clancat)
+        or ("lost" in statuses and cat.status.is_lost())
+    ):
         return False
 
     return is_exclusionary


### PR DESCRIPTION
## About The Pull Request

A recent development update removed an event filter for "lost" status and replaced it with "clancat." That seems to have broken searching for lost cats from the leader's den, since lost cats don't have the "clancat" status.
Updated _check_cat_status in event_filters.py to consider both "lost" and "clancat" statuses when finding events for a cat. Searching from the leader's den should work now.


## Linked Issues

Fixes: #5359 


## Proof of Testing

https://github.com/user-attachments/assets/9aa891e4-498e-49e4-bcbf-6e8c98e86ac6


## Changelog/Credits

Fixed crashing when searching for lost cats from the leader's den
