### PR TITLE
[DEV] Enable VSCode colour picker in JSON files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -89,5 +89,6 @@
         "Twolegs",
         "ujson",
         "verdana"
-    ]
+    ],
+    "editor.defaultColorDecorators": "always"
 }


### PR DESCRIPTION
## About The Pull Request

* Changes default vscode settings so it shows the colour picker in JSON files

## Proof of Testing

<img width="395" height="435" alt="image" src="https://github.com/user-attachments/assets/a42aff1f-fe1a-41e5-9256-8e77042c9584" />
