### PR TITLE
[BUGFIX] Better save file errors

### DIFF
--- a/main.py
+++ b/main.py
@@ -81,7 +81,7 @@ def load_data():
             game.load_events()
         except Exception as e:
             logging.exception("File failed to load")
-            if switch_get_value(Switch.error_message) is None:
+            if not switch_get_value(Switch.error_message):
                 switch_set_value(
                     Switch.error_message, "There was an error loading the cats file!"
                 )

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -2766,6 +2766,7 @@ class Cat:
 
         # just preventing any attempts to load something that isn't a cat ID
         if not cat.isdigit():
+            print(f'ERROR: in loading faded cat: "{cat}" is not a valid cat ID')
             return
 
         try:
@@ -2798,8 +2799,8 @@ class Cat:
                 encoding="utf-8",
             ) as read_file:
                 cat_info = ujson.loads(read_file.read())
-        except:
-            print("ERROR: in loading faded cat")
+        except Exception as e:
+            print(f'ERROR: in loading faded cat "{cat}": {e!r}')
             return False
 
         if isinstance(cat_info["status"], str):

--- a/scripts/clan.py
+++ b/scripts/clan.py
@@ -539,7 +539,7 @@ class Clan:
             "starting_season": self.starting_season,
             "temperament": self.temperament,
             "just_died": game.just_died,
-            "dead_cats_to_grieve": [x.ID for x in game.dead_cats_to_grieve],
+            "dead_cats_to_grieve": [x.ID for x in game.dead_cats_to_grieve if x],
             "grief_to_assign": game.clan.grief_strings,
             "version_name": SAVE_VERSION_NUMBER,
             "version_commit": get_version_info().version_number,
@@ -1016,7 +1016,9 @@ class Clan:
         # Cats who need to be grieved
         if "dead_cats_to_grieve" in clan_data:
             game.dead_cats_to_grieve = [
-                Cat.fetch_cat(x) for x in clan_data["dead_cats_to_grieve"]
+                cat
+                for x in clan_data["dead_cats_to_grieve"]
+                if (cat := Cat.fetch_cat(x))
             ]
 
         # Cats who are gonna grieve

--- a/scripts/clan.py
+++ b/scripts/clan.py
@@ -805,11 +805,23 @@ class Clan:
             for _ in range(number_other_clans):
                 self.all_other_clans.append(OtherClan())
 
+        missing_cats = []
         for cat in members:
             if cat in Cat.all_cats:
                 game.clan.add_cat(Cat.all_cats[cat])
             else:
-                print("WARNING: Cat not found:", cat)
+                missing_cats.append(cat)
+        if missing_cats:
+            error = ValueError(
+                f"clan.txt references {len(missing_cats)} cat(s) missing from "
+                f"the cat file: {', '.join(missing_cats)}"
+            )
+            switch_set_value(
+                Switch.error_message,
+                "Some cats in this save could not be loaded! Please check the cat file for missing cats.",
+            )
+            switch_set_value(Switch.traceback, error)
+            raise error
         self.load_pregnancy(game.clan)
 
         # assigning a symbol, since this save would be too old to have a chosen symbol
@@ -987,11 +999,23 @@ class Clan:
                         OtherClan(name, int(relation), temper, symbol)
                     )
 
+        missing_cats = []
         for cat in clan_data["clan_cats"].split(","):
             if cat in Cat.all_cats:
                 game.clan.add_cat(Cat.all_cats[cat])
             else:
-                print("WARNING: Cat not found:", cat)
+                missing_cats.append(cat)
+        if missing_cats:
+            error = ValueError(
+                f"clan.json references {len(missing_cats)} cat(s) missing from "
+                f"clan_cats.json: {', '.join(missing_cats)}"
+            )
+            switch_set_value(
+                Switch.error_message,
+                "Some cats in this save could not be loaded! Please check the cat file for missing cats.",
+            )
+            switch_set_value(Switch.traceback, error)
+            raise error
         if "war" in clan_data:
             game.clan.war = clan_data["war"]
 

--- a/scripts/game_structure/load_cat.py
+++ b/scripts/game_structure/load_cat.py
@@ -45,6 +45,10 @@ def load_cats():
         json_load()
     except FileNotFoundError:
         csv_load(Cat.all_cats)
+    except Exception:
+        Cat.all_cats.clear()
+        Cat.all_cats_list.clear()
+        raise
 
 
 def json_load():

--- a/scripts/screens/StartScreen.py
+++ b/scripts/screens/StartScreen.py
@@ -426,7 +426,7 @@ class StartScreen(Screens):
 
         self.reload_errors()
 
-        if game.clan is not None:
+        if game.clan is not None and not switch_get_value(Switch.error_message):
             key_copy = tuple(Cat.all_cats.keys())
             for x in key_copy:
                 if x not in game.clan.clan_cats:


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

This handles some otherwise silent or half-loaded clan errors.

1. stops load when `clan.json` references cats missing from `clan_cats.json`
2. prints referenced cat when cat cannot be found on load 
3. clears `Cat.all_cats` on partial or incomplete load
4. skips the start screen's `Cat.all_cats` prune after a failed load
5. filters unresolvable cat IDs out of `dead_cats_to_grieve` on save and load
6. errors on failed loads when switching clans

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Proof of Testing

Intentionally broken saves were loaded:
- incorrect "SKILL" skill → load fails, error shown rather than loading in half of cats
- cat not found in `clan_cats.json` → load fails with missing ID named, previously loaded silently and crashed later
- two cats with non existent IDs in `dead_cats_to_grieve` list ("99999" and "ID") → both filtered + logged, moonskip without error

screenshots:
<img width="400" alt="Key Error: 'SKILL' on main menu" src="https://github.com/user-attachments/assets/e9fd79d9-8bb9-497a-9523-1913cd1e45f6" />
<img width="400" alt="missing cat from clan_cats.json error" src="https://github.com/user-attachments/assets/f1bc2da8-bf37-49c2-a7b4-b4a343d69f84" />

and terminal output:
```
ERROR: in loading faded cat "99999": FileNotFoundError(2, 'No such file or directory')
ERROR: in loading faded cat: "ID" is not a valid cat ID
```
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->