### PR TITLE
[BUGFIX/FREQFIX] Stop Medicine Cats From Hating Each Other

### DIFF
--- a/resources/lang/en/patrols/general/medcat.json
+++ b/resources/lang/en/patrols/general/medcat.json
@@ -18142,7 +18142,8 @@
                             "cats_from": "cat_from and cat_to were in a good mood after they failed to find any ragwort and were spared its disgusting smell."
                         }
                     }
-                ]
+                ],
+                "frequency": 4
             }
         ]
     },
@@ -24528,7 +24529,8 @@
                             "cats_from": "cat_from was pleased to see cat_to bring back wildflowers to decorate the camp in newleaf."
                         }
                     }
-                ]
+                ],
+                "frequency": 3
             }
         ]
     },
@@ -26842,7 +26844,8 @@
                             "cats_from": "cat_from and cat_to kept each other's spirits up during an unsuccessful herb-gathering patrol."
                         }
                     }
-                ]
+                ],
+                "frequency": 4
             }
         ]
     },

--- a/resources/lang/en/patrols/general/medcat.json
+++ b/resources/lang/en/patrols/general/medcat.json
@@ -37,7 +37,7 @@
                             "trust",
                             "comfort"
                         ],
-                        "amount": 8,
+                        "amount": 10,
                         "log": {
                             "cats_from": "cat_from and cat_to discussed medicine cat business while sunning themselves on patrol."
                         }
@@ -61,7 +61,7 @@
                             "like",
                             "comfort"
                         ],
-                        "amount": 8,
+                        "amount": 10,
                         "log": {
                             "cats_from": "cat_from and cat_to chatted about the herb stores and herb-gathering spots while sunning themselves."
                         }
@@ -83,7 +83,7 @@
                         "values": [
                             "like"
                         ],
-                        "amount": 5,
+                        "amount": 10,
                         "log": {
                             "cats_from": "cat_from and cat_to sunned themselves on patrol before gathering herbs."
                         }
@@ -116,7 +116,7 @@
                         "values": [
                             "like"
                         ],
-                        "amount": 5,
+                        "amount": 10,
                         "log": {
                             "cats_from": "cat_from and cat_to sunned themselves on patrol before gathering herbs."
                         }
@@ -128,7 +128,7 @@
                         "values": [
                             "respect"
                         ],
-                        "amount": 5,
+                        "amount": 10,
                         "log": {
                             "cats_from": "cat_from appreciated that cat_to made sure everyone got a nice basking spot while they were relaxing."
                         }
@@ -500,7 +500,7 @@
                         "values": [
                             "trust"
                         ],
-                        "amount": 5,
+                        "amount": 10,
                         "log": {
                             "cats_from": "cat_from trusted cat_to to interpret r_c's vision."
                         }
@@ -513,7 +513,7 @@
                             "like",
                             "respect"
                         ],
-                        "amount": 8,
+                        "amount": 10,
                         "log": {
                             "cats_from": "p_l helped r_c interpret a vision."
                         }
@@ -535,7 +535,7 @@
                         "values": [
                             "trust"
                         ],
-                        "amount": 5,
+                        "amount": 10,
                         "log": {
                             "cats_from": "cat_from trusted cat_to to interpret r_c's vision."
                         }
@@ -548,7 +548,7 @@
                             "like",
                             "respect"
                         ],
-                        "amount": 8,
+                        "amount": 10,
                         "log": {
                             "cats_from": "p_l helped r_c interpret a vision."
                         }
@@ -570,7 +570,7 @@
                         "values": [
                             "trust"
                         ],
-                        "amount": 5,
+                        "amount": 10,
                         "log": {
                             "cats_from": "cat_from trusted cat_to to interpret r_c's vision."
                         }
@@ -583,7 +583,7 @@
                             "like",
                             "respect"
                         ],
-                        "amount": 8,
+                        "amount": 10,
                         "log": {
                             "cats_from": "p_l helped r_c interpret a vision."
                         }
@@ -595,7 +595,7 @@
                         "values": [
                             "comfort"
                         ],
-                        "amount": -5,
+                        "amount": -8,
                         "log": {
                             "cats_from": "cat_from worried about what cat_to's vision could mean and why {PRONOUN/cat_to/subject} received it."
                         }
@@ -685,7 +685,7 @@
                         "values": [
                             "trust"
                         ],
-                        "amount": 5,
+                        "amount": 10,
                         "log": {
                             "cats_from": "cat_from trusted cat_to to interpret r_c's vision."
                         }
@@ -698,7 +698,7 @@
                             "like",
                             "respect"
                         ],
-                        "amount": 5,
+                        "amount": 10,
                         "log": {
                             "cats_from": "r_c confided in s_c about a vision, and s_c promised to look into it."
                         }
@@ -724,7 +724,7 @@
                         "values": [
                             "trust"
                         ],
-                        "amount": 5,
+                        "amount": 10,
                         "log": {
                             "cats_from": "cat_from trusted cat_to to interpret r_c's dream."
                         }
@@ -737,7 +737,7 @@
                             "like",
                             "respect"
                         ],
-                        "amount": 8,
+                        "amount": 10,
                         "log": {
                             "cats_from": "p_l and r_c discussed a dream-vision they both had."
                         }
@@ -756,9 +756,9 @@
                         "cats_from": ["patrol"],
                         "mutual": false,
                         "values": [
-                            "respect"
+                            "trust"
                         ],
-                        "amount": -5,
+                        "amount": -10,
                         "log": {
                             "cats_from": "cat_from was disappointed to hear that cat_to couldn't interpret r_c's vision."
                         }
