### PR TITLE
[TESTING] Fix Patrol Unit Test and Linting

### DIFF
--- a/tests/test_patrols.py
+++ b/tests/test_patrols.py
@@ -691,8 +691,8 @@ class TestOutcomeExecution(unittest.TestCase):
         )
         total_herb_count = game.clan.herb_supply.total
 
-        self.patrol_class._add_patrol_cats([war1])
-        self.patrol_class._get_valid_patrol([])
+        set_up_patrol_class_w_event(self.patrol_class, [war1], [patrol])
+
         self.patrol_class._check_outcome_constraints(
             patrol.success_outcomes[0], "success"
         )


### PR DESCRIPTION
## About The Pull Request

Fixes linting issue and patrol test failure caused by two back-to-back edits the the patrol tests. `test_random_herb_supply_change` now uses `set_up_patrol_class_w_event`!

## Proof of Testing

Tests are passing! 
