### PR TITLE
[CONTENT] Failed Murders (But Extra Dramatic)

### DIFF
--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -10014,7 +10014,7 @@
         ],
         "tags": [],
         "frequency": 3,
-        "event_text": "m_c chases a trespassing o_c_n warrior off of the territory. On {PRONOUN/m_c/poss} way back, {PRONOUN/m_c/subject} {VERB/r_c/are/is} ambushed by r_c, who murders {PRONOUN/m_c/object} on the spot.",
+        "event_text": "m_c chases a trespassing o_c_n warrior off of the territory. On {PRONOUN/m_c/poss} way back, {PRONOUN/m_c/subject} {VERB/m_c/are/is} ambushed by r_c, who murders {PRONOUN/m_c/object} on the spot.",
         "m_c": {
             "status": [
                 "warrior",

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -14013,7 +14013,7 @@
             {
                 "cats_from": ["r_c"],
                 "cats_to": ["m_c"],
-                "values": ["comfort"],
+                "values": ["comfort", "trust"],
                 "amount": -30,
                 "mutual": false,
                 "log": {

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -14094,7 +14094,7 @@
             {
                 "cats_from": [
                     "clan",
-                    "high_lawful"
+                    "high_social"
                 ],
                 "cats_to": ["m_c"],
                 "values": [

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -13971,6 +13971,68 @@
             ]
         }
     },
+        {
+        "event_id": "gen_misc_failedmurderattack1",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "failed_murder"
+        ],
+        "frequency": 3,
+        "event_text": "r_c bursts into camp, frantic and covered in wounds. {PRONOUN/r_c/subject/CAP} {VERB/r_c/insist/insists} m_c attacked {PRONOUN/r_c/object} while they were on patrol together.",
+        "m_c": {},
+        "r_c": {
+            "status": [
+                "-kitten",
+                "-elder"
+            ]
+        },
+            "injury": [
+                {
+                    "cats": ["r_c"],
+                    "injuries": ["claw-wound", "cat bite"]
+                }
+            ],
+            "history": [
+                {
+                    "cats": ["r_c"],
+                "scar": "m_c was scarred after a Clanmate attacked {PRONOUN/m_c/object} while on patrol.",
+                "death": "m_c was killed by {PRONOUN/m_c/poss} wounds caused by a Clanmate."
+                }
+            ],
+        "relationships": [
+            {
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["comfort"],
+                "amount": -20,
+                "mutual": false,
+                "log": {
+                    "cats_from": "cat_from became terrified of cat_to after {PRONOUN/cat_to/subject} attacked {PRONOUN/cat_from/object} while on patrol."
+                }
+            },
+            {
+                "cats_from": [
+                    "clan",
+                    "high_lawful"
+                ],
+                "cats_to": ["m_c"],
+                "values": [
+                    "comfort",
+                    "respect"
+                ],
+                "amount": -15,
+                "mutual": false,
+                "log": {
+                    "cats_from": "cat_from was unsettled to learn cat_to attacked {PRONOUN/cat_to/poss} fellow Clanmate."
+                }
+            }
+        ]
+    },
     {
     "event_id": "gen_misc_hitmanfailedmurder1",
     "location": ["any"],

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -14110,7 +14110,7 @@
                 "cats_from": [
                     "clan",
                     "low_social",
-                    "low_aggress"
+                    "high_lawful"
                 ],
                 "cats_to": ["r_c"],
                 "values": [

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -14204,7 +14204,7 @@
         "history": [
             {
                 "cats": ["r_c"],
-                "death": ["r_c died after a Clanmate suggested {PRONOUN/r_c/subject} should try eating deathberries."]
+                "death": "r_c died after a Clanmate suggested {PRONOUN/r_c/subject} should try eating deathberries."
             }
         ],
         "relationships": [
@@ -14251,7 +14251,7 @@
         "history": [
             {
                 "cats": ["r_c"],
-                "death": ["r_c died after a Clanmate gave {PRONOUN/r_c/object} crowfood."]
+                "death": "r_c died after a Clanmate gave {PRONOUN/r_c/object} crowfood."
             }
         ],
         "relationships": [
@@ -14298,7 +14298,7 @@
         "history": [
             {
                 "cats": ["r_c"],
-                "death": ["r_c died after being pushed in the river and inhaling too much water."]
+                "death": "r_c died after being pushed in the river and inhaling too much water."
             }
         ],
         "relationships": [

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -14034,6 +14034,87 @@
         ]
     },
     {
+        "event_id": "gen_misc_failedmurderattack2",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "failed_murder"
+        ],
+        "frequency": 3,
+        "event_text": "m_c bursts into camp, frantic and covered in wounds. {PRONOUN/m_c/subject/CAP} {VERB/m_c/insist/insists} r_c attacked {PRONOUN/m_c/object} while they were on patrol together.",
+        "m_c": {},
+        "r_c": {
+            "status": [
+                "-kitten",
+                "-elder"
+            ]
+        },
+            "injury": [
+                {
+                    "cats": ["r_c"],
+                    "injuries": ["claw-wound", "cat bite"]
+                },
+                {
+                    "cats": ["m_c"],
+                    "injuries": ["scrapes", "torn pelt"]
+                }
+            ],
+            "history": [
+                {
+                    "cats": ["r_c"],
+                "scar": "m_c was scarred after a Clanmate attacked {PRONOUN/m_c/object} while on patrol.",
+                "death": "m_c was killed by {PRONOUN/m_c/poss} wounds caused by a Clanmate."
+                }
+            ],
+        "relationships": [
+            {
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["comfort", "like"],
+                "amount": -20,
+                "mutual": false,
+                "log": {
+                    "cats_from": "cat_from became terrified of cat_to after {PRONOUN/cat_to/subject} attacked {PRONOUN/cat_from/object} while on patrol and falsely accused {PRONOUN/cat_from/object} instead."
+                }
+            },
+            {
+                "cats_from": [
+                    "clan",
+                    "high_lawful"
+                ],
+                "cats_to": ["m_c"],
+                "values": [
+                    "trust"
+                ],
+                "amount": -15,
+                "mutual": false,
+                "log": {
+                    "cats_from": "cat_from thought cat_to wasn't being entirely truthful about being attacked by a fellow Clanmate."
+                }
+            },
+            {
+                "cats_from": [
+                    "clan",
+                    "low_social",
+                    "low_aggress"
+                ],
+                "cats_to": ["r_c"],
+                "values": [
+                    "comfort"
+                ],
+                "amount": -15,
+                "mutual": false,
+                "log": {
+                    "cats_from": "cat_from was unsettled after hearing cat_to attacked {PRONOUN/cat_from/object} while on patrol."
+                }
+            }
+        ]
+    },
+    {
     "event_id": "gen_misc_hitmanfailedmurder1",
     "location": ["any"],
     "season": ["any"],

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -14159,7 +14159,7 @@
                 "amount": -20,
                 "mutual": false,
                 "log": {
-                    "cats_from": "cat_from doesn't believe that cat_to accidentally poisoned {PRONOUN/cat_from/object}."
+                    "cats_from": "cat_from didn't believe that cat_to poisoned {PRONOUN/cat_from/object} by accident."
                 }
             },
             {

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -14115,6 +14115,65 @@
         ]
     },
     {
+        "event_id": "gen_misc_failedmurderpoison",
+        "location": ["any"],
+        "season": ["any"],
+        "sub_type": ["failed_murder"],
+        "tags": [],
+        "frequency": 3,
+        "event_text": "m_c poisons r_c after giving {PRONOUN/r_c/object} the wrong herb dosage. m_c claims it was an accident, but r_c isn't so sure...",
+        "m_c": {
+            "status": [
+                "medicine cat",
+                "medicine cat apprentice"
+            ]
+        },
+        "r_c": {
+            "age": [
+                "-kitten"
+            ]
+        },
+        "injury": [
+            {
+                "cats": ["r_c"],
+                "injuries": ["poisoned"]
+            }
+        ],
+        "history": [
+            {
+                "cats": ["r_c"],
+                "death": "m_c died after a Clanmate gave {PRONOUN/m_c/object} the wrong herb dosage."
+            }
+        ],
+        "relationships": [
+            {
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["trust"],
+                "amount": -20,
+                "mutual": false,
+                "log": {
+                    "cats_from": "cat_from doesn't believe that cat_to accidentally poisoned {PRONOUN/cat_from/object}."
+                }
+            },
+            {
+                "cats_from": [
+                    "clan",
+                    "high_lawful"
+                ],
+                "cats_to": ["m_c"],
+                "values": [
+                    "trust"
+                ],
+                "amount": -15,
+                "mutual": false,
+                "log": {
+                    "cats_from": "cat_from's confidence in cat_to weakened after hearing that {PRONOUN/cat_to/subject} gave a Clanmate the wrong herb dosage."
+                }
+            }
+            ]
+    },
+    {
     "event_id": "gen_misc_hitmanfailedmurder1",
     "location": ["any"],
     "season": ["any"],

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -14314,6 +14314,57 @@
             }
             ]
     },
+        {
+        "event_id": "gen_misc_failedmurderplotting1",
+        "location": ["any"],
+        "season": ["any"],
+        "sub_type": ["failed_murder"],
+        "tags": [],
+        "frequency": 3,
+        "event_text": "m_c is almost in tears as {PRONOUN/m_c/subject} {VERB/m_c/emphasize/emphasizes} to lead_name how cruel r_c has been lately. r_c looks confused and denies everything m_c says.",
+        "m_c":
+        {
+            "status": [
+                "apprentice",
+                "warrior",
+                "deputy"
+            ],
+            "trait": [
+                "childish",
+                "cunning",
+                "charismatic",
+                "insecure",
+                "shameless"
+            ]
+        },
+        "r_c": {
+            "status": [
+                "-kitten"
+            ]
+        },
+        "relationships": [
+            {
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["comfort"],
+                "amount": -15,
+                "mutual": false,
+                "log": {
+                    "cats_from": "cat_from doesn't understand why cat_to would accuse {PRONOUN/cat_from/object} of being cruel and make {PRONOUN/cat_from/object} look bad in front of the leader."
+                }
+            },
+                        {
+                "cats_from": ["m_c"],
+                "cats_to": ["r_c"],
+                "values": ["like"],
+                "amount": -15,
+                "mutual": false,
+                "log": {
+                    "cats_from": "cat_from accused cat_to of being cruel to {PRONOUN/cat_from/object} in front of the leader in hopes something would be done about {PRONOUN/cat_to/object}."
+                }
+            }
+            ]
+    },
     {
     "event_id": "gen_misc_hitmanfailedmurder1",
     "location": ["any"],

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -14356,7 +14356,7 @@
                 "amount": -15,
                 "mutual": false,
                 "log": {
-                    "cats_from": "cat_from accused cat_to of wanting to take over the Clan in hopes the leader would get rid of {PRONOUN/cat_to/object} soon."
+                    "cats_from": "cat_from accused cat_to of wanting to take over the Clan in hopes the leader would get rid of {PRONOUN/cat_to/object}."
                 }
             }
             ]

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -14270,7 +14270,7 @@
                 "amount": -20,
                 "mutual": false,
                 "log": {
-                    "cats_from": "cat_from thinks cat_to purposefully offered {PRONOUN/cat_from/object} crowfood."
+                    "cats_from": "cat_from thought cat_to purposefully offered {PRONOUN/cat_from/object} crowfood."
                 }
             }
             ]

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -14220,6 +14220,53 @@
             }
             ]
     },
