### PR TITLE
[CRASHFIX] Skill crashes and faded crash

### DIFF
--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -297,6 +297,7 @@ class Cat:
         # name is assigned by FadedCatFactory
 
         self.faded = True
+        self.set_faded()
         return True
 
     def __repr__(self):

--- a/scripts/cat/skills.py
+++ b/scripts/cat/skills.py
@@ -316,7 +316,9 @@ class CatSkills:
         return f"<CatSkills: Primary: |{self.primary}|, Secondary: |{self.secondary}|, Hidden: |{self.hidden}|>"
 
     def get_all(self) -> dict:
-        skill_dict = {self.primary.path: self.primary.tier}
+        skill_dict = {}
+        if self.primary:
+            skill_dict[self.primary.path] = self.primary.tier
         if self.secondary:
             skill_dict[self.secondary.path] = self.secondary.tier
 

--- a/scripts/events_module/patrol/patrol_outcome.py
+++ b/scripts/events_module/patrol/patrol_outcome.py
@@ -770,17 +770,9 @@ class PatrolOutcome:
                 quantity_allowed += constants.CONFIG["clan_resources"]["herbs"][
                     "general_patrol_quantity_per_cat"
                 ]
-                if cat.skills.primary.path == SkillPath.CLEVER:
-                    quantity_allowed += constants.CONFIG["clan_resources"]["herbs"][
-                        "primary_clever"
-                    ]
-                elif (
-                    cat.skills.secondary
-                    and cat.skills.secondary.path == SkillPath.CLEVER
-                ):
-                    quantity_allowed += constants.CONFIG["clan_resources"]["herbs"][
-                        "secondary_clever"
-                    ]
+                cat_skills = cat.skills.get_all()
+                quantity_allowed += cat_skills.get(SkillPath.SENSE, 0)
+                
             # get random herbs, add to storage, and get patrol outcome msg
             list_of_herb_strs, found_herbs = game.clan.herb_supply.get_found_herbs(
                 med_cat=patrol.patrol_leader,

--- a/scripts/events_module/patrol/patrol_outcome.py
+++ b/scripts/events_module/patrol/patrol_outcome.py
@@ -772,7 +772,7 @@ class PatrolOutcome:
                 ]
                 cat_skills = cat.skills.get_all()
                 quantity_allowed += cat_skills.get(SkillPath.SENSE, 0)
-                
+
             # get random herbs, add to storage, and get patrol outcome msg
             list_of_herb_strs, found_herbs = game.clan.herb_supply.get_found_herbs(
                 med_cat=patrol.patrol_leader,


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
Each fix has it's own commit, if the reviewer of this PR would like to see them individually.

- When making the skill recall func I forgot newborns don't even have a primary skill, so I've adjusted the func to account for that
- Also forgot that patrols also needed a config I removed, so I've adjusted that part of the patrol code to follow the same convention that replaced the config in `herb_supply`
- Faded cat load had it's `self.set_faded()` call removed, which is what was responsible for setting the sprite. thus anytime a sprite was needed, it would crash as none had been set. Easy fix.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
fixes #5690 
fixes #5686
fixes #5675
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
<img width="491" height="241" alt="image" src="https://github.com/user-attachments/assets/3a314d28-ace7-4c50-8c35-a610d38e7929" />

faded cat sprite!

<img width="710" height="494" alt="image" src="https://github.com/user-attachments/assets/7d32abfb-c07f-4abc-a72e-89b41f003a8c" />

i have newborns in the clan. prior to the fix, this would have crashed on moonskip when no skills could be found for them.

<img width="789" height="696" alt="image" src="https://github.com/user-attachments/assets/3db56999-7207-4c72-ab99-2edaa50e5572" />

no crash

<img width="296" height="223" alt="image" src="https://github.com/user-attachments/assets/3b8b9d3d-904c-446e-afce-1b9382bc5837" />

sending med patrol with clever skill, which would have caused a crash

<img width="472" height="500" alt="image" src="https://github.com/user-attachments/assets/8b68f4cd-499d-49dd-a5b7-942ea3f03e1e" />

no crash
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Fixed CLEVER cats crashing medicine cat patrols when they couldn't figure out what buff to provide
- Fixed newborns causing moonskips to crash due to lack of skills 
- Fixed faded cats crashing when their sprites could not be found
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
