### PR TITLE
[CRASHFIX] Unmute button problem

### DIFF
--- a/main.py
+++ b/main.py
@@ -79,7 +79,6 @@ def load_data():
             version_info = clan_class.load_clan()
             version_convert(version_info)
             game.load_events()
-            scripts.screens.screens_core.screens_core.rebuild_core()
         except Exception as e:
             logging.exception("File failed to load")
             if switch_get_value(Switch.error_message) is None:
@@ -87,6 +86,8 @@ def load_data():
                     Switch.error_message, "There was an error loading the cats file!"
                 )
                 switch_set_value(Switch.traceback, e)
+
+        scripts.screens.screens_core.screens_core.rebuild_core()
 
     finished_loading = True
 


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
So this was caused by the `rebuild_core()` being part of the try/except for `load_data()`.  If the clan failed to load during the `try` part, then `rebuild_core()` wouldn't be called. Fixed it by moving the func out of the `try/except`.  
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
fixes #5547
fixes #5414
fixes #5315
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
<img width="793" height="700" alt="image" src="https://github.com/user-attachments/assets/92ebc9d2-9027-4541-8c26-edb92145e576" />

corrupted save by removing the guide cat, previously this would cause an unmute crash! Now it just throws the normal clan error.
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Ensures the unmute button is built regardless of clan load failure
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
