### PR TITLE
[ADJUSTMENT] exclude them leaders

### DIFF
--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -14335,7 +14335,8 @@
         },
         "r_c": {
             "status": [
-                "-kitten"
+                "-kitten",
+                "-leader"
             ]
         },
         "relationships": [
@@ -14377,7 +14378,8 @@
         },
         "r_c": {
             "status": [
-                "-kitten"
+                "-kitten",
+                "-leader"
             ]
         },
         "relationships": [


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

immediate followup on my failed murders bc i forgot to exclude leaders in some events. cant have cats accusing the leader TO the leader LMFAO

## Why This Is Good For ClanGen

i did an oopsie and i fixed the oopsie

## Proof of Testing

trust.....

## Changelog/Credits

- Excludes leaders from certain events so cats don't accuse the leader of wanting to take over the Clan _to_ the leader.
