### PR TITLE
[BUGFIX] Actually add former outsider cats to clan

### DIFF
--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -950,11 +950,12 @@ class Cat:
                 and child.moons < 12
                 and not child.status.alive_in_player_clan
             ):
+                child.history.add_beginning()
                 child.status.add_to_group(
                     new_group_ID=CatGroup.PLAYER_CLAN_ID, age=child.age
                 )
-                child.add_to_clan()
-                child.history.add_beginning()
+                if game.clan:
+                    game.clan.add_cat(child)
                 ids.append(child_id)
 
         return ids

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -116,7 +116,6 @@ class Cat:
     }
 
     all_cats: Dict[str, Cat] = {}  # ID: object
-    outside_cats: Dict[str, Cat] = {}  # cats outside the clan
     id_iter = itertools.count()
 
     all_cats_list: List[Cat] = []
@@ -938,7 +937,7 @@ class Cat:
         self.status.add_to_group(new_group_ID=CatGroup.PLAYER_CLAN_ID, age=self.age)
 
         if game.clan:
-            game.clan.add_to_clan(self)
+            game.clan.add_cat(self)
 
         # check if there are kits under 12 moons with this cat and also add them to the clan
         children = self.get_children()

--- a/scripts/clan.py
+++ b/scripts/clan.py
@@ -367,17 +367,6 @@ class Clan:
         if cat.ID in Cat.all_cats and cat.ID not in self.clan_cats:
             self.clan_cats.append(cat.ID)
 
-    def add_to_clan(self, cat):
-        """
-        TODO: DOCS
-        """
-        if (
-            cat.ID in Cat.all_cats
-            and cat.status.alive_in_player_clan
-            and cat.ID in Cat.outside_cats
-        ):
-            Cat.outside_cats.pop(cat.ID)
-
     def remove_cat(self, ID):  # ID is cat.ID
         """
         This function is for completely removing the cat from the game,

--- a/scripts/screens/make_clan_screens/MakeClanScreenBase.py
+++ b/scripts/screens/make_clan_screens/MakeClanScreenBase.py
@@ -240,7 +240,6 @@ class MakeClanScreenBase(Screens):
         game.just_died.clear()
         game.dead_cats_to_grieve.clear()
         save_load.faded_ids.clear()
-        Cat.outside_cats.clear()
         Patrol.used_patrols.clear()
 
         # extra sanitization for filenames


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

EDIT: only group data was added to cat status, outsider cats were not added to the clan, resulting in data loss on reload and crashes re: unresolved references to cat IDs

No more disappearing kitties!

(I don't think this fix restores cats, but cat IDs exist in all other files except for `clan_cats.json`, so recovery from backups or recreating `clan_cats` entries is possible)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues

Fixes #5541 

<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing

To replicate bug without fix:
1. Load clan (e.g., Lone Steps, but not isolated to card)
2. Outsider joins clan, saves to clan_cats.json correctly
3. Save and exit
4. Reload, cat is gone from clan_cats.json and Cats screen but persists in all other .json references
5. click on cat profile through existing cat's relationships screen
6. get crash:

<img width="400" alt="Brindle only exists in Relationships Screen" src="https://github.com/user-attachments/assets/e6d9a52f-b604-4b5c-9602-d6c9ab3a94a2" />

To test with fix:
1. Load clan
2. Outsider joins clan
3. Save and exit
4. Reload, cat remains in clan_cats, etc. (although this cat is a rogue with a clanborn backstory... #5527 )

<img width="400" alt="Rogue cat persists, though with an inconsistency in cat history" src="https://github.com/user-attachments/assets/716148d2-384a-4cfd-a36e-d3e3a7c3a1b6" />

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->