### PR TITLE
[BUGFIX] improve supply test

### DIFF
--- a/tests/test_patrols.py
+++ b/tests/test_patrols.py
@@ -610,7 +610,7 @@ class TestOutcomeExecution(unittest.TestCase):
             msg=f"Clan and outsider reputation should be increased.",
         )
 
-    def test_supply_change(self):
+    def test_basic_supply_change(self):
         war1 = TestCatFactory.create_cat(rank=CatRank.WARRIOR)
 
         patrol = PatrolEvent(
@@ -625,7 +625,6 @@ class TestOutcomeExecution(unittest.TestCase):
                     "supply": [
                         SupplyDict(type="freshkill", adjust="increase_tiny"),
                         SupplyDict(type="honey", adjust="increase_tiny"),
-                        SupplyDict(type="random_herbs", adjust="increase_huge"),
                     ],
                 }
             ],
@@ -633,7 +632,6 @@ class TestOutcomeExecution(unittest.TestCase):
         )
         freshkill_count = game.clan.freshkill_pile.total_amount
         honey_count = game.clan.herb_supply.get_single_herb_total("honey")
-        total_herb_count = game.clan.herb_supply.total
 
         self.patrol_class._add_patrol_cats([war1])
         self.patrol_class._get_valid_patrol([])
@@ -663,15 +661,44 @@ class TestOutcomeExecution(unittest.TestCase):
             msg=f"old total ({honey_count}) + increase_amount ({increase_amount}) should equal {game.clan.herb_supply.get_single_herb_total('honey')}",
         )
 
+    def test_random_herb_supply_change(self):
+        war1 = TestCatFactory.create_cat(rank=CatRank.WARRIOR)
+
+        patrol = PatrolEvent(
+            event_id="test",
+            types=["hunting"],
+            intro_strings=["test"],
+            decline_strings=["test"],
+            involved_cats={"p_l": InvolvedCatDict()},
+            success_outcomes=[
+                {
+                    "strings": [""],
+                    "supply": [
+                        SupplyDict(type="random_herbs", adjust="increase_huge"),
+                    ],
+                }
+            ],
+            fail_outcomes=[{"strings": ["test"]}],
+        )
+        total_herb_count = game.clan.herb_supply.total
+
+        self.patrol_class._add_patrol_cats([war1])
+        self.patrol_class._get_valid_patrol([])
+        self.patrol_class._check_outcome_constraints(
+            patrol.success_outcomes[0], "success"
+        )
+        handle_consequences.disable_random = True
+        handle_consequences.execute_outcome(
+            patrol.success_outcomes[0],
+            self.patrol_class.involved_cats,
+            other_clan=OtherClan(),
+        )
+
         # check random herb change
         increase_amount = get_config(
             f"clan_resources.herbs.increase_amounts.increase_huge"
         )
-        total_without_honey = (
-            game.clan.herb_supply.total
-            - game.clan.herb_supply.get_single_herb_total("honey")
-        )
         self.assertTrue(
-            total_herb_count + increase_amount == total_without_honey,
-            msg=f"old_total ({total_herb_count}) + increase_amount ({increase_amount}) should equal {total_without_honey}",
+            total_herb_count + increase_amount == game.clan.herb_supply.total,
+            msg=f"old_total ({total_herb_count}) + increase_amount ({increase_amount}) should equal {game.clan.herb_supply.total}",
         )

--- a/tests/test_patrols.py
+++ b/tests/test_patrols.py
@@ -6,6 +6,7 @@ from scripts.cat.factories.test_cat_factory import TestCatFactory
 from scripts.cat.factories.typed_dicts import StatusDict
 from scripts.cat.sprites.load_sprites import sprites
 from scripts.clan import Clan, OtherClan
+from scripts.config import get_config
 from scripts.events_module.parameter_dicts import (
     InvolvedCatDict,
     JoinDict,
@@ -652,12 +653,23 @@ class TestOutcomeExecution(unittest.TestCase):
             msg=f"{freshkill_count} + 2 should equal {game.clan.freshkill_pile.total_amount}",
         )
         # check single herb change
+        increase_amount = get_config(
+            f"clan_resources.herbs.increase_amounts.increase_tiny"
+        )
         self.assertTrue(
-            honey_count + 2 == game.clan.herb_supply.get_single_herb_total("honey"),
-            msg=f"{honey_count} + 1 should equal {game.clan.herb_supply.get_single_herb_total('honey')}",
+            honey_count + increase_amount
+            == game.clan.herb_supply.get_single_herb_total("honey"),
+            msg=f"old total ({honey_count}) + increase_amount ({increase_amount}) should equal {game.clan.herb_supply.get_single_herb_total('honey')}",
+        )
+        increase_amount = get_config(
+            f"clan_resources.herbs.increase_amounts.increase_huge"
+        )
+        total_without_honey = (
+            game.clan.herb_supply.total
+            - game.clan.herb_supply.get_single_herb_total("honey")
         )
         # check random herb change
         self.assertTrue(
-            total_herb_count + 10 == game.clan.herb_supply.total,
-            msg=f"{total_herb_count} + 9 should equal {game.clan.herb_supply.total}",
+            total_herb_count + increase_amount == total_without_honey,
+            msg=f"old_total ({total_herb_count}) + increase_amount ({increase_amount}) should equal {total_without_honey}",
         )

--- a/tests/test_patrols.py
+++ b/tests/test_patrols.py
@@ -652,6 +652,7 @@ class TestOutcomeExecution(unittest.TestCase):
             freshkill_count + 2 == game.clan.freshkill_pile.total_amount,
             msg=f"{freshkill_count} + 2 should equal {game.clan.freshkill_pile.total_amount}",
         )
+
         # check single herb change
         increase_amount = get_config(
             f"clan_resources.herbs.increase_amounts.increase_tiny"
@@ -661,6 +662,8 @@ class TestOutcomeExecution(unittest.TestCase):
             == game.clan.herb_supply.get_single_herb_total("honey"),
             msg=f"old total ({honey_count}) + increase_amount ({increase_amount}) should equal {game.clan.herb_supply.get_single_herb_total('honey')}",
         )
+
+        # check random herb change
         increase_amount = get_config(
             f"clan_resources.herbs.increase_amounts.increase_huge"
         )
@@ -668,7 +671,6 @@ class TestOutcomeExecution(unittest.TestCase):
             game.clan.herb_supply.total
             - game.clan.herb_supply.get_single_herb_total("honey")
         )
-        # check random herb change
         self.assertTrue(
             total_herb_count + increase_amount == total_without_honey,
             msg=f"old_total ({total_herb_count}) + increase_amount ({increase_amount}) should equal {total_without_honey}",


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
Improved the herb supply test. It now uses the config amounts rather than hardcoding the defaults. I separated out the `random_herbs` test as I think it was what would interfere and cause the test to fail (likely randomly adding honey, which is the "single" herb we also test for, thus leading to it having an incorrectly total for it's own test). I improved the failure messages to be clearer.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Proof of Testing
Tests should be passing
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Fixed the occasional failure of our herb supply tests
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
