### PR TITLE
[BUGFIX] Filtering existing newcats for patrols + pronouns

### DIFF
--- a/resources/lang/en/patrols/new_cat_welcoming.json
+++ b/resources/lang/en/patrols/new_cat_welcoming.json
@@ -3602,7 +3602,6 @@
                         "age": [
                             "senior"
                         ],
-                        "gender": "male",
                         "backstory": [
                             "refugee6"
                         ]
@@ -3676,7 +3675,6 @@
                         "age": [
                             "senior"
                         ],
-                        "gender": "male",
                         "backstory": [
                             "refugee6"
                         ]
@@ -3872,7 +3870,6 @@
                         "age": [
                             "senior"
                         ],
-                        "gender": "male",
                         "backstory": [
                             "refugee6"
                         ]
@@ -3905,7 +3902,6 @@
                         "age": [
                             "senior"
                         ],
-                        "gender": "male",
                         "backstory": [
                             "refugee6"
                         ]

--- a/scripts/events_module/patrol/create_new_cat.py
+++ b/scripts/events_module/patrol/create_new_cat.py
@@ -167,6 +167,7 @@ def updated_create_new_cat(
         _assign_name(created_cat)
 
         created_cat.create_relationships_new_cat()
+        game.clan.add_cat(created_cat)
         new_cats.append(created_cat)
 
     # ESTABLISH FAMILY RELATIONSHIPS

--- a/scripts/events_module/patrol/create_new_cat.py
+++ b/scripts/events_module/patrol/create_new_cat.py
@@ -39,7 +39,14 @@ def updated_create_new_cat(
         if "clancat" in option_dict["status"]:
             status["social"] = CatSocial.CLANCAT
             possible_ranks = [r for r in option_dict["status"] if r != "clancat"]
-            possible_ranks.extend([r for r in [*CatRank] if r.is_any_clancat_rank()])
+            possible_ranks.extend(
+                [
+                    r
+                    for r in [*CatRank]
+                    if r.is_any_clancat_rank()
+                    and r not in (CatRank.LEADER, CatRank.DEPUTY)
+                ]
+            )
         else:
             possible_ranks = option_dict["status"]
 

--- a/scripts/events_module/patrol/patrol.py
+++ b/scripts/events_module/patrol/patrol.py
@@ -60,7 +60,6 @@ class Patrol:
         self.outcome_cats: TypedDict(
             "outcome_cats", {"success": dict[str, Cat], "failure": dict[str, Cat]}
         ) = {"success": {}, "failure": {}}
-        self.new_cats: list[Cat] = []
 
     def begin_patrol(self, patrol_cats: List[Cat], patrol_type: str) -> str:
         """
@@ -632,57 +631,6 @@ class Patrol:
         self.outcome_cats[outcome_type] = temp_involved_cats
 
         return True
-
-    def _find_involved_cats(
-        self,
-        abbr: str,
-        possible_cats: list[Cat],
-        relationship_constraint,
-        cat_constraints,
-        temp_involved_cats: dict,
-    ) -> tuple[bool, dict]:
-        # if relationships aren't required, just grab some cats and go!
-        if possible_cats and not relationship_constraint:
-            # take first cat
-            temp_involved_cats[abbr] = possible_cats[0]
-            return True, temp_involved_cats
-
-        # otherwise, let's make sure we fulfill the rel constraints with this cat
-        elif possible_cats:
-            while not temp_involved_cats.get(abbr):
-                # need a temp cat dict that includes our possible kitty
-                _temp_cats = temp_involved_cats.copy()
-                _temp_cats[abbr] = possible_cats[0]
-                # now we check each rel constraint to make sure our new cat is valid
-                for block in relationship_constraint:
-                    if not check_rel_constraint_groups(block, _temp_cats):
-                        # they aren't! so we remove them from the possibilities
-                        possible_cats.remove(_temp_cats[abbr])
-                        if not possible_cats:
-                            # oops! no more cats available! this patrol isn't possible
-                            return False, temp_involved_cats
-                        else:
-                            # still some possibilities, let's try the next!
-                            continue
-
-                    # if we got here, then this cat works!
-                    temp_involved_cats[abbr] = _temp_cats[abbr]
-
-        # there weren't any possible cats, so we'll create a new one if we're allowed
-        else:
-            # we don't need to check relationship constraints if we're making a new cat
-            if "n_c" in abbr and "can_create_new_cat" in cat_constraints:
-                temp_involved_cats[abbr] = updated_create_new_cat(
-                    option_dict=cat_constraints,
-                    involved_cats=temp_involved_cats,
-                    other_clan=self.other_clan,
-                )
-                self.new_cats.extend(temp_involved_cats[abbr])
-            else:
-                # if we aren't allowed to make a new one, then we can't do this patrol
-                return False, temp_involved_cats
-
-        return True, temp_involved_cats
 
     def determine_outcome(
         self, antagonize=False

--- a/scripts/events_module/text_pool_event/find_involved_cats.py
+++ b/scripts/events_module/text_pool_event/find_involved_cats.py
@@ -46,12 +46,7 @@ def find_cats(
             return {}
 
     for abbr, constraints in event.involved_cats.items():
-        possible_injuries = []
-        # grab any injuries they might get
-        if can_give_condition and event.condition:
-            for block in event.condition:
-                if abbr in block["cats"]:
-                    possible_injuries.extend(block["condition"])
+        possible_injuries = get_potential_conditions(abbr, can_give_condition, event)
 
         # CHECK ALREADY ASSIGNED CAT
         if abbr in involved_cats:
@@ -139,10 +134,23 @@ def find_cats(
     for abbr in cats_to_create:
         # this will first try to find an existing cat, but if it can't then it'll make a new one
         constraints = event.involved_cats[abbr]
+        cat_list = [c for c in outside_cats if c not in temp_involved_cats.values()]
+        possible_injuries = get_potential_conditions(abbr, can_give_condition, event)
+
+        # initial filter of the entire list of cats for the more general constraints
+        possible_cats = cat_for_event(
+            constraint_dict=constraints,
+            possible_cats=cat_list,
+            tags=event.tags,
+            injuries=possible_injuries,
+            other_involved_clan_id=other_clan.group_ID if other_clan else None,
+            return_list=True,
+            return_id=False,
+        )
 
         new_cats = _find_involved_cat(
             abbr,
-            [c for c in outside_cats if c not in temp_involved_cats.values()],
+            possible_cats,
             relationship_constraint=event.relationship_constraint,
             cat_constraints=constraints,
             temp_involved_cats=temp_involved_cats,
@@ -151,6 +159,16 @@ def find_cats(
         temp_involved_cats.update(new_cats)
 
     return temp_involved_cats
+
+
+def get_potential_conditions(abbr, can_give_condition, event):
+    possible_injuries = []
+    # grab any injuries they might get
+    if can_give_condition and event.condition:
+        for block in event.condition:
+            if abbr in block["cats"]:
+                possible_injuries.extend(block["condition"])
+    return possible_injuries
 
 
 def _check_prior_abbreviation(
@@ -198,7 +216,8 @@ def _find_involved_cat(
     Finds a cat from the available cats that can fill the abbreviation slot. This will check against relationship
     constraints and will create a new cat if necessary and allowed.
     """
-    possible_cats = possible_cats.copy()
+    if possible_cats:
+        possible_cats = possible_cats.copy()
 
     # if relationships aren't required, just grab some cats and go!
     if possible_cats and not relationship_constraint:
@@ -237,6 +256,9 @@ def _find_involved_cat(
                 involved_cats=temp_involved_cats,
                 other_clan=other_clan,
             )
+            if len(temp_involved_cats[abbr]) == 1:
+                # if this is a list of a single cat, then we take them out of the list
+                temp_involved_cats[abbr] = temp_involved_cats[abbr][0]
         else:
             # if we aren't allowed to make a new one, then we can't do this event
             return {}


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
Fixes the retrieval of existing outsiders as well as n_c pronouns.

- We weren't actually filtering the outsider list by the constraints, thus anyone was allowed in. Added the constraint check back in.
- Removed `_find_involved_cats` from `patrol.py`. Just another function I forgot to remove before oopsie. It was unused. Same for `self.new_cats`
- Removed some unnecessary gender tags I discovered while trying to debug.
- Made sure newly generated single new cats were taken out of their list. The text adjust relies upon detecting lists vs. single cats so that it can either make a list of cat names OR find a pronoun set. New cats being in a list thus was breaking pronouns, since they were being treated as a set of multiple cats.
- Fix newly generated cats not being added to the cat list and thus failing to save correctly
- Prevent `clancat` tag from assigning newcats with a current leader or deputy status (they can still receive those ranks as past statuses, just not as current)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->


## Linked Issues
Sorta #5788, but that issue also talks about newly generated cats not matching constraints, which is likely a different matter entirely? So not gonna make this PR as closing that issue.
fixes #5781
fixes #5783
fixes #5800
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
<img width="422" height="522" alt="image" src="https://github.com/user-attachments/assets/4f189a20-1c97-4687-ab72-8b8949ea5043" />
<img width="585" height="310" alt="image" src="https://github.com/user-attachments/assets/f816df73-7ed6-48ba-8705-099b471dc6f5" />
This is an existing outsider that joined the Clan, you can see that they match up with what the event required it's new cat to be (elder and kittypet)

<img width="625" height="322" alt="image" src="https://github.com/user-attachments/assets/161a509d-ee0c-42f7-8f49-3894eb650db7" />

new cat that joined the clan via a patrol. I saved, closed, reopened the clan, and was able to successfully access their profile. I also killed them, saved and reloaded and was able to timeskip successfully (attempting to recreate #5783)
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Fixes patrols not properly filtering out existing potential outsider/otherclan cats to include
- Fixes pronouns being broken for outsider/otherclan cats on patrol
- Fixes newly generated cats not being added to the cat list and thus failing to save correctly
- Prevent `clancat` tag from assigning newcats with a current leader or deputy status (they can still receive those ranks as past statuses, just not as current)
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
