### PR TITLE
[BUGFIX] Cat name duped in result message

### DIFF
--- a/scripts/events_module/text_pool_event/handle_consequences.py
+++ b/scripts/events_module/text_pool_event/handle_consequences.py
@@ -130,9 +130,10 @@ def _handle_joining(
                     cat.skills.secondary.interest_only = True
 
         joined.extend(cat_list)
-        for c in joined:
-            cat_names.append(_profile_link(c))
-            c.assign_thought(CatThought.ON_JOIN)
+        
+    for c in joined:
+        cat_names.append(_profile_link(c))
+        c.assign_thought(CatThought.ON_JOIN)
 
     relation_events.trigger_joining_relationship_events(joined)
 

--- a/scripts/events_module/text_pool_event/handle_consequences.py
+++ b/scripts/events_module/text_pool_event/handle_consequences.py
@@ -130,7 +130,7 @@ def _handle_joining(
                     cat.skills.secondary.interest_only = True
 
         joined.extend(cat_list)
-        
+
     for c in joined:
         cat_names.append(_profile_link(c))
         c.assign_thought(CatThought.ON_JOIN)

--- a/scripts/events_module/text_pool_event/handle_consequences.py
+++ b/scripts/events_module/text_pool_event/handle_consequences.py
@@ -130,11 +130,11 @@ def _handle_joining(
                     cat.skills.secondary.interest_only = True
 
         joined.extend(cat_list)
-        for c in joined:
-            cat_names.append(_profile_link(c))
-            c.get_new_thought(CatThought.ON_JOIN)
+    for c in joined:
+        cat_names.append(_profile_link(c))
+        c.get_new_thought(CatThought.ON_JOIN)
 
-        relation_events.trigger_joining_relationship_events(joined)
+    relation_events.trigger_joining_relationship_events(joined)
 
     return i18n.t("screens.patrol.new_outsider", cats=adjust_list_text(cat_names))
 


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
Fixes new cat names sometimes being listed twice when they join the clan, specifically when they're joining along with a litter of kittens. This was just due to a section of code being nested in a for loop that it shouldn't have been.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Proof of Testing
<img width="668" height="436" alt="image" src="https://github.com/user-attachments/assets/6a41bb00-adb0-4d0f-b505-b7e86b4e7505" />

No name duping!
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Fixes names sometimes being listed twice in results when a new cat joined the clan via patrol
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
