### PR TITLE
[CONTENT] Apprentice Ceremonies For Special Relations and Non-Automatic Mentors

### DIFF
--- a/resources/lang/en/events/ceremonies/apprentice.json
+++ b/resources/lang/en/events/ceremonies/apprentice.json
@@ -92,7 +92,8 @@
             }
         },
         "strings": [
-            "Watching with pride as m_c is named and given to r_c0 to apprentice under, r_c1 {VERB/r_c1/know/knows} that {PRONOUN/r_c0/subject} {VERB/r_c0/were/was} a good choice.",            "(old_name) loudly complains as r_c1 pulls {PRONOUN/m_c/object} over to quickly groom {PRONOUN/m_c/poss} pelt. {PRONOUN/m_c/subject/CAP} {VERB/m_c/manage/manages} to wriggle away and scurry off to the front of the crowd for {PRONOUN/m_c/poss} ceremony, where {PRONOUN/m_c/subject} {VERB/m_c/are/is} renamed to m_c and apprenticed to r_c0. ",
+            "Watching with pride as m_c is named and given to r_c0 to apprentice under, r_c1 {VERB/r_c1/know/knows} that {PRONOUN/r_c0/subject} {VERB/r_c0/were/was} a good choice.",            
+            "(old_name) loudly complains as r_c1 pulls {PRONOUN/m_c/object} over to quickly groom {PRONOUN/m_c/poss} pelt. {PRONOUN/m_c/subject/CAP} {VERB/m_c/manage/manages} to wriggle away and scurry off to the front of the crowd for {PRONOUN/m_c/poss} ceremony, where {PRONOUN/m_c/subject} {VERB/m_c/are/is} renamed to m_c and apprenticed to r_c0. ",
             "Even though {PRONOUN/m_c/subject} {VERB/m_c/are/is} excited to finally be made an apprentice, it takes a bit of coaxing by r_c1 for (old_name) to step forward for {PRONOUN/m_c/poss} ceremony. r_c1 watches in pride as {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} named m_c and touches noses with r_c0."
 
         ],
