### PR TITLE
[BUGFIX] Resolve pronouns before relationships

### DIFF
--- a/scripts/events_module/short/short_event.py
+++ b/scripts/events_module/short/short_event.py
@@ -265,6 +265,10 @@ class ShortEvent:
             if self.handle_accessories() is False:
                 return
 
+        # update gender before relationships
+        if self.new_gender:
+            self.handle_transition()
+
         # change relationships before killing anyone
         if self.relationships:
             # we're doing this here to make sure rel logs get adjusted text
@@ -306,10 +310,6 @@ class ShortEvent:
                 comfort=-30,
                 trust=-30,
             )
-
-        # update gender
-        if self.new_gender:
-            self.handle_transition()
 
         # kill cats
         self.handle_death()


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

Moves pronoun handling for transition events before handling relationships to fix a bug where the involved r_c's pronouns were used for an m_c shortevent.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues

Fixes #5696 

<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing

Puddlestar comes out as nonbinary to their mother Leaffeather!

<img width="400" alt="Puddlestar comes out as nonbinary to Leaffeather" src="https://github.com/user-attachments/assets/be2a4a50-d513-4f88-9faf-e7727b6374be" />

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->