### PR TITLE
[REWORK] updating gen_med_sunny

### DIFF
--- a/resources/lang/en/patrols/general/med.json
+++ b/resources/lang/en/patrols/general/med.json
@@ -33,11 +33,10 @@
                 },
                 "outcome_art": "cat_sprites/gen_med_sunny_Mc",
                 "involved_cats": {
-                    "p_l": {},
                     "r_c0": {}
                 },
                 "strings": [
-                    "p_l and r_c0 enjoy the sunlight and discuss the most recent half-moon meeting and whether will affect c_n."
+                    "p_l and r_c0 enjoy the sunlight and discuss the most recent half-moon meeting and whether it will affect c_n."
                 ],
                 "exp_gained": 20,
                 "relationship_changes": [
@@ -91,7 +90,7 @@
                         ],
                         "amount": 10,
                         "log": {
-                            "cats_from": "cat_from and cat_to chatted about the herb stores and their plans to gather them while sunning themselves."
+                            "cats_from": "While sunning themselves, cat_from and cat_to chatted about the herb stores and their plans to gather them."
                         }
                     }
                 ],
@@ -353,7 +352,7 @@
                 "outcome_art": "cat_sprites/gen_med_sunny_Mc",
                 "strings": [
                     "The patrol doesn't get much done lazing away in the sun.",
-                    "The patrol falls asleep and fail to gather any herbs.",
+                    "The patrol falls asleep and fails to gather any herbs.",
                     "The patrol spends their time daydreaming instead of gathering herbs."
                 ],
                 "exp_gained": 0,
@@ -405,7 +404,7 @@
             {
                 "frequency": 4,
                 "strings": [
-                    "s_c0 wasn't able to relax and kept the rest of the patrol from relaxing with all {PRONOUN/s_c0/poss} {VERB/r_c0/movement/movements}. The patrol returns to camp grumpy and with no herbs."
+                    "s_c0 wasn't able to relax and kept the rest of the patrol from relaxing with all {PRONOUN/s_c0/poss} {VERB/s_c0/movement/movements}. The patrol returns to camp grumpy and with no herbs."
                 ],
                 "involved_cats": {
                     "s_c0": {

--- a/resources/lang/en/patrols/general/med.json
+++ b/resources/lang/en/patrols/general/med.json
@@ -1,42 +1,43 @@
 [
     {
-        "event_id": "gen_med_sunny1",
+        "event_id": "gen_med_sunny_group",
         "types": [
             "herb_gathering"
         ],
-        "frequency": 1,
+        "season": ["greenleaf", "newleaf"],
+        "frequency": 3,
         "required_cat_types": {
-            "patrol_cats": [
-                2,
-                6
-            ],
-            "apprentice": [
-                -1,
-                -1
-            ],
-            "medicine cat": [
-                1,
-                6
-            ],
-            "normal adult": [
-                -1,
-                -1
-            ]
+            "patrol_cats": [2, 6],
+            "healer cats": [1, 6]
         },
         "chance_of_success": 60,
         "patrol_art": "cat_sprites/gen_med_talking_McMc",
         "intro_strings": [
-            "The patrol finds a nice spot to sun themselves."
+            "The patrol finds a nice spot to sun themselves.",
+            "Before the patrol gathers any herbs, they settle down to enjoy the sunshine.",
+            "p_l decides that before anything else, the patrol should take advantage of the sunlight and warm their pelts."
         ],
         "decline_strings": [
-            "They decide to stay focused."
+            "The patrol decides to stay focused.",
+            "The patrol remains stalwart against urge to relax in the sun.",
+            "The patrol doesn't have time to sun themselves."
         ],
         "success_outcomes": [
             {
                 "frequency": 4,
+                "required_cat_types": {
+                    "patrol_cats": [2, 6],
+                    "apprentice": [-1, -1],
+                    "healer cats": [2, 6],
+                    "normal adult": [-1, -1]
+                },
                 "outcome_art": "cat_sprites/gen_med_sunny_Mc",
+                "involved_cats": {
+                    "p_l": {},
+                    "r_c0": {}
+                },
                 "strings": [
-                    "The sunlight feels great and the cats have a successful discussion, talking about what came up at the last half-moon meetings and whether it'll affect c_n."
+                    "p_l and r_c0 enjoy the sunlight and discuss the most recent half-moon meeting and whether will affect c_n."
                 ],
                 "exp_gained": 20,
                 "relationship_changes": [
@@ -61,15 +62,18 @@
                 "supply": [
                     {
                         "type": "random_herbs",
-                        "adjust": "increase_medium"
+                        "adjust": "increase_small"
                     }
                 ]
             },
             {
                 "frequency": 4,
+                "required_cat_types": {
+                    "healer cats": [2, 6]
+                },
                 "outcome_art": "cat_sprites/gen_med_sunny_Mc",
                 "strings": [
-                    "The sunlight feels great and the cats have a lovely discussion, talking about what herbs need to be gathered and the best locations to gather them."
+                    "The sunlight feels great and the cats have a lovely discussion about what herbs need to be gathered and the best locations to gather them."
                 ],
                 "exp_gained": 20,
                 "relationship_changes": [
@@ -87,7 +91,7 @@
                         ],
                         "amount": 10,
                         "log": {
-                            "cats_from": "cat_from and cat_to chatted about the herb stores and herb-gathering spots while sunning themselves."
+                            "cats_from": "cat_from and cat_to chatted about the herb stores and their plans to gather them while sunning themselves."
                         }
                     }
                 ],
@@ -99,7 +103,7 @@
                 ]
             },
             {
-                "frequency": 2,
+                "frequency": 3,
                 "strings": [
                     "The sunlight energizes the cats for their herb-gathering."
                 ],
@@ -213,7 +217,8 @@
                                 "SENSE,1",
                                 "HEALER,1"
                             ]
-                        }
+                        },
+                        "status": ["medicine cat", "medicine cat apprentice"]
                     }
                 },
                 "exp_gained": 20,
