### PR TITLE
[BUGFIX] Cats being listed as dead twice

### DIFF
--- a/scripts/events_module/patrol/patrol.py
+++ b/scripts/events_module/patrol/patrol.py
@@ -4,7 +4,7 @@ import logging
 import random
 import statistics
 from os.path import exists as path_exists
-from random import choice, randint, choices
+from random import choice, randint, choices, sample
 from typing import List, Tuple, Optional, Union, Literal, TypedDict
 
 import pygame
@@ -254,7 +254,7 @@ class Patrol:
         self.involved_cats["patrol_cats"] = patrol_cats
         # some_patrol will be a random assortment of the patrol cats, but not 1 nor all
         if len(patrol_cats) >= 3:
-            self.involved_cats["some_patrol"] = choices(
+            self.involved_cats["some_patrol"] = sample(
                 patrol_cats,
                 k=randint(min(2, len(patrol_cats)), min(5, len(patrol_cats) - 1)),
             )

--- a/tests/test_patrols.py
+++ b/tests/test_patrols.py
@@ -117,6 +117,13 @@ class TestPatrolCats(unittest.TestCase):
             self.assertGreater(len(self.patrol_class.involved_cats["some_patrol"]), 1)
             self.assertLess(len(self.patrol_class.involved_cats["some_patrol"]), 6)
 
+        with self.subTest("Check full patrol, no duplicates"):
+            patrol_cats = [war1, war2, war3, war4, war5, war6]
+            self.patrol_class._add_patrol_cats(patrol_cats)
+            some_cats = self.patrol_class.involved_cats["some_patrol"]
+
+            self.assertCountEqual(set(some_cats), some_cats)
+
 
 class TestInvolvedCats(unittest.TestCase):
     @classmethod


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
Cats were being chosen twice for `some_patrol` because we were using `choices` instead of `sample`. `choices` can pick the same item multiple times, `sample` can't!
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Linked Issues
fixes #5984
<!-- If this is unrelated to an issue, you can remove this section. -->
<!-- If this was in response to a GitHub issue, please write it here with the format Fixes: #1234 so that GitHub knows to link the issues. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->

## Proof of Testing
Added a test to check that all the cats in `some_patrol` are unique
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Fixes cats being chosen twice for `some_patrol` lists (leading to them being listed as dead twice over)
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
