### PR TITLE
[BUGFIX] Fix pronoun in hunting patrol outcome

### DIFF
--- a/resources/lang/en/patrols/forest/hunting/any.json
+++ b/resources/lang/en/patrols/forest/hunting/any.json
@@ -1044,7 +1044,7 @@
         "chance_of_success": 10,
         "success_outcomes": [
             {
-                "text": "r_c tracks the noise and discovers a coyote scavenging off a carcass. This is a predator {PRONOUN/r_c/poss} cannot fight. {PRONOUN/r_c/subject/CAP} {VERB/r_c/decide/decides} to return to camp and report the intruder to the leader. Perhaps a patrol can return later to take what the coyote leaves behind.",
+                "text": "r_c tracks the noise and discovers a coyote scavenging off a carcass. This is a predator {PRONOUN/r_c/subject} cannot fight. {PRONOUN/r_c/subject/CAP} {VERB/r_c/decide/decides} to return to camp and report the intruder to the leader. Perhaps a patrol can return later to take what the coyote leaves behind.",
                 "exp": 30,
                 "frequency": 4
             },


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

Fixes typo in pronoun tag for patrol_id: `fst_hunt_howl3` outcome

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues

#1818 

<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing

`game_config`:
```
  debug_ensure_patrol_id = "fst_hunt_howl3"
  debug_override_patrol_stat_requirements = true
  debug_ensure_patrol_outcome = true
 ```

<img width="800" height="728" alt="corrected pronoun in patrol outcome" src="https://github.com/user-attachments/assets/10cde502-10a5-4ee3-9fc7-0fc6c13c80ba" />

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->