### PR TITLE
Bugfix: Require living parent for non-deadparent transition events

### DIFF
--- a/resources/lang/en/events/transition.json
+++ b/resources/lang/en/events/transition.json
@@ -292,7 +292,11 @@
                     "male"
                 ]
             },
-            "r_c0": {}
+            "r_c0": {
+		 "group": [
+             	     "player_clan"
+                 ]
+            }
         },
         "relationship_changes": [
             {
@@ -351,7 +355,11 @@
                     "female"
                 ]
             },
-            "r_c0": {}
+            "r_c0": {
+		 "group": [
+                     "player_clan"
+                 ]
+            }
         },
         "relationship_changes": [
             {
@@ -2232,7 +2240,11 @@
                     "female"
                 ]
             },
-            "r_c0": {}
+            "r_c0": {
+                "group": [
+                    "player_clan"
+                ]
+            }
         },
         "relationship_changes": [
             {
@@ -2346,7 +2358,11 @@
                     "male"
                 ]
             },
-            "r_c0": {}
+            "r_c0": {
+                "group": [
+                    "player_clan"
+                ]
+            }
         },
         "relationship_changes": [
             {


### PR DESCRIPTION
## About The Pull Request

In `resources/lang/en/events/transition.json`, four transition events involve a cat's parent (r_c0) reacting to their coming out — helping spread the news to the Clan, or giving a gift of reassurance. These events had an empty `involved_cats` constraint for `r_c0` (`"r_c0": {}`), with no requirement that the parent be alive.

The game's `cat_for_event` filter (`scripts/events_module/event_filters.py`) only applies the `group` filter when the `"group"` key is present in the constraint dict. Since these four events were left it out entirely, and the transition event generator pulls from `Cat.all_cats_list` (which includes dead/StarClan cats), a deceased parent could be selected as r_c0 — producing events where a dead cat is shown helping spread news or giving a gift.

The fix adds `"group": ["player_clan"]` to `r_c0` in the four affected events, matching the convention already used elsewhere  to require a living Clan member. The three dedicated `deadparent` variants, which correctly require `"group": ["starclan"]`, were left untouched, as were two unrelated "mates" events that share the same `{}` pattern but are outside the scope of this issue.

**Events fixed:**
- `gen_misc_transition_parentcomingout_from_male`
- `gen_misc_transition_parentcomingout_from_female`
- `gen_misc_transition_nervoustoparent_from_female`
- `gen_misc_transition_nervoustoparent_from_male`

## Linked Issues

Fixes: #5973

## Proof of Testing

Ran the existing JSON schema compliance test for transition events, both passed:

python3 -m pytest tests/test_json_model_compliance.py -k transition -q
2 passed, 721 deselected

Also validated the JSON parses correctly and manually confirmed via script that only the four intended events' `r_c0` constraints changed, while the `deadparent` and unrelated events were untouched.

I wasn't able to trigger the transition event in-game to confirm visually (still getting familiar with the game itself), so this is validated at the schema/test level rather than through live gameplay.

## Changelog/Credits

Fixed: Transition events no longer call on a dead parent when the text implies the parent is alive and present.