@@ -1081,9 +1081,7 @@
         "max_cats": 2,
         "min_max_status": {
             "medicine cat apprentice": [1, 1],
-            "medicine cat": [1, 1],
-            "warrior": [-1, -1],
-            "apprentice": [-1, -1]
+            "medicine cat": [1, 1]
         },
         "frequency": 4,
         "intro_text": "app1 looks to p_l, wondering if {PRONOUN/app1/subject} should speak to p_l about the dream {PRONOUN/app1/subject} had last night.",
@@ -1379,7 +1377,7 @@
                             "respect",
                             "trust"
                         ],
-                        "amount": -10,
+                        "amount": -8,
                         "log": {
                             "cats_from": "cat_from confided in cat_to about a vision in hopes that cat_to could help, but {PRONOUN/cat_to/subject} couldn't."
                         }
@@ -1418,7 +1416,7 @@
                             "trust",
                             "comfort"
                         ],
-                        "amount": -15,
+                        "amount": -10,
                         "log": {
                             "cats_from": "cat_from confided in cat_to about a vision, but cat_to dismissed it completely without listening."
                         }
@@ -1438,7 +1436,7 @@
                             "comfort",
                             "trust"
                         ],
-                        "amount": -10,
+                        "amount": -8,
                         "log": {
                             "cats_from": "cat_from confided in cat_to about a vision, but cat_to told {PRONOUN/cat_from/object} that it was just a normal dream."
                         }
@@ -1497,7 +1495,7 @@
                             "trust",
                             "comfort"
                         ],
-                        "amount": -15,
+                        "amount": -12,
                         "log": {
                             "cats_from": "cat_from could tell that cat_to was angry that cat_from received a vision instead of {PRONOUN/cat_to/object}."
                         }
@@ -1543,7 +1541,7 @@
                             "trust",
                             "comfort"
                         ],
-                        "amount": -15,
+                        "amount": -12,
                         "log": {
                             "cats_from": "cat_from felt embarrassed and chastened when cat_to dismissed {PRONOUN/cat_from/poss} vision and told {PRONOUN/cat_from/object} {PRONOUN/cat_from/subject} {VERB/cat_from/weren't/wasn't} the sort of cat to receive visions."
                         }
@@ -1768,7 +1766,7 @@
                         "values": [
                             "respect"
                         ],
-                        "amount": 8,
+                        "amount": 10,
                         "log": {
                             "cats_from": "cat_from was amazed to encounter a ghost while patrolling with cat_to."
                         }
@@ -1790,7 +1788,7 @@
                         "values": [
                             "respect"
                         ],
-                        "amount": 8,
+                        "amount": 10,
                         "log": {
                             "cats_from": "cat_from was amazed to encounter a ghost while patrolling with cat_to."
                         }
@@ -1816,7 +1814,7 @@
                         "values": [
                             "respect"
                         ],
-                        "amount": 10,
+                        "amount": 15,
                         "log": {
                             "cats_from": "cat_from was amazed by cat_to's confidence when the patrol encountered the spirit of a StarClan cat."
                         }
@@ -1854,7 +1852,7 @@
                             "respect",
                             "trust"
                         ],
-                        "amount": -20,
+                        "amount": -15,
                         "log": {
                             "cats_from": "cat_from lost faith in cat_to when {PRONOUN/cat_from/subject} saw {PRONOUN/cat_to/object} be rebuked by a StarClan spirit."
                         }
@@ -1910,7 +1908,6 @@
                         "cats_from": ["patrol"],
                         "mutual": false,
                         "values": [
-                            "respect",
                             "comfort"
                         ],
                         "amount": -10,
@@ -1946,7 +1943,6 @@
                         "cats_from": ["patrol"],
                         "mutual": false,
                         "values": [
-                            "respect",
                             "comfort"
                         ],
                         "amount": -10,
@@ -1979,7 +1975,6 @@
                         "cats_from": ["patrol"],
                         "mutual": false,
                         "values": [
-                            "respect",
                             "comfort"
                         ],
                         "amount": -10,
