### PR TITLE
[BUGFIX] Ceremony issues

### DIFF
--- a/resources/game_config.toml
+++ b/resources/game_config.toml
@@ -624,7 +624,7 @@ dev_tools = false
   debug_override_frequency = 0
 
   # forces ceremony with this id to occur
-  debug_ensure_ceremony_id = "warrior_default0"
+  debug_ensure_ceremony_id = ""
 
 [death_related]
   # the maximum lives a leader can have

--- a/scripts/events_module/ceremony/generate_normal_ceremony.py
+++ b/scripts/events_module/ceremony/generate_normal_ceremony.py
@@ -55,5 +55,5 @@ def create_ceremony(
     )
 
     game.cur_events_list.append(
-        EventInformation(processed_string, "ceremony", [c.ID for c in button_cats])
+        EventInformation(processed_string, ["ceremony"], [c.ID for c in button_cats])
     )

--- a/scripts/events_module/event_filters.py
+++ b/scripts/events_module/event_filters.py
@@ -570,9 +570,9 @@ def _check_cat_apprentice(cat, has_app: dict) -> bool:
 
     # check for None value instead of False-y!
     if has_app.get("former") is not None:
-        if has_app["former"] and not cat.former_apprentice:
+        if has_app["former"] and not cat.former_apprentices:
             return False
-        if not has_app["former"] and cat.former_apprentice:
+        if not has_app["former"] and cat.former_apprentices:
             return False
 
     return True


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
- Fixes a debug config that hadn't been cleared before merging
- Fixes an arg being a string when it needed to be a list
- Fixes a mistyped attribute `former_apprentice` 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->


## Linked Issues
fixes #5870
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
<img width="607" height="225" alt="image" src="https://github.com/user-attachments/assets/15ac1d07-0504-4dc4-93e1-a4c280f62683" />

new deputy successfully promoted!
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Fixes a debug config that hadn't been cleared before merging
- Fixes an arg being a string when it needed to be a list
- Fixes a mistyped attribute `former_apprentice`
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
