### PR TITLE
[TWEAK] changes beige eye name to sand brown

### DIFF
--- a/resources/lang/en/cat/eyes.en.json
+++ b/resources/lang/en/cat/eyes.en.json
@@ -41,7 +41,7 @@
 		"CACTUS": "cactus green",
         "MAPLE": "light maple",
         "LIME": "lime green",
-        "BEIGE": "beige",
+        "SAND": "sand brown",
         "PERIWINKLE": "periwinkle blue",
         "WILDFIRE": "wildfire orange"
     }

--- a/sprites/dicts/eye_sprite_data.json
+++ b/sprites/dicts/eye_sprite_data.json
@@ -51,7 +51,7 @@
 	        "CACTUS": "green",
             "MAPLE": "yellow",
             "LIME": "green",
-            "BEIGE": "yellow",
+            "SAND": "yellow",
             "PERIWINKLE": "blue",
             "WILDFIRE": "yellow"
 	}


### PR DESCRIPTION
## About The Pull Request
- changes beige eyes to sand / sand brown for display. 

## Why This Is Good For ClanGen
- consistent nature theming for names. 

## Proof of Testing
- game runs

