### PR TITLE
[BUGFIX] Random cat selection for Lone Steps Card

### DIFF
--- a/scripts/screens/make_clan_screens/ChooseCatsScreen.py
+++ b/scripts/screens/make_clan_screens/ChooseCatsScreen.py
@@ -1,4 +1,4 @@
-from random import choice
+from random import choice, randint
 from typing import Optional
 
 import i18n
@@ -339,15 +339,7 @@ class ChooseCatsScreen(MakeClanScreenBase):
         maximum_needed = self.get_config_during_creation(
             "clan_creation.maximum_membership"
         ) - len(self.clan_info.get_all_cats())
-        for i in range(
-            1,
-            choice(
-                range(
-                    minimum_needed + 1,
-                    maximum_needed,
-                )
-            ),
-        ):
+        for _ in range(randint(minimum_needed, maximum_needed)):
             self.clan_info.starting_members.append(
                 choice(
                     [


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

This fixes a bug where Lone Steps cat selection with random button creates an invalid range and crashes the game.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Issues

Fixes #5511

<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing

Replicated bug, added check to range, attempted to replicate bug again, no crash:

<img width="400" alt="choosecatscreen, I used random cat selection here, no crash" src="https://github.com/user-attachments/assets/2b3367b3-014f-4e64-8c28-683dd62df420" />

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->