### PR TITLE
[CLEANUP] Preventing thought circular imports

### DIFF
--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -38,10 +38,6 @@ from scripts.cat.personality import Personality
 from scripts.cat.skills import CatSkills, SkillPath, scale_progress
 from scripts.cat.status import Status
 from scripts.config import get_config
-from scripts.events_module.thoughts.generate_thoughts import (
-    new_thought,
-    get_other_cat_for_thought,
-)
 from scripts.cat_relations.inheritance import Inheritance
 from scripts.cat_relations.inheritance2 import inheritance_db
 from scripts.cat_relations.relationship import Relationship
@@ -245,6 +241,8 @@ class Cat:
         self.placement = None
         self.example = example
         self.thought = ""
+        self.next_thought_type: CatThought = CatThought.WHILE_ALIVE
+        self.assign_thought()
 
         # conditions setup
         self.illnesses = {}
@@ -513,7 +511,7 @@ class Cat:
         # Deal with leader death
         if self.status.is_leader:
             if game.clan.leader_lives > 0:
-                self.get_new_thought(CatThought.ON_DEATH)
+                self.assign_thought(CatThought.ON_DEATH)
                 return
 
             if game.clan.leader_lives <= 0:
@@ -525,7 +523,7 @@ class Cat:
             self.dead = True
             game.just_died.append(self.ID)
 
-        self.get_new_thought(CatThought.ON_DEATH)
+        self.assign_thought(CatThought.ON_DEATH)
 
         for app in self.apprentice.copy():
             fetched_cat = Cat.fetch_cat(app)
@@ -551,7 +549,7 @@ class Cat:
         """This is used to send a cat into exile."""
 
         self.status.exile_from_group()
-        self.get_new_thought(CatThought.ON_EXILE)
+        self.assign_thought(CatThought.ON_EXILE)
 
         for app in self.apprentice:
             fetched_cat = Cat.fetch_cat(app)
@@ -718,7 +716,7 @@ class Cat:
                 (CatSocial.KITTYPET, CatSocial.LONER, CatSocial.ROGUE)
             )
         self.status.leave_group(new_social_status=new_social_status)
-        self.get_new_thought()
+        self.assign_thought()
 
         for app in self.apprentice.copy():
             app_ob = Cat.fetch_cat(app)
@@ -744,7 +742,7 @@ class Cat:
 
         self.update_mentor()
 
-        self.get_new_thought(CatThought.ON_LOST)
+        self.assign_thought(CatThought.ON_LOST)
 
         for x in self.apprentice:
             Cat.fetch_cat(x).update_mentor()
@@ -837,11 +835,11 @@ class Cat:
             CatRank.NEWBORN,
             CatRank.KITTEN,
         ):  # newborn and kitten aren't really "ranks" to be promoted to
-            self.get_new_thought(CatThought.ON_RANK_CHANGE)
+            self.assign_thought(CatThought.ON_RANK_CHANGE)
         # however we don't want kittens to somehow have a newborn thought, so we'll have them reset to a normal kitten thought
         # just in case
         if new_thought and new_rank == CatRank.KITTEN:
-            self.get_new_thought()
+            self.assign_thought()
 
         # update class dictionary
         self.all_cats[self.ID] = self
@@ -1420,6 +1418,9 @@ class Cat:
             self.personality.facet_wobble(facet_max=2)
             self.pelt.rebuild_sprite = True
 
+        # reset next thought type
+        self.assign_thought()
+
         if not self.status.alive_in_player_clan:
             # this is handled in events.py
             self.personality.set_kit(self.age.is_baby())
@@ -1432,58 +1433,23 @@ class Cat:
         if self.status.rank.is_any_apprentice_rank():
             self.update_mentor()
 
-    def get_new_thought(
-        self,
-        thought_type: CatThought = None,
-        other_clan_cats: list = None,
-        other_cat: Cat = None,
-    ):
+    def assign_thought(self, thought_type: CatThought = None):
         """
-        Generates a thought for the cat, which displays on their profile.
+        Assigns next thought type to be displayed on cat's profile.
         :param thought_type: Indicate what type of thought should be generated
-        :param other_clan_cats: If cat is in a different clan, pass the list of their clanmates
-        :param other_cat: If a specific other cat should be included, include their object here.
         """
