### PR TITLE
[ENHANCE] Add Countdown to ConfirmDisplayChangesWindow

### DIFF
--- a/scripts/ui/windows/confirm_display_change.py
+++ b/scripts/ui/windows/confirm_display_change.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING
 
 import pygame
 import pygame_gui
+import math
 
 from scripts.game_structure.screen_settings import MANAGER
 from scripts.ui.elements.surface_image_button import UISurfaceImageButton
@@ -75,14 +76,15 @@ class ConfirmDisplayChangesWindow(GameWindow):
                 "right": "right",
                 "bottom": "bottom",
             },
-            text_kwargs={"count": 10},
+            text_kwargs={
+                "count": "10"
+            },
         )
         self.text_block.disable()
         self.text_block.rebuild_from_changed_theme_data()
 
-        # make a timeout that will call in 10 seconds - if this window isn't closed,
-        # it'll be used to revert the change
-        pygame.time.set_timer(pygame.USEREVENT + 10, 10000, loops=1)
+        self.elapsed_duration = 0
+        self.revert_duration = 15 # Duration (in seconds) before the game reverts the change
 
         self.source_screen_name = source_screen.name.replace(" ", "_")
 
@@ -91,6 +93,7 @@ class ConfirmDisplayChangesWindow(GameWindow):
         from scripts.game_structure.screen_settings import toggle_fullscreen
         from scripts.screens import all_screens
 
+        self.kill()
         toggle_fullscreen(
             None,
             source_screen=all_screens.get_screen(self.source_screen_name),
@@ -103,7 +106,14 @@ class ConfirmDisplayChangesWindow(GameWindow):
                 self.kill()
             elif event.ui_element == self.revert_button:
                 self.revert_changes()
-        elif event.type == pygame.USEREVENT + 10:
-            self.revert_changes()
-            self.kill()
         return super().process_event(event)
+
+    def update(self, time_delta: float):
+        super().update(time_delta)
+
+        self.elapsed_duration += time_delta
+        self.text_block.set_text("windows.display_change_confirm", text_kwargs={
+            "count": str(self.revert_duration - math.floor(self.elapsed_duration))
+        })
+        if self.elapsed_duration >= self.revert_duration:
+            self.revert_changes()

--- a/scripts/ui/windows/confirm_display_change.py
+++ b/scripts/ui/windows/confirm_display_change.py
@@ -76,15 +76,15 @@ class ConfirmDisplayChangesWindow(GameWindow):
                 "right": "right",
                 "bottom": "bottom",
             },
-            text_kwargs={
-                "count": "10"
-            },
+            text_kwargs={"count": "10"},
         )
         self.text_block.disable()
         self.text_block.rebuild_from_changed_theme_data()
 
         self.elapsed_duration = 0
-        self.revert_duration = 15 # Duration (in seconds) before the game reverts the change
+        self.revert_duration = (
+            15  # Duration (in seconds) before the game reverts the change
+        )
 
         self.source_screen_name = source_screen.name.replace(" ", "_")
 
@@ -112,8 +112,11 @@ class ConfirmDisplayChangesWindow(GameWindow):
         super().update(time_delta)
 
         self.elapsed_duration += time_delta
-        self.text_block.set_text("windows.display_change_confirm", text_kwargs={
-            "count": str(self.revert_duration - math.floor(self.elapsed_duration))
-        })
+        self.text_block.set_text(
+            "windows.display_change_confirm",
+            text_kwargs={
+                "count": str(self.revert_duration - math.floor(self.elapsed_duration))
+            },
+        )
         if self.elapsed_duration >= self.revert_duration:
             self.revert_changes()


### PR DESCRIPTION
## About The Pull Request
Changes the static "10 seconds" in the ConfirmDisplayChangesWindow to an actual countdown (which was increased from 10 seconds to 15). Also fixes a bug involving the countdown persisting between fullscreen toggles.

## Why This Is Good For ClanGen
It's a nice quality of life change which may be helpful for some. Definitely makes interacting with the toggle a bit better.

## Linked Issues
Fixes: #2851
Fixes: #2875

## Proof of Testing
https://github.com/user-attachments/assets/8a2978e4-1e87-4b89-9106-a4c6a107af8e
