### PR TITLE
[BUGFIX] Solo patrol rogue ambush death

### DIFF
--- a/resources/lang/en/patrols/beach/border/any.json
+++ b/resources/lang/en/patrols/beach/border/any.json
@@ -332,7 +332,7 @@
                 "relationship_changes": [
                     {
                         "cats_to": [
-                            "r_c0"
+                            "p_l"
                         ],
                         "cats_from": [
                             "some_clan"
@@ -351,7 +351,7 @@
                 "death": [
                     {
                         "cats": [
-                            "r_c0"
+                            "p_l"
                         ],
                         "history": "m_c was killed when rogues ambushed {PRONOUN/m_c/object} while on a solo patrol."
                     }

--- a/resources/lang/en/patrols/forest/border/any.json
+++ b/resources/lang/en/patrols/forest/border/any.json
@@ -332,7 +332,7 @@
                 "relationship_changes": [
                     {
                         "cats_to": [
-                            "r_c0"
+                            "p_l"
                         ],
                         "cats_from": [
                             "some_clan"
@@ -351,7 +351,7 @@
                 "death": [
                     {
                         "cats": [
-                            "r_c0"
+                            "p_l"
                         ],
                         "history": "This cat was killed when rogues ambushed {PRONOUN/m_c/object} while on a solo patrol."
                     }

--- a/resources/lang/en/patrols/mountainous/border/any.json
+++ b/resources/lang/en/patrols/mountainous/border/any.json
@@ -718,7 +718,7 @@
                 "death": [
                     {
                         "cats": [
-                            "r_c0"
+                            "p_l"
                         ],
                         "history": "m_c was killed when rogues ambushed {PRONOUN/m_c/object} while on a solo patrol."
                     }

--- a/resources/lang/en/patrols/plains/border/any.json
+++ b/resources/lang/en/patrols/plains/border/any.json
@@ -332,7 +332,7 @@
                 "relationship_changes": [
                     {
                         "cats_to": [
-                            "r_c0"
+                            "p_l"
                         ],
                         "cats_from": [
                             "some_clan"
@@ -351,7 +351,7 @@
                 "death": [
                     {
                         "cats": [
-                            "r_c0"
+                            "p_l"
                         ],
                         "history": "This cat was killed when rogues ambushed {PRONOUN/m_c/object} while on a solo patrol."
                     }


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
Fixes solo patrol cats not dying when ambushed by rogues in some scenarios. Entirely consists of changing `r_c0` to `p_l` in a few spots.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
Should fix #5761 (thanks SnowLeopardtherebel for the directions!)
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
<img width="2560" height="1600" alt="Screenshot_20260821_201115" src="https://github.com/user-attachments/assets/0b845be5-c12f-48a8-91f9-883f46e09bfc" />
(This is only one of the scenarios, if more thorough testing is needed let me know!)
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
o/ new contributor (or well, I contributed once *years* ago). I am `fulmine` on discord.
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
