### PR TITLE
Bugfix: Fix cat history being erased by erroneous conversion in load_cat_factory.py

### DIFF
--- a/scripts/cat/factories/load_cat_factory.py
+++ b/scripts/cat/factories/load_cat_factory.py
@@ -129,7 +129,7 @@ class LoadCatFactory(BaseCatFactory):
         # because of the horrible nested cat. fixme.
         if "died_by" in kwargs or "scar_event" in kwargs:
             cat.history = cls._convert_history(
-            kwargs.get("died_by", []), kwargs.get("scar_event", []), cat=cat
+                kwargs.get("died_by", []), kwargs.get("scar_event", []), cat=cat
             )
         cat.name = Name(
             prefix=kwargs["name_prefix"],

--- a/scripts/cat/factories/load_cat_factory.py
+++ b/scripts/cat/factories/load_cat_factory.py
@@ -127,10 +127,10 @@ class LoadCatFactory(BaseCatFactory):
 
         # Unfortunately, these two have to be handled *after* the creation of the cat
         # because of the horrible nested cat. fixme.
-
-        cat.history = cls._convert_history(
+        if "died_by" in kwargs or "scar_event" in kwargs:
+            cat.history = cls._convert_history(
             kwargs.get("died_by", []), kwargs.get("scar_event", []), cat=cat
-        )
+            )
         cat.name = Name(
             prefix=kwargs["name_prefix"],
             suffix=kwargs["name_suffix"],


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
Added an if statement to prevent load_cat_factory.py from running conversion logic on _every_ cat's history file, regardless of if it needed converting or not. 

Thank you to Chinch Bug for first discovering how to fix this bug.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
Fixes: #5679 
Fixes: #5678

<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
Scar history and warrior ceremony loaded correctly after saving, closing and reopening the game
<img width="932" height="725" alt="grafik" src="https://github.com/user-attachments/assets/5c55caef-8e79-4732-acb9-11daa3050a86" />

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->
