### PR TITLE
chore: increase colorDecoratorsLimit

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -103,5 +103,6 @@
         "ujson",
         "verdana"
     ],
-    "editor.defaultColorDecorators": "always"
+    "editor.defaultColorDecorators": "always",
+    "editor.colorDecoratorsLimit": 2000,
 }


### PR DESCRIPTION

## About The Pull Request

* Increases `colorDecoratorsLimit` setting so that all the colours in `pelt_color_palettes` will get the colour selector in Visual Studio Code instead of only the first 500

## Why This Is Good For ClanGen

* Can use the colour selectors on all the colours instead of just the first 500

## Proof of Testing

<img width="504" height="365" alt="image" src="https://github.com/user-attachments/assets/b54cb91e-5658-4240-a768-a59b76f7ef4c" />

Colours still appearing at the bottom of the file.
