### PR TITLE
[BUGFIX] Fix Clan Deletion Crash Bug, Remove Unneeded Print.

### DIFF
--- a/scripts/screens/SwitchClanScreen.py
+++ b/scripts/screens/SwitchClanScreen.py
@@ -231,6 +231,7 @@ class SwitchClanScreen(Screens):
                 self.clan_buttons.append([])
                 self.clan_name.append([])
                 self.delete_buttons.append([])
+                self.clan_display_names.append([])
 
         self.next_page_button = UISurfaceImageButton(
             ui_scale(pygame.Rect((456, 540), (34, 34))),

--- a/scripts/ui/windows/delete_check.py
+++ b/scripts/ui/windows/delete_check.py
@@ -57,14 +57,15 @@ class CheckDeletionWindow(GameWindow):
             if event.ui_element == self.delete_it_button:
                 rempath = get_save_dir() + "/" + self.clan_name
                 shutil.rmtree(rempath)
+
+                # Removal of clan.json or clan.txt - not required
+                # for rearranged saves, kept for legacy.
                 if os.path.exists(rempath + "/clan.json"):
                     os.remove(rempath + "/clan.json")
                 if os.path.exists(rempath + "clan.json"):
                     os.remove(rempath + "clan.json")
                 elif os.path.exists(rempath + "clan.txt"):
                     os.remove(rempath + "clan.txt")
-                else:
-                    print("No clan.json/txt???? Clan prolly wasnt initalized kekw")
                 self.kill()
                 self.reloadscreen(GameScreen.SWITCH_CLAN)
 


### PR DESCRIPTION
## About The Pull Request

The game was crashing whenever the player tried to delete a clan past the first page in the SwitchClanScreen.  This fixes that. It also removes an unnecessary warning print that is no longer important with the rearranged saves.  

## Linked Issues

Fixes #5235 

## Proof of Testing

https://github.com/user-attachments/assets/7eadcb0e-78d0-4b84-a202-d5806af9f5bd