@@ -2115,7 +2110,7 @@
         "chance_of_success": 30,
         "success_outcomes": [
             {
-                "text": "With respectful nods, the patrol pauses. app1 takes {PRONOUN/app1/poss} lead from p_l and tucks {PRONOUN/app1/poss} paws together neatly, sitting to converse with the StarClan cat.",
+                "text": "With respectful nods, the patrol pauses. app1 takes {PRONOUN/app1/poss} cue from p_l and tucks {PRONOUN/app1/poss} paws together neatly, sitting to converse with the StarClan cat.",
                 "exp": 30,
                 "herbs": [
                     "random_herbs"
@@ -2218,7 +2213,7 @@
                             "respect",
                             "trust"
                         ],
-                        "amount": -20,
+                        "amount": -15,
                         "log": {
                             "cats_from": "cat_from lost faith in cat_to when {PRONOUN/cat_from/subject} saw {PRONOUN/cat_to/object} be rebuked by a StarClan spirit."
                         }
@@ -2306,7 +2301,7 @@
                         "cats_from": ["r_c"],
                         "mutual": false,
                         "values": [
-                            "respect",
+                            "comfort",
                             "trust"
                         ],
                         "amount": 10,
@@ -2341,7 +2336,7 @@
                         "cats_from": ["r_c"],
                         "mutual": false,
                         "values": [
-                            "respect",
+                            "comfort",
                             "trust"
                         ],
                         "amount": 10,
@@ -2365,7 +2360,7 @@
                 "frequency": 1
             },
             {
-                "text": "p_l had seen before how connected s_c was to StarClan, and began telling {PRONOUN/s_c/object} more than {PRONOUN/p_l/subject} would have told any other Clan cat about their ancestors. p_l and s_c spend much of their patrol gathering herbs and discussing the hard-hitting questions on prophecies and StarClan's gifts.",
+                "text": "p_l had seen before how connected s_c was to StarClan and began telling {PRONOUN/s_c/object} more than {PRONOUN/p_l/subject} would have told any other Clan cat about their ancestors. p_l and s_c spend much of their patrol gathering herbs and discussing the hard-hitting questions on prophecies and StarClan's gifts.",
                 "exp": 10,
                 "stat_skill": [
                     "LORE,1",
@@ -2381,7 +2376,7 @@
                         "cats_from": ["s_c"],
                         "mutual": false,
                         "values": [
-                            "respect",
+                            "comfort",
                             "trust"
                         ],
                         "amount": 10,
@@ -2396,7 +2391,7 @@
                         "values": [
                             "comfort", "like", "respect"
                         ],
-                        "amount": 12,
+                        "amount": 10,
                         "log": {
                             "cats_from": "cat_from appreciated cat_to's genuine interest in learning about StarClan's mysteries and knew it came from a place of understanding."
                         }
@@ -2572,7 +2567,7 @@
                             "like",
                             "trust"
                         ],
-                        "amount": 5,
+                        "amount": 8,
                         "log": {
                             "cats_from": "cat_from and cat_to chatted while gathering herbs."
                         }
@@ -2595,7 +2590,7 @@
                             "like",
                             "trust"
                         ],
-                        "amount": 5,
+                        "amount": 8,
                         "log": {
                             "cats_from": "cat_from and cat_to gathered herbs quicker than usual so they had a chance to bask and chat in the sun."
                         }
@@ -3961,7 +3956,7 @@
                 "frequency": 4
             },
             {
-                "text": "r_c, deep in thought, asks p_l if {PRONOUN/p_l/subject}{VERB/p_l/'ve/'s} considered taking on another apprentice. p_l swishes {PRONOUN/p_l/poss} tail, and asks what brought this on. {PRONOUN/r_c/subject/CAP} {VERB/r_c/were/was} honestly just wondering, r_c explains, as {PRONOUN/r_c/subject}{VERB/r_c/'re/'s} not sure {PRONOUN/r_c/self} when {PRONOUN/r_c/subject} {VERB/r_c/want/wants} to. p_l nods, and says {PRONOUN/p_l/subject}{VERB/p_l/'ve/'s} been thinking about it — but they've reached the herbs and have to pick them now.",
+                "text": "r_c, deep in thought, asks p_l if {PRONOUN/p_l/subject}{VERB/p_l/'ve/'s} considered taking on another apprentice. p_l swishes {PRONOUN/p_l/poss} tail, and asks what brought this on. {PRONOUN/r_c/subject/CAP} {VERB/r_c/were/was} honestly just wondering, r_c explains, as {PRONOUN/r_c/subject}{VERB/r_c/'re/'s} not sure {PRONOUN/r_c/self} when {PRONOUN/r_c/subject} {VERB/r_c/want/wants} to. p_l nods, and says {PRONOUN/p_l/subject}{VERB/p_l/'ve/'s} been thinking about it, but they've reached the herbs and have to pick them now.",
                 "exp": 20,
                 "herbs": [
                     "random_herbs"
@@ -3975,7 +3970,7 @@
                             "like",
                             "trust"
                         ],
-                        "amount": 8,
+                        "amount": 10,
                         "log": {
                             "cats_from": "cat_from and cat_to spent an herb-gathering patrol discussing the possibility of taking on another medicine cat apprentice."
                         }
@@ -3995,10 +3990,10 @@
                         "cats_from": ["patrol"],
                         "mutual": false,
                         "values": [
-                            "respect",
+                            "comfort",
                             "trust"
                         ],
-                        "amount": 5,
+                        "amount": 8,
                         "log": {
                             "cats_from": "cat_from and cat_to had a good discussion about the latest news in the Clan while gathering herbs."
                         }
@@ -4021,7 +4016,7 @@
                             "respect",
                             "trust"
                         ],
-                        "amount": 5,
+                        "amount": 8,
                         "log": {
                             "cats_from": "cat_from and cat_to had a good discussion about signs from StarClan while gathering herbs."
                         }
@@ -4034,20 +4029,6 @@
             {
                 "text": "The two medicine cats walk in circles for a while before realizing that they've completely forgotten where the herb patch is since it's been so long. How embarrassing!",
                 "exp": 0,
-                "relationships": [
-                    {
-                        "cats_to": ["patrol"],
-                        "cats_from": ["patrol"],
-                        "mutual": false,
-                        "values": [
-                            "trust"
-                        ],
-                        "amount": -5,
-                        "log": {
-                            "cats_from": "cat_from and cat_to were embarrassed that they forgot the location of a herb patch."
-                        }
-                    }
-                ],
                 "frequency": 4
             },
             {
@@ -4095,7 +4076,7 @@
                         "values": [
                             "comfort"
                         ],
-                        "amount": -8,
+                        "amount": -10,
                         "log": {
                             "cats_from": "cat_from felt uncomfortable when cat_to snapped at {PRONOUN/cat_from/object} while they were gathering herbs."
                         }
@@ -4112,8 +4093,7 @@
                         "cats_from": ["patrol"],
                         "mutual": false,
                         "values": [
-                            "like",
-                            "trust"
+                            "like"
                         ],
                         "amount": -8,
                         "log": {
@@ -8314,7 +8294,7 @@
                             "like",
                             "comfort"
                         ],
-                        "amount": -10,
+                        "amount": -5,
                         "log": {
                             "cats_from": "cat_from knew cat_to was laughing at {PRONOUN/cat_from/object}."
                         }
@@ -8574,7 +8554,7 @@
                             "like",
                             "respect"
                         ],
