### PR TITLE
[BUGFIX] Fix stale rank history and loner grieving

### DIFF
--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -719,6 +719,7 @@ class Cat:
             grief_allowed
             and game.clan
             and self.status.get_last_living_group() == CatGroup.PLAYER_CLAN_ID
+            and not self.status.is_exiled(CatGroup.PLAYER_CLAN_ID)
         ):
             self.grief(body)
             game.dead_cats_to_grieve.append(self)

--- a/scripts/cat/status.py
+++ b/scripts/cat/status.py
@@ -658,9 +658,10 @@ class Status:
             ]
         else:
             past_ranks = [
-                rank
-                for rank in self.all_ranks.keys()
-                if rank not in [CatRank.LONER, CatRank.KITTYPET, CatRank.ROGUE]
+                record["rank"]
+                for record in self.group_history
+                if record["rank"]
+                not in [CatRank.LONER, CatRank.KITTYPET, CatRank.ROGUE]
             ]
         if not past_ranks:
             return None


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

This fixes two overlapping bugs where exiled deaths show stale cat rank history and prompt clan grieving thoughts.

Steps to reproduce:
1. Change the rank of any clan cat (Warrior -> Medicine cat)
2. Moonskip (required)
3. Change the rank of that clan cat again (Medicine cat -> Warrior)
4. Moonskip (required)
5. Exile cat
6. Hunt down, moonskip until death, or use F3 cheats to die()
7. Open profile

The cat will show they were an exiled, former Medicine cat, with a medicine cat death thought:
<img width="500" alt="cat in Unknown Residence that shows them as exiled, former medicine cat, when they should be exiled warrior" src="https://github.com/user-attachments/assets/29b6bb02-bb5e-491c-90fd-1c1c93d0073f" />

AND

Cats in the clan will have grieving thoughts for the exiled cat:
<img width="500" alt="clan cat grieves exiled warrior" src="https://github.com/user-attachments/assets/52f536e2-5b64-4dc0-a261-060fe179ae41" />

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues

Fixes #5329

<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing

Reproduced steps:
|  |  |
|---|---|
| <img width="300" alt="Wildcloud rank change Warrior to Medicine cat" src="https://github.com/user-attachments/assets/fe45871d-8642-47c5-86d5-ff71b8d39759" /> | <img width="300" alt="Wildcloud rank change Medicine cat to Warrior" src="https://github.com/user-attachments/assets/a41168f7-76bc-4c78-868d-033070eb3327" /> |
| <img width="300" alt="Exiled Wildcloud is hunted down" src="https://github.com/user-attachments/assets/b7cb7c23-40e2-442d-81c2-f5c54888d929" /> | <img width="300" alt="Wildcloud listed at past SwiftClan warrior, with no clan grieving thoughts" src="https://github.com/user-attachments/assets/998cf0d9-7c64-4182-b34a-109bd5a5bff9" /> |

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->