### PR TITLE
[CI] Fix Broken Patrol Test, Slight Tweaking and Renaming of a Couple Patrol Functions

### DIFF
--- a/scripts/events_module/patrol/patrol.py
+++ b/scripts/events_module/patrol/patrol.py
@@ -120,7 +120,7 @@ class Patrol:
             self.other_clan = None
 
         # Find valid patrol
-        self.patrol_event = self._get_possible_patrol(patrol_type)
+        self._set_possible_patrol(patrol_type)
         self._create_needed_cats()
 
         # Return text adjusted patrol intro
@@ -251,7 +251,7 @@ class Patrol:
 
         print("Patrol Leader:", str(self.involved_cats["p_l"].name))
 
-    def _get_possible_patrol(
+    def _set_possible_patrol(
         self,
         patrol_type: str,
     ) -> PatrolEvent:
@@ -403,13 +403,13 @@ class Patrol:
 
         # first we see if we can get a romantic patrol
         if romantic_patrols and not self.debug_patrol_id:
-            chosen_patrol = self._get_valid_patrol(
+            chosen_patrol = self._set_valid_patrol(
                 romantic_patrols.copy(), find_romance=True
             )
 
         # if no romantic patrol possible, we get a normal one!
         if not chosen_patrol:
-            chosen_patrol = self._get_valid_patrol(
+            chosen_patrol = self._set_valid_patrol(
                 normal_patrols.copy(), find_romance=False
             )
             if not chosen_patrol:
@@ -427,11 +427,16 @@ class Patrol:
         """
         Patrol.used_patrols["romance" if find_romance else "normal"].clear()
 
-        return self._get_valid_patrol(possible_patrols, find_romance)
+        return self._set_valid_patrol(possible_patrols, find_romance)
 
-    def _get_valid_patrol(
+    def _set_valid_patrol(
         self, possible_patrols: List[PatrolEvent], find_romance: bool = False
     ) -> Optional[PatrolEvent]:
+        """
+        Finds a valid patrol
+        If one if found, sets the patrol event and involved cats, 
+            and returns the patrol event. 
+        """
         chosen_patrol = None
         patrols_to_test = [
             p
@@ -457,7 +462,7 @@ class Patrol:
                 if not Patrol.used_patrols["romance" if find_romance else "normal"]:
                     # No patrols found even after resetting used patrols.
                     # This should only be possible when filtering for romance patrols.
-                    return None
+                    return None, None
 
                 # if we couldn't find a patrol, then we need to clear the used_patrols and try again
                 chosen_patrol = self._clear_used_and_retry(
@@ -466,6 +471,7 @@ class Patrol:
             else:
                 # otherwise, let's set our involved cats and move on with this patrol!
                 self.involved_cats = involved_cats
+                self.patrol_event = chosen_patrol
 
         if find_romance:
             if not self._decide_if_romantic(chosen_patrol):

--- a/scripts/events_module/patrol/patrol.py
+++ b/scripts/events_module/patrol/patrol.py
@@ -120,7 +120,7 @@ class Patrol:
             self.other_clan = None
 
         # Find valid patrol
-        self._load_patrols_and_set_possible_patrol(patrol_type)
+        self._load_patrols_and_set_patrol(patrol_type)
         self._create_needed_cats()
 
         # Return text adjusted patrol intro
@@ -372,6 +372,7 @@ class Patrol:
         possible_patrols: List[PatrolEvent],
         patrol_type: str,
     ) -> PatrolEvent:
+        
         # GET POSSIBLE PATROLS
         # run the first set of really basic constraint filtering, just to get our base of valid patrols
         possible_patrols = [
@@ -462,7 +463,7 @@ class Patrol:
                 if not Patrol.used_patrols["romance" if find_romance else "normal"]:
                     # No patrols found even after resetting used patrols.
                     # This should only be possible when filtering for romance patrols.
-                    return None, None
+                    return None
 
                 # if we couldn't find a patrol, then we need to clear the used_patrols and try again
                 chosen_patrol = self._clear_used_and_retry(

--- a/scripts/events_module/patrol/patrol.py
+++ b/scripts/events_module/patrol/patrol.py
@@ -372,7 +372,6 @@ class Patrol:
         possible_patrols: List[PatrolEvent],
         patrol_type: str,
     ) -> PatrolEvent:
-        
         # GET POSSIBLE PATROLS
         # run the first set of really basic constraint filtering, just to get our base of valid patrols
         possible_patrols = [
@@ -435,8 +434,8 @@ class Patrol:
     ) -> Optional[PatrolEvent]:
         """
         Finds a valid patrol
-        If one if found, sets the patrol event and involved cats, 
-            and returns the patrol event. 
+        If one if found, sets the patrol event and involved cats,
+            and returns the patrol event.
         """
         chosen_patrol = None
         patrols_to_test = [

--- a/scripts/events_module/patrol/patrol.py
+++ b/scripts/events_module/patrol/patrol.py
@@ -120,7 +120,7 @@ class Patrol:
             self.other_clan = None
 
         # Find valid patrol
-        self._set_possible_patrol(patrol_type)
+        self._load_patrols_and_set_possible_patrol(patrol_type)
         self._create_needed_cats()
 
         # Return text adjusted patrol intro
@@ -251,7 +251,7 @@ class Patrol:
 
         print("Patrol Leader:", str(self.involved_cats["p_l"].name))
 
-    def _set_possible_patrol(
+    def _load_patrols_and_set_patrol(
         self,
         patrol_type: str,
     ) -> PatrolEvent:
@@ -307,9 +307,9 @@ class Patrol:
             )
         # FILTER PATROLS when no debug set
         else:
-            chosen_patrol = self._filter_patrols(patrol_list, patrol_type)
+            chosen_patrol = self._filter_and_set_patrol(patrol_list, patrol_type)
 
-        return chosen_patrol
+        self.patrol_event = chosen_patrol
 
     def _decide_if_romantic(self, romantic_event: Optional[PatrolEvent]) -> bool:
         """
@@ -367,7 +367,7 @@ class Patrol:
         print("final romance chance:", chance_of_romance_patrol)
         return not int(random.random() * chance_of_romance_patrol)
 
-    def _filter_patrols(
+    def _filter_and_set_patrol(
         self,
         possible_patrols: List[PatrolEvent],
         patrol_type: str,

--- a/tests/test_patrols.py
+++ b/tests/test_patrols.py
@@ -23,6 +23,15 @@ from scripts.game_structure.game import Switch
 from scripts.game_structure.game.switches import switch_set_value
 
 
+def set_up_patrol_class_w_event(patrol_class: Patrol, patrol_cats:list[Cat], patrol_events:list[PatrolEvent]):
+    """
+    Sets up the patrol_class with the patrol cats, and patrol event. 
+    """
+    patrol_class._add_patrol_cats(patrol_cats)
+    patrol_class._set_valid_patrol(patrol_events)
+    patrol_class._create_needed_cats()
+
+
 class TestPatrolCats(unittest.TestCase):
     def setUp(self):
         game.clan = Clan("test")
@@ -347,9 +356,9 @@ class TestOutcomeExecution(unittest.TestCase):
                 fail_outcomes=[{"strings": ["test"]}],
             )
 
-            self.patrol_class._add_patrol_cats([war1])
-            self.patrol_class.patrol_event = self.patrol_class._get_valid_patrol([patrol])
-            self.patrol_class._create_needed_cats()
+
+            set_up_patrol_class_w_event(self.patrol_class, [war1], [patrol])
+
             self.patrol_class._check_outcome_constraints(
                 patrol.success_outcomes[0], "success"
             )
@@ -377,9 +386,10 @@ class TestOutcomeExecution(unittest.TestCase):
                 success_outcomes=[{"strings": [""], "join": [JoinDict(cats=["n_c0"])]}],
                 fail_outcomes=[{"strings": ["test"]}],
             )
-            self.patrol_class._add_patrol_cats([war1])
-            self.patrol_class.patrol_event = self.patrol_class._get_valid_patrol([patrol])
-            self.patrol_class._create_needed_cats()
+
+
+            set_up_patrol_class_w_event(self.patrol_class, [war1], [patrol])
+
             self.patrol_class._check_outcome_constraints(
                 patrol.success_outcomes[0], "success"
             )
@@ -416,8 +426,8 @@ class TestOutcomeExecution(unittest.TestCase):
             fail_outcomes=[{"strings": ["test"]}],
         )
 
-        self.patrol_class._add_patrol_cats([war1, app1])
-        self.patrol_class._get_valid_patrol([patrol])
+        set_up_patrol_class_w_event(self.patrol_class, [war1, app1], [patrol])
+
         self.patrol_class._check_outcome_constraints(
             patrol.success_outcomes[0], "success"
         )
@@ -458,8 +468,8 @@ class TestOutcomeExecution(unittest.TestCase):
             fail_outcomes=[{"strings": ["test"]}],
         )
 
-        self.patrol_class._add_patrol_cats([war1, app1])
-        self.patrol_class._get_valid_patrol([patrol])
+        set_up_patrol_class_w_event(self.patrol_class, [war1, app1], [patrol])
+
         self.patrol_class._check_outcome_constraints(
             patrol.success_outcomes[0], "success"
         )
@@ -495,8 +505,8 @@ class TestOutcomeExecution(unittest.TestCase):
             fail_outcomes=[{"strings": ["test"]}],
         )
 
