### PR TITLE
[DEV] Stop opening empty Pygame window when saving in Visual Studio Code

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,4 @@
+import os
+
+os.environ["SDL_VIDEODRIVER"] = "dummy"
+os.environ["SDL_AUDIODRIVER"] = "dummy"


### PR DESCRIPTION
## About The Pull Request


If you don't set the SDL drivers to `dummy` for tests, it will open an invisible Pygame window whenever the tests run, which automatically happens whenever you press save in Visual Studio Code. This sets the SDL drivers in `__init__.py`, preventing that.

## Why This Is Good For ClanGen

Fixes something that's a little annoying.

## Proof of Testing

Tests are passing, game opens, and when I save in Visual Studio Code it stops opening the window.