### PR TITLE
[CONTENT] medcat app moonplace events

### DIFF
--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -15956,5 +15956,57 @@
   "r_c": {
       "relationship_status": ["loves_only"]
   }
+},
+   {
+    "event_id": "gen_medapp_mothermouth",
+    "location": ["any"],
+    "season": ["any"],
+    "frequency": 3,
+    "poi": {
+        "name": ["moon_mothermouth"]
+    },
+    "event_text": "m_c returns from {POI/name/moon_mothermouth} and swears {PRONOUN/m_c/poss} whiskers are bent from brushing against the sides of labyrinthine tunnels for so long!",
+    "m_c": {
+      "status": ["medicine cat apprentice"]
+    }
+},
+    {
+    "event_id": "gen_medapp_moonpool",
+    "location": ["any"],
+    "season": ["any"],
+    "frequency": 3,
+    "poi": {
+        "name": ["moon_pool"]
+    },
+    "event_text": "m_c returns from {POI/name/moon_pool}, drenched and dismayed. It seems {PRONOUN/m_c/subject} took a tumble into the sacred waters.",
+    "m_c": {
+      "status": ["medicine cat apprentice"]
+    }
+},
+    {
+    "event_id": "gen_medapp_moonmeteor",
+    "location": ["any"],
+    "season": ["any"],
+    "frequency": 3,
+    "poi": {
+        "name": ["moon_meteor"]
+    },
+    "event_text": "m_c returns from {POI/name/moon_meteor} sneezing sporadically. Perhaps {PRONOUN/m_c/subject} {VERB/m_c/are/is} allergic to moon dust.",
+    "m_c": {
+      "status": ["medicine cat apprentice"]
+    }
+},
+    {
+    "event_id": "gen_medapp_mooncave",
+    "location": ["any"],
+    "season": ["any"],
+    "frequency": 3,
+    "poi": {
+        "name": ["moon_cave"]
+    },
+    "event_text": "m_c returns from {POI/name/moon_cave}, looking more like a puff of fluff than a cat after hearing StarClan's voices echo around {PRONOUN/m_c/object}.",
+    "m_c": {
+      "status": ["medicine cat apprentice"]
+    }
 }
 ]


### PR DESCRIPTION
## About The Pull Request

- A lighthearted event for a medicine cat apprentice at each moonplace currently incorporated through Points of Interest.
- frequency is set to 3 with the hopes that a medicine count will encounter this during their tenure but perhaps no more than once.
- Special thanks to Robinheart for helping develop the Mothermouth text. 

## Why This Is Good For ClanGen
- More integration of points of interest. 
- More flavor text for the learning experience of medicine cats

## Proof of Testing
Code runs locally and events generate within their constraints.
<img width="516" height="103" alt="Screenshot 2026-07-16 at 12 34 18 PM" src="https://github.com/user-attachments/assets/1ad376be-d958-4a87-91c5-695f3b1f7dd0" />
<img width="516" height="103" alt="Screenshot 2026-07-16 at 12 27 27 PM" src="https://github.com/user-attachments/assets/9e78f3c8-7fc2-40b8-8cfe-ebd5cda9923f" />
<img width="518" height="103" alt="Screenshot 2026-07-16 at 12 32 19 PM" src="https://github.com/user-attachments/assets/3905bd4e-eb5b-4ad8-85c1-a8bbe21d6e90" />
<img width="521" height="123" alt="Screenshot 2026-07-16 at 12 26 18 PM" src="https://github.com/user-attachments/assets/ae5eb375-d0e3-4147-a699-4954948656bb" />
