### PR TITLE
[BUGFIX] Hide custom pronoun ID in pronoun display

### DIFF
--- a/scripts/screens/ChangeGenderScreen.py
+++ b/scripts/screens/ChangeGenderScreen.py
@@ -529,8 +529,11 @@ class ChangeGenderScreen(Screens):
 
     def pronoun_get_cases(self, pronounset) -> str:
         # Gets all pronoun cases in pronounset for display
-        pronounset_values = list(pronounset.values())
-        displayname = (x for x in pronounset_values if not isinstance(x, int))
+        displayname = (
+            value
+            for key, value in pronounset.items()
+            if key != "ID" and not isinstance(value, int)
+        )
         displayname = "/".join(displayname)
         return displayname
 

--- a/tests/test_change_gender_screen.py
+++ b/tests/test_change_gender_screen.py
@@ -1,0 +1,49 @@
+import os
+import unittest
+
+os.environ["SDL_VIDEODRIVER"] = "dummy"
+os.environ["SDL_AUDIODRIVER"] = "dummy"
+
+from scripts.screens.ChangeGenderScreen import ChangeGenderScreen
+
+
+class TestPronounGetCases(unittest.TestCase):
+    def setUp(self):
+        # `pronoun_get_cases` does not touch instance state, and building a real
+        # screen would require a running UI manager.
+        self.screen = object.__new__(ChangeGenderScreen)
+
+    def test_custom_pronoun_id_not_displayed(self):
+        """A custom pronoun set carries an "ID" key, which is not a case."""
+        pronounset = {
+            "subject": "it",
+            "object": "it",
+            "poss": "its",
+            "inposs": "its",
+            "self": "itself",
+            "conju": 2,
+            "gender": 0,
+            "ID": "custom0",
+        }
+
+        self.assertEqual(
+            self.screen.pronoun_get_cases(pronounset),
+            "it/it/its/its/itself",
+        )
+
+    def test_default_pronoun_cases(self):
+        """A default pronoun set has no "ID" and is unaffected."""
+        pronounset = {
+            "subject": "they",
+            "object": "them",
+            "poss": "their",
+            "inposs": "theirs",
+            "self": "themself",
+            "conju": 1,
+            "gender": 0,
+        }
+
+        self.assertEqual(
+            self.screen.pronoun_get_cases(pronounset),
+            "they/them/their/theirs/themself",
+        )


### PR DESCRIPTION
## About The Pull Request

Custom pronoun sets carry an extra `"ID"` key (`"custom0"`, `"custom1"`, ...) that `PronounCreationWindow` assigns as an internal identifier. `ChangeGenderScreen.pronoun_get_cases` filtered out only `int` values, so that ID string was joined into the displayed pronoun set and rendered as a trailing `/custom0`. The `"ID"` key is now filtered by name; default sets have no ID and are unaffected.

## Linked Issues

Fixes: #5584

## Proof of Testing

Added `tests/test_change_gender_screen.py`, covering a custom set (with `ID`) and a default set. Run locally with `pytest tests/test_change_gender_screen.py`: both fail/pass as expected — `test_custom_pronoun_id_not_displayed` fails on the unpatched code (`'it/it/its/its/itself/custom0'`) and passes with the fix. Full `pytest tests/` is unchanged otherwise (445 passed; the one `test_interactions.py::test_parent_child_combo` failure is present on an unmodified checkout too).

## Changelog/Credits

Bugfix: custom pronoun sets no longer display their internal ID in the change-gender menu.

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.
