### PR TITLE
[BUGFIX] venom sickness in patrols and events + patrol bugfix

### DIFF
--- a/resources/lang/en/events/injury/beach.json
+++ b/resources/lang/en/events/injury/beach.json
@@ -1172,7 +1172,7 @@
                     "m_c"
                 ],
                 "injuries": [
-                    "poisoned"
+                    "venom sickness"
                 ]
             }
         ],

--- a/resources/lang/en/events/injury/desert.json
+++ b/resources/lang/en/events/injury/desert.json
@@ -1020,7 +1020,7 @@
                     "m_c"
                 ],
                 "injuries": [
-                    "poisoned"
+                    "venom sickness"
                 ]
             }
         ],
@@ -3250,7 +3250,7 @@
                     "m_c"
                 ],
                 "injuries": [
-                    "poisoned"
+                    "venom sickness"
                 ]
             }
         ],
@@ -4339,7 +4339,7 @@
                     "m_c"
                 ],
                 "injuries": [
-                    "poisoned"
+                    "venom sickness"
                 ]
             }
         ],
@@ -4385,7 +4385,7 @@
                     "m_c"
                 ],
                 "injuries": [
-                    "poisoned"
+                    "venom sickness"
                 ]
             }
         ],

--- a/resources/lang/en/patrols/beach/hunting/any.json
+++ b/resources/lang/en/patrols/beach/hunting/any.json
@@ -5788,7 +5788,7 @@
                         ],
                         "condition": [
                             "small cut",
-                            "poisoned"
+                            "venom sickness"
                         ],
                         "scar_pool_override": [
                             "QUILLSIDE"

--- a/resources/lang/en/patrols/beach/hunting/greenleaf.json
+++ b/resources/lang/en/patrols/beach/hunting/greenleaf.json
@@ -609,7 +609,7 @@
                         ],
                         "condition": [
                             "snake bite",
-                            "poisoned"
+                            "venom sickness"
                         ],
                         "scar_history": "m_c was scarred by a rattlesnake.",
                         "death_history": "m_c died after being bitten by a rattlesnake on patrol."

--- a/resources/lang/en/patrols/beach/hunting/leaf-bare.json
+++ b/resources/lang/en/patrols/beach/hunting/leaf-bare.json
@@ -645,7 +645,7 @@
                         ],
                         "condition": [
                             "snake bite",
-                            "poisoned"
+                            "venom sickness"
                         ],
                         "scar_history": "m_c was scarred by a rattlesnake.",
                         "death_history": "m_c died after being bitten by a rattlesnake on patrol."

--- a/resources/lang/en/patrols/beach/hunting/leaf-fall.json
+++ b/resources/lang/en/patrols/beach/hunting/leaf-fall.json
@@ -609,7 +609,7 @@
                         ],
                         "condition": [
                             "snake bite",
-                            "poisoned"
+                            "venom sickness"
                         ],
                         "scar_history": "m_c was scarred by a rattlesnake.",
                         "death_history": "m_c succumbed to a rattlesnake bite."

--- a/resources/lang/en/patrols/beach/hunting/newleaf.json
+++ b/resources/lang/en/patrols/beach/hunting/newleaf.json
@@ -609,7 +609,7 @@
                         ],
                         "condition": [
                             "snake bite",
-                            "poisoned"
+                            "venom sickness"
                         ],
                         "scar_history": "m_c was scarred by a rattlesnake.",
                         "death_history": "m_c succumbed to a rattlesnake's venom."

--- a/resources/lang/en/patrols/desert/hunting/any.json
+++ b/resources/lang/en/patrols/desert/hunting/any.json
@@ -2450,7 +2450,7 @@
                         ],
                         "condition": [
                             "bite-wound",
-                            "poisoned"
+                            "venom sickness"
                         ],
                         "scar_history": "m_c was permanently marked by the bite of a gila monster as an apprentice — but {PRONOUN/m_c/subject} survived.",
                         "death_history": "m_c died from the bite of a gila monster encountered on a hunt as a foolish apprentice."

--- a/resources/lang/en/patrols/general/border.json
+++ b/resources/lang/en/patrols/general/border.json
@@ -2136,7 +2136,7 @@
                             "p_l"
                         ],
                         "condition": [
-                            "poisoned"
+                            "venom sickness"
                         ],
                         "scar_history": "m_c was scarred by a snake bite.",
                         "death_history": "m_c died from the bite of a venomous snake."

--- a/resources/lang/en/patrols/new_cat_welcoming.json
+++ b/resources/lang/en/patrols/new_cat_welcoming.json
@@ -3585,7 +3585,7 @@
                         "condition": [
                             "carrionplace disease"
                         ],
-                        "no_results": true
+                        "death_history": "m_c died of carrionplace disease."
                     }
                 ],
                 "join": [
@@ -3658,7 +3658,7 @@
                         "condition": [
                             "carrionplace disease"
                         ],
-                        "no_results": true
+                        "death_history": "m_c died of carrionplace disease."
                     }
                 ],
                 "join": [

--- a/resources/lang/en/patrols/plains/hunting/greenleaf.json
+++ b/resources/lang/en/patrols/plains/hunting/greenleaf.json
@@ -1616,7 +1616,7 @@
                         ],
                         "condition": [
                             "snake bite",
-                            "poisoned"
+                            "venom sickness"
                         ],
                         "scar_history": "This cat was scarred by a rattlesnake while hunting.",
                         "death_history": "m_c died of a rattlesnake bite."
@@ -1657,7 +1657,7 @@
                         ],
                         "condition": [
                             "snake bite",
-                            "poisoned",
+                            "venom sickness",
                             "damaged eyes"
                         ],
                         "scar_pool_override": [


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
Replaces "poisoned" condition with "venom sickness" in patrols and injury events where appropriate (snake bites, stingray, etc).
Adds missing death_history for carrionplace disease in a patrol.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Why This Is Good For ClanGen
More accurate injuries + bug fixed
<!-- If this is a bug fix, you can remove this section. -->
<!-- Please add a short description of why you think these changes would benefit the game. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->
<!-- If you have multiple features that can stand on their own, or unrelated bugfixes, please create separate PRs for them. -->

## Linked Issues
Fixes: #5892 
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing

<img width="988" height="907" alt="Screenshot 2026-08-30 133611" src="https://github.com/user-attachments/assets/a6708038-1cc5-4a90-bc4f-3fa912ff7436" />

<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
Updates some patrols and events to use "venom sickness" instead of "poisoned" where appropriate

<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
