### PR TITLE
[BUGFIX] Rel screen

### DIFF
--- a/scripts/screens/RelationshipScreen.py
+++ b/scripts/screens/RelationshipScreen.py
@@ -363,7 +363,11 @@ class RelationshipScreen(Screens):
                 if not all([t.is_neutral for t in r.get_reltype_tiers()])
             ]
         if get_clan_setting("show_family_only"):
-            self.filtered_cats = [r for r in self.filtered_cats if r.family]
+            self.filtered_cats = [
+                r
+                for r in self.filtered_cats
+                if r.cat_from.is_related(r.cat_to, exclude_cousins=False)
+            ]
         elif get_clan_setting("show_romance_only"):
             self.filtered_cats = [
                 r for r in self.filtered_cats if self.romance_allowed(r)

--- a/scripts/screens/RelationshipScreen.py
+++ b/scripts/screens/RelationshipScreen.py
@@ -601,4 +601,7 @@ class RelationshipScreen(Screens):
                 ele.kill()
             ele_dict.clear()
 
+        self.prior_chunk.clear()
+        self.chunks.clear()
+
         super().exit_screen()


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
Fixes two problem with the relationship screen:
- prior loaded chunks weren't being cleared on screen exit, leading to issues with reload upon reentering the screen
- switched to using the `is_related()` func, which seems to be more reliable than the `family` bool in `Relationship`
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
fixes #5486 
fixes #5476
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
<img width="794" height="692" alt="image" src="https://github.com/user-attachments/assets/c62ae510-adfd-473d-87e5-019aa6b7b7ee" />

checked family display against the family tree, all the necessary cats are being shown

<img width="799" height="685" alt="image" src="https://github.com/user-attachments/assets/9783263e-204a-4b38-ad92-ea4f9a7e7f38" />

then exited and reentered the rel screen, relationships are still showing as expected
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Fixes relationships "disappearing" when exiting and reentering the relationship screen for a cat
- Fixes some family members not being included when using the "family only" filter on the relationship screen
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
