### PR TITLE
[CONTENT] New Tints

### DIFF
--- a/sprites/dicts/tint.json
+++ b/sprites/dicts/tint.json
@@ -20,23 +20,24 @@
     "GOLDEN-BROWN": "brown",
     "DARKBROWN": "darkbrown",
     "CHOCOLATE": "darkbrown",
-    "RUST": "darkbrown"
+    "RUST": "rust"
   },
   "possible_tints": {
-    "basic": ["pink", "gray", "red", "orange", "warmdilute"],
-    "white": ["yellow", "pinkdilute", "earthydilute"],
-    "lightgrey": ["purple", "black", "dilute", "pinkdilute"],
-    "darkgrey": ["blue", "black", "dilute", "cooldilute", "pinkdilute", "earthydilute"],
-    "ghost": ["blue", "black", "dilute", "cooldilute"],
-    "black": ["blue", "black", "dilute", "cooldilute", "pinkdilute", "earthydilute"],
-    "cream": ["yellow", "purple", "dilute", "cooldilute", "earthydilute"],
-    "lightginger": ["yellow", "purple", "dilute", "cooldilute", "earthydilute"],
-    "darkginger": ["yellow", "purple", "dilute", "cooldilute"],
-    "sienna": ["yellow", "purple", "black", "dilute", "cooldilute", "pinkdilute", "earthydilute"],
-    "lightbrown": ["yellow", "purple", "black", "dilute", "cooldilute", "pinkdilute", "earthydilute"],
-    "lilac": ["yellow", "purple", "black", "dilute", "cooldilute", "earthydilute"],
-    "brown": ["yellow", "purple", "black", "dilute", "cooldilute", "pinkdilute", "earthydilute"],
-    "darkbrown": ["yellow", "purple", "black", "dilute", "cooldilute", "pinkdilute", "earthydilute"]
+    "basic": ["pink", "gray", "red", "orange", "warmdilute", "patina", "tawny"],
+    "white": ["yellow", "pinkdilute", "earthydilute", "gloaming", "quartz", "lilacdilute"],
+    "lightgrey": ["purple", "black", "dilute", "pinkdilute", "night", "gloaming", "quartz", "lilacdilute"],
+    "darkgrey": ["blue", "black", "dilute", "cooldilute", "pinkdilute", "earthydilute", "night", "gloaming", "quartz", "lilacdilute"],
+    "ghost": ["blue", "black", "dilute", "cooldilute", "night"],
+    "black": ["blue", "black", "dilute", "cooldilute", "pinkdilute", "earthydilute", "night", "gloaming", "quartz"],
+    "cream": ["yellow", "purple", "dilute", "cooldilute", "earthydilute", "quartz", "lilacdilute"],
+    "lightginger": ["yellow", "purple", "dilute", "cooldilute", "earthydilute", "quartz", "lilacdilute"],
+    "darkginger": ["yellow", "purple", "dilute", "cooldilute", "night", "gloaming", "quartz", "lilacdilute"],
+    "sienna": ["yellow", "purple", "black", "dilute", "cooldilute", "pinkdilute", "earthydilute", "night", "gloaming", "quartz", "lilacdilute"],
+    "lightbrown": ["yellow", "purple", "black", "dilute", "cooldilute", "pinkdilute", "earthydilute", "gloaming", "quartz", "lilacdilute"],
+    "lilac": ["yellow", "purple", "black", "dilute", "cooldilute", "earthydilute", "gloaming", "quartz"],
+    "brown": ["yellow", "purple", "black", "dilute", "cooldilute", "pinkdilute", "earthydilute", "night", "gloaming", "quartz"],
+    "darkbrown": ["yellow", "purple", "black", "dilute", "cooldilute", "pinkdilute", "earthydilute", "gloaming", "quartz"],
+    "rust": ["yellow", "purple", "black", "dilute", "cooldilute", "pinkdilute", "earthydilute", "gloaming", "quartz", "night"]
   },
   "tint_colours":
   {
@@ -48,6 +49,11 @@
     "yellow": [250, 248, 225],
     "purple": [235, 225, 244],
     "blue": [218, 237, 245],
+    "night": [129, 132, 138],
+    "gloaming": [197, 186, 207],
+    "patina": [209, 219, 208],
+    "quartz": [216, 185, 186],
+    "tawny": [216, 197, 185],
     "none": null
   },
   "dilute_tint_colours":
@@ -57,6 +63,7 @@
     "cooldilute": [7, 15, 25],
     "pinkdilute": [80, 50, 45],
     "earthydilute": [44, 33, 11],
+    "lilacdilute": [44, 33, 11],
     "none": null
   }
 }

--- a/sprites/dicts/tint.json
+++ b/sprites/dicts/tint.json
@@ -31,7 +31,7 @@
     "black": ["blue", "black", "dilute", "cooldilute", "pinkdilute", "earthydilute", "night", "gloaming", "quartz"],
     "cream": ["yellow", "purple", "dilute", "cooldilute", "earthydilute", "quartz", "lilacdilute"],
     "lightginger": ["yellow", "purple", "dilute", "cooldilute", "earthydilute", "quartz", "lilacdilute"],
-    "darkginger": ["yellow", "purple", "dilute", "cooldilute", "night", "gloaming", "quartz", "lilacdilute"],
+    "darkginger": ["yellow", "purple", "dilute", "cooldilute", "gloaming", "quartz", "lilacdilute"],
     "sienna": ["yellow", "purple", "black", "dilute", "cooldilute", "pinkdilute", "earthydilute", "night", "gloaming", "quartz", "lilacdilute"],
     "lightbrown": ["yellow", "purple", "black", "dilute", "cooldilute", "pinkdilute", "earthydilute", "gloaming", "quartz", "lilacdilute"],
     "lilac": ["yellow", "purple", "black", "dilute", "cooldilute", "earthydilute", "gloaming", "quartz"],


### PR DESCRIPTION
## About The Pull Request

- Adds six new tints: Gloaming, Tawny, Night, Patina, Quartz, and Lilac Dilute for certain pelts
- Makes rust its own tint category due to the unique nature of the pelt. 

## Why This Is Good For ClanGen
- More variety to cat appearance without entirely new pelt color recipes. 

## Proof of Testing
No Tint:
<img width="604" height="450" alt="No Tint" src="https://github.com/user-attachments/assets/231b04c5-6e0b-4688-aae5-46627a141d9a" />


New Tints and the pelts applicable:
<img width="604" height="450" alt="Gloaming_Tint" src="https://github.com/user-attachments/assets/2f2afb8b-541e-4dd7-9c87-dda2af62eba9" />
<img width="604" height="450" alt="Lilac Dilute Tint" src="https://github.com/user-attachments/assets/8fa37c73-a4bd-465d-82b1-65901ecb8a78" />
<img width="604" height="450" alt="Night_Tint New" src="https://github.com/user-attachments/assets/b30b81be-6f66-4272-9298-9ba4df83f969" />
<img width="604" height="450" alt="Patina Tint" src="https://github.com/user-attachments/assets/000fb45b-526a-4193-a544-61ed0fdb2aa3" />
<img width="604" height="450" alt="tawny_tint" src="https://github.com/user-attachments/assets/91c58f14-4030-4c79-a4e7-29c1649a4846" />
<img width="604" height="450" alt="quartz" src="https://github.com/user-attachments/assets/eb907df6-dd05-4b96-b4c7-6751e2a0aab7" />


## Changelog/Credits

<!-- Include any changes that should be made to the changelog of the game here or any changes to the credits file of the game. -->
<!-- This is just for easy access later for senior developers gathering this information; this process is not automated. -->
