### PR TITLE
[FREQFIX] death event frequency adjustments

### DIFF
--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -2332,12 +2332,11 @@
             "war"
         ],
         "tags": [],
-        "frequency": 4,
+        "frequency": 2,
         "event_text": "m_c suffered a heart attack due to the stress of the ongoing war.",
         "m_c": {
             "age": [
                 "senior",
-                "adult",
                 "senior adult"
             ],
             "dies": true

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -1292,7 +1292,7 @@
             "any"
         ],
         "tags": [],
-        "frequency": 3,
+        "frequency": 2,
         "event_text": "m_c fell into the river. r_c drowned alongside m_c while trying to rescue {PRONOUN/m_c/object}.",
         "m_c": {
             "age": [

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -6943,7 +6943,7 @@
         "tags": [
             "low_lives"
         ],
-        "frequency": 3,
+        "frequency": 2,
         "event_text": "m_c was pushed under a monster by r_c.",
         "m_c": {
             "status": [


### PR DESCRIPTION
## About The Pull Request

reduces the frequency of 3 different events. they were previously discussed in the discord or brought up in the github:
- "gen_death_drown_any1" (freq 3 --> 2)
- "gen_death_murder_anymonster1" (freq 3 --> 2)
- "gen_death_stress_anywar1" (freq 4 --> 2 and removed "adult" constraint, leaving only "senior adult" and "senior" as possible ages)

## Why This Is Good For ClanGen

addressing feedback! we are definitely in need of more war events but this is a fine enough start. events being repetitive get annoying quickly.

## Linked Issues

https://github.com/ClanGenOfficial/clangen/issues/3896#issuecomment-5322747928

## Proof of Testing

<img width="834" height="157" alt="image" src="https://github.com/user-attachments/assets/c4fe1e42-1598-4770-a673-1ecef6cc3913" />
<img width="454" height="121" alt="image" src="https://github.com/user-attachments/assets/8ea42e88-92b2-4b77-abde-fc9d2621341a" />


## Changelog/Credits

- Reduces the frequency of "gen_death_drown_any1", "gen_death_murder_anymonster1", and "gen_death_stress_anywar1" in response to feedback that they were too common.