-        self.patrol_class._add_patrol_cats([war1, app1])
-        self.patrol_class._get_valid_patrol([patrol])
+        set_up_patrol_class_w_event(self.patrol_class, [war1, app1], [patrol])
+
         self.patrol_class._check_outcome_constraints(
             patrol.success_outcomes[0], "success"
         )

--- a/tests/test_patrols.py
+++ b/tests/test_patrols.py
@@ -23,9 +23,11 @@ from scripts.game_structure.game import Switch
 from scripts.game_structure.game.switches import switch_set_value
 
 
-def set_up_patrol_class_w_event(patrol_class: Patrol, patrol_cats:list[Cat], patrol_events:list[PatrolEvent]):
+def set_up_patrol_class_w_event(
+    patrol_class: Patrol, patrol_cats: list[Cat], patrol_events: list[PatrolEvent]
+):
     """
-    Sets up the patrol_class with the patrol cats, and patrol event. 
+    Sets up the patrol_class with the patrol cats, and patrol event.
     """
     patrol_class._add_patrol_cats(patrol_cats)
     patrol_class._set_valid_patrol(patrol_events)
@@ -356,7 +358,6 @@ class TestOutcomeExecution(unittest.TestCase):
                 fail_outcomes=[{"strings": ["test"]}],
             )
 
