### PR TITLE
[CONTENT & BALANCE] medicine cat relationship events

### DIFF
--- a/resources/lang/en/events/relationship_events/group_interactions/high/negative.json
+++ b/resources/lang/en/events/relationship_events/group_interactions/high/negative.json
@@ -42,7 +42,6 @@
             }
         ]
     },
-
     {
         "event_id": "group_3_negative_romanticrivalshigh_jealousofmate",
         "strings": [
@@ -248,7 +247,8 @@
                 "amount": -10
             }
         ]
-    },    {
+    },
+    {
         "event_id": "group_5_neg_medicinecatdebates",
         "strings": [
             "m_c, multi_cat discuss medicine amongst themselves, and it soon sours into a nasty argument.",
@@ -277,7 +277,7 @@
                 "cats_to": ["multi_cat", "m_c"],
                 "mutual": false,
                 "values": ["like", "comfort", "respect"],
-                "amount": -10
+                "amount": -5
             }
         ]
     },

--- a/resources/lang/en/events/relationship_events/group_interactions/high/positive.json
+++ b/resources/lang/en/events/relationship_events/group_interactions/high/positive.json
@@ -236,7 +236,7 @@
         "strings": [
             "m_c, multi_cat discussed their favorite herbs and places to gather them in the territory.",
             "m_c, multi_cat, bonded over the unique privilege of communing with their ancestors.",
-            "m_c, multi_cat worked together to treat an injured clanmate.",
+            "m_c, multi_cat worked together to treat an injured Clanmate.",
             "m_c, multi_cat, are grateful for each other specialties in healing."
         ],
         "involved_cats": {

--- a/resources/lang/en/events/relationship_events/group_interactions/high/positive.json
+++ b/resources/lang/en/events/relationship_events/group_interactions/high/positive.json
@@ -237,7 +237,7 @@
             "m_c, multi_cat discussed their favorite herbs and places to gather them in the territory.",
             "m_c, multi_cat, bonded over the unique privilege of communing with their ancestors.",
             "m_c, multi_cat worked together to treat an injured clanmate.",
-            "m_c, multi_cat, are grateful for each other specialties in healing. "
+            "m_c, multi_cat, are grateful for each other specialties in healing."
         ],
         "involved_cats": {
             "m_c": {

--- a/resources/lang/en/events/relationship_events/group_interactions/high/positive.json
+++ b/resources/lang/en/events/relationship_events/group_interactions/high/positive.json
@@ -235,7 +235,7 @@
         "event_id": "group_pos_medicinecatbonding",
         "strings": [
             "m_c, multi_cat discussed their favorite herbs and places to gather them in the territory.",
-            "m_c, multi_cat, bonded over the unique privilege of communing with their ancestors.",
+            "m_c, multi_cat bonded over the unique privilege of communing with their ancestors.",
             "m_c, multi_cat worked together to treat an injured Clanmate.",
             "m_c, multi_cat are grateful for each other's specialties in healing."
         ],

--- a/resources/lang/en/events/relationship_events/group_interactions/high/positive.json
+++ b/resources/lang/en/events/relationship_events/group_interactions/high/positive.json
@@ -237,7 +237,7 @@
             "m_c, multi_cat discussed their favorite herbs and places to gather them in the territory.",
             "m_c, multi_cat, bonded over the unique privilege of communing with their ancestors.",
             "m_c, multi_cat worked together to treat an injured Clanmate.",
-            "m_c, multi_cat, are grateful for each other specialties in healing."
+            "m_c, multi_cat are grateful for each other's specialties in healing."
         ],
         "involved_cats": {
             "m_c": {

--- a/resources/lang/en/events/relationship_events/group_interactions/high/positive.json
+++ b/resources/lang/en/events/relationship_events/group_interactions/high/positive.json
@@ -230,5 +230,35 @@
                 "amount": 10
             }
         ]
+    },
+    {
+        "event_id": "group_pos_medicinecatbonding",
+        "strings": [
+            "m_c, multi_cat discussed their favorite herbs and places to gather them in the territory.",
+            "m_c, multi_cat, bonded over the unique privilege of communing with their ancestors.",
+            "m_c, multi_cat worked together to treat an injured clanmate.",
+            "m_c, multi_cat, are grateful for each other specialties in healing. "
+        ],
+        "involved_cats": {
+            "m_c": {
+                "status": [
+                    "medicine cat"
+                ]
+            },
+            "multi_cat": {
+                "status": [
+                    "medicine cat"
+                ]
+            }
+        },
+        "relationship_changes": [
+            {
+                "cats_from": ["m_c", "multi_cat"],
+                "cats_to": ["multi_cat", "m_c"],
+                "mutual": false,
+                "values": ["like", "comfort", "respect"],
+                "amount": 5
+            }
+        ]
     }
 ]


### PR DESCRIPTION
## About The Pull Request

- Adds a few positive group relationship events for medicine cats.
- Changes the amount of relationship decrease for group negative medicine cat events as it was overtuned to a total of -30 relationship values. It has now become -15. 

## Why This Is Good For ClanGen
- More variety for medicine cats and hopefully better balance.

## Proof of Testing
(it took me over forty minutes to generate this 🥲)

<img width="521" height="105" alt="Screenshot 2026-09-10 at 12 39 29 PM" src="https://github.com/user-attachments/assets/d3b10e0d-15d1-4b17-ab97-9ec4bc23e787" />