### PR TITLE
[BUGFIX] adding the clan:leader tag where necessary to hopefully make the unitest work again

### DIFF
--- a/resources/lang/en/patrols/general/hunting.json
+++ b/resources/lang/en/patrols/general/hunting.json
@@ -1847,7 +1847,7 @@
         "types": [
             "hunting"
         ],
-        "tags": [],
+        "tags": ["clan:leader"],
         "patrol_art": "cat_sprites/gen_train_solo_Ap",
         "min_cats": 1,
         "max_cats": 1,

--- a/resources/lang/en/patrols/mountainous/training/greenleaf.json
+++ b/resources/lang/en/patrols/mountainous/training/greenleaf.json
@@ -860,7 +860,7 @@
         "biome": [ "mountainous" ],
         "season": [ "greenleaf" ],
         "types": [ "training" ],
-        "tags": [],
+        "tags": ["clan:leader"],
         "min_cats": 3,
         "max_cats": 6,
         "min_max_status": {


### PR DESCRIPTION
## About The Pull Request

- Adds the clan:leader tag to a few patrols that mention lead_name without using the tag

## Why This Is Good For ClanGen

- Hopefully the unitest will work again. 

## Proof of Testing
Game runs locally, moonskips, and patrol loads properly.

