### PR TITLE
Revert "[CLEANUP] remove portion of github workflow that downloads test saves"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,14 @@ jobs:
           - python-version: '3.12'
     steps:
       - uses: actions/checkout@v4
+      - name: Download the test saves
+        run: wget https://github.com/ImLvna/clangen-unittest-saves/archive/refs/heads/main.zip -O tests/saves.zip
+      - name: Unzip
+        run: unzip tests/saves.zip
+      - name: Move the folder
+        run: mv clangen-unittest-saves-main tests/testSaves
+      - name: Remove the zip
+        run: rm tests/saves.zip
       - name: Install uv
         uses: astral-sh/setup-uv@v5
         with:


### PR DESCRIPTION
Reverts ClanGenOfficial/clangen#3974

Was looking through my own PRs and can't remember if we reverted this in #4221.