### PR TITLE
[CLEANUP] Shared find_involved_cats module

### DIFF
--- a/resources/dicts/events/tags.json
+++ b/resources/dicts/events/tags.json
@@ -85,7 +85,6 @@
                 "littermates",
                 "-littermates",
                 "mates",
-                "mates_with_pl",
                 "-mates",
                 "parent/child",
                 "-parent/child",

--- a/resources/lang/en/patrols/general/training.json
+++ b/resources/lang/en/patrols/general/training.json
@@ -11878,7 +11878,7 @@
                 ],
                 "mutual": false,
                 "constraints": [
-                    "mates_with_pl"
+                    "mates"
                 ]
             },
             {

--- a/scripts/events_module/event_filters.py
+++ b/scripts/events_module/event_filters.py
@@ -1397,21 +1397,31 @@ def _filter_relationship_type_updated(
     # if the cat meets the check AND it's an exclusionary tag: return False
     # if the cat doesn't meet the check AND it's an inclusionary tag: return False
     # otherwise, continue onwards
+    cats_to = [c for c in cats_to if c not in cats_from]
 
     if "can_romance" in filter_types:
         for cat in cats_from:
             # if the cats CAN romance
-            if all([cat.is_potential_mate(inter_cat) for inter_cat in cats_to]):
+            if all(
+                [
+                    cat.is_potential_mate(inter_cat) or cat.ID in inter_cat.mate
+                    for inter_cat in cats_to
+                ]
+            ):
                 if "can_romance" in exclusionary_values:
                     return False
             # if some but not ALL can romance
             elif "can_romance" in inclusionary_values and any(
-                [cat.is_potential_mate(inter_cat) for inter_cat in cats_to]
+                [
+                    cat.is_potential_mate(inter_cat) or cat.ID in inter_cat.mate
+                    for inter_cat in cats_to
+                ]
             ):
                 return False
             # if the cats CAN'T romance
             elif "can_romance" in inclusionary_values:
                 return False
+        filter_types.remove("can_romance")
 
     if "strangers" in filter_types:
         for cat in cats_from:

--- a/scripts/events_module/patrol/patrol.py
+++ b/scripts/events_module/patrol/patrol.py
@@ -411,7 +411,7 @@ class Patrol:
         ]
         while not chosen_patrol:
             # make sure we still have possible patrols
-            if not patrols_to_test:
+            if not patrols_to_test and not patrol_override:
                 if len(checked_patrols) >= len(possible_patrols):
                     # we have checked all possible patrols and found none possible
                     # hopefully this is because we were checking romance patrols, not normal patrols
@@ -453,7 +453,11 @@ class Patrol:
             # CHECK IF CATS FIT
 
             involved_cats = find_cats(
-                interactable_cats=self.involved_cats["patrol_cats"],
+                interactable_cats=[
+                    c
+                    for c in self.involved_cats["patrol_cats"]
+                    if c != self.involved_cats["p_l"]
+                ],
                 involved_cats=self.involved_cats,
                 outside_cats=outside_cats,
                 event=test_patrol,
@@ -526,53 +530,6 @@ class Patrol:
             if not set(patrol.herbs_given).intersection(set(target_herbs)):
                 return False
 
-        return True
-
-    # TODO: remove if works
-    def _patrol_pass_cat_constraints(self, patrol: PatrolEvent) -> bool:
-        temp_involved_cats = self.involved_cats.copy()
-
-        outside_cats = [
-            c
-            for c in Cat.all_cats_list
-            if (c.status.is_other_clancat or c.status.is_outsider) and not c.dead
-        ]
-        for abbr, constraints in patrol.involved_cats.items():
-            # if we need n_c then we pull outside cats
-            if "n_c" in abbr:
-                potential_cats = [
-                    c
-                    for c in outside_cats
-                    if c not in self.new_cats and c not in temp_involved_cats.values()
-                ]
-                random.shuffle(potential_cats)
-            elif "p_l" == abbr:
-                potential_cats = [self.involved_cats["p_l"]]
-            else:
-                potential_cats = [
-                    c for c in self.patrol_cats if c not in temp_involved_cats.values()
-                ]
-
-            possible_cats = cat_for_event(
-                constraint_dict=constraints,
-                possible_cats=potential_cats,
-                tags=patrol.tags,
-                return_list=True,
-                return_id=False,
-            )
-            cats_found, temp_involved_cats = self._find_involved_cats(
-                abbr,
-                possible_cats,
-                patrol.relationship_constraint,
-                cat_constraints=constraints,
-                temp_involved_cats=temp_involved_cats,
-            )
-
-            if not cats_found:
-                return False
-
-        # if we're here, then we must have filled all the needed cats!
-        self.involved_cats.update(temp_involved_cats)
         return True
 
     def _find_allowed_outcomes(

--- a/scripts/events_module/patrol/patrol.py
+++ b/scripts/events_module/patrol/patrol.py
@@ -40,6 +40,7 @@ from scripts.events_module.patrol.generate_patrol_list import (
 )
 from scripts.events_module.patrol.patrol_event import PatrolEvent
 from scripts.events_module.text_pool_event import handle_consequences
+from scripts.events_module.text_pool_event.find_involved_cats import find_cats
 from scripts.events_module.text_pool_event.text_pool_event import TextPoolEvent
 from scripts.game_structure import constants
 from scripts.game_structure.game.settings import game_setting_get
@@ -403,6 +404,11 @@ class Patrol:
 
         patrols_to_test = possible_patrols.copy()
         checked_patrols = set()
+        outside_cats = [
+            c
+            for c in Cat.all_cats_list
+            if (c.status.is_other_clancat or c.status.is_outsider) and not c.dead
+        ]
         while not chosen_patrol:
             # make sure we still have possible patrols
             if not patrols_to_test:
@@ -445,8 +451,17 @@ class Patrol:
                 continue
 
             # CHECK IF CATS FIT
-            if self._patrol_pass_cat_constraints(test_patrol):
+
+            cats_found, involved_cats = find_cats(
+                interactable_cats=self.involved_cats["patrol_cats"],
+                involved_cats=self.involved_cats,
+                outside_cats=outside_cats,
+                event=test_patrol,
+                other_clan=self.other_clan,
+            )
+            if cats_found:
                 chosen_patrol = test_patrol
+                self.involved_cats = involved_cats
             else:
                 if test_patrol in patrols_to_test:
                     patrols_to_test.remove(test_patrol)
@@ -513,6 +528,7 @@ class Patrol:
 
         return True
 
+    # TODO: remove if works
     def _patrol_pass_cat_constraints(self, patrol: PatrolEvent) -> bool:
         temp_involved_cats = self.involved_cats.copy()
 
@@ -709,116 +725,16 @@ class Patrol:
             if (c.status.is_other_clancat or c.status.is_outsider) and not c.dead
         ]
         temp_involved_cats = self.involved_cats.copy()
-        for abbr, constraints in outcome.involved_cats.items():
-            possible_injuries = []
-            # grab any injuries they might get
-            if outcome.condition:
-                for block in outcome.condition:
-                    if abbr in block["cats"]:
-                        possible_injuries.extend(block["condition"])
 
-            # if the abbr is one we've already assigned, then we just test that cat!
-            if test_cat := self.involved_cats.get(abbr):
-                if not event_for_cat(
-                    constraints,
-                    test_cat,
-                    involved_cat_dict=temp_involved_cats,
-                    injuries=possible_injuries,
-                    event_id=self.patrol_event.event_id,
-                ):
-                    return False
-
-                # check rel constraints
-                if outcome.relationship_constraint:
-                    for block in outcome.relationship_constraint:
-                        if not check_rel_constraint_groups(
-                            constraints_dict=block, involved_cats=temp_involved_cats
-                        ):
-                            return False
-
-            # otherwise, check if this abbr wants to replace an existing one!
-            elif constraints.get("prior_abbreviation"):
-                # check for exclusionary status
-                is_exclusionary = any(
-                    value.find("-") == 0 for value in constraints["prior_abbreviation"]
-                )
-                # now grab the "clean" abbreviations
-                prior_abbreviations = [
-                    a.replace("-", "") for a in constraints["prior_abbreviation"]
-                ]
-                # find all the cats that were listed in the abbreviations
-                abbr_cats = [self.involved_cats.get(_a) for _a in prior_abbreviations]
-                # if it's "any" then that's easy-peasy, just allow any of the cats
-                if "any" in prior_abbreviations:
-                    possible_cats = self.involved_cats["patrol_cats"]
-                # if it's meant to be exclusionary, then possible_cats will be all cats not in abbr_cats
-                elif is_exclusionary:
-                    possible_cats = [
-                        c
-                        for c in self.involved_cats["patrol_cats"]
-                        if c not in abbr_cats
-                    ]
-                # otherwise it's just abbr_cats
-                else:
-                    possible_cats = abbr_cats
-
-                # now we find out if any of these possible cats will work for the patrol
-                for c in possible_cats:
-                    if not c:
-                        continue
-
-                    if not event_for_cat(
-                        constraints,
-                        c,
-                        involved_cat_dict=temp_involved_cats,
-                        injuries=possible_injuries,
-                        event_id=self.patrol_event.event_id,
-                    ):
-                        continue
-
-                    # check rel constraints
-                    if outcome.relationship_constraint:
-                        for block in outcome.relationship_constraint:
-                            if not check_rel_constraint_groups(
-                                constraints_dict=block, involved_cats=temp_involved_cats
-                            ):
-                                continue
-
-                    # if we made it here, this cat works! use them
-                    temp_involved_cats[abbr] = c
-                    break
-
-                if abbr not in temp_involved_cats:
-                    return False
-
-            # if neither of those is happening, then we check if any of our uninvolved cats can take this spot!
-            else:
-                if "n_c" in abbr:
-                    potential_cats = [c for c in outside_cats if c not in self.new_cats]
-                    random.shuffle(potential_cats)
-                else:
-                    potential_cats = [
-                        c
-                        for c in self.patrol_cats
-                        if c not in self.involved_cats.values()
-                    ]
-
-                possible_cats = cat_for_event(
-                    constraint_dict=constraints,
-                    possible_cats=potential_cats,
-                    tags=outcome.tags,
-                    return_list=True,
-                    return_id=False,
-                )
-                cats_found, temp_involved_cats = self._find_involved_cats(
-                    abbr,
-                    possible_cats,
-                    outcome.relationship_constraint,
-                    cat_constraints=constraints,
-                    temp_involved_cats=temp_involved_cats,
-                )
-                if not cats_found:
-                    return False
+        cats_found, temp_involved_cats = find_cats(
+            interactable_cats=temp_involved_cats["patrol_cats"],
+            involved_cats=temp_involved_cats,
+            outside_cats=outside_cats,
+            event=outcome,
+            other_clan=self.other_clan,
+        )
+        if not cats_found:
+            return False
 
         # if we're here, then we must have found all our cats!
         self.outcome_cats[outcome_type] = temp_involved_cats

--- a/scripts/events_module/patrol/patrol.py
+++ b/scripts/events_module/patrol/patrol.py
@@ -452,14 +452,14 @@ class Patrol:
 
             # CHECK IF CATS FIT
 
-            cats_found, involved_cats = find_cats(
+            involved_cats = find_cats(
                 interactable_cats=self.involved_cats["patrol_cats"],
                 involved_cats=self.involved_cats,
                 outside_cats=outside_cats,
                 event=test_patrol,
                 other_clan=self.other_clan,
             )
-            if cats_found:
+            if involved_cats:
                 chosen_patrol = test_patrol
                 self.involved_cats = involved_cats
             else:
@@ -726,14 +726,14 @@ class Patrol:
         ]
         temp_involved_cats = self.involved_cats.copy()
 
-        cats_found, temp_involved_cats = find_cats(
+        temp_involved_cats = find_cats(
             interactable_cats=temp_involved_cats["patrol_cats"],
             involved_cats=temp_involved_cats,
             outside_cats=outside_cats,
             event=outcome,
             other_clan=self.other_clan,
         )
-        if not cats_found:
+        if not temp_involved_cats:
             return False
 
         # if we're here, then we must have found all our cats!

--- a/scripts/events_module/relationship/generate_group_event.py
+++ b/scripts/events_module/relationship/generate_group_event.py
@@ -129,7 +129,7 @@ def _find_event_and_cats(
         involved_cats = {"m_c": main_cat}
         event_to_test = choices(possible_events, [e.weight for e in possible_events])[0]
 
-        cats_found, temp_involved_cats = find_cats(
+        temp_involved_cats = find_cats(
             interactable_cats=interactable_cats,
             involved_cats=involved_cats,
             outside_cats=outside_cats,
@@ -138,7 +138,7 @@ def _find_event_and_cats(
             if game.clan.all_other_clans
             else None,
         )
-        if not cats_found:
+        if not temp_involved_cats:
             possible_events.remove(event_to_test)
             continue
 

--- a/scripts/events_module/relationship/generate_group_event.py
+++ b/scripts/events_module/relationship/generate_group_event.py
@@ -128,7 +128,10 @@ def _find_event_and_cats(
     while not chosen_event and possible_events:
         involved_cats = {"m_c": main_cat}
         event_to_test = choices(possible_events, [e.weight for e in possible_events])[0]
-
+        # make sure none of the interactable cats are already assigned to an abbr
+        interactable_cats = [
+            c for c in interactable_cats if c not in involved_cats.values()
+        ]
         temp_involved_cats = find_cats(
             interactable_cats=interactable_cats,
             involved_cats=involved_cats,

--- a/scripts/events_module/relationship/generate_group_event.py
+++ b/scripts/events_module/relationship/generate_group_event.py
@@ -16,6 +16,7 @@ from scripts.events_module.parameter_dicts import (
     InvolvedCatDict,
 )
 from scripts.events_module.text_adjust import process_text, adjust_list_text
+from scripts.events_module.text_pool_event.find_involved_cats import find_cats
 from scripts.events_module.text_pool_event.text_pool_event import TextPoolEvent
 from scripts.game_structure import game
 from scripts.game_structure.localization import load_lang_resource
@@ -58,15 +59,12 @@ def trigger_interaction(main_cat: Cat, interactable_cats: list) -> list[str]:
 def _get_event(
     events: list[TextPoolEvent], interactable_cats: list[Cat], main_cat: Cat
 ) -> tuple[TextPoolEvent, dict[str, Union[Cat, list[Cat]]]]:
-    # find events that m_c can have
-    possible_events = _find_events_for_main_cat(main_cat, events)
-
     # set up the basic cat dict
     involved_cats: dict[str, Union[Cat, list[Cat]]] = {"m_c": main_cat}
 
     # attempt to find a valid event where we can fill the other roles
     chosen_event, involved_cats = _find_event_and_cats(
-        interactable_cats, involved_cats, main_cat, possible_events
+        interactable_cats, involved_cats, main_cat, events
     )
     return chosen_event, involved_cats
 
@@ -116,65 +114,36 @@ def _resolve_event(
 
 
 def _find_event_and_cats(
-    interactable_cats, involved_cats, main_cat, possible_events
+    interactable_cats, involved_cats, main_cat, possible_events: list[TextPoolEvent]
 ) -> tuple[TextPoolEvent, dict]:
     """
     Filters through the possible events to find the ones that we have valid cats for. Returns both the event and the valid cats.
     """
     chosen_event: Optional[TextPoolEvent] = None
-
+    outside_cats = [
+        c
+        for c in Cat.all_cats_list
+        if (c.status.is_other_clancat or c.status.is_outsider) and not c.dead
+    ]
     while not chosen_event and possible_events:
         involved_cats = {"m_c": main_cat}
-        failed = False
-        event_to_test = choice(possible_events)
-        possible_cats = interactable_cats.copy()
+        event_to_test = choices(possible_events, [e.weight for e in possible_events])[0]
 
-        # we go through each required kitty to see if we can find a match within our interactable cats
-        for other_cat, constraints in event_to_test.involved_cats.items():
-            # early break if we're out of cat options
-            if not possible_cats:
-                failed = True
-                break
-
-            # MAIN CAT
-            if other_cat == "m_c":
-                continue  # we skip this cus we already have our m_c
-
-            # MULTI CAT
-            if other_cat == "multi_cat":
-                involved_cats["multi_cat"] = _get_multi_cats(
-                    involved_cats, possible_cats.copy(), event_to_test, constraints
-                )
-                # if we found no one, then this event isn't possible, and we should try a different one
-                if not involved_cats["multi_cat"]:
-                    failed = True
-                else:
-                    # remove cats from the pool so they don't get repeated in the event
-                    for c in involved_cats["multi_cat"]:
-                        possible_cats.remove(c)
-
-            # OTHER SINGLE CATS
-            else:
-                involved_cats[other_cat] = _get_single_cat(
-                    involved_cats,
-                    possible_cats.copy(),
-                    event_to_test,
-                    other_cat,
-                    constraints,
-                )
-
-                if not involved_cats[other_cat]:
-                    failed = True
-                    break
-                else:
-                    possible_cats.remove(involved_cats[other_cat])
-
-        if failed:
+        cats_found, temp_involved_cats = find_cats(
+            interactable_cats=interactable_cats,
+            involved_cats=involved_cats,
+            outside_cats=outside_cats,
+            event=event_to_test,
+            other_clan=choice(game.clan.all_other_clans)
+            if game.clan.all_other_clans
+            else None,
+        )
+        if not cats_found:
             possible_events.remove(event_to_test)
-            chosen_event = None
             continue
-        else:
-            chosen_event = event_to_test
+
+        chosen_event = event_to_test
+        involved_cats = temp_involved_cats
 
     return chosen_event, involved_cats
 
@@ -224,125 +193,6 @@ def _find_events_for_main_cat(cat: Cat, possible_events: List[TextPoolEvent]) ->
             allowed.append(event)
 
     return allowed
-
-
-def _get_single_cat(
-    involved_cats: dict,
-    interactable_cats: list,
-    event: TextPoolEvent,
-    cat_abbr: str,
-    cat_constraints: InvolvedCatDict,
-) -> Optional[Cat]:
-    chosen_cat = None
-
-    # get the cats who qualify
-    possible_cats = cat_for_event(
-        cat_constraints,
-        interactable_cats,
-        event.tags,
-        involved_cat_dict=involved_cats,
-        return_list=True,
-        return_id=False,
-    )
-    # early return if no cats
-    if not possible_cats:
-        return None
-
-    # early return if we don't need to check anything else
-    if not event.relationship_constraint:
-        return choice(possible_cats)
-
-    # now we check who will qualify for the relationship_constraint
-    while not chosen_cat and possible_cats:
-        failed = False
-        cat = choice(possible_cats)
-
-        # tempt dict to preserve the original while we test
-        temp_involved_cats = involved_cats.copy()
-        temp_involved_cats[cat_abbr] = cat
-        # test if the cat matches the rel constraints
-        for block in event.relationship_constraint:
-            # if the cat isn't part of this constraint block, then we skip it
-            if cat_abbr not in block["cats_from"] + block["cats_to"]:
-                continue
-
-            if not check_rel_constraint_groups(block, temp_involved_cats):
-                failed = True
-                break
-        # they didn't! we take them out of the running and try again
-        if failed:
-            possible_cats.remove(cat)
-            chosen_cat = None
-            continue
-
-        # if we're here, then this is a valid cat! we move on
-        chosen_cat = cat
-
-    return chosen_cat
-
-
-def _get_multi_cats(
-    involved_cats: dict,
-    interactable_cats: list[Cat],
-    event: TextPoolEvent,
-    cat_constraints: InvolvedCatDict,
-) -> list[Cat]:
-    # find out how many cats we'll allow
-    max_cats = choice(get_config("relationship.group_events.multi_cat_amounts"))
-    chosen_cats = []
-
-    # get the cats who qualify
-    possible_cats = cat_for_event(
-        cat_constraints,
-        interactable_cats,
-        event.tags,
-        involved_cat_dict=involved_cats,
-        return_list=True,
-        return_id=False,
-    )
-    # if not enough possible cats, return empty list
-    if not possible_cats or len(possible_cats) <= 1:
-        return []
-
-    involved_cats["multi_cat"] = []  # set this up ahead of time
-
-    # if relationships aren't required, then we just pick some cats and go!
-    if not event.relationship_constraint:
-        chosen_cats = sample(possible_cats, min(len(possible_cats), max_cats))
-        return chosen_cats
-
-    # now we need to find who qualifies for the relationship constraints
-    while len(chosen_cats) < max_cats and possible_cats:
-        failed = False
-        cat = choice(possible_cats)
-
-        # copy up so that it's easier to pass this and test it, but we can still go back to the OG dict if it fails
-        _temp_involved_cats = involved_cats.copy()
-        _temp_involved_cats["multi_cat"].append(cat)
-        # find out if this cat will match the rel constraints
-        for block in event.relationship_constraint:
-            # if this block doesn't include multi_cat then we skip it
-            if "multi_cat" not in block["cats_from"] + block["cats_to"]:
-                continue
-            if not check_rel_constraint_groups(block, _temp_involved_cats):
-                failed = True
-                break
-
-        # no matter what, cat is no longer allowed in the possible_cats list
-        possible_cats.remove(cat)
-
-        # bad cat :( remove from possibilities and try a new one
-        if failed:
-            _temp_involved_cats["multi_cat"].remove(cat)
-        else:
-            # if we're here, then this is a valid cat! we move on
-            chosen_cats.append(cat)
-
-    # if we didn't find enough cats, then return empty list
-    if not chosen_cats or len(chosen_cats) <= 1:
-        return []
-    # otherwise, return all the cats we found!
-    return chosen_cats
 
 
 def _load_file(path) -> list[TextPoolEvent]:

--- a/scripts/events_module/text_pool_event/find_involved_cats.py
+++ b/scripts/events_module/text_pool_event/find_involved_cats.py
@@ -19,15 +19,16 @@ def find_cats(
     involved_cats: dict,
     outside_cats: list,
     event: Union[PatrolEvent, TextPoolEvent],
-        other_clan: OtherClan
+    other_clan: OtherClan,
 ) -> tuple[bool, dict]:
+    interactable_cats = interactable_cats.copy()
     temp_involved_cats = involved_cats.copy()
 
     cats_to_create = []
     for abbr, constraints in event.involved_cats.items():
         if abbr in involved_cats:
             potential_cats = (
-                involved_cats[abbr] if isinstance(abbr, str) else [involved_cats[abbr]]
+                involved_cats[abbr] if isinstance(abbr, list) else [involved_cats[abbr]]
             )
         elif "n_c" in abbr:
             if "can_create_new_cat" in constraints:
@@ -43,12 +44,13 @@ def find_cats(
                 involved_cats, interactable_cats.copy(), event, constraints
             )
             # if we found no one, then this event isn't possible, and we should try a different one
-            if not involved_cats["multi_cat"]:
+            if not temp_involved_cats["multi_cat"]:
                 return False, {}
             else:
                 # remove cats from the pool so they don't get repeated in the event
-                for c in involved_cats["multi_cat"]:
+                for c in temp_involved_cats["multi_cat"]:
                     interactable_cats.remove(c)
+                continue
 
         else:
             potential_cats = interactable_cats
@@ -63,6 +65,9 @@ def find_cats(
             return_list=True,
             return_id=False,
         )
+        if not possible_cats:
+            return False, {}
+
         cats_found, temp_involved_cats = _find_involved_cats(
             abbr,
             possible_cats,
@@ -73,6 +78,9 @@ def find_cats(
         )
         if not cats_found:
             return False, {}
+
+        if temp_involved_cats[abbr] in interactable_cats:
+            interactable_cats.remove(temp_involved_cats[abbr])
 
     for abbr in cats_to_create:
         constraints = event.involved_cats[abbr]
@@ -97,8 +105,10 @@ def _find_involved_cats(
     relationship_constraint,
     cat_constraints,
     temp_involved_cats: dict,
-        other_clan: OtherClan
+    other_clan: OtherClan,
 ) -> tuple[bool, dict]:
+    possible_cats = possible_cats.copy()
+
     # if relationships aren't required, just grab some cats and go!
     if possible_cats and not relationship_constraint:
         # take first cat
@@ -112,19 +122,20 @@ def _find_involved_cats(
             _temp_cats = temp_involved_cats.copy()
             _temp_cats[abbr] = possible_cats[0]
             # now we check each rel constraint to make sure our new cat is valid
-            for block in relationship_constraint:
-                if not check_rel_constraint_groups(block, _temp_cats):
-                    # they aren't! so we remove them from the possibilities
-                    possible_cats.remove(_temp_cats[abbr])
-                    if not possible_cats:
-                        # oops! no more cats available! this patrol isn't possible
-                        return False, temp_involved_cats
-                    else:
-                        # still some possibilities, let's try the next!
-                        continue
-
-                # if we got here, then this cat works!
-                temp_involved_cats[abbr] = _temp_cats[abbr]
+            if not all(
+                check_rel_constraint_groups(block, _temp_cats)
+                for block in relationship_constraint
+            ):
+                # they aren't! so we remove them from the possibilities
+                possible_cats.remove(_temp_cats[abbr])
+                if not possible_cats:
+                    # oops! no more cats available! this event isn't possible
+                    return False, temp_involved_cats
+                else:
+                    # still some possibilities, let's try the next!
+                    continue
+            # if we got here, then this cat works!
+            temp_involved_cats[abbr] = _temp_cats[abbr]
 
     # there weren't any possible cats, so we'll create a new one if we're allowed
     else:
@@ -140,6 +151,7 @@ def _find_involved_cats(
             return False, temp_involved_cats
 
     return True, temp_involved_cats
+
 
 def _get_multi_cats(
     involved_cats: dict,
@@ -179,24 +191,21 @@ def _get_multi_cats(
         # copy up so that it's easier to pass this and test it, but we can still go back to the OG dict if it fails
         _temp_involved_cats = involved_cats.copy()
         _temp_involved_cats["multi_cat"].append(cat)
-        # find out if this cat will match the rel constraints
-        for block in event.relationship_constraint:
-            # if this block doesn't include multi_cat then we skip it
-            if "multi_cat" not in block["cats_from"] + block["cats_to"]:
-                continue
-            if not check_rel_constraint_groups(block, _temp_involved_cats):
-                failed = True
-                break
 
         # no matter what, cat is no longer allowed in the possible_cats list
         possible_cats.remove(cat)
 
-        # bad cat :( remove from possibilities and try a new one
-        if failed:
+        # find out if this cat will match the rel constraints
+        if not all(
+            check_rel_constraint_groups(block, _temp_involved_cats)
+            for block in event.relationship_constraint
+            if "multi_cat" in block["cats_from"] + block["cats_to"]
+        ):
             _temp_involved_cats["multi_cat"].remove(cat)
-        else:
-            # if we're here, then this is a valid cat! we move on
-            chosen_cats.append(cat)
+            continue
+
+        # if we're here, then this is a valid cat! we move on
+        chosen_cats.append(cat)
 
     # if we didn't find enough cats, then return empty list
     if not chosen_cats or len(chosen_cats) <= 1:

--- a/scripts/events_module/text_pool_event/find_involved_cats.py
+++ b/scripts/events_module/text_pool_event/find_involved_cats.py
@@ -41,6 +41,10 @@ def find_cats(
     can_give_condition = hasattr(event, "condition")
 
     for abbr, constraints in event.involved_cats.items():
+        if not interactable_cats:
+            # uh oh, we're out of options!
+            return {}
+        
         possible_injuries = []
         # grab any injuries they might get
         if can_give_condition and event.condition:

--- a/scripts/events_module/text_pool_event/find_involved_cats.py
+++ b/scripts/events_module/text_pool_event/find_involved_cats.py
@@ -21,15 +21,50 @@ def find_cats(
     event: Union[PatrolEvent, TextPoolEvent],
     other_clan: OtherClan,
 ) -> tuple[bool, dict]:
-    interactable_cats = interactable_cats.copy()
     temp_involved_cats = involved_cats.copy()
+    # make sure none of the interactable cats are already assigned to an abbr
+    interactable_cats = [
+        c for c in interactable_cats if c not in temp_involved_cats.values()
+    ]
 
     cats_to_create = []
+
+    can_give_condition = isinstance(event, TextPoolEvent)
+
     for abbr, constraints in event.involved_cats.items():
+        possible_injuries = []
+        # grab any injuries they might get
+        if can_give_condition and event.condition:
+            for block in event.condition:
+                if abbr in block["cats"]:
+                    possible_injuries.extend(block["condition"])
+
         if abbr in involved_cats:
             potential_cats = (
                 involved_cats[abbr] if isinstance(abbr, list) else [involved_cats[abbr]]
             )
+
+        elif constraints.get("prior_abbreviation"):
+            # check for exclusionary status
+            is_exclusionary = any(
+                value.find("-") == 0 for value in constraints["prior_abbreviation"]
+            )
+            # now grab the "clean" abbreviations
+            prior_abbreviations = [
+                a.replace("-", "") for a in constraints["prior_abbreviation"]
+            ]
+            # find all the cats that were listed in the abbreviations
+            abbr_cats = [involved_cats.get(_a) for _a in prior_abbreviations]
+            # if it's "any" then that's easy-peasy, just allow any of the cats
+            if "any" in prior_abbreviations:
+                potential_cats = interactable_cats
+            # if it's meant to be exclusionary, then possible_cats will be all cats not in abbr_cats
+            elif is_exclusionary:
+                potential_cats = [c for c in interactable_cats if c not in abbr_cats]
+            # otherwise it's just abbr_cats
+            else:
+                potential_cats = abbr_cats
+
         elif "n_c" in abbr:
             if "can_create_new_cat" in constraints:
                 # these cats can be created if need be, so we'll do them after we've found all the cats that must exist
@@ -41,7 +76,11 @@ def find_cats(
             ]
         elif abbr == "multi_cat":
             temp_involved_cats["multi_cat"] = _get_multi_cats(
-                involved_cats, interactable_cats.copy(), event, constraints
+                involved_cats,
+                interactable_cats.copy(),
+                event,
+                constraints,
+                possible_injuries,
             )
             # if we found no one, then this event isn't possible, and we should try a different one
             if not temp_involved_cats["multi_cat"]:
@@ -62,6 +101,7 @@ def find_cats(
             constraint_dict=constraints,
             possible_cats=potential_cats,
             tags=event.tags,
+            injuries=possible_injuries,
             return_list=True,
             return_id=False,
         )
@@ -158,6 +198,7 @@ def _get_multi_cats(
     interactable_cats: list[Cat],
     event: TextPoolEvent,
     cat_constraints: InvolvedCatDict,
+    possible_injuries: list,
 ) -> list[Cat]:
     # find out how many cats we'll allow
     max_cats = random.choice(get_config("relationship.group_events.multi_cat_amounts"))
@@ -169,6 +210,7 @@ def _get_multi_cats(
         interactable_cats,
         event.tags,
         involved_cat_dict=involved_cats,
+        possible_injuries=possible_injuries,
         return_list=True,
         return_id=False,
     )

--- a/scripts/events_module/text_pool_event/find_involved_cats.py
+++ b/scripts/events_module/text_pool_event/find_involved_cats.py
@@ -37,6 +37,17 @@ def find_cats(
 
     can_give_condition = hasattr(event, "condition")
 
+    # just an initial relationship check to catch things like patrol_cats
+    if involved_cats and event.relationship_constraint:
+        if not all(
+            check_rel_constraint_groups(block, temp_involved_cats)
+            for block in event.relationship_constraint
+            if set(involved_cats.keys()).intersection(
+                set(block["cats_from"] + block["cats_to"])
+            )
+        ):
+            return {}
+
     for abbr, constraints in event.involved_cats.items():
         possible_injuries = []
         # grab any injuries they might get

--- a/scripts/events_module/text_pool_event/find_involved_cats.py
+++ b/scripts/events_module/text_pool_event/find_involved_cats.py
@@ -31,20 +31,13 @@ def find_cats(
     :return: Updated involved_cats dict with valid cats. If dict is empty, then valid cats were not found.
     """
     temp_involved_cats = involved_cats.copy()
-    # make sure none of the interactable cats are already assigned to an abbr
-    interactable_cats = [
-        c for c in interactable_cats if c not in temp_involved_cats.values()
-    ]
+    interactable_cats = interactable_cats.copy()
 
     cats_to_create = []
 
     can_give_condition = hasattr(event, "condition")
 
     for abbr, constraints in event.involved_cats.items():
-        if not interactable_cats:
-            # uh oh, we're out of options!
-            return {}
-        
         possible_injuries = []
         # grab any injuries they might get
         if can_give_condition and event.condition:
@@ -53,7 +46,7 @@ def find_cats(
                     possible_injuries.extend(block["condition"])
 
         if abbr in involved_cats:
-            potential_cats = (
+            possible_cats = (
                 involved_cats[abbr] if isinstance(abbr, list) else [involved_cats[abbr]]
             )
 
@@ -70,13 +63,18 @@ def find_cats(
             abbr_cats = [involved_cats.get(_a) for _a in prior_abbreviations]
             # if it's "any" then that's easy-peasy, just allow any of the cats
             if "any" in prior_abbreviations:
-                potential_cats = interactable_cats
+                possible_cats = interactable_cats
             # if it's meant to be exclusionary, then possible_cats will be all cats not in abbr_cats
             elif is_exclusionary:
-                potential_cats = [c for c in interactable_cats if c not in abbr_cats]
+                possible_cats = [c for c in interactable_cats if c not in abbr_cats]
             # otherwise it's just abbr_cats
             else:
-                potential_cats = abbr_cats
+                if abbr_cats == [None]:
+                    print(
+                        f"WARNING: issue with {abbr} prior_abbreviation setting on {event}"
+                    )
+                    return {}
+                possible_cats = abbr_cats
 
         elif "n_c" in abbr:
             if "can_create_new_cat" in constraints:
@@ -84,7 +82,7 @@ def find_cats(
                 cats_to_create.append(abbr)
                 continue
 
-            potential_cats = [
+            possible_cats = [
                 c for c in outside_cats if c not in temp_involved_cats.values()
             ]
 
@@ -106,14 +104,19 @@ def find_cats(
                 continue
 
         else:
-            potential_cats = interactable_cats
+            possible_cats = interactable_cats
+
+        if not possible_cats:
+            # uh oh, we're out of options!
+            return {}
 
         # random shuffle to ensure we aren't picking the same cats all the time
-        random.shuffle(potential_cats)
+        random.shuffle(possible_cats)
 
+        # initial filter of the entire list of cats for the more general constraints
         possible_cats = cat_for_event(
             constraint_dict=constraints,
-            possible_cats=potential_cats,
+            possible_cats=possible_cats,
             tags=event.tags,
             injuries=possible_injuries,
             return_list=True,
@@ -122,52 +125,53 @@ def find_cats(
         if not possible_cats:
             return {}
 
-        cats_found, temp_involved_cats = _find_involved_cats(
+        # now choose a cat to fill the role, checking for relationship constraints
+        temp_involved_cats = _find_involved_cat(
             abbr,
             possible_cats,
-            event.relationship_constraint,
+            relationship_constraint=event.relationship_constraint,
             cat_constraints=constraints,
             temp_involved_cats=temp_involved_cats,
             other_clan=other_clan,
         )
-        if not cats_found:
+        if not temp_involved_cats:
             return {}
 
         if temp_involved_cats[abbr] in interactable_cats:
             interactable_cats.remove(temp_involved_cats[abbr])
 
+    # create new cats if we need to!
     for abbr in cats_to_create:
         constraints = event.involved_cats[abbr]
 
-        cats_found, new_cats = _find_involved_cats(
+        new_cats = _find_involved_cat(
             abbr,
             [c for c in outside_cats if c not in temp_involved_cats.values()],
-            event.relationship_constraint,
+            relationship_constraint=event.relationship_constraint,
             cat_constraints=constraints,
             temp_involved_cats=temp_involved_cats,
             other_clan=other_clan,
         )
-        if cats_found:
-            temp_involved_cats.update(new_cats)
+        temp_involved_cats.update(new_cats)
 
     return temp_involved_cats
 
 
-def _find_involved_cats(
+def _find_involved_cat(
     abbr: str,
     possible_cats: list[Cat],
     relationship_constraint,
     cat_constraints,
     temp_involved_cats: dict,
     other_clan: OtherClan,
-) -> tuple[bool, dict]:
+) -> dict:
     possible_cats = possible_cats.copy()
 
     # if relationships aren't required, just grab some cats and go!
     if possible_cats and not relationship_constraint:
         # take first cat
         temp_involved_cats[abbr] = possible_cats[0]
-        return True, temp_involved_cats
+        return temp_involved_cats
 
     # otherwise, let's make sure we fulfill the rel constraints with this cat
     elif possible_cats:
@@ -184,7 +188,7 @@ def _find_involved_cats(
                 possible_cats.remove(_temp_cats[abbr])
                 if not possible_cats:
                     # oops! no more cats available! this event isn't possible
-                    return False, temp_involved_cats
+                    return {}
                 else:
                     # still some possibilities, let's try the next!
                     continue
@@ -201,10 +205,10 @@ def _find_involved_cats(
                 other_clan=other_clan,
             )
         else:
-            # if we aren't allowed to make a new one, then we can't do this patrol
-            return False, temp_involved_cats
+            # if we aren't allowed to make a new one, then we can't do this event
+            return {}
 
-    return True, temp_involved_cats
+    return temp_involved_cats
 
 
 def _get_multi_cats(
@@ -241,7 +245,6 @@ def _get_multi_cats(
 
     # now we need to find who qualifies for the relationship constraints
     while len(chosen_cats) < max_cats and possible_cats:
-        failed = False
         cat = random.choice(possible_cats)
 
         # copy up so that it's easier to pass this and test it, but we can still go back to the OG dict if it fails

--- a/scripts/events_module/text_pool_event/find_involved_cats.py
+++ b/scripts/events_module/text_pool_event/find_involved_cats.py
@@ -45,47 +45,32 @@ def find_cats(
                 if abbr in block["cats"]:
                     possible_injuries.extend(block["condition"])
 
+        # CHECK ALREADY ASSIGNED CAT
         if abbr in involved_cats:
             possible_cats = (
                 involved_cats[abbr] if isinstance(abbr, list) else [involved_cats[abbr]]
             )
 
+        # CHECK PRIOR ABBREVIATIONS
         elif constraints.get("prior_abbreviation"):
-            # check for exclusionary status
-            is_exclusionary = any(
-                value.find("-") == 0 for value in constraints["prior_abbreviation"]
+            possible_cats = _check_prior_abbreviation(
+                abbr, constraints, event, interactable_cats, involved_cats
             )
-            # now grab the "clean" abbreviations
-            prior_abbreviations = [
-                a.replace("-", "") for a in constraints["prior_abbreviation"]
-            ]
-            # find all the cats that were listed in the abbreviations
-            abbr_cats = [involved_cats.get(_a) for _a in prior_abbreviations]
-            # if it's "any" then that's easy-peasy, just allow any of the cats
-            if "any" in prior_abbreviations:
-                possible_cats = interactable_cats
-            # if it's meant to be exclusionary, then possible_cats will be all cats not in abbr_cats
-            elif is_exclusionary:
-                possible_cats = [c for c in interactable_cats if c not in abbr_cats]
-            # otherwise it's just abbr_cats
-            else:
-                if abbr_cats == [None]:
-                    print(
-                        f"WARNING: issue with {abbr} prior_abbreviation setting on {event}"
-                    )
-                    return {}
-                possible_cats = abbr_cats
 
+        # CHECK NEW CATS
         elif "n_c" in abbr:
+            # CATS THAT CAN BE MADE
             if "can_create_new_cat" in constraints:
                 # these cats can be created if need be, so we'll do them after we've found all the cats that must exist
                 cats_to_create.append(abbr)
                 continue
 
+            # CATS THAT MUST EXIST
             possible_cats = [
                 c for c in outside_cats if c not in temp_involved_cats.values()
             ]
 
+        # CHECK MULTI_CAT
         elif abbr == "multi_cat":
             temp_involved_cats["multi_cat"] = _get_multi_cats(
                 involved_cats,
@@ -103,6 +88,7 @@ def find_cats(
                     interactable_cats.remove(c)
                 continue
 
+        # CHECK ALL UN-USED CATS
         else:
             possible_cats = interactable_cats
 
@@ -142,6 +128,7 @@ def find_cats(
 
     # create new cats if we need to!
     for abbr in cats_to_create:
+        # this will first try to find an existing cat, but if it can't then it'll make a new one
         constraints = event.involved_cats[abbr]
 
         new_cats = _find_involved_cat(
@@ -157,6 +144,39 @@ def find_cats(
     return temp_involved_cats
 
 
+def _check_prior_abbreviation(
+    abbr, constraints, event, interactable_cats, involved_cats
+):
+    """
+    Checks which cats are allowed per prior_abbreviation constraints
+    """
+    # check for exclusionary status
+    is_exclusionary = any(
+        value.find("-") == 0 for value in constraints["prior_abbreviation"]
+    )
+    # now grab the "clean" abbreviations
+    prior_abbreviations = [
+        a.replace("-", "") for a in constraints["prior_abbreviation"]
+    ]
+    # find all the cats that were listed in the abbreviations
+    abbr_cats = [involved_cats.get(_a) for _a in prior_abbreviations]
+    # if it's "any" then that's easy-peasy, just allow any of the cats
+    if "any" in prior_abbreviations:
+        possible_cats = interactable_cats
+    # if it's meant to be exclusionary, then possible_cats will be all cats not in abbr_cats
+    elif is_exclusionary:
+        possible_cats = [c for c in interactable_cats if c not in abbr_cats]
+    # otherwise it's just abbr_cats
+    else:
+        if abbr_cats == [None]:
+            print(f"WARNING: issue with {abbr} prior_abbreviation setting on {event}")
+            return []
+
+        possible_cats = abbr_cats
+
+    return possible_cats
+
+
 def _find_involved_cat(
     abbr: str,
     possible_cats: list[Cat],
@@ -165,6 +185,10 @@ def _find_involved_cat(
     temp_involved_cats: dict,
     other_clan: OtherClan,
 ) -> dict:
+    """
+    Finds a cat from the available cats that can fill the abbreviation slot. This will check against relationship
+    constraints and will create a new cat if necessary and allowed.
+    """
     possible_cats = possible_cats.copy()
 
     # if relationships aren't required, just grab some cats and go!
@@ -218,6 +242,9 @@ def _get_multi_cats(
     cat_constraints: InvolvedCatDict,
     possible_injuries: list,
 ) -> list[Cat]:
+    """
+    Finds and returns multiple available cats for use as a group in the event.
+    """
     # find out how many cats we'll allow
     max_cats = random.choice(get_config("relationship.group_events.multi_cat_amounts"))
     chosen_cats = []

--- a/scripts/events_module/text_pool_event/find_involved_cats.py
+++ b/scripts/events_module/text_pool_event/find_involved_cats.py
@@ -42,9 +42,6 @@ def find_cats(
         if not all(
             check_rel_constraint_groups(block, temp_involved_cats)
             for block in event.relationship_constraint
-            if set(involved_cats.keys()).intersection(
-                set(block["cats_from"] + block["cats_to"])
-            )
         ):
             return {}
 

--- a/scripts/events_module/text_pool_event/find_involved_cats.py
+++ b/scripts/events_module/text_pool_event/find_involved_cats.py
@@ -20,7 +20,16 @@ def find_cats(
     outside_cats: list,
     event: Union[PatrolEvent, TextPoolEvent],
     other_clan: OtherClan,
-) -> tuple[bool, dict]:
+) -> dict:
+    """
+    Finds and returns cats for a PatrolEvent or TextPoolEvent.
+    :param interactable_cats: A list of cats within the Clan eligible to appear in the event.
+    :param involved_cats: Dict of cats already involved. Key is abbreviation, value is cat object
+    :param outside_cats: A list of cats outside the Clan eligible to appear in the event.
+    :param event: The PatrolEvent or TextPoolEvent that needs involved cats
+    :param other_clan: The OtherClan object involved in the event
+    :return: Updated involved_cats dict with valid cats. If dict is empty, then valid cats were not found.
+    """
     temp_involved_cats = involved_cats.copy()
     # make sure none of the interactable cats are already assigned to an abbr
     interactable_cats = [
@@ -29,7 +38,7 @@ def find_cats(
 
     cats_to_create = []
 
-    can_give_condition = isinstance(event, TextPoolEvent)
+    can_give_condition = hasattr(event, "condition")
 
     for abbr, constraints in event.involved_cats.items():
         possible_injuries = []
@@ -74,6 +83,7 @@ def find_cats(
             potential_cats = [
                 c for c in outside_cats if c not in temp_involved_cats.values()
             ]
+
         elif abbr == "multi_cat":
             temp_involved_cats["multi_cat"] = _get_multi_cats(
                 involved_cats,
@@ -84,7 +94,7 @@ def find_cats(
             )
             # if we found no one, then this event isn't possible, and we should try a different one
             if not temp_involved_cats["multi_cat"]:
-                return False, {}
+                return {}
             else:
                 # remove cats from the pool so they don't get repeated in the event
                 for c in temp_involved_cats["multi_cat"]:
@@ -106,7 +116,7 @@ def find_cats(
             return_id=False,
         )
         if not possible_cats:
-            return False, {}
+            return {}
 
         cats_found, temp_involved_cats = _find_involved_cats(
             abbr,
@@ -117,7 +127,7 @@ def find_cats(
             other_clan=other_clan,
         )
         if not cats_found:
-            return False, {}
+            return {}
 
         if temp_involved_cats[abbr] in interactable_cats:
             interactable_cats.remove(temp_involved_cats[abbr])
@@ -136,7 +146,7 @@ def find_cats(
         if cats_found:
             temp_involved_cats.update(new_cats)
 
-    return True, temp_involved_cats
+    return temp_involved_cats
 
 
 def _find_involved_cats(
@@ -210,7 +220,7 @@ def _get_multi_cats(
         interactable_cats,
         event.tags,
         involved_cat_dict=involved_cats,
-        possible_injuries=possible_injuries,
+        injuries=possible_injuries,
         return_list=True,
         return_id=False,
     )

--- a/scripts/events_module/text_pool_event/find_involved_cats.py
+++ b/scripts/events_module/text_pool_event/find_involved_cats.py
@@ -1,0 +1,205 @@
+import random
+from typing import Union
+
+from scripts.cat.cats import Cat
+from scripts.clan import OtherClan
+from scripts.config import get_config
+from scripts.events_module.event_filters import (
+    check_rel_constraint_groups,
+    cat_for_event,
+)
+from scripts.events_module.parameter_dicts import InvolvedCatDict
+from scripts.events_module.patrol.create_new_cat import updated_create_new_cat
+from scripts.events_module.patrol.patrol_event import PatrolEvent
+from scripts.events_module.text_pool_event.text_pool_event import TextPoolEvent
+
+
+def find_cats(
+    interactable_cats: list,
+    involved_cats: dict,
+    outside_cats: list,
+    event: Union[PatrolEvent, TextPoolEvent],
+        other_clan: OtherClan
+) -> tuple[bool, dict]:
+    temp_involved_cats = involved_cats.copy()
+
+    cats_to_create = []
+    for abbr, constraints in event.involved_cats.items():
+        if abbr in involved_cats:
+            potential_cats = (
+                involved_cats[abbr] if isinstance(abbr, str) else [involved_cats[abbr]]
+            )
+        elif "n_c" in abbr:
+            if "can_create_new_cat" in constraints:
+                # these cats can be created if need be, so we'll do them after we've found all the cats that must exist
+                cats_to_create.append(abbr)
+                continue
+
+            potential_cats = [
+                c for c in outside_cats if c not in temp_involved_cats.values()
+            ]
+        elif abbr == "multi_cat":
+            temp_involved_cats["multi_cat"] = _get_multi_cats(
+                involved_cats, interactable_cats.copy(), event, constraints
+            )
+            # if we found no one, then this event isn't possible, and we should try a different one
+            if not involved_cats["multi_cat"]:
+                return False, {}
+            else:
+                # remove cats from the pool so they don't get repeated in the event
+                for c in involved_cats["multi_cat"]:
+                    interactable_cats.remove(c)
+
+        else:
+            potential_cats = interactable_cats
+
+        # random shuffle to ensure we aren't picking the same cats all the time
+        random.shuffle(potential_cats)
+
+        possible_cats = cat_for_event(
+            constraint_dict=constraints,
+            possible_cats=potential_cats,
+            tags=event.tags,
+            return_list=True,
+            return_id=False,
+        )
+        cats_found, temp_involved_cats = _find_involved_cats(
+            abbr,
+            possible_cats,
+            event.relationship_constraint,
+            cat_constraints=constraints,
+            temp_involved_cats=temp_involved_cats,
+            other_clan=other_clan,
+        )
+        if not cats_found:
+            return False, {}
+
+    for abbr in cats_to_create:
+        constraints = event.involved_cats[abbr]
+
+        cats_found, new_cats = _find_involved_cats(
+            abbr,
+            [c for c in outside_cats if c not in temp_involved_cats.values()],
+            event.relationship_constraint,
+            cat_constraints=constraints,
+            temp_involved_cats=temp_involved_cats,
+            other_clan=other_clan,
+        )
+        if cats_found:
+            temp_involved_cats.update(new_cats)
+
+    return True, temp_involved_cats
+
+
+def _find_involved_cats(
+    abbr: str,
+    possible_cats: list[Cat],
+    relationship_constraint,
+    cat_constraints,
+    temp_involved_cats: dict,
+        other_clan: OtherClan
+) -> tuple[bool, dict]:
+    # if relationships aren't required, just grab some cats and go!
+    if possible_cats and not relationship_constraint:
+        # take first cat
+        temp_involved_cats[abbr] = possible_cats[0]
+        return True, temp_involved_cats
+
+    # otherwise, let's make sure we fulfill the rel constraints with this cat
+    elif possible_cats:
+        while not temp_involved_cats.get(abbr):
+            # need a temp cat dict that includes our possible kitty
+            _temp_cats = temp_involved_cats.copy()
+            _temp_cats[abbr] = possible_cats[0]
+            # now we check each rel constraint to make sure our new cat is valid
+            for block in relationship_constraint:
+                if not check_rel_constraint_groups(block, _temp_cats):
+                    # they aren't! so we remove them from the possibilities
+                    possible_cats.remove(_temp_cats[abbr])
+                    if not possible_cats:
+                        # oops! no more cats available! this patrol isn't possible
+                        return False, temp_involved_cats
+                    else:
+                        # still some possibilities, let's try the next!
+                        continue
+
+                # if we got here, then this cat works!
+                temp_involved_cats[abbr] = _temp_cats[abbr]
+
+    # there weren't any possible cats, so we'll create a new one if we're allowed
+    else:
+        # we don't need to check relationship constraints if we're making a new cat
+        if "n_c" in abbr and "can_create_new_cat" in cat_constraints:
+            temp_involved_cats[abbr] = updated_create_new_cat(
+                option_dict=cat_constraints,
+                involved_cats=temp_involved_cats,
+                other_clan=other_clan,
+            )
+        else:
+            # if we aren't allowed to make a new one, then we can't do this patrol
+            return False, temp_involved_cats
+
+    return True, temp_involved_cats
+
+def _get_multi_cats(
+    involved_cats: dict,
+    interactable_cats: list[Cat],
+    event: TextPoolEvent,
+    cat_constraints: InvolvedCatDict,
+) -> list[Cat]:
+    # find out how many cats we'll allow
+    max_cats = random.choice(get_config("relationship.group_events.multi_cat_amounts"))
+    chosen_cats = []
+
+    # get the cats who qualify
+    possible_cats = cat_for_event(
+        cat_constraints,
+        interactable_cats,
+        event.tags,
+        involved_cat_dict=involved_cats,
+        return_list=True,
+        return_id=False,
+    )
+    # if not enough possible cats, return empty list
+    if not possible_cats or len(possible_cats) <= 1:
+        return []
+
+    involved_cats["multi_cat"] = []  # set this up ahead of time
+
+    # if relationships aren't required, then we just pick some cats and go!
+    if not event.relationship_constraint:
+        chosen_cats = random.sample(possible_cats, min(len(possible_cats), max_cats))
+        return chosen_cats
+
+    # now we need to find who qualifies for the relationship constraints
+    while len(chosen_cats) < max_cats and possible_cats:
+        failed = False
+        cat = random.choice(possible_cats)
+
+        # copy up so that it's easier to pass this and test it, but we can still go back to the OG dict if it fails
+        _temp_involved_cats = involved_cats.copy()
+        _temp_involved_cats["multi_cat"].append(cat)
+        # find out if this cat will match the rel constraints
+        for block in event.relationship_constraint:
+            # if this block doesn't include multi_cat then we skip it
+            if "multi_cat" not in block["cats_from"] + block["cats_to"]:
+                continue
+            if not check_rel_constraint_groups(block, _temp_involved_cats):
+                failed = True
+                break
+
+        # no matter what, cat is no longer allowed in the possible_cats list
+        possible_cats.remove(cat)
+
+        # bad cat :( remove from possibilities and try a new one
+        if failed:
+            _temp_involved_cats["multi_cat"].remove(cat)
+        else:
+            # if we're here, then this is a valid cat! we move on
+            chosen_cats.append(cat)
+
+    # if we didn't find enough cats, then return empty list
+    if not chosen_cats or len(chosen_cats) <= 1:
+        return []
+    # otherwise, return all the cats we found!
+    return chosen_cats

--- a/tests/test_patrols.py
+++ b/tests/test_patrols.py
@@ -491,8 +491,6 @@ class TestOutcomeExecution(unittest.TestCase):
 
     def test_supply_change(self):
         war1 = TestCatFactory.create_cat(rank=CatRank.WARRIOR)
-        war1.skills.primary.path = SkillPath.CLIMBER
-        war1.skills.secondary = None
 
         patrol = PatrolEvent(
             event_id="test",

--- a/tests/test_patrols.py
+++ b/tests/test_patrols.py
@@ -133,7 +133,9 @@ class TestInvolvedCats(unittest.TestCase):
         )
 
         self.patrol_class._add_patrol_cats([war1, app1, app2])
-        self.patrol_class._patrol_pass_cat_constraints(patrol)
+        self.patrol_class._get_valid_patrol(
+            [], chosen_frequency=patrol.frequency, patrol_override=patrol
+        )
 
         self.assertEqual(
             war1,
@@ -157,26 +159,28 @@ class TestInvolvedCats(unittest.TestCase):
             intro_text="test",
             decline_text="test",
             involved_cats={
-                "n_c:0": InvolvedCatDict(),
-                "n_c:1": InvolvedCatDict(can_create_new_cat={}),
+                "n_c0": InvolvedCatDict(),
+                "n_c1": InvolvedCatDict(can_create_new_cat={}),
             },
             success_outcomes=[{"strings": ["test"]}],
             fail_outcomes=[{"strings": ["test"]}],
         )
 
         self.patrol_class._add_patrol_cats([war1])
-        self.patrol_class._patrol_pass_cat_constraints(patrol)
+        self.patrol_class._get_valid_patrol(
+            [], chosen_frequency=patrol.frequency, patrol_override=patrol
+        )
 
         self.assertEqual(
             outsider1,
-            self.patrol_class.involved_cats["n_c:0"],
-            msg=f"{outsider1} should be n_c:0",
+            self.patrol_class.involved_cats["n_c0"],
+            msg=f"{outsider1} should be n_c0",
         )
 
         self.assertNotEqual(
             outsider1,
-            self.patrol_class.involved_cats["n_c:1"],
-            msg=f"n_c:1 should not be {outsider1}",
+            self.patrol_class.involved_cats["n_c1"],
+            msg=f"n_c1 should not be {outsider1}",
         )
 
     def test_pl_persistence(self):
@@ -204,7 +208,9 @@ class TestInvolvedCats(unittest.TestCase):
         )
         self.patrol_class.patrol_event = patrol
         self.patrol_class._add_patrol_cats([war1, app1, app2])
-        self.patrol_class._patrol_pass_cat_constraints(patrol)
+        self.patrol_class._get_valid_patrol(
+            [], chosen_frequency=patrol.frequency, patrol_override=patrol
+        )
         self.patrol_class._check_outcome_constraints(
             patrol.success_outcomes[0], "success"
         )
@@ -236,7 +242,9 @@ class TestInvolvedCats(unittest.TestCase):
         )
         self.patrol_class.patrol_event = patrol
         self.patrol_class._add_patrol_cats([war1, app1, app2])
-        self.patrol_class._patrol_pass_cat_constraints(patrol)
+        self.patrol_class._get_valid_patrol(
+            [], chosen_frequency=patrol.frequency, patrol_override=patrol
+        )
         self.patrol_class._check_outcome_constraints(
             patrol.success_outcomes[0], "success"
         )
@@ -268,7 +276,9 @@ class TestInvolvedCats(unittest.TestCase):
         )
         self.patrol_class.patrol_event = patrol
         self.patrol_class._add_patrol_cats([war1, app1, app2])
-        self.patrol_class._patrol_pass_cat_constraints(patrol)
+        self.patrol_class._get_valid_patrol(
+            [], chosen_frequency=patrol.frequency, patrol_override=patrol
+        )
         self.patrol_class._check_outcome_constraints(
             patrol.success_outcomes[0], "success"
         )
@@ -317,7 +327,9 @@ class TestOutcomeExecution(unittest.TestCase):
         )
 
         self.patrol_class._add_patrol_cats([war1])
-        self.patrol_class._patrol_pass_cat_constraints(patrol)
+        self.patrol_class._get_valid_patrol(
+            [], chosen_frequency=patrol.frequency, patrol_override=patrol
+        )
         self.patrol_class._check_outcome_constraints(
             patrol.success_outcomes[0], "success"
         )
@@ -354,7 +366,9 @@ class TestOutcomeExecution(unittest.TestCase):
         )
 
         self.patrol_class._add_patrol_cats([war1, app1])
-        self.patrol_class._patrol_pass_cat_constraints(patrol)
+        self.patrol_class._get_valid_patrol(
+            [], chosen_frequency=patrol.frequency, patrol_override=patrol
+        )
         self.patrol_class._check_outcome_constraints(
             patrol.success_outcomes[0], "success"
         )
@@ -396,7 +410,9 @@ class TestOutcomeExecution(unittest.TestCase):
         )
 
         self.patrol_class._add_patrol_cats([war1, app1])
-        self.patrol_class._patrol_pass_cat_constraints(patrol)
+        self.patrol_class._get_valid_patrol(
+            [], chosen_frequency=patrol.frequency, patrol_override=patrol
+        )
         self.patrol_class._check_outcome_constraints(
             patrol.success_outcomes[0], "success"
         )
@@ -433,7 +449,9 @@ class TestOutcomeExecution(unittest.TestCase):
         )
 
         self.patrol_class._add_patrol_cats([war1, app1])
-        self.patrol_class._patrol_pass_cat_constraints(patrol)
+        self.patrol_class._get_valid_patrol(
+            [], chosen_frequency=patrol.frequency, patrol_override=patrol
+        )
         self.patrol_class._check_outcome_constraints(
             patrol.success_outcomes[0], "success"
         )
@@ -473,7 +491,9 @@ class TestOutcomeExecution(unittest.TestCase):
         starting_outsider_rep = game.clan.reputation
 
         self.patrol_class._add_patrol_cats([war1, app1])
-        self.patrol_class._patrol_pass_cat_constraints(patrol)
+        self.patrol_class._get_valid_patrol(
+            [], chosen_frequency=patrol.frequency, patrol_override=patrol
+        )
         self.patrol_class._check_outcome_constraints(
             patrol.success_outcomes[0], "success"
         )
@@ -515,7 +535,9 @@ class TestOutcomeExecution(unittest.TestCase):
         total_herb_count = game.clan.herb_supply.total
 
         self.patrol_class._add_patrol_cats([war1])
-        self.patrol_class._patrol_pass_cat_constraints(patrol)
+        self.patrol_class._get_valid_patrol(
+            [], chosen_frequency=patrol.frequency, patrol_override=patrol
+        )
         self.patrol_class._check_outcome_constraints(
             patrol.success_outcomes[0], "success"
         )


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
Here I am to clean up some of my own bullshit!

- Added `find_involved_cats.py` script. This script handles finding involved cats for PatrolEvent or TextPoolEvent.
- Implemented the usage of this func for patrols and group relationship events. It's not useful for pair relationship events, because those events utilize two predetermined cats. And it's not useful for thoughts due to how thoughts predetermines a second cat (something I do want to change, but felt like it would widen the scope of this too much)
- Consequently ended up fixing a problem with the relationship constraint system that would cause it to ignore constraints for `patrol_cats`. Apologies for this not being a separate PR, it's entwined enough with the system for finding involved cats that it sorta had to slot in here.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Why This Is Good For ClanGen
It will make it easy to continue switching our assorted events into the TextPoolEvent system, as they won't need to rewrite code for finding involved cats every single time.  Our usage of involved cats should really be consistent enough across all events being transferred into the new system for the sake of writer-ease, this shared func will encourage that going forward.  This also reduces some repetitive code that was building up as I transferred more systems over to TextPoolEvent.

This does mean that it's technically possible to utilize `multi_cat` in patrols and `n_c` abbreviations in group relationship events. I've not added this functionality to the documentation as I'm not certain how much we actually want to encourage it's use yet.
<!-- If this is a bug fix, you can remove this section. -->
<!-- Please add a short description of why you think these changes would benefit the game. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->
<!-- If you have multiple features that can stand on their own, or unrelated bugfixes, please create separate PRs for them. -->

## Proof of Testing
Tests are passing!

<img width="702" height="398" alt="image" src="https://github.com/user-attachments/assets/21a24f0c-b4d1-45b2-a321-6506d9320ea8" />
<img width="410" height="26" alt="image" src="https://github.com/user-attachments/assets/7cd050f7-c901-4e33-9e46-f17998d77d72" />

Couldn't make `gen_train_teamwork8` generated when ensured while the cats on patrol weren't mates! 

<img width="709" height="493" alt="image" src="https://github.com/user-attachments/assets/e9d850a5-77b6-404e-b2a8-a2147e060655" />
<img width="682" height="428" alt="image" src="https://github.com/user-attachments/assets/9653f204-2b5d-4835-8a47-86d4cdd7341f" />

However it generates just fine when all the cats *are* mates!
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Added `find_involved_cats.py` script. This script handles finding involved cats for PatrolEvent or TextPoolEvent.
- Implemented the usage of this func for patrols and group relationship events.
- Consequently ended up fixing a problem with the relationship constraint system that would cause it to ignore constraints for `patrol_cats`
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
