### PR TITLE
[BUGFIX] fix gen_train_notmentor

### DIFF
--- a/resources/lang/en/patrols/general/training.json
+++ b/resources/lang/en/patrols/general/training.json
@@ -28151,7 +28151,7 @@
                     "p_l"
                 ],
                 "cats_to": [
-                    "patrol_cats"
+                    "r_c1"
                 ],
                 "mutual": false,
                 "constraints": [


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

Changes `patrol_cats` to `r_c1` in `gen_train_notmentor`'s relationship constraints, stopping it from generating when `p_l` is not `r_c1`'s mentor.
## Why This Is Good For ClanGen


## Linked Issues

Fixes #5934

## Proof of Testing
<img width="802" height="690" alt="Screenshot 2026-08-30 210804" src="https://github.com/user-attachments/assets/af428646-7f55-42f5-8eca-75d5a3270c0e" />
<img width="669" height="279" alt="Screenshot 2026-08-30 210907" src="https://github.com/user-attachments/assets/1d7d9136-8e97-4f74-bc49-37cc8ec79e76" />

Doesn't generate when gen_train_notmentor is forced in the game_config and p_l is r_c1's mentor

## Changelog/Credits

<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
