### PR TITLE
[BUGFIX] Fix Patrol: gen_train_vision3

### DIFF
--- a/resources/lang/en/patrols/general/training.json
+++ b/resources/lang/en/patrols/general/training.json
@@ -5695,7 +5695,8 @@
             "r_c2": {
                 "status": [
                     "apprentice"
-                ]
+                ],
+                "has_mentor": {"current": true}
             }
         },
         "chance_of_success": 70,
@@ -5774,11 +5775,6 @@
                 "strings": [
                     "That's super weird, r_c1 tells {PRONOUN/r_c2/object}. Does r_c2's mentor know that {PRONOUN/r_c2/subject}{VERB/r_c2/'re/'s} so weird?"
                 ],
-                "involved_cats": {
-                    "r_c2": {
-                        "has_mentor": {"current": true}
-                    }
-                },
                 "exp_gained": 0,
                 "relationship_changes": [
                     {


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view CONTRIBUTING.md for a detailed description of the pull request process. -->
<!-- Be sure to name your PR something descriptive and succinct; include Bugfix: Feature: Enhancement: or Content: in the title to describe what type of PR it is. -->
<!-- IF YOU ARE DOING A BUGFIX: Please target the latest release branch if the bug that you are fixing is also present in the latest release. -->

## About The Pull Request

gen_train_vision3 would previously fail to find a failure outcome if r_c2 didn't have a mentor. This PR moved the requirement for r_c2 to have a mentor from the failure outcome to the overall patrol requirements. 

This will fix the current failure in the bulk timeskip test on dev. 