@@ -243,7 +248,7 @@
                 ]
             },
             {
-                "frequency": 2,
+                "frequency": 4,
                 "strings": [
                     "The sunlight refreshes the cats for their herb-gathering. s_c0 is extra bright, and {PRONOUN/s_c0/poss} jokes make the whole patrol pass by in a good mood."
                 ],
@@ -347,7 +352,9 @@
                 "frequency": 4,
                 "outcome_art": "cat_sprites/gen_med_sunny_Mc",
                 "strings": [
-                    "The patrol doesn't get much done because of that."
+                    "The patrol doesn't get much done lazing away in the sun.",
+                    "The patrol falls asleep and fail to gather any herbs.",
+                    "The patrol spends their time daydreaming instead of gathering herbs."
                 ],
                 "exp_gained": 0,
                 "relationship_changes": [
@@ -356,7 +363,7 @@
                             "patrol_cats"
                         ],
                         "cats_from": [
-                            "patrol_cats"
+                            "some_clan"
                         ],
                         "mutual": false,
                         "values": [
@@ -364,13 +371,13 @@
                         ],
                         "amount": -5,
                         "log": {
-                            "cats_from": "cat_from and cat_to lost a bit of respect for each other's work ethic when they spent a whole patrol basking instead of gathering herbs."
+                            "cats_from": "cat_from lost a bit of respect for cat_to's work ethic when {PRONOUN/cat_from/subject} heard that cat_to spent a whole patrol basking in the sun instead of gathering herbs."
                         }
                     }
                 ]
             },
             {
-                "frequency": 1,
+                "frequency": 2,
                 "outcome_art": "cat_sprites/gen_med_argue_McMc",
                 "strings": [
                     "The patrol gets into an argument and returns home with tails lashing, shooting annoyed looks at each other."
@@ -401,7 +408,6 @@
                     "s_c0 wasn't able to relax and kept the rest of the patrol from relaxing with all {PRONOUN/s_c0/poss} {VERB/r_c0/movement/movements}. The patrol returns to camp grumpy and with no herbs."
                 ],
                 "involved_cats": {
-                    "r_c0": {},
                     "s_c0": {
                         "prior_abbreviation": [
                             "any"
@@ -480,7 +486,7 @@
                         ],
                         "amount": -8,
                         "log": {
-                            "cats_from": "cat_from was peeved that cat_to took the best basking spot and ignored all conversation during a patrol."
+                            "cats_from": "cat_from was annoyed that cat_to took the best basking spot and ignored all conversation during a patrol."
                         }
                     }
                 ]
@@ -488,7 +494,7 @@
         ]
     },
     {
-        "event_id": "gen_med_sunny2",
+        "event_id": "gen_med_sunny_solo",
         "types": [
             "herb_gathering"
         ],
@@ -506,35 +512,29 @@
         "chance_of_success": 60,
         "patrol_art": "cat_sprites/gen_med_sunny_Mc",
         "intro_strings": [
-            "p_l finds a nice spot to sun {PRONOUN/p_l/self}."
+            "p_l finds a nice spot to sun {PRONOUN/p_l/self}.",
+            "Before p_l gathers any herbs, {PRONOUN/p_l/subject} decide to settle down and enjoy the sunlight.",
+            "While on patrol, p_l takes advantage of the sunlight and warms {PRONOUN/p_l/poss} pelt."
         ],
         "decline_strings": [
-            "{PRONOUN/p_l/subject/CAP} {VERB/p_l/decide/decides} to stay focused."
+            "{PRONOUN/p_l/subject/CAP} {VERB/p_l/decide/decides} to stay focused.",
+            "p_l resists the urge to bask in the sun.",
+            "p_l decides there's no time to sun."
         ],
         "success_outcomes": [
             {
                 "frequency": 4,
                 "strings": [
-                    "The sunlight feels great and p_l has a successful patrol."
+                    "The sunlight feels great and p_l has a successful patrol.",
+                    "The sunlight energizes p_l for the rest of {PRONOUN/p_l/poss} herb-gathering.",
+                    "p_l has a nice rest and soon is successful in gathering some herbs.",
+                     "Despite falling asleep, p_l still wakes up with some time to gather herbs."
                 ],
                 "exp_gained": 20,
                 "supply": [
                     {
                         "type": "random_herbs",
-                        "adjust": "increase_small"
-                    }
-                ]
-            },
-            {
-                "frequency": 1,
-                "strings": [
-                    "The sunlight energizes p_l for the rest of {PRONOUN/p_l/poss} herb-gathering."
-                ],
-                "exp_gained": 20,
-                "supply": [
-                    {
-                        "type": "random_herbs",
-                        "adjust": "increase_small"
+                        "adjust": "increase_medium"
                     }
                 ]
             },
@@ -552,7 +552,7 @@
                             "high_stable"
                         ],
                         "cats_to": [
-                            "r_c0"
+                            "p_l"
                         ],
                         "mutual": false,
                         "values": [
@@ -569,32 +569,6 @@
                     {
                         "type": "random_herbs",
                         "adjust": "increase_huge"
-                    }
-                ]
-            },
-            {
-                "frequency": 4,
-                "strings": [
-                    "p_l has a nice rest and soon is successful in gathering some herbs."
-                ],
-                "exp_gained": 20,
-                "supply": [
-                    {
-                        "type": "random_herbs",
-                        "adjust": "increase_medium"
-                    }
-                ]
-            },
-            {
-                "frequency": 4,
-                "strings": [
-                    "Despite falling asleep, p_l still wakes up with some time to gather herbs."
-                ],
-                "exp_gained": 20,
-                "supply": [
-                    {
-                        "type": "random_herbs",
-                        "adjust": "increase_medium"
                     }
                 ]
             },
