### PR TITLE
Fixes the "binglegift" patrols

### DIFF
--- a/resources/lang/en/patrols/new_cat.json
+++ b/resources/lang/en/patrols/new_cat.json
@@ -2766,8 +2766,8 @@
                         "age": [
                             "adult"
                         ],
-                        "backstory": [
-                            "loner3"
+                        "status": [
+                            "loner"
                         ]
                     }
                 },
@@ -2817,8 +2817,8 @@
                                 "p_l"
                             ]
                         },
-                        "backstory": [
-                            "loner3"
+                        "status": [
+                            "loner"
                         ]
                     }
                 },
@@ -2884,8 +2884,8 @@
                                 "p_l"
                             ]
                         },
-                        "backstory": [
-                            "loner3"
+                        "status": [
+                            "loner"
                         ]
                     }
                 },
@@ -3038,8 +3038,8 @@
                                 "p_l"
                             ]
                         },
-                        "backstory": [
-                            "loner3"
+                        "status": [
+                            "loner"
                         ]
                     }
                 },
@@ -3107,8 +3107,8 @@
                                 "p_l"
                             ]
                         },
-                        "backstory": [
-                            "loner3"
+                        "status": [
+                            "loner"
                         ]
                     }
                 },
@@ -3171,8 +3171,8 @@
                                 "p_l"
                             ]
                         },
-                        "backstory": [
-                            "loner3"
+                        "status": [
+                            "loner"
                         ]
                     }
                 },
@@ -3246,8 +3246,8 @@
                                 "p_l"
                             ]
                         },
-                        "backstory": [
-                            "loner3"
+                        "status": [
+                            "loner"
                         ]
                     }
                 },

--- a/resources/lang/en/patrols/new_cat_hostile.json
+++ b/resources/lang/en/patrols/new_cat_hostile.json
@@ -1615,8 +1615,8 @@
                         "age": [
                             "adult"
                         ],
-                        "backstory": [
-                            "loner3"
+                        "status": [
+                            "loner"
                         ]
                     }
                 },
@@ -1666,8 +1666,8 @@
                                 "p_l"
                             ]
                         },
-                        "backstory": [
-                            "loner3"
+                        "status": [
+                            "loner"
                         ]
                     }
                 },
@@ -1733,8 +1733,8 @@
                                 "p_l"
                             ]
                         },
-                        "backstory": [
-                            "loner3"
+                        "status": [
+                            "loner"
                         ]
                     }
                 },
@@ -1885,8 +1885,8 @@
                                 "p_l"
                             ]
                         },
-                        "backstory": [
-                            "loner3"
+                        "status": [
+                            "loner"
                         ]
                     }
                 },
@@ -1954,8 +1954,8 @@
                                 "p_l"
                             ]
                         },
-                        "backstory": [
-                            "loner3"
+                        "status": [
+                            "loner"
                         ]
                     }
                 },
@@ -2033,8 +2033,8 @@
                                 "p_l"
                             ]
                         },
-                        "backstory": [
-                            "loner3"
+                        "status": [
+                            "loner"
                         ]
                     }
                 },
@@ -2108,8 +2108,8 @@
                                 "p_l"
                             ]
                         },
-                        "backstory": [
-                            "loner3"
+                        "status": [
+                            "loner"
                         ]
                     }
                 },

--- a/resources/lang/en/patrols/new_cat_welcoming.json
+++ b/resources/lang/en/patrols/new_cat_welcoming.json
@@ -4052,8 +4052,8 @@
                         "age": [
                             "adult"
                         ],
-                        "backstory": [
-                            "loner3"
+                        "status": [
+                            "loner"
                         ]
                     }
                 },
@@ -4103,8 +4103,8 @@
                                 "p_l"
                             ]
                         },
-                        "backstory": [
-                            "loner3"
+                        "status": [
+                            "loner"
                         ]
                     }
                 },
@@ -4170,8 +4170,8 @@
                                 "p_l"
                             ]
                         },
-                        "backstory": [
-                            "loner3"
+                        "status": [
+                            "loner"
                         ]
                     }
                 },
@@ -4323,8 +4323,8 @@
                                 "p_l"
                             ]
                         },
-                        "backstory": [
-                            "loner3"
+                        "status": [
+                            "loner"
                         ]
                     }
                 },
@@ -4392,8 +4392,8 @@
                                 "p_l"
                             ]
                         },
-                        "backstory": [
-                            "loner3"
+                        "status": [
+                            "loner"
                         ]
                     }
                 },
@@ -4456,8 +4456,8 @@
                                 "p_l"
                             ]
                         },
-                        "backstory": [
-                            "loner3"
+                        "status": [
+                            "loner"
                         ]
                     }
                 },
@@ -4531,8 +4531,8 @@
                                 "p_l"
                             ]
                         },
-                        "backstory": [
-                            "loner3"
+                        "status": [
+                            "loner"
                         ]
                     }
                 },


### PR DESCRIPTION
## About The Pull Request
Fixes the following patrols:
"gen_bord_binglegift1"
"gen_bord_hostilebinglegift1"
"gen_bord_welcomingbinglegift1"

They were previously placing all generated cats into the Clan regardless of if the outcome called for it or not. This PR makes it so the outcomes vary and cats will not be incorrectly placed within the Clan when they should be outsiders (loners, specifically).

## Why This Is Good For ClanGen

Fixes a (rather annoying) bug that would place cats from the "bingle" patrols in the Clan no matter the outcome, even if the patrol called for the cat to be an outsider.

## Linked Issues

Fixes #5970

## Proof of Testing

<img width="710" height="544" alt="headbump" src="https://github.com/user-attachments/assets/257dd6d1-7401-4cfd-be0b-c589adca2416" />
<img width="712" height="405" alt="headbump2" src="https://github.com/user-attachments/assets/25a5c366-69a9-4f7e-b294-12ad55fd01aa" />
<img width="692" height="543" alt="lost" src="https://github.com/user-attachments/assets/eeca692c-f993-413a-8972-fb8b02c56987" />
<img width="726" height="389" alt="lost2" src="https://github.com/user-attachments/assets/887a9771-e257-41fc-b3d8-6aaefcfecde5" />
<img width="693" height="560" alt="warned" src="https://github.com/user-attachments/assets/0a8a91ef-9f0b-4710-9659-db2db26de6f4" />
<img width="714" height="381" alt="warned2" src="https://github.com/user-attachments/assets/5947c35e-85e7-4255-b2c1-21b133dd2fb0" />

## Changelog/Credits

Fixes the following patrols:
"gen_bord_binglegift1"
"gen_bord_hostilebinglegift1"
"gen_bord_welcomingbinglegift1"

Makes it so outcomes reflect accurately in the generated cats.