+        # reset current thought
+        self.thought = None
         # default thought type
         if not thought_type:
-            thought_type = (
-                CatThought.WHILE_DEAD if self.dead else CatThought.WHILE_ALIVE
-            )
+            if game.clan and self is game.clan.instructor:
+                thought_type = CatThought.IS_GUIDE
+            elif self.dead:
+                thought_type = CatThought.WHILE_DEAD
+            else:
+                thought_type = CatThought.WHILE_ALIVE
 
-        if self.status.is_other_clancat and not self.dead:
-            cat_list = other_clan_cats.copy() if other_clan_cats else []
-            other_clan_id = self.status.group_ID
-        else:
-            cat_list = self.all_cats_list.copy()
-            other_clan_id = (
-                choice(game.clan.other_clan_IDs)
-                if game.clan
-                and hasattr(game.clan, "other_clan_ids")
-                and game.clan.other_clan_IDs
-                else None
-            )  # this is so stupid convoluted because of tests and game.clan initialization
-
-        if not other_cat:
-            other_cat = get_other_cat_for_thought(
-                cat_list=cat_list,
-                main_cat=self,
-            )
-
-        # get chosen thought
-        chosen_thought = new_thought(
-            thought_type, self, other_cat, other_clan_id=other_clan_id
-        )
-
-        chosen_thought = event_text_adjust(
-            self.__class__,
-            chosen_thought,
-            main_cat=self,
-            random_cat=other_cat,
-            clan=game.clan,
-        )
-
-        # insert thought
-        self.thought = str(chosen_thought)
+        self.next_thought_type = thought_type
 
     def moon_skip_illness(self, illness):
         """handles the moon skip for illness"""

--- a/scripts/clan.py
+++ b/scripts/clan.py
@@ -17,7 +17,7 @@ import i18n
 import ujson
 
 from scripts.cat.cats import Cat, BACKSTORIES
-from scripts.cat.enums import CatRank, CatGroup, CatSocial, CatCompatibility
+from scripts.cat.enums import CatRank, CatGroup, CatSocial, CatCompatibility, CatThought
 from scripts.cat.factories.new_cat_factory import NewCatFactory
 from scripts.cat.factories.typed_dicts import StatusDict
 from scripts.cat.names import Name
@@ -768,6 +768,8 @@ class Clan:
             # update_sprite(game.clan.instructor)
             game.clan.instructor.dead = True
             game.clan.add_cat(game.clan.instructor)
+
+        game.clan.instructor.assign_thought(CatThought.IS_GUIDE)
 
         # check for symbol
         if "clan_symbol" in clan_data:

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -41,6 +41,7 @@ from scripts.events_module.relationship import relation_events
 from scripts.events_module.pregnancy import pregnancy_events
 from scripts.events_module.short.condition_events import Condition_Events
 from scripts.events_module.short.short_event_generation import create_short_event
