### PR TITLE
[ENHANCEMENT] Moonskip prey and freshkill display

### DIFF
--- a/resources/game_config.toml
+++ b/resources/game_config.toml
@@ -873,6 +873,7 @@ dev_tools = false
   # the same, but for healthy apprentices
   auto_apprentice_prey = [1,3]
 
+
   # the baseline of prey amount caught on patrol will be a warrior's prey_requirement plus this value
   additional_prey = 1
 
@@ -883,6 +884,23 @@ dev_tools = false
 
   # the amount that a cat's prey requirement increases if the cat is sick/injured/pregnant
   condition_increase = 1
+
+  # cats of each rank will choose a random num of prey from the given list to catch each moon
+  # ranks that are not leader, deputy, or warrior will only catch prey if no leader/deputy/warriors are available to do so
+  [prey.auto_catch]
+    leader = [2, 3, 3, 4]
+    deputy = [2, 3, 3, 4]
+    warrior = [2, 3, 3, 4]
+    apprentice = [1, 2, 2, 3]
+    "medicine cat" = [0, 1, 1, 2]
+    "medicine cat apprentice" = [0, 1]
+    mediator = [0, 1, 2, 2]
+    "mediator apprentice" = [0, 1, 1]
+    elder = [0, 1, 1]
+    kitten = [0, 0, 1]
+    newborn = [0]
+
+    not_working = [0, 0, 1]
 
   [prey.feeding]
     # the rank order in which cats will be fed

--- a/resources/lang/en/windows.en.json
+++ b/resources/lang/en/windows.en.json
@@ -107,7 +107,7 @@
         "priority": "<b>Prioritize</b>",
         "freshkill_help_tooltip": "The Clan will catch some amount of prey over each timeskip, but successful hunting patrols are the most important source of freshkill. Freshkill can't be stored endlessly: after three moons, prey will rot and will be discarded. Cats under 3 moons with a parent (queen) taking care of them won't need food. Cats will only display here if their hunger status is less than stuffed!<br><br>Ranks are fed in the following order, from lowest to highest. Each rank lists how much prey they will need for a moon.",
         "nutrition_text": "nutrition: %{nutrition_text}",
-        "freshkill_pile_tooltip": "<b>Current amount:</b> %{current_prey_amount} pieces  -  <b>Needed amount:</b> %{needed_amount} pieces",
+        "freshkill_pile_tooltip": "<b>Current amount:</b> %{current_prey_amount} pieces  -  <b>Needed amount:</b> %{needed_amount} pieces<br><b>Expiring soon:</b> %{expiring_amount} pieces  -  <b>Estimated catch per moon:</b> %{expected_amount} pieces",
         "no_hungry_cats": "No cats are in need of food.",
         "herb_help_tooltip": "The medicine cats will gather herbs each timeskip and treat their patients. Older herbs may expire during timeskip and will be cleared out of the supply. <br><br>Gathered, used, and expired herbs will be reported in this log. To see more information about the Clan's herb supply and sick/injured cats, check the medicine cat den.",
         "no_mediators": "The Clan has no mediators!",

--- a/scripts/clan_resources/freshkill.py
+++ b/scripts/clan_resources/freshkill.py
@@ -1,4 +1,5 @@
 import random
+from statistics import mean
 from typing import List
 
 import i18n
@@ -173,6 +174,58 @@ class FreshkillPile:
         )
 
         self.needed_prey = needed_prey
