### PR TITLE
[CONTENT] new transition events

### DIFF
--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -17017,13 +17017,13 @@
         "m_c": {
             "gender": [
                 "male"
-            ]
+            ],
+            "relationship_status": ["child/parent"]
         },
         "new_gender": [
             "trans female",
             "nonbinary"
         ],
-        "relationship_status": ["child/parent"],
       "relationships": [
           {
               "cats_from": ["m_c"],
@@ -17036,9 +17036,7 @@
             }
         }
       ],
-        "r_c": {
-            "relationship_status": ["parent/child"]
-        }
+        "r_c": {}
     },
     {
         "event_id": "gen_misc_transition_parentcomingout_from_female",
@@ -17056,16 +17054,16 @@
         "m_c": {
             "gender": [
                 "female"
-            ]
+            ],
+            "relationship_status": ["child/parent"]
         },
         "new_gender": [
             "trans male",
             "nonbinary"
         ],
-        "relationship_status": ["child/parent"],
       "relationships": [
           {
-              "cats_from": ["m_c"],
+            "cats_from": ["m_c"],
             "cats_to": ["r_c"],
             "mutual": false,
             "values": ["like", "comfort"],
@@ -17075,9 +17073,7 @@
             }
         }
       ],
-        "r_c": {
-            "relationship_status": ["parent/child"]
-        }
+        "r_c": {}
     },
     {
         "event_id": "gen_misc_transition_dysphoriareassurance_frommale",

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -17018,7 +17018,7 @@
             "gender": [
                 "male"
             ],
-            "relationship_status": ["child/parent"]
+            "relationship_status": ["child/parent", "trusts"]
         },
         "new_gender": [
             "trans female",
@@ -17055,7 +17055,7 @@
             "gender": [
                 "female"
             ],
-            "relationship_status": ["child/parent"]
+            "relationship_status": ["child/parent", "trusts"]
         },
         "new_gender": [
             "trans male",

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -16934,7 +16934,7 @@
             "transition"
         ],
         "frequency": 4,
