### PR TITLE
[BUGFIX] Remove duplicate mentorship history

### DIFF
--- a/resources/lang/en/cat/history.en.json
+++ b/resources/lang/en/cat/history.en.json
@@ -13,7 +13,6 @@
         "graduation_early": "{PRONOUN/m_c/poss/CAP} training went so well that {PRONOUN/m_c/subject} graduated early at %{age} moons old.",
         "graduation_normal": "{PRONOUN/m_c/subject/CAP} graduated at %{age} moons old.",
         "graduation_late": "{PRONOUN/m_c/subject/CAP} graduated late at %{age} moons old.",
-        "mentored": "{PRONOUN/m_c/subject/CAP} mentored %{apprentices}.",
          "comment": "Leader live strings for history text or text where m_c is included in the area its being called to",
         "leader_death_all": "lost all of {PRONOUN/m_c/poss} lives",
         "leader_death_cardinal": {

--- a/scripts/screens/ProfileScreen.py
+++ b/scripts/screens/ProfileScreen.py
@@ -1289,11 +1289,6 @@ class ProfileScreen(Screens):
             if app_history:
                 life_history.append(app_history)
 
-            # Get mentorship text if it exists
-            mentor_history = self.get_mentorship_text()
-            if mentor_history:
-                life_history.append(mentor_history)
-
             # now go get the scar history and add that if any exists
             body_history = []
             scar_history = self.get_scar_text()
@@ -1602,31 +1597,6 @@ class ProfileScreen(Screens):
         apprenticeship_history = influence_history + " " + graduation_history
         apprenticeship_history = process_text(apprenticeship_history, cat_dict)
         return apprenticeship_history
-
-    def get_mentorship_text(self):
-        """
-
-        returns full list of previously mentored apprentices.
-
-        """
-
-        text = ""
-        # Doing this is two steps
-        all_real_apprentices = [
-            str(Cat.fetch_cat(i).name)
-            for i in self.the_cat.former_apprentices
-            if isinstance(Cat.fetch_cat(i), Cat)
-        ]
-        if all_real_apprentices:
-            text = i18n.t(
-                "cat.history.mentored",
-                apprentices=adjust_list_text(all_real_apprentices),
-            )
-            cat_dict = {"m_c": (str(self.the_cat.name), choice(self.the_cat.pronouns))}
-
-            text = process_text(text, cat_dict)
-
-        return text
 
     def get_death_text(self):
         """


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

This removes `get_mentorship_text` + localization that was replaced with `get_former_apprentice_text` but not deduplicated in a previous commit.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues

Fixes: #5592

<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing

Open History tab of cat, find only one former apprentice localization:

<img width="400" alt="Endless has a former apprentice, now only listed once" src="https://github.com/user-attachments/assets/f2b0a08b-06e2-47ee-b5fd-687655c891bb" />

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->