-
             set_up_patrol_class_w_event(self.patrol_class, [war1], [patrol])
 
             self.patrol_class._check_outcome_constraints(
@@ -386,7 +387,6 @@ class TestOutcomeExecution(unittest.TestCase):
                 success_outcomes=[{"strings": [""], "join": [JoinDict(cats=["n_c0"])]}],
                 fail_outcomes=[{"strings": ["test"]}],
             )
-
 
             set_up_patrol_class_w_event(self.patrol_class, [war1], [patrol])
 

--- a/tests/test_patrols.py
+++ b/tests/test_patrols.py
@@ -173,7 +173,7 @@ class TestInvolvedCats(unittest.TestCase):
         )
 
         self.patrol_class._add_patrol_cats([war1, app1, app2])
-        self.patrol_class._get_valid_patrol([patrol])
+        self.patrol_class._set_valid_patrol([patrol])
 
         self.assertEqual(
             war1,
@@ -204,8 +204,7 @@ class TestInvolvedCats(unittest.TestCase):
             fail_outcomes=[{"strings": ["test"]}],
         )
 
-        self.patrol_class._add_patrol_cats([war1])
-        self.patrol_class.patrol_event = self.patrol_class._get_valid_patrol([patrol])
+        set_up_patrol_class_w_event(self.patrol_class, [war1], [patrol])
         self.patrol_class._create_needed_cats()
 
         self.assertEqual(
@@ -243,9 +242,9 @@ class TestInvolvedCats(unittest.TestCase):
             ],
             fail_outcomes=[{"strings": ["test"]}],
         )
