### PR TITLE
[ENHANCEMENT] Add poi to textpoolevent

### DIFF
--- a/docs/dev/writing/ceremonies/normal-ceremonies.md
+++ b/docs/dev/writing/ceremonies/normal-ceremonies.md
@@ -178,6 +178,12 @@ You can tag with a mix of "newleaf", "greenleaf", "leaf-fall", "leaf-bare", or r
 
 ***
 
+#### poi: Dict
+> Used to specify which POI (Point Of Interest) a Clan must have access to in order for this event to trigger. [POI Constraint Tagging](../points-of-interest.md/#using-points-of-interest)
+
+
+***
+
 ### tags: list[str]
 Used to dictate some odds-and-ends about event constraints: [General Tags](../reference/tag-lists.md#general-tags).
 

--- a/docs/dev/writing/patrols/patrol_outcome.md
+++ b/docs/dev/writing/patrols/patrol_outcome.md
@@ -156,6 +156,12 @@ Used to dictate some odds-and-ends about event constraints: [General Tags](../re
 
 ***
 
+#### poi: Dict
+> Used to specify which POI (Point Of Interest) a Clan must have access to in order for this event to trigger. [POI Constraint Tagging](../points-of-interest.md/#using-points-of-interest)
+
+
+***
+
 #### frequency: int
 >Controls how common a patrol is. This works on a 1-4 scale. 
 

--- a/docs/dev/writing/patrols/patrol_outcome.md
+++ b/docs/dev/writing/patrols/patrol_outcome.md
@@ -159,6 +159,10 @@ Used to dictate some odds-and-ends about event constraints: [General Tags](../re
 #### poi: Dict
 > Used to specify which POI (Point Of Interest) a Clan must have access to in order for this event to trigger. [POI Constraint Tagging](../points-of-interest.md/#using-points-of-interest)
 
+!!! tip
+    If the top level of the patrol already has a POI constraint, then that POI will be used for all the outcomes as well. You cannot specify a second, different POI to use for an outcome.  
+
+    If you're looking to utilize the top level POI in the outcome, then no extra constraints are necessary on the outcome level. You can simply refer to the POI in the text and it will use the same POI as the top level.
 
 ***
 

--- a/docs/dev/writing/relationship-events.md
+++ b/docs/dev/writing/relationship-events.md
@@ -151,6 +151,12 @@ You can tag with a mix of "newleaf", "greenleaf", "leaf-fall", "leaf-bare", or r
 
 ***
 
+#### poi: Dict
+> Used to specify which POI (Point Of Interest) a Clan must have access to in order for this event to trigger. [POI Constraint Tagging](../points-of-interest.md/#using-points-of-interest)
+
+
+***
+
 ### tags: list[str]
 Used to dictate some odds-and-ends about event constraints: [General Tags](reference/tag-lists.md#general-tags).
 

--- a/docs/dev/writing/thoughts.md
+++ b/docs/dev/writing/thoughts.md
@@ -128,6 +128,12 @@ You can tag with a mix of "newleaf", "greenleaf", "leaf-fall", "leaf-bare", or r
 
 ***
 
+#### poi: Dict
+> Used to specify which POI (Point Of Interest) a Clan must have access to in order for this event to trigger. [POI Constraint Tagging](../points-of-interest.md/#using-points-of-interest)
+
+
+***
+
 ### tags: list[str]
 Used to dictate some odds-and-ends about thought constraints: [General Tags](reference/tag-lists.md#general-tags).
 

--- a/schemas/ceremony.schema.json
+++ b/schemas/ceremony.schema.json
@@ -401,6 +401,11 @@
           "title": "Tags",
           "type": "array"
         },
+        "poi": {
+          "$ref": "#/$defs/PointsOfInterestGroup",
+          "description": "The relevant points of interest. Points of Interest never affect outcome.",
+          "title": "Poi"
+        },
         "strings": {
           "description": "List of the text that will be displayed in-game as events.",
           "items": {
@@ -1513,6 +1518,82 @@
         "persistent headaches"
       ],
       "title": "PermCondition",
+      "type": "string"
+    },
+    "PointsOfInterestCategoryEnum": {
+      "enum": [
+        "gathering",
+        "moonplace",
+        "terrain"
+      ],
+      "title": "PointsOfInterestCategoryEnum",
+      "type": "string"
+    },
+    "PointsOfInterestGroup": {
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "description": "Points of Interest with these specific IDs will be allowed.",
+          "items": {
+            "type": "string"
+          },
+          "title": "Name",
+          "type": "array"
+        },
+        "tags": {
+          "description": "Points of Interest with these tags will be allowed.",
+          "items": {
+            "$ref": "#/$defs/PointsOfInterestTag"
+          },
+          "title": "Tags",
+          "type": "array"
+        },
+        "category": {
+          "$ref": "#/$defs/PointsOfInterestCategoryEnum",
+          "description": "The category this POI belongs to.",
+          "title": "Category"
+        }
+      },
+      "title": "PointsOfInterestGroup",
+      "type": "object"
+    },
+    "PointsOfInterestTag": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/PointsOfInterestTagEnum"
+        }
+      ],
+      "title": "PointsOfInterestTag"
+    },
+    "PointsOfInterestTagEnum": {
+      "enum": [
+        "cave",
+        "covered",
+        "fall_risk",
+        "hole",
+        "prey",
+        "prey:flying",
+        "prey:water",
+        "prey:ground",
+        "prey:eggs",
+        "prey:fish",
+        "rocks",
+        "tainted",
+        "trees",
+        "Twolegs",
+        "Twolegs:abandoned",
+        "Twolegs:present",
+        "unstable",
+        "water",
+        "water:still",
+        "water:flowing",
+        "water:ocean",
+        "nests"
+      ],
+      "title": "PointsOfInterestTagEnum",
       "type": "string"
     },
     "RelationshipChange": {

--- a/schemas/patrol.schema.json
+++ b/schemas/patrol.schema.json
@@ -1382,6 +1382,11 @@
           "title": "Tags",
           "type": "array"
         },
+        "poi": {
+          "$ref": "#/$defs/PointsOfInterestGroup",
+          "description": "The relevant points of interest. Points of Interest never affect outcome.",
+          "title": "Poi"
+        },
         "strings": {
           "description": "List of the text that will be displayed in-game as events.",
           "items": {

--- a/schemas/transition.schema.json
+++ b/schemas/transition.schema.json
@@ -1347,6 +1347,82 @@
       "title": "PermCondition",
       "type": "string"
     },
+    "PointsOfInterestCategoryEnum": {
+      "enum": [
+        "gathering",
+        "moonplace",
+        "terrain"
+      ],
+      "title": "PointsOfInterestCategoryEnum",
+      "type": "string"
+    },
+    "PointsOfInterestGroup": {
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "description": "Points of Interest with these specific IDs will be allowed.",
+          "items": {
+            "type": "string"
+          },
+          "title": "Name",
+          "type": "array"
+        },
+        "tags": {
+          "description": "Points of Interest with these tags will be allowed.",
+          "items": {
+            "$ref": "#/$defs/PointsOfInterestTag"
+          },
+          "title": "Tags",
+          "type": "array"
+        },
+        "category": {
+          "$ref": "#/$defs/PointsOfInterestCategoryEnum",
+          "description": "The category this POI belongs to.",
+          "title": "Category"
+        }
+      },
+      "title": "PointsOfInterestGroup",
+      "type": "object"
+    },
+    "PointsOfInterestTag": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/PointsOfInterestTagEnum"
+        }
+      ],
+      "title": "PointsOfInterestTag"
+    },
+    "PointsOfInterestTagEnum": {
+      "enum": [
+        "cave",
+        "covered",
+        "fall_risk",
+        "hole",
+        "prey",
+        "prey:flying",
+        "prey:water",
+        "prey:ground",
+        "prey:eggs",
+        "prey:fish",
+        "rocks",
+        "tainted",
+        "trees",
+        "Twolegs",
+        "Twolegs:abandoned",
+        "Twolegs:present",
+        "unstable",
+        "water",
+        "water:still",
+        "water:flowing",
+        "water:ocean",
+        "nests"
+      ],
+      "title": "PointsOfInterestTagEnum",
+      "type": "string"
+    },
     "RelationshipChange": {
       "additionalProperties": false,
       "properties": {
@@ -2018,6 +2094,11 @@
           },
           "title": "Tags",
           "type": "array"
+        },
+        "poi": {
+          "$ref": "#/$defs/PointsOfInterestGroup",
+          "description": "The relevant points of interest. Points of Interest never affect outcome.",
+          "title": "Poi"
         },
         "strings": {
           "description": "List of the text that will be displayed in-game as events.",

--- a/scripts/events_module/patrol/patrol.py
+++ b/scripts/events_module/patrol/patrol.py
@@ -612,6 +612,13 @@ class Patrol:
 
         chosen_outcome, success = self.calculate_success(success_outcome, fail_outcome)
 
+        if not self.chosen_poi and chosen_outcome.poi:
+            self.chosen_poi = get_poi_from_constraints(
+                chosen_outcome.poi.get("name"),
+                chosen_outcome.poi.get("tags"),
+                chosen_outcome.poi.get("category"),
+            )
+
         print(f"PATROL ID: {self.patrol_event.event_id} | SUCCESS: {success}")
         print(f"Success Outcome: {success_outcome} | Failure Outcome: {fail_outcome}")
         print(

--- a/scripts/events_module/patrol/patrol.py
+++ b/scripts/events_module/patrol/patrol.py
@@ -19,7 +19,6 @@ from scripts.events_module.consequences import gather_cat_objects
 from scripts.events_module.event_filters import (
     check_relationship_value,
     get_personality_compatibility,
-    event_for_poi,
 )
 from scripts.events_module.patrol.enums import PatrolChoice
 from scripts.events_module.patrol.generate_patrol_list import (
@@ -143,7 +142,7 @@ class Patrol:
 
     def proceed_patrol(
         self, path: PatrolChoice = PatrolChoice.PROCEED
-    ) -> Tuple[str, str, list, pygame.Surface | None]:
+    ) -> Tuple[str, str, dict, pygame.Surface | None]:
         """Proceed the patrol to the next step."""
 
         if path == PatrolChoice.DECLINE:
@@ -161,11 +160,11 @@ class Patrol:
                         chosen_poi=self.chosen_poi,
                     ),
                     "",
-                    [],
+                    {},
                     None,
                 )
             else:
