### PR TITLE
[TYPOFIX] leader ceremony pronoun tags

### DIFF
--- a/resources/lang/en/events/lead_ceremony_sc.json
+++ b/resources/lang/en/events/lead_ceremony_sc.json
@@ -414,7 +414,7 @@
           "virtue": ["acceptance", "bravery", "certainty", "clear judgment", "confidence", "courage", "determination", "endurance", "sympathy", "farsightedness", "friendship", "instincts", "mercy", "strength", "unity"]
         },
         {
-          "text": "As r_c gives a life for [virtue], {PRONOUN/r_c/subject} {VERB/m_c/urge/urges} m_c to keep {PRONOUN/m_c/poss} head on straight and to remember to sheathe {PRONOUN/r_c/poss} claws.",
+          "text": "As r_c gives a life for [virtue], {PRONOUN/r_c/subject} {VERB/r_c/urge/urges} m_c to keep {PRONOUN/m_c/poss} head on straight and to remember to sheathe {PRONOUN/m_c/poss} claws.",
           "virtue": ["acceptance", "bravery", "certainty", "clear judgment", "confidence", "courage", "determination", "endurance", "sympathy", "farsightedness", "friendship", "instincts", "mercy", "strength", "unity"]
         }
       ]


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

noticed r_c and m_c were mixed up in leader ceremony text, so i went ahead and fixed that.

## Why This Is Good For ClanGen

typo bad. typo fixing good

## Proof of Testing

<img width="1054" height="89" alt="image" src="https://github.com/user-attachments/assets/789bb0ad-cdb7-49ce-bc45-5b8d92aeef2e" />

## Changelog/Credits

- Fixes a couple incorrect pronoun tags in leader ceremony text.