### PR TITLE
[CI] Split bulk timeskip into its own job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
           architecture: 'x64'
       - name: install dependencies
         run: uv sync
-      - name: Run bulk timeskip simulation
+      - name: Run bulk timeskip simulation (it's ok if this fails)
         env:
           SDL_VIDEODRIVER: "dummy"
           SDL_AUDIODRIVER: "disk"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,31 @@ jobs:
           SDL_VIDEODRIVER: "dummy"
           SDL_AUDIODRIVER: "disk"
         run: uv run python -m unittest tests/test_relation_events.py tests/test_group_interaction.py tests/test_conditions.py tests/test_utility.py tests/test_cat.py tests/test_save.py tests/test_event_filters.py tests/test_new_cat_creation.py tests/test_patrols.py tests/test_lang.py tests/test_events.py
+  bulk-timeskip:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - python-version: '3.12'
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9
+        with:
+          enable-cache: true
+          prune-cache: true
+      - name: Setup Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: 'x64'
+      - name: install dependencies
+        run: uv sync
+      - name: Run unit tests
+        env:
+          SDL_VIDEODRIVER: "dummy"
+          SDL_AUDIODRIVER: "disk"
+        run: uv run python -m unittest tests/bulk_timeskip.py
   json_test:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
           SDL_AUDIODRIVER: "disk"
         run: uv run python -m unittest tests/test_relation_events.py tests/test_group_interaction.py tests/test_conditions.py tests/test_utility.py tests/test_cat.py tests/test_save.py tests/test_event_filters.py tests/test_new_cat_creation.py tests/test_patrols.py tests/test_lang.py tests/test_events.py
   bulk_timeskip:
-    name: Bulk Timeskip Simulation (it's ok if this fails)
+    name: Bulk Timeskip Simulation (flaky; may fail for unrelated reasons)
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -50,7 +50,7 @@ jobs:
           architecture: 'x64'
       - name: install dependencies
         run: uv sync
-      - name: Run bulk timeskip simulation (it's ok if this fails)
+      - name: Run bulk timeskip simulation (flaky; may fail for unrelated reasons)
         env:
           SDL_VIDEODRIVER: "dummy"
           SDL_AUDIODRIVER: "disk"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
           SDL_VIDEODRIVER: "dummy"
           SDL_AUDIODRIVER: "disk"
         run: uv run python -m unittest tests/test_relation_events.py tests/test_group_interaction.py tests/test_conditions.py tests/test_utility.py tests/test_cat.py tests/test_save.py tests/test_event_filters.py tests/test_new_cat_creation.py tests/test_patrols.py tests/test_lang.py tests/test_events.py
-  bulk-timeskip:
+  bulk_timeskip:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,7 @@ jobs:
           SDL_AUDIODRIVER: "disk"
         run: uv run python -m unittest tests/test_relation_events.py tests/test_group_interaction.py tests/test_conditions.py tests/test_utility.py tests/test_cat.py tests/test_save.py tests/test_event_filters.py tests/test_new_cat_creation.py tests/test_patrols.py tests/test_lang.py tests/test_events.py
   bulk_timeskip:
+    name: Bulk Timeskip Simulation (it's ok if this fails)
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -49,7 +50,7 @@ jobs:
           architecture: 'x64'
       - name: install dependencies
         run: uv sync
-      - name: Run unit tests
+      - name: Run bulk timeskip simulation
         env:
           SDL_VIDEODRIVER: "dummy"
           SDL_AUDIODRIVER: "disk"

--- a/tests/bulk_timeskip.py
+++ b/tests/bulk_timeskip.py
@@ -1,4 +1,5 @@
 import os
+
 import shutil
 from typing import List
 import unittest
@@ -18,9 +19,6 @@ from scripts.clan_package.get_clan_cats import (
 )
 from scripts.clan_package.settings import set_clan_setting
 from scripts.events_module.patrol.patrol import Patrol
-from scripts.events_module.short.short_event_generation import (
-    filter_events,
-)
 from scripts.game_structure import game
 from scripts.game_structure.game.save_load import read_clans
 from scripts.housekeeping.datadir import get_save_dir
@@ -94,25 +92,60 @@ class TestEvents(unittest.TestCase):
             with open(Path(get_save_dir()) / "currentclan.txt", "w") as currentclanfile:
                 currentclanfile.write(str(cls.previously_loaded_clan))
 
-    def test_random_cat_assignment(self):
-        """
-        Testing if random_cat is incorrectly reassigned to None when no events are available.
-        """
-        main_cat = choice(Cat.all_cats_list)
-        random_cat = choice(Cat.all_cats_list)
-        while random_cat == main_cat:
-            random_cat = choice(Cat.all_cats_list)
+    def test_bulk_skip(self):
+        with self.subTest(
+            "Timeskip Failed",
+        ):
+            for _ in range(500):
+                events.one_moon()
 
-        chosen_event, new_random_cat = filter_events(
-            possible_events=[],
-            main_cat=main_cat,
-            random_cat=random_cat,
-            other_clan=game.clan.all_other_clans[0],
-            sub_types=[],
-            allowed_events=None,
-            excluded_events=None,
-            ignore_subtyping=False,
-            reduction_avoidance_chance=1,
-        )
+                if not _ % 10:
+                    # every 10 moons, top up the number of cats in the Clan to at least 8
+                    # to give a good chance for event variety without bloat
+                    while get_living_clan_cat_count(Cat) < 8:
+                        game.clan.add_cat(
+                            cat_factory.create_cat(
+                                rank=choice(
+                                    [
+                                        CatRank.KITTEN,
+                                        CatRank.APPRENTICE,
+                                        CatRank.WARRIOR,
+                                        CatRank.WARRIOR,
+                                        CatRank.ELDER,
+                                    ]
+                                )
+                            )
+                        )
 
-        self.assertEqual(random_cat, new_random_cat)
+                    can_patrol = []
+                    for cat in Cat.all_cats_list:
+                        if (
+                            cat.ID not in game.patrolled
+                            and cat.status.rank.is_allowed_to_patrol()
+                            and cat.status.alive_in_player_clan
+                            and not cat.not_working()
+                        ):
+                            can_patrol.append(cat)
+                    shuffle(can_patrol)
+
+                    while can_patrol:
+                        num_to_patrol = min(len(can_patrol), randint(1, 6))
+                        to_patrol: List[Cat] = can_patrol[:num_to_patrol]
+                        meds_to_patrol = [
+                            cat
+                            for cat in to_patrol
+                            if cat.status.rank.is_any_medicine_rank()
+                        ]
+                        if meds_to_patrol:
+                            patrol_type = "med"
+                        else:
+                            patrol_type = "general"
+
+                        new_patrol = Patrol()
+                        new_patrol.begin_patrol(to_patrol, patrol_type)
+                        new_patrol.proceed_patrol("proceed")
+
+                        can_patrol = can_patrol[num_to_patrol:]
+
+                if not _ % 100:
+                    print(f"CLANCATS ALIVE: {get_living_clan_cat_count(Cat)}")

--- a/tests/bulk_timeskip.py
+++ b/tests/bulk_timeskip.py
@@ -24,7 +24,7 @@ from scripts.game_structure.game.save_load import read_clans
 from scripts.housekeeping.datadir import get_save_dir
 
 
-class TestEvents(unittest.TestCase):
+class BulkTimeskip(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         # load in the spritesheets


### PR DESCRIPTION
## About The Pull Request

* Splits bulk timeskip simulation into its own job so it's listed separately
* Titles it so that people are aware that it's ok if it fails 

## Why This Is Good For ClanGen
* Easier to tell if a unit test failed or if it was just the bulk timeskip

## Proof of Testing

<img width="704" height="544" alt="image" src="https://github.com/user-attachments/assets/b303744a-24fd-414b-bceb-77271c3c6285" />