### PR TITLE
[CONTENT] tortie combos

### DIFF
--- a/sprites/dicts/tortie_patches_combos.json
+++ b/sprites/dicts/tortie_patches_combos.json
@@ -205,5 +205,38 @@
         "HALF",
         "HEARTBEAT",
         "GRUMPYFACE"
+    ],
+    "SATURN": [
+        "SHILOH",
+        "SIDEMASK",
+        "SAFI",
+        "ROBIN"
+    ],
+    "TWO_TURTLE": [
+        "TURTLECRAWL",
+        "TWO",
+        "UNDERTAIL_T",
+        "STREAMSTRIKE"
+    ],
+    "POWDER_HEART": [
+        "TAILTIP_T",
+        "UNDERTAIL_T",
+        "POWDERSNOW",
+        "MINIMALTHREE",
+        "HEARTBEAT"
+    ],
+    "BLAZING_HEART": [
+        "EMBER",
+        "BELOVED",
+        "HEARTBEAT",
+        "MINIMALTHREE",
+        "EYEDOT"
+    ],
+    "RISING_FIRE": [
+        "BOTHEARS_T",
+        "BELOVED",
+        "BRIE",
+        "EMBER",
+        "FRECKLED"
     ]
 }


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
adds 5 new tortie combos: ``TWO_TURTLE``, ``BLAZING_HEART``, ``SATURN``, ``RISING_FIRE``, ``POWDER_HEART``
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Why This Is Good For ClanGen
more complex variety for torties, provides more individuality and character for cats
<!-- If this is a bug fix, you can remove this section. -->
<!-- Please add a short description of why you think these changes would benefit the game. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->
<!-- If you have multiple features that can stand on their own, or unrelated bugfixes, please create separate PRs for them. -->


## Proof of Testing
<img width="325" height="535" alt="Screenshot 2026-09-04 213700" src="https://github.com/user-attachments/assets/9c5be3bb-8d74-40ab-bcb0-4cae1f572432" />
<img width="329" height="557" alt="Screenshot 2026-09-04 213445" src="https://github.com/user-attachments/assets/eeca35f7-703d-4cb0-84a8-bbb22b6239a4" />
<img width="332" height="547" alt="Screenshot 2026-09-04 213633" src="https://github.com/user-attachments/assets/42f31641-7889-4c4c-94ed-0b7085e3ed4d" />
<img width="327" height="555" alt="Screenshot 2026-09-04 213608" src="https://github.com/user-attachments/assets/3f33dd03-c13d-426a-bb13-e50f4fce3f87" />
<img width="325" height="551" alt="Screenshot 2026-09-04 213534" src="https://github.com/user-attachments/assets/2eebc54e-7d45-47f6-98da-bba5152df6f6" />


``POWDER_HEART``
<img width="445" height="326" alt="image" src="https://github.com/user-attachments/assets/4ac09836-a01d-45fd-bb50-68cff31d554a" />
<img width="521" height="250" alt="image" src="https://github.com/user-attachments/assets/0b20a130-8e20-4556-aab5-4406d94c50f7" />

``SATURN``
<img width="434" height="317" alt="image" src="https://github.com/user-attachments/assets/a4836b2d-3121-4152-8b5e-ae8696302b83" />
<img width="452" height="243" alt="image" src="https://github.com/user-attachments/assets/ca9841c4-69d9-4dcd-9159-ba1ca2495a78" />

``RISING_FIRE``
<img width="468" height="250" alt="image" src="https://github.com/user-attachments/assets/02d56234-1d3d-4d8a-a0be-21dbe5e89c10" /> 
<img width="437" height="248" alt="image" src="https://github.com/user-attachments/assets/3d537297-a730-4dd8-9692-91b3eed6bbd3" />

``TWO_TURTLE``
<img width="415" height="412" alt="image" src="https://github.com/user-attachments/assets/3f2cc980-909d-4e31-8320-c303d3966b8f" />
<img width="395" height="445" alt="image" src="https://github.com/user-attachments/assets/289f5b05-b129-4fe7-8870-641b66ee7aaa" />

``BLAZING_HEART``
<img width="351" height="447" alt="image" src="https://github.com/user-attachments/assets/98d6b787-0708-453a-b6e3-536392aac109" />
<img width="396" height="440" alt="image" src="https://github.com/user-attachments/assets/12c176b4-f23c-41b0-b7e4-93c2c7b0705a" />
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
5 new tortie combos: ``TWO_TURTLE``, ``BLAZING_HEART``, ``SATURN``, ``RISING_FIRE``, ``POWDER_HEART``-inkpawwc
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