-                return "Error - no event chosen", "", [], None
+                return "Error - no event chosen", "", {}, None
 
         return self.determine_outcome(antagonize=(path == PatrolChoice.ANTAGONIZE))
 
@@ -264,7 +263,7 @@ class Patrol:
     def _load_patrols_and_set_patrol(
         self,
         patrol_type: str,
-    ) -> PatrolEvent:
+    ):
         # ---------------------------------------------------------------------------- #
         #                                LOAD RESOURCES                                #
         # ---------------------------------------------------------------------------- #
@@ -386,17 +385,19 @@ class Patrol:
         patrol_type: str,
     ) -> PatrolEvent:
         # GET POSSIBLE PATROLS
-        # run the first set of really basic constraint filtering, just to get our base of valid patrols
+        # filter for type initially
         possible_patrols = [
             p
             for p in possible_patrols
-            if self._patrol_pass_basic_constraints(
+            if self._check_patrol_type(
                 p, patrol_type, is_debug_patrol=p.event_id == self.debug_patrol_id
             )
         ]
-        # make sure the hunting patrols are balanced
+        # make sure the hunting and herb patrols are balanced
         if patrol_type == "hunting" and not self.debug_patrol_id:
-            possible_patrols = self.balance_hunting(possible_patrols)
+            possible_patrols = self._balance_hunting(possible_patrols)
+        if patrol_type == "herb_gathering" and not self.debug_patrol_id:
+            possible_patrols = self._balance_herbs(possible_patrols)
 
         # separate into the two lists
         normal_patrols: list[PatrolEvent] = []
@@ -465,7 +466,6 @@ class Patrol:
                 possible_events=patrols_to_test,
                 other_clan=self.other_clan,
                 ensured_id=self.debug_patrol_id,
-                general_constraints_active=False,
             )
             if not chosen_patrol:
                 if not Patrol.used_patrols["romance" if find_romance else "normal"]:
@@ -491,46 +491,15 @@ class Patrol:
 
         return chosen_patrol
 
-    def _patrol_pass_basic_constraints(
-        self, patrol: PatrolEvent, patrol_type: str, is_debug_patrol: bool
+    @staticmethod
+    def _check_patrol_type(
+        patrol: PatrolEvent, patrol_type: str, is_debug_patrol: bool
     ) -> bool:
         # CHECK PATROL TYPE
         if patrol_type not in patrol.types:
             if is_debug_patrol:
                 print("DEBUG: requested patrol does not meet constraints (patrol type)")
             return False
-
-        # CHECK GENERAL
-        if not passes_general_constraints(
-            patrol,
-            self.involved_cats["p_l"],
-            self.involved_cats,
-            self.other_clan,
-            is_debug_patrol,
-        ):
-            return False
-
-        # CHECK POI
-        if not event_for_poi(patrol.poi):
-            if is_debug_patrol:
-                print("DEBUG: requested patrol does not meet constraints (PoI)")
-            return False
-
-        # CHECK NEEDED HERBS
-        if patrol_type == "herb_gathering":
-            # skip this if it's a debug patrol
-            if is_debug_patrol:
-                return True
-
-            target_herbs = game.clan.herb_supply.sorted_by_need
-
-            # if any herb can happen, then we return True
-            if "random_herbs" in patrol.herbs_given:
-                return True
-
-            # if the patrol is not able to give herbs we need, we return False
-            if not set(patrol.herbs_given).intersection(set(target_herbs)):
-                return False
 
         return True
 
@@ -635,7 +604,7 @@ class Patrol:
 
     def determine_outcome(
         self, antagonize=False
-    ) -> Tuple[str, str, list, pygame.Surface | None]:
+    ) -> Tuple[str, str, dict, pygame.Surface | None]:
         if self.patrol_event is None:
             raise Exception("No patrol event supplied")
 