-        "event_text": "m_c has always felt a disconnect in {PRONOUN/m_c/poss} concept of self. Though it has taken several seasons to realize, m_c has decided that being a tom suits {PRONOUN/m_c/object} better.",
+        "event_text": "m_c has always felt a disconnect in {PRONOUN/m_c/poss} concept of self. Though it has taken many seasons to realize, m_c has decided that being a tom suits {PRONOUN/m_c/object} better.",
         "m_c": {
             "gender": [
                 "female"

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -16986,7 +16986,7 @@
             "transition"
         ],
         "frequency": 4,
-        "event_text": "m_c has always felt a disconnect in {PRONOUN/m_c/poss} concept of self. Though it has taken several seasons to realize, m_c has decided that being just a cat suits {PRONOUN/m_c/object} better.",
+        "event_text": "m_c has always felt a disconnect in {PRONOUN/m_c/poss} concept of self. Though it has taken many seasons to realize, m_c has decided that being just a cat suits {PRONOUN/m_c/object} better.",
         "m_c": {
             "gender": [
                 "male",

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -16845,5 +16845,274 @@
         "age": ["any"],
         "dies": false
     }
-}
+},
+    {
+        "event_id": "gen_misc_transition_kittentomale",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "transition"
+        ],
+        "frequency": 4,
+        "event_text": "m_c has known since {PRONOUN/m_c/subject} {VERB/m_c/were/was} born {PRONOUN/m_c/subject} felt different about {PRONOUN/m_c/poss} gender. When m_c declares {PRONOUN/m_c/subject} {VERB/m_c/are/is} a tom, who can tell {PRONOUN/m_c/object} otherwise?",
+        "m_c": {
+            "gender": [
+                "female"
+            ],
+            "age": [
+            "kitten"
+            ]
+        },
+        "new_gender": [
+            "trans male"
+        ]
+    },
+        {
+        "event_id": "gen_misc_transition_kittentofemale",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "transition"
+        ],
+        "frequency": 4,
+        "event_text": "m_c has known since {PRONOUN/m_c/subject} {VERB/m_c/were/was} born {PRONOUN/m_c/subject} felt different about {PRONOUN/m_c/poss} gender. When m_c declares {PRONOUN/m_c/subject} {VERB/m_c/are/is} a she-cat, who can tell {PRONOUN/m_c/object} otherwise?",
+        "m_c": {
+            "gender": [
+                "male"
+            ],
+            "age": [
+            "kitten"
+            ]
+        },
+        "new_gender": [
+            "trans female"
+        ]
+    },
+    {
+        "event_id": "gen_misc_transition_kittentononbinary",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "transition"
+        ],
+        "frequency": 4,
+        "event_text": "m_c has known since {PRONOUN/m_c/subject} {VERB/m_c/were/was} born {PRONOUN/m_c/subject} felt different about {PRONOUN/m_c/poss} gender. When m_c declares {PRONOUN/m_c/subject} {VERB/m_c/are/is} not a tom, not a she-cat, <i>just</i> a cat, who can tell {PRONOUN/m_c/object} otherwise?",
+        "m_c": {
+            "gender": [
+                "female",
+                "male"
+            ],
+            "age": [
+            "kitten"
+            ]
+        },
+        "new_gender": [
+            "nonbinary"
+        ]
+    },
+    {
+        "event_id": "gen_misc_transition_eldertomale",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "transition"
+        ],
+        "frequency": 4,
+        "event_text": "m_c has always felt a disconnect in {PRONOUN/m_c/poss} concept of self. Though it has taken several seasons to realize, m_c has decided that being a tom suits {PRONOUN/m_c/object} better.",
+        "m_c": {
+            "gender": [
+                "female"
+            ],
+            "age": [
+            "senior",
+            "senior adult"
+            ]
+        },
+        "new_gender": [
+            "trans male"
+        ]
+    },
+    {
+        "event_id": "gen_misc_transition_eldertofemale",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "transition"
+        ],
+        "frequency": 4,
+        "event_text": "m_c has always felt a disconnect in {PRONOUN/m_c/poss} concept of self. Though it has taken several seasons to realize, m_c has decided that being a she-cat suits {PRONOUN/m_c/object} better.",
+        "m_c": {
+            "gender": [
+                "male"
+            ],
+            "age": [
+            "senior",
+            "senior adult"
+            ]
+        },
+        "new_gender": [
+            "trans female"
+        ]
+    },
+    {
+        "event_id": "gen_misc_transition_eldertomale",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "transition"
+        ],
+        "frequency": 4,
+        "event_text": "m_c has always felt a disconnect in {PRONOUN/m_c/poss} concept of self. Though it has taken several seasons to realize, m_c has decided that being just a cat suits {PRONOUN/m_c/object} better.",
+        "m_c": {
+            "gender": [
+                "male",
+                "female"
+            ],
+            "age": [
+            "senior",
+            "senior adult"
+            ]
+        },
+        "new_gender": [
+            "nonbinary"
+        ]
+    },
+  {
+        "event_id": "gen_misc_transition_parentcomingout_from_male",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "transition"
+        ],
+        "frequency": 4,
+        "event_text": "The first cat m_c tells about {PRONOUN/m_c/poss} transition is {PRONOUN/m_c/poss} parent, r_c. Overjoyed for {PRONOUN/r_c/poss} child, r_c helps m_c spread the news to the rest of the Clan.",
+        "m_c": {
+            "gender": [
+                "male"
+            ]
+        },
+        "new_gender": [
+            "trans female",
+            "nonbinary"
+        ],
+        "relationship_status": ["child/parent"],
+      "relationships": [
+          {
+              "cats_from": ["m_c"],
+            "cats_to": ["r_c"],
+            "mutual": false,
+            "values": ["like", "comfort"],
+            "amount": 5,
+            "log": {
+                "cats_from": "cat_to helped cat_from tell the rest of the clan about {PRONOUN/cat_from/poss} transition."
+            }
+        }
+      ],
+        "r_c": {
+            "relationship_status": ["parent/child"]
+        }
+    },
+    {
+        "event_id": "gen_misc_transition_parentcomingout_from_female",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "transition"
+        ],
+        "frequency": 4,
+        "event_text": "The first cat m_c tells about {PRONOUN/m_c/poss} transition is {PRONOUN/m_c/poss} parent, r_c. Overjoyed for {PRONOUN/r_c/poss} child, r_c helps m_c spread the news to the rest of the Clan.",
+        "m_c": {
+            "gender": [
+                "female"
+            ]
+        },
+        "new_gender": [
+            "trans male",
+            "nonbinary"
+        ],
+        "relationship_status": ["child/parent"],
+      "relationships": [
+          {
+              "cats_from": ["m_c"],
+            "cats_to": ["r_c"],
+            "mutual": false,
+            "values": ["like", "comfort"],
+            "amount": 5,
+            "log": {
+                "cats_from": "cat_to helped cat_from tell the rest of the clan about {PRONOUN/cat_from/poss} transition."
+            }
+        }
+      ],
+        "r_c": {
+            "relationship_status": ["parent/child"]
+        }
+    },
+    {
+        "event_id": "gen_misc_transition_dysphoriareassurance_frommale",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "transition"
+        ],
+        "frequency": 4,
+        "event_text": "m_c has never felt like {PRONOUN/m_c/poss} body matches the way {PRONOUN/m_c/subject} {VERB/m_c/see/sees} {PRONOUN/m_c/self}. After some time, m_c has realized, though c_n's acceptance of {PRONOUN/m_c/poss} gender may not lessen the feeling, m_c feels accepted by the Clan's support.",
+        "m_c": {
+            "age": ["-kitten"],
+            "gender": [
+                "male"
+            ]
+        },
+        "new_gender": [
+            "trans female",
+            "nonbinary"
+        ],
+      "relationships": [
+          {
+            "cats_from": ["m_c"],
+            "cats_to": ["clan"],
+            "mutual": false,
+            "values": ["like", "comfort"],
+            "amount": 5,
+            "log": {
+                "cats_from": "cat_from is comforted by the cat_to's acceptance of {PRONOUN/cat_from/poss} gender."
+            }
+        }
+      ]
+    }
 ]

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -16960,7 +16960,7 @@
             "transition"
         ],
         "frequency": 4,
