### PR TITLE
[DEV] Make auto-labeller less aggressive

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -3,9 +3,11 @@
     - any-glob-to-any-file: "**/*.py"
 "PR:writing":
   - changed-files:
-    - any-glob-to-any-file: "**/*.json"
+    - any-glob-to-any-file: "resources/lang/**/*.json"
 "PR:art":
   - changed-files:
-    - any-glob-to-any-file: "**/*.png"
+    - any-glob-to-any-file: 
+      - "**/*.png"
+      - "sprites/**/*.json"
 "target:stable":
   - base-branch: "^release"


### PR DESCRIPTION
## About The Pull Request

* Makes auto-labeller less aggressive about labelling all JSON changes as writing PRs
* Changes edits to JSONs in the sprites folder to be labelled as art PRs instead

## Why This Is Good For ClanGen

* Makes auto-labeller actually useful again