@@ -617,14 +591,8 @@
             {
                 "frequency": 4,
                 "strings": [
-                    "{PRONOUN/p_l/subject/CAP} {VERB/p_l/don't/doesn't} get much done because of that."
-                ],
-                "exp_gained": 0
-            },
-            {
-                "frequency": 4,
-                "strings": [
-                    "Due to p_l falling asleep, {PRONOUN/p_l/subject} {VERB/p_l/don't/doesn't} wake up in time to gather herbs."
+                    "{PRONOUN/p_l/subject/CAP} {VERB/p_l/don't/doesn't} get much done because of that.",
+                    "p_l falls asleep and doesn't wake up in time to gather herbs."
                 ],
                 "exp_gained": 0
             },
@@ -12415,7 +12383,9 @@
                 ],
                 "involved_cats": {
                     "r_c1": {
-                        "has_mentor": {"current": true}
+                        "has_mentor": {
+                            "current": true
+                        }
                     }
                 },
                 "exp_gained": 0,


### PR DESCRIPTION
## About The Pull Request

- changes the IDs to differentiate solo Versus individual (why they are split)
- changes the frequency which was previously 1. It is a mundane and pleasing event that I think warrants being more readily available
- changed the season constraint to available in newleaf and greenleaf
- changed the frequency of some unique outcomes to make them more frequent
- changed the relationship change of one outcome that felt odd
- condenses outcomes that share constraints
- tweaks to sentence flow and grammar
- A few intro/decline/event text variations

## Why This Is Good For ClanGen

- maximizing usage of our current patrol structure

## Proof of Testing
<img width="698" height="540" alt="Screenshot 2026-09-01 at 7 48 12 PM" src="https://github.com/user-attachments/assets/eff53000-fe24-44f3-a433-fb85f6865d52" />
<img width="726" height="555" alt="Screenshot 2026-09-01 at 7 49 15 PM" src="https://github.com/user-attachments/assets/908291ee-3ab5-446e-85ae-e5a14f70669d" />
<img width="717" height="549" alt="Screenshot 2026-09-01 at 7 48 18 PM" src="https://github.com/user-attachments/assets/63aae52a-bc60-4ee6-a986-f83891c3e80d" />
<img width="710" height="568" alt="Screenshot 2026-09-01 at 7 49 49 PM" src="https://github.com/user-attachments/assets/930911af-96b2-4308-b19e-b3c765b6d1b2" />
<img width="702" height="529" alt="Screenshot 2026-09-01 at 7 58 32 PM" src="https://github.com/user-attachments/assets/e64319fc-6206-4a71-981b-6abb84e38e18" />
<img width="720" height="552" alt="Screenshot 2026-09-01 at 7 58 53 PM" src="https://github.com/user-attachments/assets/b0ddf865-53d7-4993-92b3-dedc390ccbc7" />
<img width="735" height="455" alt="Screenshot 2026-09-01 at 7 58 35 PM" src="https://github.com/user-attachments/assets/a325acd3-c85f-45d6-a97b-06e31cb3b701" />