+from scripts.events_module.thoughts.generate_thoughts import get_new_thought
 from scripts.game_structure import constants
 from scripts.game_structure.game.switches import (
     Switch,
@@ -139,7 +140,6 @@ def one_moon():
     # Calling of "one_moon" functions.
     other_clan_cats = [c for c in Cat.all_cats_list if c.status.is_other_clancat]
     for cat in Cat.all_cats_list.copy():
-        cat.thought = None
         if cat.status.alive_in_player_clan or cat.status.group.is_afterlife():
             one_moon_cat(cat)
         elif not cat.status.group or cat.status.is_other_clancat:
@@ -159,7 +159,6 @@ def one_moon():
                     game.clan.grief_strings.pop(ID)
 
         # Generate events
-
         for cat_id, details in game.clan.grief_strings.items():
             for _info in details:
                 text = _info[0]
@@ -167,8 +166,12 @@ def one_moon():
                 grief_type = _info[2]
 
                 if grief_type == "minor":
-                    Cat.fetch_cat(cat_id).get_new_thought(
-                        text, other_cat=Cat.fetch_cat(cats[0])
+                    # we get a new thought directly instead of using assign_thought
+                    # because we need to include a specific other cat
+                    get_new_thought(
+                        main_cat=Cat.fetch_cat(cat_id),
+                        thought_type=text,
+                        other_cat=Cat.fetch_cat(cats[0]),
                     )
 
                 else:

--- a/scripts/events_module/consequences.py
+++ b/scripts/events_module/consequences.py
@@ -752,7 +752,7 @@ def create_new_cat(
             new_cat.die()
 
         # newbie thought
-        new_cat.get_new_thought(thought)
+        new_cat.assign_thought(thought)
 
         # and they exist now
         created_cats.append(new_cat)

--- a/scripts/events_module/pregnancy/create_kits.py
+++ b/scripts/events_module/pregnancy/create_kits.py
@@ -182,7 +182,7 @@ def get_kits(
                 status_dict=kitten_status,
             )
 
-        kit.get_new_thought()
+        kit.assign_thought()
 
         # make lost status match parent
         if cat and cat.status.is_lost():
@@ -280,13 +280,13 @@ def get_kits(
     # add them as adoptive parents if not
     final_adoptive_parents = []
     for adoptive_p in all_adoptive_parents:
-        Cat.fetch_cat(adoptive_p).get_new_thought(CatThought.ON_BIRTH)
+        Cat.fetch_cat(adoptive_p).assign_thought(CatThought.ON_BIRTH)
         if adoptive_p not in inheritance_db.get_relatives(all_kitten[0].ID, True):
             final_adoptive_parents.append(adoptive_p)
     if not adoptive_parents:
-        cat.get_new_thought(CatThought.ON_BIRTH)
+        cat.assign_thought(CatThought.ON_BIRTH)
         if other_cat:
-            cat.get_new_thought(CatThought.ON_BIRTH)
+            cat.assign_thought(CatThought.ON_BIRTH)
 
     # Add the adoptive parents.
     if final_adoptive_parents:
@@ -457,13 +457,13 @@ def handle_adoption(cat: Cat, other_cat: Optional[Cat] = None):
     )
 
     cats_involved = {"m_c": cat}
-    cat.get_new_thought(CatThought.ON_BIRTH)
+    cat.assign_thought(CatThought.ON_BIRTH)
     if other_cat:
         cats_involved["r_c"] = other_cat
-        other_cat.get_new_thought(CatThought.ON_BIRTH)
+        other_cat.assign_thought(CatThought.ON_BIRTH)
 
     for kit in kits:
-        kit.get_new_thought()
+        kit.assign_thought()
 
     # Normally, birth cooldown is only applied to cat who gave birth. However, if we don't apply birth cooldown to
     # adoption, we get too much adoption, since adoptive couples are using the increased two-parent kits chance.

--- a/scripts/events_module/text_pool_event/handle_consequences.py
+++ b/scripts/events_module/text_pool_event/handle_consequences.py
@@ -132,7 +132,7 @@ def _handle_joining(
         joined.extend(cat_list)
         for c in joined:
             cat_names.append(_profile_link(c))
-            c.get_new_thought(CatThought.ON_JOIN)
+            c.assign_thought(CatThought.ON_JOIN)
 
         relation_events.trigger_joining_relationship_events(joined)
 

--- a/scripts/events_module/thoughts/generate_thoughts.py
+++ b/scripts/events_module/thoughts/generate_thoughts.py
@@ -1,14 +1,16 @@
 import traceback
 from random import choice, getrandbits, choices
-from typing import TYPE_CHECKING, Optional
+from typing import Optional
 
 import i18n
 
+from scripts.cat.cats import Cat
 from scripts.cat.enums import CatGroup, CatThought, CatAge
 from scripts.events_module.event_filters import (
     event_for_cat,
     check_rel_constraint_groups,
 )
+from scripts.events_module.text_adjust import event_text_adjust
 from scripts.events_module.text_pool_event.check_general_constraints import (
     passes_general_constraints,
 )
@@ -16,14 +18,62 @@ from scripts.events_module.text_pool_event.text_pool_event import TextPoolEvent
 from scripts.game_structure import game, constants
 from scripts.game_structure.localization import load_lang_resource
 
-if TYPE_CHECKING:
-    from scripts.cat.cats import Cat
-
 loaded_thoughts = {}
 
 
-def new_thought(
-    thought_type: CatThought, main_cat: "Cat", other_cat: "Cat", other_clan_id: str
+def get_new_thought(
+    main_cat: Cat, thought_type: CatThought = None, other_cat: Cat = None
+):
+    """
+    Generates a thought for the cat, which displays on their profile.
+    :param main_cat: The cat object receiving the thought.
+    :param thought_type: Indicate what type of thought should be generated
+    :param other_cat: If a specific other cat should be included, include their object here.
+    """
+    # default thought type
+    if not thought_type:
+        thought_type = (
+            CatThought.WHILE_DEAD if main_cat.dead else CatThought.WHILE_ALIVE
+        )
+
+    if main_cat.status.is_other_clancat and not main_cat.dead:
+        cat_list = [c for c in Cat.all_cats_list if c.status.is_other_clancat]
+        other_clan_id = main_cat.status.group_ID
+    else:
+        cat_list = main_cat.all_cats_list.copy()
+        other_clan_id = (
+            choice(game.clan.other_clan_IDs)
+            if game.clan
+            and hasattr(game.clan, "other_clan_ids")
+            and game.clan.other_clan_IDs
+            else None
+        )  # this is so stupid convoluted because of tests and game.clan initialization
+
+    if not other_cat:
+        other_cat = _get_other_cat_for_thought(
+            cat_list=cat_list,
+            main_cat=main_cat,
+        )
+
+    # get chosen thought
+    chosen_thought = _new_thought(
+        thought_type, main_cat, other_cat, other_clan_id=other_clan_id
+    )
+
+    chosen_thought = event_text_adjust(
+        Cat,
+        chosen_thought,
+        main_cat=main_cat,
+        random_cat=other_cat,
+        clan=game.clan,
+    )
+
+    # insert thought
+    main_cat.thought = str(chosen_thought)
+
+
+def _new_thought(
+    thought_type: CatThought, main_cat: Cat, other_cat: Cat, other_clan_id: str
 ):
     """
     Finds a thought appropriate for the given args.
@@ -77,8 +127,8 @@ def new_thought(
 
 
 def _get_valid_event(
-    main_cat: "Cat",
-    random_cat: "Cat",
+    main_cat: Cat,
+    random_cat: Cat,
     possible_thoughts: list[TextPoolEvent],
     other_clan_id: str,
 ) -> Optional[TextPoolEvent]:
@@ -168,9 +218,7 @@ def _get_valid_event(
     return chosen_event
 
 
-def get_other_cat_for_thought(
-    cat_list: list["Cat"], main_cat: "Cat"
-) -> Optional["Cat"]:
+def _get_other_cat_for_thought(cat_list: list[Cat], main_cat: Cat) -> Optional[Cat]:
     """
     Returns a cat object selected from the given cat_list. This will be a cat acceptable as the subject of main_cat's thought.
     """
@@ -219,7 +267,7 @@ def get_other_cat_for_thought(
     return other_cat
 
 
-def _load_allowed_thoughts(thought_type: CatThought, main_cat: "Cat"):
+def _load_allowed_thoughts(thought_type: CatThought, main_cat: Cat):
     """
     Loads and returns thoughts appropriate for the given cat.
     """
@@ -317,7 +365,7 @@ def _load_allowed_thoughts(thought_type: CatThought, main_cat: "Cat"):
     return thoughts
 
 
-def _get_exiled_and_former(main_cat: "Cat", path) -> list:
+def _get_exiled_and_former(main_cat: Cat, path) -> list:
     """
     Checks if cat needs exiled or former clancat thoughts and returns loaded resources
     """
@@ -333,7 +381,7 @@ def _get_exiled_and_former(main_cat: "Cat", path) -> list:
     return thoughts
 
 
-def _get_general(main_cat: "Cat", path) -> list:
+def _get_general(main_cat: Cat, path) -> list:
     """
     Returns general thoughts if the cat is not a newborn
     """
@@ -344,7 +392,7 @@ def _get_general(main_cat: "Cat", path) -> list:
     return []
 
 
-def _get_clancat(main_cat: "Cat", path) -> list:
+def _get_clancat(main_cat: Cat, path) -> list:
     """
     Returns clancat thoughts if the cat is a clancat
     """

--- a/scripts/screens/ChangeGenderScreen.py
+++ b/scripts/screens/ChangeGenderScreen.py
@@ -75,7 +75,7 @@ class ChangeGenderScreen(Screens):
                 if self.are_boxes_full():
                     gender_identity = self.get_new_identity()
                     self.the_cat.genderalign = gender_identity
-                    self.the_cat.get_new_thought()
+                    self.the_cat.assign_thought()
                     self.selected_cat_elements["identity_changed"].show()
                     self.selected_cat_elements["cat_gender"].kill()
                     self.selected_cat_elements[
@@ -96,14 +96,14 @@ class ChangeGenderScreen(Screens):
                 if event.ui_element.cat_id == "add":
                     if event.ui_element.cat_object not in self.the_cat.pronouns:
                         self.the_cat.pronouns.append(event.ui_element.cat_object)
-                        self.the_cat.get_new_thought()
+                        self.the_cat.assign_thought()
                 elif event.ui_element.cat_id == "remove":
                     if (
                         event.ui_element.cat_object in self.the_cat.pronouns
                         and len(self.the_cat.pronouns) > 1
                     ):
                         self.the_cat.pronouns.remove(event.ui_element.cat_object)
-                        self.the_cat.get_new_thought()
+                        self.the_cat.assign_thought()
                 elif event.ui_element.cat_id == "delete":
                     if event.ui_element.cat_object in pronouns.get_custom_pronouns():
                         game.clan.custom_pronouns[i18n.config.get("locale")].remove(

--- a/scripts/screens/ProfileScreen.py
+++ b/scripts/screens/ProfileScreen.py
@@ -17,6 +17,7 @@ from scripts.cat.cats import Cat, BACKSTORIES
 from scripts.clan_resources.freshkill import FRESHKILL_ACTIVE
 from scripts.game_structure import image_cache, game
 from scripts.ui.windows.cruel_locked_action import CruelLockedAction
+from ..events_module.thoughts.generate_thoughts import get_new_thought
 from ..ui.elements.modified_image import UIModifiedImage
 from ..ui.elements.text_box_tweaked import UITextBoxTweaked
 from ..ui.elements.image_button import UIImageButton
@@ -298,7 +299,7 @@ class ProfileScreen(Screens):
                 elif self.the_cat.genderalign in ["trans female", "trans male"]:
                     self.the_cat.genderalign = "nonbinary"
                 self.the_cat.pronouns = get_new_pronouns(self.the_cat.genderalign)
-                self.the_cat.get_new_thought()
+                self.the_cat.assign_thought()
                 self.clear_profile()
                 self.build_profile()
                 self.update_disabled_buttons_and_text()
@@ -331,7 +332,7 @@ class ProfileScreen(Screens):
                                 new_group_ID=CatGroup.DARK_FOREST_ID
                             )
 
-                        self.the_cat.get_new_thought(CatThought.IS_GUIDE)
+                        self.the_cat.assign_thought(CatThought.IS_GUIDE)
                         self.the_cat.pelt.rebuild_sprite = True
                     else:
                         # DF -> UR
@@ -349,7 +350,7 @@ class ProfileScreen(Screens):
                             self.the_cat.status.add_to_group(
                                 new_group_ID=CatGroup.DARK_FOREST_ID
                             )
-                        self.the_cat.get_new_thought(CatThought.ON_AFTERLIFE_CHANGE)
+                        self.the_cat.assign_thought(CatThought.ON_AFTERLIFE_CHANGE)
                         self.the_cat.pelt.rebuild_sprite = True
 
                     update_afterlife_temper()
@@ -563,19 +564,10 @@ class ProfileScreen(Screens):
 
         # initialize thoughts if they have none
         if not self.the_cat.thought:
-            if self.the_cat is game.clan.instructor:
-                self.the_cat.get_new_thought(CatThought.IS_GUIDE)
-            elif self.the_cat.status.is_other_clancat:
-                # this isn't great, but it's only being run if someone checks an
-                # other clan cat when booting the game before doing a timeskip
-                other_clan_cats = [
-                    c for c in Cat.all_cats_list if c.status.is_other_clancat
-                ]
-                self.the_cat.get_new_thought(other_clan_cats=other_clan_cats)
-            elif self.the_cat.dead:
-                self.the_cat.get_new_thought(CatThought.WHILE_DEAD)
-            else:
-                self.the_cat.get_new_thought(CatThought.WHILE_ALIVE)
+            if not self.the_cat.next_thought_type:
+                self.the_cat.assign_thought()
+
+            get_new_thought(self.the_cat, self.the_cat.next_thought_type)
 
         # Info in string
         cat_name = str(self.the_cat.name)

--- a/tests/test_event_filters.py
+++ b/tests/test_event_filters.py
@@ -208,7 +208,7 @@ class TestPointsOfInterest(unittest.TestCase):
         prior_clan = game.clan
         self.addCleanup(setattr, game, "clan", prior_clan)
 
-        game.clan = Clan()
+        game.clan = Clan(save_id="test")
         game.clan.biome = "Forest"
         game.clan.override_biome = False
         game.clan.camp_bg = "camp1"


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
Finally kills the circular import issues we were having with thoughts!!!

So the issue with thoughts prior was that it was very very easy to introduce a circular import with `Cat` due to how much `Cat` needs to generate new thoughts (such as for rank changes.)

To fix this, I've introduced a new attribute to `Cat` called `next_thought_type`.  `Cat` doesn't really need to *generate* a thought per se, it just needs to assign a `CatThought` enum that can be utilized to do the thought generation when we next load the cat's profile.  This is what `cat.next_thought_type` is for.  

In `cat.one_moon` a new function is called: `cat.assign_thought`.  This function evaluates a default `CatThought` based on the cat's current dead/alive/guide status and it clears the current `cat.thought`.  When a profile is opened the `get_new_thought` function is called and utilizes the `cat.next_thought_type`.  This is the old function that used to live in `Cat`, but now lives in `generate_thought.py` with the rest of the thought code.

Any portion of the code that used to call `get_new_thought` in order to reassign the cat thought in response to a special event now instead utilizes `cat.assign_thought` to just assign a `cat.next_thought_type`.  The only exception to this is grief thoughts, which need to attach a specific second cat and thus must directly interface with `get_new_thought`. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Why This Is Good For ClanGen
The circular import problem was driving me crazy and making it really hard to integrate thoughts into any shared `TextPoolEvent` functionality.
<!-- If this is a bug fix, you can remove this section. -->
<!-- Please add a short description of why you think these changes would benefit the game. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->
<!-- If you have multiple features that can stand on their own, or unrelated bugfixes, please create separate PRs for them. -->

## Proof of Testing
<img width="469" height="75" alt="image" src="https://github.com/user-attachments/assets/c2dd54b8-750e-4576-91bd-3548af08327c" />
<img width="241" height="83" alt="image" src="https://github.com/user-attachments/assets/403b6206-700c-4c56-89ce-9ac9c2a3b825" />
<img width="542" height="83" alt="image" src="https://github.com/user-attachments/assets/6634e26f-1366-4089-9197-83886352ce27" />
<img width="485" height="134" alt="image" src="https://github.com/user-attachments/assets/2f6dd27c-8171-4710-bc55-aca016fef46d" />
<img width="674" height="415" alt="image" src="https://github.com/user-attachments/assets/34ce2432-e7de-4ef5-b097-e8724e824fd4" />
<img width="726" height="457" alt="image" src="https://github.com/user-attachments/assets/3e649a04-20c2-4e92-975d-da8ac1ebb35c" />
<img width="714" height="392" alt="image" src="https://github.com/user-attachments/assets/1b8a933b-f02d-4f56-b1b4-6040dadcdedc" />
<img width="757" height="411" alt="image" src="https://github.com/user-attachments/assets/86fe49f7-311c-4bfe-8b11-47e6741df02a" />
<img width="749" height="366" alt="image" src="https://github.com/user-attachments/assets/52966fe8-0370-4003-998b-7a1e5b4f35d3" />
<img width="555" height="146" alt="image" src="https://github.com/user-attachments/assets/79cbafb9-1e44-48ce-93e8-105d4701cd9d" />
<img width="506" height="115" alt="image" src="https://github.com/user-attachments/assets/5410bec1-a01c-4e29-97f2-eebf7d9e2c90" />

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Moves `get_new_thought` into `generate_thoughts.py`
- Adds new `assign_thought` function to `Cat`
- Adds new `next_thought_type` attribute to `Cat`
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
