### PR TITLE
[BUGFIX] Small fixes to leader history and healer backstory strings

### DIFF
--- a/resources/lang/en/cat/backstories.en.json
+++ b/resources/lang/en/cat/backstories.en.json
@@ -84,6 +84,7 @@
         "former_clancat_backstories": "originally from another Clan",
         "orphaned_backstories": "orphaned as a kitten",
         "abandoned_backstories": "abandoned as a kitten",
+        "healer_backstories": "formerly a healer",
         "beginning_clanborn": "{PRONOUN/m_c/subject/CAP} {VERB/m_c/were/was} born on moon %{birth_moon} during %{birth_season}.",
         "beginning_cotc": "{PRONOUN/m_c/subject/CAP} joined the Clan on moon %{moon} at the age of %{join_age}."
     }

--- a/scripts/game_structure/load_cat.py
+++ b/scripts/game_structure/load_cat.py
@@ -700,6 +700,9 @@ def version_convert(version_info):
                 if death["text"] == "multi_lives":
                     # skip these as changing them will break stuff
                     continue
+                if death["text"].startswith("m_c lost a life"):
+                    # skip these as it duplicates the existing death text 
+                    continue
                 death["text"] = (
                     "m_c lost a life when {PRONOUN/m_c/subject} " + death["text"]
                 )

--- a/scripts/game_structure/load_cat.py
+++ b/scripts/game_structure/load_cat.py
@@ -701,7 +701,7 @@ def version_convert(version_info):
                     # skip these as changing them will break stuff
                     continue
                 if death["text"].startswith("m_c lost a life"):
-                    # skip these as it duplicates the existing death text 
+                    # skip these as it duplicates the existing death text
                     continue
                 death["text"] = (
                     "m_c lost a life when {PRONOUN/m_c/subject} " + death["text"]

--- a/scripts/ui/windows/kill_cat.py
+++ b/scripts/ui/windows/kill_cat.py
@@ -95,7 +95,7 @@ class KillCat(GameWindow):
         if event.type == pygame_gui.UI_BUTTON_START_PRESS:
             if event.ui_element == self.done_button:
                 death_message = sub(
-                    r"[^A-Za-z0-9<->/.()*'&#!?,| _]+",
+                    r"[^A-Za-z0-9<>/.()*'&#!?,| _-]+",
                     "",
                     self.death_entry_box.get_text(),
                 )


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

small string changes!
1. no longer apply save conversion to history tab's "leader life lost" strings that start with {'r_c lost a life when'}
2. added localization for healer_backstories

This does not fix/dedupe the text found in issue #5374 but prevents it from happening in future!

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues

Fixes: #5374
Fixes: #5587

<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing

`revert save version to < 4 with existing 'r_c lost a life when' text, see no change in life string on reload/ save conversion applied:`
- Kill Leader button used with text "defended the Clan alongside Well-documented Bugfixes" (/j)
- Close game
- Change save data version to `3`
- Reopen game, which prompts version change, see changes to text:
<img width="400" alt="multiple lives lost with the string 'Cavestar lost a life when he defended the Clan alongside Well-documented Bugfixes.'" src="https://github.com/user-attachments/assets/599f9c40-c909-4b50-b4f5-c44e9b69af4b" />

`wandering_healer2` with backstory fix:
<img width="400"  alt="wandering_healer2 backstory History and blurb correctly render with fix applied" src="https://github.com/user-attachments/assets/652facee-30e0-4534-8f8b-4b59d11b4041" />

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->