+        {
+        "event_id": "gen_misc_failedmurderpoison3",
+        "location": ["any"],
+        "season": ["any"],
+        "sub_type": ["failed_murder"],
+        "tags": [],
+        "frequency": 3,
+        "event_text": "m_c offers r_c a piece of prey from the pile. Later, r_c is rushed to the medicine den, having been poisoned by crowfood.",
+        "m_c":
+        {
+            "status": [
+                "apprentice",
+                "warrior",
+                "deputy",
+                "leader"
+            ]
+        },
+        "r_c": {
+            "status": [
+                "-kitten"
+            ]
+        },
+        "injury": [
+            {
+                "cats": ["r_c"],
+                "injuries": ["poisoned"]
+            }
+        ],
+        "history": [
+            {
+                "cats": ["r_c"],
+                "death": ["r_c died after a Clanmate gave {PRONOUN/r_c/object} crowfood."]
+            }
+        ],
+        "relationships": [
+            {
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["trust"],
+                "amount": -20,
+                "mutual": false,
+                "log": {
+                    "cats_from": "cat_from thinks cat_to purposefully offered {PRONOUN/cat_from/object} crowfood."
+                }
+            }
+            ]
+    },
     {
     "event_id": "gen_misc_hitmanfailedmurder1",
     "location": ["any"],

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -14009,7 +14009,7 @@
                 "cats_from": ["r_c"],
                 "cats_to": ["m_c"],
                 "values": ["comfort"],
-                "amount": -20,
+                "amount": -30,
                 "mutual": false,
                 "log": {
                     "cats_from": "cat_from became terrified of cat_to after {PRONOUN/cat_to/subject} attacked {PRONOUN/cat_from/object} while on patrol."

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -14186,7 +14186,7 @@
         "sub_type": ["failed_murder"],
         "tags": [],
         "frequency": 3,
-        "event_text": "r_c is badly poisoned after eating deathberries. While being rushed to the medicine den, {PRONOUN/r_c/subject} {VERB/r_c/mumble/mumbles} that they don't taste like how m_c said they would...",
+        "event_text": "r_c is badly poisoned after eating deathberries. When rushed to the medicine den, {PRONOUN/r_c/subject} {VERB/r_c/mumble/mumbles} that they don't taste like how m_c said they would...",
         "m_c":
         {
             "status": [

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -14197,7 +14197,9 @@
                 "apprentice",
                 "warrior",
                 "deputy",
-                "leader"
+                "leader",
+                "medicine cat",
+                "medicine cat apprentice"
             ]
         },
         "r_c": {

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -14313,7 +14313,7 @@
                 "amount": -20,
                 "mutual": false,
                 "log": {
-                    "cats_from": "cat_from thinks cat_to pushed {PRONOUN/cat_from/object} into the river and pretended to save {PRONOUN/cat_from/object}."
+                    "cats_from": "cat_from thought cat_to pushed {PRONOUN/cat_from/object} into the river and pretended to save {PRONOUN/cat_from/object}."
                 }
             }
             ]

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -14138,11 +14138,7 @@
                 "medicine cat apprentice"
             ]
         },