-                        "amount": -10,
+                        "amount": -5,
                         "log": {
                             "cats_from": "cat_from was unhappy with cat_to for munching on the mallow the patrol was meant to be gathering."
                         }
@@ -8784,7 +8764,7 @@
             "LORE,1",
             "STORY,1"
         ],
-        "intro_text": "app1 is probably not <i>trying</i> to be annoying — but {PRONOUN/app1/poss} complaints about the taste of ragwort help no one, and it's just slowing the entire patrol down.",
+        "intro_text": "app1 is probably not <i>trying</i> to be annoying, but {PRONOUN/app1/poss} complaints about the taste of ragwort help no one, and it's just slowing the entire patrol down.",
         "decline_text": "Toughen up, honestly.",
         "chance_of_success": 30,
         "success_outcomes": [
@@ -8830,7 +8810,7 @@
                         ],
                         "mutual": true,
                         "values": [
-                            "respect"
+                            "like"
                         ],
                         "amount": -10,
                         "log": {
@@ -8855,7 +8835,7 @@
                         "values": [
                             "like", "comfort"
                         ],
-                        "amount": -10,
+                        "amount": -8,
                         "log": {
                             "cats_from": "p_l snapped at app1 for sidetracking an herb-gathering patrol by complaining about the foul taste of ragwort."
                         }
@@ -8941,24 +8921,6 @@
                         ]
                     }
                 ],
-                "relationships": [
-                    {
-                        "cats_to": [
-                            "p_l"
-                        ],
-                        "cats_from": [
-                            "r_c"
-                        ],
-                        "mutual": false,
-                        "values": [
-                            "like"
-                        ],
-                        "amount": -5,
-                        "log": {
-                            "cats_from": "cat_from was impatient gathering raspberry with cat_to and got scratched by the thorny bush."
-                        }
-                    }
-                ],
                 "frequency": 4
             }
         ]
@@ -9033,7 +8995,7 @@
                             "like",
                             "respect"
                         ],
-                        "amount": -10,
+                        "amount": -8,
                         "log": {
                             "cats_from": "cat_from blamed cat_to for distracting {PRONOUN/cat_from/object} when the patrol was supposed to be gathering tansy."
                         }
@@ -9070,7 +9032,7 @@
                             "respect",
                             "trust"
                         ],
-                        "amount": -10,
+                        "amount": -8,
                         "log": {
                             "cats_from": "p_l didn't keep a close enough eye on the patrol, and app1 got poisoned as a result."
                         }
@@ -9102,25 +9064,6 @@
                 "history_text": {
                     "death": "m_c poisoned {PRONOUN/m_c/self} collecting excessive amounts of tansy as an apprentice."
                 },
-                "relationships": [
-                    {
-                        "cats_to": [
-                            "app1"
-                        ],
-                        "cats_from": [
-                            "p_l"
-                        ],
-                        "mutual": false,
-                        "values": [
-                            "respect",
-                            "trust"
-                        ],
-                        "amount": -5,
-                        "log": {
-                            "cats_from": "cat_to ignored cat_from's warning about tansy and got sick."
-                        }
-                    }
-                ],
                 "frequency": 4
             }
         ]
@@ -9170,7 +9113,7 @@
                             "like",
                             "respect"
                         ],
-                        "amount": 10,
+                        "amount": 8,
                         "log": {
                             "cats_from": "cat_from learned from cat_to about how not all illnesses and injuries are physical in nature."
                         }
@@ -9638,9 +9581,9 @@
                             "respect",
                             "like"
                         ],
-                        "amount": -8,
+                        "amount": -5,
                         "log": {
-                          "cats_from": "cat_from was visibly frustrated by cat_to while patrolling in the rain empty-pawed."
+                          "cats_from": "cat_from was frustrated by cat_to while patrolling in the rain empty-pawed."
                         }
                     }
                 ],
@@ -9793,7 +9736,6 @@
                         ],
                         "mutual": false,
                         "values": [
-                            "respect",
                             "like"
                         ],
                         "amount": -5,
@@ -9950,7 +9892,7 @@
                         "values": [
                             "comfort"
                         ],
-                        "amount": -7,
+                        "amount": -5,
                         "log": {
                             "cats_from": "cat_from could tell cat_to was frustrated with {PRONOUN/cat_from/object} during an unsuccessful cobweb-gathering patrol."
                         }
@@ -9967,7 +9909,7 @@
                             "respect",
                             "like"
                         ],
-                        "amount": -7,
+                        "amount": -5,
                         "log": {
                             "cats_from": "cat_from struggled to keep {PRONOUN/cat_from/poss} temper when cat_to ruined the few cobwebs that cat_from's patrol managed to collect."
                         }
@@ -10162,7 +10104,7 @@
                             "respect",
                             "trust"
                         ],
-                        "amount": -10,
+                        "amount": -7,
                         "log": {
                             "cats_from": "cat_from was disappointed in cat_to for letting {PRONOUN/cat_to/poss} distraction sidetrack a gathering patrol."
                         }
@@ -13094,6 +13036,11 @@
         ],
         "fail_outcomes": [
             {
+                "text": "The patrol is fruitless, and the patrol returns to camp with no burdock.",
+                "exp": 0,
+                "frequency": 4
+            },
+            {
                 "text": "Maybe {PRONOUN/p_l/subject}{VERB/p_l/'re/'s} just coming down with a runny nose, but p_l doesn't manage to sniff out any burdock, and no one else on the patrol is very helpful either. {PRONOUN/p_l/subject/CAP} {VERB/p_l/return/returns} to camp without any burdock, prickling with frustration.",
                 "exp": 0,
                 "relationships": [
@@ -13108,7 +13055,7 @@
                         "values": [
                             "respect"
                         ],
-                        "amount": -8,
+                        "amount": -5,
                         "log": {
                             "cats_from": "cat_from accompanied cat_to to harvest burdock root, but cat_to wasn't able to find any, and cat_from felt like the day was a waste."
                         }
@@ -13124,13 +13071,13 @@
                         "values": [
                             "like"
                         ],
-                        "amount": -8,
+                        "amount": -5,
                         "log": {
                             "cats_from": "cat_from was irritated with cat_to for being unhelpful during an herb-gathering patrol."
                         }
                     }
                 ],
-                "frequency": 4
+                "frequency": 2
             }
         ]
     },