-        self.patrol_class.patrol_event = patrol
-        self.patrol_class._add_patrol_cats([war1, app1, app2])
-        self.patrol_class._get_valid_patrol([patrol])
+
+        set_up_patrol_class_w_event(self.patrol_class, [war1, app1, app2], [patrol])
+
         self.patrol_class._check_outcome_constraints(
             patrol.success_outcomes[0], "success"
         )
@@ -275,9 +274,9 @@ class TestInvolvedCats(unittest.TestCase):
             ],
             fail_outcomes=[{"strings": ["test"]}],
         )
-        self.patrol_class.patrol_event = patrol
-        self.patrol_class._add_patrol_cats([war1, app1, app2])
-        self.patrol_class._get_valid_patrol([patrol])
+
+        set_up_patrol_class_w_event(self.patrol_class, [war1, app1, app2], [patrol])
+
         self.patrol_class._check_outcome_constraints(
             patrol.success_outcomes[0], "success"
         )
@@ -307,9 +306,9 @@ class TestInvolvedCats(unittest.TestCase):
             ],
             fail_outcomes=[{"strings": ["test"]}],
         )
-        self.patrol_class.patrol_event = patrol
-        self.patrol_class._add_patrol_cats([war1, app1, app2])
-        self.patrol_class._get_valid_patrol([patrol])
+
+        set_up_patrol_class_w_event(self.patrol_class, [war1, app1, app2], [patrol])
+
         self.patrol_class._check_outcome_constraints(
             patrol.success_outcomes[0], "success"
         )
@@ -545,8 +544,8 @@ class TestOutcomeExecution(unittest.TestCase):
         starting_clan_rep = other_clan.relations
         starting_outsider_rep = game.clan.reputation
 
-        self.patrol_class._add_patrol_cats([war1, app1])
-        self.patrol_class._get_valid_patrol([patrol])
+        set_up_patrol_class_w_event(self.patrol_class, [war1, app1], [patrol])
+
         self.patrol_class._check_outcome_constraints(
             patrol.success_outcomes[0], "success"
         )
@@ -587,8 +586,7 @@ class TestOutcomeExecution(unittest.TestCase):
         honey_count = game.clan.herb_supply.get_single_herb_total("honey")
         total_herb_count = game.clan.herb_supply.total
 
-        self.patrol_class._add_patrol_cats([war1])
-        self.patrol_class._get_valid_patrol([])
+        set_up_patrol_class_w_event(self.patrol_class, [war1], [patrol])
         self.patrol_class._check_outcome_constraints(
             patrol.success_outcomes[0], "success"
         )

--- a/tests/test_patrols.py
+++ b/tests/test_patrols.py
@@ -369,59 +369,7 @@ class TestInvolvedCats(unittest.TestCase):
                 self.patrol_class.involved_cats["s_c1"],
                 msg=f"s_c0: {self.patrol_class.involved_cats['s_c0']} and s_c1: {self.patrol_class.involved_cats['s_c1']} match when they shouldn't.",
             )
