### PR TITLE
[CONTENT] moonplace & gathering events

### DIFF
--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -16469,7 +16469,8 @@
         "m_c": {
             "status": [
                 "apprentice"
-            ]
+            ],
+            "relationship_status": ["app/mentor"]
         },
         "r_c": {
             "status": [
@@ -16491,7 +16492,7 @@
         "poi": {
             "category": "gathering"
         },
-        "event_text": "During the Gathering at {POI/category/gathering}, c_n overhears that o_c_n is struggling to find prey.",
+        "event_text": "During the Gathering at {POI/category/gathering}, m_c overhears that o_c_n is struggling to find prey.",
         "m_c": {
             "status": [
                 "apprentice",
@@ -16511,7 +16512,7 @@
         "poi": {
             "category": "gathering"
         },
-        "event_text": "During the Gathering at {POI/category/gathering}, c_n overhears that o_c_n is suffering from a herb blight.",
+        "event_text": "During the Gathering at {POI/category/gathering}, m_c overhears that o_c_n is suffering from a herb blight.",
         "m_c": {
             "status": [
                 "apprentice",
@@ -16531,7 +16532,7 @@
         "poi": {
             "category": "gathering"
         },
-        "event_text": "During the Gathering at {POI/category/gathering}, c_n overhears that o_c_n is dealing with a greencough outbreak.",
+        "event_text": "During the Gathering at {POI/category/gathering}, m_c overhears that o_c_n is dealing with a greencough outbreak.",
         "m_c": {
             "status": [
                 "apprentice",
@@ -16581,7 +16582,7 @@
         "season": [
             "any"
         ],
-        "frequency": 4,
+        "frequency": 2,
         "poi": {
             "category": "moonplace"
         },
@@ -16601,11 +16602,11 @@
         "season": [
             "any"
         ],
-        "frequency": 4,
+        "frequency": 2,
         "poi": {
             "category": "moonplace"
         },
-        "event_text": "m_c seems shaken after their half-moon visit to {POI/category/moonplace}.",
+        "event_text": "m_c seems shaken after {PRONOUN/m_c/poss} half-moon visit to {POI/category/moonplace}.",
         "m_c": {
             "status": ["medicine cat"]
         }
@@ -16618,11 +16619,62 @@
         "season": [
             "any"
         ],
-        "frequency": 4,
+        "frequency": 2,
         "poi": {
             "category": "moonplace"
         },
         "event_text": "m_c seems disappointed by StarClan's wisdom after a visit to {POI/category/moonplace}.",
+        "m_c": {
+            "status": ["medicine cat"]
+        }
+    },
+    {
+        "event_id": "gen_moonplace_content",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "frequency": 2,
+        "poi": {
+            "category": "moonplace"
+        },
+        "event_text": "m_c seems content after {PRONOUN/m_c/poss} half-moon visit to {POI/category/moonplace}.",
+        "m_c": {
+            "status": ["medicine cat"]
+        }
+    },
+    {
+        "event_id": "gen_moonplace_comforted",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "frequency": 2,
+        "poi": {
+            "category": "moonplace"
+        },
+        "event_text": "m_c seems comforted by StarClan's wisdom after a visit to {POI/category/moonplace}.",
+        "m_c": {
+            "status": ["medicine cat"]
+        }
+    },
+        {
+        "event_id": "gen_moonplace_determined",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "frequency": 2,
+        "poi": {
+            "category": "moonplace"
+        },
+        "event_text": "m_c seems determined after {PRONOUN/m_c/poss} half-moon visit to {POI/category/moonplace}.",
         "m_c": {
             "status": ["medicine cat"]
         }

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -16465,7 +16465,7 @@
         "poi": {
             "category": "gathering"
         },
-        "event_text": "m_c won't stop asking r_c when it's their turn to join the Gathering at {POI/category/gathering}.",
+        "event_text": "m_c won't stop asking r_c when it's {PRONOUN/m_c/poss} turn to join the Gathering at {POI/category/gathering}.",
         "m_c": {
             "status": [
                 "apprentice"

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -16452,5 +16452,196 @@
     "m_c": {
       "status": ["medicine cat apprentice"]
     }
-}
+},
+    {
+        "event_id": "gen_gathering_appbegging",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "frequency": 4,
+        "poi": {
+            "category": "gathering"
+        },
+        "event_text": "m_c won't stop asking r_c when it's their turn to join the Gathering at {POI/category/gathering}.",
+        "m_c": {
+            "status": [
+                "apprentice"
+            ]
+        },
+        "r_c": {
+            "status": [
+                "warrior",
+                "leader",
+                "deputy"
+            ]
+        }
+    },
+    {
+        "event_id": "gen_gathering_gossipprey",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "frequency": 4,
+        "poi": {
+            "category": "gathering"
+        },
+        "event_text": "During the Gathering at {POI/category/gathering}, c_n overhears that o_c_n is struggling to find prey.",
+        "m_c": {
+            "status": [
+                "apprentice",
+                "warrior"
+            ]
+        }
+    },
+    {
+        "event_id": "gen_gathering_gossipherbs",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "frequency": 4,
+        "poi": {
+            "category": "gathering"
+        },
+        "event_text": "During the Gathering at {POI/category/gathering}, c_n overhears that o_c_n is suffering from a herb blight.",
+        "m_c": {
+            "status": [
+                "apprentice",
+                "warrior"
+            ]
+        }
+    },
+    {
+        "event_id": "gen_gathering_gossipillness",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "frequency": 4,
+        "poi": {
+            "category": "gathering"
+        },
+        "event_text": "During the Gathering at {POI/category/gathering}, c_n overhears that o_c_n is dealing with a greencough outbreak.",
+        "m_c": {
+            "status": [
+                "apprentice",
+                "warrior"
+            ]
+        }
+    },
+    {
+        "event_id": "gen_gathering_firstgatheringstory",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "frequency": 4,
+        "poi": {
+            "category": "gathering"
+        },
+        "event_text": "m_c gathers the Clan to tell a story about the first time the Clans convened for a Gathering at {POI/category/gathering}.",
+        "m_c": {
+            "skill": ["STORY,1", "LORE,1"]
+        }
+    },
+        {
+        "event_id": "gen_gathering_deputygossip",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "frequency": 4,
+        "poi": {
+            "category": "gathering"
+        },
+        "event_text": "m_c overhears some interesting gossip from the other deputies at {POI/category/gathering}.",
+        "m_c": {
+            "status": ["deputy"]
+        }
+    },
+    {
+        "event_id": "gen_moonplace_leadermeeting",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "frequency": 4,
+        "poi": {
+            "category": "moonplace"
+        },
+        "event_text": "As soon as m_c returns from {POI/category/moonplace}, {PRONOUN/m_c/subject} {VERB/m_c/visit/visits} r_c in {PRONOUN/r_c/poss} den for a private conversation.",
+        "m_c": {
+            "status": ["medicine cat"]
+        },
+        "r_c": {
+            "status": ["leader"]
+        }
+    },
+    {
+        "event_id": "gen_moonplace_shaken",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "frequency": 4,
+        "poi": {
+            "category": "moonplace"
+        },
+        "event_text": "m_c seems shaken after their half-moon visit to {POI/category/moonplace}.",
+        "m_c": {
+            "status": ["medicine cat"]
+        }
+    },
+    {
+        "event_id": "gen_moonplace_disappointed",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "frequency": 4,
+        "poi": {
+            "category": "moonplace"
+        },
+        "event_text": "m_c seems disappointed by StarClan's wisdom after a visit to {POI/category/moonplace}.",
+        "m_c": {
+            "status": ["medicine cat"]
+        }
+    },
+    {
+        "event_id": "gen_moonplace_gossip",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "frequency": 4,
+        "poi": {
+            "category": "moonplace"
+        },
+        "event_text": "m_c overhears some interesting gossip from the other medicine cats at {POI/category/moonplace}.",
+        "m_c": {
+            "status": ["medicine cat"]
+        }
+    }
 ]


### PR DESCRIPTION
## About The Pull Request
- Loosely constrained events to occur for warriors, apprentices, and deputies to experience at the gathering or for Medicine Cats to experience at the moonplace.
- My only concern is that frequency 4 may be too high tuned but I feel like news from the gathering or moonplace should be relatively common. Definitely open to plenty of feedback here.

## Why This Is Good For ClanGen
- More integration of POIs.

## Proof of Testing
Game runs locally, moonskips without crashing, here are a smattering of the example events:
<img width="515" height="94" alt="Screenshot 2026-07-18 at 9 56 36 PM" src="https://github.com/user-attachments/assets/1e34a0de-431e-487c-99b2-a68aa0093436" />
<img width="517" height="97" alt="Screenshot 2026-07-18 at 9 55 22 PM" src="https://github.com/user-attachments/assets/ce604ba1-54ed-4458-b858-1d870aa780df" />
<img width="514" height="202" alt="Screenshot 2026-07-18 at 9 55 03 PM" src="https://github.com/user-attachments/assets/a761eeaf-2a1c-49dc-a00b-3b5c60833d1f" />
<img width="515" height="99" alt="Screenshot 2026-07-18 at 9 47 09 PM" src="https://github.com/user-attachments/assets/4f92a7da-0f89-483a-b941-ad60d9e1fc95" />
