### PR TITLE
[BUGFIX] Outsiders no longer generate with clanborn backstories

### DIFF
--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -381,8 +381,11 @@ class Cat:
             }[self.status.social]
             if baby:
                 social_category = f"baby_{social_category}"
-            self.backstory = choice(
-                BACKSTORIES["backstory_categories"][social_category]
+            possible_backstories = BACKSTORIES["backstory_categories"][social_category]
+            self.backstory = (
+                possible_backstories[0]
+                if self.disable_random
+                else choice(possible_backstories)
             )
 
     def init_faded(self, ID, status, prefix, suffix, moons, **kwargs):

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -129,7 +129,7 @@ class Cat:
         prefix=None,
         gender=None,
         status_dict: StatusDict = None,
-        backstory: str = "clanborn",
+        backstory: str = None,
         parent1: str = None,
         parent2: str = None,
         adoptive_parents=None,
@@ -308,9 +308,7 @@ class Cat:
 
         # backstory
         if self.backstory is None:
-            self.backstory = "clanborn"
-        else:
-            self.backstory = self.backstory  # fixme why does this exist
+            self.assign_backstory()
 
         # sex!?!??!?!?!??!?!?!?!??
         if self.gender is None:
@@ -369,6 +367,23 @@ class Cat:
 
         if self.ID is not None and self.ID != "0":
             Cat.insert_cat(self)
+
+    def assign_backstory(self):
+        """Assign a backstory based on social status."""
+        if self.status.social == CatSocial.CLANCAT:
+            self.backstory = "clanborn"
+        else:
+            baby = self.age in (CatAge.NEWBORN, CatAge.KITTEN)
+            social_category = {
+                CatSocial.LONER: "loner_backstories",
+                CatSocial.ROGUE: "rogue_backstories",
+                CatSocial.KITTYPET: "kittypet_backstories",
+            }[self.status.social]
+            if baby:
+                social_category = f"baby_{social_category}"
+            self.backstory = choice(
+                BACKSTORIES["backstory_categories"][social_category]
+            )
 
     def init_faded(self, ID, status, prefix, suffix, moons, **kwargs):
         """Perform faded-specific initialization

--- a/scripts/clan.py
+++ b/scripts/clan.py
@@ -312,6 +312,8 @@ class Clan:
                     ]
                 )
                 c.status.generate_new_status(self, social=random_social)
+                # re-assign backstory once cat has new status
+                c.assign_backstory()
                 # random chance for cat to generate as dead
                 if randint(1, 3) == 1:
                     c.die()


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

Default value for backstory was `'clanborn'`, this changes it to `None`.

The issue was with the cats generated on Clan init that are not chosen for game modes like Cruel Season + Lone Steps, these cats join the outsiders tab with social status without backstories being rerolled. This assigns backstories through look-up with social rank / history for outsider cats.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues

Fixes #5527 

<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing

<img width="400" alt="cat named Cheese with outsider backstory" src="https://github.com/user-attachments/assets/ed3c482e-9aae-4164-9c68-e03fa7f296fd" />

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->