### PR TITLE
[BUG] Fixes r_c call in gen_misc_taintedPOI_stinkymate

### DIFF
--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -17496,7 +17496,7 @@
     {
         "event_id": "gen_misc_taintedPOI_stinkymate",
         "location": ["-desert"],
-        "season": ["any"],
+        "season": ["-leaf-bare"],
         "tags":["romance"],
         "poi": {
             "tags": ["tainted"]
@@ -17507,6 +17507,9 @@
             "relationship_status": ["mates"],
             "trait": ["-bloodthirsty", "-cold", "-gloomy", "-grumpy", "-strict"]
         },
+        "r_c": {
+            "group": ["player_clan"]
+        },
         "relationships": [
             {
                 "cats_from": ["r_c"],
@@ -17515,8 +17518,8 @@
                 "values": ["romance", "like", "comfort"],
                 "amount": 10,
                 "log": {
-                    "cats_from": "cats_from had a fun time splashing around together with cats_to after they enforced a bath.",
-                    "cats_to": "cats_to enjoyed pulling cats_from into the water with them and playing around like kits."
+                    "cats_from": "r_c had a fun time splashing around together with m_c after {PRONOUN/r_c/subject} enforced a bath.",
+                    "cats_to": "m_c enjoyed pulling r_c into the water with {PRONOUN/m_c/object} and playing around like kits."
                }
             }
         ]


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
Fixed up the formatting of `gen_misc_taintedPOI_stinkymate` so that it works with multiple mates. Also fixed the formatting for the relationship log messages!
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues

Fixes: #5747 
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
<img width="559" height="333" alt="image" src="https://github.com/user-attachments/assets/ec542154-cfd2-4e84-9f80-29de28545527" />
<img width="695" height="221" alt="image" src="https://github.com/user-attachments/assets/b384803e-a7cc-4a95-ae55-e841ea742bbc" />

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits

<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