@@ -13198,24 +13145,6 @@
             {
                 "text": "p_l can't find the burdock plant {PRONOUN/p_l/subject} {VERB/p_l/were/was} thinking about. Maybe it was trampled by some animal... Oh, well.",
                 "exp": 0,
-                "relationships": [
-                    {
-                        "cats_to": [
-                            "p_l"
-                        ],
-                        "cats_from": [
-                            "patrol"
-                        ],
-                        "mutual": false,
-                        "values": [
-                            "trust"
-                        ],
-                        "amount": -5,
-                        "log": {
-                            "cats_from": "cat_from felt like cat_to wasted {PRONOUN/cat_from/poss} time when their herb-gathering patrol found no burdock."
-                        }
-                    }
-                ],
                 "frequency": 4
             },
             {
@@ -13239,8 +13168,7 @@
                         "mutual": false,
                         "values": [
                             "like",
-                            "comfort",
-                            "respect"
+                            "comfort"
                         ],
                         "amount": -8,
                         "log": {
@@ -13593,7 +13521,7 @@
                             "like",
                             "respect"
                         ],
-                        "amount": -10,
+                        "amount": -7,
                         "log": {
                             "cats_from": "cat_from lost {PRONOUN/cat_from/poss} temper with cat_to when cat_to trampled a crucial catmint plant in {PRONOUN/cat_to/poss} excitement about the herb."
                         }
@@ -13830,7 +13758,7 @@
             "normal adult": [2, 5]
         },
         "frequency": 4,
-        "intro_text": "The heat of greenleaf warms {PRONOUN/p_l/poss} pelt as p_l wanders, aimlessly searching for daisies to harvest their leaves. {PRONOUN/p_l/subject/CAP} {VERB/p_l/assemble/assembles} a little group of warriors to help {PRONOUN/p_l/object} carry the herbs.",
+        "intro_text": "The heat of greenleaf warms {PRONOUN/p_l/poss} pelt as p_l wanders, searching for daisies to harvest their leaves. {PRONOUN/p_l/subject/CAP} {VERB/p_l/assemble/assembles} a little group of warriors to help {PRONOUN/p_l/object} carry the herbs.",
         "decline_text": "They're stopped before they leave camp — these warriors are needed elsewhere. p_l's expedition will have to wait.",
         "chance_of_success": 30,
         "success_outcomes": [
@@ -13926,6 +13854,11 @@
             }
         ],
         "fail_outcomes": [
+            { 
+                "text": "Despite greenleaf's abundance, other wildflowers with less useful medicinal properties have choked up the daisy patch and hogged all the sunlight. p_l's patrol returns empty-pawed.",
+                "exp": 0,   
+                "frequency": 4
+            },
             {
                 "text": "With the warriors more interested in hunting whatever has been snacking on the daisies than helping p_l find any more plants, it's a frustrating and unproductive afternoon.",
                 "exp": 0,
@@ -14367,6 +14300,11 @@
                         }
                     }
                 ],
+                "frequency": 4
+            },
+            {
+                "text": "When the patrol arrives at the dandelion fields, they find the stems stripped of their leaves. The scent of rabbits suggests the culprits.",
+                "exp": 0,
                 "frequency": 4
             }
         ]
@@ -15098,12 +15036,17 @@
                             "like",
                             "respect"
                         ],
-                        "amount": -8,
+                        "amount": -5,
                         "log": {
                             "cats_from": "cat_from and cat_to were short with each other during a herb gathering patrol."
                         }
                     }
                 ],
+                "frequency": 4
+            },
+            {
+                "text": "The greenleaf sun coupled with the lack of recent rain has left the goldenrod dry and shriveled. p_l decides it's best to leave the plants to recover, and the patrol returns home empty-pawed.",
+                "exp": 0,
                 "frequency": 4
             }
         ]
@@ -15304,7 +15247,7 @@
                             "respect",
                             "trust"
                         ],
-                        "amount": -10,
+                        "amount": -7,
                         "log": {
                             "cats_from": "cat_from lost faith in cat_to when cat_to was unable to locate a juniper tree during an herb-gathering patrol."
                         }
@@ -15425,7 +15368,7 @@
                             "like",
                             "respect"
                         ],
-                        "amount": -10,
+                        "amount": -5,
                         "log": {
                             "cats_from": "cat_from was irate when cat_to spent an herb-gathering patrol complaining about juniper needles instead of gathering them."
                         }
@@ -16271,12 +16214,17 @@
                             "like",
                             "respect"
                         ],
-                        "amount": -8,
+                        "amount": -5,
                         "log": {
                             "cats_from": "cat_from and cat_to were short with each other during an unsuccessful herb-gathering patrol."
                         }
                     }
                 ],
+                "frequency": 4
+            },
+            {
+                "text": "The mallow is surprisingly small considering greenleaf's usual abundance. Perhaps too many roots over too many seasons have leached all the nutrients from the soil. p_l realizes that c_n may need to find a new source of mallow.",
+                "exp": 0,
                 "frequency": 4
             }
         ]
