### PR TITLE
Bugfix: reset relationship page counter when no relationships match filters

### DIFF
--- a/scripts/screens/RelationshipScreen.py
+++ b/scripts/screens/RelationshipScreen.py
@@ -391,6 +391,9 @@ class RelationshipScreen(Screens):
             if self.relation_elements:
                 self.kill_relation_buttons()
             self.prior_chunk.clear()
+            self.elements["page_number"].set_text("0/0")
+            self.elements["next_page_button"].disable()
+            self.elements["previous_page_button"].disable()
             return
 
         # PAGE ARROWS

--- a/tests/test_relationship_screen.py
+++ b/tests/test_relationship_screen.py
@@ -1,0 +1,40 @@
+import os
+import unittest
+from unittest.mock import MagicMock
+
+os.environ["SDL_VIDEODRIVER"] = "dummy"
+os.environ["SDL_AUDIODRIVER"] = "dummy"
+
+from scripts.screens.RelationshipScreen import RelationshipScreen
+
+
+class TestRelationshipScreenPageNumber(unittest.TestCase):
+    @staticmethod
+    def _make_screen(chunks):
+        screen = RelationshipScreen.__new__(RelationshipScreen)
+        screen.chunks = chunks
+        screen.current_page = 1
+        screen.relation_elements = {}
+        screen.prior_chunk = []
+
+        page_number = MagicMock()
+        page_number.text = "test/test"
+        page_number.set_text = lambda text: setattr(page_number, "text", text)
+
+        screen.elements = {
+            "page_number": page_number,
+            "next_page_button": MagicMock(),
+            "previous_page_button": MagicMock(),
+        }
+        return screen
+
+    def test_page_number_with_no_visible_relationships(self):
+        """No relationship passes the current filters, so the page counter must
+        not keep the placeholder text it was created with."""
+        screen = self._make_screen([])
+
+        screen.update_relationships()
+
+        self.assertEqual(screen.elements["page_number"].text, "0/0")
+        screen.elements["next_page_button"].disable.assert_called_once()
+        screen.elements["previous_page_button"].disable.assert_called_once()


### PR DESCRIPTION
## About The Pull Request

The page counter on the relationships screen is a `UITextBox` created with the literal placeholder text `"test/test"`. That text is only ever replaced inside `update_relationships()` in the branch that runs when `self.chunks` is non-empty. When a filter combination matches no relationships, the method returns early, so the placeholder stayed visible instead of a page count.

The early-return branch now sets the counter to `0/0` and disables both page arrows, matching the state the normal path already produces for a single page.

## Linked Issues

Fixes: #5589

## Proof of Testing

Added `tests/test_relationship_screen.py`, which drives `update_relationships()` with no chunks and asserts the counter is no longer the placeholder. It fails on current `development` (counter still reads `test/test`) and passes with the fix. Full `pytest tests/` run: 445 passed, with only the pre-existing `test_interactions.py::test_parent_child_combo` failure, which is identical before and after this change. `black` reports both changed files unchanged.

## Changelog/Credits

Bugfix: the relationships screen page counter no longer shows placeholder text when no relationships match the selected filters.

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.