-
-    def test_sc_overall_patrol(self):
-        war1 = TestCatFactory.create_cat(rank=CatRank.WARRIOR)
-        war2 = TestCatFactory.create_cat(rank=CatRank.WARRIOR)
-
-        with self.subTest(
-            "Test if a single s_c0 cat can be found for the patrol overall."
-        ):
-            patrol = PatrolEvent(
-                event_id="test",
-                types=["hunting"],
-                intro_strings=["test"],
-                decline_strings=["test"],
-                involved_cats={
-                    "s_c0": InvolvedCatDict(prior_abbreviation=["any"]),
-                },
-                success_outcomes=[{"strings": ["test"]}],
-                fail_outcomes=[{"strings": ["test"]}],
-            )
-
-            set_up_patrol_class_w_event(self.patrol_class, [war1], [patrol])
-
-            self.assertEqual(
-                self.patrol_class.involved_cats["p_l"],
-                self.patrol_class.involved_cats["p_l"],
-                msg=f"p_l: {self.patrol_class.involved_cats['p_l']} and s_c0: {self.patrol_class.involved_cats['s_c0']} don't match when they should.",
-            )
-
-        with self.subTest(
-            "Test if two different s_c cats can be found for the patrol overall."
-        ):
-            patrol = PatrolEvent(
-                event_id="test",
-                types=["hunting"],
-                intro_strings=["test"],
-                decline_strings=["test"],
-                involved_cats={
-                    "s_c0": InvolvedCatDict(prior_abbreviation=["any"]),
-                    "s_c1": InvolvedCatDict(prior_abbreviation=["-s_c0"]),
-                },
-                success_outcomes=[{"strings": ["test"]}],
-                fail_outcomes=[{"strings": ["test"]}],
-            )
-
-            set_up_patrol_class_w_event(self.patrol_class, [war1, war2], [patrol])
-
-            self.assertNotEqual(
-                self.patrol_class.involved_cats["s_c0"],
-                self.patrol_class.involved_cats["s_c1"],
-                msg=f"s_c0: {self.patrol_class.involved_cats['s_c0']} and s_c1: {self.patrol_class.involved_cats['s_c1']} match when they shouldn't.",
-            )
-
-
+            
 class TestOutcomeExecution(unittest.TestCase):
     def setUp(self):
         # load in the spritesheets

--- a/tests/test_patrols.py
+++ b/tests/test_patrols.py
@@ -348,7 +348,8 @@ class TestOutcomeExecution(unittest.TestCase):
             )
 
             self.patrol_class._add_patrol_cats([war1])
-            self.patrol_class._get_valid_patrol([patrol])
+            self.patrol_class.patrol_event = self.patrol_class._get_valid_patrol([patrol])
+            self.patrol_class._create_needed_cats()
             self.patrol_class._check_outcome_constraints(
                 patrol.success_outcomes[0], "success"
             )
@@ -377,7 +378,8 @@ class TestOutcomeExecution(unittest.TestCase):
                 fail_outcomes=[{"strings": ["test"]}],
             )
             self.patrol_class._add_patrol_cats([war1])
-            self.patrol_class._get_valid_patrol([patrol])
+            self.patrol_class.patrol_event = self.patrol_class._get_valid_patrol([patrol])
+            self.patrol_class._create_needed_cats()
             self.patrol_class._check_outcome_constraints(
                 patrol.success_outcomes[0], "success"
             )

--- a/tests/test_patrols.py
+++ b/tests/test_patrols.py
@@ -369,7 +369,8 @@ class TestInvolvedCats(unittest.TestCase):
                 self.patrol_class.involved_cats["s_c1"],
                 msg=f"s_c0: {self.patrol_class.involved_cats['s_c0']} and s_c1: {self.patrol_class.involved_cats['s_c1']} match when they shouldn't.",
             )
-            
+
+
 class TestOutcomeExecution(unittest.TestCase):
     def setUp(self):
         # load in the spritesheets


### PR DESCRIPTION
## About The Pull Request

Fixes the broken patrol test. It was caused by changes in when new cats were generated. 

This PR also tweaks the behavior of `Patrol._get_valid_patrol().`   Previously, this function would set the involved_cats related to the chosen valid patrol event, but not the patrol event itself. The event was set, but a couple functions up.  For consistency, it now also sets the patrol event. (This also makes the test set-up cleaner.) I renamed some functions for clarity: 

(1) `_set_possible_patrol` -> `_load_patrols_and_set_patrol`
(2) `_filter_patrols` -> `_filter_and_set_patrol`
(3) `_get_valid_patrol` -> `set_valid_patrol`

## Why This Is Good For ClanGen

Fixes the failing tests! Also streamlines functions for that the patrol event, and the involved cats associated with that event, are set at the same time. Then renames functions to match their function. 

## Proof of Testing

https://github.com/user-attachments/assets/23f406dd-6932-441b-8bfd-675127b41937


