### PR TITLE
[CONTENT] POI tag events

### DIFF
--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -10113,5 +10113,291 @@
                 "death": "m_c died after falling out of one of the Fourtrees."
             }
         ]
+    },
+    {
+        "event_id": "gen_death_poi_cave",
+        "location": ["any"],
+        "season": ["any"],
+        "poi": {
+            "tags": ["cave"],
+            "category": "terrain"
+        },
+        "frequency": 3,
+        "event_text": "While m_c was inside POI, a piece of rubble detached from the ceiling and crushed {PRONOUN/m_c/object}.",
+        "m_c": {
+            "age": ["-newborn", "-kitten"],
+            "dies": true
+        },
+        "history": [
+            {
+                "cats": ["m_c"],
+                "death": "m_c was crushed by falling rubble."
+            }
+        ]
+    },
+    {
+        "event_id": "gen_death_poi_cave_med",
+        "location": ["any"],
+        "season": ["any"],
+        "poi": {
+            "tags": ["cave"],
+            "category": "moonplace"
+        },
+        "frequency": 2,
+        "event_text": "While m_c was inside POI, a piece of rubble detached from the ceiling and crushed {PRONOUN/m_c/object}.",
+        "m_c": {
+            "age": ["-newborn", "-kitten"],
+            "status": ["medicine cat", "medicine cat apprentice"],
+            "dies": true
+        },
+        "history": [
+            {
+                "cats": ["m_c"],
+                "death": "m_c was crushed by falling rubble."
+            }
+        ]
+    },
+    {
+        "event_id": "gen_death_poi_cave_disappear",
+        "location": ["any"],
+        "season": ["any"],
+        "tags": ["no_body"],
+        "poi": {
+            "tags": ["cave"],
+            "category": "terrain"
+        },
+        "frequency": 2,
+        "event_text": "m_c followed a strange sound into POI and did not return.",
+        "m_c": {
+            "age": ["-newborn", "-kitten"],
+            "dies": true
+        },
+        "history": [
+            {
+                "cats": ["m_c"],
+                "death": "m_c disappeared into a cave and never returned."
+            }
+        ]
+    },
+    {
+        "event_id": "gen_death_poi_cave_murder",
+        "location": ["any"],
+        "season": ["any"],
+        "sub_type": [
+            "murder"
+        ],
+        "poi": {
+            "tags": ["cave"],
+            "category": "terrain"
+        },
+        "frequency": 3,
+        "event_text": "m_c was lured into a cave by r_c and killed.",
+        "m_c": {
+            "age": ["any"],
+            "dies": true
+        },
+        "r_c": {
+            "age": ["-newborn", "-kitten"]
+        },
+        "history": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "death": "m_c was murdered by r_c."
+            }
+        ],
+        "future_event": [
+            {
+                "event_type": "misc",
+                "pool": {
+                    "sub_type": [
+                        "murder_reveal"
+                    ]
+                },
+                "moon_delay": [
+                    1,
+                    12
+                ],
+                "involved_cats": {
+                    "m_c": "r_c",
+                    "mur_c": "m_c",
+                    "r_c": {
+                        "age": [
+                            "any"
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    {
+        "event_id": "gen_death_poi_covered_blizzard",
+        "location": ["any"],
+        "season": ["leaf-bare"],
+        "poi": {
+            "tags": ["covered"],
+            "category": "terrain"
+        },
+        "frequency": 3,
+        "event_text": "m_c thought {PRONOUN/m_c/subject} would be safe from a blizzard in the shelter of {POI/tag/covered}. {PRONOUN/m_c/subject/CAP} thought wrong.",
+        "m_c": {
+            "status": ["-newborn", "-kitten", "-elder"],
+            "dies": true
+        },
+        "history": [
+            {
+                "cats": ["m_c"],
+                "death": "m_c froze to death during a blizzard."
+            }
+        ]
+    },
+    {
+        "event_id": "gen_death_poi_covered_murder",
+        "location": ["any"],
+        "season": ["any"],
+        "sub_type": [
+            "murder"
+        ],
+        "tags": ["no_body"],
+        "poi": {
+            "tags": ["covered"],
+            "category": "terrain"
+        },
+        "frequency": 3,
+        "event_text": "r_c killed m_c and hid {PRONOUN/m_c/poss} body.",
+        "m_c": {
+            "age": ["-newborn", "-kitten"],
+            "dies": true
+        },
+        "r_c": {
+            "age": ["any"]
+        },
+        "history": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "death": "m_c was murdered by r_c."
+            }
+        ],
+        "future_event": [
+            {
+                "event_type": "misc",
+                "pool": {
+                    "sub_type": [
+                        "murder_reveal"
+                    ]
+                },
+                "moon_delay": [
+                    1,
+                    12
+                ],
+                "involved_cats": {
+                    "m_c": "r_c",
+                    "mur_c": "m_c",
+                    "r_c": {
+                        "age": [
+                            "any"
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    {
+        "event_id": "gen_death_poi_fallrisk",
+        "location": ["any"],
+        "season": ["any"],
+        "poi": {
+            "tags": ["fall_risk"],
+            "category": "terrain"
+        },
+        "frequency": 3,
+        "event_text": "m_c lost {PRONOUN/m_c/poss} footing and slipped, plummeting to {PRONOUN/m_c/poss} death.",
+        "m_c": {
+            "age": ["-newborn", "-kitten"],
+            "dies": true
+        },
+        "history": [
+            {
+                "cats": ["m_c"],
+                "death": "m_c slipped and fell to their death near POI."
+            }
+        ]
+    },
+    {
+        "event_id": "gen_death_poi_fallrisk_murder_mufasa",
+        "location": ["any"],
+        "season": ["any"],
+        "sub_type": [
+            "murder"
+        ],
+        "tags": ["all_lives"],
+        "poi": {
+            "tags": ["fall_risk"],
+            "category": "terrain"
+        },
+        "frequency": 2,
+        "event_text": "When m_c and r_c were alone by POI, r_c attacked, attempting to shove {PRONOUN/m_c/object} over the edge. m_c caught {PRONOUN/m_c/self} on the ledge, but r_c pried {PRONOUN/m_c/poss} claws loose, sending {PRONOUN/m_c/object} yowling to {PRONOUN/m_c/poss} death.",
+        "m_c": {
+            "age": ["any"],
+            "dies": true
+        },
+        "r_c": {
+            "age": ["any"]
+        },
+        "history": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "death": "m_c was thrown off the edge of a ledge by r_c."
+            }
+        ],
+        "future_event": [
+            {
+                "event_type": "misc",
+                "pool": {
+                    "sub_type": [
+                        "murder_reveal"
+                    ]
+                },
+                "moon_delay": [
+                    1,
+                    12
+                ],
+                "involved_cats": {
+                    "m_c": "r_c",
+                    "mur_c": "m_c",
+                    "r_c": {
+                        "age": [
+                            "any"
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    {
+        "event_id": "gen_death_poi_prey1",
+        "location": ["any"],
+        "season": ["any"],
+        "poi": {
+            "tags": ["prey"],
+            "category": "terrain"
+        },
+        "frequency": 4,
+        "event_text": "m_c left camp for a solo hunt near POI. When {PRONOUN/m_c/subject} didn't return, a group was sent to search for {PRONOUN/m_c/object}. The group found m_c's bloodied carcass: predator turned prey.",
+        "m_c": {
+            "status": ["apprentice", "warrior", "deputy", "leader"],
+            "dies": true
+        },
+        "history": [
+            {
+                "cats": ["m_c"],
+                "death": "m_c was killed by a predator on a solo hunt."
+            }
+            ]
     }
 ]

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -10240,7 +10240,7 @@
             "category": "terrain"
         },
         "frequency": 3,
-        "event_text": "m_c thought {PRONOUN/m_c/subject} would be safe from a blizzard in the shelter of {POI/tag/covered}. {PRONOUN/m_c/subject/CAP} thought wrong.",
+        "event_text": "m_c thought {PRONOUN/m_c/subject} would be safe from a blizzard in the shelter of POI. {PRONOUN/m_c/subject/CAP} thought wrong.",
         "m_c": {
             "status": ["-newborn", "-kitten", "-elder"],
             "dies": true

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -1334,28 +1334,28 @@
                 "death": "This cat drowned alongside a Clanmate."
             }
         ]
-    },{
-        "event_id": "gen_death_horseplace",
-        "location": ["any"],
-        "season": ["any"],
-        "sub_type": [],
-        "tags": [],
-        "poi": {
-            "name": ["terrain_horseplace"]
-        },
-        "frequency": 2,
-        "event_text": "m_c is caught under a horse's hooves while hunting in POI. {PRONOUN/m_c/poss/CAP} Clanmates can't get to {PRONOUN/m_c/object} in time.",
-        "m_c": {
-            "dies": true,
-            "status": ["leader", "deputy", "warrior", "apprentice"]
-        },
-        "history": [
-            {
-                "cats": ["m_c"],
-                "death": "m_c died when {PRONOUN/m_c/subject} got caught under a horse's hooves."
-            }
-        ]
+    }, {
+    "event_id": "gen_death_horseplace",
+    "location": ["any"],
+    "season": ["any"],
+    "sub_type": [],
+    "tags": [],
+    "poi": {
+        "name": ["terrain_horseplace"]
     },
+    "frequency": 2,
+    "event_text": "m_c is caught under a horse's hooves while hunting in POI. {PRONOUN/m_c/poss/CAP} Clanmates can't get to {PRONOUN/m_c/object} in time.",
+    "m_c": {
+        "dies": true,
+        "status": ["leader", "deputy", "warrior", "apprentice"]
+    },
+    "history": [
+        {
+            "cats": ["m_c"],
+            "death": "m_c died when {PRONOUN/m_c/subject} got caught under a horse's hooves."
+        }
+    ]
+},
     {
         "event_id": "gen_death_treesPOI",
         "location": ["any"],
@@ -1421,10 +1421,10 @@
                 "death": "m_c was killed by a gang of rogues."
             }
         ],
-            "outsider": {
-        "current_rep": ["any"],
-        "changed": -3
-    }
+        "outsider": {
+            "current_rep": ["any"],
+            "changed": -3
+        }
     },
     {
         "event_id": "gen_death_greencough_any1",
@@ -1548,34 +1548,34 @@
                 "death": "This cat died of greencough."
             }
         ]
-    },{
-        "event_id": "gen_death_fallriskPOI_any1",
-        "location": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "all_lives"
-        ],
-        "poi": {
-            "tags": ["fall_risk"]
-        },
-        "frequency": 4,
-        "event_text": "m_c went missing and was found dead at the bottom of POI.",
-        "m_c": {
-            "dies": true
-        },
-        "history": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "death": "m_c went missing and was found dead after falling from a great height."
-            }
-        ]
+    }, {
+    "event_id": "gen_death_fallriskPOI_any1",
+    "location": [
+        "any"
+    ],
+    "season": [
+        "any"
+    ],
+    "tags": [
+        "all_lives"
+    ],
+    "poi": {
+        "tags": ["fall_risk"]
     },
+    "frequency": 4,
+    "event_text": "m_c went missing and was found dead at the bottom of POI.",
+    "m_c": {
+        "dies": true
+    },
+    "history": [
+        {
+            "cats": [
+                "m_c"
+            ],
+            "death": "m_c went missing and was found dead after falling from a great height."
+        }
+    ]
+},
     {
         "event_id": "gen_death_taintedPOI_any1",
         "location": [
@@ -5638,8 +5638,8 @@
                 "-kitten"
             ],
             "status": [
-            "-leader"
-          ],
+                "-leader"
+            ],
             "dies": true
         },
         "history": [
@@ -5651,7 +5651,7 @@
             }
         ]
     },
-       {
+    {
         "event_id": "gen_death_tree_any2",
         "location": [
             "beach",
@@ -5667,8 +5667,8 @@
         "event_text": "m_c fell from the top branches of a tree. The fall was too great, and {PRONOUN/m_c/subject} could not recover.",
         "m_c": {
             "status": [
-            "leader"
-          ],
+                "leader"
+            ],
             "dies": true
         },
         "history": [
@@ -9031,7 +9031,8 @@
                         ]
                     }
                 }
-            }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_hitmanmurder2",
@@ -9084,7 +9085,8 @@
                     "mur_c": "m_c",
                     "r_c": "m_c"
                 }
-            }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_hitmanmurder3",
@@ -9149,7 +9151,8 @@
                         ]
                     }
                 }
-            }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_hitmanmurder4",
@@ -9213,7 +9216,8 @@
                         ]
                     }
                 }
-            }]
+            }
+        ]
     },
     {
         "event_id": "gen_death_gathermonster",
@@ -9231,9 +9235,9 @@
         },
         "history": [
             {
-            "cats": ["m_c"],
-            "death": "m_c died of infection after being scraped by rusty metal at the Gathering."
-        }
+                "cats": ["m_c"],
+                "death": "m_c died of infection after being scraped by rusty metal at the Gathering."
+            }
         ]
     },
     {
@@ -9523,7 +9527,8 @@
         "location": [
             "forest:camp1_camp2",
             "plains:camp1_camp3_camp4",
-            "mountainous:camp1_camp2_camp4" ],
+            "mountainous:camp1_camp2_camp4"
+        ],
         "season": [
             "any"
         ],
@@ -9540,7 +9545,7 @@
         },
         "history": [
             {
-                "cats": [ "m_c" ],
+                "cats": ["m_c"],
                 "death": "m_c was eaten by a lynx."
             }
         ]
@@ -9550,7 +9555,8 @@
         "location": [
             "forest:camp1_camp2",
             "plains:camp1_camp3_camp4",
-            "mountainous:camp1_camp2_camp4" ],
+            "mountainous:camp1_camp2_camp4"
+        ],
         "season": [
             "any"
         ],
@@ -9575,7 +9581,7 @@
         },
         "history": [
             {
-                "cats": [ "m_c" ],
+                "cats": ["m_c"],
                 "death": "m_c was eaten by a lynx."
             }
         ]
@@ -9602,7 +9608,7 @@
         },
         "history": [
             {
-                "cats": [ "m_c" ],
+                "cats": ["m_c"],
                 "death": "m_c was swallowed by a heron."
             }
         ]
@@ -9635,7 +9641,7 @@
         },
         "history": [
             {
-                "cats": [ "m_c" ],
+                "cats": ["m_c"],
                 "death": "m_c was murdered by a o_c_n patrol after trespassing."
             }
         ],
@@ -9688,78 +9694,78 @@
             }
         ]
     },
-{
-  "event_id": "gen_death_guarddisappearance_any1",
-  "location": [
-    "any"
-  ],
-  "season": [
-    "any"
-  ],
-  "tags": [],
-  "frequency": 2,
-  "event_text": "The Clan grows concerned after m_c doesn't return from guard duty. {PRONOUN/m_c/poss/CAP} body is later found out in the territory, scent reeking of o_c_n.",
-  "m_c": {
-    "skill": [
-      "-FIGHTER,2"
-    ],
-    "status": [
-      "warrior",
-      "deputy"
-    ],
-    "dies": true
-  },
-  "history": [
     {
-      "cats": [
-        "m_c"
-      ],
-      "death": "m_c was killed by o_c_n warriors while on guard duty."
-    }
-  ],
-  "other_clan": {
-    "current_rep": [
-      "hostile", "neutral"
-    ],
-    "changed": -3
-  }
-},
-{
-  "event_id": "gen_death_guarddisappearance_any2",
-  "location": [
-    "any"
-  ],
-  "season": [
-    "any"
-  ],
-  "tags": [],
-  "frequency": 2,
-  "event_text": "The Clan grows concerned after m_c doesn't return from guard duty. {PRONOUN/m_c/poss/CAP} body is later found out in the territory with a rogue's scent wreathing around {PRONOUN/m_c/object}.",
-  "m_c": {
-    "skill": [
-      "-FIGHTER,2"
-    ],
-    "status": [
-      "warrior",
-      "deputy"
-    ],
-    "dies": true
-  },
-  "new_cat": [
-    [
-      "meeting",
-      "rogue",
-      "exists"
-    ]
-  ],
-  "history": [
+        "event_id": "gen_death_guarddisappearance_any1",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "tags": [],
+        "frequency": 2,
+        "event_text": "The Clan grows concerned after m_c doesn't return from guard duty. {PRONOUN/m_c/poss/CAP} body is later found out in the territory, scent reeking of o_c_n.",
+        "m_c": {
+            "skill": [
+                "-FIGHTER,2"
+            ],
+            "status": [
+                "warrior",
+                "deputy"
+            ],
+            "dies": true
+        },
+        "history": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "death": "m_c was killed by o_c_n warriors while on guard duty."
+            }
+        ],
+        "other_clan": {
+            "current_rep": [
+                "hostile", "neutral"
+            ],
+            "changed": -3
+        }
+    },
     {
-      "cats": [
-        "m_c"
-      ],
-      "death": "m_c was killed by a rogue while on guard duty."
-    }
-  ],
+        "event_id": "gen_death_guarddisappearance_any2",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "tags": [],
+        "frequency": 2,
+        "event_text": "The Clan grows concerned after m_c doesn't return from guard duty. {PRONOUN/m_c/poss/CAP} body is later found out in the territory with a rogue's scent wreathing around {PRONOUN/m_c/object}.",
+        "m_c": {
+            "skill": [
+                "-FIGHTER,2"
+            ],
+            "status": [
+                "warrior",
+                "deputy"
+            ],
+            "dies": true
+        },
+        "new_cat": [
+            [
+                "meeting",
+                "rogue",
+                "exists"
+            ]
+        ],
+        "history": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "death": "m_c was killed by a rogue while on guard duty."
+            }
+        ],
         "relationships": [
             {
                 "cats_from": ["clan"],
@@ -9769,8 +9775,8 @@
                 "mutual": false,
                 "values": [
                     "like",
-	        "comfort",
-	        "trust"
+                    "comfort",
+                    "trust"
                 ],
                 "amount": -15,
                 "log": {
@@ -9778,13 +9784,13 @@
                 }
             }
         ],
-  "outsider": {
-    "current_rep": [
-      "any"
-    ],
-    "changed": -3
-  }
-},
+        "outsider": {
+            "current_rep": [
+                "any"
+            ],
+            "changed": -3
+        }
+    },
     {
         "event_id": "gen_death_otherclanblame_murder1",
         "location": [
@@ -9825,8 +9831,8 @@
             ],
             "changed": -3
         },
-         "exclude_involved": ["r_c"],
-         "future_event": [
+        "exclude_involved": ["r_c"],
+        "future_event": [
             {
                 "event_type": "misc",
                 "pool": {
@@ -9848,7 +9854,7 @@
             }
         ]
     },
-     {
+    {
         "event_id": "gen_death_warbattle_murder1",
         "location": [
             "any"
@@ -9989,7 +9995,7 @@
             }
         ]
     },
-     {
+    {
         "event_id": "gen_death_warambush_murder1",
         "location": [
             "any"
@@ -10060,54 +10066,52 @@
             }
         ]
     },
-{
-    "event_id": "gen_death_gatheringisland",
-    "location": ["any"],
-    "season": ["any"],
-    "tags": [],
-    "poi": {
-        "name": ["gather_island"]
+    {
+        "event_id": "gen_death_gatheringisland",
+        "location": ["any"],
+        "season": ["any"],
+        "tags": [],
+        "poi": {
+            "name": ["gather_island"]
+        },
+        "frequency": 1,
+        "event_text": "m_c is so excited to be at the Gathering that {PRONOUN/m_c/subject} {VERB/m_c/forget/forgets} to watch {PRONOUN/m_c/poss} paws on the tree bridge. No cat is able to pull {PRONOUN/m_c/object} to shore in time, and the Gathering is cut short for a vigil.",
+        "m_c": {
+            "dies": true,
+            "age": ["adolescent"],
+            "trait": ["-careful", "-calm", "-wise"],
+            "skill": ["-SWIMMER,0"]
+        },
+        "history": [
+            {
+                "cats": ["m_c"],
+                "death": "m_c died after slipping off the tree bridge at the Gathering."
+            }
+        ]
     },
-    "frequency": 1,
-    "event_text": "m_c is so excited to be at the Gathering that {PRONOUN/m_c/subject} {VERB/m_c/forget/forgets} to watch {PRONOUN/m_c/poss} paws on the tree bridge. No cat is able to pull {PRONOUN/m_c/object} to shore in time, and the Gathering is cut short for a vigil.",
-    "m_c": {
-        "dies": true,
-        "age": ["adolescent"],
-        "trait": ["-careful", "-calm", "-wise"],
-        "skill": ["-SWIMMER,0"]
-    },
-    "history": [
-        {
-            "cats": ["m_c"],
-            "death": "m_c died after slipping off the tree bridge at the Gathering."
-        }
-
-    ]
-},
-{
-    "event_id": "gen_death_fourtrees",
-    "location": ["any"],
-    "season": ["any"],
-    "tags": [],
-    "poi": {
-        "name": ["gather_fourtrees"]
-    },
-    "frequency": 1,
-    "event_text": "When r_c takes m_c to POI, m_c declares {PRONOUN/m_c/poss} intention to be the first cat to climb all four trees. r_c can't stop {PRONOUN/m_c/object} in time. m_c only makes it halfway up the first when {PRONOUN/m_c/subject} {VERB/m_c/fall/falls}, never to get back up.",
-    "m_c": {
-        "dies": true,
-        "age": ["adolescent"],
-        "trait": ["arrogant", "ambitious", "confident", "rebellious"],
-        "skill": ["-CLIMBER,0"],
-        "relationship_status": ["app/mentor"]
-    },
-    "r_c": {},
-    "history": [
-        {
-            "cats": ["m_c"],
-            "death": "m_c died after falling out of one of the Fourtrees."
-        }
-
-    ]
-}
+    {
+        "event_id": "gen_death_fourtrees",
+        "location": ["any"],
+        "season": ["any"],
+        "tags": [],
+        "poi": {
+            "name": ["gather_fourtrees"]
+        },
+        "frequency": 1,
+        "event_text": "When r_c takes m_c to POI, m_c declares {PRONOUN/m_c/poss} intention to be the first cat to climb all four trees. r_c can't stop {PRONOUN/m_c/object} in time. m_c only makes it halfway up the first when {PRONOUN/m_c/subject} {VERB/m_c/fall/falls}, never to get back up.",
+        "m_c": {
+            "dies": true,
+            "age": ["adolescent"],
+            "trait": ["arrogant", "ambitious", "confident", "rebellious"],
+            "skill": ["-CLIMBER,0"],
+            "relationship_status": ["app/mentor"]
+        },
+        "r_c": {},
+        "history": [
+            {
+                "cats": ["m_c"],
+                "death": "m_c died after falling out of one of the Fourtrees."
+            }
+        ]
+    }
 ]

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -10191,7 +10191,7 @@
             "category": "terrain"
         },
         "frequency": 3,
-        "event_text": "m_c was lured into a cave by r_c and killed.",
+        "event_text": "m_c was lured into POI by r_c and killed.",
         "m_c": {
             "age": ["any"],
             "dies": true
@@ -10265,7 +10265,7 @@
             "category": "terrain"
         },
         "frequency": 3,
-        "event_text": "r_c killed m_c and hid {PRONOUN/m_c/poss} body.",
+        "event_text": "r_c killed m_c and hid {PRONOUN/m_c/poss} body in POI.",
         "m_c": {
             "age": ["-newborn", "-kitten"],
             "dies": true
@@ -10314,7 +10314,7 @@
             "category": "terrain"
         },
         "frequency": 3,
-        "event_text": "m_c lost {PRONOUN/m_c/poss} footing and slipped, plummeting to {PRONOUN/m_c/poss} death.",
+        "event_text": "m_c lost {PRONOUN/m_c/poss} footing and slipped near POI, plummeting to {PRONOUN/m_c/poss} death.",
         "m_c": {
             "age": ["-newborn", "-kitten"],
             "dies": true
@@ -10322,7 +10322,7 @@
         "history": [
             {
                 "cats": ["m_c"],
-                "death": "m_c slipped and fell to their death near POI."
+                "death": "m_c slipped and fell to their death."
             }
         ]
     },

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -10388,7 +10388,7 @@
             "category": "terrain"
         },
         "frequency": 4,
-        "event_text": "m_c left camp for a solo hunt near POI. When {PRONOUN/m_c/subject} didn't return, a group was sent to search for {PRONOUN/m_c/object}. The group found m_c's bloodied carcass: predator turned prey.",
+        "event_text": "m_c left camp for a solo hunt near POI. A search party later found m_c's bloodied carcass: predator turned prey.",
         "m_c": {
             "status": ["apprentice", "warrior", "deputy", "leader"],
             "dies": true

--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -10339,7 +10339,7 @@
             "category": "terrain"
         },
         "frequency": 2,
-        "event_text": "When m_c and r_c were alone by POI, r_c attacked, attempting to shove {PRONOUN/m_c/object} over the edge. m_c caught {PRONOUN/m_c/self} on the ledge, but r_c pried {PRONOUN/m_c/poss} claws loose, sending {PRONOUN/m_c/object} yowling to {PRONOUN/m_c/poss} death.",
+        "event_text": "When m_c and r_c were alone by POI, r_c attempted to shove {PRONOUN/m_c/object} over the edge. m_c caught {PRONOUN/m_c/self} on the ledge, but r_c pried {PRONOUN/m_c/poss} claws loose, sending {PRONOUN/m_c/object} yowling to {PRONOUN/m_c/poss} death.",
         "m_c": {
             "age": ["any"],
             "dies": true

--- a/resources/lang/en/events/injury/general.json
+++ b/resources/lang/en/events/injury/general.json
@@ -9766,9 +9766,7 @@
             "category": "terrain"
         },
         "frequency": 3,
-        "event_text": [
-            "m_c was chased by a preadator and injured before {PRONOUN/m_c/subject} could take cover by POI."
-        ],
+        "event_text": "m_c was chased by a preadator and injured before {PRONOUN/m_c/subject} could take cover by POI.",
         "m_c": {
             "age": ["-newborn", "-kitten"]
         },

--- a/resources/lang/en/events/injury/general.json
+++ b/resources/lang/en/events/injury/general.json
@@ -2546,7 +2546,8 @@
                 }
             },
             {
-                "cats_from": ["clan", "high_lawful"
+                "cats_from": [
+                    "clan", "high_lawful"
                 ],
                 "cats_to": [
                     "m_c"
@@ -2636,7 +2637,8 @@
                 }
             },
             {
-                "cats_from": ["clan", "high_lawful"
+                "cats_from": [
+                    "clan", "high_lawful"
                 ],
                 "cats_to": [
                     "m_c"
@@ -2657,7 +2659,7 @@
                 "cats_to": [
                     "m_c", "r_c"
                 ],
-                "values": [ "like" ],
+                "values": ["like"],
                 "amount": -10,
                 "mutual": true,
                 "log": {
@@ -5589,7 +5591,7 @@
             "age": [
                 "-kitten"
             ],
-"relationship_status": ["doubts"],
+            "relationship_status": ["doubts"],
             "status": [
                 "any"
             ],
@@ -6563,7 +6565,7 @@
         "event_id": "gen_injury_waterinlungs_gatheringisland",
         "location": ["any"],
         "season": ["any"],
-    "tags": [],
+        "tags": [],
         "poi": {
             "name": ["gather_island"]
         },
@@ -6584,7 +6586,6 @@
                 "cats": ["m_c"],
                 "injuries": ["water in their lungs"]
             }
-
         ],
         "history": [
             {
@@ -6634,7 +6635,6 @@
                 "scar": "m_c was scarred after trying to climb a tree at the Gathering place as an apprentice.",
                 "death": "m_c died of {PRONOUN/m_c/poss} injuries after falling out of a tree at the Gathering place."
             }
-
         ]
     },
     {
@@ -7235,60 +7235,59 @@
             }
         ]
     },
-{
-    "event_id": "gen_injury_war_onwatch",
-    "location": [
-        "any"
-    ],
-    "season": [
-        "any"
-    ],
-    "sub_type": [
-        "war"
-    ],
-    "frequency": 3,
-    "event_text": "m_c and r_c spend the night by the o_c_n border and catch a o_c_n patrol sneaking into c_n territory. While r_c gets reinforcements, m_c keeps them occupied.",
-    "m_c": {
-        "status": [
-            "warrior",
-            "deputy",
-            "leader"
-        ]
-    },
-    "r_c": {
-        "status": [
-            "warrior",
-            "deputy",
-            "leader"
-        ]
-    },
-    "injury": [
-        {
-            "cats": [
-                "m_c"
-            ],
-            "injuries": [
-                "battle_injury"
-            ]
-        }
-    ],
-    "history": [
-        {
-            "cats": [
-                "m_c"
-            ],
-            "scar": "m_c gained a scar from holding off an ambush.",
-            "death": "m_c died of {PRONOUN/m_c/poss} injuries after holding off o_c_n's ambush."
-        }
-    ],
-    "other_clan": {
-        "current_rep": [
-            "hostile"
+    {
+        "event_id": "gen_injury_war_onwatch",
+        "location": [
+            "any"
         ],
-        "changed": -2
-    }
-},
-
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "frequency": 3,
+        "event_text": "m_c and r_c spend the night by the o_c_n border and catch a o_c_n patrol sneaking into c_n territory. While r_c gets reinforcements, m_c keeps them occupied.",
+        "m_c": {
+            "status": [
+                "warrior",
+                "deputy",
+                "leader"
+            ]
+        },
+        "r_c": {
+            "status": [
+                "warrior",
+                "deputy",
+                "leader"
+            ]
+        },
+        "injury": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "injuries": [
+                    "battle_injury"
+                ]
+            }
+        ],
+        "history": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "scar": "m_c gained a scar from holding off an ambush.",
+                "death": "m_c died of {PRONOUN/m_c/poss} injuries after holding off o_c_n's ambush."
+            }
+        ],
+        "other_clan": {
+            "current_rep": [
+                "hostile"
+            ],
+            "changed": -2
+        }
+    },
     {
         "event_id": "gen_injury_war_clawwound_anymultitraitmultistatus2",
         "location": [
@@ -7932,7 +7931,22 @@
         "event_text": "m_c battles one of o_c_n's most feared warriors and winds up in the medicine den.",
         "m_c": {
             "status": ["warrior", "deputy", "leader"],
-            "trait": ["confident", "daring", "bold", "arrogant", "fierce", "bloodthirsty", "ambitious", "arrogant", "shameless", "adventurous", "loyal", "rebellious", "troublesome", "vengeful"],
+            "trait": [
+                "confident",
+                "daring",
+                "bold",
+                "arrogant",
+                "fierce",
+                "bloodthirsty",
+                "ambitious",
+                "arrogant",
+                "shameless",
+                "adventurous",
+                "loyal",
+                "rebellious",
+                "troublesome",
+                "vengeful"
+            ],
             "dies": false
         },
         "injury": [
@@ -8574,21 +8588,21 @@
             }
         ],
         "history": [
-        {
-            "cats": ["m_c"],
-            "scar": "m_c was scarred after fighting {PRONOUN/m_c/poss} own Clanmate to protect a cat from an enemy Clan.",
-            "death": "m_c died of {PRONOUN/m_c/poss} injuries after fighting {PRONOUN/m_c/poss} own Clanmate to protect a cat from an enemy Clan."
-        },
-        {
-            "cats": ["r_c"],
-            "scar": "m_c was scarred after driving off a cat from an enemy Clan and being attacked by {PRONOUN/r_c/poss} own Clanmate.",
-            "death": "m_c died of {PRONOUN/m_c/poss} injuries after driving off a cat from an enemy Clan and being attacked by {PRONOUN/r_c/poss} own Clanmate."
-        },
-        {
-            "cats": ["n_c:0"],
-            "scar": "m_c was scarred after being attacked by an enemy Clan's warrior.",
-            "death": "m_c died of {PRONOUN/m_c/poss} injuries after being attacked by an enemy Clan's warrior."
-        }
+            {
+                "cats": ["m_c"],
+                "scar": "m_c was scarred after fighting {PRONOUN/m_c/poss} own Clanmate to protect a cat from an enemy Clan.",
+                "death": "m_c died of {PRONOUN/m_c/poss} injuries after fighting {PRONOUN/m_c/poss} own Clanmate to protect a cat from an enemy Clan."
+            },
+            {
+                "cats": ["r_c"],
+                "scar": "m_c was scarred after driving off a cat from an enemy Clan and being attacked by {PRONOUN/r_c/poss} own Clanmate.",
+                "death": "m_c died of {PRONOUN/m_c/poss} injuries after driving off a cat from an enemy Clan and being attacked by {PRONOUN/r_c/poss} own Clanmate."
+            },
+            {
+                "cats": ["n_c:0"],
+                "scar": "m_c was scarred after being attacked by an enemy Clan's warrior.",
+                "death": "m_c died of {PRONOUN/m_c/poss} injuries after being attacked by an enemy Clan's warrior."
+            }
         ],
         "relationships": [
             {
@@ -9113,8 +9127,7 @@
                     "comfort"
                 ],
                 "amount": 10,
-                "log": 
-                {
+                "log": {
                     "cats_from": "m_c gave r_c the best badger rides as a kit."
                 }
             }
@@ -9146,7 +9159,7 @@
                 "shameless"
             ]
         },
-                "injury": [
+        "injury": [
             {
                 "cats": [
                     "m_c"
@@ -9157,7 +9170,7 @@
             }
         ]
     },
-        {
+    {
         "event_id": "gen_injury_soreapp_clankits",
         "location": [
             "any"
@@ -9196,7 +9209,7 @@
             }
         ]
     },
-        {
+    {
         "event_id": "any_injury_bruises_anymultiage2",
         "location": [
             "any"
@@ -9303,59 +9316,54 @@
             }
         ]
     },
-        {
-    "event_id": "gen_misc_war_skirmishvictory2",
-    "location": ["any"],
-    "season": ["any"],
-    "sub_type": ["war"],
-    "frequency": 4,
-    "event_text": "m_c and r_c return to camp, worn but triumphant after their victory against o_c_n.",
-
-    "m_c": {
-        "status": ["leader", "deputy", "warrior"]
-    },
-
-    "r_c": {
-        "status": ["leader", "deputy", "warrior", "apprentice"]
-    },
-
-    "other_clan": {
-        "current_rep": ["any"],
-        "changed": -1
-    },
-
-    "injury": [
-        {
-            "cats": ["m_c", "r_c"],
-            "injuries": ["minor_injury"],
-            "scars": []
-        }
-    ],
-
-    "relationships": [
-        {
-            "cats_from": ["m_c"],
-            "cats_to": ["r_c"],
-            "mutual": true,
-            "values": ["trust", "respect", "like"],
-            "amount": 4,
-            "log": {
-                "cats_from": "cat_from and cat_to's bond strengthened after a victory during war."
-            }
+    {
+        "event_id": "gen_misc_war_skirmishvictory2",
+        "location": ["any"],
+        "season": ["any"],
+        "sub_type": ["war"],
+        "frequency": 4,
+        "event_text": "m_c and r_c return to camp, worn but triumphant after their victory against o_c_n.",
+        "m_c": {
+            "status": ["leader", "deputy", "warrior"]
         },
-        {
-            "cats_from": ["clan"],
-            "cats_to": ["r_c", "m_c"],
-            "mutual": false,
-            "values": ["trust", "respect"],
-            "amount": 4,
-            "log": {
-                "cats_from": "cat_from is glad {PRONOUN/cat_from/subject} can count on cat_to to protect the Clan during wartime."
+        "r_c": {
+            "status": ["leader", "deputy", "warrior", "apprentice"]
+        },
+        "other_clan": {
+            "current_rep": ["any"],
+            "changed": -1
+        },
+        "injury": [
+            {
+                "cats": ["m_c", "r_c"],
+                "injuries": ["minor_injury"],
+                "scars": []
             }
-        }
-    ]
-},
-{
+        ],
+        "relationships": [
+            {
+                "cats_from": ["m_c"],
+                "cats_to": ["r_c"],
+                "mutual": true,
+                "values": ["trust", "respect", "like"],
+                "amount": 4,
+                "log": {
+                    "cats_from": "cat_from and cat_to's bond strengthened after a victory during war."
+                }
+            },
+            {
+                "cats_from": ["clan"],
+                "cats_to": ["r_c", "m_c"],
+                "mutual": false,
+                "values": ["trust", "respect"],
+                "amount": 4,
+                "log": {
+                    "cats_from": "cat_from is glad {PRONOUN/cat_from/subject} can count on cat_to to protect the Clan during wartime."
+                }
+            }
+        ]
+    },
+    {
         "event_id": "gen_injury_war_stumble",
         "location": [
             "any"
@@ -9390,7 +9398,7 @@
         ]
     },
     {
-    "event_id": "gen_injury_war_ambushnoshow",
+        "event_id": "gen_injury_war_ambushnoshow",
         "location": [
             "any"
         ],
@@ -9419,282 +9427,280 @@
         ]
     },
     {
-    "event_id": "gen_injury_war_holdbackpunish",
-    "location": [
-        "any"
-    ],
-    "season": [
-        "any"
-    ],
-    "sub_type": [
-        "war"
-    ],
-    "tags": [],
-    "frequency": 1,
-    "event_text": "m_c is punished by r_c for holding back against a o_c_n cat.",
-    "m_c": {
-        "status": [
-            "apprentice",
-            "warrior"
-        ]
-    },
-    "r_c": {
-        "status": [
-            "deputy",
-            "leader"
+        "event_id": "gen_injury_war_holdbackpunish",
+        "location": [
+            "any"
         ],
-        "trait": [
-            "-compassionate",
-            "-thoughtful",
-            "-loving",
-            "-wise",
-            "-calm",
-            "-responsible",
-            "-playful",
-            "-nervous",
-            "-careful",
-            "-sincere"
-        ]
-    },
-    "injury": [
-        {
-            "cats": [
-                "m_c"
-            ],
-            "injuries": [
-                "battle_injury"
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "tags": [],
+        "frequency": 1,
+        "event_text": "m_c is punished by r_c for holding back against a o_c_n cat.",
+        "m_c": {
+            "status": [
+                "apprentice",
+                "warrior"
             ]
-        }
-    ],
-    "history": [
-        {
-            "cats": [
-                "m_c"
-            ],
-            "scar": "m_c was scarred when r_c punished {PRONOUN/m_c/object} for holding back against the enemy Clan.",
-            "death": "m_c died from the injuries r_c inflicted as punishment for holding back against the enemy Clan."
-        }
-    ],
-    "relationships": [
-        {
-            "cats_from": [
-                "m_c"
-            ],
-            "cats_to": [
-                "r_c"
-            ],
-            "mutual": false,
-            "values": [
-                "respect",
-                "comfort"
-            ],
-            "amount": -15,
-            "log": {
-        "cats_from": "cat_from lost respect for cat_to when cat_to punished {PRONOUN/cat_from/object} for holding back in a battle."
-            }
         },
-        {
-            "cats_from": [
-                "r_c"
+        "r_c": {
+            "status": [
+                "deputy",
+                "leader"
             ],
-            "cats_to": [
-                "m_c"
-            ],
-            "mutual": false,
-            "values": [
-                "like",
-                "trust"
-            ],
-            "amount": -15,
-            "log": {
-        "cats_from": "cat_from punished cat_to for holding back during a battle."
+            "trait": [
+                "-compassionate",
+                "-thoughtful",
+                "-loving",
+                "-wise",
+                "-calm",
+                "-responsible",
+                "-playful",
+                "-nervous",
+                "-careful",
+                "-sincere"
+            ]
+        },
+        "injury": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "injuries": [
+                    "battle_injury"
+                ]
             }
-        }
-    ],
-    "future_event": []
-},
-    {
-    "event_id": "gen_injury_war_argument",
-    "location": [
-        "any"
-    ],
-    "season": [
-        "any"
-    ],
-    "sub_type": [
-        "war"
-    ],
-    "tags": [],
-    "frequency": 3,
-    "event_text": "m_c and r_c get into a scuffle during an argument regarding o_c_n.",
-    "m_c": {
-        "status": [
-            "apprentice",
-            "warrior",
-            "leader",
-            "deputy"
-        ]
+        ],
+        "history": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "scar": "m_c was scarred when r_c punished {PRONOUN/m_c/object} for holding back against the enemy Clan.",
+                "death": "m_c died from the injuries r_c inflicted as punishment for holding back against the enemy Clan."
+            }
+        ],
+        "relationships": [
+            {
+                "cats_from": [
+                    "m_c"
+                ],
+                "cats_to": [
+                    "r_c"
+                ],
+                "mutual": false,
+                "values": [
+                    "respect",
+                    "comfort"
+                ],
+                "amount": -15,
+                "log": {
+                    "cats_from": "cat_from lost respect for cat_to when cat_to punished {PRONOUN/cat_from/object} for holding back in a battle."
+                }
             },
-    "r_c": {
-        "status": [
-            "apprentice",
-            "warrior",
-            "leader",
-            "deputy"
-        ]
-    },
-    "injury": [
-        {
-            "cats": [
-                "m_c"
-            ],
-            "injuries": [
-                "minor_injury"
-            ],
-            "scars": []
-        },
-        {
-            "cats": [
-                "r_c"
-            ],
-            "injuries": [
-                "minor_injury"
-            ],
-            "scars": []
-        }
-    ],
-    "relationships": [
-        {
-            "cats_from": [
-                "m_c"
-            ],
-            "cats_to": [
-                "r_c"
-            ],
-            "mutual": true,
-            "values": [
-                "respect"
-            ],
-            "amount": -10,
-            "log": {
-        "cats_from": "cat_from lost respect for cat_to due to an argument regarding another Clan."
+            {
+                "cats_from": [
+                    "r_c"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "mutual": false,
+                "values": [
+                    "like",
+                    "trust"
+                ],
+                "amount": -15,
+                "log": {
+                    "cats_from": "cat_from punished cat_to for holding back during a battle."
+                }
             }
-        }
-    ],
-    "future_event": []
-},
-{
-    "event_id": "gen_injury_leaderpunish",
-    "location": [
-        "any"
-    ],
-    "season": [
-        "any"
-    ],
-    "sub_type": [],
-    "tags": [],
-    "frequency": 2,
-    "event_text": "After a Clanmate challenges {PRONOUN/m_c/object}, m_c commands r_c to help {PRONOUN/m_c/object} punish the protesting cat. r_c ends up hurt, but m_c feels {PRONOUN/m_c/subject} can trust r_c more.",
-    "new_accessory": [],
-    "m_c": {
-        "status": [
-            "leader"
         ],
-        "trait": [
-            "bloodthirsty",
-            "vengeful",
-            "fierce"
-        ]
+        "future_event": []
     },
-    "r_c": {
-        "status": [
-            "warrior",
-            "deputy"
-        ]
-    },
-    "injury": [
-        {
-            "cats": [
-                "r_c"
-            ],
-            "injuries": [
-                "battle_injury"
-            ],
-            "scars": [
-                "ONE",
-                "TWO",
-                "HINDLEG",
-                "FACE",
-                "SNOUT",
-                "CHEEK",
-                "BACK",
-                "CATBITE"
+    {
+        "event_id": "gen_injury_war_argument",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "tags": [],
+        "frequency": 3,
+        "event_text": "m_c and r_c get into a scuffle during an argument regarding o_c_n.",
+        "m_c": {
+            "status": [
+                "apprentice",
+                "warrior",
+                "leader",
+                "deputy"
             ]
-        }
-    ],
-    "history": [
-        {
-            "cats": [
-                "r_c"
-            ],
-            "scar": "Got a scar while punishing a Clanmate in the name of m_c.",
-            "death": "died from {PRONOUN/m_c/poss} injuries after m_c ordered {PRONOUN/m_c/object} to punish a Clanmate."
-        }
-        
-    ],
-    "relationships": [
-        {
-            "cats_from": [
-                "m_c"
-            ],
-            "cats_to": [
-                "r_c"
-            ],
-            "mutual": false,
-            "values": [
-                "comfort",
-                "trust"
-            ],
-            "amount": 10,
-            "log": {
-                "cats_from": "cat_from felt like {PRONOUN/cat_from/poss} could trust cat_to after {PRONOUN/cat_to/subject} followed orders to punish a Clanmate."
-            }
         },
-        {
-            "cats_from": [
-                "r_c"
-            ],
-            "cats_to": [
-                "m_c"
-            ],
-            "mutual": false,
-            "values": [
-                "like"
-            ],
-            "amount": 5,
-            "log": {
-                "cats_from": "cat_from was glad that cat_to trusted {PRONOUN/cat_from/object} to take {PRONOUN/cat_to/poss} side."
-            }
+        "r_c": {
+            "status": [
+                "apprentice",
+                "warrior",
+                "leader",
+                "deputy"
+            ]
         },
-        {
-            "cats_from": [
-                "r_c"
-            ],
-            "cats_to": [
-                "m_c"
-            ],
-            "mutual": false,
-            "values": [
-                "trust",
-                "comfort"
-            ],
-            "amount": -5,
-            "log": {
-                "cats_from": "cat_from grew worried that cat_to viewed {PRONOUN/cat_from/object} as something to be used after being ordered to punish a Clanmate." }
+        "injury": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "injuries": [
+                    "minor_injury"
+                ],
+                "scars": []
+            },
+            {
+                "cats": [
+                    "r_c"
+                ],
+                "injuries": [
+                    "minor_injury"
+                ],
+                "scars": []
             }
-            
-        
-    ]
-}
+        ],
+        "relationships": [
+            {
+                "cats_from": [
+                    "m_c"
+                ],
+                "cats_to": [
+                    "r_c"
+                ],
+                "mutual": true,
+                "values": [
+                    "respect"
+                ],
+                "amount": -10,
+                "log": {
+                    "cats_from": "cat_from lost respect for cat_to due to an argument regarding another Clan."
+                }
+            }
+        ],
+        "future_event": []
+    },
+    {
+        "event_id": "gen_injury_leaderpunish",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [],
+        "tags": [],
+        "frequency": 2,
+        "event_text": "After a Clanmate challenges {PRONOUN/m_c/object}, m_c commands r_c to help {PRONOUN/m_c/object} punish the protesting cat. r_c ends up hurt, but m_c feels {PRONOUN/m_c/subject} can trust r_c more.",
+        "new_accessory": [],
+        "m_c": {
+            "status": [
+                "leader"
+            ],
+            "trait": [
+                "bloodthirsty",
+                "vengeful",
+                "fierce"
+            ]
+        },
+        "r_c": {
+            "status": [
+                "warrior",
+                "deputy"
+            ]
+        },
+        "injury": [
+            {
+                "cats": [
+                    "r_c"
+                ],
+                "injuries": [
+                    "battle_injury"
+                ],
+                "scars": [
+                    "ONE",
+                    "TWO",
+                    "HINDLEG",
+                    "FACE",
+                    "SNOUT",
+                    "CHEEK",
+                    "BACK",
+                    "CATBITE"
+                ]
+            }
+        ],
+        "history": [
+            {
+                "cats": [
+                    "r_c"
+                ],
+                "scar": "Got a scar while punishing a Clanmate in the name of m_c.",
+                "death": "died from {PRONOUN/m_c/poss} injuries after m_c ordered {PRONOUN/m_c/object} to punish a Clanmate."
+            }
+        ],
+        "relationships": [
+            {
+                "cats_from": [
+                    "m_c"
+                ],
+                "cats_to": [
+                    "r_c"
+                ],
+                "mutual": false,
+                "values": [
+                    "comfort",
+                    "trust"
+                ],
+                "amount": 10,
+                "log": {
+                    "cats_from": "cat_from felt like {PRONOUN/cat_from/poss} could trust cat_to after {PRONOUN/cat_to/subject} followed orders to punish a Clanmate."
+                }
+            },
+            {
+                "cats_from": [
+                    "r_c"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "mutual": false,
+                "values": [
+                    "like"
+                ],
+                "amount": 5,
+                "log": {
+                    "cats_from": "cat_from was glad that cat_to trusted {PRONOUN/cat_from/object} to take {PRONOUN/cat_to/poss} side."
+                }
+            },
+            {
+                "cats_from": [
+                    "r_c"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "mutual": false,
+                "values": [
+                    "trust",
+                    "comfort"
+                ],
+                "amount": -5,
+                "log": {
+                    "cats_from": "cat_from grew worried that cat_to viewed {PRONOUN/cat_from/object} as something to be used after being ordered to punish a Clanmate."
+                }
+            }
+        ]
+    }
 ]
 

--- a/resources/lang/en/events/injury/general.json
+++ b/resources/lang/en/events/injury/general.json
@@ -9701,6 +9701,175 @@
                 }
             }
         ]
+    },
+    {
+        "event_id": "gen_injury_poi_cave_head",
+        "location": ["any"],
+        "season": ["any"],
+        "poi": {
+            "tags": ["cave"],
+            "category": "terrain"
+        },
+        "frequency": 3,
+        "event_text": "m_c was struck in the face by a piece of falling rubble in POI.",
+        "m_c": {
+            "age": ["-newborn", "-kitten"]
+        },
+        "injury": [
+            {
+                "cats": ["m_c"],
+                "injuries": ["head damage", "broken jaw"],
+                "scars": ["THREE", "BEAKCHEEK", "BRIDGE", "FACE", "SNOUT", "CHEEK"]
+            }
+        ],
+        "history": [
+            {
+                "cats": ["m_c"],
+                "scar": "m_c was scarred after being struck in the face by a falling piece of rubble.",
+                "death": "m_c was killed by complications of {PRONOUN/m_c/poss} injuries after being struck in the face by falling rubble."
+            }
+        ]
+    },
+    {
+        "event_id": "gen_injury_poi_cave_tail",
+        "location": ["any"],
+        "season": ["any"],
+        "poi": {
+            "tags": ["cave"],
+            "category": "terrain"
+        },
+        "frequency": 3,
+        "event_text": "m_c's tail was crushed by a piece of falling rubble in POI.",
+        "m_c": {
+            "age": ["-newborn", "-kitten"]
+        },
+        "injury": [
+            {
+                "cats": ["m_c"],
+                "injuries": ["mangled tail"]
+            }
+        ],
+        "history": [
+            {
+                "cats": ["m_c"],
+                "scar": "m_c was scarred after {PRONOUN/m_c/poss} tail was crushed by a falling piece of rubble.",
+                "death": "m_c was killed by complications of {PRONOUN/m_c/poss} injuries after {PRONOUN/m_c/poss} tail was struck by falling rubble."
+            }
+        ]
+    },
+    {
+        "event_id": "gen_injury_poi_covered_predator",
+        "location": ["any"],
+        "season": ["any"],
+        "poi": {
+            "tags": ["covered"],
+            "category": "terrain"
+        },
+        "frequency": 3,
+        "event_text": [
+            "m_c was chased by a preadator and injured before {PRONOUN/m_c/subject} could take cover by POI."
+        ],
+        "m_c": {
+            "age": ["-newborn", "-kitten"]
+        },
+        "injury": [
+            {
+                "cats": ["m_c"],
+                "injuries": ["battle_injury"]
+            }
+        ],
+        "history": [
+            {
+                "cats": ["m_c"],
+                "scar": "m_c was scarred after being attacked by a predator.",
+                "death": "m_c was killed by complications of {PRONOUN/m_c/poss} injuries after attacked by a predator."
+            }
+        ]
+    },
+    {
+        "event_id": "gen_injury_poi_fallrisk_rescue",
+        "location": ["any"],
+        "season": ["any"],
+        "poi": {
+            "tags": ["fall_risk"],
+            "category": "terrain"
+        },
+        "frequency": 3,
+        "event_text": "m_c lost {PRONOUN/m_c/poss} footing and slipped near POI. Before {PRONOUN/m_c/subject} fell, r_c grabbed {PRONOUN/m_c/poss} pelt and yanked {PRONOUN/m_c/object} to safety.",
+        "m_c": {
+            "status": ["-newborn", "-kitten", "-elder"]
+        },
+        "r_c": {
+            "status": ["-newborn", "-kitten", "-elder"]
+        },
+        "new_cat": [
+            []
+        ],
+        "injury": [
+            {
+                "cats": ["m_c"],
+                "injuries": ["torn pelt"]
+            }
+            ],
+        "relationships": [
+            {
+                "cats_from": ["m_c"],
+                "cats_to": ["r_c"],
+                "mutual": false,
+                "values": ["trust", "comfort"],
+                "amount": 15,
+                "log": {
+                    "cats_from": "cat_from couldn't thank r_c enough for saving {PRONOUN/m_c/poss} life after {PRONOUN/m_c/subject} nearly fell to {PRONOUN/m_c/poss} death."
+                }
+            }
+        ]
+    },
+    {
+        "event_id": "gen_injury_poi_prey1",
+        "location": ["any"],
+        "season": ["any"],
+        "poi": {
+            "tags": ["prey"],
+            "category": "terrain"
+        },
+        "frequency": 4,
+        "event_text": "m_c sprained {PRONOUN/m_c/poss} paw hunting near POI.",
+        "m_c": {
+            "status": ["apprentice", "warrior", "deputy", "leader"]
+        },
+        "injury": [
+            {
+                "cats": ["m_c"],
+                "injuries": ["sprain"]
+            }
+        ]
+    },
+    {
+        "event_id": "gen_injury_poi_preyflying1",
+        "location": ["any"],
+        "season": ["any"],
+        "poi": {
+            "tags": ["prey:flying"],
+            "category": "terrain"
+        },
+        "frequency": 4,
+        "event_text": "m_c swas harried by a furious flock of birds while hunting near POI.",
+        "m_c": {
+            "status": ["apprentice", "warrior", "deputy", "leader"]
+        },
+        "injury": [
+            {
+                "cats": ["m_c"],
+                "injuries": ["beak_bite"]
+            }
+        ],
+        "history": [
+            {
+                "cats": ["m_c"],
+                "scar": "m_c was scarred by an angry flock of birds",
+                "death": "m_c was killed by complications of {PRONOUN/m_c/poss} wounds after angering a flock of birds."
+            }
+        ]
     }
 ]
 

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -32,7 +32,8 @@
         },
         "relationships": [
             {
-                "cats_from": ["clan", "high_lawful"
+                "cats_from": [
+                    "clan", "high_lawful"
                 ],
                 "cats_to": [
                     "m_c"
@@ -49,7 +50,8 @@
                 }
             },
             {
-                "cats_from": ["clan", "low_lawful"
+                "cats_from": [
+                    "clan", "low_lawful"
                 ],
                 "cats_to": [
                     "m_c"
@@ -295,7 +297,8 @@
         },
         "relationships": [
             {
-                "cats_from": ["clan", "high_lawful"
+                "cats_from": [
+                    "clan", "high_lawful"
                 ],
                 "cats_to": [
                     "m_c"
@@ -312,7 +315,8 @@
                 }
             },
             {
-                "cats_from": ["clan", "low_lawful"
+                "cats_from": [
+                    "clan", "low_lawful"
                 ],
                 "cats_to": [
                     "m_c"
@@ -836,7 +840,8 @@
         },
         "relationships": [
             {
-                "cats_from": ["clan", "high_lawful"
+                "cats_from": [
+                    "clan", "high_lawful"
                 ],
                 "cats_to": [
                     "m_c"
@@ -853,7 +858,8 @@
                 }
             },
             {
-                "cats_from": ["clan", "low_lawful"
+                "cats_from": [
+                    "clan", "low_lawful"
                 ],
                 "cats_to": [
                     "m_c"
@@ -1070,7 +1076,8 @@
                 }
             },
             {
-                "cats_from": ["clan", "high_lawful"
+                "cats_from": [
+                    "clan", "high_lawful"
                 ],
                 "cats_to": [
                     "m_c"
@@ -1217,7 +1224,8 @@
         },
         "relationships": [
             {
-                "cats_from": ["clan", "high_lawful"
+                "cats_from": [
+                    "clan", "high_lawful"
                 ],
                 "cats_to": [
                     "m_c"
@@ -1234,7 +1242,8 @@
                 }
             },
             {
-                "cats_from": ["clan", "low_lawful"
+                "cats_from": [
+                    "clan", "low_lawful"
                 ],
                 "cats_to": [
                     "m_c"
@@ -1327,7 +1336,8 @@
                 }
             },
             {
-                "cats_from": ["r_c", "low_lawful"
+                "cats_from": [
+                    "r_c", "low_lawful"
                 ],
                 "cats_to": [
                     "m_c"
@@ -1395,7 +1405,8 @@
         },
         "relationships": [
             {
-                "cats_from": ["clan", "high_lawful"
+                "cats_from": [
+                    "clan", "high_lawful"
                 ],
                 "cats_to": [
                     "m_c"
@@ -1412,7 +1423,8 @@
                 }
             },
             {
-                "cats_from": ["clan", "low_lawful"
+                "cats_from": [
+                    "clan", "low_lawful"
                 ],
                 "cats_to": [
                     "m_c"
@@ -1470,7 +1482,8 @@
         },
         "relationships": [
             {
-                "cats_from": ["clan", "high_lawful"
+                "cats_from": [
+                    "clan", "high_lawful"
                 ],
                 "cats_to": [
                     "m_c"
@@ -1487,7 +1500,8 @@
                 }
             },
             {
-                "cats_from": ["clan", "low_lawful"
+                "cats_from": [
+                    "clan", "low_lawful"
                 ],
                 "cats_to": [
                     "m_c"
@@ -1531,7 +1545,8 @@
         },
         "relationships": [
             {
-                "cats_from": ["clan", "high_lawful"
+                "cats_from": [
+                    "clan", "high_lawful"
                 ],
                 "cats_to": [
                     "m_c"
@@ -1548,7 +1563,8 @@
                 }
             },
             {
-                "cats_from": ["clan", "low_lawful"
+                "cats_from": [
+                    "clan", "low_lawful"
                 ],
                 "cats_to": [
                     "m_c"
@@ -1623,7 +1639,7 @@
                 "cats_to": ["r_c"],
                 "mutual": false,
                 "values": [
-                    "comfort", 
+                    "comfort",
                     "trust"
                 ],
                 "amount": 30,
@@ -1667,7 +1683,8 @@
         },
         "relationships": [
             {
-                "cats_from": ["clan", "high_lawful"
+                "cats_from": [
+                    "clan", "high_lawful"
                 ],
                 "cats_to": [
                     "m_c"
@@ -1684,7 +1701,8 @@
                 }
             },
             {
-                "cats_from": ["clan", "low_lawful"
+                "cats_from": [
+                    "clan", "low_lawful"
                 ],
                 "cats_to": [
                     "m_c"
@@ -1701,7 +1719,8 @@
                 }
             },
             {
-                "cats_from": ["clan", "low_stable"
+                "cats_from": [
+                    "clan", "low_stable"
                 ],
                 "cats_to": [
                     "r_c"
@@ -1716,7 +1735,8 @@
                 }
             },
             {
-                "cats_from": ["clan", "high_stable"
+                "cats_from": [
+                    "clan", "high_stable"
                 ],
                 "cats_to": [
                     "r_c"
@@ -1785,19 +1805,19 @@
         },
         "relationships": [
             {
-            "cats_from": ["clan", "high_lawful"],
-            "cats_to": ["m_c"],
-            "values": ["respect"],
-            "amount": -10,
-            "mutual": false,
-            "log": {
-                "cats_from": "cat_from disapproved of cat_to wearing a collar."
+                "cats_from": ["clan", "high_lawful"],
+                "cats_to": ["m_c"],
+                "values": ["respect"],
+                "amount": -10,
+                "mutual": false,
+                "log": {
+                    "cats_from": "cat_from disapproved of cat_to wearing a collar."
+                }
             }
-        }
-    ]
+        ]
     },
     {
-        "event_id":  "gen_misc_any_misc1",
+        "event_id": "gen_misc_any_misc1",
         "location": [
             "any"
         ],
@@ -1825,15 +1845,15 @@
         },
         "relationships": [
             {
-            "cats_from": ["clan", "high_lawful"],
-            "cats_to": ["m_c"],
-            "values": ["respect"],
-            "amount": -5,
-            "mutual": false,
-            "log": {
-                "cats_from": "cat_from heard that cat_to trespassed on another Clan's territory."
+                "cats_from": ["clan", "high_lawful"],
+                "cats_to": ["m_c"],
+                "values": ["respect"],
+                "amount": -5,
+                "mutual": false,
+                "log": {
+                    "cats_from": "cat_from heard that cat_to trespassed on another Clan's territory."
+                }
             }
-        }
         ]
     },
     {
@@ -1860,15 +1880,15 @@
         },
         "relationships": [
             {
-            "cats_from": ["clan", "high_social"],
-            "cats_to": ["m_c"],
-            "values": ["respect", "like"],
-            "amount": 5,
-            "mutual": false,
-            "log": {
-                "cats_from": "cat_from enjoyed spending an evening listening to cat_to's stories."
+                "cats_from": ["clan", "high_social"],
+                "cats_to": ["m_c"],
+                "values": ["respect", "like"],
+                "amount": 5,
+                "mutual": false,
+                "log": {
+                    "cats_from": "cat_from enjoyed spending an evening listening to cat_to's stories."
+                }
             }
-        }
         ]
     },
     {
@@ -4186,7 +4206,8 @@
                 "cats_to": [
                     "r_c"
                 ],
-                "cats_from": ["clan", "high_social"
+                "cats_from": [
+                    "clan", "high_social"
                 ],
                 "mutual": false,
                 "values": [
@@ -4713,7 +4734,21 @@
         "new_accessory": ["JAY FEATHERS", "BLUE FEATHERS"],
         "m_c": {
             "status": ["-kitten"],
-            "trait": ["adventurous", "ambitious", "confident", "bold", "daring", "troublesome", "rebellious", "fierce", "competitive", "cunning", "shameless", "flamboyant", "arrogant"]
+            "trait": [
+                "adventurous",
+                "ambitious",
+                "confident",
+                "bold",
+                "daring",
+                "troublesome",
+                "rebellious",
+                "fierce",
+                "competitive",
+                "cunning",
+                "shameless",
+                "flamboyant",
+                "arrogant"
+            ]
         },
         "injury": [
             {
@@ -4746,7 +4781,21 @@
         },
         "r_c": {
             "status": ["-kitten"],
-            "trait": ["adventurous", "ambitious", "confident", "bold", "daring", "troublesome", "rebellious", "fierce", "competitive", "cunning", "shameless", "flamboyant", "arrogant"]
+            "trait": [
+                "adventurous",
+                "ambitious",
+                "confident",
+                "bold",
+                "daring",
+                "troublesome",
+                "rebellious",
+                "fierce",
+                "competitive",
+                "cunning",
+                "shameless",
+                "flamboyant",
+                "arrogant"
+            ]
         },
         "injury": [
             {
@@ -4823,7 +4872,21 @@
         "new_accessory": ["SPARROW FEATHERS"],
         "r_c": {
             "status": ["apprentice"],
-            "trait": ["adventurous", "ambitious", "confident", "bold", "daring", "troublesome", "rebellious", "fierce", "competitive", "cunning", "shameless", "flamboyant", "arrogant"]
+            "trait": [
+                "adventurous",
+                "ambitious",
+                "confident",
+                "bold",
+                "daring",
+                "troublesome",
+                "rebellious",
+                "fierce",
+                "competitive",
+                "cunning",
+                "shameless",
+                "flamboyant",
+                "arrogant"
+            ]
         },
         "m_c": {
             "status": ["apprentice"],
@@ -4858,16 +4921,16 @@
         },
         "relationships": [
             {
-            "cats_from": ["clan", "high_lawful"],
-            "cats_to": ["m_c"],
-            "values": ["respect"],
-            "amount": -10,
-            "mutual": false,
-            "log": {
-                "cats_from": "cat_from disapproved of cat_to wearing a collar."
+                "cats_from": ["clan", "high_lawful"],
+                "cats_to": ["m_c"],
+                "values": ["respect"],
+                "amount": -10,
+                "mutual": false,
+                "log": {
+                    "cats_from": "cat_from disapproved of cat_to wearing a collar."
+                }
             }
-        }
-    ]
+        ]
     },
     {
         "event_id": "gen_misc_any_accessorywaterPOI1",
@@ -5037,7 +5100,7 @@
             }
         ]
     },
-   {
+    {
         "event_id": "gen_misc_any_attentionseekingkitnursery",
         "location": ["any"],
         "season": ["any"],
@@ -5086,7 +5149,7 @@
                     "cats_from": "r_c was annoyed that m_c made a mess in the nursery."
                 }
             }
-            ]
+        ]
     },
     {
         "event_id": "gen_misc_any_attentionseekingkitfreshkillpile1",
@@ -5100,7 +5163,7 @@
         },
         "r_c": {
             "status": [
-                "warrior","deputy","leader"
+                "warrior", "deputy", "leader"
             ]
         },
         "relationships": [
@@ -5136,7 +5199,7 @@
                     "cats_from": "r_c was annoyed that m_c made a mess of the fresh-kill pile."
                 }
             }
-            ]
+        ]
     },
     {
         "event_id": "gen_misc_any_attentionseekingkitfreshkillpile2",
@@ -5150,7 +5213,7 @@
         },
         "r_c": {
             "status": [
-                "warrior","deputy","leader"
+                "warrior", "deputy", "leader"
             ]
         },
         "relationships": [
@@ -5186,7 +5249,7 @@
                     "cats_from": "cat_from was annoyed that m_c made a mess of the fresh-kill pile and ruined some of the prey."
                 }
             }
-            ],
+        ],
         "supplies": [
             {
                 "type": "freshkill",
@@ -5209,15 +5272,16 @@
             "status": [
                 "elder"
             ],
-			"trait": [ "-playful",
-					"-compassionate",
-					"-thoughtful",
-					"-calm",
-					"-careful",
-					"-loving",
-					"-responsible",
-					"-wise"
-			]
+            "trait": [
+                "-playful",
+                "-compassionate",
+                "-thoughtful",
+                "-calm",
+                "-careful",
+                "-loving",
+                "-responsible",
+                "-wise"
+            ]
         },
         "relationships": [
             {
@@ -5252,9 +5316,9 @@
                     "cats_from": "r_c was annoyed that m_c wouldn't leave {PRONOUN/r_c/object} alone."
                 }
             }
-            ]
+        ]
     },
-     {
+    {
         "event_id": "gen_misc_any_attentionseekingkitapprentice1",
         "location": ["any"],
         "season": ["any"],
@@ -5268,15 +5332,16 @@
             "age": [
                 "adolescent"
             ],
-			"trait": [ "-playful",
-					"-compassionate",
-					"-thoughtful",
-					"-calm",
-					"-careful",
-					"-loving",
-					"-responsible",
-					"-wise"
-			]
+            "trait": [
+                "-playful",
+                "-compassionate",
+                "-thoughtful",
+                "-calm",
+                "-careful",
+                "-loving",
+                "-responsible",
+                "-wise"
+            ]
         },
         "relationships": [
             {
@@ -5311,7 +5376,7 @@
                     "cats_from": "r_c was annoyed that m_c bothered {PRONOUN/r_c/object} with something silly."
                 }
             }
-            ]
+        ]
     },
     {
         "event_id": "gen_misc_any_attentionseekingkitapprentice2",
@@ -5327,20 +5392,21 @@
             "age": [
                 "adolescent"
             ],
-			"trait": [ "-troublesome",
-						"-lonesome",
-						"-fierce",
-						"-bloodthirsty",
-						"-cold",
-						"-strict",
-						"-ambitious",
-						"-shameless",
-						"-vengeful",
-						"-arrogant",
-						"-competitive",
-						"-grumpy",
-						"-gloomy"
-			]
+            "trait": [
+                "-troublesome",
+                "-lonesome",
+                "-fierce",
+                "-bloodthirsty",
+                "-cold",
+                "-strict",
+                "-ambitious",
+                "-shameless",
+                "-vengeful",
+                "-arrogant",
+                "-competitive",
+                "-grumpy",
+                "-gloomy"
+            ]
         },
         "relationships": [
             {
@@ -5375,9 +5441,9 @@
                     "cats_from": "r_c was glad to watch m_c's new trick."
                 }
             }
-            ]
+        ]
     },
-     {
+    {
         "event_id": "gen_misc_any_attentionseekingkitdeputyleader",
         "location": ["any"],
         "season": ["any"],
@@ -5389,7 +5455,7 @@
         },
         "r_c": {
             "status": [
-                "leader","deputy"
+                "leader", "deputy"
             ]
         },
         "relationships": [
@@ -5409,9 +5475,9 @@
                     "cats_from": "m_c was upset r_c didn't have time to play."
                 }
             }
-            ]
+        ]
     },
-        {
+    {
         "event_id": "gen_misc_any_attentionseekingkitmedicineden",
         "location": ["any"],
         "season": ["any"],
@@ -5459,7 +5525,7 @@
                     "cats_from": "cat_from was annoyed that m_c made a mess of {PRONOUN/r_c/poss} herbs and ruined some of them."
                 }
             }
-            ],
+        ],
         "supplies": [
             {
                 "type": "any_herb",
@@ -5511,7 +5577,7 @@
         },
         "new_cat": [
             [
-	     "exists",
+                "exists",
                 "meeting",
                 "loner",
                 "rogue"
@@ -5521,10 +5587,10 @@
             "m_c"
         ],
         "outsider": {
-        "current_rep": [
-            "welcoming"
-        ],
-        "changed": 5
+            "current_rep": [
+                "welcoming"
+            ],
+            "changed": 5
         }
     },
     {
@@ -5544,7 +5610,7 @@
         },
         "new_cat": [
             [
-	     "exists",
+                "exists",
                 "meeting",
                 "loner",
                 "rogue",
@@ -5556,10 +5622,10 @@
             "m_c"
         ],
         "outsider": {
-        "current_rep": [
-            "welcoming"
-        ],
-        "changed": 5
+            "current_rep": [
+                "welcoming"
+            ],
+            "changed": 5
         },
         "relationships": [
             {
@@ -5603,7 +5669,7 @@
         },
         "new_cat": [
             [
-	     "exists",
+                "exists",
                 "meeting",
                 "loner",
                 "rogue"
@@ -5613,11 +5679,11 @@
             "m_c"
         ],
         "outsider": {
-        "current_rep": [
-            "welcoming",
-            "neutral"
-        ],
-        "changed": 5
+            "current_rep": [
+                "welcoming",
+                "neutral"
+            ],
+            "changed": 5
         }
     },
     {
@@ -5650,11 +5716,11 @@
             "m_c"
         ],
         "other_clan": {
-        "current_rep": [
-            "ally",
-            "neutral"
-        ],
-        "changed": 3
+            "current_rep": [
+                "ally",
+                "neutral"
+            ],
+            "changed": 3
         }
     },
     {
@@ -5678,7 +5744,7 @@
         },
         "new_cat": [
             [
-	     "exists",
+                "exists",
                 "meeting",
                 "kittypet"
             ]
@@ -5687,11 +5753,11 @@
             "m_c"
         ],
         "outsider": {
-        "current_rep": [
-            "welcoming",
-            "neutral"
-        ],
-        "changed": 5
+            "current_rep": [
+                "welcoming",
+                "neutral"
+            ],
+            "changed": 5
         }
     },
     {
@@ -5741,7 +5807,8 @@
                 }
             },
             {
-                "cats_from": ["clan", "high_lawful"
+                "cats_from": [
+                    "clan", "high_lawful"
                 ],
                 "cats_to": [
                     "m_c"
@@ -5810,7 +5877,8 @@
                 }
             },
             {
-                "cats_from": ["clan", "high_lawful"
+                "cats_from": [
+                    "clan", "high_lawful"
                 ],
                 "cats_to": [
                     "m_c"
@@ -5880,7 +5948,8 @@
                 }
             },
             {
-                "cats_from": ["clan", "high_lawful"
+                "cats_from": [
+                    "clan", "high_lawful"
                 ],
                 "cats_to": [
                     "m_c"
@@ -5950,7 +6019,8 @@
                 }
             },
             {
-                "cats_from": ["clan", "high_lawful"
+                "cats_from": [
+                    "clan", "high_lawful"
                 ],
                 "cats_to": [
                     "m_c"
@@ -11063,36 +11133,36 @@
         },
         "relationships": [
             {
-            "cats_from": [
-                "clan", "high_lawful", "low_social"
-            ],
-            "cats_to": [
-                "m_c"
-            ],
-            "mutual": false,
-            "values": [
-                "respect", "trust"
-            ],
-            "amount": -10,
-            "log": {
-                "cats_from": "cat_from disapproved of cat_to clinging to {PRONOUN/cat_to/poss} friendship with an apprentice from another Clan during the war."
-            }
+                "cats_from": [
+                    "clan", "high_lawful", "low_social"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "mutual": false,
+                "values": [
+                    "respect", "trust"
+                ],
+                "amount": -10,
+                "log": {
+                    "cats_from": "cat_from disapproved of cat_to clinging to {PRONOUN/cat_to/poss} friendship with an apprentice from another Clan during the war."
+                }
             },
             {
-            "cats_from": [
-                "clan", "low_lawful", "high_social"
-            ],
-            "cats_to": [
-                "m_c"
-            ],
-            "mutual": false,
-            "values": [
-                "respect", "like"
-            ],
-            "amount": 10,
-            "log": {
-                "cats_from": "cat_from was touched that cat_to kept {PRONOUN/cat_to/poss} friendship with an apprentice from another Clan during the war."
-            }
+                "cats_from": [
+                    "clan", "low_lawful", "high_social"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "mutual": false,
+                "values": [
+                    "respect", "like"
+                ],
+                "amount": 10,
+                "log": {
+                    "cats_from": "cat_from was touched that cat_to kept {PRONOUN/cat_to/poss} friendship with an apprentice from another Clan during the war."
+                }
             }
         ],
         "other_clan": {
@@ -11133,35 +11203,35 @@
         "relationships": [
             {
                 "cats_from": [
-                "clan", "high_lawful", "low_social"
-            ],
+                    "clan", "high_lawful", "low_social"
+                ],
                 "cats_to": [
-                "m_c"
-            ],
+                    "m_c"
+                ],
                 "mutual": false,
                 "values": [
-                "respect", "trust"
-            ],
+                    "respect", "trust"
+                ],
                 "amount": -10,
                 "log": {
-                "cats_from": "cat_from disapproved of cat_to clinging to {PRONOUN/cat_to/poss} friendship with an apprentice from another Clan during the war."
-            }
+                    "cats_from": "cat_from disapproved of cat_to clinging to {PRONOUN/cat_to/poss} friendship with an apprentice from another Clan during the war."
+                }
             },
             {
-            "cats_from": [
-                "clan", "low_lawful", "high_social"
-            ],
-            "cats_to": [
-                "m_c"
-            ],
-            "mutual": false,
-            "values": [
-                "respect", "like"
-            ],
-            "amount": 10,
-            "log": {
-                "cats_from": "cat_from was touched that cat_to kept {PRONOUN/cat_to/poss} friendship with an apprentice from another Clan during the war."
-            }
+                "cats_from": [
+                    "clan", "low_lawful", "high_social"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "mutual": false,
+                "values": [
+                    "respect", "like"
+                ],
+                "amount": 10,
+                "log": {
+                    "cats_from": "cat_from was touched that cat_to kept {PRONOUN/cat_to/poss} friendship with an apprentice from another Clan during the war."
+                }
             }
         ],
         "other_clan": {
@@ -11229,36 +11299,36 @@
         },
         "relationships": [
             {
-            "cats_from": [
-                "clan", "high_lawful", "low_social"
-            ],
-            "cats_to": [
-                "m_c"
-            ],
-            "mutual": false,
-            "values": [
-                "respect", "trust"
-            ],
-            "amount": -10,
-            "log": {
-                "cats_from": "cat_from disapproved of cat_to clinging to {PRONOUN/cat_to/poss} friendship with an apprentice from another Clan during the war."
-            }
+                "cats_from": [
+                    "clan", "high_lawful", "low_social"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "mutual": false,
+                "values": [
+                    "respect", "trust"
+                ],
+                "amount": -10,
+                "log": {
+                    "cats_from": "cat_from disapproved of cat_to clinging to {PRONOUN/cat_to/poss} friendship with an apprentice from another Clan during the war."
+                }
             },
             {
-            "cats_from": [
-                "clan", "low_lawful", "high_social"
-            ],
-            "cats_to": [
-                "m_c"
-            ],
-            "mutual": false,
-            "values": [
-                "respect", "like"
-            ],
-            "amount": 10,
-            "log": {
-                "cats_from": "cat_from was touched that cat_to kept {PRONOUN/cat_to/poss} friendship with an apprentice from another Clan during the war."
-            }
+                "cats_from": [
+                    "clan", "low_lawful", "high_social"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "mutual": false,
+                "values": [
+                    "respect", "like"
+                ],
+                "amount": 10,
+                "log": {
+                    "cats_from": "cat_from was touched that cat_to kept {PRONOUN/cat_to/poss} friendship with an apprentice from another Clan during the war."
+                }
             }
         ]
     },
@@ -12432,7 +12502,7 @@
                 "leader"
             ]
         },
-       "r_c": {
+        "r_c": {
             "status": [
                 "warrior",
                 "deputy",
@@ -12441,10 +12511,10 @@
         },
         "relationships": [
             {
-                "cats_from": [ "m_c" ],
-                "cats_to": [ "r_c" ],
+                "cats_from": ["m_c"],
+                "cats_to": ["r_c"],
                 "mutual": true,
-                "values": [ "trust" ],
+                "values": ["trust"],
                 "amount": 10,
                 "log": {
                     "cats_from": "cat_from and cat_to spent the night on watch for a potential attack."
@@ -12561,10 +12631,10 @@
     },
     {
         "event_id": "gen_misc_waraggro",
-        "location": [ "any" ],
-        "season": [ "any" ],
-        "sub_type": [ "war" ],
-        "tags": [ ],
+        "location": ["any"],
+        "season": ["any"],
+        "sub_type": ["war"],
+        "tags": [],
         "frequency": 2,
         "event_text": "m_c has been eager to sink {PRONOUN/m_c/poss} claws into o_c_n during the next skirmish.",
         "m_c": {
@@ -12787,9 +12857,9 @@
         ],
         "frequency": 4,
         "event_text": "At the Gathering, m_c overheard cats from another Clan gossiping about the war between c_n and o_c_n.",
-        "m_c" : {
-			"age": ["-newborn","-kitten"]
-		},
+        "m_c": {
+            "age": ["-newborn", "-kitten"]
+        },
         "other_clan": {
             "current_rep": ["any"],
             "changed": 0
@@ -12808,11 +12878,11 @@
         ],
         "frequency": 2,
         "event_text": "While on a border patrol, m_c met a loner who demanded to know why c_n is at war with o_c_n.",
-        "m_c" : {
-            "status": ["leader","deputy","warrior","apprentice"]
+        "m_c": {
+            "status": ["leader", "deputy", "warrior", "apprentice"]
         },
         "new_cat": [
-            ["exists","meeting","loner"]
+            ["exists", "meeting", "loner"]
         ],
         "other_clan": {
             "current_rep": ["any"],
@@ -12835,14 +12905,14 @@
         "event_id": "gen_misc_war_nosykittypet",
         "location": ["any"],
         "season": ["any"],
-        "sub_type":["war"],
+        "sub_type": ["war"],
         "frequency": 2,
         "event_text": "While on a patrol, m_c encountered a kittypet who complained about c_n's war with o_c_n being annoying. {PRONOUN/n_c:0/subject/CAP} demanded to know why c_n is involved in it in the first place.",
         "m_c": {
             "status": ["leader", "deputy", "warrior", "apprentice"]
         },
         "new_cat": [
-            ["exists","meeting","loner"]
+            ["exists", "meeting", "loner"]
         ],
         "other_clan": {
             "current_rep": ["any"],
@@ -12865,14 +12935,14 @@
         "event_id": "gen_misc_war_kittypetendwar",
         "location": ["any"],
         "season": ["any"],
-        "sub_type":["war"],
+        "sub_type": ["war"],
         "frequency": 1,
         "event_text": "While on a patrol, m_c encountered a kittypet. {PRONOUN/n_c:0/subject/CAP} immediately demanded c_n ends the war. All the noise is interrupting {PRONOUN/n_c:0/poss} beauty sleep!",
         "m_c": {
             "status": ["leader", "deputy", "warrior", "apprentice"]
         },
         "new_cat": [
-            ["exists","meeting","kittypet"]
+            ["exists", "meeting", "kittypet"]
         ],
         "other_clan": {
             "current_rep": ["any"],
@@ -12895,14 +12965,14 @@
         "event_id": "gen_misc_war_lonerendwar",
         "location": ["any"],
         "season": ["any"],
-        "sub_type":["war"],
+        "sub_type": ["war"],
         "frequency": 1,
         "event_text": "While on a patrol, m_c encountered a loner. {PRONOUN/n_c:0/subject/CAP} immediately demanded c_n ends the war. All the noise is making it difficult for n_c:0 to hunt.",
         "m_c": {
             "status": ["leader", "deputy", "warrior", "apprentice"]
         },
         "new_cat": [
-            ["exists","meeting","loner"]
+            ["exists", "meeting", "loner"]
         ],
         "other_clan": {
             "current_rep": ["any"],
@@ -12928,10 +12998,11 @@
         "sub_type": ["war"],
         "frequency": 3,
         "event_text": "While on a patrol, m_c encountered a kittypet. {PRONOUN/n_c:0/subject/CAP} bounced up to {PRONOUN/m_c/object} and asked if {PRONOUN/n_c:0/subject} could join the war. It sounds like a fun game!",
-        "m_c": { "status": ["leader","deputy","warrior","apprentice"]
-            },
+        "m_c": {
+            "status": ["leader", "deputy", "warrior", "apprentice"]
+        },
         "new_cat": [
-        ["exists","meeting","kittypet"]
+            ["exists", "meeting", "kittypet"]
         ],
         "other_clan": {
             "current_rep": ["any"],
@@ -12941,7 +13012,7 @@
             {
                 "cats_from": ["m_c"],
                 "cats_to": ["n_c:0"],
-                "values": ["like","comfort"],
+                "values": ["like", "comfort"],
                 "mutual": false,
                 "amount": -5,
                 "log": {
@@ -13243,15 +13314,16 @@
                 "DARK,2",
                 "DREAM,2",
                 "GHOST,2"
-            ]},
-        "r_c": { },
+            ]
+        },
+        "r_c": {},
         "future_event": [
             {
                 "event_type": "death",
                 "pool": {
                     "sub_type": ["murder"]
                 },
-                "moon_delay": [1,3],
+                "moon_delay": [1, 3],
                 "involved_cats": {
                     "m_c": "r_c",
                     "r_c": "m_c"
@@ -13298,7 +13370,7 @@
                 "pool": {
                     "sub_type": ["murder"]
                 },
-                "moon_delay": [1,3],
+                "moon_delay": [1, 3],
                 "involved_cats": {
                     "m_c": "r_c",
                     "r_c": "m_c"
@@ -13735,7 +13807,7 @@
             ]
         }
     },
-        {
+    {
         "event_id": "gen_misc_failedmurderattack1",
         "location": [
             "any"
@@ -13751,7 +13823,7 @@
         "m_c": {
             "status": [
                 "-kitten",
-              "-elder"
+                "-elder"
             ]
         },
         "r_c": {
@@ -13760,19 +13832,19 @@
                 "-elder"
             ]
         },
-            "injury": [
-                {
-                    "cats": ["r_c"],
-                    "injuries": ["claw-wound", "cat bite"]
-                }
-            ],
-            "history": [
-                {
-                    "cats": ["r_c"],
+        "injury": [
+            {
+                "cats": ["r_c"],
+                "injuries": ["claw-wound", "cat bite"]
+            }
+        ],
+        "history": [
+            {
+                "cats": ["r_c"],
                 "scar": "m_c was scarred after a Clanmate attacked {PRONOUN/m_c/object} while on patrol.",
                 "death": "m_c was killed by {PRONOUN/m_c/poss} wounds caused by a Clanmate."
-                }
-            ],
+            }
+        ],
         "relationships": [
             {
                 "cats_from": ["r_c"],
@@ -13827,23 +13899,23 @@
                 "-elder"
             ]
         },
-            "injury": [
-                {
-                    "cats": ["r_c"],
-                    "injuries": ["claw-wound", "cat bite"]
-                },
-                {
-                    "cats": ["m_c"],
-                    "injuries": ["scrapes", "torn pelt"]
-                }
-            ],
-            "history": [
-                {
-                    "cats": ["r_c"],
+        "injury": [
+            {
+                "cats": ["r_c"],
+                "injuries": ["claw-wound", "cat bite"]
+            },
+            {
+                "cats": ["m_c"],
+                "injuries": ["scrapes", "torn pelt"]
+            }
+        ],
+        "history": [
+            {
+                "cats": ["r_c"],
                 "scar": "r_c was scarred after a Clanmate attacked {PRONOUN/r_c/object} while on patrol.",
                 "death": "r_c was killed by {PRONOUN/r_c/poss} wounds caused by a Clanmate."
-                }
-            ],
+            }
+        ],
         "relationships": [
             {
                 "cats_from": ["r_c"],
@@ -13941,7 +14013,7 @@
                     "cats_from": "cat_from's confidence in cat_to weakened after hearing that {PRONOUN/cat_to/subject} gave a Clanmate the wrong herb dosage."
                 }
             }
-            ]
+        ]
     },
     {
         "event_id": "gen_misc_failedmurderpoison2",
@@ -13951,8 +14023,7 @@
         "tags": [],
         "frequency": 3,
         "event_text": "r_c was badly poisoned after eating deathberries. When rushed to the medicine den, {PRONOUN/r_c/subject} mumbled that they don't taste like how m_c said they would...",
-        "m_c":
-        {
+        "m_c": {
             "status": [
                 "apprentice",
                 "warrior",
@@ -13990,9 +14061,9 @@
                     "cats_from": "cat_from thinks cat_to lied to {PRONOUN/cat_from/object} about how good deathberries taste."
                 }
             }
-            ]
+        ]
     },
-        {
+    {
         "event_id": "gen_misc_failedmurderpoison3",
         "location": ["any"],
         "season": ["any"],
@@ -14000,8 +14071,7 @@
         "tags": [],
         "frequency": 3,
         "event_text": "m_c offered r_c a piece of prey from the pile. Later, r_c was rushed to the medicine den, having been poisoned by crowfood.",
-        "m_c":
-        {
+        "m_c": {
             "status": [
                 "apprentice",
                 "warrior",
@@ -14037,7 +14107,7 @@
                     "cats_from": "cat_from thought cat_to purposefully offered {PRONOUN/cat_from/object} crowfood."
                 }
             }
-            ]
+        ]
     },
     {
         "event_id": "gen_misc_failedmurderriver1",
@@ -14047,8 +14117,7 @@
         "tags": [],
         "frequency": 3,
         "event_text": "r_c fell into the river. m_c helped rescue {PRONOUN/r_c/object}, but r_c swears {PRONOUN/r_c/subject} {VERB/r_c/were/was} pushed in.",
-        "m_c":
-        {
+        "m_c": {
             "status": [
                 "apprentice",
                 "warrior",
@@ -14080,9 +14149,9 @@
                     "cats_from": "cat_from thought cat_to pushed {PRONOUN/cat_from/object} into the river and pretended to save {PRONOUN/cat_from/object}."
                 }
             }
-            ]
+        ]
     },
-        {
+    {
         "event_id": "gen_misc_failedmurderplotting1",
         "location": ["any"],
         "season": ["any"],
@@ -14090,8 +14159,7 @@
         "tags": [],
         "frequency": 2,
         "event_text": "m_c met with lead_name and claimed {PRONOUN/m_c/subject} overheard r_c making plans to overthrow lead_name and take over the Clan.",
-        "m_c":
-        {
+        "m_c": {
             "status": [
                 "apprentice",
                 "warrior",
@@ -14124,9 +14192,9 @@
                     "cats_from": "cat_from accused cat_to of wanting to take over the Clan in hopes the leader would get rid of {PRONOUN/cat_to/object}."
                 }
             }
-            ]
+        ]
     },
-        {
+    {
         "event_id": "gen_misc_failedmurderplotting2",
         "location": ["any"],
         "season": ["any"],
@@ -14134,8 +14202,7 @@
         "tags": [],
         "frequency": 3,
         "event_text": "m_c was almost in tears as {PRONOUN/m_c/subject} emphasized to lead_name how cruel r_c has been lately. r_c looked confused and denied everything m_c says.",
-        "m_c":
-        {
+        "m_c": {
             "status": [
                 "apprentice",
                 "warrior",
@@ -14167,7 +14234,7 @@
                     "cats_from": "cat_from doesn't understand why cat_to would accuse {PRONOUN/cat_from/object} of being cruel and make {PRONOUN/cat_from/object} look bad in front of the leader."
                 }
             },
-                        {
+            {
                 "cats_from": ["m_c"],
                 "cats_to": ["r_c"],
                 "values": ["like"],
@@ -14177,209 +14244,209 @@
                     "cats_from": "cat_from accused cat_to of being cruel to {PRONOUN/cat_from/object} in front of the leader in hopes something would be done about {PRONOUN/cat_to/object}."
                 }
             }
-            ]
+        ]
     },
     {
-    "event_id": "gen_misc_hitmanfailedmurder1",
-    "location": ["any"],
-    "season": ["any"],
-    "sub_type": ["failed_murder"],
-    "tags": [],
-    "frequency": 2,
-    "event_text": "m_c was seen speaking to n_c:0 on the border. n_c:0 later attacked r_c's patrol, and though {PRONOUN/n_c:0/subject} {VERB/n_c:0/were/was} driven off, r_c was injured and couldn't shake the feeling n_c:0 was targeting {PRONOUN/r_c/object}.",
-    "m_c": {
-        "age": ["young adult", "adult", "senior adult"]
-    },
-    "r_c": {
-        "status": ["apprentice", "mediator apprentice", "medicine cat apprentice", "mediator", "medicine cat", "warrior", "deputy"]
-    },
-    "new_cat": [
-        ["age:adult", "rogue", "meeting", "exists"]
-    ],
-    "injury": [
-        {
-            "cats": ["r_c"],
-            "injuries": ["cat bite"]
-        }
-    ],
-    "history": [
-        {
-            "cats": ["r_c"],
-            "scar": "r_c was scarred after a rogue targeted {PRONOUN/r_c/object} in a fight.",
-            "death": "r_c died in the wake of a fight with a rogue who seemed to be targeting {PRONOUN/r_c/object}."
-        }
-    ],
-    "relationships": [
-        {
-            "cats_from": ["m_c"],
-            "cats_to": ["n_c:0"],
-            "mutual": false,
-            "values": ["trust"],
-            "amount": 10,
-            "log": {
-                "cats_from": "cat_from hired cat_to to kill r_c."
-            }
+        "event_id": "gen_misc_hitmanfailedmurder1",
+        "location": ["any"],
+        "season": ["any"],
+        "sub_type": ["failed_murder"],
+        "tags": [],
+        "frequency": 2,
+        "event_text": "m_c was seen speaking to n_c:0 on the border. n_c:0 later attacked r_c's patrol, and though {PRONOUN/n_c:0/subject} {VERB/n_c:0/were/was} driven off, r_c was injured and couldn't shake the feeling n_c:0 was targeting {PRONOUN/r_c/object}.",
+        "m_c": {
+            "age": ["young adult", "adult", "senior adult"]
         },
-        {
-            "cats_from": ["r_c"],
-            "cats_to": ["n_c:0"],
-            "mutual": false,
-            "values": ["like"],
-            "amount": -20,
-            "log": {
-                "cats_from": "cat_to seemed to be targeting cat_from in an attack on a c_n patrol."
-            }
-        }
-    ]
-    },
-    {
-    "event_id": "gen_misc_hitmanfailedmurder2",
-    "location": ["any"],
-    "season": ["any"],
-    "sub_type": ["failed_murder"],
-    "tags": [],
-    "frequency": 2,
-    "event_text": "m_c was seen speaking to n_c:0 on the border. n_c:0 later attacked r_c's patrol, but {PRONOUN/n_c:0/subject} underestimated r_c's strength, and r_c, fighting for {PRONOUN/r_c/poss} life, killed {PRONOUN/n_c:0/object}.",
-    "m_c": {
-        "age": ["young adult", "adult", "senior adult"]
-    },
-    "r_c": {
-        "age": [],
-        "status": ["mediator", "medicine cat", "warrior", "deputy"],
-        "skill": ["FIGHTER,2"]
-    },
-    "new_cat": [
-        ["age:adult", "rogue", "meeting", "dead", "exists"]
-    ],
-    "relationships": [
-        {
-            "cats_from": ["m_c"],
-            "cats_to": ["n_c:0"],
-            "mutual": false,
-            "values": ["trust"],
-            "amount": 10,
-            "log": {
-                "cats_from": "cat_from hired cat_to to kill r_c."
-            }
-        }
-    ]
-    },
-    {
-    "event_id": "gen_misc_guardasleep",
-    "location": [
-      "any"
-    ],
-    "season": [
-      "any"
-    ],
-    "frequency": 4,
-    "event_text": "m_c fell asleep when {PRONOUN/m_c/subject} {VERB/m_c/were/was} supposed to be guarding camp.",
-    "m_c": {
-        "status": [
-          "warrior",
-          "deputy"
+        "r_c": {
+            "status": ["apprentice", "mediator apprentice", "medicine cat apprentice", "mediator", "medicine cat", "warrior", "deputy"]
+        },
+        "new_cat": [
+            ["age:adult", "rogue", "meeting", "exists"]
         ],
-        "relationship_status": [],
-        "skill": [],
-        "trait": ["-strict", "-responsible"],
-        "backstory": [],
-        "dies": false
-    },
-    "relationships": [
-        {
-            "cats_from": [
-              "clan", "high_lawful"
-            ],
-            "cats_to": [
-              "m_c"
-            ],
-            "mutual": false,
-            "values": ["trust"],
-            "amount": -5,
-            "log": {
-              "cats_from": "cat_from heard cat_to fell asleep guarding camp."
+        "injury": [
+            {
+                "cats": ["r_c"],
+                "injuries": ["cat bite"]
+            }
+        ],
+        "history": [
+            {
+                "cats": ["r_c"],
+                "scar": "r_c was scarred after a rogue targeted {PRONOUN/r_c/object} in a fight.",
+                "death": "r_c died in the wake of a fight with a rogue who seemed to be targeting {PRONOUN/r_c/object}."
+            }
+        ],
+        "relationships": [
+            {
+                "cats_from": ["m_c"],
+                "cats_to": ["n_c:0"],
+                "mutual": false,
+                "values": ["trust"],
+                "amount": 10,
+                "log": {
+                    "cats_from": "cat_from hired cat_to to kill r_c."
                 }
-        }
-    ]
-},
-      {
-    "event_id": "dst_misc_any_traitmisc2_aloof",
-    "location": ["any"],
-    "season": ["any"],
-    "frequency": 4,
-    "event_text": "m_c held {PRONOUN/m_c/self} apart from the Clan this moon, {PRONOUN/m_c/poss} mood strange and irritable.",
-    "m_c": {
-      "age": ["any"],
-      "status": ["any"],
-      "trait": ["cold", "gloomy", "grumpy", "strange"]
+            },
+            {
+                "cats_from": ["r_c"],
+                "cats_to": ["n_c:0"],
+                "mutual": false,
+                "values": ["like"],
+                "amount": -20,
+                "log": {
+                    "cats_from": "cat_to seemed to be targeting cat_from in an attack on a c_n patrol."
+                }
+            }
+        ]
     },
-    "relationships": [
-      {
-        "cats_from": ["clan", "high_social"],
-        "cats_to": ["m_c"],
-        "values": ["comfort", "like"],
-        "amount": -5,
-        "log": {
-          "cats_from": "cat_from noticed that cat_to was in a foul mood."
-        }
-      }
-    ]
-  },
-        {
+    {
+        "event_id": "gen_misc_hitmanfailedmurder2",
+        "location": ["any"],
+        "season": ["any"],
+        "sub_type": ["failed_murder"],
+        "tags": [],
+        "frequency": 2,
+        "event_text": "m_c was seen speaking to n_c:0 on the border. n_c:0 later attacked r_c's patrol, but {PRONOUN/n_c:0/subject} underestimated r_c's strength, and r_c, fighting for {PRONOUN/r_c/poss} life, killed {PRONOUN/n_c:0/object}.",
+        "m_c": {
+            "age": ["young adult", "adult", "senior adult"]
+        },
+        "r_c": {
+            "age": [],
+            "status": ["mediator", "medicine cat", "warrior", "deputy"],
+            "skill": ["FIGHTER,2"]
+        },
+        "new_cat": [
+            ["age:adult", "rogue", "meeting", "dead", "exists"]
+        ],
+        "relationships": [
+            {
+                "cats_from": ["m_c"],
+                "cats_to": ["n_c:0"],
+                "mutual": false,
+                "values": ["trust"],
+                "amount": 10,
+                "log": {
+                    "cats_from": "cat_from hired cat_to to kill r_c."
+                }
+            }
+        ]
+    },
+    {
+        "event_id": "gen_misc_guardasleep",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "frequency": 4,
+        "event_text": "m_c fell asleep when {PRONOUN/m_c/subject} {VERB/m_c/were/was} supposed to be guarding camp.",
+        "m_c": {
+            "status": [
+                "warrior",
+                "deputy"
+            ],
+            "relationship_status": [],
+            "skill": [],
+            "trait": ["-strict", "-responsible"],
+            "backstory": [],
+            "dies": false
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "clan", "high_lawful"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "mutual": false,
+                "values": ["trust"],
+                "amount": -5,
+                "log": {
+                    "cats_from": "cat_from heard cat_to fell asleep guarding camp."
+                }
+            }
+        ]
+    },
+    {
+        "event_id": "dst_misc_any_traitmisc2_aloof",
+        "location": ["any"],
+        "season": ["any"],
+        "frequency": 4,
+        "event_text": "m_c held {PRONOUN/m_c/self} apart from the Clan this moon, {PRONOUN/m_c/poss} mood strange and irritable.",
+        "m_c": {
+            "age": ["any"],
+            "status": ["any"],
+            "trait": ["cold", "gloomy", "grumpy", "strange"]
+        },
+        "relationships": [
+            {
+                "cats_from": ["clan", "high_social"],
+                "cats_to": ["m_c"],
+                "values": ["comfort", "like"],
+                "amount": -5,
+                "log": {
+                    "cats_from": "cat_from noticed that cat_to was in a foul mood."
+                }
+            }
+        ]
+    },
+    {
         "event_id": "gen_misc_kitkit1_thunder",
         "location": [
-          "-desert"
+            "-desert"
         ],
         "season": ["leaf-fall", "newleaf", "greenleaf"],
-      "tags": ["clan:warrior"],
+        "tags": ["clan:warrior"],
         "frequency": 4,
         "event_text": "m_c doesn't care what the warriors say; thunder is definitely dangerous and horrible. r_c agrees, the kittens finding comfort in each other during a storm this moon.",
         "m_c": {
             "status": ["kitten"]
         },
         "r_c": {
-          "status": ["kitten"]
+            "status": ["kitten"]
         },
         "relationships": [
-          {
-            "cats_to": ["m_c"],
-            "cats_from": ["r_c"],
-            "mutual": true,
-            "values": ["like", "comfort", "trust"],
-            "amount": 15,
-            "log": {
-              "cats_from": "cat_from and cat_to agree that thunder is scary."
+            {
+                "cats_to": ["m_c"],
+                "cats_from": ["r_c"],
+                "mutual": true,
+                "values": ["like", "comfort", "trust"],
+                "amount": 15,
+                "log": {
+                    "cats_from": "cat_from and cat_to agree that thunder is scary."
+                }
             }
-          }
         ]
     },
-      {
-    "event_id": "gen_misc_any_apprentice4_mousebile",
-    "location": ["any"],
-    "season": ["any"],
-    "frequency": 4,
-    "event_text": "m_c and r_c bonded over how much they both hate mouse bile.",
-    "m_c": {
-      "age": ["adolescent"],
-      "status": ["apprentice"]
+    {
+        "event_id": "gen_misc_any_apprentice4_mousebile",
+        "location": ["any"],
+        "season": ["any"],
+        "frequency": 4,
+        "event_text": "m_c and r_c bonded over how much they both hate mouse bile.",
+        "m_c": {
+            "age": ["adolescent"],
+            "status": ["apprentice"]
+        },
+        "r_c": {
+            "age": ["adolescent"],
+            "status": ["apprentice"]
+        },
+        "relationships": [
+            {
+                "cats_to": ["m_c"],
+                "cats_from": ["r_c"],
+                "mutual": true,
+                "values": ["like", "comfort"],
+                "amount": 15,
+                "log": {
+                    "cats_from": "cat_from and cat_to bonded over hating mouse bile."
+                }
+            }
+        ]
     },
-    "r_c": {
-      "age": ["adolescent"],
-      "status": ["apprentice"]
-    },
-    "relationships": [
-        {
-          "cats_to": ["m_c"],
-            "cats_from": ["r_c"],
-            "mutual": true,
-            "values": ["like", "comfort"],
-          "amount": 15,
-          "log": {
-            "cats_from": "cat_from and cat_to bonded over hating mouse bile."
-          }
-        }
-    ]
-  },
     {
         "event_id": "gen_misc_war_pitcaught",
         "location": ["any"],
@@ -14395,262 +14462,261 @@
         },
         "exclude_involved": ["m_c"]
     },
-      {
-    "event_id": "gen_misc_war_skirmishvictory",
-    "location": ["any"],
-    "season": ["any"],
-    "sub_type": ["war"],
-    "frequency": 4,
-    "event_text": "c_n drove off o_c_n in their most recent skirmish with no notable injuries.",
-    "other_clan": {
-        "current_rep": ["any"],
-        "changed": -1
-    },
-     "exclude_involved": ["m_c"]
-},
-      {
-    "event_id": "multi_misc_war_ambush",
-    "location": ["forest", "wetlands"],
-    "season": ["any"],
-    "sub_type": ["war"],
-    "frequency": 3,
-    "event_text": "c_n used the dense foliage to their favor by ambushing o_c_n from the undergrowth and forcing their scouting patrol to scatter.",
-    "other_clan": {
-        "current_rep": ["any"],
-        "changed": -1
-    },
-     "exclude_involved": ["m_c"]
-},
-      {
-    "event_id": "gen_misc_war_ocnleaddeath",
-    "location": ["any"],
-    "season": ["any"],
-    "sub_type": ["war"],
-    "frequency": 2,
-    "event_text": "m_c is confident that o_c_n's leader lost a life during the last battle.",
-    "m_c": {
-        "status": ["leader", "deputy"]
-    },
-    "other_clan": {
-        "current_rep": ["any"],
-        "changed": -1
-    }
-},
-{
-  "event_id": "gen_misc_guardsneakout",
-  "location": [
-    "any"
-  ],
-  "season": [
-    "any"
-  ],
-  "frequency": 3,
-  "event_text": "While on guard duty, m_c caught r_c trying to sneak out of camp.",
-  "m_c": {
-    "status": [
-      "warrior",
-      "deputy"
-    ],
-    "relationship_status": [],
-    "skill": [],
-    "trait": [
-      "-oblivious"
-    ],
-    "backstory": [],
-    "dies": false
-  },
-  "r_c": {
-    "status": [
-      "apprentice",
-      "leader",
-      "warrior",
-      "elder"
-    ],
-    "relationship_status": [],
-    "skill": ["-STEALTH,1"],
-    "trait": [],
-    "backstory": [],
-    "dies": false
-  },
-  "relationships": [
     {
-      "cats_from": [
-        "m_c"
-      ],
-      "cats_to": [
-        "r_c"
-      ],
-      "mutual": false,
-      "values": [
-        "trust"
-      ],
-      "amount": -10,
-      "log": {
-        "cats_from": "cat_from became suspicious of cat_to after catching {PRONOUN/cat_to/object} trying to sneak out of camp."
-      }
+        "event_id": "gen_misc_war_skirmishvictory",
+        "location": ["any"],
+        "season": ["any"],
+        "sub_type": ["war"],
+        "frequency": 4,
+        "event_text": "c_n drove off o_c_n in their most recent skirmish with no notable injuries.",
+        "other_clan": {
+            "current_rep": ["any"],
+            "changed": -1
+        },
+        "exclude_involved": ["m_c"]
     },
     {
-      "cats_from": [
-        "r_c"
-      ],
-      "cats_to": [
-        "m_c"
-      ],
-      "mutual": false,
-      "values": [
-        "like"
-      ],
-      "amount": -10,
-      "log": {
-        "cats_from": "cat_from was annoyed that cat_to caught {PRONOUN/cat_from/object} trying to sneak out of camp."
-      }
-    }
-  ]
-},
-	{
-    "event_id": "gen_misc_war_nightmare",
-    "location": [
-		"any"
-	],
-    "season": [
-		"any"
-	],
-    "sub_type": [
-		"war"
-	],
-    "tags": [],
-    "frequency": 1,
-    "event_text": "m_c woke up from a nightmare, sobbing about a mysterious evil cat.",
-    "new_accessory": [],
-    "m_c": {
-        "age": [
-		"kitten"
-		]
-	}
-	},
-	{
-    "event_id": "gen_misc_war_apppractice",
-    "location": [
-		"any"
-	],
-    "season": [
-		"any"
-	],
-    "sub_type": [
-		"war"
-	],
-    "tags": [],
-    "frequency": 4,
-    "event_text": "m_c begged {PRONOUN/m_c/poss} mentor for more battle training, claiming {PRONOUN/m_c/subject} {VERB/m_c/need/needs} to be stronger to fight o_c_n.",
-    "new_accessory": [],
-    "m_c": {
-        "status": [
-			"apprentice"
-		],
-        "relationship_status": [
-			"app/mentor"
-		],
-        "trait": [
-			"-arrogant"
-		]
+        "event_id": "multi_misc_war_ambush",
+        "location": ["forest", "wetlands"],
+        "season": ["any"],
+        "sub_type": ["war"],
+        "frequency": 3,
+        "event_text": "c_n used the dense foliage to their favor by ambushing o_c_n from the undergrowth and forcing their scouting patrol to scatter.",
+        "other_clan": {
+            "current_rep": ["any"],
+            "changed": -1
+        },
+        "exclude_involved": ["m_c"]
     },
-    "r_c": {
-        "status": [
-			"any"
-		]
-    },
-    
-    	"relationships": [
-        {
-            "cats_from": [
-				"m_c"
-			],
-            "cats_to": [
-				"r_c"
-			],
-            "mutual": true,
-            "values": [
-				"like",
-				"trust"
-			],
-            "amount": 10,
-        "log": {
-        "cats_from": "cat_from believed that cat_to's guidance would make them strong enough to fight off any foe!",
-        "cats_to": "cat_to admired and cherished cat_from's eagerness to learn."
-      }
+    {
+        "event_id": "gen_misc_war_ocnleaddeath",
+        "location": ["any"],
+        "season": ["any"],
+        "sub_type": ["war"],
+        "frequency": 2,
+        "event_text": "m_c is confident that o_c_n's leader lost a life during the last battle.",
+        "m_c": {
+            "status": ["leader", "deputy"]
+        },
+        "other_clan": {
+            "current_rep": ["any"],
+            "changed": -1
         }
-    ]
-},
-	{
-    "event_id": "gen_misc_war_medstudy",
-    "location": [
-		"any"
-	],
-    "season": [
-		"any"
-	],
-    "sub_type": [
-		"war"
-	],
-    "tags": [],
-    "frequency": 3,
-    "event_text": "m_c studied herbs all night, wanting to help c_n as much as {PRONOUN/m_c/subject} can.",
-    "m_c": {
-        "status": [
-			"medicine cat apprentice"
-		]
     },
-    "future_event": []
-},
-	{
-    "event_id": "gen_misc_war_medsort",
-    "location": [
-		"any"
-	],
-    "season": [
-		"any"
-	],
-    "sub_type": [
-		"war"
-	],
-    "tags": [],
-    "frequency": 4,
-    "event_text": "m_c spent all night sorting the herb stores, wanting to help as much as {PRONOUN/m_c/subject} can.",
-    "m_c": {
-        "status": [
-			"medicine cat apprentice",
-			"medicine cat"
-		]
+    {
+        "event_id": "gen_misc_guardsneakout",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "frequency": 3,
+        "event_text": "While on guard duty, m_c caught r_c trying to sneak out of camp.",
+        "m_c": {
+            "status": [
+                "warrior",
+                "deputy"
+            ],
+            "relationship_status": [],
+            "skill": [],
+            "trait": [
+                "-oblivious"
+            ],
+            "backstory": [],
+            "dies": false
+        },
+        "r_c": {
+            "status": [
+                "apprentice",
+                "leader",
+                "warrior",
+                "elder"
+            ],
+            "relationship_status": [],
+            "skill": ["-STEALTH,1"],
+            "trait": [],
+            "backstory": [],
+            "dies": false
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "m_c"
+                ],
+                "cats_to": [
+                    "r_c"
+                ],
+                "mutual": false,
+                "values": [
+                    "trust"
+                ],
+                "amount": -10,
+                "log": {
+                    "cats_from": "cat_from became suspicious of cat_to after catching {PRONOUN/cat_to/object} trying to sneak out of camp."
+                }
+            },
+            {
+                "cats_from": [
+                    "r_c"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "mutual": false,
+                "values": [
+                    "like"
+                ],
+                "amount": -10,
+                "log": {
+                    "cats_from": "cat_from was annoyed that cat_to caught {PRONOUN/cat_from/object} trying to sneak out of camp."
+                }
+            }
+        ]
     },
-    "future_event": []
-},
-	{
-    "event_id": "gen_misc_war_appholdback",
-    "location": [
-		"any"
-	],
-    "season": [
-		"any"
-	],
-    "sub_type": [
-		"war"
-	],
-    "tags": [],
-    "frequency": 3,
-    "event_text": "m_c was caught holding back in a fight against a o_c_n apprentice. ",
-    "m_c": {
-        "status": [
+    {
+        "event_id": "gen_misc_war_nightmare",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "tags": [],
+        "frequency": 1,
+        "event_text": "m_c woke up from a nightmare, sobbing about a mysterious evil cat.",
+        "new_accessory": [],
+        "m_c": {
+            "age": [
+                "kitten"
+            ]
+        }
+    },
+    {
+        "event_id": "gen_misc_war_apppractice",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "tags": [],
+        "frequency": 4,
+        "event_text": "m_c begged {PRONOUN/m_c/poss} mentor for more battle training, claiming {PRONOUN/m_c/subject} {VERB/m_c/need/needs} to be stronger to fight o_c_n.",
+        "new_accessory": [],
+        "m_c": {
+            "status": [
+                "apprentice"
+            ],
+            "relationship_status": [
+                "app/mentor"
+            ],
+            "trait": [
+                "-arrogant"
+            ]
+        },
+        "r_c": {
+            "status": [
+                "any"
+            ]
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "m_c"
+                ],
+                "cats_to": [
+                    "r_c"
+                ],
+                "mutual": true,
+                "values": [
+                    "like",
+                    "trust"
+                ],
+                "amount": 10,
+                "log": {
+                    "cats_from": "cat_from believed that cat_to's guidance would make them strong enough to fight off any foe!",
+                    "cats_to": "cat_to admired and cherished cat_from's eagerness to learn."
+                }
+            }
+        ]
+    },
+    {
+        "event_id": "gen_misc_war_medstudy",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "tags": [],
+        "frequency": 3,
+        "event_text": "m_c studied herbs all night, wanting to help c_n as much as {PRONOUN/m_c/subject} can.",
+        "m_c": {
+            "status": [
+                "medicine cat apprentice"
+            ]
+        },
+        "future_event": []
+    },
+    {
+        "event_id": "gen_misc_war_medsort",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "tags": [],
+        "frequency": 4,
+        "event_text": "m_c spent all night sorting the herb stores, wanting to help as much as {PRONOUN/m_c/subject} can.",
+        "m_c": {
+            "status": [
+                "medicine cat apprentice",
+                "medicine cat"
+            ]
+        },
+        "future_event": []
+    },
+    {
+        "event_id": "gen_misc_war_appholdback",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "tags": [],
+        "frequency": 3,
+        "event_text": "m_c was caught holding back in a fight against a o_c_n apprentice. ",
+        "m_c": {
+            "status": [
                 "apprentice"
             ],
             "trait": [
                 "-bloodthirsty",
-				"-fierce",
-				"-arrogant",
-				"-vengeful"
+                "-fierce",
+                "-arrogant",
+                "-vengeful"
             ]
+        },
+        "future_event": []
     },
-    "future_event": []
-},
     {
         "event_id": "gen_misc_otherclannewleader1",
         "location": [
@@ -14681,7 +14747,7 @@
             "changed": -15
         }
     },
-       {
+    {
         "event_id": "gen_misc_otherclannewleader2",
         "location": [
             "any"
@@ -14711,7 +14777,7 @@
             "changed": -15
         }
     },
-       {
+    {
         "event_id": "gen_misc_otherclannewleader3",
         "location": [
             "any"
@@ -14741,7 +14807,7 @@
             "changed": -15
         }
     },
-           {
+    {
         "event_id": "gen_misc_otherclannewleader4",
         "location": [
             "any"
@@ -14771,7 +14837,7 @@
             "changed": -15
         }
     },
-           {
+    {
         "event_id": "gen_misc_otherclannewleader5",
         "location": [
             "any"
@@ -14789,7 +14855,6 @@
             "status": [
                 "leader"
             ]
-        
         },
         "other_clan": {
             "current_rep": [
@@ -14798,173 +14863,168 @@
             "changed": -15
         }
     },
-    
-
-        {
-            "event_id": "gen_misc_otherclannewleader6",
-            "location": [
-                "any"
-            ],
-            "season": [
-                "any"
-            ],
-            "tags": [],
-            "exclude_involved": [
-            ],
-            "frequency": 1,
-            "event_text": "During the Gathering, m_c overhears a new o_c_n apprentice gossiping about how their leader might break off the alliance with c_n.",
-            "m_c": {
-                "age": [
-                    "adolescent",
-                    "young adult",
-                    "adult",
-                    "senior adult",
-                    "senior"
-                ]
-            },
-            "other_clan": {
-                "current_rep": [
-                    "ally"
-                ],
-                "changed": -5
-            }
+    {
+        "event_id": "gen_misc_otherclannewleader6",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "tags": [],
+        "exclude_involved": [
+        ],
+        "frequency": 1,
+        "event_text": "During the Gathering, m_c overhears a new o_c_n apprentice gossiping about how their leader might break off the alliance with c_n.",
+        "m_c": {
+            "age": [
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult",
+                "senior"
+            ]
         },
-        
+        "other_clan": {
+            "current_rep": [
+                "ally"
+            ],
+            "changed": -5
+        }
+    },
+    {
+        "event_id": "gen_misc_otherclannewleader7",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "tags": ["clan:leader"],
+        "exclude_involved": [
+            "m_c"
+        ],
+        "frequency": 1,
+        "event_text": "m_c just about dies laughing when o_c_n's new leader is announced. Surely they could've picked a more capable cat? m_c has to be silenced by r_c just to continue the Gathering.",
+        "m_c": {
+            "age": [
+                "-newborn",
+                "-kitten"
+            ],
+            "status": [
+                "-leader"
+            ],
+            "trait": [
+                "bold",
+                "arrogant",
+                "bullying",
+                "troublesome",
+                "playful",
+                "childish"
+            ]
+        },
+        "r_c": {
+            "age": [
+                "-newborn",
+                "-kitten",
+                "-adolescent"
+            ],
+            "status": [
+                "leader"
+            ]
+        },
+        "relationships": [
             {
-                "event_id": "gen_misc_otherclannewleader7",
-                "location": [
-                    "any"
-                ],
-                "season": [
-                    "any"
-                ],
-                "tags": ["clan:leader"],
-                "exclude_involved": [
+                "cats_from": [
                     "m_c"
                 ],
-                "frequency": 1,
-                "event_text": "m_c just about dies laughing when o_c_n's new leader is announced. Surely they could've picked a more capable cat? m_c has to be silenced by r_c just to continue the Gathering.",
-                "m_c": {
-                    "age": [
-                        "-newborn",
-                        "-kitten"
-                    ],
-                    "status": [
-                        "-leader"
-                    ],
-                    "trait": [
-                        "bold",
-                        "arrogant",
-                        "bullying",
-                        "troublesome",
-                        "playful",
-                        "childish"
-                    ]
-                },
-                "r_c": {
-                    "age": [
-                        "-newborn",
-                        "-kitten",
-                        "-adolescent"
-                    ],
-                    "status": [
-                        "leader"
-                    ]
-                },
-                "relationships": [
-                    {
-                        "cats_from": [
-                            "m_c"
-                        ],
-                        "cats_to": [
-                            "r_c"
-                        ],
-                        "mutual": false,
-                        "values": ["respect"],
-                        "amount": -5,
-                        "log": {
-                            "cats_from": "cat_from was silenced by cat_to at a Gathering."
-                        }
-                      },
-                      {
-                        "cats_from": [
-                            "r_c"
-                        ],
-                        "cats_to": [
-                            "m_c"
-                        ],
-                        "mutual": false,
-                        "values": ["like"],
-                        "amount": -5,
-                        "log": {
-                            "cats_from": "cat_from was embarrassed by cat_to at a Gathering."
-                        }
-                    }
+                "cats_to": [
+                    "r_c"
                 ],
-                "other_clan": {
-                    "current_rep": [
-                        "ally"
-                    ],
-                    "changed": -5
+                "mutual": false,
+                "values": ["respect"],
+                "amount": -5,
+                "log": {
+                    "cats_from": "cat_from was silenced by cat_to at a Gathering."
                 }
             },
-            
-                {
-                    "event_id": "gen_misc_otherclannewleader8",
-                    "location": [
-                        "any"
-                    ],
-                    "season": [
-                        "any"
-                    ],
-                    "tags": [],
-                    "exclude_involved": [
-                    ],
-                    "frequency": 1,
-                    "event_text": "m_c purrs when o_c_n announces they have more apprentices.",
-                    "m_c": {
-                        "age": [
-                            "adolescent"
-                        ]
-                    },
-                    "other_clan": {
-                        "current_rep": [
-                            "ally"
-                        ],
-                        "changed": 5
-                    }
-                },
-                
-                    {
-                        "event_id": "gen_misc_otherclannewleader9",
-                        "location": [
-                            "any"
-                        ],
-                        "season": [
-                            "any"
-                        ],
-                        "tags": [],
-                        "exclude_involved": [
-                        ],
-                        "frequency": 1,
-                        "event_text": "During the Gathering, m_c spots a beautiful o_c_n cat. {PRONOUN/m_c/subject/CAP} can't stop staring at them until a Clanmate shoves {PRONOUN/m_c/object}, snapping {PRONOUN/m_c/object} out of it.",
-                        "m_c": {
-                            "age": [
-                                "adolescent",
-                        "young adult",
-                        "adult",
-                        "senior adult",
-                        "senior"
-                            ]
-                        },
-                        "other_clan": {
-                            "current_rep": [
-                                "ally"
-                            ],
-                            "changed": 3
-                        }
-                    },
-                    {
+            {
+                "cats_from": [
+                    "r_c"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "mutual": false,
+                "values": ["like"],
+                "amount": -5,
+                "log": {
+                    "cats_from": "cat_from was embarrassed by cat_to at a Gathering."
+                }
+            }
+        ],
+        "other_clan": {
+            "current_rep": [
+                "ally"
+            ],
+            "changed": -5
+        }
+    },
+    {
+        "event_id": "gen_misc_otherclannewleader8",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "tags": [],
+        "exclude_involved": [
+        ],
+        "frequency": 1,
+        "event_text": "m_c purrs when o_c_n announces they have more apprentices.",
+        "m_c": {
+            "age": [
+                "adolescent"
+            ]
+        },
+        "other_clan": {
+            "current_rep": [
+                "ally"
+            ],
+            "changed": 5
+        }
+    },
+    {
+        "event_id": "gen_misc_otherclannewleader9",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "tags": [],
+        "exclude_involved": [
+        ],
+        "frequency": 1,
+        "event_text": "During the Gathering, m_c spots a beautiful o_c_n cat. {PRONOUN/m_c/subject/CAP} can't stop staring at them until a Clanmate shoves {PRONOUN/m_c/object}, snapping {PRONOUN/m_c/object} out of it.",
+        "m_c": {
+            "age": [
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult",
+                "senior"
+            ]
+        },
+        "other_clan": {
+            "current_rep": [
+                "ally"
+            ],
+            "changed": 3
+        }
+    },
+    {
         "event_id": "gen_misc_otherclanhostilerelboost1",
         "location": [
             "any"
@@ -15099,108 +15159,108 @@
             "changed": 15
         }
     },
-  {
-    "event_id": "gen_rel_hate1",
-    "location": [
-      "any"
-    ],
-    "season": [
-      "any"
-    ],
-    "frequency": 1,
-    "event_text": "m_c's fur bristles when r_c is near.",
-    "m_c": {
-      "relationship_status": [
-        "hates_only"
-      ]
+    {
+        "event_id": "gen_rel_hate1",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "frequency": 1,
+        "event_text": "m_c's fur bristles when r_c is near.",
+        "m_c": {
+            "relationship_status": [
+                "hates_only"
+            ]
+        },
+        "r_c": {}
     },
-    "r_c": {}
-  },
-  {
-    "event_id": "gen_rel_hate2",
-    "location": [
-      "any"
-    ],
-    "season": [
-      "any"
-    ],
-    "frequency": 1,
-    "event_text": "r_c is always getting on m_c's nerves.",
-    "m_c": {
-      "relationship_status": [
-        "hates_only"
-      ]
+    {
+        "event_id": "gen_rel_hate2",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "frequency": 1,
+        "event_text": "r_c is always getting on m_c's nerves.",
+        "m_c": {
+            "relationship_status": [
+                "hates_only"
+            ]
+        },
+        "r_c": {}
     },
-    "r_c": {}
-  },
-  {
-    "event_id": "gen_rel_hate3",
-    "location": [
-      "any"
-    ],
-    "season": [
-      "any"
-    ],
-    "frequency": 1,
-    "event_text": "m_c often catches {PRONOUN/m_c/self} glaring at r_c.",
-    "m_c": {
-      "relationship_status": [
-        "hates_only"
-      ]
+    {
+        "event_id": "gen_rel_hate3",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "frequency": 1,
+        "event_text": "m_c often catches {PRONOUN/m_c/self} glaring at r_c.",
+        "m_c": {
+            "relationship_status": [
+                "hates_only"
+            ]
+        },
+        "r_c": {}
     },
-    "r_c": {}
-  },
-      {
-    "event_id": "gen_rel_envy1",
-    "location": [
-      "any"
-    ],
-    "season": [
-      "any"
-    ],
-    "frequency": 1,
-    "event_text": "m_c is jealous of the attention r_c receives.",
-    "m_c": {
-      "relationship_status": [
-        "envies_only"
-      ]
+    {
+        "event_id": "gen_rel_envy1",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "frequency": 1,
+        "event_text": "m_c is jealous of the attention r_c receives.",
+        "m_c": {
+            "relationship_status": [
+                "envies_only"
+            ]
+        },
+        "r_c": {}
     },
-    "r_c": {}
-  },
-          {
-    "event_id": "gen_rel_envy2",
-    "location": [
-      "any"
-    ],
-    "season": [
-      "any"
-    ],
-    "frequency": 1,
-    "event_text": "m_c wonders if {PRONOUN/m_c/poss} Clanmates like r_c more than {PRONOUN/m_c/object}.",
-    "m_c": {
-      "relationship_status": [
-        "envies_only"
-      ]
+    {
+        "event_id": "gen_rel_envy2",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "frequency": 1,
+        "event_text": "m_c wonders if {PRONOUN/m_c/poss} Clanmates like r_c more than {PRONOUN/m_c/object}.",
+        "m_c": {
+            "relationship_status": [
+                "envies_only"
+            ]
+        },
+        "r_c": {}
     },
-    "r_c": {}
-  },
-              {
-    "event_id": "gen_rel_envy3",
-    "location": [
-      "any"
-    ],
-    "season": [
-      "any"
-    ],
-    "frequency": 1,
-    "event_text": "m_c feels like {PRONOUN/m_c/poss} parent favors r_c.",
-    "m_c": {
-      "relationship_status": [
-        "envies_only", "siblings"
-      ]
+    {
+        "event_id": "gen_rel_envy3",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "frequency": 1,
+        "event_text": "m_c feels like {PRONOUN/m_c/poss} parent favors r_c.",
+        "m_c": {
+            "relationship_status": [
+                "envies_only", "siblings"
+            ]
+        },
+        "r_c": {}
     },
-    "r_c": {}
-  },
     {
         "event_id": "gen_rel_envy4",
         "location": [
@@ -15215,7 +15275,7 @@
             "relationship_status": [
                 "envies_only"
             ],
-             "status": [
+            "status": [
                 "-leader"
             ]
         },
@@ -15226,7 +15286,7 @@
             ]
         }
     },
-        {
+    {
         "event_id": "gen_rel_distrust1",
         "location": [
             "any"
@@ -15240,7 +15300,7 @@
             "status": ["warrior", "deputy"],
             "relationship_status": [
                 "distrusts_only"
-                ]
+            ]
         },
         "r_c": {
             "status": [
@@ -15248,7 +15308,7 @@
             ]
         }
     },
-            {
+    {
         "event_id": "gen_rel_distrust2",
         "location": [
             "any"
@@ -15262,7 +15322,7 @@
             "status": ["-kitten"],
             "relationship_status": [
                 "distrusts_only"
-                ]
+            ]
         },
         "r_c": {
             "status": [
@@ -15270,7 +15330,7 @@
             ]
         }
     },
-            {
+    {
         "event_id": "gen_rel_distrust3",
         "location": [
             "any"
@@ -15283,11 +15343,11 @@
         "m_c": {
             "relationship_status": [
                 "distrusts_only"
-                ]
+            ]
         },
         "r_c": {}
     },
-                {
+    {
         "event_id": "gen_rel_fears1",
         "location": [
             "any"
@@ -15301,13 +15361,13 @@
             "status": ["-kitten", "-elder"],
             "relationship_status": [
                 "fears_only"
-                ]
+            ]
         },
         "r_c": {
             "status": ["-kitten", "-elder"]
         }
     },
-                    {
+    {
         "event_id": "gen_rel_fears2",
         "location": [
             "any"
@@ -15320,11 +15380,11 @@
         "m_c": {
             "relationship_status": [
                 "fears_only"
-                ]
+            ]
         },
         "r_c": {}
     },
-     {
+    {
         "event_id": "gen_rel_fears3",
         "location": [
             "any"
@@ -15337,14 +15397,14 @@
         "m_c": {
             "relationship_status": [
                 "fears_only"
-                ],
+            ],
             "status": ["-leader"]
         },
         "r_c": {
             "status": ["leader", "deputy"]
         }
     },
-                    {
+    {
         "event_id": "gen_rel_fears4",
         "location": [
             "any"
@@ -15357,14 +15417,14 @@
         "m_c": {
             "relationship_status": [
                 "fears_only"
-                ],
+            ],
             "status": ["-medicine cat", "-medicine cat apprentice"]
         },
         "r_c": {
             "status": ["medicine cat apprentice", "medicine cat"]
         }
     },
-                   {
+    {
         "event_id": "gen_rel_fears5",
         "location": [
             "any"
@@ -15378,9 +15438,9 @@
             "status": ["kitten"],
             "relationship_status": [
                 "fears_only"
-                ]
+            ]
         },
-     "r_c": {}
+        "r_c": {}
     },
     {
         "event_id": "gen_misc_greenleaf_splashdate",
@@ -15407,8 +15467,8 @@
                 "values": ["romance"],
                 "amount": 10,
                 "log": {
-                        "cats_from": "cat_to and cat_from enjoyed splashing each other to beat the heat."
-                    }
+                    "cats_from": "cat_to and cat_from enjoyed splashing each other to beat the heat."
+                }
             }
         ]
     },
@@ -15742,30 +15802,30 @@
         }
     },
     {
-    "event_id": "gen_misc_warhalfclanquestion1",
-    "location": [
-    "any"
-],
-    "season": [
-    "any"
-],
-    "sub_type": [
-        "war"
-    ],
-    "tags": [],
-    "frequency": 2,
-    "event_text": "The war with o_c_n demands full loyalty from every cat in c_n. m_c's half-Clan heritage has made some cats question where {PRONOUN/m_c/poss} loyalties truly lie.",
-    "m_c": {
-        "status": [
-            "-kitten",
-            "-elder"
+        "event_id": "gen_misc_warhalfclanquestion1",
+        "location": [
+            "any"
         ],
-        "backstory": [
-            "halfclan1",
-            "halfclan2"
-        ]
-    },
-    "relationships": [
+        "season": [
+            "any"
+        ],
+        "sub_type": [
+            "war"
+        ],
+        "tags": [],
+        "frequency": 2,
+        "event_text": "The war with o_c_n demands full loyalty from every cat in c_n. m_c's half-Clan heritage has made some cats question where {PRONOUN/m_c/poss} loyalties truly lie.",
+        "m_c": {
+            "status": [
+                "-kitten",
+                "-elder"
+            ],
+            "backstory": [
+                "halfclan1",
+                "halfclan2"
+            ]
+        },
+        "relationships": [
             {
                 "cats_from": [
                     "clan",
@@ -15784,14 +15844,14 @@
                 }
             }
         ],
-    "other_clan": {
-        "current_rep": [
-            "hostile"
-        ],
-        "changed": 0
-    }
+        "other_clan": {
+            "current_rep": [
+                "hostile"
+            ],
+            "changed": 0
+        }
     },
-      {
+    {
         "event_id": "gen_misc_warhalfclanquestion2",
         "location": [
             "any"
@@ -15816,10 +15876,10 @@
             ]
         },
         "r_c": {
-        "relationship_status": [
-            "enjoys",
-            "trusts"
-        ]
+            "relationship_status": [
+                "enjoys",
+                "trusts"
+            ]
         },
         "relationships": [
             {
@@ -15901,7 +15961,7 @@
             "changed": 0
         }
     },
-     {
+    {
         "event_id": "gen_misc_warotherclanquestion1",
         "location": [
             "any"
@@ -15935,10 +15995,10 @@
             ]
         },
         "r_c": {
-        "relationship_status": [
-            "hates",
-            "distrusts"
-        ]
+            "relationship_status": [
+                "hates",
+                "distrusts"
+            ]
         },
         "relationships": [
             {
@@ -16018,7 +16078,7 @@
             "changed": 0
         }
     },
-     {
+    {
         "event_id": "gen_misc_warotherclanfight1",
         "location": [
             "any"
@@ -16089,7 +16149,7 @@
             "changed": -3
         }
     },
-     {
+    {
         "event_id": "gen_misc_warotherclanfight2",
         "location": [
             "any"
@@ -16161,564 +16221,564 @@
             "changed": 2
         }
     },
-      {
-    "event_id": "gen_rel_loathes1",
-    "location": ["any"],
-    "season": ["any"],
-    "frequency": 1,
-    "event_text": "m_c's claws unsheathe whenever r_c is near.",
-    "m_c": {
-        "relationship_status": ["loathes_only"]
+    {
+        "event_id": "gen_rel_loathes1",
+        "location": ["any"],
+        "season": ["any"],
+        "frequency": 1,
+        "event_text": "m_c's claws unsheathe whenever r_c is near.",
+        "m_c": {
+            "relationship_status": ["loathes_only"]
+        },
+        "r_c": {}
     },
-    "r_c": {}
-},
     {
-    "event_id": "gen_rel_loathes2",
-    "location": ["any"],
-    "season": ["any"],
-    "frequency": 1,
-    "event_text": "m_c hopes r_c gets horribly wounded.",
-    "m_c": {
-        "relationship_status": ["loathes_only"]
+        "event_id": "gen_rel_loathes2",
+        "location": ["any"],
+        "season": ["any"],
+        "frequency": 1,
+        "event_text": "m_c hopes r_c gets horribly wounded.",
+        "m_c": {
+            "relationship_status": ["loathes_only"]
+        },
+        "r_c": {}
     },
-    "r_c": {}
-},
     {
-    "event_id": "gen_rel_loathes3",
-    "location": ["any"],
-    "season": ["any"],
-    "frequency": 1,
-    "event_text": "m_c cannot stomach that fox-hearted r_c.",
-    "m_c": {
-        "relationship_status": ["loathes_only"]
+        "event_id": "gen_rel_loathes3",
+        "location": ["any"],
+        "season": ["any"],
+        "frequency": 1,
+        "event_text": "m_c cannot stomach that fox-hearted r_c.",
+        "m_c": {
+            "relationship_status": ["loathes_only"]
+        },
+        "r_c": {}
     },
-    "r_c": {}
-},
-      {
-    "event_id": "gen_rel_resents1",
-    "location": ["any"],
-    "season": ["any"],
-    "frequency": 1,
-    "event_text": "m_c thinks the praise r_c receives is a load of mouse-dung.",
-    "m_c": {
-        "relationship_status": ["resents_only"]
+    {
+        "event_id": "gen_rel_resents1",
+        "location": ["any"],
+        "season": ["any"],
+        "frequency": 1,
+        "event_text": "m_c thinks the praise r_c receives is a load of mouse-dung.",
+        "m_c": {
+            "relationship_status": ["resents_only"]
+        },
+        "r_c": {}
     },
-    "r_c": {}
-},
-      {
-    "event_id": "gen_rel_resents2",
-    "location": ["any"],
-    "season": ["any"],
-    "frequency": 1,
-    "event_text": "m_c tastes mouse-bile every time {PRONOUN/m_c/subject} {VERB/m_c/think/thinks} about r_c.",
-    "m_c": {
-        "relationship_status": ["resents_only"]
+    {
+        "event_id": "gen_rel_resents2",
+        "location": ["any"],
+        "season": ["any"],
+        "frequency": 1,
+        "event_text": "m_c tastes mouse-bile every time {PRONOUN/m_c/subject} {VERB/m_c/think/thinks} about r_c.",
+        "m_c": {
+            "relationship_status": ["resents_only"]
+        },
+        "r_c": {}
     },
-    "r_c": {}
-},
-      {
-    "event_id": "gen_rel_resents3",
-    "location": ["any"],
-    "season": ["any"],
-    "frequency": 1,
-    "event_text": "m_c thinks {PRONOUN/m_c/subject} would be a better deputy than r_c.",
-    "m_c": {
-        "status": ["-kitten", "-deputy", "-leader", "-medicine cat apprentice", "-medicine cat"],
-        "relationship_status": ["resents_only"]
+    {
+        "event_id": "gen_rel_resents3",
+        "location": ["any"],
+        "season": ["any"],
+        "frequency": 1,
+        "event_text": "m_c thinks {PRONOUN/m_c/subject} would be a better deputy than r_c.",
+        "m_c": {
+            "status": ["-kitten", "-deputy", "-leader", "-medicine cat apprentice", "-medicine cat"],
+            "relationship_status": ["resents_only"]
+        },
+        "r_c": {
+            "status": ["deputy"]
+        }
     },
-    "r_c": {
-        "status": ["deputy"]
-    }
-},
-      {
-    "event_id": "gen_rel_discredits1",
-    "location": ["any"],
-    "season": ["any"],
-    "frequency": 1,
-    "event_text": "m_c is convinced r_c is influenced by the Dark Forest.",
-    "m_c": {
-        "relationship_status": ["discredits_only"]
+    {
+        "event_id": "gen_rel_discredits1",
+        "location": ["any"],
+        "season": ["any"],
+        "frequency": 1,
+        "event_text": "m_c is convinced r_c is influenced by the Dark Forest.",
+        "m_c": {
+            "relationship_status": ["discredits_only"]
+        },
+        "r_c": {}
     },
-    "r_c": {}
-},
-          {
-    "event_id": "gen_rel_discredits2",
-    "location": ["any"],
-    "season": ["any"],
-    "frequency": 1,
-    "event_text": "m_c knows r_c is plotting against {PRONOUN/m_c/object}.",
-    "m_c": {
-        "relationship_status": ["discredits_only"]
+    {
+        "event_id": "gen_rel_discredits2",
+        "location": ["any"],
+        "season": ["any"],
+        "frequency": 1,
+        "event_text": "m_c knows r_c is plotting against {PRONOUN/m_c/object}.",
+        "m_c": {
+            "relationship_status": ["discredits_only"]
+        },
+        "r_c": {}
     },
-    "r_c": {}
-},
-      {
-    "event_id": "gen_rel_discredits3",
-    "location": ["any"],
-    "season": ["any"],
-    "frequency": 1,
-    "event_text": "m_c thinks r_c lets Clanmates {PRONOUN/r_c/subject} {VERB/r_c/don't/doesn't} like die intentionally.",
-    "m_c": {
-        "relationship_status": ["discredits_only"]
+    {
+        "event_id": "gen_rel_discredits3",
+        "location": ["any"],
+        "season": ["any"],
+        "frequency": 1,
+        "event_text": "m_c thinks r_c lets Clanmates {PRONOUN/r_c/subject} {VERB/r_c/don't/doesn't} like die intentionally.",
+        "m_c": {
+            "relationship_status": ["discredits_only"]
+        },
+        "r_c": {
+            "age": [],
+            "status": ["medicine cat", "medicine cat apprentice"]
+        }
     },
-    "r_c": {
-        "age": [],
-        "status": ["medicine cat", "medicine cat apprentice"]
-    }
-},
-          {
-    "event_id": "gen_rel_discredits4",
-    "location": ["any"],
-    "season": ["any"],
-    "frequency": 1,
-    "event_text": "m_c whispers to {PRONOUN/m_c/poss} friends doubts about r_c's leadership.",
-    "m_c": {
-        "relationship_status": ["discredits_only"],
-         "status": ["-deputy", "-leader"]
+    {
+        "event_id": "gen_rel_discredits4",
+        "location": ["any"],
+        "season": ["any"],
+        "frequency": 1,
+        "event_text": "m_c whispers to {PRONOUN/m_c/poss} friends doubts about r_c's leadership.",
+        "m_c": {
+            "relationship_status": ["discredits_only"],
+            "status": ["-deputy", "-leader"]
+        },
+        "r_c": {
+            "status": ["leader", "deputy"]
+        }
     },
-    "r_c": {
-        "status": ["leader", "deputy"]
-    }
-},
     {
-    "event_id": "gen_rel_runsfrom1",
-    "location": ["any"],
-    "season": ["any"],
-    "frequency": 1,
-    "event_text": "m_c refuses to socialize or patrol with r_c.",
-    "m_c": {
-        "relationship_status": ["runs_from_only"],
-        "status": ["-kitten", "-elder"]
+        "event_id": "gen_rel_runsfrom1",
+        "location": ["any"],
+        "season": ["any"],
+        "frequency": 1,
+        "event_text": "m_c refuses to socialize or patrol with r_c.",
+        "m_c": {
+            "relationship_status": ["runs_from_only"],
+            "status": ["-kitten", "-elder"]
+        },
+        "r_c": {
+            "status": ["-kitten", "-elder"]
+        }
     },
-    "r_c": {
-        "status": ["-kitten", "-elder"]
-    }
-},
-      {
-    "event_id": "gen_rel_runsfrom2",
-    "location": ["any"],
-    "season": ["any"],
-    "frequency": 1,
-    "event_text": "m_c thinks if they were alone together r_c would hurt {PRONOUN/m_c/object}.",
-    "m_c": {
-        "relationship_status": ["runs_from_only"]
+    {
+        "event_id": "gen_rel_runsfrom2",
+        "location": ["any"],
+        "season": ["any"],
+        "frequency": 1,
+        "event_text": "m_c thinks if they were alone together r_c would hurt {PRONOUN/m_c/object}.",
+        "m_c": {
+            "relationship_status": ["runs_from_only"]
+        },
+        "r_c": {}
     },
-    "r_c": {}
-},
-          {
-    "event_id": "gen_rel_runsfrom3",
-    "location": ["any"],
-    "season": ["any"],
-    "frequency": 1,
-    "event_text": "m_c isn't sure {PRONOUN/m_c/subject} {VERB/m_c/feel/feels} safe in c_n... not with r_c around.",
-    "m_c": {
-        "relationship_status": ["runs_from_only"]
+    {
+        "event_id": "gen_rel_runsfrom3",
+        "location": ["any"],
+        "season": ["any"],
+        "frequency": 1,
+        "event_text": "m_c isn't sure {PRONOUN/m_c/subject} {VERB/m_c/feel/feels} safe in c_n... not with r_c around.",
+        "m_c": {
+            "relationship_status": ["runs_from_only"]
+        },
+        "r_c": {}
     },
-    "r_c": {}
-},
     {
-  "event_id": "gen_rel_enjoys1",
-  "location": ["any"],
-  "season": ["any"],
-  "frequency": 1,
-  "event_text": "m_c always meows a morning greeting to r_c.",
-  "m_c": {
-    "relationship_status": ["enjoys_only"]
-  },
-  "r_c": {}
-},
-    {
-  "event_id": "gen_rel_enjoys2",
-  "location": ["any"],
-  "season": ["any"],
-  "frequency": 1,
-  "event_text": "m_c frequently shares tongues with r_c.",
-  "m_c": {
-    "relationship_status": ["enjoys_only"]
-  },
-  "r_c": {}
-},
-    {
-  "event_id": "gen_rel_enjoys3",
-  "location": ["any"],
-  "season": ["any"],
-  "frequency": 1,
-  "event_text": "m_c enjoys r_c's company.",
-  "m_c": {
-    "relationship_status": ["enjoys_only"]
-  },
-  "r_c": {}
-},
-    {
-  "event_id": "gen_rel_respects1",
-  "location": ["any"],
-  "season": ["any"],
-  "frequency": 1,
-  "event_text": "m_c rarely disagrees with r_c.",
-  "m_c": {
-    "relationship_status": ["respects_only"]
-  },
-  "r_c": {}
-},
-    {
-  "event_id": "gen_rel_respects2",
-  "location": ["any"],
-  "season": ["any"],
-  "frequency": 1,
-  "event_text": "m_c follows r_c's lead on patrol.",
-  "m_c": {
-    "relationship_status": ["respects_only"],
-      "status": ["-kitten", "-elder"]
-  },
-  "r_c": {
-      "status": ["-kitten", "-elder"]
-  }
-},
-    {
-  "event_id": "gen_rel_respects3",
-  "location": ["any"],
-  "season": ["any"],
-  "frequency": 1,
-  "event_text": "m_c looks up to r_c.",
-  "m_c": {
-    "relationship_status": ["respects_only"]
-  },
-  "r_c": {}
-},
-    {
-  "event_id": "gen_rel_trusts1",
-  "location": ["any"],
-  "season": ["any"],
-  "frequency": 1,
-  "event_text": "m_c trusts r_c's judgment.",
-  "m_c": {
-    "relationship_status": ["trusts_only"]
-  },
-  "r_c": {}
-},
-     {
-  "event_id": "gen_rel_trusts2",
-  "location": ["any"],
-  "season": ["any"],
-  "frequency": 1,
-  "event_text": "m_c is at ease with r_c around.",
-  "m_c": {
-    "relationship_status": ["trusts_only"]
-  },
-  "r_c": {}
-},
-    {
-  "event_id": "gen_rel_trusts3",
-  "location": ["any"],
-  "season": ["any"],
-  "frequency": 1,
-  "event_text": "m_c always has r_c's back on patrol.",
-  "m_c": {
-    "relationship_status": ["trusts_only"],
-      "status": ["-kitten", "-elder"]
-  },
-  "r_c": {
-      "status": ["-kitten", "-elder"]
-  }
-},
-    {
-  "event_id": "gen_rel_understands1",
-  "location": ["any"],
-  "season": ["any"],
-  "frequency": 1,
-  "event_text": "m_c understands what drives r_c.",
-  "m_c": {
-    "relationship_status": ["understands_only"]
-  },
-  "r_c": {}
-},
-    {
-  "event_id": "gen_rel_understands2",
-  "location": ["any"],
-  "season": ["any"],
-  "frequency": 1,
-  "event_text": "m_c can often read r_c's moods.",
-  "m_c": {
-    "relationship_status": ["understands_only"]
-  },
-  "r_c": {}
-},
-    {
-  "event_id": "gen_rel_understands3",
-  "location": ["any"],
-  "season": ["any"],
-  "frequency": 1,
-  "event_text": "m_c can often predict r_c's course of action.",
-  "m_c": {
-    "relationship_status": ["understands_only"]
-  },
-  "r_c": {}
-},
-    {
-  "event_id": "gen_rel_adores1",
-  "location": ["any"],
-  "season": ["any"],
-  "frequency": 1,
-  "event_text": "m_c finds r_c charming.",
-  "m_c": {
-    "relationship_status": ["adores_only"]
-  },
-  "r_c": {}
-},
-    {
-  "event_id": "gen_rel_adores2",
-  "location": ["any"],
-  "season": ["any"],
-  "frequency": 1,
-  "event_text": "m_c feels flustered around r_c.",
-  "m_c": {
-    "relationship_status": ["adores_only"]
-  },
-  "r_c": {}
-},
-     {
-  "event_id": "gen_rel_adores3",
-  "location": ["any"],
-  "season": ["any"],
-  "frequency": 1,
-  "event_text": "m_c likes being close with r_c.",
-  "m_c": {
-    "relationship_status": ["adores_only"]
-  },
-  "r_c": {}
-},
-    {
-  "event_id": "gen_rel_cherishes1",
-  "location": ["any"],
-  "season": ["any"],
-  "frequency": 1,
-  "event_text": "m_c and r_c spend all their spare time together.",
-  "m_c": {
-    "relationship_status": ["cherishes_only"]
-  },
-  "r_c": {}
-},
-    {
-  "event_id": "gen_rel_cherishes2",
-  "location": ["any"],
-  "season": ["any"],
-  "frequency": 1,
-  "event_text": "m_c holds r_c dear.",
-  "m_c": {
-    "relationship_status": ["cherishes_only"]
-  },
-  "r_c": {}
-},
-    {
-  "event_id": "gen_rel_cherishes3",
-  "location": ["any"],
-  "season": ["any"],
-  "frequency": 1,
-  "event_text": "m_c cannot imagine {PRONOUN/m_c/poss} life without r_c.",
-  "m_c": {
-    "relationship_status": ["cherishes_only"]
-  },
-  "r_c": {}
-},
-    {
-  "event_id": "gen_rel_admires1",
-  "location": ["any"],
-  "season": ["any"],
-  "frequency": 1,
-  "event_text": "m_c strives to be more like r_c.",
-  "m_c": {
-    "relationship_status": ["admires_only"]
-  },
-  "r_c": {}
-},
-    {
-  "event_id": "gen_rel_admires2",
-  "location": ["any"],
-  "season": ["any"],
-  "frequency": 1,
-  "event_text": "r_c always manages to impress m_c.",
-  "m_c": {
-    "relationship_status": ["admires_only"]
-  },
-  "r_c": {}
-},
-    {
-  "event_id": "gen_rel_admires3",
-  "location": ["any"],
-  "season": ["any"],
-  "frequency": 1,
-  "event_text": "m_c considers r_c one of the finest cats in c_n.",
-  "m_c": {
-    "relationship_status": ["admires_only"]
-  },
-  "r_c": {}
-},
-    {
-  "event_id": "gen_rel_confides_in1",
-  "location": ["any"],
-  "season": ["any"],
-  "frequency": 1,
-  "event_text": "m_c confides in r_c after a stressful day.",
-  "m_c": {
-    "relationship_status": ["confides_in_only"]
-  },
-  "r_c": {}
-},
-    {
-  "event_id": "gen_rel_confides_in2",
-  "location": ["any"],
-  "season": ["any"],
-  "frequency": 1,
-  "event_text": "m_c knows c_n is safe in r_c's paws.",
-  "m_c": {
-    "relationship_status": ["confides_in_only"]
-  },
-  "r_c": {
-      "status": ["leader", "deputy", "medicine cat"]
-  }
-},
-    {
-  "event_id": "gen_rel_confides_in3",
-  "location": ["any"],
-  "season": ["any"],
-  "frequency": 1,
-  "event_text": "m_c trusts r_c with {PRONOUN/m_c/poss} most vulnerable thoughts.",
-  "m_c": {
-    "relationship_status": ["confides_in_only"]
-  },
-  "r_c": {}
-},
-    {
-  "event_id": "gen_rel_knows_deeply1",
-  "location": ["any"],
-  "season": ["any"],
-  "frequency": 1,
-  "event_text": "m_c knows r_c better than almost anyone.",
-  "m_c": {
-    "relationship_status": ["knows_deeply_only"]
-  },
-  "r_c": {}
-},
-    {
-  "event_id": "gen_rel_knows_deeply2",
-  "location": ["any"],
-  "season": ["any"],
-  "frequency": 1,
-  "event_text": "m_c can tell what r_c is thinking at a glance.",
-  "m_c": {
-    "relationship_status": ["knows_deeply_only"]
-  },
-  "r_c": {}
-},
-    {
-  "event_id": "gen_rel_knows_deeply3",
-  "location": ["any"],
-  "season": ["any"],
-  "frequency": 1,
-  "event_text": "m_c knows r_c by heart.",
-  "m_c": {
-    "relationship_status": ["knows_deeply_only"]
-  },
-  "r_c": {}
-},
-    {
-  "event_id": "gen_rel_loves1",
-  "location": ["any"],
-  "season": ["any"],
-  "frequency": 1,
-  "event_text": "m_c's heart belongs to r_c.",
-  "m_c": {
-    "relationship_status": ["loves_only"]
-  },
-  "r_c": {}
-},
-    {
-  "event_id": "gen_rel_loves2",
-  "location": ["any"],
-  "season": ["any"],
-  "frequency": 1,
-  "event_text": "m_c wants to share everything in life with r_c.",
-  "m_c": {
-    "relationship_status": ["loves_only"]
-  },
-  "r_c": {}
-},
-    {
-  "event_id": "gen_rel_loves3",
-  "location": ["any"],
-  "season": ["any"],
-  "frequency": 1,
-  "event_text": "m_c sighs and purrs and the mere thought of r_c.",
-  "m_c": {
-    "relationship_status": ["loves_only"]
-  },
-  "r_c": {}
-},
-    {
-  "event_id": "gen_rel_loves4",
-  "location": ["any"],
-  "season": ["any"],
-  "frequency": 1,
-  "event_text": "m_c and r_c twine tails when they pass by each other.",
-  "m_c": {
-    "relationship_status": ["loves_only"]
-  },
-  "r_c": {
-      "relationship_status": ["loves_only"]
-  }
-},
-   {
-    "event_id": "gen_medapp_mothermouth",
-    "location": ["any"],
-    "season": ["any"],
-    "frequency": 3,
-    "poi": {
-        "name": ["moon_mothermouth"]
+        "event_id": "gen_rel_enjoys1",
+        "location": ["any"],
+        "season": ["any"],
+        "frequency": 1,
+        "event_text": "m_c always meows a morning greeting to r_c.",
+        "m_c": {
+            "relationship_status": ["enjoys_only"]
+        },
+        "r_c": {}
     },
-    "event_text": "m_c returned from POI and swears {PRONOUN/m_c/poss} whiskers are bent from brushing against the sides of labyrinthine tunnels for so long!",
-    "m_c": {
-      "status": ["medicine cat apprentice"]
-    }
-},
     {
-    "event_id": "gen_medapp_moonpool",
-    "location": ["any"],
-    "season": ["any"],
-    "frequency": 3,
-    "poi": {
-        "name": ["moon_pool"]
+        "event_id": "gen_rel_enjoys2",
+        "location": ["any"],
+        "season": ["any"],
+        "frequency": 1,
+        "event_text": "m_c frequently shares tongues with r_c.",
+        "m_c": {
+            "relationship_status": ["enjoys_only"]
+        },
+        "r_c": {}
     },
-    "event_text": "m_c returned from POI, drenched and dismayed. It seems {PRONOUN/m_c/subject} took a tumble into the sacred waters.",
-    "m_c": {
-      "status": ["medicine cat apprentice"]
-    }
-},
     {
-    "event_id": "gen_medapp_moonmeteor",
-    "location": ["any"],
-    "season": ["any"],
-    "frequency": 3,
-    "poi": {
-        "name": ["moon_meteor"]
+        "event_id": "gen_rel_enjoys3",
+        "location": ["any"],
+        "season": ["any"],
+        "frequency": 1,
+        "event_text": "m_c enjoys r_c's company.",
+        "m_c": {
+            "relationship_status": ["enjoys_only"]
+        },
+        "r_c": {}
     },
-    "event_text": "m_c returned from POI sneezing sporadically. Perhaps {PRONOUN/m_c/subject} {VERB/m_c/are/is} allergic to moon dust.",
-    "m_c": {
-      "status": ["medicine cat apprentice"]
-    }
-},
     {
-    "event_id": "gen_medapp_mooncave",
-    "location": ["any"],
-    "season": ["any"],
-    "frequency": 3,
-    "poi": {
-        "name": ["moon_cave"]
+        "event_id": "gen_rel_respects1",
+        "location": ["any"],
+        "season": ["any"],
+        "frequency": 1,
+        "event_text": "m_c rarely disagrees with r_c.",
+        "m_c": {
+            "relationship_status": ["respects_only"]
+        },
+        "r_c": {}
     },
-    "event_text": "m_c returned from POI, looking more like a puff of fluff than a cat after hearing StarClan's voices echo around {PRONOUN/m_c/object}.",
-    "m_c": {
-      "status": ["medicine cat apprentice"]
-    }
-},
+    {
+        "event_id": "gen_rel_respects2",
+        "location": ["any"],
+        "season": ["any"],
+        "frequency": 1,
+        "event_text": "m_c follows r_c's lead on patrol.",
+        "m_c": {
+            "relationship_status": ["respects_only"],
+            "status": ["-kitten", "-elder"]
+        },
+        "r_c": {
+            "status": ["-kitten", "-elder"]
+        }
+    },
+    {
+        "event_id": "gen_rel_respects3",
+        "location": ["any"],
+        "season": ["any"],
+        "frequency": 1,
+        "event_text": "m_c looks up to r_c.",
+        "m_c": {
+            "relationship_status": ["respects_only"]
+        },
+        "r_c": {}
+    },
+    {
+        "event_id": "gen_rel_trusts1",
+        "location": ["any"],
+        "season": ["any"],
+        "frequency": 1,
+        "event_text": "m_c trusts r_c's judgment.",
+        "m_c": {
+            "relationship_status": ["trusts_only"]
+        },
+        "r_c": {}
+    },
+    {
+        "event_id": "gen_rel_trusts2",
+        "location": ["any"],
+        "season": ["any"],
+        "frequency": 1,
+        "event_text": "m_c is at ease with r_c around.",
+        "m_c": {
+            "relationship_status": ["trusts_only"]
+        },
+        "r_c": {}
+    },
+    {
+        "event_id": "gen_rel_trusts3",
+        "location": ["any"],
+        "season": ["any"],
+        "frequency": 1,
+        "event_text": "m_c always has r_c's back on patrol.",
+        "m_c": {
+            "relationship_status": ["trusts_only"],
+            "status": ["-kitten", "-elder"]
+        },
+        "r_c": {
+            "status": ["-kitten", "-elder"]
+        }
+    },
+    {
+        "event_id": "gen_rel_understands1",
+        "location": ["any"],
+        "season": ["any"],
+        "frequency": 1,
+        "event_text": "m_c understands what drives r_c.",
+        "m_c": {
+            "relationship_status": ["understands_only"]
+        },
+        "r_c": {}
+    },
+    {
+        "event_id": "gen_rel_understands2",
+        "location": ["any"],
+        "season": ["any"],
+        "frequency": 1,
+        "event_text": "m_c can often read r_c's moods.",
+        "m_c": {
+            "relationship_status": ["understands_only"]
+        },
+        "r_c": {}
+    },
+    {
+        "event_id": "gen_rel_understands3",
+        "location": ["any"],
+        "season": ["any"],
+        "frequency": 1,
+        "event_text": "m_c can often predict r_c's course of action.",
+        "m_c": {
+            "relationship_status": ["understands_only"]
+        },
+        "r_c": {}
+    },
+    {
+        "event_id": "gen_rel_adores1",
+        "location": ["any"],
+        "season": ["any"],
+        "frequency": 1,
+        "event_text": "m_c finds r_c charming.",
+        "m_c": {
+            "relationship_status": ["adores_only"]
+        },
+        "r_c": {}
+    },
+    {
+        "event_id": "gen_rel_adores2",
+        "location": ["any"],
+        "season": ["any"],
+        "frequency": 1,
+        "event_text": "m_c feels flustered around r_c.",
+        "m_c": {
+            "relationship_status": ["adores_only"]
+        },
+        "r_c": {}
+    },
+    {
+        "event_id": "gen_rel_adores3",
+        "location": ["any"],
+        "season": ["any"],
+        "frequency": 1,
+        "event_text": "m_c likes being close with r_c.",
+        "m_c": {
+            "relationship_status": ["adores_only"]
+        },
+        "r_c": {}
+    },
+    {
+        "event_id": "gen_rel_cherishes1",
+        "location": ["any"],
+        "season": ["any"],
+        "frequency": 1,
+        "event_text": "m_c and r_c spend all their spare time together.",
+        "m_c": {
+            "relationship_status": ["cherishes_only"]
+        },
+        "r_c": {}
+    },
+    {
+        "event_id": "gen_rel_cherishes2",
+        "location": ["any"],
+        "season": ["any"],
+        "frequency": 1,
+        "event_text": "m_c holds r_c dear.",
+        "m_c": {
+            "relationship_status": ["cherishes_only"]
+        },
+        "r_c": {}
+    },
+    {
+        "event_id": "gen_rel_cherishes3",
+        "location": ["any"],
+        "season": ["any"],
+        "frequency": 1,
+        "event_text": "m_c cannot imagine {PRONOUN/m_c/poss} life without r_c.",
+        "m_c": {
+            "relationship_status": ["cherishes_only"]
+        },
+        "r_c": {}
+    },
+    {
+        "event_id": "gen_rel_admires1",
+        "location": ["any"],
+        "season": ["any"],
+        "frequency": 1,
+        "event_text": "m_c strives to be more like r_c.",
+        "m_c": {
+            "relationship_status": ["admires_only"]
+        },
+        "r_c": {}
+    },
+    {
+        "event_id": "gen_rel_admires2",
+        "location": ["any"],
+        "season": ["any"],
+        "frequency": 1,
+        "event_text": "r_c always manages to impress m_c.",
+        "m_c": {
+            "relationship_status": ["admires_only"]
+        },
+        "r_c": {}
+    },
+    {
+        "event_id": "gen_rel_admires3",
+        "location": ["any"],
+        "season": ["any"],
+        "frequency": 1,
+        "event_text": "m_c considers r_c one of the finest cats in c_n.",
+        "m_c": {
+            "relationship_status": ["admires_only"]
+        },
+        "r_c": {}
+    },
+    {
+        "event_id": "gen_rel_confides_in1",
+        "location": ["any"],
+        "season": ["any"],
+        "frequency": 1,
+        "event_text": "m_c confides in r_c after a stressful day.",
+        "m_c": {
+            "relationship_status": ["confides_in_only"]
+        },
+        "r_c": {}
+    },
+    {
+        "event_id": "gen_rel_confides_in2",
+        "location": ["any"],
+        "season": ["any"],
+        "frequency": 1,
+        "event_text": "m_c knows c_n is safe in r_c's paws.",
+        "m_c": {
+            "relationship_status": ["confides_in_only"]
+        },
+        "r_c": {
+            "status": ["leader", "deputy", "medicine cat"]
+        }
+    },
+    {
+        "event_id": "gen_rel_confides_in3",
+        "location": ["any"],
+        "season": ["any"],
+        "frequency": 1,
+        "event_text": "m_c trusts r_c with {PRONOUN/m_c/poss} most vulnerable thoughts.",
+        "m_c": {
+            "relationship_status": ["confides_in_only"]
+        },
+        "r_c": {}
+    },
+    {
+        "event_id": "gen_rel_knows_deeply1",
+        "location": ["any"],
+        "season": ["any"],
+        "frequency": 1,
+        "event_text": "m_c knows r_c better than almost anyone.",
+        "m_c": {
+            "relationship_status": ["knows_deeply_only"]
+        },
+        "r_c": {}
+    },
+    {
+        "event_id": "gen_rel_knows_deeply2",
+        "location": ["any"],
+        "season": ["any"],
+        "frequency": 1,
+        "event_text": "m_c can tell what r_c is thinking at a glance.",
+        "m_c": {
+            "relationship_status": ["knows_deeply_only"]
+        },
+        "r_c": {}
+    },
+    {
+        "event_id": "gen_rel_knows_deeply3",
+        "location": ["any"],
+        "season": ["any"],
+        "frequency": 1,
+        "event_text": "m_c knows r_c by heart.",
+        "m_c": {
+            "relationship_status": ["knows_deeply_only"]
+        },
+        "r_c": {}
+    },
+    {
+        "event_id": "gen_rel_loves1",
+        "location": ["any"],
+        "season": ["any"],
+        "frequency": 1,
+        "event_text": "m_c's heart belongs to r_c.",
+        "m_c": {
+            "relationship_status": ["loves_only"]
+        },
+        "r_c": {}
+    },
+    {
+        "event_id": "gen_rel_loves2",
+        "location": ["any"],
+        "season": ["any"],
+        "frequency": 1,
+        "event_text": "m_c wants to share everything in life with r_c.",
+        "m_c": {
+            "relationship_status": ["loves_only"]
+        },
+        "r_c": {}
+    },
+    {
+        "event_id": "gen_rel_loves3",
+        "location": ["any"],
+        "season": ["any"],
+        "frequency": 1,
+        "event_text": "m_c sighs and purrs and the mere thought of r_c.",
+        "m_c": {
+            "relationship_status": ["loves_only"]
+        },
+        "r_c": {}
+    },
+    {
+        "event_id": "gen_rel_loves4",
+        "location": ["any"],
+        "season": ["any"],
+        "frequency": 1,
+        "event_text": "m_c and r_c twine tails when they pass by each other.",
+        "m_c": {
+            "relationship_status": ["loves_only"]
+        },
+        "r_c": {
+            "relationship_status": ["loves_only"]
+        }
+    },
+    {
+        "event_id": "gen_medapp_mothermouth",
+        "location": ["any"],
+        "season": ["any"],
+        "frequency": 3,
+        "poi": {
+            "name": ["moon_mothermouth"]
+        },
+        "event_text": "m_c returned from POI and swears {PRONOUN/m_c/poss} whiskers are bent from brushing against the sides of labyrinthine tunnels for so long!",
+        "m_c": {
+            "status": ["medicine cat apprentice"]
+        }
+    },
+    {
+        "event_id": "gen_medapp_moonpool",
+        "location": ["any"],
+        "season": ["any"],
+        "frequency": 3,
+        "poi": {
+            "name": ["moon_pool"]
+        },
+        "event_text": "m_c returned from POI, drenched and dismayed. It seems {PRONOUN/m_c/subject} took a tumble into the sacred waters.",
+        "m_c": {
+            "status": ["medicine cat apprentice"]
+        }
+    },
+    {
+        "event_id": "gen_medapp_moonmeteor",
+        "location": ["any"],
+        "season": ["any"],
+        "frequency": 3,
+        "poi": {
+            "name": ["moon_meteor"]
+        },
+        "event_text": "m_c returned from POI sneezing sporadically. Perhaps {PRONOUN/m_c/subject} {VERB/m_c/are/is} allergic to moon dust.",
+        "m_c": {
+            "status": ["medicine cat apprentice"]
+        }
+    },
+    {
+        "event_id": "gen_medapp_mooncave",
+        "location": ["any"],
+        "season": ["any"],
+        "frequency": 3,
+        "poi": {
+            "name": ["moon_cave"]
+        },
+        "event_text": "m_c returned from POI, looking more like a puff of fluff than a cat after hearing StarClan's voices echo around {PRONOUN/m_c/object}.",
+        "m_c": {
+            "status": ["medicine cat apprentice"]
+        }
+    },
     {
         "event_id": "gen_gathering_appbegging",
         "location": [
@@ -16823,7 +16883,7 @@
             "skill": ["STORY,1", "LORE,1"]
         }
     },
-        {
+    {
         "event_id": "gen_gathering_deputygossip",
         "location": [
             "any"
@@ -16928,7 +16988,7 @@
             "status": ["medicine cat"]
         }
     },
-        {
+    {
         "event_id": "gen_moonplace_determined",
         "location": [
             "any"
@@ -17157,137 +17217,137 @@
         }
     },
     {
-    "event_id": "gen_misc_accessoryrookeryPOI3",
-    "location": ["any"],
-    "season": ["any"],
-    "sub_type": ["accessory"],
-    "tags": [],
-    "frequency": 3,
-    "poi": {
-    "name": ["terrain_rookery"]
+        "event_id": "gen_misc_accessoryrookeryPOI3",
+        "location": ["any"],
+        "season": ["any"],
+        "sub_type": ["accessory"],
+        "tags": [],
+        "frequency": 3,
+        "poi": {
+            "name": ["terrain_rookery"]
         },
-    "event_text": "m_c returned from a hunt at POI, adorned with some feathers from {PRONOUN/m_c/poss} catch.",
-    "new_accessory": ["BLUE FEATHERS","JAY FEATHERS"],
-    "m_c": {
-        "status": ["-kitten","-elder"]
+        "event_text": "m_c returned from a hunt at POI, adorned with some feathers from {PRONOUN/m_c/poss} catch.",
+        "new_accessory": ["BLUE FEATHERS", "JAY FEATHERS"],
+        "m_c": {
+            "status": ["-kitten", "-elder"]
         }
     },
     {
-    "event_id": "gen_misc_accessoryrookeryPOI4",
-    "location": ["any"],
-    "season": ["any"],
-    "sub_type": ["accessory"],
-    "tags": [],
-    "frequency": 3,
-    "poi": {
-    "name": ["terrain_rookery"]
-    },
-    "event_text": "r_c returned from a hunt at POI and gifted some beautiful feathers from {PRONOUN/r_c/poss} catch to m_c.",
-    "new_accessory": ["BLUE FEATHERS","JAY FEATHERS"],
-    "m_c": {
-        "age": ["any"],
-        "dies": false
-    },
-    "r_c": {
-        "status": ["-newborn", "-kitten","-elder"],
-        "relationship_status": ["likes"],
-        "dies": false
-    },
-    "relationships": [
-        {
-            "cats_from": ["r_c"],
-            "cats_to": ["m_c"],
-            "mutual": true,
-            "values": ["like"],
-            "amount": 8,
-            "log": {
-                 "cats_from": "r_c gifted m_c feathers from a hunt."
+        "event_id": "gen_misc_accessoryrookeryPOI4",
+        "location": ["any"],
+        "season": ["any"],
+        "sub_type": ["accessory"],
+        "tags": [],
+        "frequency": 3,
+        "poi": {
+            "name": ["terrain_rookery"]
+        },
+        "event_text": "r_c returned from a hunt at POI and gifted some beautiful feathers from {PRONOUN/r_c/poss} catch to m_c.",
+        "new_accessory": ["BLUE FEATHERS", "JAY FEATHERS"],
+        "m_c": {
+            "age": ["any"],
+            "dies": false
+        },
+        "r_c": {
+            "status": ["-newborn", "-kitten", "-elder"],
+            "relationship_status": ["likes"],
+            "dies": false
+        },
+        "relationships": [
+            {
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "mutual": true,
+                "values": ["like"],
+                "amount": 8,
+                "log": {
+                    "cats_from": "r_c gifted m_c feathers from a hunt."
                 }
+            }
+        ]
+    },
+    {
+        "event_id": "gen_misc_accessoryeaglenestPOI3",
+        "location": [],
+        "season": [],
+        "sub_type": [],
+        "tags": [],
+        "frequency": 3,
+        "poi": {
+            "name": ["terrain_eaglenest"]
+        },
+        "event_text": "After a visit near POI, m_c returned to camp adorned with feathers.",
+        "new_accessory": ["SPARROW FEATHERS"],
+        "m_c": {
+            "status": ["-kitten", "-elder"],
+            "dies": false
         }
-    ]
-},
-{
-    "event_id": "gen_misc_accessoryeaglenestPOI3",
-    "location": [],
-    "season": [],
-    "sub_type": [],
-    "tags": [],
-    "frequency": 3,
-    "poi": {
-    "name": ["terrain_eaglenest"]
     },
-    "event_text": "After a visit near POI, m_c returned to camp adorned with feathers.",
-    "new_accessory": ["SPARROW FEATHERS"],
-    "m_c": {
-        "status": ["-kitten","-elder"],
-        "dies": false
-    }
-},
-{
-    "event_id": "gen_misc_accessorygullcliffsPOI3",
-    "location": ["beach"],
-    "season": ["any"],
-    "sub_type": ["accessory"],
-    "tags": [],
-    "frequency": 3,
-    "poi": {
-    "name": ["terrain_gullcliffs"]
-    },
-    "event_text": "r_c returned from a hunt at POI and gifted some beautiful feathers from {PRONOUN/r_c/poss} catch to m_c.",
-    "new_accessory": ["GULL FEATHERS"],
-    "m_c": {
-        "age": ["any"],
-        "dies": false
-    },
-    "r_c": {
-        "status": ["-kitten","-elder"],
-        "relationship_status": ["likes"],
-        "dies": false
-    },
-    "relationships": [
-        {
-            "cats_from": ["r_c"],
-            "cats_to": ["m_c"],
-            "mutual": true,
-            "values": ["like"],
-            "amount": 8,
-            "log": {
-                 "cats_from": "r_c gifted m_c feathers from a hunt."
+    {
+        "event_id": "gen_misc_accessorygullcliffsPOI3",
+        "location": ["beach"],
+        "season": ["any"],
+        "sub_type": ["accessory"],
+        "tags": [],
+        "frequency": 3,
+        "poi": {
+            "name": ["terrain_gullcliffs"]
+        },
+        "event_text": "r_c returned from a hunt at POI and gifted some beautiful feathers from {PRONOUN/r_c/poss} catch to m_c.",
+        "new_accessory": ["GULL FEATHERS"],
+        "m_c": {
+            "age": ["any"],
+            "dies": false
+        },
+        "r_c": {
+            "status": ["-kitten", "-elder"],
+            "relationship_status": ["likes"],
+            "dies": false
+        },
+        "relationships": [
+            {
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "mutual": true,
+                "values": ["like"],
+                "amount": 8,
+                "log": {
+                    "cats_from": "r_c gifted m_c feathers from a hunt."
                 }
-        }
-    ]
-},
-{
-    "event_id": "gen_misc_accessorygullcliffsPOI4",
-    "location": ["beach"],
-    "season": ["any"],
-    "sub_type": ["accessory"],
-    "tags": [],
-    "frequency": 3,
-    "poi": {
-    "name": ["terrain_gullcliffs"]
+            }
+        ]
     },
-    "event_text": "m_c returned from a hunt at POI, adorned with some feathers from {PRONOUN/m_c/poss} catch.",
-    "new_accessory": ["GULL FEATHERS"],
-    "m_c": {
-        "status": ["-kitten","-elder"],
-        "dies": false
-    }
-},
-{
-    "event_id": "gen_misc_accessory8",
-    "location": ["any"],
-    "season": ["any"],
-    "sub_type": ["accessory"],
-    "tags": [],
-    "frequency": 2,
-    "event_text": "m_c took a moment to pick a specific bird from the fresh-kill pile and was later seen wearing its feathers.",
-    "new_accessory": ["BLUE FEATHERS","SPARROW FEATHERS","JAY FEATHERS","RED FEATHERS"],
-    "m_c": {
-        "age": ["any"],
-        "dies": false
-    }
-},
+    {
+        "event_id": "gen_misc_accessorygullcliffsPOI4",
+        "location": ["beach"],
+        "season": ["any"],
+        "sub_type": ["accessory"],
+        "tags": [],
+        "frequency": 3,
+        "poi": {
+            "name": ["terrain_gullcliffs"]
+        },
+        "event_text": "m_c returned from a hunt at POI, adorned with some feathers from {PRONOUN/m_c/poss} catch.",
+        "new_accessory": ["GULL FEATHERS"],
+        "m_c": {
+            "status": ["-kitten", "-elder"],
+            "dies": false
+        }
+    },
+    {
+        "event_id": "gen_misc_accessory8",
+        "location": ["any"],
+        "season": ["any"],
+        "sub_type": ["accessory"],
+        "tags": [],
+        "frequency": 2,
+        "event_text": "m_c took a moment to pick a specific bird from the fresh-kill pile and was later seen wearing its feathers.",
+        "new_accessory": ["BLUE FEATHERS", "SPARROW FEATHERS", "JAY FEATHERS", "RED FEATHERS"],
+        "m_c": {
+            "age": ["any"],
+            "dies": false
+        }
+    },
     {
         "event_id": "gen_misc_taintedPOI_stinky1",
         "location": [
@@ -17345,7 +17405,7 @@
         "event_id": "gen_misc_taintedPOI_stinkymate",
         "location": ["-desert"],
         "season": ["-leaf-bare"],
-        "tags":["romance"],
+        "tags": ["romance"],
         "poi": {
             "tags": ["tainted"]
         },
@@ -17368,7 +17428,7 @@
                 "log": {
                     "cats_from": "r_c had a fun time splashing around together with m_c after {PRONOUN/r_c/subject} enforced a bath.",
                     "cats_to": "m_c enjoyed pulling r_c into the water with {PRONOUN/m_c/object} and playing around like kits."
-               }
+                }
             }
         ]
     }

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -17431,5 +17431,184 @@
                 }
             }
         ]
+    },
+    {
+        "event_id": "gen_misc_poi_anyterrain",
+        "location": ["any"],
+        "season": ["any"],
+        "poi": {
+            "category": "terrain"
+        },
+        "frequency": 4,
+        "event_text": "m_c and r_c played hide and seek by POI.",
+        "m_c": {
+            "status": ["kitten", "apprentice"]
+        },
+        "r_c": {
+            "status": ["kitten", "apprentice"]
+        },
+        "relationships": [
+            {
+                "cats_from": ["m_c"],
+                "cats_to": ["r_c"],
+                "mutual": true,
+                "values": ["like"],
+                "amount": 5,
+                "log": {
+                    "cats_from": "cat_from and cat_to played hide and seek together."
+                }
+            }
+        ]
+    },
+    {
+        "event_id": "gen_misc_poi_cave_rescue",
+        "location": ["any"],
+        "season": ["any"],
+        "poi": {
+            "tags": ["cave"],
+            "category": "terrain"
+        },
+        "frequency": 4,
+        "event_text": "m_c followed a strange sound into POI and found a loner, disoriented in the darkness. m_c guided {PRONOUN/n_c:0/object} out of POI and back to the light where {PRONOUN/n_c:0/subject} went on {PRONOUN/n_c:0/poss} way.",
+        "m_c": {
+            "status": ["-kitten", "-newborn", "-elder"],
+            "dies": false
+        },
+        "new_cat": [
+            [
+                "loner",
+                "meeting"
+            ]
+        ],
+        "relationships": [
+            {
+                "cats_from": ["n_c:0"],
+                "cats_to": ["m_c"],
+                "mutual": false,
+                "values": ["like", "comfort"],
+                "amount": 8,
+                "log": {
+                    "cats_from": "cat_from was grateful cat_to found them in the darkness."
+                }
+            }
+        ],
+        "outsider": {
+            "changed": 2
+        }
+    },
+    {
+        "event_id": "gen_misc_poi_cave_app2app",
+        "location": ["any"],
+        "season": ["any"],
+        "poi": {
+            "tags": ["cave"],
+            "category": "terrain"
+        },
+        "frequency": 3,
+        "event_text": "m_c and r_c entertained themselves by sitting at the entrance of POI, yowling into its maw, and giggling as their calls echoed back to them.",
+        "m_c": {
+            "status": ["apprentice"]
+        },
+        "r_c": {
+            "status": ["apprentice"]
+        },
+        "relationships": [
+            {
+                "cats_from": ["m_c"],
+                "cats_to": ["r_c"],
+                "mutual": true,
+                "values": ["like"],
+                "amount": 10,
+                "log": {
+                    "cats_from": "cat_from and cat_to had fun making their voices echo in the mouth of a cave."
+                }
+            }
+        ]
+    },
+    {
+        "event_id": "gen_misc_poi_prey1",
+        "location": ["any"],
+        "season": ["any"],
+        "poi": {
+            "tags": ["prey"],
+            "category": "terrain"
+        },
+        "frequency": 4,
+        "event_text": "m_c hoped to catch r_c's favorite prey near POI but came back empty-pawed.",
+        "m_c": {
+            "status": ["apprentice", "warrior", "deputy", "leader"],
+            "relationship_status": ["likes", "praises", "relates_to", "fancies"]
+        },
+        "r_c": {},
+        "relationships": [
+            {
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "mutual": false,
+                "values": ["like"],
+                "amount": 3,
+                "log": {
+                    "cats_from": "cat_from thought it was nice that cat_to tried to find {PRONOUN/cat_from/poss} favorite prey."
+                }
+            }
+        ]
+    },
+    {
+        "event_id": "gen_misc_poi_prey2",
+        "location": ["any"],
+        "season": ["any"],
+        "poi": {
+            "tags": ["prey"],
+            "category": "terrain"
+        },
+        "frequency": 4,
+        "event_text": "m_c told r_c {PRONOUN/m_c/subject} {VERB/m_c/were/was} concerned about the lack of prey near POI.",
+        "m_c": {
+            "status": ["apprentice", "warrior"]
+        },
+        "r_c": {
+            "status": ["deputy", "leader"]
+        },
+        "relationships": [
+            {
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "mutual": false,
+                "values": ["trust"],
+                "amount": 3,
+                "log": {
+                    "cats_from": "cat_from appreciated cat_to's thoughts about prey movement in the terrain."
+                }
+            }
+        ]
+    },
+    {
+        "event_id": "gen_misc_poi_prey3",
+        "location": ["any"],
+        "season": ["any"],
+        "poi": {
+            "tags": ["prey"],
+            "category": "terrain"
+        },
+        "frequency": 4,
+        "event_text": "m_c encouraged r_c to send more hunting patrols to POI; there has been a surplus of prey in the area.",
+        "m_c": {
+            "status": ["apprentice", "warrior"]
+        },
+        "r_c": {
+            "status": ["deputy", "leader"]
+        },
+        "relationships": [
+            {
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "mutual": false,
+                "values": ["trust"],
+                "amount": 3,
+                "log": {
+                    "cats_from": "cat_from appreciated cat_to's thoughts about prey movement in the terrain."
+                }
+            }
+        ]
     }
 ]

--- a/resources/lang/en/events/new_cat/general.json
+++ b/resources/lang/en/events/new_cat/general.json
@@ -321,7 +321,8 @@
             "status": [
                 "leader", "deputy", "warrior", "medicine cat", "apprentice", "medicine cat apprentice", "mediator", "mediator apprentice"
             ]
-        },"new_cat": [
+        },
+        "new_cat": [
             ["age:has_kits", "meeting", "rogue", "can_birth"],
             [
                 "new_name",
@@ -368,8 +369,8 @@
             "age": ["young adult", "adult", "senior adult", "senior"],
             "status": ["any"],
             "relationship_status": ["mates"]
-          },
-          "r_c": {
+        },
+        "r_c": {
             "age": ["young adult", "adult", "senior adult", "senior"],
             "status": ["any"]
         },
@@ -383,16 +384,16 @@
             ]
         ],
         "relationships": [
-          {
-            "cats_from": ["m_c", "r_c"],
-            "cats_to": ["n_c:0"],
-            "mutual": true,
-            "values": ["romance", "trust", "comfort", "like"],
-            "amount": 50,
-            "log": {
-                "cats_from": "m_c and r_c brought n_c:0 into the Clan to join their relationship."
+            {
+                "cats_from": ["m_c", "r_c"],
+                "cats_to": ["n_c:0"],
+                "mutual": true,
+                "values": ["romance", "trust", "comfort", "like"],
+                "amount": 50,
+                "log": {
+                    "cats_from": "m_c and r_c brought n_c:0 into the Clan to join their relationship."
+                }
             }
-          }
         ]
     },
     {
@@ -448,7 +449,7 @@
             ]
         ],
         "outsider": {
-            "current_rep": ["neutral","welcoming"],
+            "current_rep": ["neutral", "welcoming"],
             "changed": 1
         },
         "relationships": [
@@ -474,7 +475,8 @@
             "status": [
                 "leader", "deputy", "warrior", "medicine cat"
             ]
-        },"new_cat": [
+        },
+        "new_cat": [
             [
                 "old_name",
                 "loner",
@@ -483,7 +485,7 @@
             ]
         ],
         "outsider": {
-            "current_rep": ["neutral","welcoming"],
+            "current_rep": ["neutral", "welcoming"],
             "changed": 1
         },
         "relationships": [
@@ -518,7 +520,7 @@
             ]
         ],
         "outsider": {
-            "current_rep": ["neutral","welcoming"],
+            "current_rep": ["neutral", "welcoming"],
             "changed": 1
         },
         "relationships": [
@@ -568,62 +570,66 @@
             }
         ]
     },
-        {
-    "event_id": "gen_new_cat_lonerapp1",
-    "location": ["any"],
-    "season": ["any"],
-    "frequency": 4,
-    "event_text": "m_c finds a young cat who asks to join the Clan. The loner is welcomed into the Clan and renamed n_c:0.",
-    "m_c": {
-        "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
-        "status": ["any"]
-    },
-    "new_cat": [
-        ["new_name",
-        "loner",
-        "status:apprentice"]
-    ],
-    "relationships": [
-        {
-            "cats_from": ["m_c"],
-            "cats_to": ["n_c:0"],
-            "mutual": false,
-            "values": ["trust", "respect"],
-            "amount": 20,
-            "log": {
+    {
+        "event_id": "gen_new_cat_lonerapp1",
+        "location": ["any"],
+        "season": ["any"],
+        "frequency": 4,
+        "event_text": "m_c finds a young cat who asks to join the Clan. The loner is welcomed into the Clan and renamed n_c:0.",
+        "m_c": {
+            "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+            "status": ["any"]
+        },
+        "new_cat": [
+            [
+                "new_name",
+                "loner",
+                "status:apprentice"
+            ]
+        ],
+        "relationships": [
+            {
+                "cats_from": ["m_c"],
+                "cats_to": ["n_c:0"],
+                "mutual": false,
+                "values": ["trust", "respect"],
+                "amount": 20,
+                "log": {
                     "cats_from": "m_c found n_c:0 and brought {PRONOUN/n_c:0/object} into the Clan."
                 }
-        }
-    ]
-},
-    {
-    "event_id": "gen_new_cat_lonerapp2",
-    "location": ["any"],
-    "season": ["any"],
-    "frequency": 3,
-    "event_text": "m_c couldn't keep {PRONOUN/m_c/poss} new loner friend a secret forever. The two quietly came back to camp one day, m_c cheering the loudest when n_c:0 is welcomed as an apprentice of c_n.",
-    "m_c": {
-        "age": ["adolescent"],
-        "status": ["any"]
+            }
+        ]
     },
-    "new_cat": [
-        ["new_name",
-        "loner",
-        "status:apprentice"]
-    ],
-    "relationships": [
-        {
-            "cats_from": ["m_c"],
-            "cats_to": ["n_c:0"],
-            "mutual": true,
-            "values": ["trust", "respect"],
-            "amount": 30,
-            "log": {
+    {
+        "event_id": "gen_new_cat_lonerapp2",
+        "location": ["any"],
+        "season": ["any"],
+        "frequency": 3,
+        "event_text": "m_c couldn't keep {PRONOUN/m_c/poss} new loner friend a secret forever. The two quietly came back to camp one day, m_c cheering the loudest when n_c:0 is welcomed as an apprentice of c_n.",
+        "m_c": {
+            "age": ["adolescent"],
+            "status": ["any"]
+        },
+        "new_cat": [
+            [
+                "new_name",
+                "loner",
+                "status:apprentice"
+            ]
+        ],
+        "relationships": [
+            {
+                "cats_from": ["m_c"],
+                "cats_to": ["n_c:0"],
+                "mutual": true,
+                "values": ["trust", "respect"],
+                "amount": 30,
+                "log": {
                     "cats_from": "m_c and n_c:0 became friends along the border before the latter joined the Clan."
                 }
-        }
-    ]
-},
+            }
+        ]
+    },
     {
         "event_id": "gen_new_cat_anykittypet1",
         "location": ["any"],
@@ -678,7 +684,7 @@
             ]
         ],
         "outsider": {
-            "current_rep": ["neutral","welcoming"],
+            "current_rep": ["neutral", "welcoming"],
             "changed": 1
         },
         "relationships": [
@@ -764,62 +770,66 @@
             }
         ]
     },
+    {
+        "event_id": "gen_new_cat_kittypetapp1",
+        "location": ["any"],
+        "season": ["any"],
+        "frequency": 4,
+        "event_text": "m_c finds a young cat who asks to join the Clan. The kittypet is welcomed into the Clan and renamed n_c:0.",
+        "m_c": {
+            "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+            "status": ["any"]
+        },
+        "new_cat": [
+            [
+                "new_name",
+                "kittypet",
+                "status:apprentice"
+            ]
+        ],
+        "relationships": [
             {
-    "event_id": "gen_new_cat_kittypetapp1",
-    "location": ["any"],
-    "season": ["any"],
-    "frequency": 4,
-    "event_text": "m_c finds a young cat who asks to join the Clan. The kittypet is welcomed into the Clan and renamed n_c:0.",
-    "m_c": {
-        "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
-        "status": ["any"]
-    },
-    "new_cat": [
-        ["new_name",
-        "kittypet",
-        "status:apprentice"]
-    ],
-    "relationships": [
-        {
-            "cats_from": ["m_c"],
-            "cats_to": ["n_c:0"],
-            "mutual": false,
-            "values": ["trust", "respect"],
-            "amount": 20,
-            "log": {
+                "cats_from": ["m_c"],
+                "cats_to": ["n_c:0"],
+                "mutual": false,
+                "values": ["trust", "respect"],
+                "amount": 20,
+                "log": {
                     "cats_from": "m_c found n_c:0 and brought {PRONOUN/n_c:0/object} into the Clan."
                 }
-        }
-    ]
-},
-    {
-    "event_id": "gen_new_cat_kittypetapp2",
-    "location": ["any"],
-    "season": ["any"],
-    "frequency": 3,
-    "event_text": "m_c couldn't keep {PRONOUN/m_c/poss} new kittypet friend a secret forever. The two quietly came back to camp one day, m_c cheering the loudest when n_c:0 is welcomed as an apprentice of c_n.",
-    "m_c": {
-        "age": ["adolescent"],
-        "status": ["any"]
+            }
+        ]
     },
-    "new_cat": [
-        ["new_name",
-        "kittypet",
-        "status:apprentice"]
-    ],
-    "relationships": [
-        {
-            "cats_from": ["m_c"],
-            "cats_to": ["n_c:0"],
-            "mutual": true,
-            "values": ["trust", "respect"],
-            "amount": 30,
-            "log": {
+    {
+        "event_id": "gen_new_cat_kittypetapp2",
+        "location": ["any"],
+        "season": ["any"],
+        "frequency": 3,
+        "event_text": "m_c couldn't keep {PRONOUN/m_c/poss} new kittypet friend a secret forever. The two quietly came back to camp one day, m_c cheering the loudest when n_c:0 is welcomed as an apprentice of c_n.",
+        "m_c": {
+            "age": ["adolescent"],
+            "status": ["any"]
+        },
+        "new_cat": [
+            [
+                "new_name",
+                "kittypet",
+                "status:apprentice"
+            ]
+        ],
+        "relationships": [
+            {
+                "cats_from": ["m_c"],
+                "cats_to": ["n_c:0"],
+                "mutual": true,
+                "values": ["trust", "respect"],
+                "amount": 30,
+                "log": {
                     "cats_from": "m_c and n_c:0 became friends along the border before the latter joined the Clan."
                 }
-        }
-    ]
-},
+            }
+        ]
+    },
     {
         "event_id": "gen_new_cat_anyrogue1",
         "location": ["any"],
@@ -839,7 +849,7 @@
             ]
         ],
         "outsider": {
-            "current_rep": ["neutral","welcoming"],
+            "current_rep": ["neutral", "welcoming"],
             "changed": 1
         },
         "relationships": [
@@ -874,7 +884,7 @@
             ]
         ],
         "outsider": {
-            "current_rep": ["neutral","welcoming"],
+            "current_rep": ["neutral", "welcoming"],
             "changed": 1
         },
         "relationships": [
@@ -958,62 +968,66 @@
             }
         ]
     },
-        {
-    "event_id": "gen_new_cat_rogueapp1",
-    "location": ["any"],
-    "season": ["any"],
-    "frequency": 4,
-    "event_text": "m_c finds a young cat who asks to join the Clan. The rogue is welcomed into the Clan and renamed n_c:0.",
-    "m_c": {
-        "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
-        "status": ["any"]
-    },
-    "new_cat": [
-        ["new_name",
-        "rogue",
-        "status:apprentice"]
-    ],
-    "relationships": [
-        {
-            "cats_from": ["m_c"],
-            "cats_to": ["n_c:0"],
-            "mutual": false,
-            "values": ["trust", "respect"],
-            "amount": 20,
-            "log": {
+    {
+        "event_id": "gen_new_cat_rogueapp1",
+        "location": ["any"],
+        "season": ["any"],
+        "frequency": 4,
+        "event_text": "m_c finds a young cat who asks to join the Clan. The rogue is welcomed into the Clan and renamed n_c:0.",
+        "m_c": {
+            "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+            "status": ["any"]
+        },
+        "new_cat": [
+            [
+                "new_name",
+                "rogue",
+                "status:apprentice"
+            ]
+        ],
+        "relationships": [
+            {
+                "cats_from": ["m_c"],
+                "cats_to": ["n_c:0"],
+                "mutual": false,
+                "values": ["trust", "respect"],
+                "amount": 20,
+                "log": {
                     "cats_from": "m_c found n_c:0 and brought {PRONOUN/n_c:0/object} into the Clan."
                 }
-        }
-    ]
-},
-    {
-    "event_id": "gen_new_cat_rogueapp2",
-    "location": ["any"],
-    "season": ["any"],
-    "frequency": 3,
-    "event_text": "m_c couldn't keep {PRONOUN/m_c/poss} new rogue friend a secret forever. The two quietly came back to camp one day, m_c cheering the loudest when n_c:0 is welcomed as an apprentice of c_n.",
-    "m_c": {
-        "age": ["adolescent"],
-        "status": ["any"]
+            }
+        ]
     },
-    "new_cat": [
-        ["new_name",
-        "rogue",
-        "status:apprentice"]
-    ],
-    "relationships": [
-        {
-            "cats_from": ["m_c"],
-            "cats_to": ["n_c:0"],
-            "mutual": true,
-            "values": ["trust", "respect"],
-            "amount": 30,
-            "log": {
+    {
+        "event_id": "gen_new_cat_rogueapp2",
+        "location": ["any"],
+        "season": ["any"],
+        "frequency": 3,
+        "event_text": "m_c couldn't keep {PRONOUN/m_c/poss} new rogue friend a secret forever. The two quietly came back to camp one day, m_c cheering the loudest when n_c:0 is welcomed as an apprentice of c_n.",
+        "m_c": {
+            "age": ["adolescent"],
+            "status": ["any"]
+        },
+        "new_cat": [
+            [
+                "new_name",
+                "rogue",
+                "status:apprentice"
+            ]
+        ],
+        "relationships": [
+            {
+                "cats_from": ["m_c"],
+                "cats_to": ["n_c:0"],
+                "mutual": true,
+                "values": ["trust", "respect"],
+                "amount": 30,
+                "log": {
                     "cats_from": "m_c and n_c:0 became friends along the border before the latter joined the Clan."
                 }
-        }
-    ]
-},
+            }
+        ]
+    },
     {
         "event_id": "gen_new_cat_anyotherclancat1",
         "location": ["any"],
@@ -1067,10 +1081,10 @@
             ]
         ],
         "injury": [
-           {
-            "cats": ["n_c:0"],
-            "injuries": ["battle_injury", "big_bite_injury"]
-           }
+            {
+                "cats": ["n_c:0"],
+                "injuries": ["battle_injury", "big_bite_injury"]
+            }
         ],
         "other_clan": {
             "current_rep": ["hostile"],
@@ -1102,11 +1116,11 @@
             ]
         },
         "new_cat": [
-          [
-            "old_name",
-            "backstory:ostracized_warrior,disgraced1,disgraced2,otherclan1",
-            "status:warrior"
-          ]
+            [
+                "old_name",
+                "backstory:ostracized_warrior,disgraced1,disgraced2,otherclan1",
+                "status:warrior"
+            ]
         ],
         "other_clan": {
             "current_rep": ["hostile"],
@@ -1148,11 +1162,11 @@
             ]
         },
         "new_cat": [
-          [
-            "old_name",
-            "backstory:ostracized_warrior,disgraced1,disgraced2,disgraced3,otherclan1",
-            "status:warrior"
-          ]
+            [
+                "old_name",
+                "backstory:ostracized_warrior,disgraced1,disgraced2,disgraced3,otherclan1",
+                "status:warrior"
+            ]
         ],
         "other_clan": {
             "current_rep": ["hostile"],
@@ -1194,11 +1208,11 @@
             ]
         },
         "new_cat": [
-          [
-            "old_name",
-            "backstory:medicine_cat",
-            "status:medicine cat"
-          ]
+            [
+                "old_name",
+                "backstory:medicine_cat",
+                "status:medicine cat"
+            ]
         ],
         "other_clan": {
             "current_rep": ["hostile"],
@@ -1580,608 +1594,631 @@
             }
         ]
     },
-        {
-    "event_id": "gen_new_cat_war_sololoner",
-    "location": ["any"],
-    "season": ["any"],
-    "sub_type": ["war"],
-    "frequency": 2,
-    "event_text": "In a battle against o_c_n, m_c and {PRONOUN/m_c/poss} opponent spot a loner caught in the crossfire and, working together, help get {PRONOUN/n_c:0/object} to safety.",
-    "m_c": {
-        "status": ["apprentice", "warrior", "deputy", "leader"]
-    },
-    "new_cat": [
-    [
-    "old_name",
-    "loner",
-    "meeting",
-    "exists"
-    ]
-    ],
-    "relationships": [
-        {
-            "cats_from": ["m_c"],
-            "cats_to": ["n_c:0"],
-            "mutual": true,
-            "values": ["trust", "like"],
-            "amount": 10,
-            "log": {
+    {
+        "event_id": "gen_new_cat_war_sololoner",
+        "location": ["any"],
+        "season": ["any"],
+        "sub_type": ["war"],
+        "frequency": 2,
+        "event_text": "In a battle against o_c_n, m_c and {PRONOUN/m_c/poss} opponent spot a loner caught in the crossfire and, working together, help get {PRONOUN/n_c:0/object} to safety.",
+        "m_c": {
+            "status": ["apprentice", "warrior", "deputy", "leader"]
+        },
+        "new_cat": [
+            [
+                "old_name",
+                "loner",
+                "meeting",
+                "exists"
+            ]
+        ],
+        "relationships": [
+            {
+                "cats_from": ["m_c"],
+                "cats_to": ["n_c:0"],
+                "mutual": true,
+                "values": ["trust", "like"],
+                "amount": 10,
+                "log": {
                     "cats_from": "cat_from helped cat_to get to safety during a battle against another Clan."
                 }
+            }
+        ],
+        "outsider": {
+            "current_rep": ["any"],
+            "changed": 1
+        },
+        "other_clan": {
+            "current_rep": ["hostile"],
+            "changed": 1
         }
-    ],
-    "outsider": {
-        "current_rep": ["any"],
-        "changed": 1
     },
-    "other_clan": {
-        "current_rep": ["hostile"],
-        "changed": 1
-    }
-},
     {
-    "event_id": "gen_new_cat_war_solorogue",
-    "location": ["any"],
-    "season": ["any"],
-    "sub_type": ["war"],
-    "frequency": 2,
-    "event_text": "In a battle against o_c_n, m_c and {PRONOUN/m_c/poss} opponent spot a rogue attempting to pick off wounded Clan cats and, working together, chase {PRONOUN/n_c:0/object} away.",
-    "m_c": {
-        "status": ["apprentice", "warrior", "deputy", "leader"]
-    },
-    "new_cat": [
-    [
-    "old_name",
-    "rogue",
-    "meeting",
-    "exists"
-    ]
-    ],
-    "relationships": [
-        {
-            "cats_from": ["m_c"],
-            "cats_to": ["n_c:0"],
-            "mutual": true,
-            "values": ["trust", "like"],
-            "amount": -10,
-            "log": {
+        "event_id": "gen_new_cat_war_solorogue",
+        "location": ["any"],
+        "season": ["any"],
+        "sub_type": ["war"],
+        "frequency": 2,
+        "event_text": "In a battle against o_c_n, m_c and {PRONOUN/m_c/poss} opponent spot a rogue attempting to pick off wounded Clan cats and, working together, chase {PRONOUN/n_c:0/object} away.",
+        "m_c": {
+            "status": ["apprentice", "warrior", "deputy", "leader"]
+        },
+        "new_cat": [
+            [
+                "old_name",
+                "rogue",
+                "meeting",
+                "exists"
+            ]
+        ],
+        "relationships": [
+            {
+                "cats_from": ["m_c"],
+                "cats_to": ["n_c:0"],
+                "mutual": true,
+                "values": ["trust", "like"],
+                "amount": -10,
+                "log": {
                     "cats_from": "cat_from chased cat_to away after catching {PRONOUN/n_c:0/object} harming other Clan cats during a battle."
                 }
-        }
-    ],
-    "outsider": {
-        "current_rep": ["any"],
-        "changed": -1
-    },
-    "other_clan": {
-        "current_rep": ["hostile"],
-        "changed": 1
-    }
-},
-    {
-    "event_id": "gen_new_cat_war_solokittypet",
-    "location": ["any"],
-    "season": ["any"],
-    "sub_type": ["war"],
-    "frequency": 2,
-    "event_text": "In a battle against o_c_n, m_c and {PRONOUN/m_c/poss} opponent spot a kittypet caught in the crossfire and, working together, help get {PRONOUN/n_c:0/object} to safety.",
-    "m_c": {
-        "status": ["apprentice", "warrior", "deputy", "leader"]
-    },
-    "new_cat": [
-    [
-    "old_name",
-    "kittypet",
-    "meeting",
-    "exists"
-    ]
-    ],
-    "relationships": [
-        {
-            "cats_from": ["m_c"],
-            "cats_to": ["n_c:0"],
-            "mutual": true,
-            "values": ["trust", "like"],
-            "amount": 10,
-            "log": {
-                    "cats_from": "cat_from helped cat_to get to safety during a battle against another Clan."
-                }
-        }
-    ],
-    "outsider": {
-        "current_rep": ["any"],
-        "changed": 1
-    },
-    "other_clan": {
-        "current_rep": ["hostile"],
-        "changed": 1
-    }
-},
-    {
-    "event_id": "gen_new_cat_war_duoloner",
-    "location": ["any"],
-    "season": ["any"],
-    "sub_type": ["war"],
-    "frequency": 2,
-    "event_text": "In a battle against o_c_n, m_c and {PRONOUN/m_c/poss} opponent spot two loners caught in the crossfire and, working together, help the pair get to safety.",
-    "m_c": {
-        "status": ["apprentice", "warrior", "deputy", "leader"]
-    },
-    "new_cat": [
-    [
-    "old_name",
-    "loner",
-    "meeting",
-    "exists"
-    ],
-    [
-    "old_name",
-    "loner",
-    "meeting",
-    "exists"
-    ]
-    ],
-    "relationships": [
-        {
-            "cats_from": ["m_c"],
-            "cats_to": ["n_c:0"],
-            "mutual": true,
-            "values": ["trust", "like"],
-            "amount": 10,
-            "log": {
-                    "cats_from": "cat_from helped cat_to get to safety during a battle against another Clan."
-                }
+            }
+        ],
+        "outsider": {
+            "current_rep": ["any"],
+            "changed": -1
         },
-        {
-            "cats_from": ["m_c"],
-            "cats_to": ["n_c:1"],
-            "mutual": true,
-            "values": ["trust", "like"],
-            "amount": 10,
-            "log": {
+        "other_clan": {
+            "current_rep": ["hostile"],
+            "changed": 1
+        }
+    },
+    {
+        "event_id": "gen_new_cat_war_solokittypet",
+        "location": ["any"],
+        "season": ["any"],
+        "sub_type": ["war"],
+        "frequency": 2,
+        "event_text": "In a battle against o_c_n, m_c and {PRONOUN/m_c/poss} opponent spot a kittypet caught in the crossfire and, working together, help get {PRONOUN/n_c:0/object} to safety.",
+        "m_c": {
+            "status": ["apprentice", "warrior", "deputy", "leader"]
+        },
+        "new_cat": [
+            [
+                "old_name",
+                "kittypet",
+                "meeting",
+                "exists"
+            ]
+        ],
+        "relationships": [
+            {
+                "cats_from": ["m_c"],
+                "cats_to": ["n_c:0"],
+                "mutual": true,
+                "values": ["trust", "like"],
+                "amount": 10,
+                "log": {
                     "cats_from": "cat_from helped cat_to get to safety during a battle against another Clan."
                 }
+            }
+        ],
+        "outsider": {
+            "current_rep": ["any"],
+            "changed": 1
+        },
+        "other_clan": {
+            "current_rep": ["hostile"],
+            "changed": 1
         }
-    ],
-    "outsider": {
-        "current_rep": ["any"],
-        "changed": 2
     },
-    "other_clan": {
-        "current_rep": ["hostile"],
-        "changed": 2
-    }
-},
     {
-    "event_id": "gen_new_cat_war_duorogue",
-    "location": ["any"],
-    "season": ["any"],
-    "sub_type": ["war"],
-    "frequency": 2,
-    "event_text": "In a battle against o_c_n, m_c and {PRONOUN/m_c/poss} opponent spot two rogues attempting to pick off injured Clan cats and, working together, chase the pair away.",
-    "m_c": {
-        "status": ["apprentice", "warrior", "deputy", "leader"]
+        "event_id": "gen_new_cat_war_duoloner",
+        "location": ["any"],
+        "season": ["any"],
+        "sub_type": ["war"],
+        "frequency": 2,
+        "event_text": "In a battle against o_c_n, m_c and {PRONOUN/m_c/poss} opponent spot two loners caught in the crossfire and, working together, help the pair get to safety.",
+        "m_c": {
+            "status": ["apprentice", "warrior", "deputy", "leader"]
+        },
+        "new_cat": [
+            [
+                "old_name",
+                "loner",
+                "meeting",
+                "exists"
+            ],
+            [
+                "old_name",
+                "loner",
+                "meeting",
+                "exists"
+            ]
+        ],
+        "relationships": [
+            {
+                "cats_from": ["m_c"],
+                "cats_to": ["n_c:0"],
+                "mutual": true,
+                "values": ["trust", "like"],
+                "amount": 10,
+                "log": {
+                    "cats_from": "cat_from helped cat_to get to safety during a battle against another Clan."
+                }
+            },
+            {
+                "cats_from": ["m_c"],
+                "cats_to": ["n_c:1"],
+                "mutual": true,
+                "values": ["trust", "like"],
+                "amount": 10,
+                "log": {
+                    "cats_from": "cat_from helped cat_to get to safety during a battle against another Clan."
+                }
+            }
+        ],
+        "outsider": {
+            "current_rep": ["any"],
+            "changed": 2
+        },
+        "other_clan": {
+            "current_rep": ["hostile"],
+            "changed": 2
+        }
     },
-    "new_cat": [
-    [
-    "old_name",
-    "rogue",
-    "meeting",
-    "exists"
-    ],
-    [
-    "old_name",
-    "rogue",
-    "meeting",
-    "exists"
-    ]
-    ],
-    "relationships": [
-        {
-            "cats_from": ["m_c"],
-            "cats_to": ["n_c:0"],
-            "mutual": true,
-            "values": ["trust", "like"],
-            "amount": -10,
-            "log": {
+    {
+        "event_id": "gen_new_cat_war_duorogue",
+        "location": ["any"],
+        "season": ["any"],
+        "sub_type": ["war"],
+        "frequency": 2,
+        "event_text": "In a battle against o_c_n, m_c and {PRONOUN/m_c/poss} opponent spot two rogues attempting to pick off injured Clan cats and, working together, chase the pair away.",
+        "m_c": {
+            "status": ["apprentice", "warrior", "deputy", "leader"]
+        },
+        "new_cat": [
+            [
+                "old_name",
+                "rogue",
+                "meeting",
+                "exists"
+            ],
+            [
+                "old_name",
+                "rogue",
+                "meeting",
+                "exists"
+            ]
+        ],
+        "relationships": [
+            {
+                "cats_from": ["m_c"],
+                "cats_to": ["n_c:0"],
+                "mutual": true,
+                "values": ["trust", "like"],
+                "amount": -10,
+                "log": {
                     "cats_from": "cat_from chased cat_to away after catching {PRONOUN/n_c:0/object} harming other Clan cats during a battle."
                 }
-        },
-        {
-            "cats_from": ["m_c"],
-            "cats_to": ["n_c:1"],
-            "mutual": true,
-            "values": ["trust", "like"],
-            "amount": -10,
-            "log": {
+            },
+            {
+                "cats_from": ["m_c"],
+                "cats_to": ["n_c:1"],
+                "mutual": true,
+                "values": ["trust", "like"],
+                "amount": -10,
+                "log": {
                     "cats_from": "cat_from chased cat_to away after catching {PRONOUN/n_c:0/object} harming other Clan cats during a battle."
                 }
-        }
-    ],
-    "outsider": {
-        "current_rep": ["any"],
-        "changed": -2
-    },
-    "other_clan": {
-        "current_rep": ["hostile"],
-        "changed": 2
-    }
-},
-    {
-    "event_id": "gen_new_cat_war_duokittypet",
-    "location": ["any"],
-    "season": ["any"],
-    "sub_type": ["war"],
-    "frequency": 2,
-    "event_text": "In a battle against o_c_n, m_c and {PRONOUN/m_c/poss} opponent spot two kittypets caught in the crossfire and, working together, help the pair get to safety.",
-    "m_c": {
-        "status": ["apprentice", "warrior", "deputy", "leader"]
-    },
-    "new_cat": [
-    [
-    "old_name",
-    "kittypet",
-    "meeting",
-    "exists"
-    ],
-    [
-    "old_name",
-    "kittypet",
-    "meeting",
-    "exists"
-    ]
-    ],
-    "relationships": [
-        {
-            "cats_from": ["m_c"],
-            "cats_to": ["n_c:0"],
-            "mutual": true,
-            "values": ["trust", "like"],
-            "amount": 10,
-            "log": {
-                    "cats_from": "cat_from helped cat_to get to safety during a battle against another Clan."
-                }
+            }
+        ],
+        "outsider": {
+            "current_rep": ["any"],
+            "changed": -2
         },
-        {
-            "cats_from": ["m_c"],
-            "cats_to": ["n_c:1"],
-            "mutual": true,
-            "values": ["trust", "like"],
-            "amount": 10,
-            "log": {
-                    "cats_from": "cat_from helped cat_to get to safety during a battle against another Clan."
-                }
+        "other_clan": {
+            "current_rep": ["hostile"],
+            "changed": 2
         }
-    ],
-    "outsider": {
-        "current_rep": ["any"],
-        "changed": 2
-    },
-    "other_clan": {
-        "current_rep": ["hostile"],
-        "changed": 2
-    }
     },
     {
-    "event_id": "gen_new_cat_war_mediator1",
-    "location": ["any"],
-    "season": ["any"],
-    "sub_type": ["war"],
-    "frequency": 2,
-    "event_text": "When a battle against o_c_n spills into a loner's territory, n_c:0 successfully mediates between the two battle patrols so no further harm would come to pass.",
-    "new_cat": [
-        ["old_name",
-        "loner",
-        "meeting",
-        "exists"]
-    ],
-      "exclude_involved": [
-    "m_c",
-    "r_c"
-    ],
-    "relationships": [
-        {
-            "cats_from": ["clan"],
-            "cats_to": ["n_c:0"],
-            "mutual": false,
-            "values": ["trust", "like"],
-            "amount": 20,
+        "event_id": "gen_new_cat_war_duokittypet",
+        "location": ["any"],
+        "season": ["any"],
+        "sub_type": ["war"],
+        "frequency": 2,
+        "event_text": "In a battle against o_c_n, m_c and {PRONOUN/m_c/poss} opponent spot two kittypets caught in the crossfire and, working together, help the pair get to safety.",
+        "m_c": {
+            "status": ["apprentice", "warrior", "deputy", "leader"]
+        },
+        "new_cat": [
+            [
+                "old_name",
+                "kittypet",
+                "meeting",
+                "exists"
+            ],
+            [
+                "old_name",
+                "kittypet",
+                "meeting",
+                "exists"
+            ]
+        ],
+        "relationships": [
+            {
+                "cats_from": ["m_c"],
+                "cats_to": ["n_c:0"],
+                "mutual": true,
+                "values": ["trust", "like"],
+                "amount": 10,
+                "log": {
+                    "cats_from": "cat_from helped cat_to get to safety during a battle against another Clan."
+                }
+            },
+            {
+                "cats_from": ["m_c"],
+                "cats_to": ["n_c:1"],
+                "mutual": true,
+                "values": ["trust", "like"],
+                "amount": 10,
+                "log": {
+                    "cats_from": "cat_from helped cat_to get to safety during a battle against another Clan."
+                }
+            }
+        ],
+        "outsider": {
+            "current_rep": ["any"],
+            "changed": 2
+        },
+        "other_clan": {
+            "current_rep": ["hostile"],
+            "changed": 2
+        }
+    },
+    {
+        "event_id": "gen_new_cat_war_mediator1",
+        "location": ["any"],
+        "season": ["any"],
+        "sub_type": ["war"],
+        "frequency": 2,
+        "event_text": "When a battle against o_c_n spills into a loner's territory, n_c:0 successfully mediates between the two battle patrols so no further harm would come to pass.",
+        "new_cat": [
+            [
+                "old_name",
+                "loner",
+                "meeting",
+                "exists"
+            ]
+        ],
+        "exclude_involved": [
+            "m_c",
+            "r_c"
+        ],
+        "relationships": [
+            {
+                "cats_from": ["clan"],
+                "cats_to": ["n_c:0"],
+                "mutual": false,
+                "values": ["trust", "like"],
+                "amount": 20,
                 "log": {
                     "cats_from": "cat_from was thankful that cat_to prevented a bloody battle against an enemy Clan."
                 }
+            }
+        ],
+        "outsider": {
+            "current_rep": ["any"],
+            "changed": 2
+        },
+        "other_clan": {
+            "current_rep": ["hostile"],
+            "changed": 2
         }
-    ],
-    "outsider": {
-        "current_rep": ["any"],
-        "changed": 2
     },
-    "other_clan": {
-        "current_rep": ["hostile"],
-        "changed": 2
-    }
-},
     {
-    "event_id": "gen_new_cat_war_mediator2",
-    "location": ["any"],
-    "season": ["any"],
-    "sub_type": ["war"],
-    "frequency": 2,
-    "event_text": "When a battle against o_c_n spills into a loner's territory, n_c:0's attempts to mediate between the two Clans ends with {PRONOUN/n_c:0/poss} being chased away.",
-    "new_cat": [
-        ["old_name",
-        "loner",
-        "meeting",
-        "exists"]
-    ],
-      "exclude_involved": [
-    "m_c",
-    "r_c"
-    ],
-    "relationships": [
-        {
-            "cats_from": ["clan"],
-            "cats_to": ["n_c:0"],
-            "mutual": false,
-            "values": ["trust", "like"],
-            "amount": -10,
-            "log": {
+        "event_id": "gen_new_cat_war_mediator2",
+        "location": ["any"],
+        "season": ["any"],
+        "sub_type": ["war"],
+        "frequency": 2,
+        "event_text": "When a battle against o_c_n spills into a loner's territory, n_c:0's attempts to mediate between the two Clans ends with {PRONOUN/n_c:0/poss} being chased away.",
+        "new_cat": [
+            [
+                "old_name",
+                "loner",
+                "meeting",
+                "exists"
+            ]
+        ],
+        "exclude_involved": [
+            "m_c",
+            "r_c"
+        ],
+        "relationships": [
+            {
+                "cats_from": ["clan"],
+                "cats_to": ["n_c:0"],
+                "mutual": false,
+                "values": ["trust", "like"],
+                "amount": -10,
+                "log": {
                     "cats_from": "cat_from thinks that cat_to shouldn't have stuck {PRONOUN/n_c:0/poss} nose in c_n's business."
                 }
+            }
+        ],
+        "outsider": {
+            "current_rep": ["any"],
+            "changed": -2
+        },
+        "other_clan": {
+            "current_rep": ["hostile"],
+            "changed": 2
         }
-    ],
-    "outsider": {
-        "current_rep": ["any"],
-        "changed": -2
     },
-    "other_clan": {
-        "current_rep": ["hostile"],
-        "changed": 2
-    }
-},
     {
-    "event_id": "gen_new_cat_war_lonertruce",
-    "location": ["any"],
-    "season": ["any"],
-    "sub_type": ["war"],
-    "frequency": 1,
-    "event_text": "In the midst of a tense stalemate between c_n and o_c_n, it is the suggestion of a passing group of loners that allows for a night of peace between the two Clans.",
-    "new_cat": [
-        ["old_name",
-        "loner",
-        "meeting",
-        "exists"],
-        ["old_name",
-        "loner",
-        "meeting",
-        "exists"],
-        ["old_name",
-        "loner",
-        "meeting",
-        "exists"]
-    ],
-      "exclude_involved": [
-    "m_c",
-    "r_c"
-    ],
-    "relationships": [
-        {
-            "cats_from": ["clan"],
-            "cats_to": ["n_c:0", "n_c:1", "n_c:2"],
-            "mutual": false,
-            "values": ["trust", "like"],
-            "amount": 10,
-            "log": {
+        "event_id": "gen_new_cat_war_lonertruce",
+        "location": ["any"],
+        "season": ["any"],
+        "sub_type": ["war"],
+        "frequency": 1,
+        "event_text": "In the midst of a tense stalemate between c_n and o_c_n, it is the suggestion of a passing group of loners that allows for a night of peace between the two Clans.",
+        "new_cat": [
+            [
+                "old_name",
+                "loner",
+                "meeting",
+                "exists"
+            ],
+            [
+                "old_name",
+                "loner",
+                "meeting",
+                "exists"
+            ],
+            [
+                "old_name",
+                "loner",
+                "meeting",
+                "exists"
+            ]
+        ],
+        "exclude_involved": [
+            "m_c",
+            "r_c"
+        ],
+        "relationships": [
+            {
+                "cats_from": ["clan"],
+                "cats_to": ["n_c:0", "n_c:1", "n_c:2"],
+                "mutual": false,
+                "values": ["trust", "like"],
+                "amount": 10,
+                "log": {
                     "cats_from": "cat_from will remember the loners who gave their Clan a night of badly needed respite during a war."
                 }
-        },
-        {
-            "cats_from": ["clan", "high_aggress"],
-            "cats_to": ["n_c:0", "n_c:1", "n_c:2"],
-            "mutual": false,
-            "values": ["trust", "like"],
-            "amount": -10,
-            "log": {
+            },
+            {
+                "cats_from": ["clan", "high_aggress"],
+                "cats_to": ["n_c:0", "n_c:1", "n_c:2"],
+                "mutual": false,
+                "values": ["trust", "like"],
+                "amount": -10,
+                "log": {
                     "cats_from": "cat_from will remember the loners who foiled a perfectly good battle for their own bleeding hearts."
                 }
+            }
+        ],
+        "outsider": {
+            "current_rep": ["neutral", "welcoming"],
+            "changed": 3
+        },
+        "other_clan": {
+            "current_rep": ["hostile"],
+            "changed": 3
         }
-    ],
-    "outsider": {
-        "current_rep": ["neutral", "welcoming"],
-        "changed": 3
     },
-    "other_clan": {
-        "current_rep": ["hostile"],
-        "changed": 3
-    }
-},
     {
-    "event_id": "gen_new_cat_war_rogueretaliate",
-    "location": ["any"],
-    "season": ["any"],
-    "sub_type": ["war"],
-    "frequency": 1,
-    "event_text": "In the midst of a vicious battle between c_n and o_c_n, a large group of rogues takes a chance to weaken both of their enemies in one fell swoop. They did not expect the two Clans to quickly make a temporary truce and retaliate.",
-    "new_cat": [
-        ["old_name",
-        "rogue",
-        "meeting",
-        "exists"],
-        ["old_name",
-        "rogue",
-        "meeting",
-        "exists"],
-        ["old_name",
-        "rogue",
-        "meeting",
-        "exists"]
-    ],
-      "exclude_involved": [
-    "m_c",
-    "r_c"
-    ],
-    "relationships": [
-        {
-            "cats_from": ["clan"],
-            "cats_to": ["n_c:0", "n_c:1", "n_c:2"],
-            "mutual": false,
-            "values": ["trust", "like"],
-            "amount": -10,
-            "log": {
+        "event_id": "gen_new_cat_war_rogueretaliate",
+        "location": ["any"],
+        "season": ["any"],
+        "sub_type": ["war"],
+        "frequency": 1,
+        "event_text": "In the midst of a vicious battle between c_n and o_c_n, a large group of rogues takes a chance to weaken both of their enemies in one fell swoop. They did not expect the two Clans to quickly make a temporary truce and retaliate.",
+        "new_cat": [
+            [
+                "old_name",
+                "rogue",
+                "meeting",
+                "exists"
+            ],
+            [
+                "old_name",
+                "rogue",
+                "meeting",
+                "exists"
+            ],
+            [
+                "old_name",
+                "rogue",
+                "meeting",
+                "exists"
+            ]
+        ],
+        "exclude_involved": [
+            "m_c",
+            "r_c"
+        ],
+        "relationships": [
+            {
+                "cats_from": ["clan"],
+                "cats_to": ["n_c:0", "n_c:1", "n_c:2"],
+                "mutual": false,
+                "values": ["trust", "like"],
+                "amount": -10,
+                "log": {
                     "cats_from": "cat_from will remember the rogue who dared to attack c_n so brazenly during a battle against an enemy Clan."
                 }
+            }
+        ],
+        "outsider": {
+            "current_rep": ["any"],
+            "changed": -3
+        },
+        "other_clan": {
+            "current_rep": ["hostile"],
+            "changed": 3
         }
-    ],
-    "outsider": {
-        "current_rep": ["any"],
-        "changed": -3
     },
-    "other_clan": {
-        "current_rep": ["hostile"],
-        "changed": 3
-    }
-},
     {
-    "event_id": "gen_new_cat_war_kittypetpeace",
-    "location": ["any"],
-    "season": ["any"],
-    "sub_type": ["war"],
-    "frequency": 1,
-    "event_text": "Before a major battle between c_n and o_c_n can take place, their battlefield is overrun by a group of kittypets who refuse to leave and let them fight. Instead, the two Clans intermingle under the hopeful eyes of the gathered cats.",
-    "new_cat": [
-        ["old_name",
-        "kittypet",
-        "meeting",
-        "exists"],
-        ["old_name",
-        "kittypet",
-        "meeting",
-        "exists"],
-        ["old_name",
-        "kittypet",
-        "meeting",
-        "exists"]
-    ],
-      "exclude_involved": [
-    "m_c",
-    "r_c"
-    ],
-    "relationships": [
-        {
-            "cats_from": ["clan"],
-            "cats_to": ["n_c:0", "n_c:1", "n_c:2"],
-            "mutual": false,
-            "values": ["trust", "like"],
-            "amount": 10,
-            "log": {
+        "event_id": "gen_new_cat_war_kittypetpeace",
+        "location": ["any"],
+        "season": ["any"],
+        "sub_type": ["war"],
+        "frequency": 1,
+        "event_text": "Before a major battle between c_n and o_c_n can take place, their battlefield is overrun by a group of kittypets who refuse to leave and let them fight. Instead, the two Clans intermingle under the hopeful eyes of the gathered cats.",
+        "new_cat": [
+            [
+                "old_name",
+                "kittypet",
+                "meeting",
+                "exists"
+            ],
+            [
+                "old_name",
+                "kittypet",
+                "meeting",
+                "exists"
+            ],
+            [
+                "old_name",
+                "kittypet",
+                "meeting",
+                "exists"
+            ]
+        ],
+        "exclude_involved": [
+            "m_c",
+            "r_c"
+        ],
+        "relationships": [
+            {
+                "cats_from": ["clan"],
+                "cats_to": ["n_c:0", "n_c:1", "n_c:2"],
+                "mutual": false,
+                "values": ["trust", "like"],
+                "amount": 10,
+                "log": {
                     "cats_from": "cat_from will remember the kittypet who dared to stop an entire battle against an enemy Clan."
                 }
-        },
-        {
-            "cats_from": ["clan", "high_lawful"],
-            "cats_to": ["n_c:0", "n_c:1", "n_c:2"],
-            "mutual": false,
-            "values": ["trust", "like"],
-            "amount": -15,
-            "log": {
+            },
+            {
+                "cats_from": ["clan", "high_lawful"],
+                "cats_to": ["n_c:0", "n_c:1", "n_c:2"],
+                "mutual": false,
+                "values": ["trust", "like"],
+                "amount": -15,
+                "log": {
                     "cats_from": "cat_from really thinks that this kittypet should have left the peacemaking for the mediators."
                 }
-        }
-    ],
-    "outsider": {
-        "current_rep": ["neutral", "welcoming"],
-        "changed": 3
-    },
-    "other_clan": {
-        "current_rep": ["hostile"],
-        "changed": 3
-    }
-},
-{
-    "event_id": "gen_new_cat_queenhelp",
-    "location": ["any"],
-    "season": ["any"],
-    "tags": [],
-    "frequency": 1,
-    "event_text": "A loner named n_c:0 seeks m_c's help with kitting. A half-moon after the birth, n_c:0 bids farewell to the Clan and thanks m_c again for {PRONOUN/m_c/poss} help.",
-    "m_c": {
-        "status": ["medicine cat"]
-    },
-    "new_cat": [
-        ["age:has_kits",
-        "can_birth",
-        "meeting",
-        "exists",
-        "old_name",
-        "loner"
+            }
         ],
-        [
-            "parent:0",
-            "litter",
-            "age:newborn",
-            "meeting",
-            "unknown"
-        ]
-    ],
-    "relationships": [
-        {
-            "cats_from": ["n_c:0"],
-            "cats_to": ["m_c"],
-            "mutual": false,
-            "values": ["trust", "respect"],
-            "amount": 15,
-            "log": {
-                "cats_from": "cat_from sought cat_to's help when {PRONOUN/cat_from/subject} {VERB/cat_from/were/was} giving birth."
-            }
+        "outsider": {
+            "current_rep": ["neutral", "welcoming"],
+            "changed": 3
         },
-        {
-            "cats_from": ["n_c:1"],
-            "cats_to": ["m_c"],
-            "mutual": false,
-            "values": ["respect"],
-            "amount": 15,
-            "log": {
-                "cats_from": "cat_from heard stories about how cat_to helped n_c:0 when {PRONOUN/n_c:0/subject} gave birth to cat_from."
-            }
+        "other_clan": {
+            "current_rep": ["hostile"],
+            "changed": 3
         }
-    ],
-    "outsider": {
-        "current_rep": ["neutral", "welcoming"],
-        "changed": 2
-    }
-},
-{
-  "event_id": "gen_new_cat_otherclanexile1_unknown",
-  "location": [
-    "any"
-  ],
-  "season": [
-    "any"
-  ],
-  "tags": [],
-  "exclude_involved": [
-    "m_c"
-  ],
-  "frequency": 2,
-  "event_text": "At the Gathering, o_c_n's leader announces they have exiled a warrior for an unforgivable crime. They advise the other Clans to keep their guards up.",
-  "m_c": {
-    "age": [
-      "adolescent",
-      "young adult",
-      "adult",
-      "senior adult",
-      "senior"
-    ]
-  },
-  "new_cat": [
-    [
-      "former clancat",
-      "status:warrior",
-      "meeting",
-      "unknown",
-      "backstory:disgraced1, disgraced2",
-      "new_name"
-    ]
-  ],
+    },
+    {
+        "event_id": "gen_new_cat_queenhelp",
+        "location": ["any"],
+        "season": ["any"],
+        "tags": [],
+        "frequency": 1,
+        "event_text": "A loner named n_c:0 seeks m_c's help with kitting. A half-moon after the birth, n_c:0 bids farewell to the Clan and thanks m_c again for {PRONOUN/m_c/poss} help.",
+        "m_c": {
+            "status": ["medicine cat"]
+        },
+        "new_cat": [
+            [
+                "age:has_kits",
+                "can_birth",
+                "meeting",
+                "exists",
+                "old_name",
+                "loner"
+            ],
+            [
+                "parent:0",
+                "litter",
+                "age:newborn",
+                "meeting",
+                "unknown"
+            ]
+        ],
+        "relationships": [
+            {
+                "cats_from": ["n_c:0"],
+                "cats_to": ["m_c"],
+                "mutual": false,
+                "values": ["trust", "respect"],
+                "amount": 15,
+                "log": {
+                    "cats_from": "cat_from sought cat_to's help when {PRONOUN/cat_from/subject} {VERB/cat_from/were/was} giving birth."
+                }
+            },
+            {
+                "cats_from": ["n_c:1"],
+                "cats_to": ["m_c"],
+                "mutual": false,
+                "values": ["respect"],
+                "amount": 15,
+                "log": {
+                    "cats_from": "cat_from heard stories about how cat_to helped n_c:0 when {PRONOUN/n_c:0/subject} gave birth to cat_from."
+                }
+            }
+        ],
+        "outsider": {
+            "current_rep": ["neutral", "welcoming"],
+            "changed": 2
+        }
+    },
+    {
+        "event_id": "gen_new_cat_otherclanexile1_unknown",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "tags": [],
+        "exclude_involved": [
+            "m_c"
+        ],
+        "frequency": 2,
+        "event_text": "At the Gathering, o_c_n's leader announces they have exiled a warrior for an unforgivable crime. They advise the other Clans to keep their guards up.",
+        "m_c": {
+            "age": [
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult",
+                "senior"
+            ]
+        },
+        "new_cat": [
+            [
+                "former clancat",
+                "status:warrior",
+                "meeting",
+                "unknown",
+                "backstory:disgraced1, disgraced2",
+                "new_name"
+            ]
+        ],
         "relationships": [
             {
                 "cats_from": ["some_clan", "high_social"],
@@ -2190,7 +2227,7 @@
                 ],
                 "mutual": false,
                 "values": [
-	        "trust"
+                    "trust"
                 ],
                 "amount": -10,
                 "log": {
@@ -2198,46 +2235,46 @@
                 }
             }
         ],
-  "other_clan": {
-    "current_rep": [
-      "any"
-    ],
-    "changed": 0
-  }
-},
-{
-  "event_id": "gen_new_cat_otherclanexile2_unknown",
-  "location": [
-    "any"
-  ],
-  "season": [
-    "any"
-  ],
-  "tags": [],
-  "exclude_involved": [
-    "m_c"
-  ],
-  "frequency": 1,
-  "event_text": "At the Gathering, o_c_n's deputy takes their place among the other leaders and declares the previous leader was driven out, but may still stalk the borders.",
-  "m_c": {
-    "age": [
-      "adolescent",
-      "young adult",
-      "adult",
-      "senior adult",
-      "senior"
-    ]
-  },
-  "new_cat": [
-    [
-      "former clancat",
-      "status:warrior",
-      "meeting",
-      "unknown",
-      "backstory:disgraced3",
-      "new_name"
-    ]
-  ],
+        "other_clan": {
+            "current_rep": [
+                "any"
+            ],
+            "changed": 0
+        }
+    },
+    {
+        "event_id": "gen_new_cat_otherclanexile2_unknown",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "tags": [],
+        "exclude_involved": [
+            "m_c"
+        ],
+        "frequency": 1,
+        "event_text": "At the Gathering, o_c_n's deputy takes their place among the other leaders and declares the previous leader was driven out, but may still stalk the borders.",
+        "m_c": {
+            "age": [
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult",
+                "senior"
+            ]
+        },
+        "new_cat": [
+            [
+                "former clancat",
+                "status:warrior",
+                "meeting",
+                "unknown",
+                "backstory:disgraced3",
+                "new_name"
+            ]
+        ],
         "relationships": [
             {
                 "cats_from": ["some_clan", "high_social"],
@@ -2246,7 +2283,7 @@
                 ],
                 "mutual": false,
                 "values": [
-	        "trust"
+                    "trust"
                 ],
                 "amount": -10,
                 "log": {
@@ -2254,46 +2291,46 @@
                 }
             }
         ],
-  "other_clan": {
-    "current_rep": [
-      "any"
-    ],
-    "changed": 0
-  }
-},
-{
-  "event_id": "gen_new_cat_otherclanexile3_unknown",
-  "location": [
-    "any"
-  ],
-  "season": [
-    "any"
-  ],
-  "tags": [],
-  "exclude_involved": [
-    "m_c"
-  ],
-  "frequency": 1,
-  "event_text": "At the Gathering, o_c_n's leader announces their medicine cat has been exiled for a terrible transgression. They warn the other Clans that the exiled cat is not to be trusted and should be killed on sight.",
-  "m_c": {
-    "age": [
-      "adolescent",
-      "young adult",
-      "adult",
-      "senior adult",
-      "senior"
-    ]
-  },
-  "new_cat": [
-    [
-      "former clancat",
-      "status:medicine cat",
-      "meeting",
-      "unknown",
-      "backstory:disgraced2, disgraced3",
-      "new_name"
-    ]
-  ],
+        "other_clan": {
+            "current_rep": [
+                "any"
+            ],
+            "changed": 0
+        }
+    },
+    {
+        "event_id": "gen_new_cat_otherclanexile3_unknown",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "tags": [],
+        "exclude_involved": [
+            "m_c"
+        ],
+        "frequency": 1,
+        "event_text": "At the Gathering, o_c_n's leader announces their medicine cat has been exiled for a terrible transgression. They warn the other Clans that the exiled cat is not to be trusted and should be killed on sight.",
+        "m_c": {
+            "age": [
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult",
+                "senior"
+            ]
+        },
+        "new_cat": [
+            [
+                "former clancat",
+                "status:medicine cat",
+                "meeting",
+                "unknown",
+                "backstory:disgraced2, disgraced3",
+                "new_name"
+            ]
+        ],
         "relationships": [
             {
                 "cats_from": ["some_clan", "high_social"],
@@ -2302,7 +2339,7 @@
                 ],
                 "mutual": false,
                 "values": [
-	        "trust", "comfort"
+                    "trust", "comfort"
                 ],
                 "amount": -10,
                 "log": {
@@ -2310,46 +2347,46 @@
                 }
             }
         ],
-  "other_clan": {
-    "current_rep": [
-      "any"
-    ],
-    "changed": 0
-  }
-},
-{
-  "event_id": "gen_new_cat_otherclanexile4_unknown",
-  "location": [
-    "any"
-  ],
-  "season": [
-    "any"
-  ],
-  "tags": [],
-  "exclude_involved": [
-    "m_c"
-  ],
-  "frequency": 1,
-  "event_text": "At the Gathering, o_c_n's leader announces their deputy did something terrible and was exiled. They look mournful as they deliver the news and advise the others to watch their borders closely.",
-  "m_c": {
-    "age": [
-      "adolescent",
-      "young adult",
-      "adult",
-      "senior adult",
-      "senior"
-    ]
-  },
-  "new_cat": [
-    [
-      "former clancat",
-      "status:warrior",
-      "meeting",
-      "unknown",
-      "backstory:disgraced3",
-      "new_name"
-    ]
-  ],
+        "other_clan": {
+            "current_rep": [
+                "any"
+            ],
+            "changed": 0
+        }
+    },
+    {
+        "event_id": "gen_new_cat_otherclanexile4_unknown",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "tags": [],
+        "exclude_involved": [
+            "m_c"
+        ],
+        "frequency": 1,
+        "event_text": "At the Gathering, o_c_n's leader announces their deputy did something terrible and was exiled. They look mournful as they deliver the news and advise the others to watch their borders closely.",
+        "m_c": {
+            "age": [
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult",
+                "senior"
+            ]
+        },
+        "new_cat": [
+            [
+                "former clancat",
+                "status:warrior",
+                "meeting",
+                "unknown",
+                "backstory:disgraced3",
+                "new_name"
+            ]
+        ],
         "relationships": [
             {
                 "cats_from": ["some_clan", "high_social"],
@@ -2358,7 +2395,7 @@
                 ],
                 "mutual": false,
                 "values": [
-	        "trust"
+                    "trust"
                 ],
                 "amount": -10,
                 "log": {
@@ -2366,871 +2403,883 @@
                 }
             }
         ],
-  "other_clan": {
-    "current_rep": [
-      "any"
-    ],
-    "changed": 0
-  }},
+        "other_clan": {
+            "current_rep": [
+                "any"
+            ],
+            "changed": 0
+        }
+    },
     {
-    "event_id": "gen_new_cat_queenhelpabandon",
-    "location": ["any"],
-    "season": ["any"],
-    "tags": [],
-    "frequency": 1,
-    "event_text": "A loner named n_c:0 seeks m_c's help with kitting. The night after the birth, the Clan awakes to helpless mewls and the fading scent of the loner.",
-    "m_c": {
-        "status": ["medicine cat"]
-    },
-    "new_cat": [
-        ["age:has_kits",
-        "can_birth",
-        "meeting",
-        "exists",
-        "old_name",
-        "loner"
+        "event_id": "gen_new_cat_queenhelpabandon",
+        "location": ["any"],
+        "season": ["any"],
+        "tags": [],
+        "frequency": 1,
+        "event_text": "A loner named n_c:0 seeks m_c's help with kitting. The night after the birth, the Clan awakes to helpless mewls and the fading scent of the loner.",
+        "m_c": {
+            "status": ["medicine cat"]
+        },
+        "new_cat": [
+            [
+                "age:has_kits",
+                "can_birth",
+                "meeting",
+                "exists",
+                "old_name",
+                "loner"
+            ],
+            [
+                "parent:0",
+                "litter",
+                "age:newborn"
+            ]
         ],
-        [
-            "parent:0",
-            "litter",
-            "age:newborn"
-        ]
-    ],
-    "relationships": [
-        {
-            "cats_from": ["clan", "high_social", "high_aggress"],
-            "cats_to": ["n_c:0"],
-            "mutual": false,
-            "values": ["like", "respect"],
-            "amount": -15,
-            "log": {
-                "cats_from": "cat_from was disgusted that cat_to would abandon {PRONOUN/cat_to/poss} kits."
+        "relationships": [
+            {
+                "cats_from": ["clan", "high_social", "high_aggress"],
+                "cats_to": ["n_c:0"],
+                "mutual": false,
+                "values": ["like", "respect"],
+                "amount": -15,
+                "log": {
+                    "cats_from": "cat_from was disgusted that cat_to would abandon {PRONOUN/cat_to/poss} kits."
+                }
+            },
+            {
+                "cats_from": ["clan", "high_social", "low_aggress", "high_stable"],
+                "cats_to": ["n_c:0"],
+                "mutual": false,
+                "values": ["comfort"],
+                "amount": 10,
+                "log": {
+                    "cats_from": "cat_from felt sympathetic thinking about the terrible circumstances that must have convinced cat_to to give up {PRONOUN/cat_to/poss} kits."
+                }
+            },
+            {
+                "cats_from": ["n_c:1"],
+                "cats_to": ["m_c"],
+                "mutual": false,
+                "values": ["like", "trust"],
+                "amount": 15,
+                "log": {
+                    "cats_from": "cat_to helped care for cat_from after {PRONOUN/cat_from/poss} parent abandoned {PRONOUN/cat_from/object}."
+                }
+            },
+            {
+                "cats_from": ["n_c:1", "high_aggress"],
+                "cats_to": ["n_c:0"],
+                "mutual": false,
+                "values": ["like", "trust"],
+                "amount": -30,
+                "log": {
+                    "cats_from": "cat_from heard that cat_to abandoned {PRONOUN/cat_from/object} as a kit."
+                }
+            },
+            {
+                "cats_from": ["n_c:1", "low_aggress"],
+                "cats_to": ["n_c:0"],
+                "mutual": false,
+                "values": ["like", "trust"],
+                "amount": -15,
+                "log": {
+                    "cats_from": "cat_from heard that cat_to abandoned {PRONOUN/cat_from/object} as a kit, though {PRONOUN/cat_from/subject} believed there must have been a reason."
+                }
             }
-        },
-        {
-            "cats_from": ["clan", "high_social", "low_aggress", "high_stable"],
-            "cats_to": ["n_c:0"],
-            "mutual": false,
-            "values": ["comfort"],
-            "amount": 10,
-            "log": {
-                "cats_from": "cat_from felt sympathetic thinking about the terrible circumstances that must have convinced cat_to to give up {PRONOUN/cat_to/poss} kits."
-            }
-        },
-        {
-            "cats_from": ["n_c:1"],
-            "cats_to": ["m_c"],
-            "mutual": false,
-            "values": ["like", "trust"],
-            "amount": 15,
-            "log": {
-                "cats_from": "cat_to helped care for cat_from after {PRONOUN/cat_from/poss} parent abandoned {PRONOUN/cat_from/object}."
-            }
-        },
-        {
-            "cats_from": ["n_c:1", "high_aggress"],
-            "cats_to": ["n_c:0"],
-            "mutual": false,
-            "values": ["like", "trust"],
-            "amount": -30,
-            "log": {
-                "cats_from": "cat_from heard that cat_to abandoned {PRONOUN/cat_from/object} as a kit."
-            }
-        },
-        {
-            "cats_from": ["n_c:1", "low_aggress"],
-            "cats_to": ["n_c:0"],
-            "mutual": false,
-            "values": ["like", "trust"],
-            "amount": -15,
-            "log": {
-                "cats_from": "cat_from heard that cat_to abandoned {PRONOUN/cat_from/object} as a kit, though {PRONOUN/cat_from/subject} believed there must have been a reason."
-            }
+        ],
+        "outsider": {
+            "current_rep": ["neutral", "welcoming"],
+            "changed": -2
         }
-    ],
-    "outsider": {
-        "current_rep": ["neutral", "welcoming"],
-        "changed": -2
-    }
-},
-{
-    "event_id": "gen_new_cat_queenhelpdeath",
-    "location": ["any"],
-    "season": ["any"],
-    "tags": [],
-    "frequency": 1,
-    "event_text": "A loner named n_c:0 seeks m_c's help with kitting. As n_c:0 feared, the birth is hard, and even m_c's knowledge cannot save {PRONOUN/n_c:0/object}. The Clan is left with n_c:0's litter.",
-    "m_c": {
-        "status": ["medicine cat"]
     },
-    "new_cat": [
-        ["age:has_kits",
-        "can_birth",
-        "meeting",
-        "exists",
-        "old_name",
-        "loner",
-        "dead"
+    {
+        "event_id": "gen_new_cat_queenhelpdeath",
+        "location": ["any"],
+        "season": ["any"],
+        "tags": [],
+        "frequency": 1,
+        "event_text": "A loner named n_c:0 seeks m_c's help with kitting. As n_c:0 feared, the birth is hard, and even m_c's knowledge cannot save {PRONOUN/n_c:0/object}. The Clan is left with n_c:0's litter.",
+        "m_c": {
+            "status": ["medicine cat"]
+        },
+        "new_cat": [
+            [
+                "age:has_kits",
+                "can_birth",
+                "meeting",
+                "exists",
+                "old_name",
+                "loner",
+                "dead"
+            ],
+            [
+                "parent:0",
+                "litter",
+                "age:newborn"
+            ]
         ],
-        [
-            "parent:0",
-            "litter",
-            "age:newborn"
-        ]
-    ],
-    "relationships": [
-        {
-            "cats_from": ["n_c:1"],
-            "cats_to": ["m_c"],
-            "mutual": false,
-            "values": ["like", "trust"],
-            "amount": 15,
-            "log": {
-                "cats_from": "cat_to cared for cat_from after {PRONOUN/cat_from/poss} parent died giving birth to {PRONOUN/cat_from/object}."
+        "relationships": [
+            {
+                "cats_from": ["n_c:1"],
+                "cats_to": ["m_c"],
+                "mutual": false,
+                "values": ["like", "trust"],
+                "amount": 15,
+                "log": {
+                    "cats_from": "cat_to cared for cat_from after {PRONOUN/cat_from/poss} parent died giving birth to {PRONOUN/cat_from/object}."
+                }
             }
+        ],
+        "outsider": {
+            "current_rep": ["neutral", "welcoming"],
+            "changed": 0
         }
-    ],
-    "outsider": {
-        "current_rep": ["neutral", "welcoming"],
-        "changed": 0
-    }
-},
-{
-    "event_id": "gen_new_cat_queenhelpmurder",
-    "location": ["any"],
-    "season": ["any"],
-    "tags": [],
-    "frequency": 1,
-    "event_text": "A loner named n_c:0 seeks m_c's help with kitting. As n_c:0 feared, the birth is hard. m_c watches {PRONOUN/n_c:0/object} struggle and bleed out. The Clan could use more kits, after all.",
-    "m_c": {
-        "status": ["medicine cat"],
-        "trait": ["bloodthirsty", "cold", "cunning"]
     },
-    "new_cat": [
-        ["age:has_kits",
-        "can_birth",
-        "meeting",
-        "exists",
-        "old_name",
-        "loner",
-        "dead"
+    {
+        "event_id": "gen_new_cat_queenhelpmurder",
+        "location": ["any"],
+        "season": ["any"],
+        "tags": [],
+        "frequency": 1,
+        "event_text": "A loner named n_c:0 seeks m_c's help with kitting. As n_c:0 feared, the birth is hard. m_c watches {PRONOUN/n_c:0/object} struggle and bleed out. The Clan could use more kits, after all.",
+        "m_c": {
+            "status": ["medicine cat"],
+            "trait": ["bloodthirsty", "cold", "cunning"]
+        },
+        "new_cat": [
+            [
+                "age:has_kits",
+                "can_birth",
+                "meeting",
+                "exists",
+                "old_name",
+                "loner",
+                "dead"
+            ],
+            [
+                "parent:0",
+                "litter",
+                "age:newborn"
+            ]
         ],
-        [
-            "parent:0",
-            "litter",
-            "age:newborn"
-        ]
-    ],
-    "relationships": [
-        {
-            "cats_from": ["n_c:1"],
-            "cats_to": ["m_c"],
-            "mutual": false,
-            "values": ["like", "trust"],
-            "amount": 15,
-            "log": {
-                "cats_from": "cat_to cared for cat_from after {PRONOUN/cat_from/poss} parent died giving birth to {PRONOUN/cat_from/object}."
+        "relationships": [
+            {
+                "cats_from": ["n_c:1"],
+                "cats_to": ["m_c"],
+                "mutual": false,
+                "values": ["like", "trust"],
+                "amount": 15,
+                "log": {
+                    "cats_from": "cat_to cared for cat_from after {PRONOUN/cat_from/poss} parent died giving birth to {PRONOUN/cat_from/object}."
+                }
             }
+        ],
+        "outsider": {
+            "current_rep": ["any"],
+            "changed": -3
         }
-    ],
-    "outsider": {
-        "current_rep": ["any"],
-        "changed": -3
-    }
-},
-{
-    "event_id": "gen_new_cat_queenhelpadopt",
-    "location": ["any"],
-    "season": ["any"],
-    "tags": [],
-    "frequency": 1,
-    "event_text": "A loner named n_c:0 seeks m_c's help with kitting. After the birth, n_c:0 admits {PRONOUN/n_c:0/subject} cannot care for them. r_c steps up to take them as {PRONOUN/r_c/poss} own.",
-    "m_c": {
-        "status": ["medicine cat"]
     },
-    "r_c": {
-        "age": ["young adult", "adult", "senior adult"]
-    },
-    "new_cat": [
-        ["age:has_kits",
-        "can_birth",
-        "meeting",
-        "exists",
-        "old_name",
-        "loner"
+    {
+        "event_id": "gen_new_cat_queenhelpadopt",
+        "location": ["any"],
+        "season": ["any"],
+        "tags": [],
+        "frequency": 1,
+        "event_text": "A loner named n_c:0 seeks m_c's help with kitting. After the birth, n_c:0 admits {PRONOUN/n_c:0/subject} cannot care for them. r_c steps up to take them as {PRONOUN/r_c/poss} own.",
+        "m_c": {
+            "status": ["medicine cat"]
+        },
+        "r_c": {
+            "age": ["young adult", "adult", "senior adult"]
+        },
+        "new_cat": [
+            [
+                "age:has_kits",
+                "can_birth",
+                "meeting",
+                "exists",
+                "old_name",
+                "loner"
+            ],
+            [
+                "parent:0",
+                "adoptive:r_c",
+                "litter",
+                "age:newborn"
+            ]
         ],
-        [
-            "parent:0",
-            "adoptive:r_c",
-            "litter",
-            "age:newborn"
-        ]
-    ],
-    "relationships": [
-        {
-            "cats_from": ["n_c:1"],
-            "cats_to": ["m_c"],
-            "mutual": false,
-            "values": ["respect", "trust"],
-            "amount": 15,
-            "log": {
-                "cats_from": "cat_from grew up hearing about how m_c helped {PRONOUN/cat_from/poss} biological parent give birth to {PRONOUN/cat_from/object}."
+        "relationships": [
+            {
+                "cats_from": ["n_c:1"],
+                "cats_to": ["m_c"],
+                "mutual": false,
+                "values": ["respect", "trust"],
+                "amount": 15,
+                "log": {
+                    "cats_from": "cat_from grew up hearing about how m_c helped {PRONOUN/cat_from/poss} biological parent give birth to {PRONOUN/cat_from/object}."
+                }
+            },
+            {
+                "cats_from": ["n_c:1", "high_aggress"],
+                "cats_to": ["n_c:0"],
+                "mutual": false,
+                "values": ["like", "trust"],
+                "amount": -30,
+                "log": {
+                    "cats_from": "cat_from heard that cat_to abandoned {PRONOUN/cat_from/object} as a kit."
+                }
+            },
+            {
+                "cats_from": ["n_c:1", "low_aggress"],
+                "cats_to": ["n_c:0"],
+                "mutual": false,
+                "values": ["like", "trust"],
+                "amount": -15,
+                "log": {
+                    "cats_from": "cat_from heard that cat_to abandoned {PRONOUN/cat_from/object} as a kit, though {PRONOUN/cat_from/subject} believed there must have been a reason."
+                }
             }
-        },
-        {
-            "cats_from": ["n_c:1", "high_aggress"],
-            "cats_to": ["n_c:0"],
-            "mutual": false,
-            "values": ["like", "trust"],
-            "amount": -30,
-            "log": {
-                "cats_from": "cat_from heard that cat_to abandoned {PRONOUN/cat_from/object} as a kit."
-            }
-        },
-        {
-            "cats_from": ["n_c:1", "low_aggress"],
-            "cats_to": ["n_c:0"],
-            "mutual": false,
-            "values": ["like", "trust"],
-            "amount": -15,
-            "log": {
-                "cats_from": "cat_from heard that cat_to abandoned {PRONOUN/cat_from/object} as a kit, though {PRONOUN/cat_from/subject} believed there must have been a reason."
-            }
+        ],
+        "outsider": {
+            "current_rep": ["any"],
+            "changed": 1
         }
-    ],
-    "outsider": {
-        "current_rep": ["any"],
-        "changed": 1
-    }
-},
-{
-    "event_id": "gen_new_cat_queenhelpsteal",
-    "location": ["any"],
-    "season": ["any"],
-    "tags": [],
-    "frequency": 1,
-    "event_text": "A loner named n_c:0 seeks m_c's help with kitting. After the birth, r_c orders n_c:0 to leave camp. These kits belong to c_n, now.",
-    "m_c": {
-        "status": ["medicine cat"],
-        "trait": ["-bloodthirsty", "-cold", "-fierce"]
     },
-    "r_c": {
-        "status": ["leader"],
-        "trait": ["bloodthirsty", "fierce", "cold", "cunning", "shameless"]
-    },
-    "new_cat": [
-        ["age:has_kits",
-        "can_birth",
-        "meeting",
-        "exists",
-        "old_name",
-        "loner"
+    {
+        "event_id": "gen_new_cat_queenhelpsteal",
+        "location": ["any"],
+        "season": ["any"],
+        "tags": [],
+        "frequency": 1,
+        "event_text": "A loner named n_c:0 seeks m_c's help with kitting. After the birth, r_c orders n_c:0 to leave camp. These kits belong to c_n, now.",
+        "m_c": {
+            "status": ["medicine cat"],
+            "trait": ["-bloodthirsty", "-cold", "-fierce"]
+        },
+        "r_c": {
+            "status": ["leader"],
+            "trait": ["bloodthirsty", "fierce", "cold", "cunning", "shameless"]
+        },
+        "new_cat": [
+            [
+                "age:has_kits",
+                "can_birth",
+                "meeting",
+                "exists",
+                "old_name",
+                "loner"
+            ],
+            [
+                "parent:0",
+                "litter",
+                "age:newborn"
+            ]
         ],
-        [
-            "parent:0",
-            "litter",
-            "age:newborn"
-        ]
-    ],
-    "relationships": [
-        {
-            "cats_from": ["n_c:1"],
-            "cats_to": ["m_c"],
-            "mutual": false,
-            "values": ["respect", "trust"],
-            "amount": 15,
-            "log": {
-                "cats_from": "cat_from grew up hearing about how m_c helped {PRONOUN/cat_from/poss} biological parent give birth to {PRONOUN/cat_from/object}."
+        "relationships": [
+            {
+                "cats_from": ["n_c:1"],
+                "cats_to": ["m_c"],
+                "mutual": false,
+                "values": ["respect", "trust"],
+                "amount": 15,
+                "log": {
+                    "cats_from": "cat_from grew up hearing about how m_c helped {PRONOUN/cat_from/poss} biological parent give birth to {PRONOUN/cat_from/object}."
+                }
+            },
+            {
+                "cats_from": ["n_c:1", "high_aggress"],
+                "cats_to": ["n_c:0"],
+                "mutual": false,
+                "values": ["like", "trust"],
+                "amount": -30,
+                "log": {
+                    "cats_from": "cat_from heard that cat_to abandoned {PRONOUN/cat_from/object} as a kit."
+                }
+            },
+            {
+                "cats_from": ["n_c:1", "low_aggress"],
+                "cats_to": ["n_c:0"],
+                "mutual": false,
+                "values": ["like", "trust"],
+                "amount": -15,
+                "log": {
+                    "cats_from": "cat_from heard that cat_to abandoned {PRONOUN/cat_from/object} as a kit, though {PRONOUN/cat_from/subject} believed there must have been a reason."
+                }
+            },
+            {
+                "cats_from": ["n_c:0"],
+                "cats_to": ["r_c"],
+                "mutual": false,
+                "values": ["like", "trust", "comfort"],
+                "amount": -40,
+                "log": {
+                    "cats_from": "cat_to stole cat_from's kits from {PRONOUN/cat_from/object}, and cat_from will do anything to get them back."
+                }
+            },
+            {
+                "cats_from": ["m_c"],
+                "cats_to": ["r_c"],
+                "mutual": false,
+                "values": ["trust", "comfort"],
+                "amount": -20,
+                "log": {
+                    "cats_from": "cat_from aided a loner in giving birth and was horrified when cat_to forced the loner out of the camp and stole {PRONOUN/n_c:0/poss} kits."
+                }
             }
-        },
-        {
-            "cats_from": ["n_c:1", "high_aggress"],
-            "cats_to": ["n_c:0"],
-            "mutual": false,
-            "values": ["like", "trust"],
-            "amount": -30,
-            "log": {
-                "cats_from": "cat_from heard that cat_to abandoned {PRONOUN/cat_from/object} as a kit."
-            }
-        },
-        {
-            "cats_from": ["n_c:1", "low_aggress"],
-            "cats_to": ["n_c:0"],
-            "mutual": false,
-            "values": ["like", "trust"],
-            "amount": -15,
-            "log": {
-                "cats_from": "cat_from heard that cat_to abandoned {PRONOUN/cat_from/object} as a kit, though {PRONOUN/cat_from/subject} believed there must have been a reason."
-            }
-        },
-        {
-            "cats_from": ["n_c:0"],
-            "cats_to": ["r_c"],
-            "mutual": false,
-            "values": ["like", "trust", "comfort"],
-            "amount": -40,
-            "log": {
-                "cats_from": "cat_to stole cat_from's kits from {PRONOUN/cat_from/object}, and cat_from will do anything to get them back."
-            }
-        },
-        {
-            "cats_from": ["m_c"],
-            "cats_to": ["r_c"],
-            "mutual": false,
-            "values": ["trust", "comfort"],
-            "amount": -20,
-            "log": {
-                "cats_from": "cat_from aided a loner in giving birth and was horrified when cat_to forced the loner out of the camp and stole {PRONOUN/n_c:0/poss} kits."
-            }
+        ],
+        "outsider": {
+            "current_rep": ["any"],
+            "changed": -5
         }
-    ],
-    "outsider": {
-        "current_rep": ["any"],
-        "changed": -5
-    }
-},
-{
-    "event_id": "gen_new_cat_queenhelpstealdeath",
-    "location": ["any"],
-    "season": ["any"],
-    "tags": [],
-    "frequency": 1,
-    "event_text": "A loner named n_c:0 seeks m_c's help with kitting. After the birth, r_c orders n_c:0 to leave camp. These kits belong to c_n, now. n_c:0 fights with all the fury of a new parent, but {PRONOUN/n_c:0/subject}{VERB/n_c:0/'re/'s} weak from the birth. The body is buried far from camp, where the kits will never find it.",
-    "m_c": {
-        "status": ["medicine cat"]
     },
-    "r_c": {
-        "status": ["leader"],
-        "trait": ["bloodthirsty", "fierce", "cold", "cunning", "shameless"]
-    },
-    "new_cat": [
-        ["age:has_kits",
-        "can_birth",
-        "meeting",
-        "exists",
-        "old_name",
-        "loner",
-        "dead"
+    {
+        "event_id": "gen_new_cat_queenhelpstealdeath",
+        "location": ["any"],
+        "season": ["any"],
+        "tags": [],
+        "frequency": 1,
+        "event_text": "A loner named n_c:0 seeks m_c's help with kitting. After the birth, r_c orders n_c:0 to leave camp. These kits belong to c_n, now. n_c:0 fights with all the fury of a new parent, but {PRONOUN/n_c:0/subject}{VERB/n_c:0/'re/'s} weak from the birth. The body is buried far from camp, where the kits will never find it.",
+        "m_c": {
+            "status": ["medicine cat"]
+        },
+        "r_c": {
+            "status": ["leader"],
+            "trait": ["bloodthirsty", "fierce", "cold", "cunning", "shameless"]
+        },
+        "new_cat": [
+            [
+                "age:has_kits",
+                "can_birth",
+                "meeting",
+                "exists",
+                "old_name",
+                "loner",
+                "dead"
+            ],
+            [
+                "parent:0",
+                "litter",
+                "age:newborn"
+            ]
         ],
-        [
-            "parent:0",
-            "litter",
-            "age:newborn"
-        ]
-    ],
-    "injury": [
-        {
-            "cats": ["r_c"],
-            "injuries": ["battle_injury"]
+        "injury": [
+            {
+                "cats": ["r_c"],
+                "injuries": ["battle_injury"]
+            }
+        ],
+        "relationships": [
+            {
+                "cats_from": ["n_c:1"],
+                "cats_to": ["m_c"],
+                "mutual": false,
+                "values": ["respect", "trust"],
+                "amount": 15,
+                "log": {
+                    "cats_from": "cat_from grew up hearing about how m_c helped {PRONOUN/cat_from/poss} biological parent give birth to {PRONOUN/cat_from/object}."
+                }
+            },
+            {
+                "cats_from": ["n_c:1", "high_aggress"],
+                "cats_to": ["n_c:0"],
+                "mutual": false,
+                "values": ["like", "trust"],
+                "amount": -30,
+                "log": {
+                    "cats_from": "cat_from heard that cat_to abandoned {PRONOUN/cat_from/object} as a kit."
+                }
+            },
+            {
+                "cats_from": ["n_c:1", "low_aggress"],
+                "cats_to": ["n_c:0"],
+                "mutual": false,
+                "values": ["like", "trust"],
+                "amount": -15,
+                "log": {
+                    "cats_from": "cat_from heard that cat_to abandoned {PRONOUN/cat_from/object} as a kit, though {PRONOUN/cat_from/subject} believed there must have been a reason."
+                }
+            },
+            {
+                "cats_from": ["m_c"],
+                "cats_to": ["r_c"],
+                "mutual": false,
+                "values": ["trust", "comfort"],
+                "amount": -20,
+                "log": {
+                    "cats_from": "cat_from aided a loner in giving birth and was horrified when cat_to killed the loner and stole {PRONOUN/n_c:0/poss} kits."
+                }
+            },
+            {
+                "cats_from": ["clan", "high_social", "high_stable"],
+                "cats_to": ["r_c"],
+                "mutual": false,
+                "values": ["like", "comfort"],
+                "amount": -15,
+                "log": {
+                    "cats_from": "cat_from thought it was fox-hearted of cat_to to steal kits from a loner."
+                }
+            },
+            {
+                "cats_from": ["clan", "low_social", "low_stable", "high_aggress"],
+                "cats_to": ["r_c"],
+                "mutual": false,
+                "values": ["respect"],
+                "amount": 10,
+                "log": {
+                    "cats_from": "cat_from approved of cat_to strengthening c_n by taking kits from a loner."
+                }
+            }
+        ],
+        "outsider": {
+            "current_rep": ["any"],
+            "changed": -5
         }
-    ],
-    "relationships": [
-        {
-            "cats_from": ["n_c:1"],
-            "cats_to": ["m_c"],
-            "mutual": false,
-            "values": ["respect", "trust"],
-            "amount": 15,
-            "log": {
-                "cats_from": "cat_from grew up hearing about how m_c helped {PRONOUN/cat_from/poss} biological parent give birth to {PRONOUN/cat_from/object}."
-            }
+    },
+    {
+        "event_id": "gen_new_cat_queenhelppayment",
+        "location": ["any"],
+        "season": ["any"],
+        "tags": [],
+        "frequency": 1,
+        "event_text": "A loner named n_c:0 seeks m_c's help with kitting. After the birth, r_c insists n_c:0 leave a kit with c_n as payment. n_c:0 is in disbelief but is outnumbered, so {PRONOUN/n_c:0/subject} {VERB/n_c:0/surrender/surrenders} n_c:2 to the Clan.",
+        "m_c": {
+            "status": ["medicine cat"]
         },
-        {
-            "cats_from": ["n_c:1", "high_aggress"],
-            "cats_to": ["n_c:0"],
-            "mutual": false,
-            "values": ["like", "trust"],
-            "amount": -30,
-            "log": {
-                "cats_from": "cat_from heard that cat_to abandoned {PRONOUN/cat_from/object} as a kit."
-            }
+        "r_c": {
+            "status": ["leader"],
+            "trait": ["shameless", "arrogant", "bold", "cold", "ambitious", "cunning"]
         },
-        {
-            "cats_from": ["n_c:1", "low_aggress"],
-            "cats_to": ["n_c:0"],
-            "mutual": false,
-            "values": ["like", "trust"],
-            "amount": -15,
-            "log": {
-                "cats_from": "cat_from heard that cat_to abandoned {PRONOUN/cat_from/object} as a kit, though {PRONOUN/cat_from/subject} believed there must have been a reason."
+        "new_cat": [
+            [
+                "age:has_kits",
+                "can_birth",
+                "meeting",
+                "exists",
+                "old_name",
+                "loner"
+            ],
+            [
+                "parent:0",
+                "litter",
+                "age:newborn",
+                "meeting"
+            ],
+            [
+                "parent:0",
+                "age:newborn"
+            ]
+        ],
+        "relationships": [
+            {
+                "cats_from": ["n_c:0"],
+                "cats_to": ["m_c"],
+                "mutual": false,
+                "values": ["trust", "respect"],
+                "amount": 15,
+                "log": {
+                    "cats_from": "cat_from sought cat_to's help when {PRONOUN/cat_from/subject} {VERB/cat_from/were/was} giving birth."
+                }
+            },
+            {
+                "cats_from": ["n_c:1"],
+                "cats_to": ["m_c"],
+                "mutual": false,
+                "values": ["respect"],
+                "amount": 15,
+                "log": {
+                    "cats_from": "cat_from heard stories about how cat_to helped n_c:0 when {PRONOUN/n_c:0/subject} gave birth to cat_from."
+                }
+            },
+            {
+                "cats_from": ["n_c:0"],
+                "cats_to": ["r_c"],
+                "mutual": false,
+                "values": ["like", "trust"],
+                "amount": -15,
+                "log": {
+                    "cats_from": "cat_to stole one of cat_from's kits as \"payment\" for m_c's help during the kitting."
+                }
+            },
+            {
+                "cats_from": ["n_c:2"],
+                "cats_to": ["n_c:0"],
+                "mutual": false,
+                "values": ["like", "trust"],
+                "amount": -15,
+                "log": {
+                    "cats_from": "cat_from heard that cat_to abandoned {PRONOUN/cat_from/object} as a kit."
+                }
+            },
+            {
+                "cats_from": ["clan", "high_social", "low_aggress"],
+                "cats_to": ["r_c"],
+                "mutual": false,
+                "values": ["like", "trust"],
+                "amount": -15,
+                "log": {
+                    "cats_from": "cat_from thought it was cruel of cat_to to force a loner to surrender one of {PRONOUN/cat_to/poss} kits to c_n."
+                }
+            },
+            {
+                "cats_from": ["clan", "low_social", "high_aggress", "low_lawful"],
+                "cats_to": ["r_c"],
+                "mutual": false,
+                "values": ["like", "respect"],
+                "amount": 10,
+                "log": {
+                    "cats_from": "cat_from approved of cat_to strengthening c_n by keeping a loner's kit as payment for help with {PRONOUN/n_c:0/poss} kitting."
+                }
             }
-        },
-        {
-            "cats_from": ["m_c"],
-            "cats_to": ["r_c"],
-            "mutual": false,
-            "values": ["trust", "comfort"],
-            "amount": -20,
-            "log": {
-                "cats_from": "cat_from aided a loner in giving birth and was horrified when cat_to killed the loner and stole {PRONOUN/n_c:0/poss} kits."
-            }
-        },
-        {
-            "cats_from": ["clan", "high_social", "high_stable"],
-            "cats_to": ["r_c"],
-            "mutual": false,
-            "values": ["like", "comfort"],
-            "amount": -15,
-            "log": {
-                "cats_from": "cat_from thought it was fox-hearted of cat_to to steal kits from a loner."
-            }
-        },
-        {
-            "cats_from": ["clan", "low_social", "low_stable", "high_aggress"],
-            "cats_to": ["r_c"],
-            "mutual": false,
-            "values": ["respect"],
-            "amount": 10,
-            "log": {
-                "cats_from": "cat_from approved of cat_to strengthening c_n by taking kits from a loner."
-            }
+        ],
+        "outsider": {
+            "current_rep": ["any"],
+            "changed": -3
         }
-    ],
-    "outsider": {
-        "current_rep": ["any"],
-        "changed": -5
-    }
-},
-{
-    "event_id": "gen_new_cat_queenhelppayment",
-    "location": ["any"],
-    "season": ["any"],
-    "tags": [],
-    "frequency": 1,
-    "event_text": "A loner named n_c:0 seeks m_c's help with kitting. After the birth, r_c insists n_c:0 leave a kit with c_n as payment. n_c:0 is in disbelief but is outnumbered, so {PRONOUN/n_c:0/subject} {VERB/n_c:0/surrender/surrenders} n_c:2 to the Clan.",
-    "m_c": {
-        "status": ["medicine cat"]
     },
-    "r_c": {
-        "status": ["leader"],
-        "trait": ["shameless", "arrogant", "bold", "cold", "ambitious", "cunning"]
-    },
-    "new_cat": [
-        ["age:has_kits",
-        "can_birth",
-        "meeting",
-        "exists",
-        "old_name",
-        "loner"
+    {
+        "event_id": "gen_new_cat_queenhelpgaslight",
+        "location": ["any"],
+        "season": ["any"],
+        "tags": [],
+        "frequency": 1,
+        "event_text": "A loner named n_c:0 seeks m_c's help with kitting. After the birth, m_c breaks the news to n_c:0 that one kit was stillborn. Once n_c:0 has left the territory, m_c allows n_c:2 out of the medicine den to join {PRONOUN/n_c:2/poss} new Clan.",
+        "m_c": {
+            "status": ["medicine cat"],
+            "trait": ["shameless", "arrogant", "bold", "cold", "ambitious", "cunning"]
+        },
+        "new_cat": [
+            [
+                "age:has_kits",
+                "can_birth",
+                "meeting",
+                "exists",
+                "old_name",
+                "loner"
+            ],
+            [
+                "parent:0",
+                "litter",
+                "age:newborn",
+                "meeting"
+            ],
+            [
+                "parent:0",
+                "age:newborn"
+            ]
         ],
-        [
-            "parent:0",
-            "litter",
-            "age:newborn",
-            "meeting"
+        "relationships": [
+            {
+                "cats_from": ["n_c:0"],
+                "cats_to": ["m_c"],
+                "mutual": false,
+                "values": ["trust", "respect"],
+                "amount": 15,
+                "log": {
+                    "cats_from": "cat_from sought cat_to's help when {PRONOUN/cat_from/subject} {VERB/cat_from/were/was} giving birth."
+                }
+            },
+            {
+                "cats_from": ["n_c:1"],
+                "cats_to": ["m_c"],
+                "mutual": false,
+                "values": ["respect"],
+                "amount": 15,
+                "log": {
+                    "cats_from": "cat_from heard stories about how cat_to helped n_c:0 when {PRONOUN/n_c:0/subject} gave birth to cat_from."
+                }
+            },
+            {
+                "cats_from": ["n_c:2"],
+                "cats_to": ["n_c:0"],
+                "mutual": false,
+                "values": ["like", "trust"],
+                "amount": -15,
+                "log": {
+                    "cats_from": "cat_from heard that cat_to abandoned {PRONOUN/cat_from/object} as a kit."
+                }
+            },
+            {
+                "cats_from": ["clan", "high_aggress", "low_stable", "low_social"],
+                "cats_to": ["n_c:0"],
+                "mutual": false,
+                "values": ["like", "trust"],
+                "amount": -15,
+                "log": {
+                    "cats_from": "cat_from was disgusted that cat_to would abandon one of {PRONOUN/cat_to/poss} own kits."
+                }
+            },
+            {
+                "cats_from": ["clan", "low_aggress", "low_stable"],
+                "cats_to": ["n_c:0"],
+                "mutual": false,
+                "values": ["like", "trust"],
+                "amount": -5,
+                "log": {
+                    "cats_from": "cat_from didn't understand why cat_to would abandon one of {PRONOUN/cat_to/poss} own kits."
+                }
+            },
+            {
+                "cats_from": ["clan", "low_aggress", "high_stable", "high_social"],
+                "cats_to": ["m_c"],
+                "mutual": false,
+                "values": ["trust"],
+                "amount": -15,
+                "log": {
+                    "cats_from": "cat_from suspected cat_to wasn't being entirely honest about how n_c:2 was abandoned by {PRONOUN/n_c:2/poss} parent."
+                }
+            },
+            {
+                "cats_from": ["clan", "high_aggress", "low_stable", "high_social", "low_lawful"],
+                "cats_to": ["m_c"],
+                "mutual": false,
+                "values": ["respect"],
+                "amount": 10,
+                "log": {
+                    "cats_from": "cat_from concluded that cat_to's story about n_c:0 abandoning n_c:2 was an excuse to keep a kit and strengthen c_n. cat_from approved of cat_to's plan and told no one."
+                }
+            }
         ],
-        [
-            "parent:0",
-            "age:newborn"
-        ]
-    ],
-    "relationships": [
-        {
-            "cats_from": ["n_c:0"],
-            "cats_to": ["m_c"],
-            "mutual": false,
-            "values": ["trust", "respect"],
-            "amount": 15,
-            "log": {
-                "cats_from": "cat_from sought cat_to's help when {PRONOUN/cat_from/subject} {VERB/cat_from/were/was} giving birth."
-            }
-        },
-        {
-            "cats_from": ["n_c:1"],
-            "cats_to": ["m_c"],
-            "mutual": false,
-            "values": ["respect"],
-            "amount": 15,
-            "log": {
-                "cats_from": "cat_from heard stories about how cat_to helped n_c:0 when {PRONOUN/n_c:0/subject} gave birth to cat_from."
-            }
-        },
-        {
-            "cats_from": ["n_c:0"],
-            "cats_to": ["r_c"],
-            "mutual": false,
-            "values": ["like", "trust"],
-            "amount": -15,
-            "log": {
-                "cats_from": "cat_to stole one of cat_from's kits as \"payment\" for m_c's help during the kitting."
-            }
-        },
-        {
-            "cats_from": ["n_c:2"],
-            "cats_to": ["n_c:0"],
-            "mutual": false,
-            "values": ["like", "trust"],
-            "amount": -15,
-            "log": {
-                "cats_from": "cat_from heard that cat_to abandoned {PRONOUN/cat_from/object} as a kit."
-            }
-        },
-        {
-            "cats_from": ["clan", "high_social", "low_aggress"],
-            "cats_to": ["r_c"],
-            "mutual": false,
-            "values": ["like", "trust"],
-            "amount": -15,
-            "log": {
-                "cats_from": "cat_from thought it was cruel of cat_to to force a loner to surrender one of {PRONOUN/cat_to/poss} kits to c_n."
-            }
-        },
-        {
-            "cats_from": ["clan", "low_social", "high_aggress", "low_lawful"],
-            "cats_to": ["r_c"],
-            "mutual": false,
-            "values": ["like", "respect"],
-            "amount": 10,
-            "log": {
-                "cats_from": "cat_from approved of cat_to strengthening c_n by keeping a loner's kit as payment for help with {PRONOUN/n_c:0/poss} kitting."
-            }
+        "outsider": {
+            "current_rep": ["any"],
+            "changed": 2
         }
-    ],
-    "outsider": {
-        "current_rep": ["any"],
-        "changed": -3
-    }
-},
-{
-    "event_id": "gen_new_cat_queenhelpgaslight",
-    "location": ["any"],
-    "season": ["any"],
-    "tags": [],
-    "frequency": 1,
-    "event_text": "A loner named n_c:0 seeks m_c's help with kitting. After the birth, m_c breaks the news to n_c:0 that one kit was stillborn. Once n_c:0 has left the territory, m_c allows n_c:2 out of the medicine den to join {PRONOUN/n_c:2/poss} new Clan.",
-    "m_c": {
-        "status": ["medicine cat"],
-        "trait": ["shameless", "arrogant", "bold", "cold", "ambitious", "cunning"]
     },
-    "new_cat": [
-        ["age:has_kits",
-        "can_birth",
-        "meeting",
-        "exists",
-        "old_name",
-        "loner"
+    {
+        "event_id": "gen_new_cat_queenhelpgiantlitter",
+        "location": ["any"],
+        "season": ["any"],
+        "tags": [],
+        "frequency": 1,
+        "event_text": "A loner named n_c:0 seeks m_c's help with kitting. As n_c:0 feared, the birth is hard; {PRONOUN/n_c:0/subject} {VERB/n_c:0/have/has} an enormous litter and begs c_n to raise some of the kits. r_c agrees to adopt them.",
+        "m_c": {
+            "status": ["medicine cat"]
+        },
+        "r_c": {
+            "age": ["young adult", "adult", "senior adult"]
+        },
+        "new_cat": [
+            [
+                "age:has_kits",
+                "can_birth",
+                "meeting",
+                "exists",
+                "old_name",
+                "loner"
+            ],
+            [
+                "parent:0",
+                "litter",
+                "age:newborn",
+                "meeting",
+                "unknown"
+            ],
+            [
+                "parent:0",
+                "adoptive:r_c",
+                "litter",
+                "age:newborn"
+            ]
         ],
-        [
-            "parent:0",
-            "litter",
-            "age:newborn",
-            "meeting"
+        "relationships": [
+            {
+                "cats_from": ["n_c:0"],
+                "cats_to": ["m_c"],
+                "mutual": false,
+                "values": ["trust", "respect"],
+                "amount": 15,
+                "log": {
+                    "cats_from": "cat_from sought cat_to's help when {PRONOUN/cat_from/subject} {VERB/cat_from/were/was} giving birth."
+                }
+            },
+            {
+                "cats_from": ["n_c:1"],
+                "cats_to": ["m_c"],
+                "mutual": false,
+                "values": ["respect"],
+                "amount": 15,
+                "log": {
+                    "cats_from": "cat_from heard stories about how cat_to helped n_c:0 when {PRONOUN/n_c:0/subject} gave birth to cat_from."
+                }
+            },
+            {
+                "cats_from": ["n_c:2"],
+                "cats_to": ["n_c:0"],
+                "mutual": false,
+                "values": ["like", "trust"],
+                "amount": -15,
+                "log": {
+                    "cats_from": "cat_from heard that cat_to left {PRONOUN/cat_from/object} as a kit because {PRONOUN/cat_to/subject} could not care for so many kits."
+                }
+            }
         ],
-        [
-            "parent:0",
-            "age:newborn"
-        ]
-    ],
-    "relationships": [
-        {
-            "cats_from": ["n_c:0"],
-            "cats_to": ["m_c"],
-            "mutual": false,
-            "values": ["trust", "respect"],
-            "amount": 15,
-            "log": {
-                "cats_from": "cat_from sought cat_to's help when {PRONOUN/cat_from/subject} {VERB/cat_from/were/was} giving birth."
-            }
-        },
-        {
-            "cats_from": ["n_c:1"],
-            "cats_to": ["m_c"],
-            "mutual": false,
-            "values": ["respect"],
-            "amount": 15,
-            "log": {
-                "cats_from": "cat_from heard stories about how cat_to helped n_c:0 when {PRONOUN/n_c:0/subject} gave birth to cat_from."
-            }
-        },
-        {
-            "cats_from": ["n_c:2"],
-            "cats_to": ["n_c:0"],
-            "mutual": false,
-            "values": ["like", "trust"],
-            "amount": -15,
-            "log": {
-                "cats_from": "cat_from heard that cat_to abandoned {PRONOUN/cat_from/object} as a kit."
-            }
-        },
-        {
-            "cats_from": ["clan", "high_aggress", "low_stable", "low_social"],
-            "cats_to": ["n_c:0"],
-            "mutual": false,
-            "values": ["like", "trust"],
-            "amount": -15,
-            "log": {
-                "cats_from": "cat_from was disgusted that cat_to would abandon one of {PRONOUN/cat_to/poss} own kits."
-            }
-        },
-        {
-            "cats_from": ["clan", "low_aggress", "low_stable"],
-            "cats_to": ["n_c:0"],
-            "mutual": false,
-            "values": ["like", "trust"],
-            "amount": -5,
-            "log": {
-                "cats_from": "cat_from didn't understand why cat_to would abandon one of {PRONOUN/cat_to/poss} own kits."
-            }
-        },
-        {
-            "cats_from": ["clan", "low_aggress", "high_stable", "high_social"],
-            "cats_to": ["m_c"],
-            "mutual": false,
-            "values": ["trust"],
-            "amount": -15,
-            "log": {
-                "cats_from": "cat_from suspected cat_to wasn't being entirely honest about how n_c:2 was abandoned by {PRONOUN/n_c:2/poss} parent."
-            }
-        },
-        {
-            "cats_from": ["clan", "high_aggress", "low_stable", "high_social", "low_lawful"],
-            "cats_to": ["m_c"],
-            "mutual": false,
-            "values": ["respect"],
-            "amount": 10,
-            "log": {
-                "cats_from": "cat_from concluded that cat_to's story about n_c:0 abandoning n_c:2 was an excuse to keep a kit and strengthen c_n. cat_from approved of cat_to's plan and told no one."
-            }
+        "outsider": {
+            "current_rep": ["any"],
+            "changed": 2
         }
-    ],
-    "outsider": {
-        "current_rep": ["any"],
-        "changed": 2
-    }
-},
-{
-    "event_id": "gen_new_cat_queenhelpgiantlitter",
-    "location": ["any"],
-    "season": ["any"],
-    "tags": [],
-    "frequency": 1,
-    "event_text": "A loner named n_c:0 seeks m_c's help with kitting. As n_c:0 feared, the birth is hard; {PRONOUN/n_c:0/subject} {VERB/n_c:0/have/has} an enormous litter and begs c_n to raise some of the kits. r_c agrees to adopt them.",
-    "m_c": {
-        "status": ["medicine cat"]
     },
-    "r_c": {
-        "age": ["young adult", "adult", "senior adult"]
-    },
-    "new_cat": [
-        ["age:has_kits",
-        "can_birth",
-        "meeting",
-        "exists",
-        "old_name",
-        "loner"
-        ],
-        [
-            "parent:0",
-            "litter",
-            "age:newborn",
-            "meeting",
-            "unknown"
-        ],
-        [
-            "parent:0",
-            "adoptive:r_c",
-            "litter",
-            "age:newborn"
-        ]
-    ],
-    "relationships": [
-        {
-            "cats_from": ["n_c:0"],
-            "cats_to": ["m_c"],
-            "mutual": false,
-            "values": ["trust", "respect"],
-            "amount": 15,
-            "log": {
-                "cats_from": "cat_from sought cat_to's help when {PRONOUN/cat_from/subject} {VERB/cat_from/were/was} giving birth."
-            }
+    {
+        "event_id": "gen_new_cat_queenhelpchildsupport",
+        "location": ["any"],
+        "season": ["any"],
+        "tags": [],
+        "frequency": 1,
+        "event_text": "A loner named n_c:0 seeks m_c's help with kitting. As n_c:0 feared, the birth is hard, and m_c cannot save {PRONOUN/n_c:0/object}. r_c organizes a search party to track down any cat who knew n_c:0. c_n finds n_c:1, who agrees to raise the kits in n_c:0's memory.",
+        "m_c": {
+            "status": ["medicine cat"]
         },
-        {
-            "cats_from": ["n_c:1"],
-            "cats_to": ["m_c"],
-            "mutual": false,
-            "values": ["respect"],
-            "amount": 15,
-            "log": {
-                "cats_from": "cat_from heard stories about how cat_to helped n_c:0 when {PRONOUN/n_c:0/subject} gave birth to cat_from."
-            }
+        "r_c": {
+            "status": ["leader"]
         },
-        {
-            "cats_from": ["n_c:2"],
-            "cats_to": ["n_c:0"],
-            "mutual": false,
-            "values": ["like", "trust"],
-            "amount": -15,
-            "log": {
-                "cats_from": "cat_from heard that cat_to left {PRONOUN/cat_from/object} as a kit because {PRONOUN/cat_to/subject} could not care for so many kits."
+        "new_cat": [
+            [
+                "age:has_kits",
+                "can_birth",
+                "meeting",
+                "exists",
+                "old_name",
+                "loner",
+                "dead"
+            ],
+            [
+                "meeting",
+                "exists",
+                "loner",
+                "age:senior adult"
+            ],
+            [
+                "parent:0",
+                "adoptive:1",
+                "litter",
+                "age:newborn",
+                "meeting"
+            ]
+        ],
+        "relationships": [
+            {
+                "cats_from": ["n_c:2"],
+                "cats_to": ["m_c"],
+                "mutual": false,
+                "values": ["respect"],
+                "amount": 15,
+                "log": {
+                    "cats_from": "cat_from heard stories about how cat_to helped n_c:0 when {PRONOUN/n_c:0/subject} gave birth to cat_from."
+                }
+            },
+            {
+                "cats_from": ["n_c:1"],
+                "cats_to": ["r_c"],
+                "mutual": false,
+                "values": ["like", "trust"],
+                "amount": 15,
+                "log": {
+                    "cats_from": "cat_from appreciated that cat_to reached out to {PRONOUN/cat_from/object} after n_c:0 died in kitting."
+                }
+            },
+            {
+                "cats_from": ["clan", "high_social", "high_lawful"],
+                "cats_to": ["r_c"],
+                "mutual": false,
+                "values": ["respect"],
+                "amount": 15,
+                "log": {
+                    "cats_from": "cat_from approved of cat_to seeking out the living relatives of an outsider to raise {PRONOUN/n_c:0/poss} kits."
+                }
+            },
+            {
+                "cats_from": ["clan", "low_social", "high_lawful"],
+                "cats_to": ["r_c"],
+                "mutual": false,
+                "values": ["respect"],
+                "amount": -8,
+                "log": {
+                    "cats_from": "cat_from thought it was a waste of time for cat_to to track down the living relatives of a dead outsider to raise {PRONOUN/n_c:0/poss} kits."
+                }
+            },
+            {
+                "cats_from": ["clan", "low_social", "low_lawful", "high_aggress"],
+                "cats_to": ["r_c"],
+                "mutual": false,
+                "values": ["respect"],
+                "amount": -12,
+                "log": {
+                    "cats_from": "cat_from thought cat_to should have kept the kits of a dead outsider to strengthen c_n instead of leaving them to another outsider."
+                }
             }
+        ],
+        "outsider": {
+            "current_rep": ["any"],
+            "changed": 2
         }
-    ],
-    "outsider": {
-        "current_rep": ["any"],
-        "changed": 2
-    }
-},
-{
-    "event_id": "gen_new_cat_queenhelpchildsupport",
-    "location": ["any"],
-    "season": ["any"],
-    "tags": [],
-    "frequency": 1,
-    "event_text": "A loner named n_c:0 seeks m_c's help with kitting. As n_c:0 feared, the birth is hard, and m_c cannot save {PRONOUN/n_c:0/object}. r_c organizes a search party to track down any cat who knew n_c:0. c_n finds n_c:1, who agrees to raise the kits in n_c:0's memory.",
-    "m_c": {
-        "status": ["medicine cat"]
     },
-    "r_c": {
-        "status": ["leader"]
-    },
-    "new_cat": [
-        ["age:has_kits",
-        "can_birth",
-        "meeting",
-        "exists",
-        "old_name",
-        "loner",
-        "dead"
+    {
+        "event_id": "gen_new_cat_queenhelpimpliedhalfclan",
+        "location": ["any"],
+        "season": ["any"],
+        "tags": [],
+        "exclude_involved": ["r_c"],
+        "frequency": 1,
+        "event_text": "A loner named n_c:0 seeks m_c's help with kitting. After the birth, n_c:0 demands that c_n take in and raise the kits, insisting that they have Clan heritage.",
+        "m_c": {
+            "status": ["medicine cat"]
+        },
+        "r_c": {
+            "age": ["young adult", "adult", "senior adult"],
+            "trait": ["charismatic"],
+            "gender": ["male"]
+        },
+        "new_cat": [
+            [
+                "age:has_kits",
+                "can_birth",
+                "meeting",
+                "exists",
+                "old_name",
+                "loner"
+            ],
+            [
+                "parent:0",
+                "litter",
+                "age:newborn",
+                "backstory:outsider2"
+            ]
         ],
-        [
-            "meeting",
-            "exists",
-            "loner",
-            "age:senior adult"
+        "relationships": [
+            {
+                "cats_from": ["n_c:0"],
+                "cats_to": ["m_c"],
+                "mutual": false,
+                "values": ["respect"],
+                "amount": 15,
+                "log": {
+                    "cats_from": "cat_from appreciated cat_to's help during {PRONOUN/cat_from/poss} kitting."
+                }
+            },
+            {
+                "cats_from": ["n_c:1"],
+                "cats_to": ["m_c"],
+                "mutual": false,
+                "values": ["respect"],
+                "amount": 15,
+                "log": {
+                    "cats_from": "cat_from was cared for by cat_to after {PRONOUN/cat_from/poss} parent left {PRONOUN/cat_from/object} to the Clan."
+                }
+            },
+            {
+                "cats_from": ["some_clan", "high_social", "low_stable", "low_lawful"],
+                "cats_to": ["r_c"],
+                "mutual": false,
+                "values": ["trust"],
+                "amount": -15,
+                "log": {
+                    "cats_from": "After n_c:0 left {PRONOUN/n_c:0/poss} kits to the Clan and claimed they had Clan heritage, cat_from gossiped that cat_to might have been involved."
+                }
+            }
         ],
-        [
-            "parent:0",
-            "adoptive:1",
-            "litter",
-            "age:newborn",
-            "meeting"
-        ]
-    ],
-    "relationships": [
-        {
-            "cats_from": ["n_c:2"],
-            "cats_to": ["m_c"],
-            "mutual": false,
-            "values": ["respect"],
-            "amount": 15,
-            "log": {
-                "cats_from": "cat_from heard stories about how cat_to helped n_c:0 when {PRONOUN/n_c:0/subject} gave birth to cat_from."
-            }
-        },
-        {
-            "cats_from": ["n_c:1"],
-            "cats_to": ["r_c"],
-            "mutual": false,
-            "values": ["like", "trust"],
-            "amount": 15,
-            "log": {
-                "cats_from": "cat_from appreciated that cat_to reached out to {PRONOUN/cat_from/object} after n_c:0 died in kitting."
-            }
-        },
-        {
-            "cats_from": ["clan", "high_social", "high_lawful"],
-            "cats_to": ["r_c"],
-            "mutual": false,
-            "values": ["respect"],
-            "amount": 15,
-            "log": {
-                "cats_from": "cat_from approved of cat_to seeking out the living relatives of an outsider to raise {PRONOUN/n_c:0/poss} kits."
-            }
-        },
-        {
-            "cats_from": ["clan", "low_social", "high_lawful"],
-            "cats_to": ["r_c"],
-            "mutual": false,
-            "values": ["respect"],
-            "amount": -8,
-            "log": {
-                "cats_from": "cat_from thought it was a waste of time for cat_to to track down the living relatives of a dead outsider to raise {PRONOUN/n_c:0/poss} kits."
-            }
-        },
-        {
-            "cats_from": ["clan", "low_social", "low_lawful", "high_aggress"],
-            "cats_to": ["r_c"],
-            "mutual": false,
-            "values": ["respect"],
-            "amount": -12,
-            "log": {
-                "cats_from": "cat_from thought cat_to should have kept the kits of a dead outsider to strengthen c_n instead of leaving them to another outsider."
-            }
+        "outsider": {
+            "current_rep": ["any"],
+            "changed": 1
         }
-    ],
-    "outsider": {
-        "current_rep": ["any"],
-        "changed": 2
-    }
-},
-{
-    "event_id": "gen_new_cat_queenhelpimpliedhalfclan",
-    "location": ["any"],
-    "season": ["any"],
-    "tags": [],
-    "exclude_involved": ["r_c"],
-    "frequency": 1,
-    "event_text": "A loner named n_c:0 seeks m_c's help with kitting. After the birth, n_c:0 demands that c_n take in and raise the kits, insisting that they have Clan heritage.",
-    "m_c": {
-        "status": ["medicine cat"]
     },
-    "r_c": {
-        "age": ["young adult", "adult", "senior adult"],
-        "trait": ["charismatic"],
-        "gender": ["male"]
-    },
-    "new_cat": [
-        ["age:has_kits",
-        "can_birth",
-        "meeting",
-        "exists",
-        "old_name",
-        "loner"
-        ],
-        [
-            "parent:0",
-            "litter",
-            "age:newborn",
-            "backstory:outsider2"
-        ]
-    ],
-    "relationships": [
-        {
-            "cats_from": ["n_c:0"],
-            "cats_to": ["m_c"],
-            "mutual": false,
-            "values": ["respect"],
-            "amount": 15,
-            "log": {
-                "cats_from": "cat_from appreciated cat_to's help during {PRONOUN/cat_from/poss} kitting."
-            }
-        },
-        {
-            "cats_from": ["n_c:1"],
-            "cats_to": ["m_c"],
-            "mutual": false,
-            "values": ["respect"],
-            "amount": 15,
-            "log": {
-                "cats_from": "cat_from was cared for by cat_to after {PRONOUN/cat_from/poss} parent left {PRONOUN/cat_from/object} to the Clan."
-            }
-        },
-        {
-            "cats_from": ["some_clan", "high_social", "low_stable", "low_lawful"],
-            "cats_to": ["r_c"],
-            "mutual": false,
-            "values": ["trust"],
-            "amount": -15,
-            "log": {
-                "cats_from": "After n_c:0 left {PRONOUN/n_c:0/poss} kits to the Clan and claimed they had Clan heritage, cat_from gossiped that cat_to might have been involved."
-            }
-        }
-    ],
-    "outsider": {
-        "current_rep": ["any"],
-        "changed": 1
-    }
-},
     {
         "event_id": "gen_newcat_senior_longwayloner",
         "location": [
@@ -3298,24 +3347,24 @@
         }
     },
     {
-    "event_id": "gen_newcat_senior_kittypetdeadowner",
-    "location": ["any"],
-    "season": ["any"],
-    "sub_type": [],
-    "tags": [],
-    "frequency": 3,
-    "event_text": "m_c finds a lost, elderly kittypet whose owner is dead. {PRONOUN/n_c:0/subject/CAP} {VERB/n_c:0/are/is} looking for a new home and m_c meows that c_n would be willing to care for {PRONOUN/n_c:0/object}.",
-    "m_c": {
-        "status": ["leader", "deputy", "medicine cat"]
+        "event_id": "gen_newcat_senior_kittypetdeadowner",
+        "location": ["any"],
+        "season": ["any"],
+        "sub_type": [],
+        "tags": [],
+        "frequency": 3,
+        "event_text": "m_c finds a lost, elderly kittypet whose owner is dead. {PRONOUN/n_c:0/subject/CAP} {VERB/n_c:0/are/is} looking for a new home and m_c meows that c_n would be willing to care for {PRONOUN/n_c:0/object}.",
+        "m_c": {
+            "status": ["leader", "deputy", "medicine cat"]
+        },
+        "new_cat": [
+            ["kittypet", "age:senior", "old_name"]
+        ],
+        "outsider": {
+            "current_rep": ["welcoming"],
+            "changed": 1
+        }
     },
-      "new_cat": [
-        ["kittypet", "age:senior", "old_name"]
-    ],
-    "outsider": {
-        "current_rep": ["welcoming"],
-        "changed": 1
-    }
-},
     {
         "event_id": "gen_newcat_senior_loneliestloner",
         "location": [
@@ -3380,531 +3429,531 @@
         }
     },
     {
-    "event_id": "gen_newcat_senior_securityloner",
-    "location": ["any"],
-    "season": ["any"],
-    "sub_type": [],
-    "tags": [],
-    "frequency": 3,
-    "event_text": "An old loner asks to join c_n, seeking community and security in {PRONOUN/n_c:0/poss} golden years. When welcomed in, the loner decides to adopt a Clan-like name: n_c:0.",
-    "new_cat": [
-        ["loner", "age:senior", "new_name"]
-    ],
-    "outsider": {
-        "current_rep": ["neutral", "welcoming"],
-        "changed": 1
-    },
+        "event_id": "gen_newcat_senior_securityloner",
+        "location": ["any"],
+        "season": ["any"],
+        "sub_type": [],
+        "tags": [],
+        "frequency": 3,
+        "event_text": "An old loner asks to join c_n, seeking community and security in {PRONOUN/n_c:0/poss} golden years. When welcomed in, the loner decides to adopt a Clan-like name: n_c:0.",
+        "new_cat": [
+            ["loner", "age:senior", "new_name"]
+        ],
+        "outsider": {
+            "current_rep": ["neutral", "welcoming"],
+            "changed": 1
+        },
         "exclude_involved": ["m_c"]
     },
-        {
-    "event_id": "gen_newcat_senior_securityrogue",
-    "location": ["any"],
-    "season": ["any"],
-    "sub_type": [],
-    "tags": [],
-    "frequency": 3,
-    "event_text": "An old rogue asks to join c_n, seeking community and security in {PRONOUN/n_c:0/poss} golden years. When welcomed in, the rogue decides to adopt a Clan-like name: n_c:0.",
-    "new_cat": [
-        ["rogue", "age:senior", "new_name"]
-    ],
-    "outsider": {
-        "current_rep": ["neutral", "welcoming"],
-        "changed": 1
-    },
+    {
+        "event_id": "gen_newcat_senior_securityrogue",
+        "location": ["any"],
+        "season": ["any"],
+        "sub_type": [],
+        "tags": [],
+        "frequency": 3,
+        "event_text": "An old rogue asks to join c_n, seeking community and security in {PRONOUN/n_c:0/poss} golden years. When welcomed in, the rogue decides to adopt a Clan-like name: n_c:0.",
+        "new_cat": [
+            ["rogue", "age:senior", "new_name"]
+        ],
+        "outsider": {
+            "current_rep": ["neutral", "welcoming"],
+            "changed": 1
+        },
         "exclude_involved": ["m_c"]
     },
- {
-    "event_id": "gen_new_cat_rogueredemption_success1",
-    "location": [
-      "any"
-    ],
-    "season": [
-      "any"
-    ],
-    "sub_type": [],
-    "tags": [],
-    "frequency": 1,
-    "event_text": "m_c is called to the camp's entrance where n_c:0 waits, head ducked in respect. n_c:0 apologizes for any misdeeds, mischief, or hardship {PRONOUN/n_c:0/subject}{VERB/n_c:0/'ve/'s} caused c_n in the past and asks to join the Clan. m_c accepts.",
-    "m_c": {
-      "status": [
-        "leader"
-      ],
-      "trait": [
-        "-bloodthirsty",
-        "-cold",
-        "-strict",
-        "-vengeful"  
-      ],
-      "dies": false
+    {
+        "event_id": "gen_new_cat_rogueredemption_success1",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [],
+        "tags": [],
+        "frequency": 1,
+        "event_text": "m_c is called to the camp's entrance where n_c:0 waits, head ducked in respect. n_c:0 apologizes for any misdeeds, mischief, or hardship {PRONOUN/n_c:0/subject}{VERB/n_c:0/'ve/'s} caused c_n in the past and asks to join the Clan. m_c accepts.",
+        "m_c": {
+            "status": [
+                "leader"
+            ],
+            "trait": [
+                "-bloodthirsty",
+                "-cold",
+                "-strict",
+                "-vengeful"
+            ],
+            "dies": false
+        },
+        "new_cat": [
+            [
+                "rogue",
+                "age:senior adult",
+                "exists"
+            ]
+        ],
+        "outsider": {
+            "current_rep": [
+                "any"
+            ],
+            "changed": 1
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "clan",
+                    "high_social"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "mutual": false,
+                "values": [
+                    "respect"
+                ],
+                "amount": 10,
+                "log": {
+                    "cats_from": "cat_from was impressed that cat_to gave an old rogue a chance to join the clan."
+                }
+            },
+            {
+                "cats_from": [
+                    "n_c:0"
+                ],
+                "cats_to": [
+                    "m_c",
+                    "some_clan"
+                ],
+                "mutual": false,
+                "values": [
+                    "like",
+                    "comfort"
+                ],
+                "amount": 5,
+                "log": {
+                    "cats_from": "cat_from was grateful to be welcomed into c_n by cat_to."
+                }
+            }
+        ]
     },
-    "new_cat": [
-      [
-        "rogue",
-        "age:senior adult",
-        "exists"
-      ]
-    ],
-    "outsider": {
-      "current_rep": [
-        "any"
-      ],
-      "changed": 1
+    {
+        "event_id": "gen_new_cat_rogueredemption_success2",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [],
+        "tags": [],
+        "frequency": 1,
+        "event_text": "m_c is called to the camp's entrance where n_c:0 waits, head ducked in respect. n_c:0 apologizes for any misdeeds, mischief, or hardship {PRONOUN/n_c:0/subject}{VERB/n_c:0/'ve/'s} caused c_n in the past and asks to join the Clan. m_c accepts.",
+        "m_c": {
+            "status": [
+                "leader"
+            ],
+            "trait": [
+                "-bloodthirsty",
+                "-cold",
+                "-strict",
+                "-vengeful"
+            ],
+            "dies": false
+        },
+        "new_cat": [
+            [
+                "rogue",
+                "age:senior",
+                "exists"
+            ]
+        ],
+        "outsider": {
+            "current_rep": [
+                "any"
+            ],
+            "changed": 1
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "clan",
+                    "high_social"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "mutual": false,
+                "values": [
+                    "respect"
+                ],
+                "amount": 10,
+                "log": {
+                    "cats_from": "cat_from was impressed that cat_to gave an old rogue a chance to join the clan."
+                }
+            },
+            {
+                "cats_from": [
+                    "n_c:0"
+                ],
+                "cats_to": [
+                    "m_c",
+                    "some_clan"
+                ],
+                "mutual": false,
+                "values": [
+                    "like",
+                    "comfort"
+                ],
+                "amount": 5,
+                "log": {
+                    "cats_from": "cat_from was grateful to be welcomed into c_n by cat_to."
+                }
+            }
+        ]
     },
-    "relationships": [
-      {
-        "cats_from": [
-          "clan",
-          "high_social"
+    {
+        "event_id": "gen_new_cat_rogueredemption_deny1",
+        "location": [
+            "any"
         ],
-        "cats_to": [
-          "m_c"
+        "season": [
+            "any"
         ],
-        "mutual": false,
-        "values": [
-          "respect"
+        "sub_type": [],
+        "tags": [],
+        "frequency": 1,
+        "event_text": "m_c is called to the camp's entrance where n_c:0 waits, head ducked in respect. n_c:0 apologizes for any misdeeds, mischief, or hardship {PRONOUN/n_c:0/subject}{VERB/n_c:0/'ve/'s} caused c_n in the past and asks to join the Clan. m_c turns {PRONOUN/n_c:0/object} away.",
+        "m_c": {
+            "status": [
+                "leader"
+            ],
+            "trait": [
+                "-bloodthirsty"
+            ],
+            "dies": false
+        },
+        "new_cat": [
+            [
+                "rogue",
+                "age:senior adult",
+                "exists",
+                "old_name",
+                "meeting",
+                "unknown"
+            ]
         ],
-        "amount": 10,
-        "log": {
-          "cats_from": "cat_from was impressed that cat_to gave an old rogue a chance to join the clan."
-        }
-      },
-     {
-        "cats_from": [
-          "n_c:0"
-        ],
-        "cats_to": [
-          "m_c",
-            "some_clan"
-        ],
-        "mutual": false,
-        "values": [
-          "like",
-            "comfort"
-        ],
-        "amount": 5,
-        "log": {
-          "cats_from": "cat_from was grateful to be welcomed into c_n by cat_to."
-        }
-      }
-    ]
-  },
-  {
-    "event_id": "gen_new_cat_rogueredemption_success2",
-    "location": [
-      "any"
-    ],
-    "season": [
-      "any"
-    ],
-    "sub_type": [],
-    "tags": [],
-    "frequency": 1,
-    "event_text": "m_c is called to the camp's entrance where n_c:0 waits, head ducked in respect. n_c:0 apologizes for any misdeeds, mischief, or hardship {PRONOUN/n_c:0/subject}{VERB/n_c:0/'ve/'s} caused c_n in the past and asks to join the Clan. m_c accepts.",
-    "m_c": {
-      "status": [
-        "leader"
-      ],
-      "trait": [
-        "-bloodthirsty",
-        "-cold",
-        "-strict", 
-        "-vengeful"
-      ],
-      "dies": false
+        "outsider": {
+            "current_rep": [
+                "any"
+            ],
+            "changed": -1
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "clan",
+                    "high_social"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "mutual": false,
+                "values": [
+                    "respect"
+                ],
+                "amount": -5,
+                "log": {
+                    "cats_from": "cat_from thought cat_to should've given an old rogue a chance to join the clan."
+                }
+            },
+            {
+                "cats_from": [
+                    "n_c:0"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "mutual": false,
+                "values": [
+                    "like",
+                    "trust"
+                ],
+                "amount": -5,
+                "log": {
+                    "cats_from": "cat_from was disappointed that cat_to shunned {PRONOUN/cat_from/object}."
+                }
+            },
+            {
+                "cats_from": [
+                    "n_c:0",
+                    "high_aggress",
+                    "low_stable"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "mutual": false,
+                "values": [
+                    "like",
+                    "trust"
+                ],
+                "amount": -15,
+                "log": {
+                    "cats_from": "cat_from regretted ever offering c_n their forgiveness."
+                }
+            }
+        ]
     },
-    "new_cat": [
-      [
-        "rogue",
-        "age:senior",
-        "exists"
-      ]
-    ],
-    "outsider": {
-      "current_rep": [
-        "any"
-      ],
-      "changed": 1
+    {
+        "event_id": "gen_new_cat_rogueredemption_deny2",
+        "location": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "sub_type": [],
+        "tags": [],
+        "frequency": 1,
+        "event_text": "m_c is called to the camp's entrance where n_c:0 waits, head ducked in respect. n_c:0 apologizes for any misdeeds, mischief, or hardship {PRONOUN/n_c:0/subject}{VERB/n_c:0/'ve/'s} caused c_n in the past and asks to join the Clan. m_c turns {PRONOUN/n_c:0/object} away.",
+        "m_c": {
+            "status": [
+                "leader"
+            ],
+            "trait": [
+                "-bloodthirsty"
+            ],
+            "dies": false
+        },
+        "new_cat": [
+            [
+                "rogue",
+                "age:senior",
+                "exists",
+                "old_name",
+                "meeting",
+                "unknown"
+            ]
+        ],
+        "outsider": {
+            "current_rep": [
+                "any"
+            ],
+            "changed": -1
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "clan",
+                    "high_social"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "mutual": false,
+                "values": [
+                    "respect"
+                ],
+                "amount": -5,
+                "log": {
+                    "cats_from": "cat_from thought cat_from should've given an old rogue a chance to join the clan."
+                }
+            },
+            {
+                "cats_from": [
+                    "n_c:0"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "mutual": false,
+                "values": [
+                    "like",
+                    "trust"
+                ],
+                "amount": -5,
+                "log": {
+                    "cats_from": "cat_from was disappointed that cat_to shunned {PRONOUN/cat_from/object}."
+                }
+            },
+            {
+                "cats_from": [
+                    "n_c:0",
+                    "high_aggress",
+                    "low_stable"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "mutual": false,
+                "values": [
+                    "like",
+                    "trust"
+                ],
+                "amount": -15,
+                "log": {
+                    "cats_from": "cat_from regretted ever offering c_n their forgiveness."
+                }
+            }
+        ]
     },
-    "relationships": [
-      {
-        "cats_from": [
-          "clan",
-          "high_social"
+    {
+        "event_id": "gen_new_cat_rogueredemption_kill1",
+        "location": [
+            "any"
         ],
-        "cats_to": [
-          "m_c"
+        "season": [
+            "any"
         ],
-        "mutual": false,
-        "values": [
-          "respect"
+        "sub_type": [],
+        "tags": [],
+        "frequency": 1,
+        "event_text": "m_c is called to the camp's entrance where n_c:0 waits, head ducked in respect. n_c:0 apologizes for any misdeeds, mischief, or hardship {PRONOUN/n_c:0/subject}{VERB/n_c:0/'ve/'s} caused c_n in the past and asks to join the Clan. m_c ruthlessly uses the opportunity to slay the nuisance where {PRONOUN/n_c:0/subject} {VERB/n_c:0/stand/stands}.",
+        "m_c": {
+            "status": [
+                "leader"
+            ],
+            "trait": [
+                "bloodthirsty",
+                "vengeful"
+            ],
+            "dies": false
+        },
+        "new_cat": [
+            [
+                "rogue",
+                "age:senior adult",
+                "exists",
+                "dead",
+                "old_name"
+            ]
         ],
-        "amount": 10,
-        "log": {
-          "cats_from": "cat_from was impressed that cat_to gave an old rogue a chance to join the clan."
-        }
-      },
-      {
-        "cats_from": [
-          "n_c:0"
-        ],
-        "cats_to": [
-          "m_c",
-            "some_clan"
-        ],
-        "mutual": false,
-        "values": [
-          "like",
-            "comfort"
-        ],
-        "amount": 5,
-        "log": {
-          "cats_from": "cat_from was grateful to be welcomed into c_n by cat_to."
-        }
-      }
-    ]
-  },
-  {
-    "event_id": "gen_new_cat_rogueredemption_deny1",
-    "location": [
-      "any"
-    ],
-    "season": [
-      "any"
-    ],
-    "sub_type": [],
-    "tags": [],
-    "frequency": 1,
-    "event_text": "m_c is called to the camp's entrance where n_c:0 waits, head ducked in respect. n_c:0 apologizes for any misdeeds, mischief, or hardship {PRONOUN/n_c:0/subject}{VERB/n_c:0/'ve/'s} caused c_n in the past and asks to join the Clan. m_c turns {PRONOUN/n_c:0/object} away.",
-    "m_c": {
-      "status": [
-        "leader"
-      ],
-      "trait": [
-        "-bloodthirsty"
-      ],
-      "dies": false
+        "outsider": {
+            "current_rep": [
+                "any"
+            ],
+            "changed": -3
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "clan",
+                    "high_social",
+                    "low_aggress"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "mutual": false,
+                "values": [
+                    "like",
+                    "comfort",
+                    "trust"
+                ],
+                "amount": -15,
+                "log": {
+                    "cats_from": "cat_from was stunned to see cat_to ruthlessly kill an old rogue who sought c_n's forgiveness."
+                }
+            },
+            {
+                "cats_from": [
+                    "clan",
+                    "high_aggress",
+                    "low_lawful"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "mutual": false,
+                "values": [
+                    "trust",
+                    "respect"
+                ],
+                "amount": 10,
+                "log": {
+                    "cats_from": "cat_from approved of cat_to killing an old loner who once wronged c_n."
+                }
+            }
+        ]
     },
-    "new_cat": [
-      [
-        "rogue",
-        "age:senior adult",
-        "exists",
-         "old_name",
-          "meeting",
-          "unknown"
-      ]
-    ],
-    "outsider": {
-      "current_rep": [
-        "any"
-      ],
-      "changed": -1
-    },
-    "relationships": [
-      {
-        "cats_from": [
-          "clan",
-          "high_social"
+    {
+        "event_id": "gen_new_cat_rogueredemption_kill2",
+        "location": [
+            "any"
         ],
-        "cats_to": [
-          "m_c"
+        "season": [
+            "any"
         ],
-        "mutual": false,
-        "values": [
-          "respect"
+        "sub_type": [],
+        "tags": [],
+        "frequency": 1,
+        "event_text": "m_c is called to the camp's entrance where n_c:0 waits, head ducked in respect. n_c:0 apologizes for any misdeeds, mischief, or hardship {PRONOUN/n_c:0/subject}{VERB/n_c:0/'ve/'s} caused c_n in the past and asks to join the Clan. m_c ruthlessly uses the opportunity to slay the nuisance where {PRONOUN/n_c:0/subject} {VERB/n_c:0/stand/stands}.",
+        "m_c": {
+            "status": [
+                "leader"
+            ],
+            "trait": [
+                "bloodthirsty",
+                "vengeful"
+            ],
+            "dies": false
+        },
+        "new_cat": [
+            [
+                "rogue",
+                "age:senior",
+                "exists",
+                "dead",
+                "old_name"
+            ]
         ],
-        "amount": -5,
-        "log": {
-          "cats_from": "cat_from thought cat_to should've given an old rogue a chance to join the clan."
-        }
-      },
-                        {
-        "cats_from": [
-          "n_c:0"
-        ],
-        "cats_to": [
-          "m_c"
-        ],
-        "mutual": false,
-        "values": [
-          "like",
-          "trust"
-        ],
-        "amount": -5,
-        "log": {
-          "cats_from": "cat_from was disappointed that cat_to shunned {PRONOUN/cat_from/object}."
-        }
-      },
-        {
-        "cats_from": [
-          "n_c:0",
-            "high_aggress",
-            "low_stable"
-        ],
-        "cats_to": [
-          "m_c"
-        ],
-        "mutual": false,
-        "values": [
-          "like",
-          "trust"
-        ],
-        "amount": -15,
-        "log": {
-          "cats_from": "cat_from regretted ever offering c_n their forgiveness."
-        }
-      }
-    ]
-  },
-  {
-    "event_id": "gen_new_cat_rogueredemption_deny2",
-    "location": [
-      "any"
-    ],
-    "season": [
-      "any"
-    ],
-    "sub_type": [],
-    "tags": [],
-    "frequency": 1,
-    "event_text": "m_c is called to the camp's entrance where n_c:0 waits, head ducked in respect. n_c:0 apologizes for any misdeeds, mischief, or hardship {PRONOUN/n_c:0/subject}{VERB/n_c:0/'ve/'s} caused c_n in the past and asks to join the Clan. m_c turns {PRONOUN/n_c:0/object} away.",
-    "m_c": {
-      "status": [
-        "leader"
-      ],
-      "trait": [
-        "-bloodthirsty"
-      ],
-      "dies": false
-    },
-    "new_cat": [
-      [
-        "rogue",
-        "age:senior",
-        "exists",
-        "old_name",
-          "meeting",
-          "unknown"
-      ]
-    ],
-    "outsider": {
-      "current_rep": [
-        "any"
-      ],
-      "changed": -1
-    },
-    "relationships": [
-      {
-        "cats_from": [
-          "clan",
-          "high_social"
-        ],
-        "cats_to": [
-          "m_c"
-        ],
-        "mutual": false,
-        "values": [
-          "respect"
-        ],
-        "amount": -5,
-        "log": {
-          "cats_from": "cat_from thought cat_from should've given an old rogue a chance to join the clan."
-        }
-      },
-                {
-        "cats_from": [
-          "n_c:0"
-        ],
-        "cats_to": [
-          "m_c"
-        ],
-        "mutual": false,
-        "values": [
-          "like",
-          "trust"
-        ],
-        "amount": -5,
-        "log": {
-          "cats_from": "cat_from was disappointed that cat_to shunned {PRONOUN/cat_from/object}."
-        }
-      },
-        {
-        "cats_from": [
-          "n_c:0",
-            "high_aggress",
-            "low_stable"
-        ],
-        "cats_to": [
-          "m_c"
-        ],
-        "mutual": false,
-        "values": [
-          "like",
-          "trust"
-        ],
-        "amount": -15,
-        "log": {
-          "cats_from": "cat_from regretted ever offering c_n their forgiveness."
-        }
-      }
-    ]
-  },
-  {
-    "event_id": "gen_new_cat_rogueredemption_kill1",
-    "location": [
-      "any"
-    ],
-    "season": [
-      "any"
-    ],
-    "sub_type": [],
-    "tags": [],
-    "frequency": 1,
-    "event_text": "m_c is called to the camp's entrance where n_c:0 waits, head ducked in respect. n_c:0 apologizes for any misdeeds, mischief, or hardship {PRONOUN/n_c:0/subject}{VERB/n_c:0/'ve/'s} caused c_n in the past and asks to join the Clan. m_c ruthlessly uses the opportunity to slay the nuisance where {PRONOUN/n_c:0/subject} {VERB/n_c:0/stand/stands}.",
-    "m_c": {
-      "status": [
-        "leader"
-      ],
-      "trait": [
-        "bloodthirsty",
-          "vengeful"
-      ],
-      "dies": false
-    },
-    "new_cat": [
-      [
-        "rogue",
-        "age:senior adult",
-        "exists",
-        "dead",
-          "old_name"
-      ]
-    ],
-    "outsider": {
-      "current_rep": [
-        "any"
-      ],
-      "changed": -3
-    },
-    "relationships": [
-      {
-        "cats_from": [
-          "clan",
-          "high_social",
-          "low_aggress"
-        ],
-        "cats_to": [
-          "m_c"
-        ],
-        "mutual": false,
-        "values": [
-          "like",
-          "comfort",
-          "trust"
-        ],
-        "amount": -15,
-        "log": {
-          "cats_from": "cat_from was stunned to see cat_to ruthlessly kill an old rogue who sought c_n's forgiveness."
-        }
-      },
-      {
-        "cats_from": [
-          "clan",
-          "high_aggress",
-            "low_lawful"
-        ],
-        "cats_to": [
-          "m_c"
-        ],
-        "mutual": false,
-        "values": [
-          "trust",
-          "respect"
-        ],
-        "amount": 10,
-        "log": {
-          "cats_from": "cat_from approved of cat_to killing an old loner who once wronged c_n."
-        }
-      }
-    ]
-  },
-  {
-    "event_id": "gen_new_cat_rogueredemption_kill2",
-    "location": [
-      "any"
-    ],
-    "season": [
-      "any"
-    ],
-    "sub_type": [],
-    "tags": [],
-    "frequency": 1,
-    "event_text": "m_c is called to the camp's entrance where n_c:0 waits, head ducked in respect. n_c:0 apologizes for any misdeeds, mischief, or hardship {PRONOUN/n_c:0/subject}{VERB/n_c:0/'ve/'s} caused c_n in the past and asks to join the Clan. m_c ruthlessly uses the opportunity to slay the nuisance where {PRONOUN/n_c:0/subject} {VERB/n_c:0/stand/stands}.",
-    "m_c": {
-      "status": [
-        "leader"
-      ],
-      "trait": [
-        "bloodthirsty",
-          "vengeful"
-      ],
-      "dies": false
-    },
-    "new_cat": [
-      [
-        "rogue",
-        "age:senior",
-        "exists",
-        "dead",
-          "old_name"
-      ]
-    ],
-    "outsider": {
-      "current_rep": [
-        "any"
-      ],
-      "changed": -3
-    },
-    "relationships": [
-      {
-        "cats_from": [
-          "clan",
-          "high_social",
-          "low_aggress"
-        ],
-        "cats_to": [
-          "m_c"
-        ],
-        "mutual": false,
-        "values": [
-          "like",
-          "comfort",
-          "trust"
-        ],
-        "amount": -15,
-        "log": {
-          "cats_from": "cat_from was stunned to see cat_to ruthlessly kill an old rogue who sought c_n's forgiveness."
-        }
-      },
-      {
-        "cats_from": [
-          "clan",
-          "high_aggress",
-            "low_lawful"
-        ],
-        "cats_to": [
-          "m_c"
-        ],
-        "mutual": false,
-        "values": [
-          "like",
-          "respect"
-        ],
-        "amount": 10,
-        "log": {
-          "cats_from": "cat_from approved of cat_to killing an old rogue who once wronged c_n."
-        }
-      }
-    ]
-  }
+        "outsider": {
+            "current_rep": [
+                "any"
+            ],
+            "changed": -3
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "clan",
+                    "high_social",
+                    "low_aggress"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "mutual": false,
+                "values": [
+                    "like",
+                    "comfort",
+                    "trust"
+                ],
+                "amount": -15,
+                "log": {
+                    "cats_from": "cat_from was stunned to see cat_to ruthlessly kill an old rogue who sought c_n's forgiveness."
+                }
+            },
+            {
+                "cats_from": [
+                    "clan",
+                    "high_aggress",
+                    "low_lawful"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "mutual": false,
+                "values": [
+                    "like",
+                    "respect"
+                ],
+                "amount": 10,
+                "log": {
+                    "cats_from": "cat_from approved of cat_to killing an old rogue who once wronged c_n."
+                }
+            }
+        ]
+    }
 ]

--- a/resources/lang/en/events/new_cat/general.json
+++ b/resources/lang/en/events/new_cat/general.json
@@ -4034,7 +4034,7 @@
             "category": "terrain"
         },
         "frequency": 2,
-        "event_text": "m_c discovered an outsider stuck at the bottom of POI. {PRONOUN/m_c/subject/CAP} brought {PRONOUN/m_c/poss} clanmates to help rescue {PRONOUN/n_c:0/object} and took {PRONOUN/n_c:0object} back to camp for healing. Grateful, n_c:0 joins the Clan.",
+        "event_text": "m_c discovered an outsider stuck at the bottom of POI. {PRONOUN/m_c/subject/CAP} brought {PRONOUN/m_c/poss} clanmates to help rescue {PRONOUN/n_c:0/object} and took {PRONOUN/n_c:0/object} back to camp for healing. Grateful, n_c:0 joins the Clan.",
         "m_c": {
             "status": ["-kitten", "-newborn", "-elder"],
             "dies": false

--- a/resources/lang/en/events/new_cat/general.json
+++ b/resources/lang/en/events/new_cat/general.json
@@ -3984,7 +3984,7 @@
                 "values": ["like", "comfort"],
                 "amount": 8,
                 "log": {
-                    "cats_from": "cat_from was grateful cat_to found them in the darkness."
+                    "cats_from": "cat_from was grateful cat_to found {PRONOUN/cat_from/object} in the darkness."
                 }
             }
         ],
@@ -4017,7 +4017,7 @@
                 "values": ["like", "comfort"],
                 "amount": 8,
                 "log": {
-                    "cats_from": "cat_from was grateful cat_to introduced them to c_n."
+                    "cats_from": "cat_from was grateful cat_to introduced {PRONOUN/cat_from/object} to c_n."
                 }
             }
         ],

--- a/resources/lang/en/events/new_cat/general.json
+++ b/resources/lang/en/events/new_cat/general.json
@@ -3955,5 +3955,157 @@
                 }
             }
         ]
+    },
+    {
+        "event_id": "gen_newcat_poi_cave1",
+        "location": ["any"],
+        "season": ["any"],
+        "poi": {
+            "tags": ["cave"],
+            "category": "terrain"
+        },
+        "frequency": 3,
+        "event_text": "m_c followed a strange sound into POI and found a loner, disoriented in the darkness. m_c guided {PRONOUN/n_c:0/object} out of POI and back to the light. n_c:0 decided to join c_n.",
+        "m_c": {
+            "status": ["-kitten", "-newborn", "-elder"],
+            "dies": false
+        },
+        "new_cat": [
+            [
+                "loner",
+                "exists"
+            ]
+        ],
+        "relationships": [
+            {
+                "cats_from": ["n_c:0"],
+                "cats_to": ["m_c"],
+                "mutual": false,
+                "values": ["like", "comfort"],
+                "amount": 8,
+                "log": {
+                    "cats_from": "cat_from was grateful cat_to found them in the darkness."
+                }
+            }
+        ],
+        "outsider": {
+            "changed": 2
+        }
+    },
+    {
+        "event_id": "gen_newcat_poi_covered1",
+        "location": ["any"],
+        "season": ["any"],
+        "poi": {
+            "tags": ["covered"],
+            "category": "terrain"
+        },
+        "frequency": 3,
+        "event_text": "m_c found a strange cat sheltering by POI during a downpour and invites them to wait out the rain with c_n. After staying the night, the stranger decides to stay for good. n_c:0 joins the Clan.",
+        "m_c": {
+            "status": ["-kitten", "-newborn", "-elder"],
+            "dies": false
+        },
+        "new_cat": [
+            []
+        ],
+        "relationships": [
+            {
+                "cats_from": ["n_c:0"],
+                "cats_to": ["m_c"],
+                "mutual": false,
+                "values": ["like", "comfort"],
+                "amount": 8,
+                "log": {
+                    "cats_from": "cat_from was grateful cat_to introduced them to c_n."
+                }
+            }
+        ],
+        "outsider": {
+            "changed": 2
+        }
+    },
+    {
+        "event_id": "gen_newcat_poi_fallrisk1",
+        "location": ["any"],
+        "season": ["any"],
+        "poi": {
+            "tags": ["fall_risk"],
+            "category": "terrain"
+        },
+        "frequency": 2,
+        "event_text": "m_c discovered an outsider stuck at the bottom of POI. {PRONOUN/m_c/subject/CAP} brought {PRONOUN/m_c/poss} clanmates to help rescue {PRONOUN/n_c:0/object} and took {PRONOUN/n_c:0object} back to camp for healing. Grateful, n_c:0 joins the Clan.",
+        "m_c": {
+            "status": ["-kitten", "-newborn", "-elder"],
+            "dies": false
+        },
+        "new_cat": [
+            [
+                "exists"
+            ]
+        ],
+        "injury": [
+            {
+                "cats": ["n_c:0"],
+                "injuries": ["broken bone"]
+            }
+        ],
+        "history": [
+            {
+                "cats": ["n_c:0"],
+                "scar": "n_c:0 was scarred after breaking a bone.",
+                "death": "n_c:0 died from complications of a broken bone."
+            }
+        ],
+        "relationships": [
+            {
+                "cats_from": ["n_c:0"],
+                "cats_to": ["m_c", "some_clan"],
+                "mutual": false,
+                "values": ["like", "trust"],
+                "amount": 8,
+                "log": {
+                    "cats_from": "cat_from was grateful cat_to rescued {PRONOUN/m_c/object} after {PRONOUN/m_c/poss} fall."
+                }
+            }
+        ],
+        "outsider": {
+            "changed": 2
+        }
+    },
+    {
+        "event_id": "gen_newcat_poi_prey_encounterpoach",
+        "location": ["any"],
+        "season": ["any"],
+        "poi": {
+            "tags": ["prey"],
+            "category": "terrain"
+        },
+        "frequency": 4,
+        "event_text": "m_c caught a strange cat poaching prey by POI!",
+        "m_c": {
+            "status": ["-newborn", "-kitten", "-elder"]
+        },
+        "new_cat": [
+            [
+                "exists",
+                "meeting"
+            ]
+        ],
+        "relationships": [
+            {
+                "cats_from": ["m_c"],
+                "cats_to": ["n_c:0"],
+                "mutual": false,
+                "values": ["like", "respect"],
+                "amount": -4,
+                "log": {
+                    "cats_from": "cat_from caught cat_to poaching prey in c_n territory."
+                }
+            }
+        ],
+        "outsider": {
+            "changed": -2
+        }
     }
 ]


### PR DESCRIPTION
## About The Pull Request

- Adds new events for the following POI tags: ```CAVE```, ```COVERED```, ```FALL_RISK```, ```PREY```, and ```PREY:FLYING```.
- There are a total of 8 death events, 6 injury events, 4 new cat events, and 6 miscellaneous events added.
- Any other edits were automated formatting changes to affected files for ease of reading. The first commit was these formatting changes. It will likely be easier to review the added content itself by looking at the second commit.
- Note for screenshots below: events were generated in game with override config on for the ease of screenshots, however most are constrained to appear solely for terrain POIs.

## Why This Is Good For ClanGen
- More content to individualize POIs and the clans with them.
- By using tags it will be applicable to any future POIs created with those tags as well as existing ones.

## Proof of Testing
A selection of the additions:
<img width="521" height="130" alt="Screenshot 2026-09-06 at 1 08 20 PM" src="https://github.com/user-attachments/assets/96f00c11-7106-4f2d-b176-230d29428441" />
<img width="525" height="102" alt="Screenshot 2026-09-06 at 1 37 07 PM" src="https://github.com/user-attachments/assets/55a9ac49-023e-4243-a5e2-dcf8eeac4723" />
<img width="514" height="153" alt="Screenshot 2026-09-05 at 1 16 47 PM" src="https://github.com/user-attachments/assets/bcf4ba9c-5f0d-4b96-a8ae-fba419da378a" />
<img width="511" height="173" alt="Screenshot 2026-09-05 at 5 00 50 PM" src="https://github.com/user-attachments/assets/54908d5a-5c25-4561-9059-1cd8a48bce51" />
<img width="514" height="103" alt="Screenshot 2026-09-05 at 12 52 37 PM" src="https://github.com/user-attachments/assets/d53fd2bf-0806-459b-9112-feec9c2d3379" />
