### PR TITLE
[DEV] Template checkbox that game is unmodded

### DIFF
--- a/.github/ISSUE_TEMPLATE/3-bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/3-bug_report.yml
@@ -12,6 +12,8 @@ body:
           required: true
         - label: This issue was encountered (or replicated) on a non-edited Clan
           required: true
+        - label: I confirm that I am NOT playing on a modded version of the game (e.g. LifeGen)
+          required: true
   - type: textarea
     id: description
     attributes:


### PR DESCRIPTION
## About The Pull Request

* Adds required checkbox to PR template saying that the game is unmodded

## Why This Is Good For ClanGen

* Won't necessarily prevent people from reporting bugs encountered on mods, but... it *might* help, right?