### PR TITLE
[CONTENT] More transition events

### DIFF
--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -18899,7 +18899,7 @@
             "transition"
         ],
         "frequency": 4,
-        "event_text": "r_c and m_c were on a walk together when m_c mentioned that {PRONOUN/m_c/subject} might not be a tom. While a bit surprised, r_c assured {PRONOUN/m_c/subject} that doesn't matter. {PRONOUN/r_c/subject} would be proud to have m_c as {PRONOUN/r_c/poss} partner no matter what.",
+        "event_text": "r_c and m_c were on a walk together when m_c mentioned that {PRONOUN/m_c/subject} might not be a tom. While a bit surprised, r_c assured {PRONOUN/m_c/subject} that doesn't matter. {PRONOUN/r_c/subject/CAP} would be proud to have m_c as {PRONOUN/r_c/poss} partner no matter what.",
         "m_c": {
             "age": ["-kitten"],
             "relationship_status": ["mates"],
@@ -18959,7 +18959,7 @@
             "transition"
         ],
         "frequency": 4,
-        "event_text": "r_c and m_c were on a walk together when m_c mentioned that {PRONOUN/m_c/subject} might not be a she-cat. While a bit surprised, r_c assured {PRONOUN/m_c/subject} that doesn't matter. {PRONOUN/r_c/subject} would be proud to have m_c as {PRONOUN/r_c/poss} partner no matter what.",
+        "event_text": "r_c and m_c were on a walk together when m_c mentioned that {PRONOUN/m_c/subject} might not be a she-cat. While a bit surprised, r_c assured {PRONOUN/m_c/subject} that doesn't matter. {PRONOUN/r_c/subject/CAP} would be proud to have m_c as {PRONOUN/r_c/poss} partner no matter what.",
         "m_c": {
             "age": ["-kitten"],
             "relationship_status": ["mates"],

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -17639,6 +17639,1628 @@
       ]
     },
     {
+        "event_id": "gen_misc_transition_nonbinaryacceptance",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "transition"
+        ],
+        "frequency": 4,
+        "event_text": "m_c could never put a paw on what exactly they were feeling, but they realized they don't need to know the details. For now, simply <i>not</i> being a tom or she-cat is more than enough.",
+        "m_c": {
+            "age": ["-kitten"],
+            "gender": [
+                "male",
+                "female"
+            ]
+        },
+        "new_gender": [
+            "nonbinary"
+        ],
+      "relationships": [
+          {
+            "cats_from": ["m_c"],
+            "cats_to": ["clan"],
+            "mutual": false,
+            "values": ["like", "comfort"],
+            "amount": 5,
+            "log": {
+                "cats_from": "cat_from is comforted by the cat_to's acceptance of {PRONOUN/cat_from/poss} gender."
+            }
+        }
+      ]
+    },
+    {
+        "event_id": "gen_misc_transition_apprentice_to_nonbinary",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "transition"
+        ],
+        "frequency": 4,
+        "event_text": "m_c is growing up, and with that comes figuring out who {PRONOUN/m_c/subject} {VERB/m_c/are/is}, which turned out to be neither a tom nor a she-cat.",
+        "m_c": {
+            "status": ["apprentice", "mediator apprentice", "medicine cat apprentice"],
+            "gender": [
+                "male",
+                "female"
+            ]
+        },
+        "new_gender": [
+            "nonbinary"
+        ],
+      "relationships": [
+          {
+            "cats_from": ["m_c"],
+            "cats_to": ["clan"],
+            "mutual": false,
+            "values": ["like", "comfort"],
+            "amount": 5,
+            "log": {
+                "cats_from": "cat_from is comforted by the cat_to's acceptance of {PRONOUN/cat_from/poss} gender."
+            }
+        }
+      ]
+    },
+    {
+        "event_id": "gen_misc_transition_apprentice_to_female",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "transition"
+        ],
+        "frequency": 4,
+        "event_text": "m_c is growing up, and with that comes figuring out who {PRONOUN/m_c/subject} {VERB/m_c/are/is}, which turned out to be a she-cat.",
+        "m_c": {
+            "status": ["apprentice", "mediator apprentice", "medicine cat apprentice"],
+            "gender": [
+                "male"
+            ]
+        },
+        "new_gender": [
+            "trans female"
+        ],
+      "relationships": [
+          {
+            "cats_from": ["m_c"],
+            "cats_to": ["clan"],
+            "mutual": false,
+            "values": ["like", "comfort"],
+            "amount": 5,
+            "log": {
+                "cats_from": "cat_from is comforted by the cat_to's acceptance of {PRONOUN/cat_from/poss} gender."
+            }
+        }
+      ]
+    },
+    {
+        "event_id": "gen_misc_transition_apprentice_to_male",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "transition"
+        ],
+        "frequency": 4,
+        "event_text": "m_c is growing up, and with that comes figuring out who {PRONOUN/m_c/subject} {VERB/m_c/are/is}, which turned out to be a tom.",
+        "m_c": {
+            "status": ["apprentice", "mediator apprentice", "medicine cat apprentice"],
+            "gender": [
+                "female"
+            ]
+        },
+        "new_gender": [
+            "trans male"
+        ],
+      "relationships": [
+          {
+            "cats_from": ["m_c"],
+            "cats_to": ["clan"],
+            "mutual": false,
+            "values": ["like", "comfort"],
+            "amount": 5,
+            "log": {
+                "cats_from": "cat_from is comforted by the cat_to's acceptance of {PRONOUN/cat_from/poss} gender."
+            }
+        }
+      ]
+    },
+    {
+        "event_id": "gen_misc_transition_nobigdeal_to_male",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "transition"
+        ],
+        "frequency": 4,
+        "event_text": "While {PRONOUN/m_c/subject} didn't want to make a big deal out of it, m_c didn't mind c_n quietly celebrating when {PRONOUN/m_c/subject} mentioned {PRONOUN/m_c/subject} would go through life as a tom from now on.",
+        "m_c": {
+            "trait": ["lonesome", "cold", "nervous", "insecure", "strict", "calm", "careful", "sincere"],
+            "gender": [
+                "female"
+            ]
+        },
+        "new_gender": [
+            "trans male"
+        ],
+      "relationships": [
+          {
+            "cats_from": ["m_c"],
+            "cats_to": ["clan"],
+            "mutual": false,
+            "values": ["like", "comfort"],
+            "amount": 5,
+            "log": {
+                "cats_from": "cat_from is comforted by the cat_to's acceptance of {PRONOUN/cat_from/poss} gender."
+            }
+        }
+      ]
+    },
+    {
+        "event_id": "gen_misc_transition_nobigdeal_to_female",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "transition"
+        ],
+        "frequency": 4,
+        "event_text": "While {PRONOUN/m_c/subject} didn't want to make a big deal out of it, m_c didn't mind c_n quietly celebrating when {PRONOUN/m_c/subject} mentioned {PRONOUN/m_c/subject} would go through life as a she-cat from now on.",
+        "m_c": {
+            "trait": ["lonesome", "cold", "nervous", "insecure", "strict", "calm", "careful", "sincere"],
+            "gender": [
+                "male"
+            ]
+        },
+        "new_gender": [
+            "trans female"
+        ],
+      "relationships": [
+          {
+            "cats_from": ["m_c"],
+            "cats_to": ["clan"],
+            "mutual": false,
+            "values": ["like", "comfort"],
+            "amount": 5,
+            "log": {
+                "cats_from": "cat_from is comforted by the cat_to's acceptance of {PRONOUN/cat_from/poss} gender."
+            }
+        }
+      ]
+    },
+    {
+        "event_id": "gen_misc_transition_nobigdeal_to_nonbinary",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "transition"
+        ],
+        "frequency": 4,
+        "event_text": "While {PRONOUN/m_c/subject} didn't want to make a big deal out of it, m_c didn't mind c_n quietly celebrating when {PRONOUN/m_c/subject} mentioned {PRONOUN/m_c/subject} would go through life as neither a tom nor a she-cat from now on.",
+        "m_c": {
+            "trait": ["lonesome", "cold", "nervous", "insecure", "strict", "calm", "careful", "sincere"],
+            "gender": [
+                "female",
+                "male"
+            ]
+        },
+        "new_gender": [
+            "nonbinary"
+        ],
+      "relationships": [
+          {
+            "cats_from": ["m_c"],
+            "cats_to": ["clan"],
+            "mutual": false,
+            "values": ["like", "comfort"],
+            "amount": 5,
+            "log": {
+                "cats_from": "cat_from is comforted by the cat_to's acceptance of {PRONOUN/cat_from/poss} gender."
+            }
+        }
+      ]
+    },
+    {
+        "event_id": "gen_misc_transition_flamboyant_accessory_to_nonbinary",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "transition"
+        ],
+        "frequency": 4,
+        "event_text": "m_c realized {PRONOUN/m_c/subject} would much rather not be known as either a tom nor a she-cat, and decided to announce this with a pretty new accessory. After all, the discovery deserved a celebration!",
+       "new_accessory": ["WILD"],
+        "m_c": {
+            "trait": ["playful", "bold", "daring", "confident", "shameless", "flamboyant"],
+            "gender": [
+                "female",
+                "male"
+            ]
+        },
+        "new_gender": [
+            "nonbinary"
+        ],
+      "relationships": [
+          {
+            "cats_from": ["m_c"],
+            "cats_to": ["clan"],
+            "mutual": false,
+            "values": ["like", "comfort"],
+            "amount": 5,
+            "log": {
+                "cats_from": "cat_from is comforted by the cat_to's acceptance of {PRONOUN/cat_from/poss} gender."
+            }
+        }
+      ]
+    },
+    {
+        "event_id": "gen_misc_transition_flamboyant_accessory_to_male",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "transition"
+        ],
+        "frequency": 4,
+        "event_text": "m_c realized {PRONOUN/m_c/subject} would much rather not be known as either a tom nor a she-cat, and decided to announce this with a pretty new accessory. After all, the discovery deserved a celebration!",
+       "new_accessory": ["WILD"],
+        "m_c": {
+            "trait": ["playful", "bold", "daring", "confident", "shameless", "flamboyant"],
+            "gender": [
+                "female"
+            ]
+        },
+        "new_gender": [
+            "trans male"
+        ],
+      "relationships": [
+          {
+            "cats_from": ["m_c"],
+            "cats_to": ["clan"],
+            "mutual": false,
+            "values": ["like", "comfort"],
+            "amount": 5,
+            "log": {
+                "cats_from": "cat_from is comforted by the cat_to's acceptance of {PRONOUN/cat_from/poss} gender."
+            }
+        }
+      ]
+    },   
+    {
+        "event_id": "gen_misc_transition_flamboyant_accessory_to_female",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "transition"
+        ],
+        "frequency": 4,
+        "event_text": "m_c realized {PRONOUN/m_c/subject} would much rather not be known as either a tom nor a she-cat, and decided to announce this with a pretty new accessory. After all, the discovery deserved a celebration!",
+       "new_accessory": ["WILD"],
+        "m_c": {
+            "trait": ["playful", "bold", "daring", "confident", "shameless", "flamboyant"],
+            "gender": [
+                "male"
+            ]
+        },
+        "new_gender": [
+            "trans female"
+        ],
+      "relationships": [
+          {
+            "cats_from": ["m_c"],
+            "cats_to": ["clan"],
+            "mutual": false,
+            "values": ["like", "comfort"],
+            "amount": 5,
+            "log": {
+                "cats_from": "cat_from is comforted by the cat_to's acceptance of {PRONOUN/cat_from/poss} gender."
+            }
+        }
+      ]
+    },
+    {
+        "event_id": "gen_misc_transition_calm_to_nonbinary",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "transition"
+        ],
+        "frequency": 4,
+        "event_text": "It's surprisingly obvious on hindsight, m_c explains. {PRONOUN/m_c/subject/CAP} just <i>know</i> {PRONOUN/m_c/subject} {VERB/m_c/are/is} not a tom or a she-cat, there's no other logical explanation for this feeling. c_n is happy to celebrate their discovery.",
+        "m_c": {
+            "trait": ["strict", "thoughtful", "calm", "sincere", "responsible", "wise"],
+            "gender": [
+                "female",
+                "male"
+            ]
+        },
+        "new_gender": [
+            "nonbinary"
+        ],
+      "relationships": [
+          {
+            "cats_from": ["m_c"],
+            "cats_to": ["clan"],
+            "mutual": false,
+            "values": ["like", "comfort"],
+            "amount": 5,
+            "log": {
+                "cats_from": "cat_from is comforted by the cat_to's acceptance of {PRONOUN/cat_from/poss} gender."
+            }
+        }
+      ]
+    }, 
+    {
+        "event_id": "gen_misc_transition_calm_to_female",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "transition"
+        ],
+        "frequency": 4,
+        "event_text": "It's surprisingly obvious on hindsight, m_c explains. {PRONOUN/m_c/subject/CAP} just <i>know</i> {PRONOUN/m_c/subject} {VERB/m_c/are/is} a she-cat, there's no other logical explanation for this feeling. c_n is happy to celebrate their discovery.",
+        "m_c": {
+            "trait": ["strict", "thoughtful", "calm", "sincere", "responsible", "wise"],
+            "gender": [
+                "male"
+            ]
+        },
+        "new_gender": [
+            "trans female"
+        ],
+      "relationships": [
+          {
+            "cats_from": ["m_c"],
+            "cats_to": ["clan"],
+            "mutual": false,
+            "values": ["like", "comfort"],
+            "amount": 5,
+            "log": {
+                "cats_from": "cat_from is comforted by the cat_to's acceptance of {PRONOUN/cat_from/poss} gender."
+            }
+        }
+      ]
+    },
+    {
+        "event_id": "gen_misc_transition_calm_to_male",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "transition"
+        ],
+        "frequency": 4,
+        "event_text": "It's surprisingly obvious on hindsight, m_c explains. {PRONOUN/m_c/subject/CAP} just <i>know</i> {PRONOUN/m_c/subject} {VERB/m_c/are/is} a tom, there's no other logical explanation for this feeling. c_n is happy to celebrate their discovery.",
+        "m_c": {
+            "trait": ["strict", "thoughtful", "calm", "sincere", "responsible", "wise"],
+            "gender": [
+                "female"
+            ]
+        },
+        "new_gender": [
+            "trans male"
+        ],
+      "relationships": [
+          {
+            "cats_from": ["m_c"],
+            "cats_to": ["clan"],
+            "mutual": false,
+            "values": ["like", "comfort"],
+            "amount": 5,
+            "log": {
+                "cats_from": "cat_from is comforted by the cat_to's acceptance of {PRONOUN/cat_from/poss} gender."
+            }
+        }
+      ]
+    },
+    {
+        "event_id": "gen_misc_transition_growth_to_male",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "transition"
+        ],
+        "frequency": 4,
+        "event_text": "Life is about changing and growing, and m_c has done just that. With c_n's support, {PRONOUN/m_c/subject} announced that {PRONOUN/m_c/subject} {VERB/m_c/are/is} a tom.",
+        "m_c": {
+            "age": ["-kitten"],
+            "gender": [
+                "female"
+            ]
+        },
+        "new_gender": [
+            "trans male"
+        ],
+      "relationships": [
+          {
+            "cats_from": ["m_c"],
+            "cats_to": ["clan"],
+            "mutual": false,
+            "values": ["like", "comfort"],
+            "amount": 5,
+            "log": {
+                "cats_from": "cat_from is comforted by the cat_to's acceptance of {PRONOUN/cat_from/poss} gender."
+            }
+        }
+      ]
+    },
+    {
+        "event_id": "gen_misc_transition_growth_to_female",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "transition"
+        ],
+        "frequency": 4,
+        "event_text": "Life is about changing and growing, and m_c has done just that. With c_n's support, {PRONOUN/m_c/subject} announced that {PRONOUN/m_c/subject} {VERB/m_c/are/is} a she-cat.",
+        "m_c": {
+            "age": ["-kitten"],
+            "gender": [
+                "male"
+            ]
+        },
+        "new_gender": [
+            "trans female"
+        ],
+      "relationships": [
+          {
+            "cats_from": ["m_c"],
+            "cats_to": ["clan"],
+            "mutual": false,
+            "values": ["like", "comfort"],
+            "amount": 5,
+            "log": {
+                "cats_from": "cat_from is comforted by the cat_to's acceptance of {PRONOUN/cat_from/poss} gender."
+            }
+        }
+      ]
+    },
+    {
+        "event_id": "gen_misc_transition_growth_to_nonbinary",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "transition"
+        ],
+        "frequency": 4,
+        "event_text": "Life is about changing and growing, and m_c has done just that. With c_n's support, {PRONOUN/m_c/subject} announced that {PRONOUN/m_c/subject} {VERB/m_c/are/is} neither a she-cat nor a tom.",
+        "m_c": {
+            "age": ["-kitten"],
+            "gender": [
+                "male",
+                "female"
+            ]
+        },
+        "new_gender": [
+            "nonbinary"
+        ],
+      "relationships": [
+          {
+            "cats_from": ["m_c"],
+            "cats_to": ["clan"],
+            "mutual": false,
+            "values": ["like", "comfort"],
+            "amount": 5,
+            "log": {
+                "cats_from": "cat_from is comforted by the cat_to's acceptance of {PRONOUN/cat_from/poss} gender."
+            }
+        }
+      ]
+    },
+    {
+        "event_id": "gen_misc_transition_deadparent_to_nonbinary",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "transition"
+        ],
+        "frequency": 4,
+        "event_text": "m_c was glad for c_n's support when {PRONOUN/m_c/subject} announced {PRONOUN/m_c/subject} {{VERB/m_c/are/is} neither a she-cat nor a tom. The moment still felt bittersweet when {PRONOUN/m_c/subject} later looked at the night sky, knowing a particularly bright star meant r_c is proud of the cat {PRONOUN/r_c/poss} child has become.",
+        "m_c": {
+            "age": ["-kitten"],
+            "relationship_status": ["child/parent"],
+            "gender": [
+                "male",
+                "female"
+            ],
+            "backstory": ["-orphaned_backstories", "-abandoned_backstories"]
+        },
+        "new_gender": [
+            "nonbinary"
+        ],
+        "r_c": {
+            "group": ["starclan"]
+        },
+      "relationships": [
+          {
+            "cats_from": ["m_c"],
+            "cats_to": ["clan"],
+            "mutual": false,
+            "values": ["like", "comfort"],
+            "amount": 5,
+            "log": {
+                "cats_from": "cat_from is comforted by the cat_to's acceptance of {PRONOUN/cat_from/poss} gender."
+            }
+        }
+      ]
+    },
+    {
+        "event_id": "gen_misc_transition_deadparent_to_female",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "transition"
+        ],
+        "frequency": 4,
+        "event_text": "m_c was glad for c_n's support when {PRONOUN/m_c/subject} announced {PRONOUN/m_c/subject} {{VERB/m_c/are/is} a she-cat. The moment still felt bittersweet when {PRONOUN/m_c/subject} later looked at the night sky, knowing a particularly bright star meant r_c is proud of the cat {PRONOUN/r_c/poss} daughter has become.",
+        "m_c": {
+            "age": ["-kitten"],
+            "relationship_status": ["child/parent"],
+            "gender": [
+                "male"
+            ],
+            "backstory": ["-orphaned_backstories", "-abandoned_backstories"]
+        },
+        "new_gender": [
+            "trans female"
+        ],
+        "r_c": {
+            "group": ["starclan"]
+        },
+      "relationships": [
+          {
+            "cats_from": ["m_c"],
+            "cats_to": ["clan"],
+            "mutual": false,
+            "values": ["like", "comfort"],
+            "amount": 5,
+            "log": {
+                "cats_from": "cat_from is comforted by the cat_to's acceptance of {PRONOUN/cat_from/poss} gender."
+            }
+        }
+      ]
+    },
+    {
+        "event_id": "gen_misc_transition_deadparent_to_male",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "transition"
+        ],
+        "frequency": 4,
+        "event_text": "m_c was glad for c_n's support when {PRONOUN/m_c/subject} announced {PRONOUN/m_c/subject} {{VERB/m_c/are/is} a tom. The moment still felt bittersweet when {PRONOUN/m_c/subject} later looked at the night sky, knowing a particularly bright star meant r_c is proud of the cat {PRONOUN/r_c/poss} son has become.",
+        "m_c": {
+            "age": ["-kitten"],
+            "relationship_status": ["child/parent"],
+            "gender": [
+                "female"
+            ],
+            "backstory": ["-orphaned_backstories", "-abandoned_backstories"]
+        },
+        "new_gender": [
+            "trans male"
+        ],
+        "r_c": {
+            "group": ["starclan"]
+        },
+      "relationships": [
+          {
+            "cats_from": ["m_c"],
+            "cats_to": ["clan"],
+            "mutual": false,
+            "values": ["like", "comfort"],
+            "amount": 5,
+            "log": {
+                "cats_from": "cat_from is comforted by the cat_to's acceptance of {PRONOUN/cat_from/poss} gender."
+            }
+        }
+      ]
+    },
+    {
+        "event_id": "gen_misc_transition_kitfriends_from_male",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "transition"
+        ],
+        "frequency": 4,
+        "event_text": "m_c explained to r_c that {PRONOUN/m_c/subject} don't feel like a tom. r_c nodded impatiently, happy for m_c, but could they get back to playing now?",
+        "m_c": {
+            "age": ["kitten"],
+            "relationship_status": ["likes", "listens_to", "relates_to"],
+            "gender": [
+                "male"
+            ]
+        },
+        "new_gender": [
+            "trans female",
+            "nonbinary"
+        ],
+        "r_c": {
+            "age": ["kitten"]
+        },
+      "relationships": [
+          {
+            "cats_from": ["m_c"],
+            "cats_to": ["clan"],
+            "mutual": false,
+            "values": ["like", "comfort"],
+            "amount": 5,
+            "log": {
+                "cats_from": "cat_from is comforted by the cat_to's acceptance of {PRONOUN/cat_from/poss} gender."
+            }
+        }
+      ]
+    },
+    {
+        "event_id": "gen_misc_transition_kitfriends_from_female",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "transition"
+        ],
+        "frequency": 4,
+        "event_text": "m_c explained to r_c that {PRONOUN/m_c/subject} don't feel like a she-cat. r_c nodded impatiently, happy for m_c, but could they get back to playing now?",
+        "m_c": {
+            "age": ["kitten"],
+            "relationship_status": ["likes", "listens_to", "relates_to"],
+            "gender": [
+                "female"
+            ]
+        },
+        "new_gender": [
+            "trans male",
+            "nonbinary"
+        ],
+        "r_c": {
+            "age": ["kitten"]
+        },
+      "relationships": [
+          {
+            "cats_from": ["m_c"],
+            "cats_to": ["clan"],
+            "mutual": false,
+            "values": ["like", "comfort"],
+            "amount": 5,
+            "log": {
+                "cats_from": "cat_from is comforted by the cat_to's acceptance of {PRONOUN/cat_from/poss} gender."
+            }
+        }
+      ]
+    },
+    {
+        "event_id": "gen_misc_transition_apprenticementor_from_female",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "transition"
+        ],
+        "frequency": 4,
+        "event_text": "m_c quietly talked to {PRONOUN/m_c/poss} mentor, r_c, and confessed {PRONOUN/m_c/subject} don't feel like a she-cat. r_c reassured {PRONOUN/m_c/subject}, and offered to help tell c_n, if that was what m_c wanted. After all, it's r_c's job to help.",
+        "m_c": {
+            "status": ["apprentice", "mediator apprentice", "medicine cat apprentice"],
+            "relationship_status": ["trusts", "app/mentor"],
+            "gender": [
+                "female"
+            ]
+        },
+        "new_gender": [
+            "trans male",
+            "nonbinary"
+        ],
+        "r_c": {
+            "status": ["warrior", "medicine cat", "mediator"]
+        },
+      "relationships": [
+          {
+            "cats_from": ["m_c"],
+            "cats_to": ["clan"],
+            "mutual": false,
+            "values": ["like", "comfort"],
+            "amount": 5,
+            "log": {
+                "cats_from": "cat_from is comforted by the cat_to's acceptance of {PRONOUN/cat_from/poss} gender."
+            }
+        },
+        {
+            "cats_from": ["m_c"],
+            "cats_to": ["r_c"],
+            "mutual": false,
+            "values": ["like", "comfort", "trust"],
+            "amount": 5,
+            "log": {
+                "cats_from": "cat_from trusts cat_to enough to talk about {PRONOUN/cat_from/poss} gender."
+            }
+        },
+        {
+            "cats_from": ["r_c"],
+            "cats_to": ["m_c"],
+            "mutual": false,
+            "values": ["like", "comfort", "trust"],
+            "amount": 5,
+            "log": {
+                "cats_from": "cat_from was happy to help cat_to feel more comfortable with {PRONOUN/cat_to/poss} gender."
+            }
+        }
+      ]
+    },
+    {
+        "event_id": "gen_misc_transition_apprenticementor_from_male",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "transition"
+        ],
+        "frequency": 4,
+        "event_text": "m_c quietly talked to {PRONOUN/m_c/poss} mentor, r_c, and confessed {PRONOUN/m_c/subject} don't feel like a tom. r_c reassured {PRONOUN/m_c/subject}, and offered to help tell c_n, if that was what m_c wanted. After all, it's r_c's job to help.",
+        "m_c": {
+            "status": ["apprentice", "mediator apprentice", "medicine cat apprentice"],
+            "relationship_status": ["trusts", "app/mentor"],
+            "gender": [
+                "male"
+            ]
+        },
+        "new_gender": [
+            "trans female",
+            "nonbinary"
+        ],
+        "r_c": {
+            "status": ["warrior", "medicine cat", "mediator"]
+        },
+      "relationships": [
+          {
+            "cats_from": ["m_c"],
+            "cats_to": ["clan"],
+            "mutual": false,
+            "values": ["like", "comfort"],
+            "amount": 5,
+            "log": {
+                "cats_from": "cat_from is comforted by the cat_to's acceptance of {PRONOUN/cat_from/poss} gender."
+            }
+        },
+        {
+            "cats_from": ["m_c"],
+            "cats_to": ["r_c"],
+            "mutual": false,
+            "values": ["like", "comfort", "trust"],
+            "amount": 5,
+            "log": {
+                "cats_from": "cat_from trusts cat_to enough to talk about {PRONOUN/cat_from/poss} gender."
+            }
+        },
+        {
+            "cats_from": ["r_c"],
+            "cats_to": ["m_c"],
+            "mutual": false,
+            "values": ["like", "comfort", "trust"],
+            "amount": 5,
+            "log": {
+                "cats_from": "cat_from was happy to help cat_to feel more comfortable with {PRONOUN/cat_to/poss} gender."
+            }
+        }
+      ]
+    },
+    {
+        "event_id": "gen_misc_transition_relatable_to_female",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "transition"
+        ],
+        "frequency": 4,
+        "event_text": "m_c sighed over the very relatable experience of wishing to be a she-cat. r_c noted that that probably wasn't a universal experience. The next day, m_c had an announcement to make.",
+        "m_c": {
+            "age": ["-kitten"],
+            "relationship_status": ["trusts", "likes"],
+            "gender": [
+                "male"
+            ]
+        },
+        "new_gender": [
+            "trans female"
+        ],
+        "r_c": {
+            "age": ["-kitten"]
+        },
+      "relationships": [
+          {
+            "cats_from": ["m_c"],
+            "cats_to": ["clan"],
+            "mutual": false,
+            "values": ["like", "comfort"],
+            "amount": 5,
+            "log": {
+                "cats_from": "cat_from is comforted by the cat_to's acceptance of {PRONOUN/cat_from/poss} gender."
+            }
+        }
+      ]
+    },
+    {
+        "event_id": "gen_misc_transition_relatable_to_male",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "transition"
+        ],
+        "frequency": 4,
+        "event_text": "m_c sighed over the very relatable experience of wishing to be a tom. r_c noted that that probably wasn't a universal experience. The next day, m_c had an announcement to make.",
+        "m_c": {
+            "age": ["-kitten"],
+            "relationship_status": ["trusts", "likes"],
+            "gender": [
+                "female"
+            ]
+        },
+        "new_gender": [
+            "trans male"
+        ],
+        "r_c": {
+            "age": ["-kitten"]
+        },
+      "relationships": [
+          {
+            "cats_from": ["m_c"],
+            "cats_to": ["clan"],
+            "mutual": false,
+            "values": ["like", "comfort"],
+            "amount": 5,
+            "log": {
+                "cats_from": "cat_from is comforted by the cat_to's acceptance of {PRONOUN/cat_from/poss} gender."
+            }
+        }
+      ]
+    },
+    {
+        "event_id": "gen_misc_transition_relatable_to_nonbinary",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "transition"
+        ],
+        "frequency": 4,
+        "event_text": "m_c sighed over the very relatable experience of not wanting to be a tom or she-cat. r_c noted that that probably wasn't a universal experience. The next day, m_c had an announcement to make.",
+        "m_c": {
+            "age": ["-kitten"],
+            "relationship_status": ["trusts", "likes"],
+            "gender": [
+                "female",
+                "male"
+            ]
+        },
+        "new_gender": [
+            "nonbinary"
+        ],
+        "r_c": {
+            "age": ["-kitten"]
+        },
+      "relationships": [
+          {
+            "cats_from": ["m_c"],
+            "cats_to": ["clan"],
+            "mutual": false,
+            "values": ["like", "comfort"],
+            "amount": 5,
+            "log": {
+                "cats_from": "cat_from is comforted by the cat_to's acceptance of {PRONOUN/cat_from/poss} gender."
+            }
+        }
+      ]
+    },
+    {
+        "event_id": "gen_misc_transition_parent_to_nonbinary",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "transition"
+        ],
+        "frequency": 4,
+        "event_text": "Looking at {PRONOUN/m_c/poss} adorable litter, m_c realized {PRONOUN/m_c/subject} would rather just be a parent than what {PRONOUN/m_c/subject} had assumed {PRONOUN/m_c/subject} were.",
+        "m_c": {
+            "age": ["-kitten"],
+            "relationship_status": ["parent/child"],
+            "gender": [
+                "female",
+                "male"
+            ]
+        },
+        "new_gender": [
+            "nonbinary"
+        ],
+        "r_c": {
+            "age": ["kitten", "newborn"]
+        },
+      "relationships": [
+          {
+            "cats_from": ["m_c"],
+            "cats_to": ["clan"],
+            "mutual": false,
+            "values": ["like", "comfort"],
+            "amount": 5,
+            "log": {
+                "cats_from": "cat_from is comforted by the cat_to's acceptance of {PRONOUN/cat_from/poss} gender."
+            }
+        }
+      ]
+    },
+    {
+        "event_id": "gen_misc_transition_parent_to_male",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "transition"
+        ],
+        "frequency": 4,
+        "event_text": "Looking at {PRONOUN/m_c/poss} adorable litter, m_c realized {PRONOUN/m_c/subject} would rather be a father than a mother.",
+        "m_c": {
+            "age": ["-kitten"],
+            "relationship_status": ["parent/child"],
+            "gender": [
+                "female"
+            ]
+        },
+        "new_gender": [
+            "trans male"
+        ],
+        "r_c": {
+            "age": ["kitten", "newborn"]
+        },
+      "relationships": [
+          {
+            "cats_from": ["m_c"],
+            "cats_to": ["clan"],
+            "mutual": false,
+            "values": ["like", "comfort"],
+            "amount": 5,
+            "log": {
+                "cats_from": "cat_from is comforted by the cat_to's acceptance of {PRONOUN/cat_from/poss} gender."
+            }
+        }
+      ]
+    },
+    {
+        "event_id": "gen_misc_transition_parent_to_female",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "transition"
+        ],
+        "frequency": 4,
+        "event_text": "Looking at {PRONOUN/m_c/poss} adorable litter, m_c realized {PRONOUN/m_c/subject} would rather be a mother than a father.",
+        "m_c": {
+            "age": ["-kitten"],
+            "relationship_status": ["parent/child"],
+            "gender": [
+                "male"
+            ]
+        },
+        "new_gender": [
+            "trans female"
+        ],
+        "r_c": {
+            "age": ["kitten", "newborn"]
+        },
+      "relationships": [
+          {
+            "cats_from": ["m_c"],
+            "cats_to": ["clan"],
+            "mutual": false,
+            "values": ["like", "comfort"],
+            "amount": 5,
+            "log": {
+                "cats_from": "cat_from is comforted by the cat_to's acceptance of {PRONOUN/cat_from/poss} gender."
+            }
+        }
+      ]
+    },
+    {
+        "event_id": "gen_misc_transition_nervoustoparent_from_female",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "transition"
+        ],
+        "frequency": 4,
+        "event_text": "It took m_c a while to muster up the courage to talk to their parent, r_c, but finally quietly mentioned {PRONOUN/m_c/subject} would rather not be seen as a she-cat. r_c later gave m_c a gift as congratulations on figuring this out, saying {PRONOUN/r_c/subject} would always be proud of m_c.",
+        "new_accessory": ["WILD"],
+        "m_c": {
+            "age": ["-kitten"],
+            "relationship_status": ["child/parent"],
+            "gender": [
+                "female"
+            ]
+        },
+        "new_gender": [
+            "trans male",
+            "nonbinary"
+        ],
+        "r_c": {
+            "age": ["any"]
+        },
+      "relationships": [
+          {
+            "cats_from": ["m_c"],
+            "cats_to": ["clan"],
+            "mutual": false,
+            "values": ["like", "comfort"],
+            "amount": 5,
+            "log": {
+                "cats_from": "cat_from is comforted by the cat_to's acceptance of {PRONOUN/cat_from/poss} gender."
+            }
+        },
+        {
+            "cats_from": ["m_c"],
+            "cats_to": ["r_c"],
+            "mutual": false,
+            "values": ["like", "comfort", "trust"],
+            "amount": 5,
+            "log": {
+                "cats_from": "cat_from trusts cat_to enough to talk about {PRONOUN/cat_from/poss} gender."
+            }
+        },
+        {
+            "cats_from": ["r_c"],
+            "cats_to": ["m_c"],
+            "mutual": false,
+            "values": ["like", "comfort", "trust"],
+            "amount": 5,
+            "log": {
+                "cats_from": "cat_from was happy to help cat_to feel more comfortable with {PRONOUN/cat_to/poss} gender."
+            }
+        }
+      ]
+    },
+    {
+        "event_id": "gen_misc_transition_nervoustoparent_from_male",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "transition"
+        ],
+        "frequency": 4,
+        "event_text": "It took m_c a while to muster up the courage to talk to their parent, r_c, but finally quietly mentioned {PRONOUN/m_c/subject} would rather not be seen as a tom. r_c later gave m_c a gift as congratulations on figuring this out, saying {PRONOUN/r_c/subject} would always be proud of m_c.",
+        "new_accessory": ["WILD"],
+        "m_c": {
+            "age": ["-kitten"],
+            "trait": ["nervous", "insecure", "gloomy"],
+            "relationship_status": ["child/parent"],
+            "gender": [
+                "male"
+            ]
+        },
+        "new_gender": [
+            "trans female",
+            "nonbinary"
+        ],
+        "r_c": {
+            "age": ["any"]
+        },
+      "relationships": [
+          {
+            "cats_from": ["m_c"],
+            "cats_to": ["clan"],
+            "mutual": false,
+            "values": ["like", "comfort"],
+            "amount": 5,
+            "log": {
+                "cats_from": "cat_from is comforted by the cat_to's acceptance of {PRONOUN/cat_from/poss} gender."
+            }
+        },
+        {
+            "cats_from": ["m_c"],
+            "cats_to": ["r_c"],
+            "mutual": false,
+            "values": ["like", "comfort", "trust"],
+            "amount": 5,
+            "log": {
+                "cats_from": "cat_from trusts cat_to enough to talk about {PRONOUN/cat_from/poss} gender."
+            }
+        },
+        {
+            "cats_from": ["r_c"],
+            "cats_to": ["m_c"],
+            "mutual": false,
+            "values": ["like", "comfort", "trust"],
+            "amount": 5,
+            "log": {
+                "cats_from": "cat_from was happy to help cat_to feel more comfortable with {PRONOUN/cat_to/poss} gender."
+            }
+        }
+      ]
+    },
+    {
+        "event_id": "gen_misc_transition_mates_from_male",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "transition"
+        ],
+        "frequency": 4,
+        "event_text": "r_c and m_c were on a walk together when m_c mentioned that {PRONOUN/m_c/subject} might not be a tom. While a bit surprised, r_c assured {PRONOUN/m_c/subject} that doesn't matter. {PRONOUN/r_c/subject} would be proud to have m_c as {PRONOUN/r_c/poss} partner no matter what.",
+        "m_c": {
+            "age": ["-kitten"],
+            "relationship_status": ["mates"],
+            "gender": [
+                "male"
+            ]
+        },
+        "new_gender": [
+            "trans female",
+            "nonbinary"
+        ],
+        "r_c": {
+            "age": ["any"]
+        },
+      "relationships": [
+          {
+            "cats_from": ["m_c"],
+            "cats_to": ["clan"],
+            "mutual": false,
+            "values": ["like", "comfort"],
+            "amount": 5,
+            "log": {
+                "cats_from": "cat_from is comforted by the cat_to's acceptance of {PRONOUN/cat_from/poss} gender."
+            }
+        },
+        {
+            "cats_from": ["m_c"],
+            "cats_to": ["r_c"],
+            "mutual": false,
+            "values": ["like", "comfort", "trust"],
+            "amount": 5,
+            "log": {
+                "cats_from": "cat_from trusts cat_to enough to talk about {PRONOUN/cat_from/poss} gender."
+            }
+        },
+        {
+            "cats_from": ["r_c"],
+            "cats_to": ["m_c"],
+            "mutual": false,
+            "values": ["like", "comfort", "trust"],
+            "amount": 5,
+            "log": {
+                "cats_from": "cat_from was happy to help cat_to feel more comfortable with {PRONOUN/cat_to/poss} gender."
+            }
+        }
+      ]
+    },
+    {
+        "event_id": "gen_misc_transition_mates_from_female",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "transition"
+        ],
+        "frequency": 4,
+        "event_text": "r_c and m_c were on a walk together when m_c mentioned that {PRONOUN/m_c/subject} might not be a she-cat. While a bit surprised, r_c assured {PRONOUN/m_c/subject} that doesn't matter. {PRONOUN/r_c/subject} would be proud to have m_c as {PRONOUN/r_c/poss} partner no matter what.",
+        "m_c": {
+            "age": ["-kitten"],
+            "relationship_status": ["mates"],
+            "gender": [
+                "female"
+            ]
+        },
+        "new_gender": [
+            "trans male",
+            "nonbinary"
+        ],
+        "r_c": {
+            "age": ["any"]
+        },
+      "relationships": [
+          {
+            "cats_from": ["m_c"],
+            "cats_to": ["clan"],
+            "mutual": false,
+            "values": ["like", "comfort"],
+            "amount": 5,
+            "log": {
+                "cats_from": "cat_from is comforted by the cat_to's acceptance of {PRONOUN/cat_from/poss} gender."
+            }
+        },
+        {
+            "cats_from": ["m_c"],
+            "cats_to": ["r_c"],
+            "mutual": false,
+            "values": ["like", "comfort", "trust"],
+            "amount": 5,
+            "log": {
+                "cats_from": "cat_from trusts cat_to enough to talk about {PRONOUN/cat_from/poss} gender."
+            }
+        },
+        {
+            "cats_from": ["r_c"],
+            "cats_to": ["m_c"],
+            "mutual": false,
+            "values": ["like", "comfort", "trust"],
+            "amount": 5,
+            "log": {
+                "cats_from": "cat_from was happy to help cat_to feel more comfortable with {PRONOUN/cat_to/poss} gender."
+            }
+        }
+      ]
+    },
+    {
+        "event_id": "gen_misc_transition_butterfly_from_male",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "transition"
+        ],
+        "frequency": 4,
+        "event_text": "m_c had found a acc_singular to wear. Taking it as a sign, {PRONOUN/m_c/subject} announced that tom doesn't describe {PRONOUN/m_c/object} anymore. Going through life as {PRONOUN/m_c/poss} true self might be a scary change, but a positive one, like the butterfly going trough metamorphosis.",
+        "new_accessory": ["ROSY MOTH WINGS", "MORPHO BUTTERFLY", "MONARCH BUTTERFLY"],
+        "m_c": {
+            "age": ["-kitten"],
+            "gender": [
+                "male"
+            ]
+        },
+        "new_gender": [
+            "trans female",
+            "nonbinary"
+        ],
+      "relationships": [
+          {
+            "cats_from": ["m_c"],
+            "cats_to": ["clan"],
+            "mutual": false,
+            "values": ["like", "comfort"],
+            "amount": 5,
+            "log": {
+                "cats_from": "cat_from is comforted by the cat_to's acceptance of {PRONOUN/cat_from/poss} gender."
+            }
+        }
+      ]
+    },
+    {
+        "event_id": "gen_misc_transition_butterfly_from_female",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "transition"
+        ],
+        "frequency": 4,
+        "event_text": "m_c had found a acc_singular to wear. Taking it as a sign, {PRONOUN/m_c/subject} announced that she-cat doesn't describe {PRONOUN/m_c/object} anymore. Going through life as {PRONOUN/m_c/poss} true self might be a scary change, but a positive one, like the butterfly going trough metamorphosis.",
+        "new_accessory": ["ROSY MOTH WINGS", "MORPHO BUTTERFLY", "MONARCH BUTTERFLY"],
+        "m_c": {
+            "age": ["-kitten"],
+            "gender": [
+                "female"
+            ]
+        },
+        "new_gender": [
+            "trans male",
+            "nonbinary"
+        ],
+      "relationships": [
+          {
+            "cats_from": ["m_c"],
+            "cats_to": ["clan"],
+            "mutual": false,
+            "values": ["like", "comfort"],
+            "amount": 5,
+            "log": {
+                "cats_from": "cat_from is comforted by the cat_to's acceptance of {PRONOUN/cat_from/poss} gender."
+            }
+        }
+      ]
+    },
+    {
+        "event_id": "gen_misc_transition_flower_to_male",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "transition"
+        ],
+        "frequency": 4,
+        "event_text": "Flowers bloom and change into beautiful versions of themselves. m_c took a acc_singular to wear, before telling c_n {PRONOUN/m_c/subject} {VERB/m_c/are/is} a tom.",
+        "new_accessory": ["POPPY", "FORGET ME NOTS", "ORANGE POPPY", "CYAN POPPY", "WHITE POPPY", "PINK POPPY", "BLUEBELLS", "LILY OF THE VALLEY", "SNAPDRAGON", "HEATHER", "GORSE", "LAVENDER", "BULB WHITE", "BULB YELLOW", "BULB ORANGE", "BULB PINK", "BULB BLUE", "ROSE MALLOW", "PICKLEWEED", "DESERT WILLOW", "CACTUS FLOWER", "PRAIRIE FIRE", "VERBENA EAR", "VERBENA PELT", "WISTERIA", "GOLDEN CREEPING JENNY", "DAISY"],
+        "m_c": {
+            "age": ["-kitten"],
+            "gender": [
+                "female"
+            ]
+        },
+        "new_gender": [
+            "trans male"
+        ],
+      "relationships": [
+          {
+            "cats_from": ["m_c"],
+            "cats_to": ["clan"],
+            "mutual": false,
+            "values": ["like", "comfort"],
+            "amount": 5,
+            "log": {
+                "cats_from": "cat_from is comforted by the cat_to's acceptance of {PRONOUN/cat_from/poss} gender."
+            }
+        }
+      ]
+    },
+    {
+        "event_id": "gen_misc_transition_flower_to_female",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "transition"
+        ],
+        "frequency": 4,
+        "event_text": "Flowers bloom and change into beautiful versions of themselves. m_c took a acc_singular to wear, before telling c_n {PRONOUN/m_c/subject} {VERB/m_c/are/is} a she-cat.",
+        "new_accessory": ["POPPY", "FORGET ME NOTS", "ORANGE POPPY", "CYAN POPPY", "WHITE POPPY", "PINK POPPY", "BLUEBELLS", "LILY OF THE VALLEY", "SNAPDRAGON", "HEATHER", "GORSE", "LAVENDER", "BULB WHITE", "BULB YELLOW", "BULB ORANGE", "BULB PINK", "BULB BLUE", "ROSE MALLOW", "PICKLEWEED", "DESERT WILLOW", "CACTUS FLOWER", "PRAIRIE FIRE", "VERBENA EAR", "VERBENA PELT", "WISTERIA", "GOLDEN CREEPING JENNY", "DAISY"],
+        "m_c": {
+            "age": ["-kitten"],
+            "gender": [
+                "male"
+            ]
+        },
+        "new_gender": [
+            "trans female"
+        ],
+      "relationships": [
+          {
+            "cats_from": ["m_c"],
+            "cats_to": ["clan"],
+            "mutual": false,
+            "values": ["like", "comfort"],
+            "amount": 5,
+            "log": {
+                "cats_from": "cat_from is comforted by the cat_to's acceptance of {PRONOUN/cat_from/poss} gender."
+            }
+        }
+      ]
+    },
+    {
+        "event_id": "gen_misc_transition_flower_to_nonbinary",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "transition"
+        ],
+        "frequency": 4,
+        "event_text": "Flowers bloom and change into beautiful versions of themselves. m_c took a acc_singular to wear, before telling c_n {PRONOUN/m_c/subject} {VERB/m_c/are/is} not a she-cat nor a tom.",
+        "new_accessory": ["POPPY", "FORGET ME NOTS", "ORANGE POPPY", "CYAN POPPY", "WHITE POPPY", "PINK POPPY", "BLUEBELLS", "LILY OF THE VALLEY", "SNAPDRAGON", "HEATHER", "GORSE", "LAVENDER", "BULB WHITE", "BULB YELLOW", "BULB ORANGE", "BULB PINK", "BULB BLUE", "ROSE MALLOW", "PICKLEWEED", "DESERT WILLOW", "CACTUS FLOWER", "PRAIRIE FIRE", "VERBENA EAR", "VERBENA PELT", "WISTERIA", "GOLDEN CREEPING JENNY", "DAISY"],
+        "m_c": {
+            "age": ["-kitten"],
+            "gender": [
+                "male",
+                "female"
+            ]
+        },
+        "new_gender": [
+            "nonbinary"
+        ],
+      "relationships": [
+          {
+            "cats_from": ["m_c"],
+            "cats_to": ["clan"],
+            "mutual": false,
+            "values": ["like", "comfort"],
+            "amount": 5,
+            "log": {
+                "cats_from": "cat_from is comforted by the cat_to's acceptance of {PRONOUN/cat_from/poss} gender."
+            }
+        }
+      ]
+    },
+    {
+        "event_id": "gen_misc_transition_whatisgender_male_to_nonbinary",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "transition"
+        ],
+        "frequency": 4,
+        "event_text": "m_c was baffled when {PRONOUN/m_c/subject} realized some cats <i>do</i> care about being called a tom, a she-cat, or anything else. {PRONOUN/m_c/subject/CAP} don't particularly care what {PRONOUN/m_c/subject} {VERB/m_c/are/is} called, but {PRONOUN/m_c/subject} suppose {PRONOUN/m_c/subject} {VERB/m_c/are/is}n't a tom in that case.",
+            "m_c": {
+            "age": ["-kitten"],
+            "gender": [
+                "male"
+            ]
+        },
+        "new_gender": [
+            "nonbinary"
+        ],
+      "relationships": [
+          {
+            "cats_from": ["m_c"],
+            "cats_to": ["clan"],
+            "mutual": false,
+            "values": ["like", "comfort"],
+            "amount": 5,
+            "log": {
+                "cats_from": "cat_from is comforted by the cat_to's acceptance of {PRONOUN/cat_from/poss} gender."
+            }
+        }
+      ]
+    },
+    {
+        "event_id": "gen_misc_transition_whatisgender_female_to_nonbinary",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "transition"
+        ],
+        "frequency": 4,
+        "event_text": "m_c was baffled when {PRONOUN/m_c/subject} realized some cats <i>do</i> care about being called a tom, a she-cat, or anything else. {PRONOUN/m_c/subject/CAP} don't particularly care what {PRONOUN/m_c/subject} {VERB/m_c/are/is} called, but {PRONOUN/m_c/subject} suppose {PRONOUN/m_c/subject} {VERB/m_c/are/is}n't a she-cat in that case.",
+            "m_c": {
+            "age": ["-kitten"],
+            "gender": [
+                "female"
+            ]
+        },
+        "new_gender": [
+            "nonbinary"
+        ],
+      "relationships": [
+          {
+            "cats_from": ["m_c"],
+            "cats_to": ["clan"],
+            "mutual": false,
+            "values": ["like", "comfort"],
+            "amount": 5,
+            "log": {
+                "cats_from": "cat_from is comforted by the cat_to's acceptance of {PRONOUN/cat_from/poss} gender."
+            }
+        }
+      ]
+    },
+    {
         "event_id": "gen_misc_taintedPOI_stinky1",
         "location": [
             "any"

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -17686,7 +17686,7 @@
             "transition"
         ],
         "frequency": 4,
-        "event_text": "m_c is growing up, and with that comes figuring out who {PRONOUN/m_c/subject} {VERB/m_c/are/is}, which turned out to be neither a tom nor a she-cat.",
+        "event_text": "m_c is growing up, and with that comes figuring out who {PRONOUN/m_c/subject} {VERB/m_c/are/is}. As it turned out, who {PRONOUN/m_c/subject} {VERB/m_c/are/is} happened to be neither a tom nor a she-cat.",
         "m_c": {
             "status": ["apprentice", "mediator apprentice", "medicine cat apprentice"],
             "gender": [
@@ -17722,7 +17722,7 @@
             "transition"
         ],
         "frequency": 4,
-        "event_text": "m_c is growing up, and with that comes figuring out who {PRONOUN/m_c/subject} {VERB/m_c/are/is}, which turned out to be a she-cat.",
+        "event_text": "m_c is growing up, and with that comes figuring out who {PRONOUN/m_c/subject} {VERB/m_c/are/is}. As it turned out, who {PRONOUN/m_c/subject} {VERB/m_c/are/is} happened to be a she-cat.",
         "m_c": {
             "status": ["apprentice", "mediator apprentice", "medicine cat apprentice"],
             "gender": [
@@ -17757,7 +17757,7 @@
             "transition"
         ],
         "frequency": 4,
-        "event_text": "m_c is growing up, and with that comes figuring out who {PRONOUN/m_c/subject} {VERB/m_c/are/is}, which turned out to be a tom.",
+        "event_text": "m_c is growing up, and with that comes figuring out who {PRONOUN/m_c/subject} {VERB/m_c/are/is}. As it turned out, who {PRONOUN/m_c/subject} {VERB/m_c/are/is} happened to be a tom.",
         "m_c": {
             "status": ["apprentice", "mediator apprentice", "medicine cat apprentice"],
             "gender": [
@@ -18007,7 +18007,7 @@
             "transition"
         ],
         "frequency": 4,
-        "event_text": "It's surprisingly obvious on hindsight, m_c explains. {PRONOUN/m_c/subject/CAP} just <i>{VERB/m_c/know/knows}</i> {PRONOUN/m_c/subject} {VERB/m_c/are/is} not a tom or a she-cat, there's no other logical explanation for this feeling. c_n is happy to celebrate the discovery.",
+        "event_text": "It's surprisingly obvious on hindsight, m_c explained. {PRONOUN/m_c/subject/CAP} just <i>knew</i> {PRONOUN/m_c/subject} {VERB/m_c/were/was}n't a tom or a she-cat, there's no other logical explanation for this feeling. c_n was happy to celebrate the discovery.",
         "m_c": {
             "trait": ["strict", "thoughtful", "calm", "sincere", "responsible", "wise"],
             "gender": [
@@ -18043,7 +18043,7 @@
             "transition"
         ],
         "frequency": 4,
-        "event_text": "It's surprisingly obvious on hindsight, m_c explains. {PRONOUN/m_c/subject/CAP} just <i>{VERB/m_c/know/knows}</i> {PRONOUN/m_c/subject} {VERB/m_c/are/is} a she-cat, there's no other logical explanation for this feeling. c_n is happy to celebrate the discovery.",
+        "event_text": "It's surprisingly obvious on hindsight, m_c explained. {PRONOUN/m_c/subject/CAP} just <i>knew</i> {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} a she-cat, there's no other logical explanation for this feeling. c_n was happy to celebrate the discovery.",
         "m_c": {
             "trait": ["strict", "thoughtful", "calm", "sincere", "responsible", "wise"],
             "gender": [
@@ -18078,7 +18078,7 @@
             "transition"
         ],
         "frequency": 4,
-        "event_text": "It's surprisingly obvious on hindsight, m_c explains. {PRONOUN/m_c/subject/CAP} just <i>{VERB/m_c/know/knows}</i> {PRONOUN/m_c/subject} {VERB/m_c/are/is} a tom, there's no other logical explanation for this feeling. c_n is happy to celebrate the discovery.",
+        "event_text": "It's surprisingly obvious on hindsight, m_c explained. {PRONOUN/m_c/subject/CAP} just <i>knew</i> {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} a tom, there's no other logical explanation for this feeling. c_n was happy to celebrate the discovery.",
         "m_c": {
             "trait": ["strict", "thoughtful", "calm", "sincere", "responsible", "wise"],
             "gender": [
@@ -18340,7 +18340,7 @@
             "transition"
         ],
         "frequency": 4,
-        "event_text": "m_c explained to r_c that {PRONOUN/m_c/subject} don't feel like a tom. r_c nodded impatiently, happy for m_c, but could they get back to playing now?",
+        "event_text": "m_c explained to r_c that {PRONOUN/m_c/subject} {VERB/m_c/don't/doesn't} feel like a tom. r_c nodded impatiently, happy for m_c, but could they get back to playing now?",
         "m_c": {
             "age": ["kitten"],
             "relationship_status": ["likes", "listens_to", "relates_to"],
@@ -18380,7 +18380,7 @@
             "transition"
         ],
         "frequency": 4,
-        "event_text": "m_c explained to r_c that {PRONOUN/m_c/subject} don't feel like a she-cat. r_c nodded impatiently, happy for m_c, but could they get back to playing now?",
+        "event_text": "m_c explained to r_c that {PRONOUN/m_c/subject} {VERB/m_c/don't/doesn't} feel like a she-cat. r_c nodded impatiently, happy for m_c, but could they get back to playing now?",
         "m_c": {
             "age": ["kitten"],
             "relationship_status": ["likes", "listens_to", "relates_to"],
@@ -18420,7 +18420,7 @@
             "transition"
         ],
         "frequency": 4,
-        "event_text": "m_c quietly talked to {PRONOUN/m_c/poss} mentor, r_c, and confessed {PRONOUN/m_c/subject} don't feel like a she-cat. r_c reassured {PRONOUN/m_c/object}, and offered to help tell c_n, if that was what m_c wanted. After all, it's r_c's job to help.",
+        "event_text": "m_c quietly talked to {PRONOUN/m_c/poss} mentor, r_c, and confessed that {PRONOUN/m_c/subject} {VERB/m_c/don't/doesn't} feel like a she-cat. r_c reassured {PRONOUN/m_c/object} and offered to help tell c_n, if that was what m_c wanted. After all, it's r_c's job to help.",
         "m_c": {
             "status": ["apprentice", "mediator apprentice", "medicine cat apprentice"],
             "relationship_status": ["trusts", "app/mentor"],
@@ -18480,7 +18480,7 @@
             "transition"
         ],
         "frequency": 4,
-        "event_text": "m_c quietly talked to {PRONOUN/m_c/poss} mentor, r_c, and confessed {PRONOUN/m_c/subject} don't feel like a tom. r_c reassured {PRONOUN/m_c/object}, and offered to help tell c_n, if that was what m_c wanted. After all, it's r_c's job to help.",
+        "event_text": "m_c quietly talked to {PRONOUN/m_c/poss} mentor, r_c, and confessed that {PRONOUN/m_c/subject} {VERB/m_c/don't/doesn't} feel like a tom. r_c reassured {PRONOUN/m_c/object} and offered to help tell c_n, if that was what m_c wanted. After all, it's r_c's job to help.",
         "m_c": {
             "status": ["apprentice", "mediator apprentice", "medicine cat apprentice"],
             "relationship_status": ["trusts", "app/mentor"],
@@ -18618,7 +18618,7 @@
             "transition"
         ],
         "frequency": 4,
-        "event_text": "m_c sighed over the very relatable experience of not wanting to be a tom or she-cat. r_c noted that that probably wasn't a universal experience. The next day, m_c had an announcement to make.",
+        "event_text": "m_c sighed over the very relatable experience of wanting to be neither a tom or she-cat. r_c noted that that probably wasn't a universal experience. The next day, m_c had an announcement to make.",
         "m_c": {
             "age": ["-kitten"],
             "relationship_status": ["trusts", "likes"],
@@ -18899,7 +18899,7 @@
             "transition"
         ],
         "frequency": 4,
-        "event_text": "r_c and m_c were on a walk together when m_c mentioned that {PRONOUN/m_c/subject} might not be a tom. While a bit surprised, r_c assured {PRONOUN/m_c/subject} that doesn't matter. {PRONOUN/r_c/subject/CAP} would be proud to have m_c as {PRONOUN/r_c/poss} partner no matter what.",
+        "event_text": "r_c and m_c were on a walk together when m_c mentioned that {PRONOUN/m_c/subject} might not be a tom. While a bit surprised, r_c assured {PRONOUN/m_c/object} that {PRONOUN/m_c/poss} gender doesn't matter. {PRONOUN/r_c/subject/CAP} would be proud to have m_c as {PRONOUN/r_c/poss} partner no matter what.",
         "m_c": {
             "age": ["-kitten"],
             "relationship_status": ["mates"],
@@ -18959,7 +18959,7 @@
             "transition"
         ],
         "frequency": 4,
-        "event_text": "r_c and m_c were on a walk together when m_c mentioned that {PRONOUN/m_c/subject} might not be a she-cat. While a bit surprised, r_c assured {PRONOUN/m_c/subject} that doesn't matter. {PRONOUN/r_c/subject/CAP} would be proud to have m_c as {PRONOUN/r_c/poss} partner no matter what.",
+        "event_text": "r_c and m_c were on a walk together when m_c mentioned that {PRONOUN/m_c/subject} might not be a she-cat. While a bit surprised, r_c assured {PRONOUN/m_c/object} that {PRONOUN/m_c/poss} gender doesn't matter. {PRONOUN/r_c/subject/CAP} would be proud to have m_c as {PRONOUN/r_c/poss} partner no matter what.",
         "m_c": {
             "age": ["-kitten"],
             "relationship_status": ["mates"],
@@ -19019,7 +19019,7 @@
             "transition"
         ],
         "frequency": 4,
-        "event_text": "m_c had found a acc_singular to wear. Taking it as a sign, {PRONOUN/m_c/subject} announced that tom doesn't describe {PRONOUN/m_c/object} anymore. Going through life as {PRONOUN/m_c/poss} true self might be a scary change, but a positive one, like the butterfly going trough metamorphosis.",
+        "event_text": "m_c found a acc_singular to wear. Taking it as a sign, {PRONOUN/m_c/subject} announced that tom doesn't describe {PRONOUN/m_c/object} anymore. Going through life as {PRONOUN/m_c/poss} true self might be a scary change, but a positive one, like the butterfly going through metamorphosis.",
         "new_accessory": ["ROSY MOTH WINGS", "MORPHO BUTTERFLY", "MONARCH BUTTERFLY"],
         "m_c": {
             "age": ["-kitten"],
@@ -19056,7 +19056,7 @@
             "transition"
         ],
         "frequency": 4,
-        "event_text": "m_c had found a acc_singular to wear. Taking it as a sign, {PRONOUN/m_c/subject} announced that she-cat doesn't describe {PRONOUN/m_c/object} anymore. Going through life as {PRONOUN/m_c/poss} true self might be a scary change, but a positive one, like the butterfly going trough metamorphosis.",
+        "event_text": "m_c found a acc_singular to wear. Taking it as a sign, {PRONOUN/m_c/subject} announced that she-cat doesn't describe {PRONOUN/m_c/object} anymore. Going through life as {PRONOUN/m_c/poss} true self might be a scary change, but a positive one, like the butterfly going through metamorphosis.",
         "new_accessory": ["ROSY MOTH WINGS", "MORPHO BUTTERFLY", "MONARCH BUTTERFLY"],
         "m_c": {
             "age": ["-kitten"],
@@ -19093,7 +19093,7 @@
             "transition"
         ],
         "frequency": 4,
-        "event_text": "Flowers bloom and change into beautiful versions of themselves. m_c took a acc_singular to wear, before telling c_n {PRONOUN/m_c/subject} {VERB/m_c/are/is} a tom.",
+        "event_text": "Flowers bloom and change into beautiful versions of themselves. m_c took a acc_singular to wear before telling c_n {PRONOUN/m_c/subject} {VERB/m_c/are/is} a tom.",
         "new_accessory": ["POPPY", "FORGET ME NOTS", "ORANGE POPPY", "CYAN POPPY", "WHITE POPPY", "PINK POPPY", "BLUEBELLS", "LILY OF THE VALLEY", "SNAPDRAGON", "HEATHER", "GORSE", "LAVENDER", "BULB WHITE", "BULB YELLOW", "BULB ORANGE", "BULB PINK", "BULB BLUE", "ROSE MALLOW", "PICKLEWEED", "DESERT WILLOW", "CACTUS FLOWER", "PRAIRIE FIRE", "VERBENA EAR", "VERBENA PELT", "WISTERIA", "GOLDEN CREEPING JENNY", "DAISY"],
         "m_c": {
             "age": ["-kitten"],
@@ -19129,7 +19129,7 @@
             "transition"
         ],
         "frequency": 4,
-        "event_text": "Flowers bloom and change into beautiful versions of themselves. m_c took a acc_singular to wear, before telling c_n {PRONOUN/m_c/subject} {VERB/m_c/are/is} a she-cat.",
+        "event_text": "Flowers bloom and change into beautiful versions of themselves. m_c took a acc_singular to wear before telling c_n {PRONOUN/m_c/subject} {VERB/m_c/are/is} a she-cat.",
         "new_accessory": ["POPPY", "FORGET ME NOTS", "ORANGE POPPY", "CYAN POPPY", "WHITE POPPY", "PINK POPPY", "BLUEBELLS", "LILY OF THE VALLEY", "SNAPDRAGON", "HEATHER", "GORSE", "LAVENDER", "BULB WHITE", "BULB YELLOW", "BULB ORANGE", "BULB PINK", "BULB BLUE", "ROSE MALLOW", "PICKLEWEED", "DESERT WILLOW", "CACTUS FLOWER", "PRAIRIE FIRE", "VERBENA EAR", "VERBENA PELT", "WISTERIA", "GOLDEN CREEPING JENNY", "DAISY"],
         "m_c": {
             "age": ["-kitten"],
@@ -19165,7 +19165,7 @@
             "transition"
         ],
         "frequency": 4,
-        "event_text": "Flowers bloom and change into beautiful versions of themselves. m_c took a acc_singular to wear, before telling c_n {PRONOUN/m_c/subject} {VERB/m_c/are/is} not a she-cat nor a tom.",
+        "event_text": "Flowers bloom and change into beautiful versions of themselves. m_c took a acc_singular to wear before telling c_n {PRONOUN/m_c/subject} {VERB/m_c/are/is} neither a she-cat nor a tom.",
         "new_accessory": ["POPPY", "FORGET ME NOTS", "ORANGE POPPY", "CYAN POPPY", "WHITE POPPY", "PINK POPPY", "BLUEBELLS", "LILY OF THE VALLEY", "SNAPDRAGON", "HEATHER", "GORSE", "LAVENDER", "BULB WHITE", "BULB YELLOW", "BULB ORANGE", "BULB PINK", "BULB BLUE", "ROSE MALLOW", "PICKLEWEED", "DESERT WILLOW", "CACTUS FLOWER", "PRAIRIE FIRE", "VERBENA EAR", "VERBENA PELT", "WISTERIA", "GOLDEN CREEPING JENNY", "DAISY"],
         "m_c": {
             "age": ["-kitten"],
@@ -19202,7 +19202,7 @@
             "transition"
         ],
         "frequency": 4,
-        "event_text": "m_c was baffled when {PRONOUN/m_c/subject} realized some cats <i>do</i> care about being called a tom, a she-cat, or anything else. {PRONOUN/m_c/subject/CAP} don't particularly care what {PRONOUN/m_c/subject} {VERB/m_c/are/is} called, but {PRONOUN/m_c/subject} suppose {PRONOUN/m_c/subject} {VERB/m_c/are/is}n't a tom in that case.",
+        "event_text": "m_c was baffled when {PRONOUN/m_c/subject} realized some cats <i>do</i> care about being called a tom, a she-cat, or anything else. {PRONOUN/m_c/subject/CAP} {VERB/m_c/don't/doesn't} particularly care what {PRONOUN/m_c/subject} {VERB/m_c/are/is} called, but {PRONOUN/m_c/subject} {VERB/m_c/suppose/supposes} {PRONOUN/m_c/subject} {VERB/m_c/are/is}n't a tom in that case.",
             "m_c": {
             "age": ["-kitten"],
             "gender": [

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -17650,7 +17650,7 @@
             "transition"
         ],
         "frequency": 4,
-        "event_text": "m_c could never put a paw on what exactly they were feeling, but they realized they don't need to know the details. For now, simply <i>not</i> being a tom or she-cat is more than enough.",
+        "event_text": "m_c could never put a paw on what exactly {PRONOUN/m_c/subject} {VERB/m_c/were/was} feeling, but {PRONOUN/m_c/subject} realized {PRONOUN/m_c/subject} {VERB/m_c/don't/doesn't} need to know the details. For now, simply <i>not</i> being a tom or she-cat is more than enough.",
         "m_c": {
             "age": ["-kitten"],
             "gender": [
@@ -18658,7 +18658,7 @@
             "transition"
         ],
         "frequency": 4,
-        "event_text": "Looking at {PRONOUN/m_c/poss} adorable litter, m_c realized {PRONOUN/m_c/subject} would rather just be a parent than what {PRONOUN/m_c/subject} had assumed {PRONOUN/m_c/subject} were.",
+        "event_text": "Looking at {PRONOUN/m_c/poss} adorable litter, m_c realized {PRONOUN/m_c/subject} would rather just be a parent instead of a mother or father.",
         "m_c": {
             "age": ["-kitten"],
             "relationship_status": ["parent/child"],

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -17935,7 +17935,7 @@
             "transition"
         ],
         "frequency": 4,
-        "event_text": "m_c realized {PRONOUN/m_c/subject} would much rather not be known as either a tom nor a she-cat, and decided to announce this with a pretty new accessory. After all, the discovery deserved a celebration!",
+        "event_text": "m_c realized {PRONOUN/m_c/subject} would much rather be known as a tom, and decided to announce this with a pretty new accessory. After all, the discovery deserved a celebration!",
        "new_accessory": ["WILD"],
         "m_c": {
             "trait": ["playful", "bold", "daring", "confident", "shameless", "flamboyant"],
@@ -17971,7 +17971,7 @@
             "transition"
         ],
         "frequency": 4,
-        "event_text": "m_c realized {PRONOUN/m_c/subject} would much rather not be known as either a tom nor a she-cat, and decided to announce this with a pretty new accessory. After all, the discovery deserved a celebration!",
+        "event_text": "m_c realized {PRONOUN/m_c/subject} would much rather be known as a she-cat, and decided to announce this with a pretty new accessory. After all, the discovery deserved a celebration!",
        "new_accessory": ["WILD"],
         "m_c": {
             "trait": ["playful", "bold", "daring", "confident", "shameless", "flamboyant"],
@@ -18007,7 +18007,7 @@
             "transition"
         ],
         "frequency": 4,
-        "event_text": "It's surprisingly obvious on hindsight, m_c explains. {PRONOUN/m_c/subject/CAP} just <i>know</i> {PRONOUN/m_c/subject} {VERB/m_c/are/is} not a tom or a she-cat, there's no other logical explanation for this feeling. c_n is happy to celebrate their discovery.",
+        "event_text": "It's surprisingly obvious on hindsight, m_c explains. {PRONOUN/m_c/subject/CAP} just <i>{VERB/m_c/know/knows}</i> {PRONOUN/m_c/subject} {VERB/m_c/are/is} not a tom or a she-cat, there's no other logical explanation for this feeling. c_n is happy to celebrate the discovery.",
         "m_c": {
             "trait": ["strict", "thoughtful", "calm", "sincere", "responsible", "wise"],
             "gender": [
@@ -18043,7 +18043,7 @@
             "transition"
         ],
         "frequency": 4,
-        "event_text": "It's surprisingly obvious on hindsight, m_c explains. {PRONOUN/m_c/subject/CAP} just <i>know</i> {PRONOUN/m_c/subject} {VERB/m_c/are/is} a she-cat, there's no other logical explanation for this feeling. c_n is happy to celebrate their discovery.",
+        "event_text": "It's surprisingly obvious on hindsight, m_c explains. {PRONOUN/m_c/subject/CAP} just <i>{VERB/m_c/know/knows}</i> {PRONOUN/m_c/subject} {VERB/m_c/are/is} a she-cat, there's no other logical explanation for this feeling. c_n is happy to celebrate the discovery.",
         "m_c": {
             "trait": ["strict", "thoughtful", "calm", "sincere", "responsible", "wise"],
             "gender": [
@@ -18078,7 +18078,7 @@
             "transition"
         ],
         "frequency": 4,
-        "event_text": "It's surprisingly obvious on hindsight, m_c explains. {PRONOUN/m_c/subject/CAP} just <i>know</i> {PRONOUN/m_c/subject} {VERB/m_c/are/is} a tom, there's no other logical explanation for this feeling. c_n is happy to celebrate their discovery.",
+        "event_text": "It's surprisingly obvious on hindsight, m_c explains. {PRONOUN/m_c/subject/CAP} just <i>{VERB/m_c/know/knows}</i> {PRONOUN/m_c/subject} {VERB/m_c/are/is} a tom, there's no other logical explanation for this feeling. c_n is happy to celebrate the discovery.",
         "m_c": {
             "trait": ["strict", "thoughtful", "calm", "sincere", "responsible", "wise"],
             "gender": [
@@ -18219,7 +18219,7 @@
             "transition"
         ],
         "frequency": 4,
-        "event_text": "m_c was glad for c_n's support when {PRONOUN/m_c/subject} announced {PRONOUN/m_c/subject} {{VERB/m_c/are/is} neither a she-cat nor a tom. The moment still felt bittersweet when {PRONOUN/m_c/subject} later looked at the night sky, knowing a particularly bright star meant r_c is proud of the cat {PRONOUN/r_c/poss} child has become.",
+        "event_text": "m_c was glad for c_n's support when {PRONOUN/m_c/subject} announced {PRONOUN/m_c/subject} {VERB/m_c/are/is} neither a she-cat nor a tom. The moment still felt bittersweet when {PRONOUN/m_c/subject} later looked at the night sky, knowing a particularly bright star meant r_c is proud of the cat {PRONOUN/r_c/poss} child has become.",
         "m_c": {
             "age": ["-kitten"],
             "relationship_status": ["child/parent"],
@@ -18260,7 +18260,7 @@
             "transition"
         ],
         "frequency": 4,
-        "event_text": "m_c was glad for c_n's support when {PRONOUN/m_c/subject} announced {PRONOUN/m_c/subject} {{VERB/m_c/are/is} a she-cat. The moment still felt bittersweet when {PRONOUN/m_c/subject} later looked at the night sky, knowing a particularly bright star meant r_c is proud of the cat {PRONOUN/r_c/poss} daughter has become.",
+        "event_text": "m_c was glad for c_n's support when {PRONOUN/m_c/subject} announced {PRONOUN/m_c/subject} {VERB/m_c/are/is} a she-cat. The moment still felt bittersweet when {PRONOUN/m_c/subject} later looked at the night sky, knowing a particularly bright star meant r_c is proud of the cat {PRONOUN/r_c/poss} daughter has become.",
         "m_c": {
             "age": ["-kitten"],
             "relationship_status": ["child/parent"],
@@ -18300,7 +18300,7 @@
             "transition"
         ],
         "frequency": 4,
-        "event_text": "m_c was glad for c_n's support when {PRONOUN/m_c/subject} announced {PRONOUN/m_c/subject} {{VERB/m_c/are/is} a tom. The moment still felt bittersweet when {PRONOUN/m_c/subject} later looked at the night sky, knowing a particularly bright star meant r_c is proud of the cat {PRONOUN/r_c/poss} son has become.",
+        "event_text": "m_c was glad for c_n's support when {PRONOUN/m_c/subject} announced {PRONOUN/m_c/subject} {VERB/m_c/are/is} a tom. The moment still felt bittersweet when {PRONOUN/m_c/subject} later looked at the night sky, knowing a particularly bright star meant r_c is proud of the cat {PRONOUN/r_c/poss} son has become.",
         "m_c": {
             "age": ["-kitten"],
             "relationship_status": ["child/parent"],
@@ -18420,7 +18420,7 @@
             "transition"
         ],
         "frequency": 4,
-        "event_text": "m_c quietly talked to {PRONOUN/m_c/poss} mentor, r_c, and confessed {PRONOUN/m_c/subject} don't feel like a she-cat. r_c reassured {PRONOUN/m_c/subject}, and offered to help tell c_n, if that was what m_c wanted. After all, it's r_c's job to help.",
+        "event_text": "m_c quietly talked to {PRONOUN/m_c/poss} mentor, r_c, and confessed {PRONOUN/m_c/subject} don't feel like a she-cat. r_c reassured {PRONOUN/m_c/object}, and offered to help tell c_n, if that was what m_c wanted. After all, it's r_c's job to help.",
         "m_c": {
             "status": ["apprentice", "mediator apprentice", "medicine cat apprentice"],
             "relationship_status": ["trusts", "app/mentor"],
@@ -18480,7 +18480,7 @@
             "transition"
         ],
         "frequency": 4,
-        "event_text": "m_c quietly talked to {PRONOUN/m_c/poss} mentor, r_c, and confessed {PRONOUN/m_c/subject} don't feel like a tom. r_c reassured {PRONOUN/m_c/subject}, and offered to help tell c_n, if that was what m_c wanted. After all, it's r_c's job to help.",
+        "event_text": "m_c quietly talked to {PRONOUN/m_c/poss} mentor, r_c, and confessed {PRONOUN/m_c/subject} don't feel like a tom. r_c reassured {PRONOUN/m_c/object}, and offered to help tell c_n, if that was what m_c wanted. After all, it's r_c's job to help.",
         "m_c": {
             "status": ["apprentice", "mediator apprentice", "medicine cat apprentice"],
             "relationship_status": ["trusts", "app/mentor"],
@@ -19191,7 +19191,7 @@
       ]
     },
     {
-        "event_id": "gen_misc_transition_whatisgender_male_to_nonbinary",
+        "event_id": "gen_misc_transition_whatisgender_to_nonbinary",
         "location": [
             "any"
         ],
@@ -19206,41 +19206,7 @@
             "m_c": {
             "age": ["-kitten"],
             "gender": [
-                "male"
-            ]
-        },
-        "new_gender": [
-            "nonbinary"
-        ],
-      "relationships": [
-          {
-            "cats_from": ["m_c"],
-            "cats_to": ["clan"],
-            "mutual": false,
-            "values": ["like", "comfort"],
-            "amount": 5,
-            "log": {
-                "cats_from": "cat_from is comforted by the cat_to's acceptance of {PRONOUN/cat_from/poss} gender."
-            }
-        }
-      ]
-    },
-    {
-        "event_id": "gen_misc_transition_whatisgender_female_to_nonbinary",
-        "location": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "sub_type": [
-            "transition"
-        ],
-        "frequency": 4,
-        "event_text": "m_c was baffled when {PRONOUN/m_c/subject} realized some cats <i>do</i> care about being called a tom, a she-cat, or anything else. {PRONOUN/m_c/subject/CAP} don't particularly care what {PRONOUN/m_c/subject} {VERB/m_c/are/is} called, but {PRONOUN/m_c/subject} suppose {PRONOUN/m_c/subject} {VERB/m_c/are/is}n't a she-cat in that case.",
-            "m_c": {
-            "age": ["-kitten"],
-            "gender": [
+                "male",
                 "female"
             ]
         },


### PR DESCRIPTION
## About The Pull Request

Adds 16 more events for cats, including two non-binary specific ones and a few specific to traits or relationships

## Why This Is Good For ClanGen

Adds more variety! Can also make the transition events feel a bit more unique to the cats' personalities and story

## Proof of Testing

With debug tool (including one gender for every event, if an event has more types they're identical except some word swap). Also did fix the capitalization issue on the mates-specific one, just didn't have the time to find a new screenshot
<img width="674" height="397" alt="image" src="https://github.com/user-attachments/assets/b68241e7-2874-40f4-a1d4-d93bb21f0ee4" />
<img width="637" height="166" alt="image" src="https://github.com/user-attachments/assets/771a42a0-7de5-440b-afa4-ced728d3c958" />
<img width="654" height="192" alt="image" src="https://github.com/user-attachments/assets/f2e8c224-8a85-48e7-9b84-cecaf587e103" />
<img width="648" height="142" alt="image" src="https://github.com/user-attachments/assets/04434a54-5875-4b15-bd59-16e90e99ee71" />
<img width="632" height="151" alt="image" src="https://github.com/user-attachments/assets/36abdc14-2dc7-4795-9b11-fb8eaed64537" />
<img width="645" height="164" alt="image" src="https://github.com/user-attachments/assets/a13781b5-c004-4936-8cfb-df5b23deeaba" />
<img width="619" height="218" alt="image" src="https://github.com/user-attachments/assets/7b4c5a49-71ff-4bc7-a8aa-bbc2f2eef239" />
<img width="639" height="400" alt="image" src="https://github.com/user-attachments/assets/ec4e9c26-a6c7-4f83-8786-aa2a8947af0a" />
<img width="650" height="197" alt="image" src="https://github.com/user-attachments/assets/2a3ccde3-512b-48b7-80a5-4707116e647d" />
<img width="655" height="290" alt="image" src="https://github.com/user-attachments/assets/8a911f51-f72b-47b6-b494-eb549f456c39" />
<img width="649" height="161" alt="image" src="https://github.com/user-attachments/assets/c6c23625-5a07-4b0e-8161-4f72ca11a720" />
<img width="640" height="195" alt="image" src="https://github.com/user-attachments/assets/9d18cd1d-90a8-4250-ac53-3e6f6087fbff" />
<img width="642" height="124" alt="image" src="https://github.com/user-attachments/assets/e672c60c-9636-4085-a1e5-e5d73f8fd432" />
<img width="642" height="199" alt="image" src="https://github.com/user-attachments/assets/f555eb5a-59b3-446d-b6c9-8cebbaf8a68a" />
<img width="671" height="207" alt="image" src="https://github.com/user-attachments/assets/9cbb6724-4b2e-49ab-be17-cfbff56eee55" />


## Changelog/Credits

Adds 16 new transition events to ClanGen, including two non-binary specific ones and a few specific to traits or relationships
