### PR TITLE
[BUGFIX] Adoption and Pregnancy

### DIFF
--- a/scripts/events_module/consequences.py
+++ b/scripts/events_module/consequences.py
@@ -85,7 +85,12 @@ def create_new_cat_block(
                 index = f"n_c:{index}"
             if in_event_cats[index].ID not in adoptive_parents:
                 adoptive_parents.append(in_event_cats[index].ID)
-                adoptive_parents.extend(in_event_cats[index].mate)
+                for mate_id in in_event_cats[index].mate:
+                    mate = Cat.fetch_cat(mate_id)
+                    if not mate or not mate.status.alive_in_player_clan:
+                        continue
+                    if mate.ID not in adoptive_parents:
+                        adoptive_parents.append(mate.ID)
 
     # gather mates
     give_mates = []

--- a/scripts/events_module/pregnancy/create_kits.py
+++ b/scripts/events_module/pregnancy/create_kits.py
@@ -80,7 +80,7 @@ def get_kits(
                 continue
 
             mate = Cat.fetch_cat(mate_id)
-            if not mate:
+            if not mate or not mate.status.alive_in_player_clan:
                 continue
 
             add_poly_mate = poly_parenting and mate.ID != other_cat.ID
@@ -101,7 +101,7 @@ def get_kits(
                 continue
 
             mate = Cat.fetch_cat(mate_id)
-            if not mate:
+            if not mate or not mate.status.alive_in_player_clan:
                 continue
 
             add_poly_mate = poly_parenting and mate.ID != cat.ID

--- a/scripts/events_module/pregnancy/handle_become_pregnant.py
+++ b/scripts/events_module/pregnancy/handle_become_pregnant.py
@@ -67,22 +67,16 @@ def _handle_pregnancy_notice(pregnant_cat, second_parent):
     mate = []
     afab_mate = []
     amab_mate = []
-    # afab/amab only matters if same sex setting is off
-    if get_clan_setting("same sex birth"):
-        mate = [
-            Cat.fetch_cat(mate_id)
-            for mate_id in pregnant_cat.mate
-            if Cat.fetch_cat(mate_id)
-        ]
-    else:
-        for mate_id in pregnant_cat.mate:
-            mate_cat = Cat.fetch_cat(mate_id)
-            mate.append(mate_cat)
+    for mate_id in pregnant_cat.mate:
+        mate_cat = Cat.fetch_cat(mate_id)
+        if not mate_cat:
+            continue
+        mate.append(mate_cat)
 
-            if mate_cat.gender == "female":
-                afab_mate.append(mate_cat)
-            else:
-                amab_mate.append(mate_cat)
+        if mate_cat.gender == "female":
+            afab_mate.append(mate_cat)
+        else:
+            amab_mate.append(mate_cat)
 
     # if both cats are faithful to each other and aren't cheaters,
     # the pregnancy will be announced as normal
@@ -97,21 +91,7 @@ def _handle_pregnancy_notice(pregnant_cat, second_parent):
         text, involved_cats = _create_pregnancy_announcement(
             pregnant_cat, "announcement_surprise"
         )
-    # if the pregnant cat is in a same-sex relationship (and we aren't allowing samesex pregnancy)
-    # and they get knocked-up by another cat, let there be some drama for that!
-    elif get_clan_setting("same sex birth") and (
-        allow_affair is True
-        and second_parent
-        and second_parent.ID not in pregnant_cat.mate
-        and afab_mate
-    ):
-        random_cat = afab_mate[0] if afab_mate else None
-        text, involved_cats = _create_pregnancy_announcement(
-            pregnant_cat,
-            "announcement_affair_samesex",
-            random_cat=random_cat,
-        )
-    # and lastly, if the pregnant cat got knocked up by another cat who ISN'T their mate,
+    # if the pregnant cat got knocked up by another cat who ISN'T their mate,
     # let the player guess whether it's an affair or not, sometimes the events will tell you,
     # sometimes they won't...
     elif (
@@ -122,12 +102,23 @@ def _handle_pregnancy_notice(pregnant_cat, second_parent):
     ):
         announcement_key = choice(["announcement_affair", "announcement"])
         _set_affair_visibility(pregnant_cat, announcement_key == "announcement_affair")
-        if get_clan_setting("same sex birth"):
-            random_cat = mate[0]
-        else:
-            random_cat = amab_mate[0] if amab_mate else None
+        random_cat = amab_mate[0]
         text, involved_cats = _create_pregnancy_announcement(
             pregnant_cat, announcement_key, random_cat=random_cat
+        )
+    # and lastly, if the pregnant cat only has female mates and they get knocked-up
+    # by another cat, let there be some drama for that!
+    elif (
+        allow_affair is True
+        and second_parent
+        and second_parent.ID not in pregnant_cat.mate
+        and afab_mate
+    ):
+        random_cat = afab_mate[0]
+        text, involved_cats = _create_pregnancy_announcement(
+            pregnant_cat,
+            "announcement_affair_samesex",
+            random_cat=random_cat,
         )
     # if all else fails, just a regular announcement happens
     else:


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

Fixes three bugs relating to kit adoption and pregnancy!

First one is that kits were being adopted by dead or outside mates, this now more checks for `status.alive_in_player_clan` on finding adoptive parents and in assigning parents to kits. Biological parents of kits remain untouched.

Next one is that `r_c` was a string appearing in pregnancy announcements for same-sex announcements. This was an issue with the handling `same_sex_birth` setting, where random cat was None with female mates. This now categorizes mates without checking the setting so cats with any gender mate can resolve tags.

Last one was unreported but showed up when forcing affairs/ testing previous bug:
`KeyError: 'mates_breakup'`. This was due to `handle_become_pregnant.py` looking for a missing config `mates.mates_breakup.affair_breakup_chance` which I changed to `mates.breakup.affair_breakup_chance` and set to a placeholder `0.3`. This seems to fix the error now.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->
## Linked Issues

Fixes #5137 and Fixes #5745 and an unreported bug/ perhaps already closed #3539

<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->
## Proof of Testing

Adoption:
| | | |
|---|---|---|
| <img width="400" alt="recovering from birth parent with two mates (one dead)" src="https://github.com/user-attachments/assets/341a45df-62bf-4466-88df-353679ad8563" /> | <img width="400" alt="kit with two parents" src="https://github.com/user-attachments/assets/400d63ee-4f86-4367-8871-a14d6c6f8d2d" /> | <img width="400" alt="Dead mate" src="https://github.com/user-attachments/assets/1da061fc-1cb6-4ee5-99dd-4cbadfe09396" /> |

Pregnancy fixes:
<img width="400" alt="image" src="https://github.com/user-attachments/assets/44935044-35ec-4f22-88a8-fec37827be89" />

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->