### PR TITLE
fix: remove duplicate freshkill on pln_hunt_greenleaf_heat1

### DIFF
--- a/resources/lang/en/patrols/plains/hunting/greenleaf.json
+++ b/resources/lang/en/patrols/plains/hunting/greenleaf.json
@@ -56,10 +56,6 @@
                 "supply": [
                     {
                         "type": "freshkill",
-                        "adjust": "increase_small"
-                    },
-                    {
-                        "type": "freshkill",
                         "adjust": "increase_medium"
                     }
                 ]
@@ -89,10 +85,6 @@
                     }
                 ],
                 "supply": [
-                    {
-                        "type": "freshkill",
-                        "adjust": "increase_small"
-                    },
                     {
                         "type": "freshkill",
                         "adjust": "increase_medium"

--- a/resources/lang/pl/patrols/plains/hunting/greenleaf.json
+++ b/resources/lang/pl/patrols/plains/hunting/greenleaf.json
@@ -56,10 +56,6 @@
                 "supply": [
                     {
                         "type": "freshkill",
-                        "adjust": "increase_small"
-                    },
-                    {
-                        "type": "freshkill",
                         "adjust": "increase_medium"
                     }
                 ]
@@ -89,10 +85,6 @@
                     }
                 ],
                 "supply": [
-                    {
-                        "type": "freshkill",
-                        "adjust": "increase_small"
-                    },
                     {
                         "type": "freshkill",
                         "adjust": "increase_medium"


### PR DESCRIPTION
## Summary
Both success outcomes on `pln_hunt_greenleaf_heat1` listed two `freshkill` supply entries (`increase_small` + `increase_medium`), so prey was applied twice (PREY ADDED ×2).

This keeps a single `increase_medium` on each success outcome in EN and PL patrol JSON.

## Test plan
- [ ] Trigger `pln_hunt_greenleaf_heat1` success once and confirm a single PREY ADDED line
- [ ] Spot-check other plains/greenleaf hunting patrols unchanged

Closes #5901.