### PR TITLE
[BUGFIX] Minor patrol fixes

### DIFF
--- a/resources/lang/en/patrols/forest/border/any.json
+++ b/resources/lang/en/patrols/forest/border/any.json
@@ -581,9 +581,6 @@
                         "condition": [
                             "battle_injury"
                         ],
-                        "scar_pool_override": [
-                            "SNOUT"
-                        ],
                         "scar_history": "m_c was badly scarred when rogues attacked {PRONOUN/m_c/poss} patrol.",
                         "death_history": "m_c died of an injury sustained in a rogue ambush."
                     }
@@ -833,9 +830,6 @@
                         ],
                         "condition": [
                             "battle_injury"
-                        ],
-                        "scar_pool_override": [
-                            "MANLEG"
                         ],
                         "scar_history": "m_c was scarred by a badger.",
                         "death_history": "m_c died of an injury inflicted by a badger."
@@ -1114,9 +1108,6 @@
                         "condition": [
                             "big_bite_injury"
                         ],
-                        "scar_pool_override": [
-                            "SIDE"
-                        ],
                         "scar_history": "m_c was scarred by a badger.",
                         "death_history": "m_c died of an injury inflicted by a badger."
                     }
@@ -1380,9 +1371,6 @@
                         "condition": [
                             "battle_injury"
                         ],
-                        "scar_pool_override": [
-                            "BRIDGE"
-                        ],
                         "scar_history": "m_c was scarred by an invading rogue.",
                         "death_history": "m_c died of an injury inflicted by an invading rogue."
                     }
@@ -1526,9 +1514,6 @@
                         ],
                         "condition": [
                             "battle_injury"
-                        ],
-                        "scar_pool_override": [
-                            "CHEEK"
                         ],
                         "scar_history": "m_c was scarred by an invading rogue.",
                         "death_history": "m_c died of an injury inflicted by an invading rogue."
@@ -1990,9 +1975,6 @@
                         "condition": [
                             "battle_injury"
                         ],
-                        "scar_pool_override": [
-                            "BRIDGE"
-                        ],
                         "scar_history": "m_c was scarred by an invading rogue.",
                         "death_history": "m_c died of an injury inflicted by an invading rogue."
                     }
@@ -2238,9 +2220,6 @@
                         ],
                         "condition": [
                             "battle_injury"
-                        ],
-                        "scar_pool_override": [
-                            "CHEEK"
                         ],
                         "scar_history": "m_c was scarred by an invading rogue.",
                         "death_history": "m_c died of an injury inflicted by an invading rogue."
@@ -3696,9 +3675,6 @@
                         "condition": [
                             "big_bite_injury"
                         ],
-                        "scar_pool_override": [
-                            "MANLEG"
-                        ],
                         "scar_history": "m_c was scarred while defending the Clan against a dog.",
                         "death_history": "m_c died of injuries inflicted by a large dog."
                     }
@@ -3893,9 +3869,6 @@
                         "condition": [
                             "big_bite_injury"
                         ],
-                        "scar_pool_override": [
-                            "BRIGHTHEART"
-                        ],
                         "scar_history": "m_c was scarred while defending the Clan against a dog.",
                         "death_history": "m_c died of injuries inflicted by a large dog."
                     }
@@ -4047,9 +4020,6 @@
                         ],
                         "condition": [
                             "small_bite_injury"
-                        ],
-                        "scar_pool_override": [
-                            "LEGBITE"
                         ],
                         "scar_history": "m_c got a scar from a fight with a small dog, but {PRONOUN/m_c/subject} always {VERB/m_c/say/says} it was a huge dog.",
                         "death_history": "m_c died of injuries inflicted by a small dog."
@@ -4222,9 +4192,6 @@
                         ],
                         "condition": [
                             "small_bite_injury"
-                        ],
-                        "scar_pool_override": [
-                            "LEGBITE"
                         ],
                         "scar_history": "m_c got a scar from a fight with a small dog, but {PRONOUN/m_c/subject} always {VERB/m_c/say/says} it was a huge dog.",
                         "death_history": "m_c died of injuries inflicted by a small dog."
@@ -4730,9 +4697,6 @@
                         "condition": [
                             "big_bite_injury"
                         ],
-                        "scar_pool_override": [
-                            "ONE"
-                        ],
                         "scar_history": "m_c carries a scar from a fox fight.",
                         "death_history": "m_c died of an injury inflicted by a red vixen."
                     }
@@ -4782,9 +4746,6 @@
                         ],
                         "condition": [
                             "big_bite_injury"
-                        ],
-                        "scar_pool_override": [
-                            "ONE"
                         ],
                         "scar_history": "m_c carries a scar from a fox fight.",
                         "death_history": "m_c died of an injury inflicted by a fox."

--- a/resources/lang/en/patrols/general/training.json
+++ b/resources/lang/en/patrols/general/training.json
@@ -23826,6 +23826,9 @@
             "training"
         ],
         "frequency": 4,
+        "tags": [
+            "clan:medicine cat"
+        ],
         "required_cat_types": {
             "patrol_cats": [
                 3,

--- a/resources/lang/en/patrols/general/training.json
+++ b/resources/lang/en/patrols/general/training.json
@@ -23826,9 +23826,6 @@
             "training"
         ],
         "frequency": 4,
-        "tags": [
-            "clan:medicine cat"
-        ],
         "required_cat_types": {
             "patrol_cats": [
                 3,
@@ -23871,6 +23868,9 @@
         "success_outcomes": [
             {
                 "frequency": 4,
+                "tags": [
+                    "clan:medicine cat"
+                ],
                 "strings": [
                     "The sun has nearly set before what was meant to be a quick little training patrol heads back to camp. The cats pad forward with confidence, p_l leading the way, {PRONOUN/p_l/poss} tail held high as {PRONOUN/p_l/subject} {VERB/p_l/seek/seeks} out med_name to pass on what {PRONOUN/p_l/subject} and {PRONOUN/p_l/poss} friends have figured out."
                 ],


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
Adds `clan:medicine cat` tag to `gen_train_prophetlocked1` and removes leftover `scar_pool_override` from forest/border/any patrols.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
Fixes #5425 
Fixes #5335 
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->