### PR TITLE
[CONTENT] adds yew berries as a supply that can be gathered on applicable patrols

### DIFF
--- a/resources/lang/en/patrols/general/med.json
+++ b/resources/lang/en/patrols/general/med.json
@@ -2516,7 +2516,7 @@
             {
                 "frequency": 1,
                 "strings": [
-                    "The scent of a familiar pelt reaches r_c's nose — {PRONOUN/r_c0/subject} {VERB/r_c0/know/knows} this cat! With a friendly purr, {PRONOUN/r_c0/subject} {VERB/r_c0/turn/turns} to greet {PRONOUN/r_c0/poss} friend from beyond the grave. The rest of the patrol gives them some space."
+                    "The scent of a familiar pelt reaches s_c0's nose — {PRONOUN/s_c0/subject} {VERB/s_c0/know/knows} this cat! With a friendly purr, {PRONOUN/s_c0/subject} {VERB/s_c0/turn/turns} to greet {PRONOUN/s_c0/poss} friend from beyond the grave. The rest of the patrol gives them some space."
                 ],
                 "involved_cats": {
                     "s_c0": {
@@ -2527,7 +2527,7 @@
                 "relationship_changes": [
                     {
                         "cats_to": [
-                            "p_l"
+                            "patrol_cats"
                         ],
                         "cats_from": [
                             "patrol_cats"
@@ -18900,8 +18900,7 @@
             "r_c1": {
                 "status": [
                     "medicine cat apprentice"
-                ],
-                "has_mentor": {"current": true}
+                ]
             }
         },
         "chance_of_success": 60,

--- a/resources/lang/en/patrols/general/med.json
+++ b/resources/lang/en/patrols/general/med.json
@@ -51698,6 +51698,12 @@
                 "strings": [
                     "p_l explains how to identify the berries and decides to harvest a few in case they are needed for deadly injuries."
                 ],
+                "supply": [
+                    {
+                        "type": "yew_berries",
+                        "adjust": "increase_small"
+                    }
+                ],
                 "exp_gained": 30,
                 "relationship_changes": [
                     {
@@ -51818,6 +51824,12 @@
                 "frequency": 3,
                 "strings": [
                     "p_l explains the danger of deathberries but reminds the patrol that all herbs have their purpose. In this case, the flesh can be used to treat festering wounds, and the entire berry can be used to alleviate the suffering of mortally wounded warriors."
+                ],
+                "supply": [
+                    {
+                        "type": "yew_berries",
+                        "adjust": "increase_small"
+                    }
                 ],
                 "exp_gained": 30,
                 "relationship_changes": [

--- a/resources/lang/en/patrols/general/med.json
+++ b/resources/lang/en/patrols/general/med.json
@@ -4102,7 +4102,9 @@
                     "apprentice",
                     "medicine cat apprentice"
                 ],
-                "has_mentor": {"current": true}
+                "has_mentor": {
+                    "current": true
+                }
             }
         },
         "chance_of_success": 40,
@@ -11552,7 +11554,9 @@
         },
         "involved_cats": {
             "p_l": {
-                "has_mentor": {"current": true}
+                "has_mentor": {
+                    "current": true
+                }
             }
         },
         "chance_of_success": 50,
@@ -12352,7 +12356,9 @@
                 "status": [
                     "apprentice"
                 ],
-                "has_mentor": {"current": true}
+                "has_mentor": {
+                    "current": true
+                }
             }
         },
         "chance_of_success": 30,
@@ -13253,7 +13259,9 @@
                 "status": [
                     "medicine cat apprentice"
                 ],
-                "has_mentor": {"current": true}
+                "has_mentor": {
+                    "current": true
+                }
             }
         },
         "chance_of_success": 60,
@@ -19271,7 +19279,9 @@
                     "apprentice",
                     "medicine cat apprentice"
                 ],
-                "has_mentor": {"current": true}
+                "has_mentor": {
+                    "current": true
+                }
             }
         },
         "chance_of_success": 60,
@@ -25136,7 +25146,9 @@
         },
         "involved_cats": {
             "p_l": {
-                "has_mentor": {"current": true}
+                "has_mentor": {
+                    "current": true
+                }
             }
         },
         "chance_of_success": 50,
