### PR TITLE
[TYPOFIX] pronoun tag fix in patrol

### DIFF
--- a/resources/lang/en/patrols/general/training.json
+++ b/resources/lang/en/patrols/general/training.json
@@ -24099,7 +24099,7 @@
         },
         "chance_of_success": 60,
         "patrol_art": "train_general_intro",
-        "intro_text": "While the cats are out training, the discussion turns to rogues. p_l perks {PRONOUN/p_l/poss} ears up — {PRONOUN/p_l/object} {VERB/p_l/know/knows} all about it.",
+        "intro_text": "While the cats are out training, the discussion turns to rogues. p_l perks {PRONOUN/p_l/poss} ears up — {PRONOUN/p_l/subject} {VERB/p_l/know/knows} all about it.",
         "decline_text": "But {PRONOUN/p_l/object} {VERB/p_l/decide/decides} to listen instead of joining in the conversation.",
         "success_outcomes": [
             {


### PR DESCRIPTION

## About The Pull Request

just fixes an incorrect instance of a pronoun tag in the "gen_train_roguelonerlocked1" patrol (object when it should be subject)

## Why This Is Good For ClanGen

typofix good

## Linked Issues

https://github.com/ClanGenOfficial/clangen/issues/1818#issuecomment-5312417521

## Proof of Testing

<img width="1027" height="89" alt="image" src="https://github.com/user-attachments/assets/b3dd144b-28c5-4a90-9367-254a4e0a0a88" />

## Changelog/Credits

- Fixes an incorrect pronoun tag in a training patrol.