### PR TITLE
[BUGFIX] nearly falling to one's death no longer spawns a third cat in the event.

### DIFF
--- a/resources/lang/en/events/injury/general.json
+++ b/resources/lang/en/events/injury/general.json
@@ -9800,9 +9800,6 @@
         "r_c": {
             "status": ["-newborn", "-kitten", "-elder"]
         },
-        "new_cat": [
-            []
-        ],
         "injury": [
             {
                 "cats": ["m_c"],


### PR DESCRIPTION
## About The Pull Request

- There was accidentally a new cat block in an injury event that did not mention a new cat.
## Proof of Testing
<img width="525" height="106" alt="Screenshot 2026-09-07 at 10 03 00 PM" src="https://github.com/user-attachments/assets/ab50c948-ee8f-4365-ace2-8873f132d412" />
Event no longer generates a third cat. 