@@ -720,7 +689,9 @@ class Patrol:
 
         return success_outcome if success else fail_outcome, success
 
-    def balance_hunting(self, possible_patrols: list[PatrolEvent]) -> list[PatrolEvent]:
+    def _balance_hunting(
+        self, possible_patrols: list[PatrolEvent]
+    ) -> list[PatrolEvent]:
         """
         Check which prey amount we want to allow this clan to get and filter the possible_patrols accordingly to ensure
         they only have patrols where that amount is possible.
@@ -781,6 +752,25 @@ class Patrol:
             return possible_patrols
 
         return filtered_patrols
+
+    @staticmethod
+    def _balance_herbs(possible_patrols: list[PatrolEvent]) -> list[PatrolEvent]:
+        """
+        Finds and returns patrols that add herbs the medicine cats are currently looking for
+        """
+        target_herbs = game.clan.herb_supply.sorted_by_need
+
+        allowed_patrols = []
+        for patrol in possible_patrols:
+            # if any herb can happen, then we return True
+            if "random_herbs" in patrol.herbs_given:
+                allowed_patrols.append(patrol)
+
+            # if the patrol is not able to give herbs we need, we return False
+            if set(patrol.herbs_given).intersection(set(target_herbs)):
+                allowed_patrols.append(patrol)
+
+        return allowed_patrols
 
     def get_patrol_art(self, outcome: TextPoolEvent = None) -> Optional[pygame.Surface]:
         """Return's patrol art surface"""

--- a/scripts/events_module/text_pool_event/check_general_constraints.py
+++ b/scripts/events_module/text_pool_event/check_general_constraints.py
@@ -11,6 +11,7 @@ from scripts.events_module.event_filters import (
     event_for_freshkill_supply,
     event_for_herb_supply,
     event_for_temperament,
+    event_for_poi,
 )
 from scripts.events_module.patrol.patrol_event import PatrolEvent
 from scripts.events_module.text_pool_event.text_pool_event import TextPoolEvent