-        "event_text": "m_c has always felt a disconnect in {PRONOUN/m_c/poss} concept of self. Though it has taken several seasons to realize, m_c has decided that being a she-cat suits {PRONOUN/m_c/object} better.",
+        "event_text": "m_c has always felt a disconnect in {PRONOUN/m_c/poss} concept of self. Though it has taken many seasons to realize, m_c has decided that being a she-cat suits {PRONOUN/m_c/object} better.",
         "m_c": {
             "gender": [
                 "male"


### PR DESCRIPTION
## About The Pull Request

- Four new transition events! One is constrained for kittens, another for seniors/senior adults, a third for child/parent relationships.

## Why This Is Good For ClanGen
- Shows some more variety for transition events and personalization. Trans joy!

## Proof of Testing
Game loads and moonskips appropriately. Here are the events in game:
<img width="514" height="122" alt="Screenshot 2026-07-29 at 12 59 35 PM" src="https://github.com/user-attachments/assets/4370518e-dbe6-41b0-a5e3-5c72d5e0c1ac" />
<img width="511" height="149" alt="Screenshot 2026-07-29 at 12 59 15 PM" src="https://github.com/user-attachments/assets/3f98c116-ab8d-4088-a1aa-3e56aa2da3aa" />
<img width="516" height="125" alt="Screenshot 2026-07-29 at 12 58 58 PM" src="https://github.com/user-attachments/assets/be7463f9-6dc3-4c99-be21-447c351f9e36" />
<img width="518" height="130" alt="Screenshot 2026-07-29 at 12 58 06 PM" src="https://github.com/user-attachments/assets/cb479967-cde2-4565-8aa1-aacdf93f4d3e" />
