### PR TITLE
[LAGFIX] restructure thought retrieval

### DIFF
--- a/scripts/events_module/event_filters.py
+++ b/scripts/events_module/event_filters.py
@@ -362,6 +362,8 @@ def event_for_required_cat_types(
     """
     Checks if the required_types dict is being fulfilled
     """
+    if not required_types:
+        return True
 
     for c_type, amount_range in required_types.items():
         type_list = current_cat_types.get(c_type, [])

--- a/scripts/events_module/text_pool_event/check_general_constraints.py
+++ b/scripts/events_module/text_pool_event/check_general_constraints.py
@@ -51,7 +51,7 @@ def passes_general_constraints(
             print("DEBUG: requested event does not meet constraints (tags)")
         return False
 
-    if hasattr(event, "required_reputation"):
+    if hasattr(event, "required_reputation") and event.required_reputation:
         if not event_for_reputation(event.required_reputation.get("outsider")):
             if is_debug_event:
                 print(
@@ -68,7 +68,7 @@ def passes_general_constraints(
                 )
                 return False
 
-    if hasattr(event, "supply"):
+    if hasattr(event, "supply") and event.supply:
         clan_size = get_living_clan_cat_count(primary_cat)
         for block in event.supply:
             if not block.get("trigger"):

--- a/scripts/events_module/thoughts/generate_thoughts.py
+++ b/scripts/events_module/thoughts/generate_thoughts.py
@@ -1,5 +1,5 @@
 import traceback
-from random import choice, getrandbits
+from random import choice, getrandbits, choices
 from typing import TYPE_CHECKING, Optional
 
 import i18n
@@ -44,30 +44,21 @@ def new_thought(
                 "debug_ensure_thought_id"
             ]
 
-            thought_options = []
-            for thought in _load_allowed_thoughts(thought_type, main_cat):
-                if _constraints_fulfilled(
-                    main_cat=main_cat,
-                    random_cat=other_cat,
-                    thought=thought,
-                    other_clan_id=other_clan_id,
-                ):
-                    if ensured_id and ensured_id != thought.event_id:
-                        continue
-
-                    thought_options.append(thought)
-
-            if not thought_options and ensured_id:
+            chosen_thought_group = _get_valid_event(
+                main_cat=main_cat,
+                random_cat=other_cat,
+                possible_thoughts=_load_allowed_thoughts(thought_type, main_cat),
+                other_clan_id=other_clan_id,
+            )
+            if ensured_id and ensured_id != chosen_thought_group.event_id:
                 print(
                     "Thought ID ensured, but the ensured thoughts could not be found. This cat likely doesn't meet the constraints."
                 )
 
-            chosen_thought_group = choice(thought_options)
-
             # only use ensured index if a thought as been ensured
             ensured_index: int = (
                 constants.CONFIG["thought_generation"]["debug_ensure_thought_index"]
-                if constants.CONFIG["thought_generation"]["debug_ensure_thought_id"]
+                if ensured_id
                 else None
             )
 
@@ -78,16 +69,19 @@ def new_thought(
                 else choice(chosen_thought_group.strings)
             )
 
-    except IndexError:
+    except ValueError:
         traceback.print_exc()
         chosen_thought = i18n.t("defaults.thought")
 
     return chosen_thought
 
 
-def _constraints_fulfilled(
-    main_cat: "Cat", random_cat: "Cat", thought: TextPoolEvent, other_clan_id: str
-) -> bool:
+def _get_valid_event(
+    main_cat: "Cat",
+    random_cat: "Cat",
+    possible_thoughts: list[TextPoolEvent],
+    other_clan_id: str,
+) -> Optional[TextPoolEvent]:
     """Check if thought constraints are fulfilled"""
     involved_cats = {
         "m_c": main_cat,
@@ -101,49 +95,77 @@ def _constraints_fulfilled(
     else:
         other_clan = None
 
-    if not passes_general_constraints(
-        thought,
-        primary_cat=main_cat,
-        involved_cats=involved_cats,
-        other_clan=other_clan,
-    ):
-        return False
+    ensured_id = constants.CONFIG["thought_generation"]["debug_ensure_thought_id"]
+    ensured_event: Optional[TextPoolEvent] = None
+    if ensured_id:
+        ensured = [e for e in possible_thoughts if e.event_id == ensured_id]
+        ensured_event = ensured[0] if ensured else None
 
-    # check that we have a random cat if the thought requires one
-    if not random_cat:
-        r_c_in_text = [
-            thought_str for thought_str in thought.strings if "r_c" in thought_str
-        ]
-        r_c_constraint = thought.involved_cats.get("r_c")
-        # r_c mentioned in text or required with constraints, so we dump this thought
-        if r_c_in_text or r_c_constraint or thought.relationship_constraint:
-            return False
+    chosen_event: Optional[TextPoolEvent] = None
+    possible_thoughts = possible_thoughts.copy()
+    while not chosen_event and possible_thoughts:
+        event_to_test = (
+            ensured_event
+            if ensured_event
+            else choices(possible_thoughts, [e.weight for e in possible_thoughts])[0]
+        )
+        # clear this value so that if we can't use the event, we just move on to unensured ones
+        ensured_event = None
 
-    if thought.involved_cats:
-        if not event_for_cat(
-            thought.involved_cats.get("m_c", {}),
-            cat=main_cat,
-            involved_cat_dict=involved_cats,
-            event_id=thought.event_id,
-            other_involved_clan_id=other_clan_id,
+        if not passes_general_constraints(
+            event_to_test,
+            primary_cat=main_cat,
+            involved_cats=involved_cats,
+            other_clan=other_clan,
         ):
-            return False
+            possible_thoughts.remove(event_to_test)
+            continue
 
-        if not event_for_cat(
-            thought.involved_cats.get("r_c", {}),
+        # check that we have a random cat if the thought requires one
+        if not random_cat:
+            r_c_in_text = [
+                thought_str
+                for thought_str in event_to_test.strings
+                if "r_c" in thought_str
+            ]
+            r_c_constraint = event_to_test.involved_cats.get("r_c")
+            # r_c mentioned in text or required with constraints, so we dump this thought
+            if r_c_in_text or r_c_constraint or event_to_test.relationship_constraint:
+                possible_thoughts.remove(event_to_test)
+                continue
+
+        if event_to_test.involved_cats:
+            if not event_for_cat(
+                event_to_test.involved_cats.get("m_c", {}),
+                cat=main_cat,
+                involved_cat_dict=involved_cats,
+                event_id=event_to_test.event_id,
+                other_involved_clan_id=other_clan_id,
+            ):
+                possible_thoughts.remove(event_to_test)
+                continue
+
+        if random_cat and not event_for_cat(
+            event_to_test.involved_cats.get("r_c", {}),
             cat=random_cat,
             involved_cat_dict=involved_cats,
-            event_id=thought.event_id,
+            event_id=event_to_test.event_id,
             other_involved_clan_id=other_clan_id,
         ):
-            return False
+            possible_thoughts.remove(event_to_test)
+            continue
 
-    if thought.relationship_constraint:
-        for constraints in thought.relationship_constraint:
-            if not check_rel_constraint_groups(constraints, involved_cats):
-                return False
+        if event_to_test.relationship_constraint:
+            if not all(
+                check_rel_constraint_groups(constraints, involved_cats)
+                for constraints in event_to_test.relationship_constraint
+            ):
+                possible_thoughts.remove(event_to_test)
+                continue
 
-    return True
+        chosen_event = event_to_test
+
+    return chosen_event
 
 
 def get_other_cat_for_thought(


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
Fixes the thought lag!
This was mainly being caused by the `.supply` check, so having that only run if the event *has* a supply value rly mitigated the problem that was added by hooking up the `check_general_constraints()` to thoughts.

However, thoughts were also still running on the old "filter all thoughts, pick one of those filtered thoughts" system.  So to *further* speed us up, I've changed them over to our new convention of "pick one thought from unfiltered list, check if its constraints pass, use if it does or test the next thought".  This means that we *don't* filter every single possible thought. We just filter *until* we find one that passes all it's constraints. This makes it significantly faster.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Why This Is Good For ClanGen
Via a line profile looking at our two bottlenecks: `passes_general_constraints` and `event_for_cat` calls in thoughts. This was for the generation of a single thought upon opening a cat profile page.

With PR changes:
435 microseconds spent on `passes_general_constraints` 
720 microseconds spent on `event_for_cat`

Without PR changes:
164290 microseconds spent on `passes_general_constraints` 
8824 microseconds spent on `event_for_cat`
<!-- If this is a bug fix, you can remove this section. -->
<!-- Please add a short description of why you think these changes would benefit the game. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->
<!-- If you have multiple features that can stand on their own, or unrelated bugfixes, please create separate PRs for them. -->

## Linked Issues
fixes #5791
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
<img width="390" height="53" alt="image" src="https://github.com/user-attachments/assets/6750ef83-66be-401e-b4a3-8e43fd65257d" />
<img width="264" height="68" alt="image" src="https://github.com/user-attachments/assets/cb03562b-eed1-4c49-aff4-d41c531b765f" />

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Fixes the lag caused by generating a thought
- Thoughts also now utilize weights, so a more highly constrained thought will have higher chances of occurring when it's possible.
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
