### PR TITLE
[BUGFIX] Stale clan states

### DIFF
--- a/scripts/clan.py
+++ b/scripts/clan.py
@@ -105,6 +105,7 @@ class Clan:
 
         # needs to happen immediately so that any config retrievals will be accurate
         self.cruel_cards: list[str] = cruel_cards if cruel_cards else []
+        game.clan = self
 
         self.leader = leader
         self._leader_lives = 9

--- a/scripts/clan_resources/point_of_interest.py
+++ b/scripts/clan_resources/point_of_interest.py
@@ -101,8 +101,9 @@ def clear_pois():
     """
     _poi_tags.clear()
     _poi_names.clear()
-
     _poi_by_tags.clear()
+    for names in _poi_by_category.values():
+        names.clear()
 
     global _undiscovered_poi_remaining
     _undiscovered_poi_remaining = 3

--- a/scripts/screens/make_clan_screens/ChooseModeScreen.py
+++ b/scripts/screens/make_clan_screens/ChooseModeScreen.py
@@ -30,6 +30,8 @@ class ChooseModeScreen(MakeClanScreenBase):
         self.game_mode = "classic"
 
     def screen_switches(self):
+        super().screen_switches()
+
         # Reset variables
         if not switch_get_value(Switch.possible_cats):
             switch_set_value(
@@ -44,7 +46,6 @@ class ChooseModeScreen(MakeClanScreenBase):
                 ),
             )
 
-        super().screen_switches()
         self.elements["previous_step"].disable()
         self.elements["next_step"].enable()
 


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->
## About The Pull Request
Batch of small fixes for some stale clan data:
- clears names in `_poi_by_category` on `clear_pois()` to prevent stale save data
- resets variables in `screen_switches` after screen switching to actually reset stale configs
- defines `clan_data` within init to actually access cruel card / other config data like `FreshkillPile`
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->
## Linked Issues
Fixes #5556
Fixes #5565
Fixes #5566
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->
## Proof of Testing
Since these bugs rely on stale states, testing requires making multiple save games that vary in their settings/ game modes:
`FreshkillPile` fix (check fresh kill pile in each save):
1. cruel season (barren stockpiles card)
2. cruel season (not barren stockpiles card)
3. cruel season (barren stockpiles card)

| | | | |
|---|---|---|---|
| FreshkillPile: | <img width="200" alt="DuckClan has 0 freshkill on init" src="https://github.com/user-attachments/assets/3cfe1895-75a5-4108-885d-330b6befa457" /> | <img width="200" alt="SwanClan has 60 freshkill on init" src="https://github.com/user-attachments/assets/8e325969-fdc3-43f6-8e50-5d0796dcc619" /> | <img width="200" alt="EagleClan has 0 freshkill on init" src="https://github.com/user-attachments/assets/52a24982-8ee2-49ca-a5ac-cb7d075e159d" /> |

Apprentice fix: (check choose cats screen):
1. cruel season (young hearts card)
2. classic mode

| | | |
|---|---|---|
| Apprentice: | <img width="200" alt="apprentices chosen for cruel season mode step" src="https://github.com/user-attachments/assets/1d4c351d-339b-4811-b1d3-cc73cfed2077" /> | <img width="200" alt="cats of all ages chosen for classic mode step" src="https://github.com/user-attachments/assets/55ca11c2-680c-431d-bf29-91b84ce5aff2" /> |

POI clear fix (check save file `clan.json`, can likely overlap with another fix check):
1. make clan in any biome
2. without closing game, check POI in save file
3. make another clan in any other biome
4. check second clan POI

| | | |
|---|---|---|
| POI clear: | <img width="200" alt="SwanClan has 4 POI on init" src="https://github.com/user-attachments/assets/e48a1499-f910-4ca4-970d-cc349497bf9b" /> | <img width="200" alt="EagleClan has 4 new POI on init" src="https://github.com/user-attachments/assets/6df71f76-9ee8-4f10-9712-b11c1b93395e" /> |

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->