-        "r_c": {
-            "age": [
-                "-kitten"
-            ]
-        },
+        "r_c": {},
         "injury": [
             {
                 "cats": ["r_c"],

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -14292,11 +14292,7 @@
                 "leader"
             ]
         },
-        "r_c": {
-            "status": [
-                "-kitten"
-            ]
-        },
+        "r_c": {},
         "injury": [
             {
                 "cats": ["r_c"],

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -14180,12 +14180,14 @@
         "sub_type": ["failed_murder"],
         "tags": [],
         "frequency": 3,
-        "event_text": "r_c is badly poisoned after eating deathberries. {PRONOUN/r_c/subject/CAP} {VERB/r_c/mumble/mumbles} that they don't taste like how m_c said they would...",
+        "event_text": "r_c is badly poisoned after eating deathberries. While being rushed to the medicine den, {PRONOUN/r_c/subject} {VERB/r_c/mumble/mumbles} that they don't taste like how m_c said they would...",
         "m_c":
         {
             "status": [
-                "medicine cat",
-                "medicine cat apprentice"
+                "apprentice",
+                "warrior",
+                "deputy",
+                "leader"
             ]
         },
         "r_c": {

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -14325,7 +14325,7 @@
         "sub_type": ["failed_murder"],
         "tags": [],
         "frequency": 2,
-        "event_text": "m_c requests to meet up with lead_name, where {PRONOUN/m_c/subject} {VERB/m_c/claim/claims} {PRONOUN/m_c/subject} overheard r_c making plans to overthrow lead_name and take over the Clan.",
+        "event_text": "m_c meets with lead_name and claims {PRONOUN/m_c/subject} overheard r_c making plans to overthrow lead_name and take over the Clan.",
         "m_c":
         {
             "status": [

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -14066,8 +14066,8 @@
             "history": [
                 {
                     "cats": ["r_c"],
-                "scar": "m_c was scarred after a Clanmate attacked {PRONOUN/m_c/object} while on patrol.",
-                "death": "m_c was killed by {PRONOUN/m_c/poss} wounds caused by a Clanmate."
+                "scar": "r_c was scarred after a Clanmate attacked {PRONOUN/r_c/object} while on patrol.",
+                "death": "r_c was killed by {PRONOUN/r_c/poss} wounds caused by a Clanmate."
                 }
             ],
         "relationships": [
@@ -14115,7 +14115,7 @@
         ]
     },
     {
-        "event_id": "gen_misc_failedmurderpoison",
+        "event_id": "gen_misc_failedmurderpoison1",
         "location": ["any"],
         "season": ["any"],
         "sub_type": ["failed_murder"],
@@ -14142,7 +14142,7 @@
         "history": [
             {
                 "cats": ["r_c"],
-                "death": "m_c died after a Clanmate gave {PRONOUN/m_c/object} the wrong herb dosage."
+                "death": "r_c died after a Clanmate gave {PRONOUN/r_c/object} the wrong herb dosage."
             }
         ],
         "relationships": [
@@ -14169,6 +14169,51 @@
                 "mutual": false,
                 "log": {
                     "cats_from": "cat_from's confidence in cat_to weakened after hearing that {PRONOUN/cat_to/subject} gave a Clanmate the wrong herb dosage."
+                }
+            }
+            ]
+    },
+    {
+        "event_id": "gen_misc_failedmurderpoison2",
+        "location": ["any"],
+        "season": ["any"],
+        "sub_type": ["failed_murder"],
+        "tags": [],
+        "frequency": 3,
+        "event_text": "r_c is badly poisoned after eating deathberries. {PRONOUN/r_c/subject/CAP} {VERB/r_c/mumble/mumbles} that they don't taste like how m_c said they would...",
+        "m_c":
+        {
+            "status": [
+                "medicine cat",
+                "medicine cat apprentice"
+            ]
+        },
+        "r_c": {
+            "status": [
+                "kitten"
+            ]
+        },
+        "injury": [
+            {
+                "cats": ["r_c"],
+                "injuries": ["poisoned"]
+            }
+        ],
+        "history": [
+            {
+                "cats": ["r_c"],
+                "death": ["r_c died after a Clanmate suggested {PRONOUN/r_c/subject} should try eating deathberries."]
+            }
+        ],
+        "relationships": [
+            {
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["trust"],
+                "amount": -20,
+                "mutual": false,
+                "log": {
+                    "cats_from": "cat_from thinks cat_to lied to {PRONOUN/cat_from/object} about how good deathberries taste."
                 }
             }
             ]

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -13984,7 +13984,12 @@
         ],
         "frequency": 3,
         "event_text": "r_c bursts into camp, frantic and covered in wounds. {PRONOUN/r_c/subject/CAP} {VERB/r_c/insist/insists} m_c attacked {PRONOUN/r_c/object} while they were on patrol together.",
-        "m_c": {},
+        "m_c": {
+            "status": [
+                "-kitten",
+              "-elder"
+            ]
+        },
         "r_c": {
             "status": [
                 "-kitten",
@@ -14046,7 +14051,12 @@
         ],
         "frequency": 3,
         "event_text": "m_c bursts into camp, frantic and covered in wounds. {PRONOUN/m_c/subject/CAP} {VERB/m_c/insist/insists} r_c attacked {PRONOUN/m_c/object} while they were on patrol together.",
-        "m_c": {},
+        "m_c": {
+            "status": [
+                "-kitten",
+                "-elder"
+            ]
+        },
         "r_c": {
             "status": [
                 "-kitten",

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -14268,6 +14268,53 @@
             ]
     },
     {
+        "event_id": "gen_misc_failedmurderriver1",
+        "location": ["any"],
+        "season": ["any"],
+        "sub_type": ["failed_murder"],
+        "tags": [],
+        "frequency": 3,
+        "event_text": "r_c falls into the river. m_c helps rescue {PRONOUN/r_c/object}, but r_c swears {PRONOUN/r_c/subject} {VERB/r_c/were/was} pushed in.",
+        "m_c":
+        {
+            "status": [
+                "apprentice",
+                "warrior",
+                "deputy",
+                "leader"
+            ]
+        },
+        "r_c": {
+            "status": [
+                "-kitten"
+            ]
+        },
+        "injury": [
+            {
+                "cats": ["r_c"],
+                "injuries": ["water in their lungs"]
+            }
+        ],
+        "history": [
+            {
+                "cats": ["r_c"],
+                "death": ["r_c died after being pushed in the river and inhaling too much water."]
+            }
+        ],
+        "relationships": [
+            {
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["trust"],
+                "amount": -20,
+                "mutual": false,
+                "log": {
+                    "cats_from": "cat_from thinks cat_to pushed {PRONOUN/cat_from/object} into the river and pretended to save {PRONOUN/cat_from/object}."
+                }
+            }
+            ]
+    },
+    {
     "event_id": "gen_misc_hitmanfailedmurder1",
     "location": ["any"],
     "season": ["any"],

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -14114,7 +14114,7 @@
                 ],
                 "cats_to": ["r_c"],
                 "values": [
-                    "comfort"
+                    "comfort", "trust"
                 ],
                 "amount": -15,
                 "mutual": false,

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -14320,6 +14320,49 @@
         "season": ["any"],
         "sub_type": ["failed_murder"],
         "tags": [],
+        "frequency": 2,
+        "event_text": "m_c requests to meet up with lead_name, where {PRONOUN/m_c/subject} {VERB/m_c/claim/claims} {PRONOUN/m_c/subject} overheard r_c making plans to overthrow lead_name and take over the Clan.",
+        "m_c":
+        {
+            "status": [
+                "apprentice",
+                "warrior",
+                "deputy"
+            ],
+            "trait": [
+                "cunning",
+                "charismatic",
+                "troublesome",
+                "bold",
+                "daring",
+                "confident",
+                "vengeful"
+            ]
+        },
+        "r_c": {
+            "status": [
+                "-kitten"
+            ]
+        },
+        "relationships": [
+            {
+                "cats_from": ["m_c"],
+                "cats_to": ["r_c"],
+                "values": ["like"],
+                "amount": -15,
+                "mutual": false,
+                "log": {
+                    "cats_from": "cat_from accused cat_to of wanting to take over the Clan in hopes the leader would get rid of {PRONOUN/cat_to/object} soon."
+                }
+            }
+            ]
+    },
+        {
+        "event_id": "gen_misc_failedmurderplotting2",
+        "location": ["any"],
+        "season": ["any"],
+        "sub_type": ["failed_murder"],
+        "tags": [],
         "frequency": 3,
         "event_text": "m_c is almost in tears as {PRONOUN/m_c/subject} {VERB/m_c/emphasize/emphasizes} to lead_name how cruel r_c has been lately. r_c looks confused and denies everything m_c says.",
         "m_c":
@@ -14334,7 +14377,8 @@
                 "cunning",
                 "charismatic",
                 "insecure",
-                "shameless"
+                "shameless",
+                "troublesome"
             ]
         },
         "r_c": {

--- a/resources/lang/en/events/new_cat/general.json
+++ b/resources/lang/en/events/new_cat/general.json
@@ -1141,7 +1141,7 @@
         "season": ["any"],
         "sub_type": ["war"],
         "frequency": 2,
-        "event_text": "n_c:0, the deputy of o_c_n, has defected to c_n in the war, m_c finds {PRONOUN/n_c:0/object} at the border.",
+        "event_text": "The deputy of o_c_n, n_c:0, meets m_c at the border. {PRONOUN/n_c:0/subject/CAP}{VERB/n_c:0/'ve/'s} defected to c_n in the war.",
         "m_c": {
             "status": [
                 "leader", "deputy", "warrior", "medicine cat", "apprentice", "medicine cat apprentice", "mediator", "mediator apprentice"
@@ -1187,7 +1187,7 @@
         "season": ["any"],
         "sub_type": ["war"],
         "frequency": 3,
-        "event_text": "n_c:0, the medicine cat of o_c_n, has defected to c_n in the war, {PRONOUN/n_c:0/subject} {VERB/n_c:0/meet/meets} m_c at the border.",
+        "event_text": "The medicine cat of o_c_n, n_c:0, meets m_c at the border. {PRONOUN/n_c:0/subject/CAP}{VERB/n_c:0/'ve/'s} defected to c_n in the war.",
         "m_c": {
             "status": [
                 "leader", "deputy", "warrior", "medicine cat", "apprentice", "medicine cat apprentice", "mediator", "mediator apprentice"


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

adds 9 failed murders where there are more consequences! be it the victim getting injured, or misinfo being spread about them! these are meant to mislead the player a little and make them buy the murderer's story... but a peek at the relationship logs might reveal the truth.
also rewords two events where another clan's deputy or medicine cat defects from their clan in a war and joins yours instead because they were kinda clunky.
also also fixes an incorrect pronoun tag in one of my own events because im stupid dumb dumb.

## Why This Is Good For ClanGen

event variety!!!

## Linked Issues
https://github.com/ClanGenOfficial/clangen/issues/1818#issuecomment-4962221779

## Proof of Testing

gen_misc_failedmurderattack1
<img width="508" height="103" alt="image" src="https://github.com/user-attachments/assets/df8c37ee-b8ed-4024-b29e-9423d3a571fb" />

gen_misc_failedmurderattack2
<img width="507" height="100" alt="image" src="https://github.com/user-attachments/assets/2ecf76e8-23f2-41f7-bd9b-3d93284c0d78" />
<img width="349" height="495" alt="image" src="https://github.com/user-attachments/assets/4ab808d7-32bd-4c6f-b63e-a26eef0fa0ff" />
(visually, it's the same as failedmurderattack1, but m_c and r_c are reversed so the murderer is falsely accusing the victim of attacking them!)

gen_misc_failedmurderpoison1
<img width="506" height="96" alt="image" src="https://github.com/user-attachments/assets/97ea5478-ea2f-4c5c-89a9-9330c4a64ad4" />
<img width="357" height="494" alt="image" src="https://github.com/user-attachments/assets/3d74adbf-5856-40dc-8032-ed4e9bc4c2cb" />

gen_misc_failedmurderpoison2
<img width="507" height="130" alt="image" src="https://github.com/user-attachments/assets/16bfe5cf-e282-436d-a1b1-c09631414e31" />

gen_misc_failedmurderpoison3
<img width="511" height="124" alt="image" src="https://github.com/user-attachments/assets/ff0292a5-e7f8-4cb6-a5a8-f424d0d21475" />
<img width="361" height="370" alt="image" src="https://github.com/user-attachments/assets/9199e66f-40a0-463a-a155-92bda0d30fba" />

gen_misc_failedmurderriver1
<img width="511" height="95" alt="image" src="https://github.com/user-attachments/assets/0191d44a-6f91-4ce0-9ddd-4d07fbde053e" />

gen_misc_failedmurderplotting1
<img width="512" height="125" alt="image" src="https://github.com/user-attachments/assets/81faa9a2-7e2b-4929-bf80-24c4510eaf4f" />

gen_misc_failedmurderplotting2 
<img width="511" height="127" alt="image" src="https://github.com/user-attachments/assets/b06530c6-b9a7-438a-b9c8-484b6b177ad8" />
<img width="722" height="545" alt="image" src="https://github.com/user-attachments/assets/b5bb9b64-1d62-491d-89f9-49538c104411" />


## Changelog/Credits

- Adds 9 failed murders! Sometimes, a murderer may enact a plan that isn't exactly successful. Victims might be injured in a murder attempt. Perhaps a real schemer could go up to the leader and claim a cat they don't like is planning to do something terrible... Be sure to watch out for relationship logs to find out the truth!
- Also rewords two war events as they felt kind of clunky.