@@ -50,6 +51,12 @@ def passes_general_constraints(
     if not event_for_tags(event.tags, primary_cat):
         if is_debug_event:
             print("DEBUG: requested event does not meet constraints (tags)")
+        return False
+
+    # CHECK POI
+    if not event_for_poi(event.poi):
+        if is_debug_event:
+            print("DEBUG: requested event does not meet constraints (PoI)")
         return False
 
     # CHECK TEMPERAMENT

--- a/scripts/events_module/text_pool_event/text_pool_event.py
+++ b/scripts/events_module/text_pool_event/text_pool_event.py
@@ -41,6 +41,7 @@ class TextPoolEvent:
     location: list[str] = field(default_factory=list)
     season: list[str] = field(default_factory=list)
     tags: list[str] = field(default_factory=list)
+    poi: Optional[dict[str, list]] = field(default_factory=dict)
     required_reputation: RequiredReputationDict = field(default_factory=dict)
     required_cat_types: dict[str, list[int]] = field(default_factory=dict)
     involved_cats: dict[str, Union[InvolvedCatDict, dict]] = field(default_factory=dict)
@@ -76,6 +77,16 @@ class TextPoolEvent:
             self.weight += 4 * (len(constants.SEASONS) - len(self.season))
         if self.tags:
             self.weight += len(self.tags) * 2
+
+        # add 8, 6, 4 or 2 if there are between 1-4 specific named locations
+        # todo: check for balancing
+        if self.poi.get("name") and not 1 > len(self.poi["name"]) > 5:
+            self.weight += 8 - 2 * len(self.poi["name"])
+        elif self.poi.get("tags"):
+            # add 4-1 depending on how many specific points of interest are included
+            # but only if specific ones are not already requested
+            self.weight += min(4, len(self.poi.get("tags", [])))
+
         self.weight += self.involved_cat_weight(self.involved_cats)
 
         if self.relationship_constraint:

--- a/scripts/models/text_pool_event/base_text_pool_event.py
+++ b/scripts/models/text_pool_event/base_text_pool_event.py
@@ -8,6 +8,7 @@ from pydantic_core import MISSING
 from scripts.models.common.future_event import FutureEvent
 from scripts.models.common.gather_cat import GatherCat
 from scripts.models.common.location import Location
+from scripts.models.common.points_of_interest import PointsOfInterestGroup
 from scripts.models.common.season import Season
 from scripts.models.common.tag import Tag
 from scripts.models.common.temperament import Temperament
@@ -40,6 +41,10 @@ class BaseTextPoolEvent(BaseModel):
     )
     tags: List[Tag] | MISSING = Field(
         MISSING, description="Used for some filtering purposes"
+    )
+    poi: PointsOfInterestGroup | MISSING = Field(
+        MISSING,
+        description="The relevant points of interest. Points of Interest never affect outcome.",
     )
     strings: List[str] = Field(
         ..., description="List of the text that will be displayed in-game as events."


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request
- Added POI filtering to the general constraints filter, allowing outcomes, thoughts, transition, and relationship events to use them
- Made some structural changes to `patrol.py` since it no longer needs to do special POI filtering on its own and can instead share the general filtering.  I broke up the old filter function that would handle this into a patrol type filter func and a `balance_herb` func to mirror the `balance_prey` func we already have.  Also fixed some miscellaneous typehinting problems.
- Schemas and docs were updated accordingly
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage senior developers from merging your PR! -->

## Why This Is Good For ClanGen
Necessary both for the ongoing short event reformat as well as just some valuable flexibility for patrols.
<!-- If this is a bug fix, you can remove this section. -->
<!-- Please add a short description of why you think these changes would benefit the game. -->
<!-- If this PR was the result of discussion/testing on the discord, please add a link to the discord conversation here. -->
<!-- If you have multiple features that can stand on their own, or unrelated bugfixes, please create separate PRs for them. -->

## Proof of Testing
<img width="426" height="389" alt="image" src="https://github.com/user-attachments/assets/8828fc6f-6cb3-4fe7-8a71-9b2b0710269f" />

top-level POI filter+retrieval still works

<img width="415" height="422" alt="image" src="https://github.com/user-attachments/assets/832f8ff4-8db8-4c3a-b38d-daad264c9019" />

Added POI constraints to an outcome and had no trouble filtering/retrieving it.
<!-- Include any screenshots, debugging steps, or links to beta testing threads here. At least one form of proof of testing is REQUIRED for all new content. You must be able to run the code locally before you PR it here. -->

## Changelog/Credits
- Added POI filtering to the general constraints filter, allowing outcomes, thoughts, transition, and relationship events to use them
- Made some structural changes to `patrol.py` since it no longer needs to do special POI filtering on its own and can instead share the general filtering.  I broke up the old filter function that would handle this into a patrol type filter func and a `balance_herb` func to mirror the `balance_prey` func we already have.  Also fixed some miscellaneous typehinting problems.
- Schemas and docs were updated accordingly
<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