@@ -16600,12 +16548,17 @@
                             "like",
                             "respect"
                         ],
-                        "amount": -8,
+                        "amount": -5,
                         "log": {
                             "cats_from": "cat_from and cat_to were short with each other during an unsuccessful herb-gathering patrol."
                         }
                     }
                 ],
+                "frequency": 4
+            },
+            {
+                "text": "Marigold being easy to spot means it's easy to tell when there is <i>no</i> marigold nearby, either. p_l calls off the patrol, resigned to returning to camp with empty paws.",
+                "exp": 0,
                 "frequency": 4
             }
         ]
@@ -16898,7 +16851,7 @@
                 "frequency": 1
             },
             {
-                "text": "s_c spots mullein plants growing plenty of leaves on their strange central stems, and knocks them over so that the entire bundle can be carried home by the patrol. As a bonus, {PRONOUN/s_c/poss} plant pruning operation exposes a couple hidden thyme plants creeping along the soil, and {PRONOUN/s_c/subject}'re added to the day's harvest.",
+                "text": "s_c spots mullein plants growing plenty of leaves on their strange central stems and knocks them over so that the entire bundle can be carried home by the patrol. As a bonus, {PRONOUN/s_c/poss} plant pruning operation exposes a couple hidden thyme plants creeping along the soil, and {PRONOUN/s_c/subject}'re added to the day's harvest.",
                 "exp": 10,
                 "stat_skill": [
                     "SENSE,2"
@@ -16932,27 +16885,8 @@
         ],
         "fail_outcomes": [
             {
-                "text": "p_l could swear that there's usually some mullein around here — but not this time.",
+                "text": "p_l could swear that there's usually some mullein around here, but not this time.",
                 "exp": 0,
-                "relationships": [
-                    {
-                        "cats_to": [
-                            "p_l"
-                        ],
-                        "cats_from": [
-                            "patrol"
-                        ],
-                        "mutual": false,
-                        "values": [
-                            "trust",
-                            "respect"
-                        ],
-                        "amount": -7,
-                        "log": {
-                            "cats_from": "cat_from was unimpressed that cat_to couldn't find any of the mullein the patrol was supposed to be gathering."
-                        }
-                    }
-                ],
                 "frequency": 4
             }
         ]
@@ -17542,13 +17476,18 @@
                             "like",
                             "respect"
                         ],
-                        "amount": -10,
+                        "amount": -7,
                         "log": {
                             "cats_from": "p_l was cross with cat_to when {PRONOUN/p_l/subject} discovered {PRONOUN/cat_to/subject} had been trampling plantain on purpose."
                         }
                     }
                 ],
                 "frequency": 4
+            },
+            {
+                "text": "The plantain hasn't been as aggressive this year, which is fortunate for the warriors but unfortunate for p_l's herb-gathering mission. {PRONOUN/p_l/subject/CAP} must return to camp empty-pawed.",
+                "exp": 0,
+                "frequency": 3
             }
         ]
     },
@@ -18182,13 +18121,28 @@
                             "trust",
                             "respect"
                         ],
-                        "amount": -10,
+                        "amount": -7,
                         "log": {
                             "cats_from": "cat_from lost faith in cat_to when cat_to admitted to not being able to identify ragwort during an herb-gathering patrol."
                         }
                     }
                 ],
                 "frequency": 4
+            },
+            {
+                "text": "p_l isn't able to locate any ragwort, which everyone pretends to be disappointed about. The patrol is in a good mood heading home without stinky ragwort in their jaws.",
+                "exp": 0,
+                "relationships": [
+                    {
+                        "cats_from": ["patrol"],
+                        "cats_to": ["patrol"],
+                        "values": ["like"],
+                        "amount": 5,
+                        "log": {
+                            "cats_from": "cat_from and cat_to were in a good mood after they failed to find any ragwort and were spared its disgusting smell."
+                        }
+                    }
+                ]
             }
         ]
     },
@@ -18670,7 +18624,7 @@
                             "trust",
                             "respect"
                         ],
-                        "amount": -10,
+                        "amount": -7,
                         "log": {
                             "cats_from": "cat_from lost faith in cat_to when cat_to admitted to not being able to identify tansy during an herb-gathering patrol."
                         }
@@ -19005,25 +18959,6 @@
             {
                 "text": "p_l has no time — and no thyme. {PRONOUN/p_l/subject/CAP}{VERB/p_l/'re/'s} forced to give up on the search for today.",
                 "exp": 0,
-                "relationships": [
-                    {
-                        "cats_to": [
-                            "p_l"
-                        ],
-                        "cats_from": [
-                            "patrol"
-                        ],
-                        "mutual": false,
-                        "values": [
-                            "like",
-                            "respect"
-                        ],
-                        "amount": -5,
-                        "log": {
-                            "cats_from": "cat_from felt like cat_to wasted {PRONOUN/cat_from/poss} time with an unsuccessful thyme-gathering patrol."
-                        }
-                    }
-                ],
                 "frequency": 4
             }
         ]
@@ -19362,12 +19297,17 @@
                             "trust",
                             "respect"
                         ],
-                        "amount": -10,
+                        "amount": -7,
                         "log": {
                             "cats_from": "cat_from lost faith in cat_to when cat_to admitted to not being able to identify wild garlic during an herb-gathering patrol."
                         }
                     }
                 ],
+                "frequency": 4
+            },
+            {
+                "text": "p_l returns to a patch of wild garlic {PRONOUN/p_l/subject}{VERB/p_l/'ve/'s} harvested from in the past, but it seems another animal has found {PRONOUN/p_l/poss} stash. The churned-up earth and the flecks of chewed bulbs are no good to the medicine den.",
+                "exp": 0,
                 "frequency": 4
             }
         ]
