### PR TITLE
[BUGFIX] Use current pronouns for leader ceremony

### DIFF
--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -1266,11 +1266,6 @@ class Cat:
 
         if chosen_intro := choice(possible_intros):
             intro = choice(chosen_intro["text"])
-            intro = leader_ceremony_text_adjust(
-                Cat,
-                intro,
-                self,
-            )
         else:
             intro = "this should not appear"
 
@@ -1314,7 +1309,7 @@ class Cat:
         # if we have relations, then make sure we only take the top 8
         if dead_relations:
             for i, rel in enumerate(dead_relations):
-                if i <= num_of_lives_to_give - 1:
+                if i >= num_of_lives_to_give - 1:
                     break
                 if rel.cat_to.status.is_leader:
                     life_giving_leader = rel.cat_to
@@ -1376,7 +1371,7 @@ class Cat:
 
         extra_lives = num_of_lives_to_give - len(life_givers)
         possible_lives = ceremony_dict["lives"]
-        lives = []
+        ceremony_entries = [{"involved": None, "text": intro}]
         used_lives = []
         used_virtues = []
         for giver in life_givers:
@@ -1467,14 +1462,12 @@ class Cat:
             else:
                 virtue = None
 
-            lives.append(
-                leader_ceremony_text_adjust(
-                    Cat,
-                    chosen_life["text"],
-                    leader=self,
-                    life_giver=giver,
-                    virtue=virtue,
-                )
+            ceremony_entries.append(
+                {
+                    "involved": giver_cat.ID,
+                    "text": chosen_life["text"],
+                    "virtue": virtue,
+                }
             )
         if unknown_blessing:
             possible_blessing = []
@@ -1492,16 +1485,14 @@ class Cat:
                 possible_blessing.append(possible_lives[life])
             chosen_blessing = choice(possible_blessing)
             chosen_text = choice(chosen_blessing["life_giving"])
-            lives.append(
-                leader_ceremony_text_adjust(
-                    Cat,
-                    chosen_text["text"],
-                    leader=self,
-                    virtue=chosen_text["virtue"],
-                    extra_lives=extra_lives,
-                )
+            ceremony_entries.append(
+                {
+                    "involved": None,
+                    "text": chosen_text["text"],
+                    "virtue": chosen_text["virtue"],
+                    "extra_lives": extra_lives,
+                }
             )
-        all_lives = "<br><br>".join(lives)
 
         # ---------------------------------------------------------------------------- #
         #                                    OUTRO                                     #
@@ -1530,21 +1521,42 @@ class Cat:
 
         if chosen_outro:
             if life_givers:
-                giver = life_givers[-1]
+                outro_giver_cat = self.fetch_cat(life_givers[-1])
+                outro_giver = outro_giver_cat.ID if outro_giver_cat else None
             else:
-                giver = None
-            outro = choice(chosen_outro["text"])
-            outro = leader_ceremony_text_adjust(
-                Cat,
-                outro,
-                leader=self,
-                life_giver=giver,
-            )
+                outro_giver = None
+            outro_text = choice(chosen_outro["text"])
         else:
-            outro = "this should not appear"
+            outro_text = "this should not appear"
+            outro_giver = None
 
-        full_ceremony = "<br><br>".join([intro, all_lives, outro])
-        self.history.lead_ceremony = full_ceremony
+        ceremony_entries.append({"involved": outro_giver, "text": outro_text})
+
+        self.history.lead_ceremony = ceremony_entries
+
+    def render_lead_ceremony(self):
+        """Render data with current name and pronouns."""
+
+        data = self.history.lead_ceremony
+        if not data:
+            return ""
+        if isinstance(data, str):
+            # legacy ceremony is a string
+            return data
+
+        paragraphs = [
+            leader_ceremony_text_adjust(
+                Cat,
+                entry["text"],
+                leader=self,
+                life_giver=entry.get("involved"),
+                virtue=entry.get("virtue"),
+                extra_lives=entry.get("extra_lives"),
+            )
+            for entry in data
+        ]
+
+        return "<br><br>".join(paragraphs)
 
     # ---------------------------------------------------------------------------- #
     #                              moon skip functions                             #

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -1522,9 +1522,10 @@ class Cat:
         outro_entry = {"involved": None, "text": "this should not appear"}
         if chosen_outro:
             outro_entry["text"] = choice(chosen_outro["text"])
-            outro_giver_cat = self.fetch_cat(life_givers[-1]) if life_givers else None
-            if outro_giver_cat:
-                outro_entry["involved"] = outro_giver_cat.ID
+            if "r_c" in outro_entry["text"] and life_givers:
+                outro_giver_cat = self.fetch_cat(life_givers[-1])
+                if outro_giver_cat:
+                    outro_entry["involved"] = outro_giver_cat.ID
 
         ceremony_entries.append(outro_entry)
 

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -1519,18 +1519,14 @@ class Cat:
 
         chosen_outro = choice(possible_outros)
 
+        outro_entry = {"involved": None, "text": "this should not appear"}
         if chosen_outro:
-            if life_givers:
-                outro_giver_cat = self.fetch_cat(life_givers[-1])
-                outro_giver = outro_giver_cat.ID if outro_giver_cat else None
-            else:
-                outro_giver = None
-            outro_text = choice(chosen_outro["text"])
-        else:
-            outro_text = "this should not appear"
-            outro_giver = None
+            outro_entry["text"] = choice(chosen_outro["text"])
+            outro_giver_cat = self.fetch_cat(life_givers[-1]) if life_givers else None
+            if outro_giver_cat:
+                outro_entry["involved"] = outro_giver_cat.ID
 
-        ceremony_entries.append({"involved": outro_giver, "text": outro_text})
+        ceremony_entries.append(outro_entry)
 
         self.history.lead_ceremony = ceremony_entries
 

--- a/scripts/cat/history.py
+++ b/scripts/cat/history.py
@@ -94,7 +94,14 @@ class History:
             "graduation_age": age,
             "moon": moon
             },
-        "lead_ceremony": full ceremony text,
+        "lead_ceremony": [
+            {
+                "involved": ID or None,
+                "text": text,
+                "virtue": virtue or None,
+                "extra_lives": count or None
+            },
+            ],
         "possible_history": {
             "condition name": {
                 "involved": ID
@@ -569,7 +576,7 @@ class History:
         generates and adds lead ceremony to history
         """
 
-        self.lead_ceremony = self.cat.generate_lead_ceremony()
+        self.cat.generate_lead_ceremony()
 
     # ---------------------------------------------------------------------------- #
     #                                 retrieving                                   #
@@ -582,7 +589,7 @@ class History:
 
         if not self.lead_ceremony:
             self.cat.generate_lead_ceremony()
-        return str(self.lead_ceremony)
+        return self.cat.render_lead_ceremony()
 
     def get_possible_history(self, condition=None):
         """

--- a/scripts/events_module/text_adjust.py
+++ b/scripts/events_module/text_adjust.py
@@ -625,10 +625,9 @@ def leader_ceremony_text_adjust(
     }
 
     if life_giver:
-        replace_dict["r_c"] = (
-            str(Cat.fetch_cat(life_giver).name),
-            choice(Cat.fetch_cat(life_giver).pronouns),
-        )
+        giver_cat = Cat.fetch_cat(life_giver)
+        if giver_cat:
+            replace_dict["r_c"] = (str(giver_cat.name), choice(giver_cat.pronouns))
 
     text = process_text(text, replace_dict)
 

--- a/scripts/screens/ChangeGenderScreen.py
+++ b/scripts/screens/ChangeGenderScreen.py
@@ -76,6 +76,7 @@ class ChangeGenderScreen(Screens):
                 if self.are_boxes_full():
                     gender_identity = self.get_new_identity()
                     self.the_cat.genderalign = gender_identity
+                    self.the_cat.get_new_thought()
                     self.selected_cat_elements["identity_changed"].show()
                     self.selected_cat_elements["cat_gender"].kill()
                     self.selected_cat_elements[
@@ -96,12 +97,14 @@ class ChangeGenderScreen(Screens):
                 if event.ui_element.cat_id == "add":
                     if event.ui_element.cat_object not in self.the_cat.pronouns:
                         self.the_cat.pronouns.append(event.ui_element.cat_object)
+                        self.the_cat.get_new_thought()
                 elif event.ui_element.cat_id == "remove":
                     if (
                         event.ui_element.cat_object in self.the_cat.pronouns
                         and len(self.the_cat.pronouns) > 1
                     ):
                         self.the_cat.pronouns.remove(event.ui_element.cat_object)
+                        self.the_cat.get_new_thought()
                 elif event.ui_element.cat_id == "delete":
                     if event.ui_element.cat_object in pronouns.get_custom_pronouns():
                         game.clan.custom_pronouns[i18n.config.get("locale")].remove(

--- a/scripts/screens/ProfileScreen.py
+++ b/scripts/screens/ProfileScreen.py
@@ -298,6 +298,7 @@ class ProfileScreen(Screens):
                 elif self.the_cat.genderalign in ["trans female", "trans male"]:
                     self.the_cat.genderalign = "nonbinary"
                 self.the_cat.pronouns = get_new_pronouns(self.the_cat.genderalign)
+                self.the_cat.get_new_thought()
                 self.clear_profile()
                 self.build_profile()
                 self.update_disabled_buttons_and_text()

--- a/scripts/screens/RoleScreen.py
+++ b/scripts/screens/RoleScreen.py
@@ -542,7 +542,7 @@ class RoleScreen(Screens):
         else:
             output = "screens.role.blurb_unknown"
 
-        return i18n.t(output, name=self.the_cat.name, clan=game.clan.name)
+        return i18n.t(output, name=self.the_cat.name, clan=game.clan.prefix)
 
     def exit_screen(self):
         self.back_button.kill()

--- a/scripts/screens/RoleScreen.py
+++ b/scripts/screens/RoleScreen.py
@@ -542,7 +542,7 @@ class RoleScreen(Screens):
         else:
             output = "screens.role.blurb_unknown"
 
-        return i18n.t(output, name=self.the_cat.name, clan=game.clan.prefix)
+        return i18n.t(output, name=self.the_cat.name, clan=game.clan.name)
 
     def exit_screen(self):
         self.back_button.kill()


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

A number of changes but, in order:

### Bug fix:
- fixes calculation error for cat relations used to determine leader ceremony `life_giver` picks

### Pronoun handling in leader ceremony:
(uses similar structure to death histories with `'involved'` cat and `'text'` in `ceremony_entries`)
- intro, life-giving, and outro texts chosen and generated as \*templates\* for `ceremony_entries`
- preserves legacy save leader ceremonies (plain `string`)
- resolve template tags on load of ceremony screen with `fetch_cat()`
- checks each text string for `r_c` as `'involved'`

Then I noticed cat thoughts do not update on pronoun change so:

### Bug fix:
- use `get_new_thoughts()` on pronoun change

This **does not convert past save games!** Existing saves with pronoun discrepancy can be manually edited in save folder's cat history `.json` as plain text !!

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Why This Is Good For ClanGen

Previously, leader ceremony was saved as static text for readability in save files. 

This fix allows for in-game consistency of leader and `life_giver` pronouns and names, at the cost of some readability.

<!-- If this is a bug fix, you can remove this section. -->
<!-- Please add a short description of why you think these changes would benefit the game. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->
<!-- If you have multiple features that can stand on their own, or unrelated bugfixes, please create separate PRs for them. -->

## Linked Issues

Fixes: #5481 and 
Fixes: #1818 comment

<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing

Tested the following:
1. New Clan or leader
2. Change name, gender, pronouns of either Leader or any `life_giver`
3. tested with StarClan and Dark Forest guides

Name, pronouns reflect change in leader ceremony on open. This works for cats with multiple pronoun sets applied as well.

Faded cats are resolved with `fetch_cat()`.

<img width="400" alt="proposed json structure for cat history" src="https://github.com/user-attachments/assets/1a88b658-a855-4324-bb55-21e298482e47" />
<img width="400" alt="resolved leader ceremony with current pronouns and name" src="https://github.com/user-attachments/assets/a9ab5cf2-2e54-48db-8d2f-4364c8782249" />

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->