@@ -112,6 +113,36 @@
             {
                 "cats_to": [
                     "r_c1"
+                ],
+                "cats_from": [
+                    "m_c"
+                ],
+                "mutual": false,
+                "constraints": [
+                    "child/parent"
+                ]
+            }
+        ]
+    },
+    {
+        "event_id": "app_living_parent_mentor_unmentioned0",
+        "involved_cats": {
+            "m_c": {},
+            "r_c0": {
+                "group": [
+                    "player_clan"
+                ]
+            }
+        },
+        "strings": [        
+            "(old_name) loudly complains as r_c0 pulls {PRONOUN/m_c/object} over to quickly groom {PRONOUN/m_c/poss} pelt. {PRONOUN/m_c/subject/CAP} {VERB/m_c/manage/manages} to wriggle away and scurry off to the front of the crowd for {PRONOUN/m_c/poss} ceremony, where {PRONOUN/m_c/subject} {VERB/m_c/are/is} renamed to m_c.",
+            "Even though {PRONOUN/m_c/subject} {VERB/m_c/are/is} excited to finally be made an apprentice, it takes a bit of coaxing by r_c0 for (old_name) to step forward for {PRONOUN/m_c/poss} ceremony. r_c0 watches in pride as {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} named m_c."
+
+        ],
+        "relationship_constraint": [
+            {
+                "cats_to": [
+                    "r_c0"
                 ],
                 "cats_from": [
                     "m_c"
@@ -171,6 +202,39 @@
         ]
     },
     {
+        "event_id": "app_dead_parent_mentor_unmentioned0",
+        "involved_cats": {
+            "m_c": {
+                "backstory": [
+                    "-orphaned_backstories"
+                ]
+            },
+            "r_c0": {
+                "group": [
+                    "afterlife"
+                ]
+            }
+        },
+        "strings": [
+            "m_c hopes that r_c0 is watching from StarClan with pride as {PRONOUN/m_c/subject} {VERB/m_c/are/is} apprenticed.",
+            "m_c smiles up at the stars as {PRONOUN/m_c/subject} {VERB/m_c/sit/sits} recieves {PRONOUN/m_c/poss} apprentice name. The stars seem to shine brighter in response: m_c knows it's a sign that r_c0 is still watching over {PRONOUN/m_c/object}."
+        ],
+        "relationship_constraint": [
+            {
+                "cats_to": [
+                    "r_c0"
+                ],
+                "cats_from": [
+                    "m_c"
+                ],
+                "mutual": false,
+                "constraints": [
+                    "child/parent"
+                ]
+            }
+        ]
+    },
+    {
         "event_id": "app_dead_parent1",
         "involved_cats": {
             "m_c": {
@@ -217,6 +281,39 @@
         ]
     },
     {
+        "event_id": "app_dead_parent_mentor_unmentioned1",
+        "involved_cats": {
+            "m_c": {
+                "backstory": [
+                    "clanborn"
+                ]
+            },
+            "r_c0": {
+                "group": [
+                    "afterlife"
+                ]
+            }
+        },
+        "strings": [
+            "m_c wishes that {PRONOUN/m_c/subject} could be happier about being made an apprentice, but all {PRONOUN/m_c/subject} can think about is how much {PRONOUN/m_c/subject} {VERB/m_c/wish/wishes} that r_c0 was still there to chant {PRONOUN/m_c/poss} name with the rest of the Clan.",
+            "m_c tries to keep up a brave face as {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} apprenticed, but {PRONOUN/m_c/subject} {VERB/m_c/keep/keeps} stealing glances at the crowd, as if trying to find r_c0 despite knowing {PRONOUN/r_c0/subject}{VERB/r_c0/'re/'s} no longer with {PRONOUN/m_c/object}."
+        ],
+        "relationship_constraint": [
+            {
+                "cats_to": [
+                    "r_c0"
+                ],
+                "cats_from": [
+                    "m_c"
+                ],
+                "mutual": false,
+                "constraints": [
+                    "child/parent"
+                ]
+            }
+        ]
+    },
+    {
         "event_id": "app_dead_both_parents0",
         "involved_cats": {
             "m_c": {
@@ -237,7 +334,7 @@
             }
         },
         "strings": [
-            "As m_c touches noses with {PRONOUN/m_c/poss} new mentor r_c0, {PRONOUN/m_c/subject} {VERB/m_c/make/makes} a silent promise to r_c1 to make {PRONOUN/r_c1/object} proud and to take care of the Clan in {PRONOUN/r_c1/poss} absence."
+            "As m_c touches noses with {PRONOUN/m_c/poss} new mentor r_c0, {PRONOUN/m_c/subject} {VERB/m_c/make/makes} a silent promise to r_c1 and r_c2 to make them proud and to take care of the Clan in their absence."
         ],
         "relationship_constraint": [
             {
@@ -252,6 +349,78 @@
                     "app/mentor"
                 ]
             },
+            {
+                "cats_to": [
+                    "r_c2",
+                    "r_c1"
+                ],
+                "cats_from": [
+                    "m_c"
+                ],
+                "mutual": false,
+                "constraints": [
+                    "child/parent"
+                ]
+            }
+        ]
+    },
+    {
+        "event_id": "app_dead_both_parents_mentor_unmentioned0",
+        "involved_cats": {
+            "m_c": {
+                "backstory": [
+                    "-orphaned_backstories"
+                ]
+            },
+            "r_c0": {
+                "group": [
+                    "afterlife"
+                ]
+            },
+            "r_c1": {
+                "group": [
+                    "afterlife"
+                ]
+            }
+        },
+        "strings": [
+            "As the clan chant's m_c's new name, {PRONOUN/m_c/subject} {VERB/m_c/make/makes} a silent promise to r_c0 and r_c1 to make them proud and to take care of the Clan in their absence."
+        ],
+        "relationship_constraint": [
+            {
+                "cats_to": [
+                    "r_c0",
+                    "r_c1"
+                ],
+                "cats_from": [
+                    "m_c"
+                ],
+                "mutual": false,
+                "constraints": [
+                    "child/parent"
+                ]
+            }
+        ]
+    },
+    {
+        "event_id": "app_living_both_parents0",
+        "involved_cats": {
+            "m_c": {},
+            "r_c1": {
+                "group": [
+                    "player_clan"
+                ]
+            },
+            "r_c2": {
+                "group": [
+                    "player_clan"
+                ]
+            }
+        },
+        "strings": [
+            "(old_name) runs up to the front of the crowd, eager to get {PRONOUN/m_c/poss} new name. When {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} called m_c for the first time, r_c1 and r_c2's voices can be heard the loudest as the Clan welcomes the new apprentice."
+        ],
+        "relationship_constraint": [
             {
                 "cats_to": [
                     "r_c2",

--- a/resources/lang/en/events/ceremonies/apprentice.json
+++ b/resources/lang/en/events/ceremonies/apprentice.json
@@ -1526,7 +1526,7 @@
         },
         "strings": [
             "r_c1 is delighted that m_c is apprenticed to r_c0. It will be great to see {PRONOUN/r_c1/poss} kits working so closely.",
-            "When m_c is apprenticed to r_c0, r_c1 mewls in delight. {PRONOUN/r_c1/poss} kits, training together! How wonderful!"
+            "When m_c is apprenticed to r_c0, r_c1 mewls in delight. {PRONOUN/r_c1/poss/CAP} kits, training together! How wonderful!"
         ],
         "relationship_constraint": [
             {

--- a/resources/lang/en/events/ceremonies/apprentice.json
+++ b/resources/lang/en/events/ceremonies/apprentice.json
@@ -33,6 +33,53 @@
             }
         ]
     },
+        {
+        "event_id": "app_no_mentors_available0",
+        "tags": ["-clan:warrior-like(min:1)"],
+        "involved_cats": {
+            "m_c": {
+                "has_mentor": {
+                    "current": false
+                }
+            }
+        },
+        "strings": [
+            "Newly-made apprentice m_c wishes {PRONOUN/m_c/subject} had someone to mentor {PRONOUN/m_c/object}.",
+            "m_c isn't confident in {PRONOUN/m_c/poss} ability to train {PRONOUN/m_c/self}, but will try anyway.",
+            "m_c is frustrated that {PRONOUN/m_c/subject} {VERB/m_c/don't/doesn't} have a mentor.",
+            "m_c isn't sure what to do without the guidance of a mentor.",
+            "m_c wonders if {PRONOUN/m_c/subject} can get by without the guidance of a mentor."
+        ]
+    },
+    {
+        "event_id": "app_no_leader0",
+        "tags": [
+            "-clan:leader"
+        ],
+        "involved_cats": {
+            "m_c": {},
+            "r_c0": {}
+        },
+        "strings": [
+            "The Clan gathers around and urges (old_name) to go to the front of the crowd. Not having a leader isn't an excuse to force a cat to stay in the nursery when they're six moons old. (old_name) is renamed m_c, and the Clan votes to make r_c0 {PRONOUN/m_c/poss} mentor.",
+            "The Clan cheers for the new apprentice, m_c. They allow {PRONOUN/m_c/object} to choose {PRONOUN/m_c/poss} own mentor: m_c chooses r_c0.",
+            "With m_c's apprentice ceremony completed, there's still the problem of figuring out who will mentor {PRONOUN/m_c/object}. r_c0 steps forward first, so m_c touches noses with {PRONOUN/r_c0/object}."
+        ],
+        "relationship_constraint": [
+            {
+                "cats_from": [
+                    "m_c"
+                ],
+                "cats_to": [
+                    "r_c0"
+                ],
+                "mutual": false,
+                "constraints": [
+                    "app/mentor"
+                ]
+            }
+        ]
+    },
     {
         "event_id": "app_living_parent0",
         "involved_cats": {

--- a/resources/lang/en/events/ceremonies/apprentice.json
+++ b/resources/lang/en/events/ceremonies/apprentice.json
@@ -1161,11 +1161,7 @@
             "clan:leader"
         ],
         "involved_cats": {
-            "m_c": {
-                "has_mentor": {
-                    "current": false
-                }
-            },
+            "m_c": {},
             "r_c0": {
                 "status": [
                     "warrior", 
@@ -1268,11 +1264,7 @@
             "clan:leader"
         ],
         "involved_cats": {
-            "m_c": {
-                "has_mentor": {
-                    "current": false
-                }
-            },
+            "m_c": {},
             "r_c0": {
                 "has_apprentice": {
                     "current": false,

--- a/resources/lang/en/events/ceremonies/apprentice.json
+++ b/resources/lang/en/events/ceremonies/apprentice.json
@@ -1450,7 +1450,7 @@
             }
         },
         "strings": [
-            "At m_c's apprentice ceremony, r_c0 watches lead_name with ambition. If r_c0 has any change of being deputy, {PRONOUN/r_c0/subject} {VERB/r_c0/need/needs} an apprentice, and m_c would be perfect."
+            "At m_c's apprentice ceremony, r_c0 watches lead_name with ambition. If r_c0 has any chance of becoming deputy, {PRONOUN/r_c0/subject} {VERB/r_c0/need/needs} an apprentice, and m_c would be perfect."
         ]
     },
     {

--- a/resources/lang/en/events/ceremonies/apprentice.json
+++ b/resources/lang/en/events/ceremonies/apprentice.json
@@ -1491,7 +1491,7 @@
             "r_c0": {}
         },
         "strings": [
-            "(old_name) is old enough to begin training, and is apprenticed to r_c0, {PRONOUN/m_c/poss} older sibling. (clan_leader) that m_c's kin will guide them into a fine warrior.",
+            "(old_name) is old enough to begin training, and is apprenticed to r_c0, {PRONOUN/m_c/poss} older sibling. lead_name knows m_c's kin will guide them into a fine warrior.",
             "m_c is apprenticed to {PRONOUN/m_c/poss} older sibling, r_c0. lead_name knows that there will be extra challenges involved with mentoring kin, but r_c0 is willing to take it on. "
         ],
         "relationship_constraint": [

--- a/resources/lang/en/events/ceremonies/apprentice.json
+++ b/resources/lang/en/events/ceremonies/apprentice.json
@@ -1439,7 +1439,6 @@
                     "trait": [
                         "ambitious",
                         "competitive",
-                        "bossy",
                         "confident",
                         "flamboyant",
                         "charismatic",

--- a/resources/lang/en/events/ceremonies/apprentice.json
+++ b/resources/lang/en/events/ceremonies/apprentice.json
@@ -1408,8 +1408,8 @@
             }
         },
         "strings": [
-            "r_c0 hopes {PRONOUN/r_c0/subject}'ll get to mentor the clan's newest apprentice, m_c. {PRONOUN/r_c0/subject/CAP}{VERB/r_c0/'ve/'s} been praying for an apprentice for moons now!",
-            "The clan cheers for their newest apprentice, m_c. r_c0 sits up extra straight; {PRONOUN/r_c0/subject} {VERB/r_c0/know/knows} m_c would be perfect for {PRONOUN/r_c0/poss} first apprentice."
+            "r_c0 hopes {PRONOUN/r_c0/subject}'ll get to mentor the Clan's newest apprentice, m_c. {PRONOUN/r_c0/subject/CAP}{VERB/r_c0/'ve/'s} been praying for an apprentice for moons now!",
+            "The Clan cheers for their newest apprentice, m_c. r_c0 sits up extra straight; {PRONOUN/r_c0/subject} {VERB/r_c0/know/knows} m_c would be perfect for {PRONOUN/r_c0/poss} first apprentice."
         ]
     },
      {

--- a/resources/lang/en/events/ceremonies/apprentice.json
+++ b/resources/lang/en/events/ceremonies/apprentice.json
@@ -125,9 +125,14 @@
         ]
     },
     {
-        "event_id": "app_living_parent_mentor_unmentioned0",
+        "event_id": "app_living_parent_no_mentor0",
+        "tags": ["clan:warrior-like(min:1)"],
         "involved_cats": {
-            "m_c": {},
+            "m_c": {
+                "has_mentor": {
+                    "current": false
+                }
+            },
             "r_c0": {
                 "group": [
                     "player_clan"
@@ -202,12 +207,16 @@
         ]
     },
     {
-        "event_id": "app_dead_parent_mentor_unmentioned0",
+        "event_id": "app_dead_parent_no_mentor0",
+        "tags": ["clan:warrior-like(min:1)"],
         "involved_cats": {
             "m_c": {
                 "backstory": [
                     "-orphaned_backstories"
-                ]
+                ],
+                "has_mentor": {
+                    "current": false
+                }
             },
             "r_c0": {
                 "group": [
@@ -281,12 +290,16 @@
         ]
     },
     {
-        "event_id": "app_dead_parent_mentor_unmentioned1",
+        "event_id": "app_dead_parent_no_mentor1",
+        "tags": ["clan:warrior-like(min:1)"],
         "involved_cats": {
             "m_c": {
                 "backstory": [
                     "clanborn"
-                ]
+                ],
+                "has_mentor": {
+                    "current": false
+                }
             },
             "r_c0": {
                 "group": [
@@ -365,12 +378,16 @@
         ]
     },
     {
-        "event_id": "app_dead_both_parents_mentor_unmentioned0",
+        "event_id": "app_dead_both_parents_no_mentor0",
+        "tags": ["clan:warrior-like(min:1)"],
         "involved_cats": {
             "m_c": {
                 "backstory": [
                     "-orphaned_backstories"
-                ]
+                ],
+                "has_mentor": {
+                    "current": false
+                }
             },
             "r_c0": {
                 "group": [
@@ -1256,6 +1273,297 @@
                 "mutual": false,
                 "constraints": [
                     "app/mentor"
+                ]
+            }
+        ]
+    },
+    {
+        "event_id": "app_mentor_dislikes0",
+        "tags": [
+            "clan:leader"
+        ],
+        "involved_cats": {
+            "m_c": {},
+            "r_c0": {}
+        },
+        "strings": [
+            "m_c is overjoyed to finally be an apprentice. But why, oh why, did lead_name assign r_c0 as {PRONOUN/m_c/poss} mentor? {PRONOUN/r_c1/subject/CAP} {VERB/r_c1/are/is} the worst!"
+        ],
+        "relationship_constraint": [
+            {
+                "cats_from": [
+                    "m_c"
+                ],
+                "cats_to": [
+                    "r_c0"
+                ],
+                "mutual": false,
+                "constraints": [
+                    "app/mentor",
+                    "dislikes"
+                ]
+            }
+        ]
+    },
+    {
+        "event_id": "app_no_mentor_dislikes0",
+        "tags": [
+            "clan:leader"
+        ],
+        "involved_cats": {
+            "m_c": {
+                "has_mentor": {
+                    "current": false
+                }
+            },
+            "r_c0": {
+                "status": [
+                    "warrior", 
+                    "leader", 
+                    "deputy"
+                ]
+            }
+        },
+        "strings": [
+            "As m_c recieves {PRONOUN/m_c/poss} apprentice name, {PRONOUN/m_c/subject} {VERB/m_c/send/sends} a small prayer to StarClan that r_c0 won't be {PRONOUN/m_c/poss} mentor."
+        ],
+        "relationship_constraint": [
+            {
+                "cats_from": [
+                    "m_c"
+                ],
+                "cats_to": [
+                    "r_c0"
+                ],
+                "mutual": false,
+                "constraints": [
+                    "dislikes"
+                ]
+            }
+        ]
+    },
+    {
+        "event_id": "app_no_mentor_likes0",
+        "tags": [
+            "clan:leader",
+            "clan:warrior-like(min:1)"
+        ],
+        "involved_cats": {
+            "m_c": {
+                "has_mentor": {
+                    "current": false
+                }
+            },
+            "r_c0": {
+                "status": [
+                    "warrior", 
+                    "leader", 
+                    "deputy"
+                ]
+            }
+        },
+        "strings": [
+            "As (old_name) prepares for {PRONOUN/m_c/poss} apprentice ceremony, {PRONOUN/m_c/subject} {VERB/m_c/wonder/wonders} who {PRONOUN/m_c/poss} mentor will be. Oh! Maybe it will be r_c0, that would be cool! At the next clan meeting, {PRONOUN/m_c/subject} {VERB/m_c/are/is} named m_c and welcomed as a new apprentice.",
+            "m_c is finally made an apprentice. {PRONOUN/m_c/subject/CAP} {VERB/m_c/hope/hopes} that r_c0 will be {PRONOUN/m_c/poss} mentor."
+        ],
+        "relationship_constraint": [
+            {
+                "cats_from": [
+                    "m_c"
+                ],
+                "cats_to": [
+                    "r_c0"
+                ],
+                "mutual": true,
+                "constraints": [
+                    "likes",
+                    "-child/parent"
+                ]
+            }
+        ]
+    },
+    {
+        "event_id": "app_no_mentor_mentor_hoping0",
+        "tags": [
+            "clan:leader"
+        ],
+        "involved_cats": {
+            "m_c": {
+                "has_mentor": {
+                    "current": false
+                }
+            },
+            "r_c0": {
+                "has_apprentice": {
+                    "current": false,
+                    "former": false
+                },
+                "age": ["-young adult", "-adolescent"],
+                "status": [
+                    "warrior"
+                ],
+                "group": [
+                    "player_clan"
+                ]
+            }
+        },
+        "strings": [
+            "r_c0 hopes {PRONOUN/r_c0/subject}'ll get to mentor the clan's newest apprentice, m_c. {PRONOUN/r_c0/subject/CAP}{VERB/r_c0/'ve/'s} been praying for an apprentice for moons now!",
+            "The clan cheers for their newest apprentice, m_c. r_c0 sit up extra straight; {PRONOUN/r_c0/subject} {VERB/r_c0/know/knows} m_c would be perfect for {PRONOUN/r_c0/poss} first apprentice."
+        ]
+    },
+     {
+        "event_id": "app_no_mentor_mentor_hoping1",
+        "tags": [
+            "clan:leader"
+        ],
+        "involved_cats": {
+            "m_c": {
+                "has_mentor": {
+                    "current": false
+                }
+            },
+            "r_c0": {
+                "has_apprentice": {
+                    "current": false,
+                    "former": false
+                },
+                "age": ["-young adult", "-adolescent"],
+                "status": [
+                    "warrior"
+                ],
+                "group": [
+                    "player_clan"
+                ],
+                "stat": {
+                    "trait": [
+                        "ambitious",
+                        "competitive",
+                        "bossy",
+                        "confident",
+                        "flamboyant",
+                        "charismatic",
+                        "cunning"
+                    ]
+                },
+                "past_status": ["-deputy"]
+            }
+        },
+        "strings": [
+            "At m_c's apprentice ceremony, r_c0 watches lead_name with ambition. If r_c0 has any change of being deputy, {PRONOUN/r_c0/subject} {VERB/r_c0/need/needs} an apprentice, and m_c would be perfect."
+        ]
+    },
+    {
+        "event_id": "app_mentor_likes0",
+        "tags": [
+            "clan:leader"
+        ],
+        "involved_cats": {
+            "m_c": {},
+            "r_c0": {}
+        },
+        "strings": [
+            "m_c's heart swells with joy when {PRONOUN/m_c/subject}{VERB/m_c/'ve/'s} apprenticed to r_c0. {PRONOUN/m_c/subject/CAP} can't wait to learn from the coolest cat in the whole clan."
+        ],
+        "relationship_constraint": [
+            {
+                "cats_from": [
+                    "m_c"
+                ],
+                "cats_to": [
+                    "r_c0"
+                ],
+                "mutual": false,
+                "constraints": [
+                    "app/mentor",
+                    "likes"
+                ]
+            }
+        ]
+    },
+    {
+        "event_id": "app_mentor_sibling0",
+        "tags": [
+            "clan:leader"
+        ],
+        "involved_cats": {
+            "m_c": {},
+            "r_c0": {}
+        },
+        "strings": [
+            "(old_name) is old enough to begin training, and is apprenticed to r_c0, {PRONOUN/m_c/poss} older sibling. (clan_leader) that m_c's kin will guide them into a fine warrior.",
+            "m_c is apprenticed to {PRONOUN/m_c/poss} older sibling, r_c0. lead_name {PRONOUN/lead_name/know/knows} that there will be extra challenges involved with mentoring kin, but r_c0 is willing to take it on. "
+        ],
+        "relationship_constraint": [
+            {
+                "cats_from": [
+                    "m_c"
+                ],
+                "cats_to": [
+                    "r_c0"
+                ],
+                "mutual": false,
+                "constraints": [
+                    "app/mentor",
+                    "siblings"
+                ]
+            }
+        ]
+    },
+    {
+        "event_id": "app_mentor_sibling_parentHappy0",
+        "tags": [
+            "clan:leader"
+        ],
+        "involved_cats": {
+            "m_c": {},
+            "r_c0": {},
+            "r_c1": {
+                "group": [
+                    "player_clan"
+                ]
+            }
+        },
+        "strings": [
+            "r_c1 is delighted that m_c is apprenticed to r_c0. It will be great to see {PRONOUN/r_c1/poss} kits working so closely.",
+            "When m_c is apprenticed to r_c0, r_c1 mewls in delight. {PRONOUN/r_c1/poss} kits, training together! How wonderful!"
+        ],
+        "relationship_constraint": [
+            {
+                "cats_from": [
+                    "m_c"
+                ],
+                "cats_to": [
+                    "r_c0"
+                ],
+                "mutual": false,
+                "constraints": [
+                    "app/mentor"
+                ]
+            },
+            {
+                "cats_from": [
+                    "r_c1"
+                ],
+                "cats_to": [
+                    "m_c",
+                    "r_c0"
+                ],
+                "mutual": false,
+                "constraints": [
+                    "parent/child"
+                ]
+            },
+            {
+                 "cats_from": [
+                    "r_c1"
+                ],
+                "cats_to": [
+                    "r_c0"
+                ],
+                "mutual": false,
+                "constraints": [
+                    "likes"
                 ]
             }
         ]

--- a/resources/lang/en/events/ceremonies/apprentice.json
+++ b/resources/lang/en/events/ceremonies/apprentice.json
@@ -34,53 +34,6 @@
         ]
     },
     {
-        "event_id": "app_no_mentors_available0",
-        "tags": ["-clan:warrior-like(min:1)"],
-        "involved_cats": {
-            "m_c": {
-                "has_mentor": {
-                    "current": false
-                }
-            }
-        },
-        "strings": [
-            "Newly-made apprentice m_c wishes {PRONOUN/m_c/subject} had someone to mentor {PRONOUN/m_c/object}.",
-            "m_c isn't confident in {PRONOUN/m_c/poss} ability to train {PRONOUN/m_c/self}, but will try anyway.",
-            "m_c is frustrated that {PRONOUN/m_c/subject} {VERB/m_c/don't/doesn't} have a mentor.",
-            "m_c isn't sure what to do without the guidance of a mentor.",
-            "m_c wonders if {PRONOUN/m_c/subject} can get by without the guidance of a mentor."
-        ]
-    },
-    {
-        "event_id": "app_no_leader0",
-        "tags": [
-            "-clan:leader"
-        ],
-        "involved_cats": {
-            "m_c": {},
-            "r_c0": {}
-        },
-        "strings": [
-            "The Clan gathers around and urges (old_name) to go to the front of the crowd. Not having a leader isn't an excuse to force a cat to stay in the nursery when they're six moons old. (old_name) is renamed m_c, and the Clan votes to make r_c0 {PRONOUN/m_c/poss} mentor.",
-            "The Clan cheers for the new apprentice, m_c. They allow {PRONOUN/m_c/object} to choose {PRONOUN/m_c/poss} own mentor: m_c chooses r_c0.",
-            "With m_c's apprentice ceremony completed, there's still the problem of figuring out who will mentor {PRONOUN/m_c/object}. r_c0 steps forward first, so m_c touches noses with {PRONOUN/r_c0/object}."
-        ],
-        "relationship_constraint": [
-            {
-                "cats_from": [
-                    "m_c"
-                ],
-                "cats_to": [
-                    "r_c0"
-                ],
-                "mutual": false,
-                "constraints": [
-                    "app/mentor"
-                ]
-            }
-        ]
-    },
-    {
         "event_id": "app_living_parent0",
         "involved_cats": {
             "m_c": {},
@@ -113,41 +66,6 @@
             {
                 "cats_to": [
                     "r_c1"
-                ],
-                "cats_from": [
-                    "m_c"
-                ],
-                "mutual": false,
-                "constraints": [
-                    "child/parent"
-                ]
-            }
-        ]
-    },
-    {
-        "event_id": "app_living_parent_no_mentor0",
-        "tags": ["clan:warrior-like(min:1)"],
-        "involved_cats": {
-            "m_c": {
-                "has_mentor": {
-                    "current": false
-                }
-            },
-            "r_c0": {
-                "group": [
-                    "player_clan"
-                ]
-            }
-        },
-        "strings": [        
-            "(old_name) loudly complains as r_c0 pulls {PRONOUN/m_c/object} over to quickly groom {PRONOUN/m_c/poss} pelt. {PRONOUN/m_c/subject/CAP} {VERB/m_c/manage/manages} to wriggle away and scurry off to the front of the crowd for {PRONOUN/m_c/poss} ceremony, where {PRONOUN/m_c/subject} {VERB/m_c/are/is} renamed to m_c.",
-            "Even though {PRONOUN/m_c/subject} {VERB/m_c/are/is} excited to finally be made an apprentice, it takes a bit of coaxing by r_c0 for (old_name) to step forward for {PRONOUN/m_c/poss} ceremony. r_c0 watches in pride as {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} named m_c."
-
-        ],
-        "relationship_constraint": [
-            {
-                "cats_to": [
-                    "r_c0"
                 ],
                 "cats_from": [
                     "m_c"
@@ -207,43 +125,6 @@
         ]
     },
     {
-        "event_id": "app_dead_parent_no_mentor0",
-        "tags": ["clan:warrior-like(min:1)"],
-        "involved_cats": {
-            "m_c": {
-                "backstory": [
-                    "-orphaned_backstories"
-                ],
-                "has_mentor": {
-                    "current": false
-                }
-            },
-            "r_c0": {
-                "group": [
-                    "afterlife"
-                ]
-            }
-        },
-        "strings": [
-            "m_c hopes that r_c0 is watching from StarClan with pride as {PRONOUN/m_c/subject} {VERB/m_c/are/is} apprenticed.",
-            "m_c smiles up at the stars as {PRONOUN/m_c/subject} {VERB/m_c/sit/sits} recieves {PRONOUN/m_c/poss} apprentice name. The stars seem to shine brighter in response: m_c knows it's a sign that r_c0 is still watching over {PRONOUN/m_c/object}."
-        ],
-        "relationship_constraint": [
-            {
-                "cats_to": [
-                    "r_c0"
-                ],
-                "cats_from": [
-                    "m_c"
-                ],
-                "mutual": false,
-                "constraints": [
-                    "child/parent"
-                ]
-            }
-        ]
-    },
-    {
         "event_id": "app_dead_parent1",
         "involved_cats": {
             "m_c": {
@@ -278,43 +159,6 @@
             {
                 "cats_to": [
                     "r_c1"
-                ],
-                "cats_from": [
-                    "m_c"
-                ],
-                "mutual": false,
-                "constraints": [
-                    "child/parent"
-                ]
-            }
-        ]
-    },
-    {
-        "event_id": "app_dead_parent_no_mentor1",
-        "tags": ["clan:warrior-like(min:1)"],
-        "involved_cats": {
-            "m_c": {
-                "backstory": [
-                    "clanborn"
-                ],
-                "has_mentor": {
-                    "current": false
-                }
-            },
-            "r_c0": {
-                "group": [
-                    "afterlife"
-                ]
-            }
-        },
-        "strings": [
-            "m_c wishes that {PRONOUN/m_c/subject} could be happier about being made an apprentice, but all {PRONOUN/m_c/subject} can think about is how much {PRONOUN/m_c/subject} {VERB/m_c/wish/wishes} that r_c0 was still there to chant {PRONOUN/m_c/poss} name with the rest of the Clan.",
-            "m_c tries to keep up a brave face as {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} apprenticed, but {PRONOUN/m_c/subject} {VERB/m_c/keep/keeps} stealing glances at the crowd, as if trying to find r_c0 despite knowing {PRONOUN/r_c0/subject}{VERB/r_c0/'re/'s} no longer with {PRONOUN/m_c/object}."
-        ],
-        "relationship_constraint": [
-            {
-                "cats_to": [
-                    "r_c0"
                 ],
                 "cats_from": [
                     "m_c"
@@ -377,48 +221,7 @@
             }
         ]
     },
-    {
-        "event_id": "app_dead_both_parents_no_mentor0",
-        "tags": ["clan:warrior-like(min:1)"],
-        "involved_cats": {
-            "m_c": {
-                "backstory": [
-                    "-orphaned_backstories"
-                ],
-                "has_mentor": {
-                    "current": false
-                }
-            },
-            "r_c0": {
-                "group": [
-                    "afterlife"
-                ]
-            },
-            "r_c1": {
-                "group": [
-                    "afterlife"
-                ]
-            }
-        },
-        "strings": [
-            "As the Clan chant's m_c's new name, {PRONOUN/m_c/subject} {VERB/m_c/make/makes} a silent promise to r_c0 and r_c1 to make them proud and to take care of the Clan in their absence."
-        ],
-        "relationship_constraint": [
-            {
-                "cats_to": [
-                    "r_c0",
-                    "r_c1"
-                ],
-                "cats_from": [
-                    "m_c"
-                ],
-                "mutual": false,
-                "constraints": [
-                    "child/parent"
-                ]
-            }
-        ]
-    },
+    
     {
         "event_id": "app_living_both_parents0",
         "involved_cats": {

--- a/resources/lang/en/events/ceremonies/apprentice.json
+++ b/resources/lang/en/events/ceremonies/apprentice.json
@@ -401,7 +401,7 @@
             }
         },
         "strings": [
-            "As the clan chant's m_c's new name, {PRONOUN/m_c/subject} {VERB/m_c/make/makes} a silent promise to r_c0 and r_c1 to make them proud and to take care of the Clan in their absence."
+            "As the Clan chant's m_c's new name, {PRONOUN/m_c/subject} {VERB/m_c/make/makes} a silent promise to r_c0 and r_c1 to make them proud and to take care of the Clan in their absence."
         ],
         "relationship_constraint": [
             {
@@ -1409,7 +1409,7 @@
         },
         "strings": [
             "r_c0 hopes {PRONOUN/r_c0/subject}'ll get to mentor the clan's newest apprentice, m_c. {PRONOUN/r_c0/subject/CAP}{VERB/r_c0/'ve/'s} been praying for an apprentice for moons now!",
-            "The clan cheers for their newest apprentice, m_c. r_c0 sit up extra straight; {PRONOUN/r_c0/subject} {VERB/r_c0/know/knows} m_c would be perfect for {PRONOUN/r_c0/poss} first apprentice."
+            "The clan cheers for their newest apprentice, m_c. r_c0 sits up extra straight; {PRONOUN/r_c0/subject} {VERB/r_c0/know/knows} m_c would be perfect for {PRONOUN/r_c0/poss} first apprentice."
         ]
     },
      {
@@ -1492,7 +1492,7 @@
         },
         "strings": [
             "(old_name) is old enough to begin training, and is apprenticed to r_c0, {PRONOUN/m_c/poss} older sibling. (clan_leader) that m_c's kin will guide them into a fine warrior.",
-            "m_c is apprenticed to {PRONOUN/m_c/poss} older sibling, r_c0. lead_name {VERB/lead_name/know/knows} that there will be extra challenges involved with mentoring kin, but r_c0 is willing to take it on. "
+            "m_c is apprenticed to {PRONOUN/m_c/poss} older sibling, r_c0. lead_name knows that there will be extra challenges involved with mentoring kin, but r_c0 is willing to take it on. "
         ],
         "relationship_constraint": [
             {

--- a/resources/lang/en/events/ceremonies/apprentice.json
+++ b/resources/lang/en/events/ceremonies/apprentice.json
@@ -1492,7 +1492,7 @@
         },
         "strings": [
             "(old_name) is old enough to begin training, and is apprenticed to r_c0, {PRONOUN/m_c/poss} older sibling. (clan_leader) that m_c's kin will guide them into a fine warrior.",
-            "m_c is apprenticed to {PRONOUN/m_c/poss} older sibling, r_c0. lead_name {PRONOUN/lead_name/know/knows} that there will be extra challenges involved with mentoring kin, but r_c0 is willing to take it on. "
+            "m_c is apprenticed to {PRONOUN/m_c/poss} older sibling, r_c0. lead_name {VERB/lead_name/know/knows} that there will be extra challenges involved with mentoring kin, but r_c0 is willing to take it on. "
         ],
         "relationship_constraint": [
             {


### PR DESCRIPTION
## About The Pull Request

Add a handful of new warrior apprentice ceremonies. This includes: 

- ~~Versions of the living and dead parent ceremonies for non-auto mentors.~~
- Some ceremonies for non-auto mentors where the apprentice hopes (or doesn't hope) for a specific mentor. 
- Some ceremonies, for non-auto mentors, where a specific cat hopes to be a mentor. 
- Special ceremonies for when the apprentice doesn't like their mentor. 
- Special ceremony where the apprentice likes their mentor.
- Special ceremonies for instances where the mentor is an older sibling. 

Also, fixed a dead parent ceremony which required two parents to be dead, but only mentioned one of them. 

## Why This Is Good For ClanGen

Some more special ceremonies for special relation, and some more variety in ceremonies for non-auto mentors. 


## Proof of Testing

<img width="800" height="700" alt="python_oRnmTBnziE" src="https://github.com/user-attachments/assets/12a2812e-2bc8-4bfb-8d74-b542d47fe486" />