@@ -19717,7 +19657,7 @@
             ]
         },
         "frequency": 4,
-        "intro_text": "Hmm. p_l heads out, deciding that c_n needs more blackberry leaves in their stores.",
+        "intro_text": "p_l heads out, deciding that c_n needs more blackberry leaves in their stores.",
         "decline_text": "{PRONOUN/p_l/subject/CAP} {VERB/p_l/have/has} second thoughts about leaving {PRONOUN/p_l/poss} patients behind and {VERB/p_l/decide/decides} to go another day.",
         "chance_of_success": 40,
         "success_outcomes": [
@@ -20220,7 +20160,7 @@
             ]
         },
         "frequency": 4,
-        "intro_text": "Hmm. p_l heads out, deciding that c_n needs more blackberry leaves in their stores, bringing along anyone who isn't busy with other work.",
+        "intro_text": "p_l heads out, deciding that c_n needs more blackberry leaves in their stores, bringing along anyone who isn't busy with other work.",
         "decline_text": "They're stopped before they leave camp — these warriors are needed elsewhere. p_l's expedition will have to wait.",
         "chance_of_success": 20,
         "success_outcomes": [
@@ -20401,24 +20341,6 @@
                     "scar": "m_c was scarred by frostbite after searching for berries in leaf-bare.",
                     "death": "m_c died of frostbite after searching for berries in leaf-bare."
                 },
-                "relationships": [
-                    {
-                        "cats_to": [
-                            "r_c"
-                        ],
-                        "cats_from": [
-                            "patrol"
-                        ],
-                        "mutual": false,
-                        "values": [
-                            "respect"
-                        ],
-                        "amount": -5,
-                        "log": {
-                            "cats_from": "cat_from saw cat_to mess up while on patrol."
-                        }
-                    }
-                ],
                 "frequency": 3
             },
             {
@@ -20438,24 +20360,6 @@
                     "scar": "m_c was scarred by frostbite after searching for berries in leaf-bare.",
                     "death": "m_c died of frostbite after searching for berries in leaf-bare."
                 },
-                "relationships": [
-                    {
-                        "cats_to": [
-                            "p_l"
-                        ],
-                        "cats_from": [
-                            "patrol"
-                        ],
-                        "mutual": false,
-                        "values": [
-                            "respect"
-                        ],
-                        "amount": -5,
-                        "log": {
-                            "cats_from": "cat_from saw p_l mess up while on patrol."
-                        }
-                    }
-                ],
                 "frequency": 3
             },
             {
@@ -20816,7 +20720,6 @@
                         "mutual": false,
                         "values": [
                             "like",
-                            "respect",
                             "comfort",
                             "trust"
                         ],
@@ -20835,7 +20738,6 @@
                         "mutual": false,
                         "values": [
                             "like",
-                            "respect",
                             "comfort",
                             "trust"
                         ],
@@ -22871,24 +22773,6 @@
                     "scar": "m_c was scarred after falling from a juniper tree, trying to harvest its leaves in the cold snow of leaf-bare.",
                     "death": "m_c died from injuries sustained after falling from a juniper tree."
                 },
-                "relationships": [
-                    {
-                        "cats_to": [
-                            "r_c"
-                        ],
-                        "cats_from": [
-                            "patrol"
-                        ],
-                        "mutual": false,
-                        "values": [
-                            "respect"
-                        ],
-                        "amount": -5,
-                        "log": {
-                            "cats_from": "cat_from saw cat_to mess up while on patrol."
-                        }
-                    }
-                ],
                 "frequency": 3
             },
             {
@@ -22909,24 +22793,6 @@
                     "scar": "m_c was scarred after falling from a juniper tree, trying to harvest its leaves in the cold snow of leaf-bare.",
                     "death": "m_c died from injuries sustained after falling from a juniper tree."
                 },
-                "relationships": [
-                    {
-                        "cats_to": [
-                            "p_l"
-                        ],
-                        "cats_from": [
-                            "patrol"
-                        ],
-                        "mutual": false,
-                        "values": [
-                            "respect"
-                        ],
-                        "amount": -5,
-                        "log": {
-                            "cats_from": "cat_from saw p_l mess up while on patrol."
-                        }
-                    }
-                ],
                 "frequency": 3
             },
             {
@@ -23602,6 +23468,11 @@
                     }
                 ],
                 "frequency": 4
+            },
+            {
+                "text": "The betony hasn't quite recovered from a late frost, and p_l decides it's best to let the plants recover before harvesting any this season.",
+                "exp": 0,
+                "frequency": 4
             }
         ]
     },
@@ -24267,7 +24138,7 @@
                         "values": [
                             "respect"
                         ],
-                        "amount": -8,
+                        "amount": -5,
                         "log": {
                             "cats_from": "cat_from accompanied cat_to to harvest burdock root, but cat_to wasn't able to find any, and cat_from felt like the day was a waste."
                         }
@@ -24289,6 +24160,11 @@
                         }
                     }
                 ],
+                "frequency": 4
+            },
+            {
+                "text": "After a late frost, the ground is too solid to dig up any burdock roots. The patrol gives up and heads home.",
+                "exp": 0,
                 "frequency": 4
             }
         ]
@@ -24638,6 +24514,21 @@
                     }
                 ],
                 "frequency": 4
+            },
+            {
+                "text": "The warriors bring back heaps of wildflowers but no daisies. p_l is amused by their helplessness. At least these flowers can help beautify the camp, and after all, gathering daisies isn't life-or-death.",
+                "exp": 0,
+                "relationships": [
+                    {
+                        "cats_from": ["clan", "high_social", "-patrol"],
+                        "cats_to": ["patrol"],
+                        "values": ["like"],
+                        "amount": 8,
+                        "log": {
+                            "cats_from": "cat_from was pleased to see cat_to bring back wildflowers to decorate the camp in newleaf."
+                        }
+                    }
+                ]
             }
         ]
     },
