### PR TITLE
[BUGFIX] lilac dilute fix

### DIFF
--- a/sprites/dicts/tint.json
+++ b/sprites/dicts/tint.json
@@ -64,7 +64,7 @@
     "cooldilute": [7, 15, 25],
     "pinkdilute": [80, 50, 45],
     "earthydilute": [44, 33, 11],
-    "lilacdilute": [44, 33, 11],
+    "lilacdilute": [31, 25, 36],
     "none": null
   }
 }


### PR DESCRIPTION
## About The Pull Request
- Lilac dilute was accidentally using the same color as earthydilute instead of its proper color displayed in the photos when it was PR'd. 

## Proof of Testing
<img width="193" height="188" alt="Screenshot 2026-09-09 at 2 46 05 PM" src="https://github.com/user-attachments/assets/9241a748-da1c-441b-85ea-b7b6085d576d" />
Color displays correctly now