@@ -27264,7 +27276,9 @@
                     "apprentice",
                     "medicine cat apprentice"
                 ],
-                "has_mentor": {"current": true}
+                "has_mentor": {
+                    "current": true
+                }
             }
         },
         "chance_of_success": 40,
@@ -38694,7 +38708,9 @@
                     "apprentice",
                     "medicine cat apprentice"
                 ],
-                "has_mentor": {"current": true}
+                "has_mentor": {
+                    "current": true
+                }
             }
         },
         "chance_of_success": 70,
@@ -41011,7 +41027,9 @@
                     "apprentice",
                     "medicine cat apprentice"
                 ],
-                "has_mentor": {"current": true}
+                "has_mentor": {
+                    "current": true
+                }
             }
         },
         "chance_of_success": 70,
@@ -50665,7 +50683,9 @@
         },
         "involved_cats": {
             "p_l": {
-                "has_mentor": {"current": true}
+                "has_mentor": {
+                    "current": true
+                }
             }
         },
         "chance_of_success": 50,
@@ -52345,6 +52365,12 @@
                 "strings": [
                     "p_l explains how to identify the berries and decides to harvest a few in case they are needed for deadly injuries."
                 ],
+                "supply": [
+                    {
+                        "type": "yew_berries",
+                        "adjust": "increase_small"
+                    }
+                ],
                 "exp_gained": 30,
                 "relationship_changes": [
                     {
@@ -52465,6 +52491,12 @@
                 "frequency": 3,
                 "strings": [
                     "p_l explains the danger of deathberries but reminds the patrol that all herbs have their purpose. In this case, the flesh can be used to treat festering wounds, and the entire berry can be used to alleviate the suffering of mortally wounded warriors."
+                ],
+                "supply": [
+                    {
+                        "type": "yew_berries",
+                        "adjust": "increase_small"
+                    }
                 ],
                 "exp_gained": 30,
                 "relationship_changes": [
@@ -52853,271 +52885,271 @@
         ]
     },
     {
-  "event_id": "gen_med_mossgathering",
-  "types": [
-    "herb_gathering"
-  ],
-  "frequency": 4,
-  "required_cat_types": {
-    "patrol_cats": [1, 4]
-  },
-  "chance_of_success": 70,
-  "patrol_art": "cat_sprites/gen_med_gatheringmoss_Mc",
-  "intro_text": "p_l notices that the moss in the medicine cat den is getting old. {PRONOUN/p_l/subject/CAP} {VERB/p_l/need/needs} to go and gather some more.",
-  "decline_text": "A cat requires {PRONOUN/p_l/poss} attention just as {PRONOUN/p_l/subject} {VERB/p_l/are/is} ready to leave. Unfortunately, the moss will have to wait.",
-  "success_outcomes": [
-    {
-      "required_cat_types": {
-        "patrol_cats": [1, 1]
-      },
-     "frequency": 4,
-      "strings": [
-        "p_l makes {PRONOUN/p_l/poss} way to {PRONOUN/p_l/poss} favorite moss patch. {PRONOUN/p_l/subject/CAP} {VERB/p_l/slice/slices} patches with {PRONOUN/p_l/poss} claws, careful to exclude any roots or dirt. Once {PRONOUN/p_l/subject}{VERB/p_l/'re/'s} satisfied with {PRONOUN/p_l/poss} pile, {PRONOUN/p_l/subject} gently {VERB/p_l/wrap/wraps} {PRONOUN/p_l/poss} jaws around the heap and {VERB/p_l/make/makes} {PRONOUN/p_l/poss} way back to camp."
-      ],
-      "exp_gained": 10,
-      "supply": [
-        {
-          "type": "moss",
-          "adjust": "increase_medium"
-        }
-      ],
-      "relationship_changes": [
-        {
-          "cats_to": [
-            "patrol_cats"
-          ],
-          "cats_from": [
-            "some_clan"
-          ],
-          "mutual": false,
-          "values": [
-            "like"
-          ],
-          "amount": 6,
-          "log": {
-            "cats_from": "cat_from is grateful for cat_to's diligence in gathering moss."
-          }
-        }
-      ]
-    },
-    {
-      "required_cat_types": {
-        "patrol_cats": [1, 1]
-      },
-      "frequency": 2,
-      "strings": [
-        "p_l arrives at {PRONOUN/p_l/poss} favorite moss gathering patch. The moss is tender and fluffy beneath {PRONOUN/p_l/poss} paws. With all the nagging responsibilities weighing on {PRONOUN/p_l/object} as a medicine cat, p_l supposes it might be alright to take a moment away from {PRONOUN/p_l/poss} duties to relax. p_l nestles into the soft moss for a quick respite. {PRONOUN/p_l/subject/CAP} {VERB/p_l/awaken/awakens} refreshed and {VERB/m_c/are/is} still able to gather a few pieces of moss before sunset."
-      ],
-      "exp_gained": 5,
-      "supply": [
-        {
-          "type": "moss",
-          "adjust": "increase_small"
-        }
-      ]
-    },
-    {
-      "required_cat_types": {
-        "patrol_cats": [2, 2]
-      },
-      "involved_cats": {
-        "r_c0": {}
-         },
-      "frequency": 4,
-      "strings": [
-        "p_l leads the way to the best moss patch {PRONOUN/p_l/subject} {VERB/p_l/know/knows}, with r_c0 not far behind. The cats begin cutting off bits of moss and making their respective piles. Once the piles turn into mouthfuls, they pick up the bundles of fresh moss and start back towards camp."
+        "event_id": "gen_med_mossgathering",
+        "types": [
+            "herb_gathering"
         ],
-      "exp_gained": 10,
-      "relationship_changes": [
-        {
-          "cats_to": [
-            "patrol_cats"
-          ],
-          "cats_from": [
-            "patrol_cats"
-          ],
-          "mutual": false,
-          "values": [
-            "like"
-          ],
-          "amount": 6,
-          "log": {
-            "cats_from": "cat_to and cat_from enjoyed a low-stress afternoon gathering plenty of fresh moss for the medicine cat den."
-          }
-        }
-      ],
-      "supply": [
-        {
-          "type": "moss",
-          "adjust": "increase_medium"
-        }
-      ]
-    },
-    {
-      "required_cat_types": {
-        "patrol_cats": [2, 2],
-        "medicine cat": [1, 1],
-        "medicine cat apprentice": [1, 1]
-      },
-      "frequency": 3,
-      "involved_cats": {
-        "r_c0": {}
-      },
-      "strings": [
-        "p_l leads the way to {PRONOUN/p_l/poss} favorite moss patch and carefully instructs r_c0 in how to gather the moss without waste while leaving enough to regrow. If they tend the patch carefully, they will be able to find moss in almost every season."
+        "frequency": 4,
+        "required_cat_types": {
+            "patrol_cats": [1, 4]
+        },
+        "chance_of_success": 70,
+        "patrol_art": "cat_sprites/gen_med_gatheringmoss_Mc",
+        "intro_text": "p_l notices that the moss in the medicine cat den is getting old. {PRONOUN/p_l/subject/CAP} {VERB/p_l/need/needs} to go and gather some more.",
+        "decline_text": "A cat requires {PRONOUN/p_l/poss} attention just as {PRONOUN/p_l/subject} {VERB/p_l/are/is} ready to leave. Unfortunately, the moss will have to wait.",
+        "success_outcomes": [
+            {
+                "required_cat_types": {
+                    "patrol_cats": [1, 1]
+                },
+                "frequency": 4,
+                "strings": [
+                    "p_l makes {PRONOUN/p_l/poss} way to {PRONOUN/p_l/poss} favorite moss patch. {PRONOUN/p_l/subject/CAP} {VERB/p_l/slice/slices} patches with {PRONOUN/p_l/poss} claws, careful to exclude any roots or dirt. Once {PRONOUN/p_l/subject}{VERB/p_l/'re/'s} satisfied with {PRONOUN/p_l/poss} pile, {PRONOUN/p_l/subject} gently {VERB/p_l/wrap/wraps} {PRONOUN/p_l/poss} jaws around the heap and {VERB/p_l/make/makes} {PRONOUN/p_l/poss} way back to camp."
+                ],
+                "exp_gained": 10,
+                "supply": [
+                    {
+                        "type": "moss",
+                        "adjust": "increase_medium"
+                    }
+                ],
+                "relationship_changes": [
+                    {
+                        "cats_to": [
+                            "patrol_cats"
+                        ],
+                        "cats_from": [
+                            "some_clan"
+                        ],
+                        "mutual": false,
+                        "values": [
+                            "like"
+                        ],
+                        "amount": 6,
+                        "log": {
+                            "cats_from": "cat_from is grateful for cat_to's diligence in gathering moss."
+                        }
+                    }
+                ]
+            },
+            {
+                "required_cat_types": {
+                    "patrol_cats": [1, 1]
+                },
+                "frequency": 2,
+                "strings": [
+                    "p_l arrives at {PRONOUN/p_l/poss} favorite moss gathering patch. The moss is tender and fluffy beneath {PRONOUN/p_l/poss} paws. With all the nagging responsibilities weighing on {PRONOUN/p_l/object} as a medicine cat, p_l supposes it might be alright to take a moment away from {PRONOUN/p_l/poss} duties to relax. p_l nestles into the soft moss for a quick respite. {PRONOUN/p_l/subject/CAP} {VERB/p_l/awaken/awakens} refreshed and {VERB/m_c/are/is} still able to gather a few pieces of moss before sunset."
+                ],
+                "exp_gained": 5,
+                "supply": [
+                    {
+                        "type": "moss",
+                        "adjust": "increase_small"
+                    }
+                ]
+            },
+            {
+                "required_cat_types": {
+                    "patrol_cats": [2, 2]
+                },
+                "involved_cats": {
+                    "r_c0": {}
+                },
+                "frequency": 4,
+                "strings": [
+                    "p_l leads the way to the best moss patch {PRONOUN/p_l/subject} {VERB/p_l/know/knows}, with r_c0 not far behind. The cats begin cutting off bits of moss and making their respective piles. Once the piles turn into mouthfuls, they pick up the bundles of fresh moss and start back towards camp."
+                ],
+                "exp_gained": 10,
+                "relationship_changes": [
+                    {
+                        "cats_to": [
+                            "patrol_cats"
+                        ],
+                        "cats_from": [
+                            "patrol_cats"
+                        ],
+                        "mutual": false,
+                        "values": [
+                            "like"
+                        ],
+                        "amount": 6,
+                        "log": {
+                            "cats_from": "cat_to and cat_from enjoyed a low-stress afternoon gathering plenty of fresh moss for the medicine cat den."
+                        }
+                    }
+                ],
+                "supply": [
+                    {
+                        "type": "moss",
+                        "adjust": "increase_medium"
+                    }
+                ]
+            },
+            {
+                "required_cat_types": {
+                    "patrol_cats": [2, 2],
+                    "medicine cat": [1, 1],
+                    "medicine cat apprentice": [1, 1]
+                },
+                "frequency": 3,
+                "involved_cats": {
+                    "r_c0": {}
+                },
+                "strings": [
+                    "p_l leads the way to {PRONOUN/p_l/poss} favorite moss patch and carefully instructs r_c0 in how to gather the moss without waste while leaving enough to regrow. If they tend the patch carefully, they will be able to find moss in almost every season."
+                ],
+                "exp_gained": 15,
+                "relationship_changes": [
+                    {
+                        "cats_to": [
+                            "p_l"
+                        ],
+                        "cats_from": [
+                            "r_c"
+                        ],
+                        "mutual": false,
+                        "values": [
+                            "like"
+                        ],
+                        "amount": 6,
+                        "log": {
+                            "cats_from": "cat_from appreciated cat_to's instruction while gathering moss."
+                        }
+                    }
+                ],
+                "supply": [
+                    {
+                        "type": "moss",
+                        "adjust": "increase_medium"
+                    }
+                ]
+            },
+            {
+                "required_cat_types": {
+                    "patrol_cats": [3, 4]
+                },
+                "frequency": 4,
+                "strings": [
+                    "p_l leads the way to the best moss patch {PRONOUN/p_l/subject} {VERB/p_l/know/knows}, with {PRONOUN/p_l/poss} helpers following close behind. The cats begin cutting off bits of moss and making their respective piles. Once the piles turn into mouthfuls, they pick up the bundles of fresh moss and start back towards camp."
+                ],
+                "exp_gained": 10,
+                "relationship_changes": [
+                    {
+                        "cats_to": [
+                            "patrol_cats"
+                        ],
+                        "cats_from": [
+                            "patrol_cats"
+                        ],
+                        "mutual": false,
+                        "values": [
+                            "like"
+                        ],
+                        "amount": 6,
+                        "log": {
+                            "cats_from": "cat_to and cat_from enjoyed a low-stress afternoon gathering plenty of fresh moss for the medicine cat den."
+                        }
+                    }
+                ],
+                "supply": [
+                    {
+                        "type": "moss",
+                        "adjust": "increase_medium"
+                    }
+                ]
+            },
+            {
+                "required_cat_types": {
+                    "patrol_cats": [3, 4],
+                    "all apprentices": [-1, -1]
+                },
+                "strings": [
+                    "p_l leads the way to {PRONOUN/p_l/poss} favorite moss patch, attempting to ignore {PRONOUN/p_l/poss} reluctant helpers complaining about how the duty is beneath them. Their grouchiness, however, fades as they realize that moss gathering can be a relaxing, peaceful time to chat with their peers."
+                ],
+                "exp_gained": 10,
+                "relationship_changes": [
+                    {
+                        "cats_to": [
+                            "p_l"
+                        ],
+                        "cats_from": [
+                            "patrol_cats"
+                        ],
+                        "mutual": true,
+                        "values": [
+                            "like",
+                            "comfort"
+                        ],
+                        "amount": 4,
+                        "log": {
+                            "cats_from": "While initially reluctant, cat_from admitted {PRONOUN/cat_from/subject} enjoyed {PRONOUN/cat_from/poss} time socializing and gathering moss with cat_to."
+                        }
+                    }
+                ],
+                "frequency": 4,
+                "supply": [
+                    {
+                        "type": "moss",
+                        "adjust": "increase_medium"
+                    }
+                ]
+            }
         ],
-      "exp_gained": 15,
-      "relationship_changes": [
-        {
-          "cats_to": [
-            "p_l"
-          ],
-          "cats_from": [
-            "r_c"
-          ],
-          "mutual": false,
-          "values": [
-            "like"
-          ],
-          "amount": 6,
-          "log": {
-            "cats_from": "cat_from appreciated cat_to's instruction while gathering moss."
-          }
-        }
-      ],
-      "supply": [
-        {
-          "type": "moss",
-          "adjust": "increase_medium"
-        }
-      ]
-    },
-    {
-      "required_cat_types": {
-        "patrol_cats": [3, 4]
-      },
-      "frequency": 4,
-      "strings": [
-        "p_l leads the way to the best moss patch {PRONOUN/p_l/subject} {VERB/p_l/know/knows}, with {PRONOUN/p_l/poss} helpers following close behind. The cats begin cutting off bits of moss and making their respective piles. Once the piles turn into mouthfuls, they pick up the bundles of fresh moss and start back towards camp."
-        ],
-      "exp_gained": 10,
-      "relationship_changes": [
-        {
-          "cats_to": [
-            "patrol_cats"
-          ],
-          "cats_from": [
-            "patrol_cats"
-          ],
-          "mutual": false,
-          "values": [
-            "like"
-          ],
-          "amount": 6,
-          "log": {
-            "cats_from": "cat_to and cat_from enjoyed a low-stress afternoon gathering plenty of fresh moss for the medicine cat den."
-          }
-        }
-      ],
-      "supply": [
-        {
-          "type": "moss",
-          "adjust": "increase_medium"
-        }
-      ]
-    },
-    {
-      "required_cat_types": {
-        "patrol_cats": [3, 4],
-        "all apprentices": [-1, -1]
-      },
-      "strings": [
-        "p_l leads the way to {PRONOUN/p_l/poss} favorite moss patch, attempting to ignore {PRONOUN/p_l/poss} reluctant helpers complaining about how the duty is beneath them. Their grouchiness, however, fades as they realize that moss gathering can be a relaxing, peaceful time to chat with their peers."
-        ],
-      "exp_gained": 10,
-      "relationship_changes": [
-        {
-          "cats_to": [
-            "p_l"
-          ],
-          "cats_from": [
-            "patrol_cats"
-          ],
-          "mutual": true,
-          "values": [
-            "like",
-            "comfort"
-          ],
-          "amount": 4,
-          "log": {
-            "cats_from": "While initially reluctant, cat_from admitted {PRONOUN/cat_from/subject} enjoyed {PRONOUN/cat_from/poss} time socializing and gathering moss with cat_to."
-          }
-        }
-      ],
-      "frequency": 4,
-      "supply": [
-        {
-          "type": "moss",
-          "adjust": "increase_medium"
-        }
-      ]
-    }
-  ],
-  "fail_outcomes": [
-    {
-      "required_cat_types": {
-        "patrol_cats": [
-          1,
-          4
-        ]
-      },
-      "strings": [
-        "Mouse-dung! When p_l gets to the best moss gathering spot, {PRONOUN/p_l/subject} {VERB/p_l/find/finds} that some animal has dug up most of the moss. {PRONOUN/p_l/subject/CAP}'ll have to leave the rest to repopulate before gathering from this spot again."
-      ],
-      "exp_gained": 0,
-      "frequency": 4
-    },
-    {
-      "required_cat_types": {
-        "patrol_cats": [
-          1,
-          1
-        ]
-      },
-      "strings": [
-        "p_l arrives at {PRONOUN/p_l/poss} favorite moss gathering patch. The moss is tender and fluffy beneath {PRONOUN/p_l/poss} paws. With all the nagging responsibilities weighing on {PRONOUN/p_l/object} as a medicine cat, p_l supposes it might be alright to take a moment away from {PRONOUN/p_l/poss} duties to relax. p_l nestles into the soft moss for a quick respite... only to wake after dusk and return to camp empty-pawed."
-      ],
-      "relationship_changes": [
-        {
-          "cats_to": [
-            "patrol_cats"
-          ],
-          "cats_from": [
-            "some_clan",
-            "high_lawful"
-          ],
-          "mutual": false,
-          "values": [
-            "like"
-          ],
-          "amount": -3,
-          "log": {
-            "cats_from": "cat_from thought it was odd that cat_to spent so long out \"gathering moss\" only to return with empty paws."
-          }
-        }
-      ],
-      "exp_gained": 0,
-      "frequency": 2
-    },
-    {
-      "required_cat_types": {
-        "patrol_cats": [3, 4]
-      },
-      "frequency": 4,
-      "strings": [
-        "p_l leads the way to {PRONOUN/p_l/poss} favorite moss patch and watches bitterly as {PRONOUN/p_l/poss} patrol make a mess of it with their clumsy paws and lackadaisical attitudes. There's barely a scrap worth taking back to camp!"
-      ],
-      "relationship_changes": [
+        "fail_outcomes": [
+            {
+                "required_cat_types": {
+                    "patrol_cats": [
+                        1,
+                        4
+                    ]
+                },
+                "strings": [
+                    "Mouse-dung! When p_l gets to the best moss gathering spot, {PRONOUN/p_l/subject} {VERB/p_l/find/finds} that some animal has dug up most of the moss. {PRONOUN/p_l/subject/CAP}'ll have to leave the rest to repopulate before gathering from this spot again."
+                ],
+                "exp_gained": 0,
+                "frequency": 4
+            },
+            {
+                "required_cat_types": {
+                    "patrol_cats": [
+                        1,
+                        1
+                    ]
+                },
+                "strings": [
+                    "p_l arrives at {PRONOUN/p_l/poss} favorite moss gathering patch. The moss is tender and fluffy beneath {PRONOUN/p_l/poss} paws. With all the nagging responsibilities weighing on {PRONOUN/p_l/object} as a medicine cat, p_l supposes it might be alright to take a moment away from {PRONOUN/p_l/poss} duties to relax. p_l nestles into the soft moss for a quick respite... only to wake after dusk and return to camp empty-pawed."
+                ],
+                "relationship_changes": [
+                    {
+                        "cats_to": [
+                            "patrol_cats"
+                        ],
+                        "cats_from": [
+                            "some_clan",
+                            "high_lawful"
+                        ],
+                        "mutual": false,
+                        "values": [
+                            "like"
+                        ],
+                        "amount": -3,
+                        "log": {
+                            "cats_from": "cat_from thought it was odd that cat_to spent so long out \"gathering moss\" only to return with empty paws."
+                        }
+                    }
+                ],
+                "exp_gained": 0,
+                "frequency": 2
+            },
+            {
+                "required_cat_types": {
+                    "patrol_cats": [3, 4]
+                },
+                "frequency": 4,
+                "strings": [
+                    "p_l leads the way to {PRONOUN/p_l/poss} favorite moss patch and watches bitterly as {PRONOUN/p_l/poss} patrol make a mess of it with their clumsy paws and lackadaisical attitudes. There's barely a scrap worth taking back to camp!"
+                ],
+                "relationship_changes": [
                     {
                         "cats_to": [
                             "patrol_cats"
@@ -53135,37 +53167,37 @@
                         }
                     }
                 ],
-      "exp_gained": 0
-    },
-    {
-      "required_cat_types": {
-        "patrol_cats": [3, 4],
-        "all apprentices": [-1, -1]
-      },
-      "frequency": 4,
-      "strings": [
-        "p_l leads the way to {PRONOUN/p_l/poss} favorite moss patch, attempting to ignore {PRONOUN/p_l/poss} reluctant helpers complaining about how the duty is beneath them. Their gripes and complaints become too much to bear and p_l turns the patrol around without getting anything done."
-        ],
-      "exp_gained": 0,
-      "relationship_changes": [
-        {
-          "cats_to": [
-            "p_l"
-          ],
-          "cats_from": [
-            "patrol_cats"
-          ],
-          "mutual": true,
-          "values": [
-            "like"
-          ],
-          "amount": -8,
-          "log": {
-            "cats_from": "cat_from had to call off a moss gathering patrol when cat_to insisted it was beneath {PRONOUN/cat_to/object}."
-          }
-        }
-      ]
+                "exp_gained": 0
+            },
+            {
+                "required_cat_types": {
+                    "patrol_cats": [3, 4],
+                    "all apprentices": [-1, -1]
+                },
+                "frequency": 4,
+                "strings": [
+                    "p_l leads the way to {PRONOUN/p_l/poss} favorite moss patch, attempting to ignore {PRONOUN/p_l/poss} reluctant helpers complaining about how the duty is beneath them. Their gripes and complaints become too much to bear and p_l turns the patrol around without getting anything done."
+                ],
+                "exp_gained": 0,
+                "relationship_changes": [
+                    {
+                        "cats_to": [
+                            "p_l"
+                        ],
+                        "cats_from": [
+                            "patrol_cats"
+                        ],
+                        "mutual": true,
+                        "values": [
+                            "like"
+                        ],
+                        "amount": -8,
+                        "log": {
+                            "cats_from": "cat_from had to call off a moss gathering patrol when cat_to insisted it was beneath {PRONOUN/cat_to/object}."
+                        }
+                    }
+                ]
+            }
+        ]
     }
-  ]
-}
 ]

--- a/resources/lang/en/patrols/general/training.json
+++ b/resources/lang/en/patrols/general/training.json
@@ -32671,6 +32671,12 @@
                     }
                 },
                 "exp_gained": 0,
+                "supply": [
+                    {
+                        "type": "yew_berries",
+                        "adjust": "increase_tiny"
+                    }
+                ],
                 "condition": [
                     {
                         "cats": [


### PR DESCRIPTION
## About The Pull Request

- Added yew berries as a supply that could be gathered
- Cleaned up the json formatting of some patrols

## Why This Is Good For ClanGen
- Able to gather yew berries in relevant patrols not just via moonskip or random chance. 
- Files are easier to view

## Proof of Testing
<img width="398" height="440" alt="Screenshot 2026-08-28 at 11 58 37 AM" src="https://github.com/user-attachments/assets/88ce0395-5a2f-4b3c-a7eb-d6e2d75faded" />