+
+    @staticmethod
+    def get_moonskip_catch_amount(disable_random: bool = False) -> int:
+        # first try to find all the warrior-like healthy cats
+        possible_hunters = list(
+            filter(
+                lambda c: c.status.rank
+                in (CatRank.WARRIOR, CatRank.APPRENTICE, CatRank.LEADER, CatRank.DEPUTY)
+                and c.status.alive_in_player_clan
+                and not c.not_working(),
+                Cat.all_cats.values(),
+            )
+        )
+
+        # uh oh! there aren't any, so we'll try and find any healthy cats of other ranks
+        if not possible_hunters:
+            possible_hunters = list(
+                filter(
+                    lambda c: c.status.alive_in_player_clan and not c.not_working(),
+                    Cat.all_cats.values(),
+                )
+            )
+
+        # still none, so this time we take whoever is left
+        using_sick_hunters = False
+        if not possible_hunters:
+            possible_hunters = list(
+                filter(
+                    lambda c: c.status.alive_in_player_clan,
+                    Cat.all_cats.values(),
+                )
+            )
+            using_sick_hunters = True
+
+        prey_amount = 0
+        for cat in possible_hunters:
+            if using_sick_hunters:
+                if disable_random:
+                    prey_amount += mean(get_config("prey.auto_catch.not_working"))
+                    continue
+                prey_amount += random.choice(get_config("prey.auto_catch.not_working"))
+            else:
+                if disable_random:
+                    prey_amount += mean(
+                        get_config(f"prey.auto_catch.{cat.status.rank}")
+                    )
+                    continue
+                prey_amount += random.choice(
+                    get_config(f"prey.auto_catch.{cat.status.rank}")
+                )
+
+        return prey_amount
 
     def time_skip(self, living_cats: list, event_list: list) -> None:
         """Handles the time skip for the freshkill pile. Decrements the timers on prey items and feeds listed cats

--- a/scripts/clan_resources/freshkill.py
+++ b/scripts/clan_resources/freshkill.py
@@ -133,7 +133,9 @@ class FreshkillPile:
         self.total_amount = sum(self.pile.values())
 
     def _update_needed_food(self, living_cats: List[Cat]) -> None:
-        queen_dict, living_kits = get_alive_clan_queens(self.living_cats)
+        queen_dict, living_kits = get_alive_clan_queens(
+            living_cats if living_cats else self.living_cats
+        )
         relevant_queens = []
         # kits under 3 months are feed by the queen
         for queen_id, their_kits in queen_dict.items():

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -606,25 +606,8 @@ def mediator_events(cat):
 
 def get_moon_freshkill():
     """Adding auto freshkill for the current moon."""
-    healthy_hunter = list(
-        filter(
-            lambda c: c.status.rank
-            in (CatRank.WARRIOR, CatRank.APPRENTICE, CatRank.LEADER, CatRank.DEPUTY)
-            and c.status.alive_in_player_clan
-            and not c.not_working(),
-            Cat.all_cats.values(),
-        )
-    )
 
-    prey_amount = 0
-    for cat in healthy_hunter:
-        lower_value = constants.CONFIG["prey"]["auto_warrior_prey"][0]
-        upper_value = constants.CONFIG["prey"]["auto_warrior_prey"][1]
-        if cat.status.rank == CatRank.APPRENTICE:
-            lower_value = constants.CONFIG["prey"]["auto_apprentice_prey"][0]
-            upper_value = constants.CONFIG["prey"]["auto_apprentice_prey"][1]
-
-        prey_amount += random.randint(lower_value, upper_value)
+    prey_amount = game.clan.freshkill_pile.get_moonskip_catch_amount()
     game.freshkill_event_list.append(
         i18n.t("hardcoded.prey_catch_count", count=prey_amount)
     )

--- a/scripts/ui/windows/freshkill.py
+++ b/scripts/ui/windows/freshkill.py
@@ -236,13 +236,13 @@ class FreshkillManagementWindow(GameWindow):
             self.feed_view_elements.pop("cat_list")
 
         self.feed_view_elements["cat_list"] = UICatListDisplay(
-            ui_scale(pygame.Rect((45, 40), (455, 300))),
+            ui_scale(pygame.Rect((45, 40), (455, 270))),
             container=self,
             manager=MANAGER,
             cat_list=self.low_nutrition_cats,
             cats_displayed=12,
             x_px_between=ui_scale_value(5),
-            y_px_between=ui_scale_value(10),
+            y_px_between=ui_scale_value(5),
             columns=4,
             rows=3,
             show_names=True,
@@ -262,14 +262,20 @@ class FreshkillManagementWindow(GameWindow):
 
         current_prey_amount = int(game.clan.freshkill_pile.total_amount)
         needed_amount = math.ceil(game.clan.freshkill_pile.amount_food_needed())
+        predicted_catch = game.clan.freshkill_pile.get_moonskip_catch_amount(
+            disable_random=True
+        )
+        expiring_amount = int(game.clan.freshkill_pile.pile["expires_in_1"])
 
-        scale_rect = ui_scale(pygame.Rect((0, 0), (450, -1)))
-        scale_rect.bottomleft = ui_scale_offset((0, -90))
+        scale_rect = ui_scale(pygame.Rect((0, 0), (530, -1)))
+        scale_rect.bottomleft = ui_scale_offset((0, -110))
         self.feed_view_elements["status_text"] = UITextBoxTweaked(
             i18n.t(
                 "windows.freshkill_pile_tooltip",
                 current_prey_amount=current_prey_amount,
                 needed_amount=needed_amount,
+                expiring_amount=expiring_amount,
+                expected_amount=predicted_catch,
             ),
             scale_rect,
             object_id="#text_box_30_horizcenter",

--- a/scripts/ui/windows/freshkill.py
+++ b/scripts/ui/windows/freshkill.py
@@ -262,8 +262,8 @@ class FreshkillManagementWindow(GameWindow):
 
         current_prey_amount = int(game.clan.freshkill_pile.total_amount)
         needed_amount = math.ceil(game.clan.freshkill_pile.amount_food_needed())
-        predicted_catch = game.clan.freshkill_pile.get_moonskip_catch_amount(
-            disable_random=True
+        predicted_catch = round(
+            game.clan.freshkill_pile.get_moonskip_catch_amount(disable_random=True)
         )
         expiring_amount = int(game.clan.freshkill_pile.pile["expires_in_1"])
 


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
- Added the ability for non-warrior-like ranks to also hunt for themselves when there's no other choice. If no warrior-like cats are healthy and available, then all healthy non-warrior cats will attempt to hunt. If there's no healthy non-warrior cats, then all cats, regardless of health, will attempt to hunt
- Each rank has a unique range of possible prey amounts they can bring back during a moonskip hunt. Sick cats also have their own range. Kittens, for example, have a much harder time hunting.
- Moved the func for determining moonskip hunting amounts into `freshkill.py` so it could also be utilized for displaying information
- Consequently, the freshkill window now displays additional info: The amount of prey expiring next moon and an estimated catch for next moon (this is the average for the current cats in the clan)
- Fixed a bug that could cause the freshkill window to display as 0 prey needed

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Why This Is Good For ClanGen
This allows starting scenarios with all-kits or otherwise non-hunting ranks to still subsist in some fashion. It's still fairly difficult to keep them alive, but they won't simply lay down and die because they don't have the right "job".

Freshkill window improvements better allow the player to plan ahead for the next moon.

<!-- If this is a bug fix, you can remove this section. -->
<!-- Please add a short description of why you think these changes would benefit the game. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->
<!-- If you have multiple features that can stand on their own, or unrelated bugfixes, please create separate PRs for them. -->

## Proof of Testing
<img width="607" height="456" alt="image" src="https://github.com/user-attachments/assets/d5089749-7691-4c5b-ab95-bdd7d163f796" />

(an all kitten clan)

<img width="606" height="452" alt="image" src="https://github.com/user-attachments/assets/d42e44de-1b19-4beb-a390-fa684d10e94f" />
<img width="583" height="448" alt="image" src="https://github.com/user-attachments/assets/5cca7a4c-e91d-41f2-b4ac-f5ca37123c3e" />

their next moon!

<img width="598" height="456" alt="image" src="https://github.com/user-attachments/assets/f595233e-f686-4e25-bb7c-d471a91cfaaf" />

a much larger and established clan, to show off the freshkill info specifically

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Allows non-warrior ranks to hunt on moonskip when they have no choice
- Adds information to the freshkill window regarding expiring prey and expected catches
- Fixed a bug that could cause the freshkill window to display as 0 prey needed
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