@@ -24998,12 +24889,17 @@
                             "like",
                             "respect"
                         ],
-                        "amount": -10,
+                        "amount": -7,
                         "log": {
                             "cats_from": "cat_from lost {PRONOUN/cat_from/poss} temper with cat_to when cat_to trampled a crucial catmint plant in {PRONOUN/cat_to/poss} excitement about the herb."
                         }
                     }
                 ],
+                "frequency": 4
+            },
+            {
+                "text": "p_l is suspicious when the patrol finds the catmint half-chewed and missing leaves. The patrol gets an earful about how important the herb is for all sorts of coughs and illnesses, but no cat wants to fess up to snacking.",
+                "exp": 0,
                 "frequency": 4
             }
         ]
@@ -26096,14 +25992,14 @@
                             "patrol"
                         ],
                         "cats_from": [
-                            "patrol"
+                            "p_l"
                         ],
-                        "mutual": false,
+                        "mutual": true,
                         "values": [
                             "like",
                             "respect"
                         ],
-                        "amount": -8,
+                        "amount": -5,
                         "log": {
                             "cats_from": "cat_from and cat_to were short with each other during a herb gathering patrol."
                         }
@@ -26310,7 +26206,7 @@
                             "respect",
                             "trust"
                         ],
-                        "amount": -10,
+                        "amount": -7,
                         "log": {
                             "cats_from": "cat_from lost faith in cat_to when cat_to was unable to locate a juniper tree during an herb-gathering patrol."
                         }
@@ -26431,7 +26327,7 @@
                             "like",
                             "respect"
                         ],
-                        "amount": -10,
+                        "amount": -7,
                         "log": {
                             "cats_from": "cat_from was irate when cat_to spent an herb-gathering patrol complaining about juniper needles instead of gathering them."
                         }
@@ -26932,6 +26828,21 @@
                     }
                 ],
                 "frequency": 3
+            },
+            {
+                "text": "Though they fail to find any lungwort, the patrol keeps each other's spirits up. They can always try again another day.",
+                "exp": 0,
+                "relationships": [
+                    {
+                        "cats_from": ["patrol"],
+                        "cats_to": ["patrol"],
+                        "values": ["like"],
+                        "amount": 5,
+                        "log": {
+                            "cats_from": "cat_from and cat_to kept each other's spirits up during an unsuccessful herb-gathering patrol."
+                        }
+                    }
+                ]
             }
         ]
     },
@@ -27273,7 +27184,7 @@
                             "like",
                             "respect"
                         ],
-                        "amount": -8,
+                        "amount": -5,
                         "log": {
                             "cats_from": "cat_from was irritated when cat_to dismissed {PRONOUN/cat_from/poss} concerns over the poor growth of mallow."
                         }
@@ -27604,7 +27515,7 @@
                             "like",
                             "respect"
                         ],
-                        "amount": -8,
+                        "amount": -5,
                         "log": {
                             "cats_from": "cat_from was irritated when cat_to dismissed {PRONOUN/cat_from/poss} concerns over the poor growth of marigold."
                         }
@@ -27951,7 +27862,7 @@
                             "like",
                             "respect"
                         ],
-                        "amount": -8,
+                        "amount": -5,
                         "log": {
                             "cats_from": "cat_from was irritated when cat_to dismissed {PRONOUN/cat_from/poss} concerns over the poor growth of mullein."
                         }
@@ -28569,7 +28480,7 @@
                             "like",
                             "respect"
                         ],
-                        "amount": -8,
+                        "amount": -5,
                         "log": {
                             "cats_from": "cat_from was irritated when cat_to dismissed {PRONOUN/cat_from/poss} concerns over the poor growth of plantain."
                         }
@@ -29575,7 +29486,7 @@
                             "trust",
                             "respect"
                         ],
-                        "amount": -10,
+                        "amount": -7,
                         "log": {
                             "cats_from": "cat_from lost faith in cat_to when cat_to admitted to not being able to identify tansy during an herb-gathering patrol."
                         }
@@ -30268,7 +30179,7 @@
                             "trust",
                             "respect"
                         ],
-                        "amount": -10,
+                        "amount": -7,
                         "log": {
                             "cats_from": "cat_from lost faith in cat_to when cat_to admitted to not being able to identify wild garlic during an herb-gathering patrol."
                         }
@@ -33655,7 +33566,7 @@
                             "respect",
                             "trust"
                         ],
-                        "amount": -10,
+                        "amount": -7,
                         "log": {
                             "cats_from": "cat_from lost faith in cat_to when cat_to was unable to locate a juniper tree during an herb-gathering patrol."
                         }


### PR DESCRIPTION
## About The Pull Request

both in my own saves and from hearing other people's chatter, it seems like I was overzealous with some of the relationship changes on the medicine cat patrols. Medicine cats were often ending up with strong negative relationships with each other, and after some investigation in the files, it seems like part of the reason is that many of the herb gathering patrols only have one failure outcome. Because I added negative relationship changes to most of those failure outcomes, every failure was worsening relationships.

I've addressed this in two ways: first, I've decreased/increased the intensity of the changes for negative and positive relationships respectively. Second, I've added neutral failures to several herb-gathering patrols to allow for failures that don't worsen relationships.

Along the way, I also tweaked values where I thought another would fit better and occasionally modified wording.

## Why This Is Good For ClanGen

We don't want the medicine cats always hating each other.

## Linked Issues

Fixes: #3896

## Proof of Testing

