### PR TITLE
[BUGFIX] Add Missing clan:leader tags to Warrior Ceremonies

### DIFF
--- a/resources/lang/en/events/ceremonies/warrior.json
+++ b/resources/lang/en/events/ceremonies/warrior.json
@@ -314,6 +314,9 @@
     },
     {
         "event_id": "warrior_both_parents0",
+        "tags": [
+            "clan:leader"
+        ],
         "involved_cats": {
             "m_c": {},
              "r_c0": {
@@ -372,6 +375,9 @@
     },
     {
         "event_id": "warrior_dead_both_parents0",
+        "tags": [
+            "clan:leader"
+        ],
         "involved_cats": {
             "m_c": {
                 "backstory": [
@@ -847,6 +853,9 @@
     },
     {
         "event_id": "warrior_compassionate0",
+        "tags": [
+            "clan:leader"
+        ],
         "involved_cats": {
             "m_c": {
                 "stat": {


### PR DESCRIPTION
## About The Pull Request

Adds some missing clan:leader tags to warrior ceremonies. Fixes a crash. 

